### PR TITLE
fix(remote): carry SSH workspace identity end-to-end for sessions

### DIFF
--- a/src/crates/assembly/core/src/agentic/session/session_store_port.rs
+++ b/src/crates/assembly/core/src/agentic/session/session_store_port.rs
@@ -186,7 +186,10 @@ impl SessionStorePort for CoreSessionStorePort {
         .ok_or_else(|| {
             PortError::new(
                 PortErrorKind::InvalidRequest,
-                "Session workspace_path is required",
+                format!(
+                    "Session workspace_path does not resolve to a local workspace or a \
+                     registered remote workspace: {workspace_path}"
+                ),
             )
         })?;
 

--- a/src/crates/assembly/core/src/service/remote_connect/bot/command_router.rs
+++ b/src/crates/assembly/core/src/service/remote_connect/bot/command_router.rs
@@ -24,7 +24,7 @@ use super::menu::{MenuItem, MenuView};
 pub use bitfun_services_integrations::remote_connect::bot::{
     parse_command, BotAction, BotActionStyle, BotChatState, BotCommand, BotDisplayMode,
     BotInteractionHandler, BotInteractiveRequest, BotMessageSender, BotQuestion, BotQuestionOption,
-    PendingAction, RemoteDeviceTarget,
+    BotWorkspaceChoice, BotWorkspaceRef, PendingAction, RemoteDeviceTarget,
 };
 
 // ── Constants ──────────────────────────────────────────────────────
@@ -139,7 +139,7 @@ fn ready_to_chat_body(state: &BotChatState, s: &'static BotStrings) -> Option<St
     // user wants to manage sessions they can use /resume which renders
     // proper session names.
     if state.display_mode == BotDisplayMode::Pro {
-        match &state.current_workspace {
+        match state.current_workspace_path() {
             Some(p) => Some(format!(
                 "{}: {}",
                 s.current_workspace_label,
@@ -847,6 +847,105 @@ async fn set_verbose(state: &mut BotChatState, on: bool, s: &'static BotStrings)
 // ── Switch context (workspace or assistant) ────────────────────────
 
 async fn start_switch(state: &mut BotChatState, s: &'static BotStrings) -> HandleResult {
+    // Remote-device control: list/switch workspaces on the peer, not the local desktop.
+    if state.active_remote_device.is_some() {
+        if state.display_mode != BotDisplayMode::Pro {
+            return result_from_menu(
+                state,
+                MenuView::plain(s.switch_no_assistants)
+                    .with_items(vec![MenuItem::default(s.item_back, "/menu")]),
+            );
+        }
+        let cmd = serde_json::json!({ "cmd": "list_recent_workspaces" });
+        let cmd_json = serde_json::to_string(&cmd).unwrap_or_default();
+        match exec_remote_rpc(state, &cmd_json).await {
+            Ok(resp) => {
+                let val: serde_json::Value = match serde_json::from_str(&resp) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        return result_from_menu(
+                            state,
+                            MenuView::plain(format!("{}{e}", s.workspace_open_failed_prefix))
+                                .with_items(vec![MenuItem::default(s.item_back, "/menu")]),
+                        );
+                    }
+                };
+                if val.get("resp").and_then(|value| value.as_str()) == Some("error") {
+                    let message = val
+                        .get("message")
+                        .and_then(|value| value.as_str())
+                        .unwrap_or(s.workspace_service_unavailable);
+                    return result_from_menu(
+                        state,
+                        MenuView::plain(message.to_string())
+                            .with_items(vec![MenuItem::default(s.item_back, "/menu")]),
+                    );
+                }
+                let workspaces = val
+                    .get("workspaces")
+                    .and_then(|value| value.as_array())
+                    .cloned()
+                    .unwrap_or_default();
+                if workspaces.is_empty() {
+                    return result_from_menu(
+                        state,
+                        MenuView::plain(s.switch_no_workspaces)
+                            .with_items(vec![MenuItem::default(s.item_back, "/menu")]),
+                    );
+                }
+                let options: Vec<BotWorkspaceChoice> = workspaces
+                    .iter()
+                    .filter_map(|workspace| {
+                        let path = workspace
+                            .get("path")
+                            .and_then(|value| value.as_str())
+                            .map(str::trim)
+                            .filter(|value| !value.is_empty())?;
+                        let name = workspace
+                            .get("name")
+                            .and_then(|value| value.as_str())
+                            .map(str::trim)
+                            .filter(|value| !value.is_empty())
+                            .unwrap_or(path);
+                        Some(BotWorkspaceChoice::new(
+                            path.to_string(),
+                            name.to_string(),
+                            workspace
+                                .get("remote_connection_id")
+                                .and_then(|value| value.as_str())
+                                .map(str::trim)
+                                .filter(|value| !value.is_empty())
+                                .map(str::to_string),
+                            workspace
+                                .get("remote_ssh_host")
+                                .and_then(|value| value.as_str())
+                                .map(str::trim)
+                                .filter(|value| !value.is_empty())
+                                .map(str::to_string),
+                        ))
+                    })
+                    .collect();
+                if options.is_empty() {
+                    return result_from_menu(
+                        state,
+                        MenuView::plain(s.switch_no_workspaces)
+                            .with_items(vec![MenuItem::default(s.item_back, "/menu")]),
+                    );
+                }
+                let view = workspace_selection_view(state, &options, s);
+                state.set_pending(PendingAction::SelectWorkspace { options });
+                return result_from_menu(state, view);
+            }
+            Err(error) => {
+                return result_from_menu(
+                    state,
+                    MenuView::plain(format!("{}{error}", s.workspace_open_failed_prefix))
+                        .with_items(vec![MenuItem::default(s.item_back, "/menu")]),
+                );
+            }
+        }
+    }
+
     use crate::service::workspace::get_global_workspace_service;
 
     let ws_service = match get_global_workspace_service() {
@@ -869,9 +968,23 @@ async fn start_switch(state: &mut BotChatState, s: &'static BotStrings) -> Handl
                     .with_items(vec![MenuItem::default(s.item_back, "/menu")]),
             );
         }
-        let options: Vec<(String, String)> = workspaces
+        let options: Vec<BotWorkspaceChoice> = workspaces
             .iter()
-            .map(|ws| (ws.root_path.to_string_lossy().to_string(), ws.name.clone()))
+            .map(|ws| {
+                let ssh_host = ws
+                    .metadata
+                    .get("sshHost")
+                    .and_then(|value| value.as_str())
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(str::to_string);
+                BotWorkspaceChoice::new(
+                    ws.root_path.to_string_lossy().to_string(),
+                    ws.name.clone(),
+                    ws.remote_ssh_connection_id().map(str::to_string),
+                    ssh_host,
+                )
+            })
             .collect();
         let view = workspace_selection_view(state, &options, s);
         state.set_pending(PendingAction::SelectWorkspace { options });
@@ -897,17 +1010,33 @@ async fn start_switch(state: &mut BotChatState, s: &'static BotStrings) -> Handl
 
 fn workspace_selection_view(
     state: &BotChatState,
-    options: &[(String, String)],
+    options: &[BotWorkspaceChoice],
     s: &'static BotStrings,
 ) -> MenuView {
     let mut items = Vec::new();
     let mut body = String::new();
-    for (i, (path, name)) in options.iter().enumerate() {
-        let is_current = state.current_workspace.as_deref() == Some(path.as_str());
+    for (i, choice) in options.iter().enumerate() {
+        let is_current = state.current_workspace.as_ref().is_some_and(|current| {
+            current.path == choice.path
+                && current.remote_connection_id == choice.remote_connection_id
+                && current.remote_ssh_host == choice.remote_ssh_host
+        });
         let marker = if is_current { s.current_marker } else { "" };
-        body.push_str(&format!("{}. {}{}\n", i + 1, name, marker));
+        let host_hint = choice
+            .remote_ssh_host
+            .as_deref()
+            .filter(|host| !host.is_empty())
+            .map(|host| format!(" ({host})"))
+            .unwrap_or_default();
+        body.push_str(&format!(
+            "{}. {}{}{}\n",
+            i + 1,
+            choice.name,
+            host_hint,
+            marker
+        ));
         items.push(MenuItem::default(
-            truncate_label(name, 24),
+            truncate_label(&choice.name, 24),
             (i + 1).to_string(),
         ));
     }
@@ -979,10 +1108,81 @@ fn session_selection_view(
 
 async fn select_workspace(
     state: &mut BotChatState,
-    path: &str,
-    name: &str,
+    choice: &BotWorkspaceChoice,
     s: &'static BotStrings,
 ) -> HandleResult {
+    if state.active_remote_device.is_some() {
+        let cmd = serde_json::json!({
+            "cmd": "set_workspace",
+            "path": choice.path,
+            "remote_connection_id": choice.remote_connection_id,
+            "remote_ssh_host": choice.remote_ssh_host,
+        });
+        let cmd_json = serde_json::to_string(&cmd).unwrap_or_default();
+        return match exec_remote_rpc(state, &cmd_json).await {
+            Ok(resp) => {
+                let val: serde_json::Value = match serde_json::from_str(&resp) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        return result_from_menu(
+                            state,
+                            MenuView::plain(format!("{}{e}", s.workspace_open_failed_prefix)),
+                        );
+                    }
+                };
+                if val.get("success").and_then(|value| value.as_bool()) != Some(true) {
+                    let message = val
+                        .get("error")
+                        .and_then(|value| value.as_str())
+                        .or_else(|| val.get("message").and_then(|value| value.as_str()))
+                        .unwrap_or(s.workspace_open_failed_prefix);
+                    return result_from_menu(
+                        state,
+                        MenuView::plain(message.to_string())
+                            .with_items(vec![MenuItem::default(s.item_back, "/menu")]),
+                    );
+                }
+                let workspace_path = val
+                    .get("path")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or(&choice.path)
+                    .to_string();
+                let workspace_ref = BotWorkspaceRef::with_identity(
+                    workspace_path.clone(),
+                    val.get("remote_connection_id")
+                        .and_then(|value| value.as_str())
+                        .map(str::to_string)
+                        .or_else(|| choice.remote_connection_id.clone()),
+                    val.get("remote_ssh_host")
+                        .and_then(|value| value.as_str())
+                        .map(str::to_string)
+                        .or_else(|| choice.remote_ssh_host.clone()),
+                );
+                state.current_workspace = Some(workspace_ref);
+                state.current_session_id = None;
+                let body = format!(
+                    "{}: {}\n{}: {}",
+                    s.devices_remote_prefix,
+                    state
+                        .active_remote_device
+                        .as_ref()
+                        .map(|device| device.device_name.as_str())
+                        .unwrap_or("remote"),
+                    s.current_workspace_label,
+                    choice.name,
+                );
+                let mut view = main_menu_view(state, s);
+                view = view.with_body(body);
+                result_from_menu(state, view)
+            }
+            Err(error) => result_from_menu(
+                state,
+                MenuView::plain(format!("{}{error}", s.workspace_open_failed_prefix))
+                    .with_items(vec![MenuItem::default(s.item_back, "/menu")]),
+            ),
+        };
+    }
+
     use crate::service::workspace::get_global_workspace_service;
 
     let ws_service = match get_global_workspace_service() {
@@ -991,8 +1191,15 @@ async fn select_workspace(
             return result_from_menu(state, MenuView::plain(s.workspace_service_unavailable));
         }
     };
-    let path_buf = std::path::PathBuf::from(path);
-    match ws_service.open_workspace(path_buf).await {
+    let path_buf = std::path::PathBuf::from(&choice.path);
+    match ws_service
+        .open_workspace_resolving_known(
+            path_buf,
+            choice.remote_connection_id.as_deref(),
+            choice.remote_ssh_host.as_deref(),
+        )
+        .await
+    {
         Ok(info) => {
             if let Err(e) = crate::service::snapshot::initialize_snapshot_manager_for_workspace(
                 info.root_path.clone(),
@@ -1002,15 +1209,36 @@ async fn select_workspace(
             {
                 error!("Failed to init snapshot after bot workspace switch: {e}");
             }
-            state.current_workspace = Some(path.to_string());
+            let workspace_path = info.root_path.to_string_lossy().to_string();
+            let remote_connection_id = info
+                .remote_ssh_connection_id()
+                .map(str::to_string)
+                .or_else(|| choice.remote_connection_id.clone());
+            let remote_ssh_host = info
+                .metadata
+                .get("sshHost")
+                .and_then(|value| value.as_str())
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_string)
+                .or_else(|| choice.remote_ssh_host.clone());
+            let workspace_ref = BotWorkspaceRef::with_identity(
+                workspace_path.clone(),
+                remote_connection_id,
+                remote_ssh_host,
+            );
+            state.current_workspace = Some(workspace_ref.clone());
             state.current_session_id = None;
-            info!("Bot switched workspace to: {path}");
+            info!(
+                "Bot switched workspace to: {workspace_path} (connection_id={:?}, ssh_host={:?})",
+                workspace_ref.remote_connection_id, workspace_ref.remote_ssh_host
+            );
 
-            let session_count = count_workspace_sessions(path).await;
+            let session_count = count_workspace_sessions_for_ref(&workspace_ref).await;
             let body = format!(
                 "{}: {} · {}",
                 s.current_workspace_label,
-                name,
+                choice.name,
                 fmt_count(s.workspace_session_count_fmt, session_count),
             );
             let mut view = main_menu_view(state, s);
@@ -1072,11 +1300,90 @@ async fn select_assistant(
     }
 }
 
-async fn count_workspace_sessions(workspace_path: &str) -> usize {
+/// Looks up SSH identity for a workspace path already known to WorkspaceService.
+async fn bot_workspace_remote_identity(workspace_path: &str) -> (Option<String>, Option<String>) {
+    use crate::service::remote_ssh::normalize_remote_workspace_path;
+    use crate::service::workspace::{get_global_workspace_service, WorkspaceKind};
+
+    let Some(service) = get_global_workspace_service() else {
+        return (None, None);
+    };
+    let want = normalize_remote_workspace_path(workspace_path);
+    let path_buf = std::path::PathBuf::from(workspace_path);
+
+    let candidates = {
+        let mut list = Vec::new();
+        if let Some(current) = service.get_current_workspace().await {
+            list.push(current);
+        }
+        if let Some(by_path) = service.get_workspace_by_path(&path_buf).await {
+            list.push(by_path);
+        }
+        list.extend(service.get_recent_workspaces().await);
+        list
+    };
+
+    for workspace in candidates {
+        if workspace.workspace_kind != WorkspaceKind::Remote {
+            continue;
+        }
+        let root = normalize_remote_workspace_path(&workspace.root_path.to_string_lossy());
+        if root != want {
+            continue;
+        }
+        let connection_id = workspace.remote_ssh_connection_id().map(str::to_string);
+        let ssh_host = workspace
+            .metadata
+            .get("sshHost")
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
+        return (connection_id, ssh_host);
+    }
+
+    (None, None)
+}
+
+/// Resolves the on-disk sessions directory for a bot workspace ref.
+///
+/// Remote SSH workspaces store sessions under `~/.bitfun/remote_ssh/{host}/...`,
+/// not under the remote POSIX path itself. Prefer identity captured at workspace
+/// selection time; fall back to registry lookup only for legacy path-only state.
+async fn resolve_bot_session_storage_path_for_ref(
+    workspace: &BotWorkspaceRef,
+) -> Option<std::path::PathBuf> {
+    use crate::agentic::session::CoreSessionStorePort;
+    use bitfun_runtime_ports::{SessionStoragePathRequest, SessionStorePort};
+
+    let mut remote_connection_id = workspace.remote_connection_id.clone();
+    let mut remote_ssh_host = workspace.remote_ssh_host.clone();
+    if remote_connection_id.is_none() && remote_ssh_host.is_none() {
+        let (fallback_connection_id, fallback_ssh_host) =
+            bot_workspace_remote_identity(&workspace.path).await;
+        remote_connection_id = fallback_connection_id;
+        remote_ssh_host = fallback_ssh_host;
+    }
+
+    CoreSessionStorePort::default()
+        .resolve_session_storage_path(SessionStoragePathRequest {
+            workspace_path: std::path::PathBuf::from(&workspace.path),
+            remote_connection_id,
+            remote_ssh_host,
+        })
+        .await
+        .ok()
+        .map(|resolution| resolution.effective_storage_path)
+}
+
+async fn count_workspace_sessions_for_ref(workspace: &BotWorkspaceRef) -> usize {
     use crate::agentic::persistence::PersistenceManager;
     use crate::infrastructure::PathManager;
 
-    let wp = std::path::PathBuf::from(workspace_path);
+    let storage_path = match resolve_bot_session_storage_path_for_ref(workspace).await {
+        Some(path) => path,
+        None => return 0,
+    };
     let pm = match PathManager::new() {
         Ok(pm) => std::sync::Arc::new(pm),
         Err(_) => return 0,
@@ -1086,10 +1393,14 @@ async fn count_workspace_sessions(workspace_path: &str) -> usize {
         Err(_) => return 0,
     };
     store
-        .list_session_metadata(&wp)
+        .list_session_metadata(&storage_path)
         .await
         .map(|v| v.len())
         .unwrap_or(0)
+}
+
+async fn count_workspace_sessions(workspace_path: &str) -> usize {
+    count_workspace_sessions_for_ref(&BotWorkspaceRef::local(workspace_path)).await
 }
 
 fn truncate_label(label: &str, max_chars: usize) -> String {
@@ -1104,6 +1415,53 @@ fn truncate_label(label: &str, max_chars: usize) -> String {
 
 // ── Resume / new session ──────────────────────────────────────────
 
+#[derive(Debug, Clone)]
+struct RemoteDeviceWorkspaceFacts {
+    path: String,
+    remote_connection_id: Option<String>,
+    remote_ssh_host: Option<String>,
+}
+
+async fn query_remote_device_workspace(
+    state: &BotChatState,
+) -> Result<RemoteDeviceWorkspaceFacts, String> {
+    let cmd = serde_json::json!({ "cmd": "device_query_info" });
+    let cmd_json = serde_json::to_string(&cmd).unwrap_or_default();
+    let resp = exec_remote_rpc(state, &cmd_json).await?;
+    let val: serde_json::Value = serde_json::from_str(&resp).map_err(|error| error.to_string())?;
+    if val.get("resp").and_then(|value| value.as_str()) == Some("error") {
+        return Err(val
+            .get("message")
+            .and_then(|value| value.as_str())
+            .unwrap_or("Failed to query remote device workspace")
+            .to_string());
+    }
+    let path = val
+        .get("workspace_path")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            "No workspace is open on the remote device; select a recent workspace or create one first"
+                .to_string()
+        })?;
+    Ok(RemoteDeviceWorkspaceFacts {
+        path: path.to_string(),
+        remote_connection_id: val
+            .get("remote_connection_id")
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string),
+        remote_ssh_host: val
+            .get("remote_ssh_host")
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string),
+    })
+}
+
 async fn start_resume(
     state: &mut BotChatState,
     page: usize,
@@ -1111,9 +1469,21 @@ async fn start_resume(
 ) -> HandleResult {
     // ── Remote device branch ──
     if state.active_remote_device.is_some() {
+        let workspace = match query_remote_device_workspace(state).await {
+            Ok(workspace) => workspace,
+            Err(error) => {
+                return result_from_menu(
+                    state,
+                    MenuView::plain(format!("{}{error}", s.session_create_failed_prefix))
+                        .with_items(vec![MenuItem::default(s.item_back, "/menu")]),
+                );
+            }
+        };
         let cmd = serde_json::json!({
             "cmd": "list_sessions",
-            "workspace_path": null,
+            "workspace_path": workspace.path,
+            "remote_connection_id": workspace.remote_connection_id,
+            "remote_ssh_host": workspace.remote_ssh_host,
             "limit": 10,
             "offset": page * 10,
         });
@@ -1129,6 +1499,17 @@ async fn start_resume(
                         );
                     }
                 };
+                if val.get("resp").and_then(|value| value.as_str()) == Some("error") {
+                    let message = val
+                        .get("message")
+                        .and_then(|value| value.as_str())
+                        .unwrap_or(s.session_create_failed_prefix);
+                    return result_from_menu(
+                        state,
+                        MenuView::plain(message.to_string())
+                            .with_items(vec![MenuItem::default(s.item_back, "/menu")]),
+                    );
+                }
                 let sessions = val
                     .get("sessions")
                     .and_then(|v| v.as_array())
@@ -1217,9 +1598,9 @@ async fn start_resume(
     use crate::agentic::persistence::PersistenceManager;
     use crate::infrastructure::PathManager;
 
-    let ws_path = if state.display_mode == BotDisplayMode::Pro {
-        match &state.current_workspace {
-            Some(p) => std::path::PathBuf::from(p),
+    let workspace_ref = if state.display_mode == BotDisplayMode::Pro {
+        match state.current_workspace.clone() {
+            Some(workspace) => workspace,
             None => {
                 return result_from_menu(
                     state,
@@ -1232,7 +1613,7 @@ async fn start_resume(
         }
     } else {
         match &state.current_assistant {
-            Some(p) => std::path::PathBuf::from(p),
+            Some(p) => BotWorkspaceRef::local(p.clone()),
             None => {
                 return result_from_menu(
                     state,
@@ -1243,6 +1624,17 @@ async fn start_resume(
                 );
             }
         }
+    };
+
+    let Some(storage_path) = resolve_bot_session_storage_path_for_ref(&workspace_ref).await else {
+        return result_from_menu(
+            state,
+            MenuView::plain(format!(
+                "{}{}",
+                s.session_create_failed_prefix,
+                "Failed to resolve session storage for the current workspace"
+            )),
+        );
     };
 
     let page_size = 10usize;
@@ -1266,7 +1658,7 @@ async fn start_resume(
             );
         }
     };
-    let all_meta = match store.list_session_metadata(&ws_path).await {
+    let all_meta = match store.list_session_metadata(&storage_path).await {
         Ok(m) => m,
         Err(e) => {
             return result_from_menu(
@@ -1346,7 +1738,7 @@ async fn select_session(
     info!("Bot resumed session: {session_id}");
 
     let last_pair =
-        load_last_dialog_pair_from_turns(state.current_workspace.as_deref(), session_id).await;
+        load_last_dialog_pair_from_turns(state.current_workspace.as_ref(), session_id).await;
     let mut body = format!("{}{}\n", s.resume_resumed_prefix, session_name);
     if let Some((user_text, ai_text)) = last_pair {
         body.push('\n');
@@ -1367,7 +1759,7 @@ async fn select_session(
 }
 
 async fn load_last_dialog_pair_from_turns(
-    workspace_path: Option<&str>,
+    workspace: Option<&BotWorkspaceRef>,
     session_id: &str,
 ) -> Option<(String, String)> {
     use crate::agentic::persistence::PersistenceManager;
@@ -1376,10 +1768,14 @@ async fn load_last_dialog_pair_from_turns(
     const MAX_USER_LEN: usize = 200;
     const MAX_AI_LEN: usize = 400;
 
-    let wp = std::path::PathBuf::from(workspace_path?);
+    let workspace = workspace?;
+    let storage_path = resolve_bot_session_storage_path_for_ref(workspace).await?;
     let pm = std::sync::Arc::new(PathManager::new().ok()?);
     let store = PersistenceManager::new(pm).ok()?;
-    let turns = store.load_session_turns(&wp, session_id).await.ok()?;
+    let turns = store
+        .load_session_turns(&storage_path, session_id)
+        .await
+        .ok()?;
     let turn = turns.last()?;
 
     let user_text = strip_user_message_tags(&turn.user_message.content);
@@ -1482,16 +1878,39 @@ async fn create_session(state: &mut BotChatState, agent_type: &str) -> HandleRes
         } else {
             "Remote Session"
         };
+        let workspace = match query_remote_device_workspace(state).await {
+            Ok(workspace) => workspace,
+            Err(error) => {
+                return result_from_menu(
+                    state,
+                    MenuView::plain(format!("{}{error}", s.session_create_failed_prefix))
+                        .with_items(vec![MenuItem::default(s.item_back, "/menu")]),
+                );
+            }
+        };
         let cmd = serde_json::json!({
             "cmd": "create_session",
             "agent_type": agent_type,
             "session_name": session_name,
-            "workspace_path": null,
+            "workspace_path": workspace.path,
+            "remote_connection_id": workspace.remote_connection_id,
+            "remote_ssh_host": workspace.remote_ssh_host,
         });
         let cmd_json = serde_json::to_string(&cmd).unwrap_or_default();
         match exec_remote_rpc(state, &cmd_json).await {
             Ok(resp) => {
                 if let Ok(val) = serde_json::from_str::<serde_json::Value>(&resp) {
+                    if val.get("resp").and_then(|value| value.as_str()) == Some("error") {
+                        let message = val
+                            .get("message")
+                            .and_then(|value| value.as_str())
+                            .unwrap_or(s.session_create_failed_prefix);
+                        return result_from_menu(
+                            state,
+                            MenuView::plain(message.to_string())
+                                .with_items(vec![MenuItem::default(s.item_back, "/menu")]),
+                        );
+                    }
                     if let Some(sid) = val.get("session_id").and_then(|v| v.as_str()) {
                         state.current_session_id = Some(sid.to_string());
                         let body = format!(
@@ -1522,6 +1941,7 @@ async fn create_session(state: &mut BotChatState, agent_type: &str) -> HandleRes
     use crate::agentic::coordination::get_global_coordinator;
     use crate::service::workspace::get_global_workspace_service;
     use crate::service_agent_runtime::CoreServiceAgentRuntime;
+    use bitfun_runtime_ports::RemoteSessionWorkspaceIdentity;
     use bitfun_services_integrations::remote_connect::{
         build_remote_session_create_request, RemoteConnectSubmissionSource,
     };
@@ -1535,9 +1955,9 @@ async fn create_session(state: &mut BotChatState, agent_type: &str) -> HandleRes
         }
     };
 
-    let ws_path = if is_claw {
+    let workspace_ref = if is_claw {
         if let Some(p) = state.current_assistant.clone() {
-            Some(p)
+            Some(BotWorkspaceRef::local(p))
         } else {
             let ws_service = match get_global_workspace_service() {
                 Some(s) => s,
@@ -1574,7 +1994,7 @@ async fn create_session(state: &mut BotChatState, agent_type: &str) -> HandleRes
                 state.current_assistant = Some(path.clone());
                 state.current_assistant_name = Some(name.clone());
             }
-            resolved.map(|(p, _)| p)
+            resolved.map(|(path, _)| BotWorkspaceRef::local(path))
         }
     } else {
         state.current_workspace.clone()
@@ -1604,7 +2024,7 @@ async fn create_session(state: &mut BotChatState, agent_type: &str) -> HandleRes
         }
     };
 
-    let Some(workspace_path) = ws_path else {
+    let Some(workspace_ref) = workspace_ref else {
         let view = if is_claw {
             MenuView::plain(s.no_assistant).with_items(vec![
                 MenuItem::primary(s.item_switch_assistant, "/switch"),
@@ -1619,11 +2039,20 @@ async fn create_session(state: &mut BotChatState, agent_type: &str) -> HandleRes
         return result_from_menu(state, view);
     };
 
+    let (mut remote_connection_id, mut remote_ssh_host) = (
+        workspace_ref.remote_connection_id.clone(),
+        workspace_ref.remote_ssh_host.clone(),
+    );
+    if remote_connection_id.is_none() && remote_ssh_host.is_none() {
+        let fallback = bot_workspace_remote_identity(&workspace_ref.path).await;
+        remote_connection_id = fallback.0;
+        remote_ssh_host = fallback.1;
+    }
     let request = build_remote_session_create_request(
         session_name,
         agent_type,
-        Some(workspace_path.clone()),
-        Default::default(),
+        Some(workspace_ref.path.clone()),
+        RemoteSessionWorkspaceIdentity::new(remote_connection_id, remote_ssh_host),
         RemoteConnectSubmissionSource::Bot,
     );
     let runtime = match CoreServiceAgentRuntime::agent_runtime(coordinator.clone()) {
@@ -1643,7 +2072,7 @@ async fn create_session(state: &mut BotChatState, agent_type: &str) -> HandleRes
                 s.session_created_prefix,
                 session_name,
                 s.session_workspace_label,
-                short_path_name(&workspace_path),
+                short_path_name(&workspace_ref.path),
                 s.session_start_hint,
             );
             let view = MenuView::plain("").with_body(body);
@@ -1722,8 +2151,8 @@ async fn route_pending(
                 }
                 Some(n) if n >= 1 && n <= options.len() => {
                     state.clear_pending();
-                    let (path, name) = options[n - 1].clone();
-                    select_workspace(state, &path, &name, s).await
+                    let choice = options[n - 1].clone();
+                    select_workspace(state, &choice, s).await
                 }
                 _ => {
                     state.set_pending(PendingAction::SelectWorkspace { options });
@@ -2675,7 +3104,7 @@ mod state_tests {
             "assistant path is the fallback when no Pro workspace is set"
         );
 
-        state.current_workspace = Some("/tmp/pro-ws".to_string());
+        state.current_workspace = Some(BotWorkspaceRef::local("/tmp/pro-ws"));
         assert_eq!(
             state.active_workspace_path().as_deref(),
             Some("/tmp/pro-ws"),
@@ -2768,7 +3197,7 @@ mod menu_tests {
     fn expert_mode_body_still_uses_workspace_dir_name() {
         let mut state = BotChatState::new("c".into());
         state.display_mode = BotDisplayMode::Pro;
-        state.current_workspace = Some("/tmp/projects/MyApp".to_string());
+        state.current_workspace = Some(BotWorkspaceRef::local("/tmp/projects/MyApp"));
         // `current_assistant_name` should not affect Pro mode at all.
         state.current_assistant_name = Some("ignored".to_string());
         let s = strings_for(BotLanguage::ZhCN);

--- a/src/crates/assembly/core/src/service/remote_connect/remote_server.rs
+++ b/src/crates/assembly/core/src/service/remote_connect/remote_server.rs
@@ -200,6 +200,47 @@ impl RemoteCommandRuntimeHost for CoreRemoteCommandRuntimeHost<'_> {
 
     async fn handle_device_command(&self, command: &RemoteCommand) -> RemoteResponse {
         match command {
+            RemoteCommand::DeviceQueryInfo => {
+                use bitfun_runtime_ports::RemoteSessionWorkspaceIdentity;
+                use bitfun_services_integrations::remote_connect::{
+                    RemoteInitialSyncRuntimeHost, RemoteWorkspaceRuntimeHost,
+                };
+
+                let workspace_host = CoreServiceAgentRuntime::remote_workspace_host();
+                let workspace =
+                    RemoteWorkspaceRuntimeHost::current_workspace(&workspace_host).await;
+                let session_count = if let Some(ref facts) = workspace {
+                    let sync_host = CoreServiceAgentRuntime::remote_initial_sync_host();
+                    let identity = RemoteSessionWorkspaceIdentity::from_workspace(facts);
+                    match RemoteInitialSyncRuntimeHost::list_session_metadata(
+                        &sync_host,
+                        std::path::Path::new(&facts.path),
+                        identity,
+                    )
+                    .await
+                    {
+                        Ok(metadata) => Some(metadata.len()),
+                        Err(_) => None,
+                    }
+                } else {
+                    Some(0)
+                };
+
+                RemoteResponse::DeviceInfo {
+                    device_name: None,
+                    workspace_path: workspace.as_ref().map(|facts| facts.path.clone()),
+                    workspace_kind: workspace
+                        .as_ref()
+                        .map(|facts| facts.kind.as_wire_str().to_string()),
+                    remote_connection_id: workspace
+                        .as_ref()
+                        .and_then(|facts| facts.remote_connection_id.clone()),
+                    remote_ssh_host: workspace
+                        .as_ref()
+                        .and_then(|facts| facts.remote_ssh_host.clone()),
+                    session_count,
+                }
+            }
             RemoteCommand::CreateWorkspace { path } => {
                 let path = std::path::PathBuf::from(path);
                 // Create the directory if it doesn't exist, then open it
@@ -215,6 +256,8 @@ impl RemoteCommandRuntimeHost for CoreRemoteCommandRuntimeHost<'_> {
                     &host,
                     &RemoteCommand::SetWorkspace {
                         path: path.to_string_lossy().to_string(),
+                        remote_connection_id: None,
+                        remote_ssh_host: None,
                     },
                 )
                 .await

--- a/src/crates/assembly/core/src/service/remote_ssh/workspace_state.rs
+++ b/src/crates/assembly/core/src/service/remote_ssh/workspace_state.rs
@@ -53,7 +53,24 @@ pub async fn resolve_workspace_session_identity(
         });
     }
 
-    workspace_session_identity(workspace_path, None, None)
+    if let Some(identity) = workspace_session_identity(workspace_path, None, None) {
+        return Some(identity);
+    }
+
+    // The path cannot be resolved as a local workspace root (remote workspace
+    // paths do not exist on the local filesystem). Callers such as dialog-turn
+    // submission may legitimately lose the remote connection id, so fall back
+    // to the remote workspace registry before failing: a registered remote
+    // workspace must never be misclassified as an invalid local path.
+    if let Some(entry) = lookup_remote_connection_with_hint(workspace_path, None).await {
+        return Some(WorkspaceSessionIdentity {
+            hostname: entry.ssh_host,
+            logical_workspace_path: entry.remote_root,
+            remote_connection_id: Some(entry.connection_id),
+        });
+    }
+
+    None
 }
 /// Local directory where persisted sessions for this remote workspace root are stored.
 pub fn remote_workspace_runtime_root(ssh_host: &str, remote_root_norm: &str) -> PathBuf {
@@ -479,6 +496,55 @@ mod tests {
         m.set_active_connection_hint(Some("c1".to_string())).await;
         let x = m.lookup_connection("/x", Some("c2")).await.unwrap();
         assert_eq!(x.connection_id, "c2");
+    }
+
+    #[tokio::test]
+    async fn identity_falls_back_to_registry_when_connection_id_is_missing() {
+        let manager = super::init_remote_workspace_manager();
+        manager
+            .register_remote_workspace(
+                "/bitfun-tests/identity-fallback/repo".to_string(),
+                "conn-identity-fallback".to_string(),
+                "Fallback Server".to_string(),
+                "fallback-host".to_string(),
+            )
+            .await;
+
+        let identity = super::resolve_workspace_session_identity(
+            "/bitfun-tests/identity-fallback/repo",
+            None,
+            None,
+        )
+        .await
+        .expect("registered remote workspace must resolve without an explicit connection id");
+
+        assert_eq!(identity.hostname, "fallback-host");
+        assert_eq!(
+            identity.remote_connection_id.as_deref(),
+            Some("conn-identity-fallback")
+        );
+        assert_eq!(
+            identity.logical_workspace_path(),
+            "/bitfun-tests/identity-fallback/repo"
+        );
+
+        manager
+            .unregister_remote_workspace(
+                "conn-identity-fallback",
+                "/bitfun-tests/identity-fallback/repo",
+            )
+            .await;
+
+        assert!(
+            super::resolve_workspace_session_identity(
+                "/bitfun-tests/identity-fallback/repo",
+                None,
+                None,
+            )
+            .await
+            .is_none(),
+            "unregistered non-local paths must still fail to resolve"
+        );
     }
 
     #[tokio::test]

--- a/src/crates/assembly/core/src/service/workspace/service.rs
+++ b/src/crates/assembly/core/src/service/workspace/service.rs
@@ -13,8 +13,8 @@ use crate::service::bootstrap::{
     ensure_workspace_gitignore_ignores_bitfun, initialize_workspace_persona_files,
 };
 use crate::service::remote_ssh::workspace_state::{
-    canonicalize_local_workspace_root, get_remote_workspace_manager, local_workspace_roots_equal,
-    normalize_remote_workspace_path, remote_workspace_stable_id,
+    canonicalize_local_workspace_root, get_remote_workspace_manager, init_remote_workspace_manager,
+    local_workspace_roots_equal, normalize_remote_workspace_path, remote_workspace_stable_id,
 };
 use crate::service::workspace_runtime::{
     try_get_workspace_runtime_service_arc, WorkspaceRuntimeService,
@@ -271,6 +271,48 @@ impl WorkspaceService {
             .await
     }
 
+    /// Opens a workspace by path, recovering remote SSH metadata from known
+    /// workspace history when the caller only has a remote POSIX path.
+    ///
+    /// IM bots, mobile Remote Connect, and similar path-only surfaces must use
+    /// this instead of [`Self::open_workspace`]: remote roots such as
+    /// `/root/repos` do not exist on the desktop host filesystem, so a bare
+    /// local open fails with "Workspace path does not exist".
+    pub async fn open_workspace_resolving_known(
+        &self,
+        path: PathBuf,
+        preferred_connection_id: Option<&str>,
+        preferred_ssh_host: Option<&str>,
+    ) -> BitFunResult<WorkspaceInfo> {
+        let path_str = path.to_string_lossy().to_string();
+        if let Some(known) = self
+            .find_known_remote_workspace_for_path(
+                &path_str,
+                preferred_connection_id,
+                preferred_ssh_host,
+            )
+            .await
+        {
+            return self.open_known_remote_workspace(&known).await;
+        }
+
+        match self.open_workspace(path).await {
+            Ok(info) => Ok(info),
+            Err(error) => {
+                let message = error.to_string();
+                if message.contains("Workspace path does not exist") {
+                    Err(BitFunError::service(format!(
+                        "Workspace path does not exist locally and is not a known remote SSH \
+                         workspace: {path_str}. Open it once from the desktop SSH remote UI so \
+                         BitFun can remember the connection, then try again."
+                    )))
+                } else {
+                    Err(error)
+                }
+            }
+        }
+    }
+
     /// Opens a workspace with explicit workspace metadata.
     pub async fn open_workspace_with_options(
         &self,
@@ -290,6 +332,9 @@ impl WorkspaceService {
                 .await;
             self.ensure_workspace_runtime_best_effort(workspace, "opened")
                 .await;
+            if workspace.workspace_kind == WorkspaceKind::Remote {
+                self.register_remote_workspace_runtime(workspace).await;
+            }
         }
 
         if result.is_ok() {
@@ -299,6 +344,163 @@ impl WorkspaceService {
         }
 
         result
+    }
+
+    async fn find_known_remote_workspace_for_path(
+        &self,
+        path: &str,
+        preferred_connection_id: Option<&str>,
+        preferred_ssh_host: Option<&str>,
+    ) -> Option<WorkspaceInfo> {
+        let want_path = normalize_remote_workspace_path(path);
+        let preferred_connection_id = preferred_connection_id
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+        let preferred_ssh_host = preferred_ssh_host
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+
+        let manager = self.manager.read().await;
+        let mut matches: Vec<&WorkspaceInfo> = manager
+            .get_workspaces()
+            .values()
+            .filter(|workspace| {
+                workspace.workspace_kind == WorkspaceKind::Remote
+                    && normalize_remote_workspace_path(&workspace.root_path.to_string_lossy())
+                        == want_path
+            })
+            .collect();
+
+        if matches.is_empty() {
+            return None;
+        }
+
+        if let Some(connection_id) = preferred_connection_id {
+            if let Some(matched) = matches
+                .iter()
+                .find(|workspace| workspace.remote_ssh_connection_id() == Some(connection_id))
+            {
+                return Some((*matched).clone());
+            }
+        }
+
+        if let Some(ssh_host) = preferred_ssh_host {
+            if let Some(matched) = matches.iter().find(|workspace| {
+                workspace
+                    .metadata
+                    .get("sshHost")
+                    .and_then(|value| value.as_str())
+                    .map(str::trim)
+                    == Some(ssh_host)
+            }) {
+                return Some((*matched).clone());
+            }
+        }
+
+        // Prefer the most recently accessed match when the path alone is ambiguous
+        // (e.g. the same POSIX root opened on two SSH hosts).
+        matches.sort_by(|left, right| right.last_accessed.cmp(&left.last_accessed));
+        matches.first().map(|workspace| (*workspace).clone())
+    }
+
+    async fn open_known_remote_workspace(
+        &self,
+        known: &WorkspaceInfo,
+    ) -> BitFunResult<WorkspaceInfo> {
+        let connection_id = known.remote_ssh_connection_id().ok_or_else(|| {
+            BitFunError::service(format!(
+                "Remote workspace is missing connectionId metadata: {}",
+                known.id
+            ))
+        })?;
+        let ssh_host = known
+            .metadata
+            .get("sshHost")
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                BitFunError::service(format!(
+                    "Remote workspace is missing sshHost metadata: {}",
+                    known.id
+                ))
+            })?;
+
+        let remote_path = normalize_remote_workspace_path(&known.root_path.to_string_lossy());
+        let options = WorkspaceCreateOptions {
+            workspace_kind: WorkspaceKind::Remote,
+            display_name: Some(known.name.clone()),
+            remote_connection_id: Some(connection_id.to_string()),
+            remote_ssh_host: Some(ssh_host.to_string()),
+            stable_workspace_id: Some(known.id.clone()),
+            ..Default::default()
+        };
+
+        let mut opened = self
+            .open_workspace_with_options(PathBuf::from(&remote_path), options)
+            .await?;
+
+        // Preserve desktop-authored metadata keys (connectionName, etc.) that are
+        // not reconstructed from open options alone.
+        {
+            let mut manager = self.manager.write().await;
+            if let Some(workspace) = manager.get_workspaces_mut().get_mut(&opened.id) {
+                for (key, value) in &known.metadata {
+                    workspace
+                        .metadata
+                        .entry(key.clone())
+                        .or_insert(value.clone());
+                }
+                opened.metadata = workspace.metadata.clone();
+            }
+        }
+
+        Ok(opened)
+    }
+
+    async fn register_remote_workspace_runtime(&self, workspace: &WorkspaceInfo) {
+        let Some(connection_id) = workspace.remote_ssh_connection_id() else {
+            warn!(
+                "Skipping remote workspace registry update: missing connectionId for {}",
+                workspace.id
+            );
+            return;
+        };
+        let Some(ssh_host) = workspace
+            .metadata
+            .get("sshHost")
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        else {
+            warn!(
+                "Skipping remote workspace registry update: missing sshHost for {}",
+                workspace.id
+            );
+            return;
+        };
+        let connection_name = workspace
+            .metadata
+            .get("connectionName")
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or(ssh_host)
+            .to_string();
+        let remote_path = normalize_remote_workspace_path(&workspace.root_path.to_string_lossy());
+
+        let state_manager = init_remote_workspace_manager();
+        state_manager
+            .register_remote_workspace(
+                remote_path,
+                connection_id.to_string(),
+                connection_name,
+                ssh_host.to_string(),
+            )
+            .await;
+        state_manager
+            .set_active_connection_hint(Some(connection_id.to_string()))
+            .await;
     }
 
     /// Registers or refreshes workspace activity without marking it as opened in the UI.
@@ -2305,6 +2507,73 @@ mod tests {
         );
         assert_eq!(tracked.root_path, remote_workspace_root);
         assert!(service.get_opened_workspaces().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn open_workspace_resolving_known_reopens_remote_without_local_exists() {
+        let env = TestEnvironment::new();
+        let service = build_test_workspace_service(env.path_manager.clone()).await;
+        let remote_path = PathBuf::from("/root/repos");
+
+        service
+            .track_workspace_activity(
+                remote_path.clone(),
+                WorkspaceCreateOptions {
+                    workspace_kind: WorkspaceKind::Remote,
+                    remote_connection_id: Some("conn-remote-open".to_string()),
+                    remote_ssh_host: Some("remote-host".to_string()),
+                    display_name: Some("repos".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("remote workspace should be remembered");
+
+        let opened = service
+            .open_workspace_resolving_known(remote_path.clone(), None, None)
+            .await
+            .expect("known remote workspace must open without a local path");
+
+        assert_eq!(opened.workspace_kind, WorkspaceKind::Remote);
+        assert_eq!(opened.root_path, remote_path);
+        assert_eq!(opened.remote_ssh_connection_id(), Some("conn-remote-open"));
+        assert_eq!(
+            opened
+                .metadata
+                .get("sshHost")
+                .and_then(|value| value.as_str()),
+            Some("remote-host")
+        );
+
+        let entry = get_remote_workspace_manager()
+            .expect("remote workspace manager should exist")
+            .lookup_connection("/root/repos", Some("conn-remote-open"))
+            .await
+            .expect("opened remote workspace must be registered");
+        assert_eq!(entry.connection_id, "conn-remote-open");
+        assert_eq!(entry.ssh_host, "remote-host");
+    }
+
+    #[tokio::test]
+    async fn open_workspace_resolving_known_reports_unknown_remote_paths_clearly() {
+        let env = TestEnvironment::new();
+        let service = build_test_workspace_service(env.path_manager.clone()).await;
+
+        let error = service
+            .open_workspace_resolving_known(
+                PathBuf::from("/bitfun-tests/unknown-remote-path"),
+                None,
+                None,
+            )
+            .await
+            .expect_err("unknown remote paths must fail with a clear message");
+
+        assert!(
+            error
+                .to_string()
+                .contains("not a known remote SSH workspace"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]

--- a/src/crates/assembly/core/src/service_agent_runtime.rs
+++ b/src/crates/assembly/core/src/service_agent_runtime.rs
@@ -115,12 +115,14 @@ async fn current_remote_workspace_facts() -> Option<RemoteWorkspaceFacts> {
 async fn open_workspace_with_snapshot(
     path: &str,
     snapshot_log_context: &str,
+    remote_connection_id: Option<&str>,
+    remote_ssh_host: Option<&str>,
 ) -> Result<RemoteWorkspaceUpdate, String> {
     let workspace_service = crate::service::workspace::get_global_workspace_service()
         .ok_or_else(|| "Workspace service not available".to_string())?;
     let path_buf = std::path::PathBuf::from(path);
     let info = workspace_service
-        .open_workspace(path_buf)
+        .open_workspace_resolving_known(path_buf, remote_connection_id, remote_ssh_host)
         .await
         .map_err(|error| error.to_string())?;
     if let Err(error) = crate::service::snapshot::initialize_snapshot_manager_for_workspace(
@@ -131,9 +133,19 @@ async fn open_workspace_with_snapshot(
     {
         error!("Failed to initialize snapshot after {snapshot_log_context}: {error}");
     }
+    let remote_connection_id = info.remote_ssh_connection_id().map(str::to_string);
+    let remote_ssh_host = info
+        .metadata
+        .get("sshHost")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
     Ok(RemoteWorkspaceUpdate {
         path: info.root_path.to_string_lossy().to_string(),
         name: info.name,
+        remote_connection_id,
+        remote_ssh_host,
     })
 }
 
@@ -1226,15 +1238,31 @@ impl RemoteWorkspaceRuntimeHost for CoreRemoteWorkspaceRuntimeHost {
             .into_iter()
             .map(|workspace| RemoteRecentWorkspaceFacts {
                 path: workspace.root_path.to_string_lossy().to_string(),
-                name: workspace.name,
+                name: workspace.name.clone(),
                 last_opened: workspace.last_accessed.to_rfc3339(),
                 kind: remote_workspace_kind(workspace.workspace_kind),
+                remote_connection_id: workspace_metadata_string(
+                    &workspace.metadata,
+                    "connectionId",
+                ),
+                remote_ssh_host: workspace_metadata_string(&workspace.metadata, "sshHost"),
             })
             .collect()
     }
 
-    async fn open_workspace(&self, path: &str) -> Result<RemoteWorkspaceUpdate, String> {
-        open_workspace_with_snapshot(path, "remote workspace set").await
+    async fn open_workspace(
+        &self,
+        path: &str,
+        remote_connection_id: Option<&str>,
+        remote_ssh_host: Option<&str>,
+    ) -> Result<RemoteWorkspaceUpdate, String> {
+        open_workspace_with_snapshot(
+            path,
+            "remote workspace set",
+            remote_connection_id,
+            remote_ssh_host,
+        )
+        .await
     }
 
     async fn assistant_workspaces(&self) -> Vec<RemoteAssistantWorkspaceFacts> {
@@ -1255,7 +1283,7 @@ impl RemoteWorkspaceRuntimeHost for CoreRemoteWorkspaceRuntimeHost {
     }
 
     async fn open_assistant_workspace(&self, path: &str) -> Result<RemoteWorkspaceUpdate, String> {
-        open_workspace_with_snapshot(path, "remote assistant set").await
+        open_workspace_with_snapshot(path, "remote assistant set", None, None).await
     }
 }
 

--- a/src/crates/contracts/runtime-ports/src/lib.rs
+++ b/src/crates/contracts/runtime-ports/src/lib.rs
@@ -836,6 +836,10 @@ pub struct RemoteRecentWorkspaceFacts {
     pub name: String,
     pub last_opened: String,
     pub kind: RemoteWorkspaceKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote_connection_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote_ssh_host: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -852,6 +856,10 @@ pub struct RemoteAssistantWorkspaceFacts {
 pub struct RemoteWorkspaceUpdate {
     pub path: String,
     pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote_connection_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote_ssh_host: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -902,7 +910,12 @@ pub struct RemoteFileChunkRange {
 pub trait RemoteWorkspaceRuntimeHost: Send + Sync {
     async fn current_workspace(&self) -> Option<RemoteWorkspaceFacts>;
     async fn recent_workspaces(&self) -> Vec<RemoteRecentWorkspaceFacts>;
-    async fn open_workspace(&self, path: &str) -> Result<RemoteWorkspaceUpdate, String>;
+    async fn open_workspace(
+        &self,
+        path: &str,
+        remote_connection_id: Option<&str>,
+        remote_ssh_host: Option<&str>,
+    ) -> Result<RemoteWorkspaceUpdate, String>;
     async fn assistant_workspaces(&self) -> Vec<RemoteAssistantWorkspaceFacts>;
     async fn open_assistant_workspace(&self, path: &str) -> Result<RemoteWorkspaceUpdate, String>;
 }

--- a/src/crates/execution/runtime-services/src/test_support.rs
+++ b/src/crates/execution/runtime-services/src/test_support.rs
@@ -194,10 +194,17 @@ impl RemoteWorkspaceRuntimeHost for FakeRuntimePort {
         Vec::new()
     }
 
-    async fn open_workspace(&self, path: &str) -> Result<RemoteWorkspaceUpdate, String> {
+    async fn open_workspace(
+        &self,
+        path: &str,
+        _remote_connection_id: Option<&str>,
+        _remote_ssh_host: Option<&str>,
+    ) -> Result<RemoteWorkspaceUpdate, String> {
         Ok(RemoteWorkspaceUpdate {
             path: path.to_string(),
             name: "project".to_string(),
+            remote_connection_id: None,
+            remote_ssh_host: None,
         })
     }
 
@@ -209,6 +216,8 @@ impl RemoteWorkspaceRuntimeHost for FakeRuntimePort {
         Ok(RemoteWorkspaceUpdate {
             path: path.to_string(),
             name: "assistant".to_string(),
+            remote_connection_id: None,
+            remote_ssh_host: None,
         })
     }
 }

--- a/src/crates/services/services-integrations/src/remote_connect.rs
+++ b/src/crates/services/services-integrations/src/remote_connect.rs
@@ -896,6 +896,8 @@ pub fn remote_recent_workspaces_response(
                 name: workspace.name,
                 last_opened: workspace.last_opened,
                 workspace_kind: Some(workspace.kind.as_wire_str().to_string()),
+                remote_connection_id: workspace.remote_connection_id,
+                remote_ssh_host: workspace.remote_ssh_host,
             })
             .collect(),
     }
@@ -924,12 +926,16 @@ pub fn remote_workspace_updated_response(
             success: true,
             path: Some(update.path),
             project_name: Some(update.name),
+            remote_connection_id: update.remote_connection_id,
+            remote_ssh_host: update.remote_ssh_host,
             error: None,
         },
         Err(message) => RemoteResponse::WorkspaceUpdated {
             success: false,
             path: None,
             project_name: None,
+            remote_connection_id: None,
+            remote_ssh_host: None,
             error: Some(message),
         },
     }
@@ -1052,9 +1058,18 @@ where
         RemoteCommand::ListRecentWorkspaces => {
             remote_recent_workspaces_response(host.recent_workspaces().await)
         }
-        RemoteCommand::SetWorkspace { path } => {
-            remote_workspace_updated_response(host.open_workspace(path).await)
-        }
+        RemoteCommand::SetWorkspace {
+            path,
+            remote_connection_id,
+            remote_ssh_host,
+        } => remote_workspace_updated_response(
+            host.open_workspace(
+                path,
+                remote_connection_id.as_deref(),
+                remote_ssh_host.as_deref(),
+            )
+            .await,
+        ),
         RemoteCommand::ListAssistants => {
             remote_assistant_list_response(host.assistant_workspaces().await)
         }
@@ -1982,6 +1997,10 @@ pub struct RecentWorkspaceEntry {
     pub last_opened: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub workspace_kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote_connection_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote_ssh_host: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -2026,6 +2045,10 @@ pub enum RemoteCommand {
     ListRecentWorkspaces,
     SetWorkspace {
         path: String,
+        #[serde(default)]
+        remote_connection_id: Option<String>,
+        #[serde(default)]
+        remote_ssh_host: Option<String>,
     },
     ListAssistants,
     SetAssistant {
@@ -2193,6 +2216,10 @@ pub enum RemoteResponse {
         success: bool,
         path: Option<String>,
         project_name: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        remote_connection_id: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        remote_ssh_host: Option<String>,
         error: Option<String>,
     },
     AssistantList {
@@ -2311,6 +2338,12 @@ pub enum RemoteResponse {
     DeviceInfo {
         device_name: Option<String>,
         workspace_path: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        workspace_kind: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        remote_connection_id: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        remote_ssh_host: Option<String>,
         session_count: Option<usize>,
     },
     /// Result of a HostInvoke proxy call (JSON-compatible with local invoke).
@@ -3328,13 +3361,22 @@ mod tests {
                 name: "project".to_string(),
                 last_opened: "2026-05-29T00:00:00Z".to_string(),
                 kind: RemoteWorkspaceKind::Normal,
+                remote_connection_id: None,
+                remote_ssh_host: None,
             }]
         }
 
-        async fn open_workspace(&self, path: &str) -> Result<RemoteWorkspaceUpdate, String> {
+        async fn open_workspace(
+            &self,
+            path: &str,
+            _remote_connection_id: Option<&str>,
+            _remote_ssh_host: Option<&str>,
+        ) -> Result<RemoteWorkspaceUpdate, String> {
             Ok(RemoteWorkspaceUpdate {
                 path: path.to_string(),
                 name: "opened".to_string(),
+                remote_connection_id: None,
+                remote_ssh_host: None,
             })
         }
 
@@ -3353,6 +3395,8 @@ mod tests {
             Ok(RemoteWorkspaceUpdate {
                 path: path.to_string(),
                 name: "assistant".to_string(),
+                remote_connection_id: None,
+                remote_ssh_host: None,
             })
         }
     }
@@ -3380,6 +3424,8 @@ mod tests {
                 &host,
                 &RemoteCommand::SetWorkspace {
                     path: "/workspace/next".to_string(),
+                    remote_connection_id: None,
+                    remote_ssh_host: None,
                 },
             )
             .await,
@@ -3387,6 +3433,8 @@ mod tests {
                 success: true,
                 path: Some("/workspace/next".to_string()),
                 project_name: Some("opened".to_string()),
+                remote_connection_id: None,
+                remote_ssh_host: None,
                 error: None,
             }
         );

--- a/src/crates/services/services-integrations/src/remote_connect/bot/mod.rs
+++ b/src/crates/services/services-integrations/src/remote_connect/bot/mod.rs
@@ -19,8 +19,8 @@ pub use locale::{fmt_count, strings_for, BotLanguage, BotStrings};
 pub use menu::{MenuItem, MenuItemStyle, MenuView};
 pub use state::{
     BotAction, BotActionStyle, BotChatState, BotDisplayMode, BotInteractionHandler,
-    BotInteractiveRequest, BotMessageSender, BotQuestion, BotQuestionOption, PendingAction,
-    RemoteDeviceTarget,
+    BotInteractiveRequest, BotMessageSender, BotQuestion, BotQuestionOption, BotWorkspaceChoice,
+    BotWorkspaceRef, PendingAction, RemoteDeviceTarget,
 };
 pub use telegram::{TelegramBotApi, TelegramConfig};
 pub use weixin::{WeixinConfig, WeixinProviderClient};

--- a/src/crates/services/services-integrations/src/remote_connect/bot/state.rs
+++ b/src/crates/services/services-integrations/src/remote_connect/bot/state.rs
@@ -17,11 +17,126 @@ pub enum BotDisplayMode {
     Assistant,
 }
 
+/// Workspace selection retained by the bot, including SSH identity when remote.
+///
+/// Persisted bot state historically stored `current_workspace` as a bare path
+/// string. Deserialization still accepts that form and upgrades it in memory.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BotWorkspaceRef {
+    pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote_connection_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote_ssh_host: Option<String>,
+}
+
+impl BotWorkspaceRef {
+    pub fn local(path: impl Into<String>) -> Self {
+        Self {
+            path: path.into(),
+            remote_connection_id: None,
+            remote_ssh_host: None,
+        }
+    }
+
+    pub fn with_identity(
+        path: impl Into<String>,
+        remote_connection_id: Option<String>,
+        remote_ssh_host: Option<String>,
+    ) -> Self {
+        Self {
+            path: path.into(),
+            remote_connection_id: remote_connection_id
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty()),
+            remote_ssh_host: remote_ssh_host
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty()),
+        }
+    }
+
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+}
+
+fn deserialize_optional_workspace_ref<'de, D>(
+    deserializer: D,
+) -> Result<Option<BotWorkspaceRef>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Raw {
+        Null,
+        Path(String),
+        Full(BotWorkspaceRef),
+    }
+
+    match Option::<Raw>::deserialize(deserializer)? {
+        None | Some(Raw::Null) => Ok(None),
+        Some(Raw::Path(path)) => {
+            let trimmed = path.trim();
+            if trimmed.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(BotWorkspaceRef::local(trimmed)))
+            }
+        }
+        Some(Raw::Full(workspace)) => {
+            if workspace.path.trim().is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(workspace))
+            }
+        }
+    }
+}
+
+/// One selectable workspace row in the bot `/switch` picker.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BotWorkspaceChoice {
+    pub path: String,
+    pub name: String,
+    pub remote_connection_id: Option<String>,
+    pub remote_ssh_host: Option<String>,
+}
+
+impl BotWorkspaceChoice {
+    pub fn new(
+        path: impl Into<String>,
+        name: impl Into<String>,
+        remote_connection_id: Option<String>,
+        remote_ssh_host: Option<String>,
+    ) -> Self {
+        Self {
+            path: path.into(),
+            name: name.into(),
+            remote_connection_id,
+            remote_ssh_host,
+        }
+    }
+
+    pub fn to_workspace_ref(&self) -> BotWorkspaceRef {
+        BotWorkspaceRef::with_identity(
+            self.path.clone(),
+            self.remote_connection_id.clone(),
+            self.remote_ssh_host.clone(),
+        )
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BotChatState {
     pub chat_id: String,
     pub paired: bool,
-    pub current_workspace: Option<String>,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_optional_workspace_ref",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub current_workspace: Option<BotWorkspaceRef>,
     pub current_assistant: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub current_assistant_name: Option<String>,
@@ -87,8 +202,25 @@ impl BotChatState {
 
     pub fn active_workspace_path(&self) -> Option<String> {
         self.current_workspace
-            .clone()
+            .as_ref()
+            .map(|workspace| workspace.path.clone())
             .or_else(|| self.current_assistant.clone())
+    }
+
+    pub fn current_workspace_path(&self) -> Option<&str> {
+        self.current_workspace.as_ref().map(BotWorkspaceRef::path)
+    }
+
+    pub fn current_workspace_identity(&self) -> (Option<String>, Option<String>) {
+        self.current_workspace
+            .as_ref()
+            .map(|workspace| {
+                (
+                    workspace.remote_connection_id.clone(),
+                    workspace.remote_ssh_host.clone(),
+                )
+            })
+            .unwrap_or((None, None))
     }
 
     pub fn set_pending(&mut self, action: PendingAction) {
@@ -132,7 +264,7 @@ fn now_secs() -> i64 {
 #[derive(Debug, Clone)]
 pub enum PendingAction {
     SelectWorkspace {
-        options: Vec<(String, String)>,
+        options: Vec<BotWorkspaceChoice>,
     },
     SelectAssistant {
         options: Vec<(String, String)>,
@@ -254,7 +386,7 @@ mod tests {
         state.current_assistant = Some("/assistant".into());
         assert_eq!(state.active_workspace_path().as_deref(), Some("/assistant"));
 
-        state.current_workspace = Some("/workspace".into());
+        state.current_workspace = Some(BotWorkspaceRef::local("/workspace"));
         assert_eq!(state.active_workspace_path().as_deref(), Some("/workspace"));
     }
 
@@ -272,5 +404,53 @@ mod tests {
         assert!(state.pending_action.is_none());
         assert_eq!(state.pending_expires_at, 0);
         assert_eq!(state.pending_invalid_count, 0);
+    }
+
+    #[test]
+    fn current_workspace_deserializes_legacy_path_string() {
+        let state: BotChatState = serde_json::from_value(serde_json::json!({
+            "chat_id": "c1",
+            "paired": true,
+            "current_workspace": "/root/repos",
+            "current_assistant": null,
+            "current_session_id": null,
+            "display_mode": "pro"
+        }))
+        .expect("legacy path string must deserialize");
+
+        assert_eq!(
+            state.current_workspace,
+            Some(BotWorkspaceRef::local("/root/repos"))
+        );
+    }
+
+    #[test]
+    fn current_workspace_deserializes_identity_object() {
+        let state: BotChatState = serde_json::from_value(serde_json::json!({
+            "chat_id": "c1",
+            "paired": true,
+            "current_workspace": {
+                "path": "/root/repos",
+                "remote_connection_id": "conn-a",
+                "remote_ssh_host": "host-a"
+            },
+            "current_assistant": null,
+            "current_session_id": null,
+            "display_mode": "pro"
+        }))
+        .expect("identity object must deserialize");
+
+        assert_eq!(
+            state.current_workspace,
+            Some(BotWorkspaceRef::with_identity(
+                "/root/repos",
+                Some("conn-a".into()),
+                Some("host-a".into()),
+            ))
+        );
+        assert_eq!(
+            state.current_workspace_identity(),
+            (Some("conn-a".into()), Some("host-a".into()))
+        );
     }
 }

--- a/src/crates/services/services-integrations/tests/remote_connect_contracts.rs
+++ b/src/crates/services/services-integrations/tests/remote_connect_contracts.rs
@@ -1638,6 +1638,8 @@ fn remote_connect_workspace_response_helpers_own_wire_shape() {
             name: workspace.name.clone(),
             last_opened: "2026-05-25T00:00:00Z".to_string(),
             kind: workspace.kind,
+            remote_connection_id: workspace.remote_connection_id.clone(),
+            remote_ssh_host: workspace.remote_ssh_host.clone(),
         },
     ]))
     .expect("serialize recent workspaces");
@@ -1647,6 +1649,11 @@ fn remote_connect_workspace_response_helpers_own_wire_shape() {
         recent_json["workspaces"][0]["last_opened"],
         "2026-05-25T00:00:00Z"
     );
+    assert_eq!(
+        recent_json["workspaces"][0]["remote_connection_id"],
+        "ssh-1"
+    );
+    assert_eq!(recent_json["workspaces"][0]["remote_ssh_host"], "dev-host");
 
     let assistant_json = serde_json::to_value(remote_assistant_list_response(vec![
         RemoteAssistantWorkspaceFacts {
@@ -1666,11 +1673,15 @@ fn remote_connect_workspace_response_helpers_own_wire_shape() {
         remote_workspace_updated_response(Ok(RemoteWorkspaceUpdate {
             path: "D:/workspace/project".to_string(),
             name: "project".to_string(),
+            remote_connection_id: None,
+            remote_ssh_host: None,
         })),
         RemoteResponse::WorkspaceUpdated {
             success: true,
             path: Some("D:/workspace/project".to_string()),
             project_name: Some("project".to_string()),
+            remote_connection_id: None,
+            remote_ssh_host: None,
             error: None,
         }
     );

--- a/src/mobile-web/src/pages/PairingPage.tsx
+++ b/src/mobile-web/src/pages/PairingPage.tsx
@@ -172,6 +172,8 @@ const PairingPage: React.FC<PairingPageProps> = ({ onPaired }) => {
             git_branch: initialSync.git_branch,
             workspace_kind: initialSync.workspace_kind,
             assistant_id: initialSync.assistant_id,
+            remote_connection_id: initialSync.remote_connection_id,
+            remote_ssh_host: initialSync.remote_ssh_host,
           });
         }
       }

--- a/src/mobile-web/src/pages/SessionListPage.tsx
+++ b/src/mobile-web/src/pages/SessionListPage.tsx
@@ -172,7 +172,14 @@ const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectS
 
   const [assistantList, setAssistantList] = useState<Array<{ path: string; name: string; assistant_id?: string }>>([]);
   const [showAssistantPicker, setShowAssistantPicker] = useState(false);
-  const [workspaceList, setWorkspaceList] = useState<Array<{ path: string; name: string; last_opened: string }>>([]);
+  const [workspaceList, setWorkspaceList] = useState<Array<{
+    path: string;
+    name: string;
+    last_opened: string;
+    workspace_kind?: 'normal' | 'assistant' | 'remote';
+    remote_connection_id?: string;
+    remote_ssh_host?: string;
+  }>>([]);
   const [showWorkspacePicker, setShowWorkspacePicker] = useState(false);
 
   // Search, rename & delete state
@@ -313,12 +320,22 @@ const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectS
     }
   }, [sessionMgr, currentAssistant, setCurrentAssistant, setError]);
 
-  const loadFirstPage = useCallback(async (workspacePath: string | undefined, query = '') => {
+  const loadFirstPage = useCallback(async (
+    workspacePath: string | undefined,
+    query = '',
+    identity?: { remoteConnectionId?: string; remoteSshHost?: string },
+  ) => {
     const requestSeq = ++listRequestSeqRef.current;
     setLoading(true);
     offsetRef.current = 0;
     try {
-      const resp = await sessionMgr.listSessions(workspacePath, PAGE_SIZE, 0, query);
+      const resp = await sessionMgr.listSessions(
+        workspacePath,
+        PAGE_SIZE,
+        0,
+        query,
+        identity,
+      );
       if (requestSeq !== listRequestSeqRef.current) return;
       setSessions(resp.sessions);
       setHasMore(resp.has_more);
@@ -343,17 +360,35 @@ const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectS
     }
   }, [sessionMgr, setError]);
 
-  const handleSelectWorkspace = useCallback(async (workspace: { path: string; name: string }) => {
+  const handleSelectWorkspace = useCallback(async (workspace: {
+    path: string;
+    name: string;
+    remote_connection_id?: string;
+    remote_ssh_host?: string;
+  }) => {
     try {
-      const result = await sessionMgr.setWorkspace(workspace.path);
+      const result = await sessionMgr.setWorkspace(workspace.path, {
+        remoteConnectionId: workspace.remote_connection_id,
+        remoteSshHost: workspace.remote_ssh_host,
+      });
       if (result.success) {
+        const path = result.path || workspace.path;
+        const remoteConnectionId =
+          result.remote_connection_id ?? workspace.remote_connection_id;
+        const remoteSshHost = result.remote_ssh_host ?? workspace.remote_ssh_host;
+        const identity = { remoteConnectionId, remoteSshHost };
         setCurrentWorkspace({
           has_workspace: true,
-          path: result.path || workspace.path,
+          path,
           project_name: result.project_name || workspace.name,
+          workspace_kind: remoteConnectionId || remoteSshHost
+            ? 'remote'
+            : undefined,
+          remote_connection_id: remoteConnectionId,
+          remote_ssh_host: remoteSshHost,
         });
         setShowWorkspacePicker(false);
-        loadFirstPage(workspace.path, searchQuery);
+        loadFirstPage(path, searchQuery, identity);
       } else {
         setError(result.error || 'Failed to set workspace');
       }
@@ -367,14 +402,27 @@ const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectS
       const list = await sessionMgr.listRecentWorkspaces();
       const candidate = pickFirstProWorkspace(list);
       if (!candidate) return false;
-      const result = await sessionMgr.setWorkspace(candidate.path);
+      const result = await sessionMgr.setWorkspace(candidate.path, {
+        remoteConnectionId: candidate.remote_connection_id,
+        remoteSshHost: candidate.remote_ssh_host,
+      });
       if (result.success) {
+        const path = result.path || candidate.path;
+        const remoteConnectionId =
+          result.remote_connection_id ?? candidate.remote_connection_id;
+        const remoteSshHost = result.remote_ssh_host ?? candidate.remote_ssh_host;
+        const identity = { remoteConnectionId, remoteSshHost };
         setCurrentWorkspace({
           has_workspace: true,
-          path: result.path || candidate.path,
+          path,
           project_name: result.project_name || candidate.name,
+          workspace_kind: remoteConnectionId || remoteSshHost
+            ? 'remote'
+            : candidate.workspace_kind,
+          remote_connection_id: remoteConnectionId,
+          remote_ssh_host: remoteSshHost,
         });
-        await loadFirstPage(result.path || candidate.path, searchQuery);
+        await loadFirstPage(path, searchQuery, identity);
         return true;
       }
       setError(result.error || t('workspace.failedToSetWorkspace'));
@@ -385,12 +433,22 @@ const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectS
     }
   }, [sessionMgr, setCurrentWorkspace, setError, loadFirstPage, searchQuery, t]);
 
-  const loadNextPage = useCallback(async (workspacePath: string | undefined, query = '') => {
+  const loadNextPage = useCallback(async (
+    workspacePath: string | undefined,
+    query = '',
+    identity?: { remoteConnectionId?: string; remoteSshHost?: string },
+  ) => {
     if (loadingMore || !hasMore) return;
     const requestSeq = listRequestSeqRef.current;
     setLoadingMore(true);
     try {
-      const resp = await sessionMgr.listSessions(workspacePath, PAGE_SIZE, offsetRef.current, query);
+      const resp = await sessionMgr.listSessions(
+        workspacePath,
+        PAGE_SIZE,
+        offsetRef.current,
+        query,
+        identity,
+      );
       if (requestSeq !== listRequestSeqRef.current) return;
       appendSessions(resp.sessions);
       setHasMore(resp.has_more);
@@ -424,7 +482,10 @@ const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectS
           setCurrentWorkspace(ws);
           if (ws?.path) {
             initLoadedPathRef.current = ws.path;
-            await loadFirstPage(ws.path);
+            await loadFirstPage(ws.path, '', {
+              remoteConnectionId: ws.remote_connection_id,
+              remoteSshHost: ws.remote_ssh_host,
+            });
           } else {
             await trySelectFirstProWorkspace();
           }
@@ -454,7 +515,10 @@ const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectS
         }
         const ws = info.has_workspace ? info : null;
         setCurrentWorkspace(ws);
-        const resp = await sessionMgr.listSessions(ws?.path, PAGE_SIZE, 0, searchQuery);
+        const resp = await sessionMgr.listSessions(ws?.path, PAGE_SIZE, 0, searchQuery, {
+          remoteConnectionId: ws?.remote_connection_id,
+          remoteSshHost: ws?.remote_ssh_host,
+        });
         if (requestSeq !== listRequestSeqRef.current) return;
         setSessions(resp.sessions);
         setHasMore(resp.has_more);
@@ -485,11 +549,25 @@ const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectS
       initLoadedPathRef.current = undefined;
       return;
     }
+    const identity = displayMode === 'assistant'
+      ? undefined
+      : {
+          remoteConnectionId: currentWorkspace?.remote_connection_id,
+          remoteSshHost: currentWorkspace?.remote_ssh_host,
+        };
     const timer = setTimeout(() => {
-      loadFirstPage(workspacePath, searchQuery);
+      loadFirstPage(workspacePath, searchQuery, identity);
     }, 250);
     return () => clearTimeout(timer);
-  }, [currentAssistant?.path, currentWorkspace?.path, displayMode, loadFirstPage, searchQuery]);
+  }, [
+    currentAssistant?.path,
+    currentWorkspace?.path,
+    currentWorkspace?.remote_connection_id,
+    currentWorkspace?.remote_ssh_host,
+    displayMode,
+    loadFirstPage,
+    searchQuery,
+  ]);
 
   const PULL_THRESHOLD = 60;
 
@@ -527,9 +605,23 @@ const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectS
     const el = e.currentTarget;
     if (el.scrollHeight - el.scrollTop - el.clientHeight < 150) {
       const workspacePath = displayMode === 'assistant' ? currentAssistant?.path : currentWorkspace?.path;
-      loadNextPage(workspacePath, searchQuery);
+      const identity = displayMode === 'assistant'
+        ? undefined
+        : {
+            remoteConnectionId: currentWorkspace?.remote_connection_id,
+            remoteSshHost: currentWorkspace?.remote_ssh_host,
+          };
+      loadNextPage(workspacePath, searchQuery, identity);
     }
-  }, [displayMode, currentAssistant?.path, currentWorkspace?.path, loadNextPage, searchQuery]);
+  }, [
+    displayMode,
+    currentAssistant?.path,
+    currentWorkspace?.path,
+    currentWorkspace?.remote_connection_id,
+    currentWorkspace?.remote_ssh_host,
+    loadNextPage,
+    searchQuery,
+  ]);
 
   const handleCreate = useCallback(async (agentType: string) => {
     if (creating) return;
@@ -538,8 +630,14 @@ const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectS
       // For assistant mode (Claw), use currentAssistant.path
       // For pro mode (Code/Cowork), use currentWorkspace.path
       const workspacePath = displayMode === 'assistant' ? currentAssistant?.path : currentWorkspace?.path;
-      const id = await sessionMgr.createSession(agentType, undefined, workspacePath);
-      await loadFirstPage(workspacePath, searchQuery);
+      const identity = displayMode === 'assistant'
+        ? undefined
+        : {
+            remoteConnectionId: currentWorkspace?.remote_connection_id,
+            remoteSshHost: currentWorkspace?.remote_ssh_host,
+          };
+      const id = await sessionMgr.createSession(agentType, undefined, workspacePath, identity);
+      await loadFirstPage(workspacePath, searchQuery, identity);
       const label = isClawAgent(agentType)
         ? t('sessions.remoteClawSession')
         : isCoworkAgent(agentType)
@@ -551,7 +649,20 @@ const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectS
     } finally {
       setCreating(false);
     }
-  }, [creating, currentWorkspace?.path, currentAssistant?.path, displayMode, loadFirstPage, onSelectSession, searchQuery, sessionMgr, setError, t]);
+  }, [
+    creating,
+    currentWorkspace?.path,
+    currentWorkspace?.remote_connection_id,
+    currentWorkspace?.remote_ssh_host,
+    currentAssistant?.path,
+    displayMode,
+    loadFirstPage,
+    onSelectSession,
+    searchQuery,
+    sessionMgr,
+    setError,
+    t,
+  ]);
 
   const handleSelectMode = useCallback(async (mode: DisplayMode) => {
     setDisplayMode(mode);
@@ -561,7 +672,10 @@ const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectS
       loadFirstPage(assistantPath, searchQuery);
     } else {
       if (currentWorkspace?.path) {
-        await loadFirstPage(currentWorkspace.path, searchQuery);
+        await loadFirstPage(currentWorkspace.path, searchQuery, {
+          remoteConnectionId: currentWorkspace.remote_connection_id,
+          remoteSshHost: currentWorkspace.remote_ssh_host,
+        });
       } else {
         await trySelectFirstProWorkspace();
       }
@@ -750,21 +864,34 @@ const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectS
                     {workspaceList.length === 0 ? (
                       <div className="session-list__picker-empty">{t('sessions.noWorkspaces')}</div>
                     ) : (
-                      workspaceList.map((workspace, index) => (
+                      workspaceList.map((workspace, index) => {
+                        const isSelected =
+                          currentWorkspace?.path === workspace.path
+                          && (currentWorkspace?.remote_connection_id ?? undefined)
+                            === (workspace.remote_connection_id ?? undefined)
+                          && (currentWorkspace?.remote_ssh_host ?? undefined)
+                            === (workspace.remote_ssh_host ?? undefined);
+                        const itemKey = [
+                          workspace.remote_connection_id ?? 'local',
+                          workspace.remote_ssh_host ?? '',
+                          workspace.path || String(index),
+                        ].join(':');
+                        return (
                         <button
-                          key={workspace.path || index}
-                          className={`session-list__picker-item session-list__picker-item--workspace ${currentWorkspace?.path === workspace.path ? 'is-selected' : ''}`}
+                          key={itemKey}
+                          className={`session-list__picker-item session-list__picker-item--workspace ${isSelected ? 'is-selected' : ''}`}
                           onClick={() => handleSelectWorkspace(workspace)}
                         >
                           <span className="session-list__picker-item-icon">
                             <WorkspaceIcon />
                           </span>
                           <span className="session-list__picker-item-name">{workspace.name}</span>
-                          {currentWorkspace?.path === workspace.path && (
+                          {isSelected && (
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
                           )}
                         </button>
-                      ))
+                        );
+                      })
                     )}
                   </div>
                 </div>

--- a/src/mobile-web/src/pages/WorkspacePage.tsx
+++ b/src/mobile-web/src/pages/WorkspacePage.tsx
@@ -50,12 +50,15 @@ const WorkspacePage: React.FC<WorkspacePageProps> = ({ sessionMgr, onReady }) =>
     await loadRecentWorkspaces();
   };
 
-  const handleSelectWorkspace = useCallback(async (path: string) => {
+  const handleSelectWorkspace = useCallback(async (workspace: RecentWorkspaceEntry) => {
     if (switching) return;
     setSwitching(true);
     setError(null);
     try {
-      const result = await sessionMgr.setWorkspace(path);
+      const result = await sessionMgr.setWorkspace(workspace.path, {
+        remoteConnectionId: workspace.remote_connection_id,
+        remoteSshHost: workspace.remote_ssh_host,
+      });
       if (result.success) {
         await loadWorkspaceInfo();
         setShowRecent(false);
@@ -142,9 +145,9 @@ const WorkspacePage: React.FC<WorkspacePageProps> = ({ sessionMgr, onReady }) =>
               <div className="workspace-page__recent-list">
                 {recentWorkspaces.map((ws) => (
                   <button
-                    key={ws.path}
+                    key={`${ws.remote_connection_id ?? 'local'}:${ws.path}`}
                     className="workspace-page__recent-item"
-                    onClick={() => handleSelectWorkspace(ws.path)}
+                    onClick={() => handleSelectWorkspace(ws)}
                     disabled={switching}
                   >
                     <div className="workspace-page__recent-item-name">{ws.name}</div>

--- a/src/mobile-web/src/services/RemoteSessionManager.ts
+++ b/src/mobile-web/src/services/RemoteSessionManager.ts
@@ -18,6 +18,14 @@ export interface WorkspaceInfo {
   /** Mirrors desktop `WorkspaceKind`: normal project, Claw assistant workspace, or remote SSH. */
   workspace_kind?: 'normal' | 'assistant' | 'remote';
   assistant_id?: string;
+  /** Required to disambiguate multiple SSH hosts that share the same POSIX path. */
+  remote_connection_id?: string;
+  remote_ssh_host?: string;
+}
+
+export interface RemoteWorkspaceIdentity {
+  remoteConnectionId?: string;
+  remoteSshHost?: string;
 }
 
 export interface RecentWorkspaceEntry {
@@ -25,6 +33,8 @@ export interface RecentWorkspaceEntry {
   name: string;
   last_opened: string;
   workspace_kind?: 'normal' | 'assistant' | 'remote';
+  remote_connection_id?: string;
+  remote_ssh_host?: string;
 }
 
 export interface AssistantEntry {
@@ -134,6 +144,8 @@ export interface InitialSyncData {
   git_branch?: string;
   workspace_kind?: 'normal' | 'assistant' | 'remote';
   assistant_id?: string;
+  remote_connection_id?: string;
+  remote_ssh_host?: string;
   sessions: SessionInfo[];
   has_more_sessions: boolean;
   authenticated_user_id?: string;
@@ -181,6 +193,8 @@ export class RemoteSessionManager {
       git_branch: resp.git_branch,
       workspace_kind: resp.workspace_kind,
       assistant_id: resp.assistant_id,
+      remote_connection_id: resp.remote_connection_id,
+      remote_ssh_host: resp.remote_ssh_host,
     };
   }
 
@@ -194,13 +208,24 @@ export class RemoteSessionManager {
 
   async setWorkspace(
     path: string,
+    options?: {
+      remoteConnectionId?: string;
+      remoteSshHost?: string;
+    },
   ): Promise<{
     success: boolean;
     path?: string;
     project_name?: string;
+    remote_connection_id?: string;
+    remote_ssh_host?: string;
     error?: string;
   }> {
-    return this.request({ cmd: 'set_workspace', path });
+    return this.request({
+      cmd: 'set_workspace',
+      path,
+      remote_connection_id: options?.remoteConnectionId,
+      remote_ssh_host: options?.remoteSshHost,
+    });
   }
 
   async listAssistants(): Promise<AssistantEntry[]> {
@@ -227,6 +252,7 @@ export class RemoteSessionManager {
     limit = 30,
     offset = 0,
     query?: string,
+    identity?: RemoteWorkspaceIdentity,
   ): Promise<{ sessions: SessionInfo[]; has_more: boolean }> {
     const resp = await this.request<{
       resp: string;
@@ -235,6 +261,8 @@ export class RemoteSessionManager {
     }>({
       cmd: 'list_sessions',
       workspace_path: workspacePath ?? null,
+      remote_connection_id: identity?.remoteConnectionId,
+      remote_ssh_host: identity?.remoteSshHost,
       limit,
       offset,
       query: query?.trim() || null,
@@ -249,12 +277,15 @@ export class RemoteSessionManager {
     agentType?: string,
     sessionName?: string,
     workspacePath?: string,
+    identity?: RemoteWorkspaceIdentity,
   ): Promise<string> {
     const resp = await this.request<{ resp: string; session_id: string }>({
       cmd: 'create_session',
       agent_type: agentType || undefined,
       session_name: sessionName || undefined,
       workspace_path: workspacePath ?? null,
+      remote_connection_id: identity?.remoteConnectionId,
+      remote_ssh_host: identity?.remoteSshHost,
     });
     return resp.session_id;
   }

--- a/src/web-ui/src/app/layout/AppLayout.tsx
+++ b/src/web-ui/src/app/layout/AppLayout.tsx
@@ -612,13 +612,24 @@ const AppLayout: React.FC<AppLayoutProps> = ({ className = '' }) => {
     const handler = (e: Event) => {
       const clientId = (e as CustomEvent<{ clientId?: string }>).detail?.clientId?.trim();
       if (!clientId) return;
+      const config = currentWorkspace
+        ? {
+            workspacePath: currentWorkspace.rootPath,
+            ...(currentWorkspace.workspaceKind === WorkspaceKind.Remote && currentWorkspace.connectionId
+              ? { remoteConnectionId: currentWorkspace.connectionId }
+              : {}),
+            ...(currentWorkspace.workspaceKind === WorkspaceKind.Remote && currentWorkspace.sshHost
+              ? { remoteSshHost: currentWorkspace.sshHost }
+              : {}),
+          }
+        : {};
       void FlowChatManager.getInstance()
-        .createAcpChatSession(clientId)
+        .createAcpChatSession(clientId, config)
         .catch(error => log.error('Failed to create ACP FlowChat session', error));
     };
     window.addEventListener('bitfun:create-acp-session', handler);
     return () => window.removeEventListener('bitfun:create-acp-session', handler);
-  }, []);
+  }, [currentWorkspace]);
 
   React.useEffect(() => {
     const handler = (event: Event) => {

--- a/src/web-ui/src/app/scenes/miniapps/MiniAppScene.tsx
+++ b/src/web-ui/src/app/scenes/miniapps/MiniAppScene.tsx
@@ -41,7 +41,7 @@ const MiniAppScene: React.FC<MiniAppSceneProps> = ({ appId }) => {
   const markCustomizationActive = useMiniAppStore((state) => state.markCustomizationActive);
   const markCustomizationIdle = useMiniAppStore((state) => state.markCustomizationIdle);
   const { themeType } = useTheme();
-  const { workspacePath } = useCurrentWorkspace();
+  const { workspace, workspacePath } = useCurrentWorkspace();
   const { closeScene } = useSceneManager();
   const { t, currentLanguage } = useI18n('scenes/miniapp');
 
@@ -247,6 +247,8 @@ const MiniAppScene: React.FC<MiniAppSceneProps> = ({ appId }) => {
             appName={appName}
             themeType={themeType ?? 'dark'}
             workspacePath={workspacePath || undefined}
+            remoteConnectionId={workspace?.connectionId}
+            remoteSshHost={workspace?.sshHost}
             previewOpen={Boolean(customizePreview)}
             onPreviewChange={setCustomizePreview}
             onClose={() => setCustomizeOpen(false)}

--- a/src/web-ui/src/app/scenes/miniapps/customization/MiniAppCustomizePanel.tsx
+++ b/src/web-ui/src/app/scenes/miniapps/customization/MiniAppCustomizePanel.tsx
@@ -46,6 +46,8 @@ interface MiniAppCustomizePanelProps {
   appName: string;
   themeType?: string;
   workspacePath?: string;
+  remoteConnectionId?: string;
+  remoteSshHost?: string;
   previewOpen: boolean;
   onPreviewChange: (preview: { draft: MiniAppDraft; previewKey: number } | null) => void;
   onClose: () => void;
@@ -58,6 +60,8 @@ export const MiniAppCustomizePanel: React.FC<MiniAppCustomizePanelProps> = ({
   appName,
   themeType,
   workspacePath,
+  remoteConnectionId,
+  remoteSshHost,
   previewOpen,
   onPreviewChange,
   onClose,
@@ -138,6 +142,8 @@ export const MiniAppCustomizePanel: React.FC<MiniAppCustomizePanelProps> = ({
       appId: app.id,
       appName,
       workspacePath: workspace,
+      remoteConnectionId,
+      remoteSshHost,
       sessionName: t('customize.sessionName', { name: appName }),
       prompt,
       displayMessage: request,
@@ -149,7 +155,7 @@ export const MiniAppCustomizePanel: React.FC<MiniAppCustomizePanelProps> = ({
       customizationSessionId: created.sessionId,
       error: null,
     }));
-  }, [app.id, appName, ensureWorkspace, t]);
+  }, [app.id, appName, ensureWorkspace, remoteConnectionId, remoteSshHost, t]);
 
   const handleStart = useCallback(async () => {
     if (!trimmedRequest || busy) {

--- a/src/web-ui/src/app/scenes/miniapps/customization/miniAppCustomizationSession.ts
+++ b/src/web-ui/src/app/scenes/miniapps/customization/miniAppCustomizationSession.ts
@@ -7,6 +7,8 @@ export interface BuildMiniAppCustomizationSessionRequestInput {
   sessionId: string;
   sessionName: string;
   workspacePath: string;
+  remoteConnectionId?: string;
+  remoteSshHost?: string;
 }
 
 export function buildMiniAppCustomizationSessionRequest(
@@ -17,12 +19,16 @@ export function buildMiniAppCustomizationSessionRequest(
     sessionName: input.sessionName,
     agentType: 'agentic',
     workspacePath: input.workspacePath,
+    remoteConnectionId: input.remoteConnectionId,
+    remoteSshHost: input.remoteSshHost,
     sessionKind: 'subagent',
     config: {
       enableTools: true,
       safeMode: true,
       autoCompact: true,
       enableContextCompression: true,
+      remoteConnectionId: input.remoteConnectionId,
+      remoteSshHost: input.remoteSshHost,
     },
   };
 }
@@ -35,6 +41,8 @@ export async function launchMiniAppCustomizationSession(params: {
   appId: string;
   appName: string;
   workspacePath: string;
+  remoteConnectionId?: string;
+  remoteSshHost?: string;
   sessionName: string;
   prompt: string;
   displayMessage: string;
@@ -52,6 +60,8 @@ export async function launchMiniAppCustomizationSession(params: {
     sessionId: createMiniAppCustomizationSessionId(params.appId),
     sessionName: params.sessionName,
     workspacePath: params.workspacePath,
+    remoteConnectionId: params.remoteConnectionId,
+    remoteSshHost: params.remoteSshHost,
   });
   const created = await agentAPI.createSession(request);
 
@@ -65,6 +75,8 @@ export async function launchMiniAppCustomizationSession(params: {
       isTransient: true,
       agentBackedTransient: true,
     },
+    params.remoteConnectionId,
+    params.remoteSshHost,
   );
 
   await FlowChatManager.getInstance().sendMessage(

--- a/src/web-ui/src/app/utils/projectSessionWorkspace.ts
+++ b/src/web-ui/src/app/utils/projectSessionWorkspace.ts
@@ -30,5 +30,8 @@ export function flowChatSessionConfigForWorkspace(workspace: WorkspaceInfo) {
     ...(isRemoteWorkspace(workspace) && workspace.connectionId
       ? { remoteConnectionId: workspace.connectionId }
       : {}),
+    ...(isRemoteWorkspace(workspace) && workspace.sshHost
+      ? { remoteSshHost: workspace.sshHost }
+      : {}),
   };
 }

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/MessageModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/MessageModule.ts
@@ -352,6 +352,8 @@ export async function sendMessage(
           turnId: dialogTurnId,
           agentType: currentAgentType,
           workspacePath,
+          remoteConnectionId: updatedSession.remoteConnectionId,
+          remoteSshHost: updatedSession.remoteSshHost,
           imageContexts: options?.imageContexts,
           userMessageMetadata: options?.userMessageMetadata,
         });
@@ -372,6 +374,8 @@ export async function sendMessage(
             turnId: dialogTurnId,
             agentType: currentAgentType,
             workspacePath,
+            remoteConnectionId: updatedSession.remoteConnectionId,
+            remoteSshHost: updatedSession.remoteSshHost,
             imageContexts: options?.imageContexts,
             userMessageMetadata: options?.userMessageMetadata,
           });

--- a/src/web-ui/src/infrastructure/api/service-api/AgentAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/AgentAPI.ts
@@ -70,6 +70,8 @@ export interface StartDialogTurnRequest {
   turnId?: string; 
   agentType: string; 
   workspacePath?: string;
+  remoteConnectionId?: string;
+  remoteSshHost?: string;
   /** Optional multimodal image contexts (snake_case fields, aligned with backend ImageContextData). */
   imageContexts?: ImageInputContextData[];
   userMessageMetadata?: Record<string, unknown>;


### PR DESCRIPTION
## Summary
- Retain `remote_connection_id` / `remote_ssh_host` when opening remote workspaces and listing/creating sessions across IM bot, mobile-web, and desktop paths, so multi-host same POSIX path cases no longer fall back to a process-global host hint.
- Resolve bot/mobile session storage through `CoreSessionStorePort` (remote mirror under `~/.bitfun/remote_ssh/{host}/...`) instead of scanning the bare remote path, fixing empty session counts and broken `/resume`.
- Implement `DeviceQueryInfo`, return identity on `WorkspaceUpdated` / `DeviceInfo`, and wire bot remote-device switch/resume/create so peer RPC no longer uses `workspace_path: null` or swallows errors as empty lists.

## Test plan
- [x] `cargo check -p bitfun-core --features product-full`
- [x] `cargo test -p bitfun-services-integrations --features remote-connect --lib current_workspace_deserializes`
- [x] `cargo test -p bitfun-core --features product-full --lib open_workspace_resolving_known`
- [x] `pnpm --dir src/mobile-web run type-check`
- [x] `pnpm run type-check:web`
- [ ] Desktop: open a remote SSH workspace, confirm session list is non-empty; with two hosts sharing the same POSIX path, switch between them and verify sessions stay host-scoped
- [ ] IM bot: `/switch` to remote workspace shows non-zero session count; `/resume` lists sessions; remote-device mode resume/create uses peer workspace
- [ ] mobile-web: select a recent remote workspace and confirm sessions load; create session stays on the selected host