### PR TITLE
feat(cli): always-on account device daemon; fix peer-mode SSH workspace removal and settings-applied refresh

### DIFF
--- a/src/apps/cli/README.md
+++ b/src/apps/cli/README.md
@@ -61,6 +61,15 @@ a headless Peer Host process that restores the persisted account session and hol
 device-routing connection, so other devices on the account can reach this machine whenever it is
 up.
 
+Full setup flow on a server:
+
+```bash
+bash src/apps/cli/install.sh    # build + install the CLI (see below)
+bitfun-cli                      # start the TUI, then /login with your account
+bitfun-cli daemon install       # register auto-start; device stays reachable after exit/reboot
+bitfun-cli daemon status        # verify: daemon running + service installed/active
+```
+
 ```bash
 bitfun-cli daemon status      # daemon liveness + auto-start service status
 bitfun-cli daemon install     # register and start the auto-start service (requires /login first)
@@ -68,10 +77,14 @@ bitfun-cli daemon uninstall   # stop and remove the auto-start service
 bitfun-cli daemon run         # foreground mode (used by the service manager; also for debugging)
 ```
 
+- Prerequisites: a persisted account session (`/login` inside the TUI first), and on Linux a
+  working systemd user session (`systemctl --user`). Containers, WSL, and some minimal images do
+  not have one; there `daemon install` reports a clear error and you can instead run
+  `bitfun-cli daemon run` under your own supervisor (tmux, nohup, a custom unit, ...).
 - Linux: installs a systemd user unit (`~/.config/systemd/user/bitfun-cli-daemon.service`) and
   enables linger, so the daemon starts at boot and keeps running without an interactive login
   session. macOS: installs a LaunchAgent. Windows is not supported for auto-start; use
-  `daemon run` in a terminal instead.
+  `daemon run` instead.
 - The interactive CLI detects a running daemon and skips its own relay connection (same-machine
   processes share one `device_id`; last AuthConnect wins). Without a daemon, the interactive CLI
   connects by itself as before.
@@ -105,6 +118,9 @@ Then run:
 ```bash
 bitfun-cli
 ```
+
+On a server that should stay reachable for account multi-device access, continue with the
+[daemon section](#always-on-account-device-host-daemon) above after `/login`.
 
 ### Options / environment
 

--- a/src/apps/cli/README.md
+++ b/src/apps/cli/README.md
@@ -53,6 +53,32 @@ file is created even when the diff is empty.
 live probes for Network, Git, or MCP integrations that are currently represented by compatibility
 registrations.
 
+## Always-on account device host (daemon)
+
+Account multi-device access requires the target device to hold a live relay connection. On a
+server that is usually not true while no interactive CLI is running. The daemon solves this: it is
+a headless Peer Host process that restores the persisted account session and holds the relay
+device-routing connection, so other devices on the account can reach this machine whenever it is
+up.
+
+```bash
+bitfun-cli daemon status      # daemon liveness + auto-start service status
+bitfun-cli daemon install     # register and start the auto-start service (requires /login first)
+bitfun-cli daemon uninstall   # stop and remove the auto-start service
+bitfun-cli daemon run         # foreground mode (used by the service manager; also for debugging)
+```
+
+- Linux: installs a systemd user unit (`~/.config/systemd/user/bitfun-cli-daemon.service`) and
+  enables linger, so the daemon starts at boot and keeps running without an interactive login
+  session. macOS: installs a LaunchAgent. Windows is not supported for auto-start; use
+  `daemon run` in a terminal instead.
+- The interactive CLI detects a running daemon and skips its own relay connection (same-machine
+  processes share one `device_id`; last AuthConnect wins). Without a daemon, the interactive CLI
+  connects by itself as before.
+- Logging out (`/logout`) signals the daemon to shut down so the device goes offline immediately;
+  a daemon whose token is rejected by the relay exits on its own instead of staying "online" with
+  a doomed token.
+
 ## One-click install (Linux / macOS, amd64 + arm64)
 
 From the repository root:

--- a/src/apps/cli/install.sh
+++ b/src/apps/cli/install.sh
@@ -251,6 +251,8 @@ echo ""
 echo "=== Install complete ==="
 echo "Run:  bitfun-cli"
 echo "Login (Peer Host): open /login inside the TUI after start."
+echo "Server use: after /login, run \`bitfun-cli daemon install\` to keep this"
+echo "device reachable by your account even after exit or reboot."
 if ! command -v bitfun-cli >/dev/null 2>&1; then
   echo ""
   echo "Note: \`bitfun-cli\` is not yet visible in this shell's command lookup."

--- a/src/apps/cli/src/account.rs
+++ b/src/apps/cli/src/account.rs
@@ -89,8 +89,7 @@ pub(crate) async fn try_restore_session() -> Option<String> {
 }
 
 /// Whether the relay has reported the account token as expired/invalid.
-/// Intended for the TUI to prompt re-login when account pages open.
-#[allow(dead_code)]
+/// The TUI prompts re-login via this; the daemon exits on it.
 pub(crate) fn is_token_expired() -> bool {
     TOKEN_EXPIRED.load(Ordering::Relaxed)
 }
@@ -159,10 +158,15 @@ pub(crate) async fn login_with_credentials(
 
     TOKEN_EXPIRED.store(false, Ordering::Relaxed);
 
-    let connect_result = spawn_device_routing(relay_url, &device_name).await;
-    let routing_msg = match connect_result {
-        Ok(()) => " Device routing connected (Peer Host ready).".to_string(),
-        Err(e) => format!(" (Warning: device routing failed: {e})"),
+    let routing_msg = if crate::daemon::is_daemon_running() {
+        // The daemon already holds the relay connection; a second connection
+        // from this process would flap the shared device_id registration.
+        " Device routing is handled by the running CLI daemon.".to_string()
+    } else {
+        match spawn_device_routing(relay_url, &device_name).await {
+            Ok(()) => " Device routing connected (Peer Host ready). Tip: `bitfun-cli daemon install` keeps this device reachable after exit or reboot.".to_string(),
+            Err(e) => format!(" (Warning: device routing failed: {e})"),
+        }
     };
 
     Ok(LoginResult {
@@ -270,6 +274,12 @@ async fn is_current_routing_client(client: &Arc<RelayClient>) -> bool {
 /// Log out: tear down routing, revoke the token (best-effort), clear state.
 pub(crate) async fn logout() -> Result<()> {
     stop_device_routing().await;
+    // Take the always-on daemon down with the account: the token is revoked
+    // below, so leaving the daemon connected would keep this device online
+    // with a doomed token until its next reconnect fails.
+    if crate::daemon::request_daemon_shutdown() {
+        tracing::info!("Signalled the CLI daemon to shut down after logout");
+    }
     let result = read_account_context().await;
     if let Ok((session, relay_url)) = result {
         let _ = AccountClient::new()

--- a/src/apps/cli/src/daemon/mod.rs
+++ b/src/apps/cli/src/daemon/mod.rs
@@ -1,0 +1,16 @@
+//! Always-on CLI daemon: keeps this device reachable for account peers by
+//! holding the relay device-routing connection in a headless process.
+//!
+//! The daemon is the single device-routing owner on this machine: interactive
+//! CLI processes detect it via the pid file and skip their own relay
+//! connection (same-machine processes share one `device_id`; last
+//! AuthConnect wins). `install`/`uninstall` register it with the platform
+//! service manager (systemd user unit / LaunchAgent) so it survives reboots.
+
+mod pid;
+mod runner;
+mod service;
+
+pub(crate) use pid::{is_daemon_running, request_daemon_shutdown};
+pub(crate) use runner::run_daemon;
+pub(crate) use service::{install_service, print_status, uninstall_service};

--- a/src/apps/cli/src/daemon/pid.rs
+++ b/src/apps/cli/src/daemon/pid.rs
@@ -1,0 +1,133 @@
+//! PID-file based liveness tracking for the CLI daemon.
+//!
+//! The daemon records its pid in `~/.bitfun/cli_daemon.pid` so interactive
+//! CLI processes can detect a running daemon and yield device routing to it
+//! (same-machine processes share one `device_id`; last AuthConnect wins).
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, Context, Result};
+
+fn default_pid_file_path() -> Result<PathBuf> {
+    let home = dirs::home_dir().ok_or_else(|| anyhow!("cannot determine home directory"))?;
+    Ok(home.join(".bitfun").join("cli_daemon.pid"))
+}
+
+fn write_pid_file_to(path: &Path, pid: u32) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create pid file directory {}", parent.display()))?;
+    }
+    std::fs::write(path, pid.to_string())
+        .with_context(|| format!("write pid file {}", path.display()))
+}
+
+fn read_pid_file_from(path: &Path) -> Option<u32> {
+    std::fs::read_to_string(path).ok()?.trim().parse().ok()
+}
+
+fn remove_pid_file_at(path: &Path) {
+    if let Err(error) = std::fs::remove_file(path) {
+        if error.kind() != std::io::ErrorKind::NotFound {
+            tracing::warn!(
+                "Failed to remove daemon pid file {}: {error}",
+                path.display()
+            );
+        }
+    }
+}
+
+/// Write the current process id to the daemon pid file.
+pub(crate) fn write_pid_file() -> Result<()> {
+    write_pid_file_to(&default_pid_file_path()?, std::process::id())
+}
+
+/// Remove the daemon pid file. Called on daemon shutdown.
+pub(crate) fn remove_pid_file() {
+    if let Ok(path) = default_pid_file_path() {
+        remove_pid_file_at(&path);
+    }
+}
+
+/// Whether a daemon process recorded in the pid file is alive right now.
+pub(crate) fn is_daemon_running() -> bool {
+    default_pid_file_path()
+        .ok()
+        .and_then(|path| read_pid_file_from(&path))
+        .is_some_and(process_alive)
+}
+
+/// Ask a running daemon (if any) to shut down. Returns true when a live
+/// daemon was signalled.
+#[cfg(unix)]
+pub(crate) fn request_daemon_shutdown() -> bool {
+    let Some(pid) = default_pid_file_path()
+        .ok()
+        .and_then(|path| read_pid_file_from(&path))
+    else {
+        return false;
+    };
+    if !process_alive(pid) {
+        return false;
+    }
+    // SAFETY: signalling a recorded pid; no memory involved.
+    unsafe { libc::kill(pid as libc::pid_t, libc::SIGTERM) == 0 }
+}
+
+#[cfg(not(unix))]
+pub(crate) fn request_daemon_shutdown() -> bool {
+    false
+}
+
+/// Whether the given pid refers to a live process.
+#[cfg(unix)]
+pub(crate) fn process_alive(pid: u32) -> bool {
+    // kill(pid, 0) performs error checking without sending a signal.
+    // EPERM means the process exists but is owned by another user.
+    // SAFETY: signal 0 delivers nothing; no memory involved.
+    if unsafe { libc::kill(pid as libc::pid_t, 0) } == 0 {
+        return true;
+    }
+    matches!(
+        std::io::Error::last_os_error().raw_os_error(),
+        Some(libc::EPERM)
+    )
+}
+
+#[cfg(not(unix))]
+pub(crate) fn process_alive(_pid: u32) -> bool {
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pid_file_roundtrip() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("cli_daemon.pid");
+
+        write_pid_file_to(&path, 12345).expect("write pid file");
+        assert_eq!(read_pid_file_from(&path), Some(12345));
+
+        remove_pid_file_at(&path);
+        assert_eq!(read_pid_file_from(&path), None);
+    }
+
+    #[test]
+    fn read_pid_file_rejects_garbage() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("cli_daemon.pid");
+        std::fs::write(&path, "not-a-pid").expect("write garbage");
+        assert_eq!(read_pid_file_from(&path), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn process_alive_detects_self_and_missing() {
+        assert!(process_alive(std::process::id()));
+        // 2^30 is far beyond any realistic pid on Linux/macOS.
+        assert!(!process_alive(1 << 30));
+    }
+}

--- a/src/apps/cli/src/daemon/runner.rs
+++ b/src/apps/cli/src/daemon/runner.rs
@@ -1,0 +1,102 @@
+//! Headless daemon main loop.
+//!
+//! The daemon is a full Peer Device Mode host without the TUI: it initializes
+//! the same core services as the interactive CLI, restores the persisted
+//! account session, and holds the relay device-routing connection so this
+//! device stays reachable whenever the machine is up.
+
+use std::time::Duration;
+
+use anyhow::{anyhow, Result};
+
+use bitfun_core::service::remote_connect::DeviceIdentity;
+
+use crate::{account, runtime, BootstrapProfile};
+
+use super::pid;
+
+/// Run the daemon in the foreground until signalled to stop, or until the
+/// relay rejects the account token (logout / token revoked elsewhere).
+pub(crate) async fn run_daemon() -> Result<()> {
+    if pid::is_daemon_running() {
+        return Err(anyhow!(
+            "another bitfun-cli daemon is already running (see `bitfun-cli daemon status`)"
+        ));
+    }
+
+    // The daemon is not bound to the caller's cwd; peer commands carry their
+    // own workspace paths. Home is a stable root for the runtime context.
+    let workspace_root = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
+    let _runtime = crate::initialize_core_services(
+        &workspace_root,
+        runtime::approval::CliApprovalPolicy::Ask,
+        BootstrapProfile::Interactive,
+    )
+    .await?;
+
+    let Some(user_id) = account::try_restore_session().await else {
+        return Err(anyhow!(
+            "not logged in; run `bitfun-cli`, log in with `/login`, then start the daemon again"
+        ));
+    };
+    tracing::info!("Daemon restored account session for user {user_id}");
+
+    let device =
+        DeviceIdentity::from_current_machine().map_err(|e| anyhow!("detect device: {e}"))?;
+    account::restore_device_routing(&device.device_name).await?;
+
+    pid::write_pid_file()?;
+    tracing::info!("bitfun-cli daemon running (pid {})", std::process::id());
+
+    let mut expired_check = tokio::time::interval(Duration::from_secs(5));
+    expired_check.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        tokio::select! {
+            _ = shutdown_signal() => {
+                tracing::info!("Daemon shutdown signal received");
+                break;
+            }
+            _ = expired_check.tick() => {
+                if account::is_token_expired() {
+                    // Exit 0 on purpose: re-authentication needs a human, so
+                    // Restart=on-failure must not loop the daemon.
+                    tracing::warn!("Account token rejected by the relay; daemon exiting");
+                    break;
+                }
+            }
+        }
+    }
+
+    account::stop_device_routing().await;
+    pid::remove_pid_file();
+    crate::shutdown_mcp_servers().await;
+    tracing::info!("bitfun-cli daemon stopped");
+    Ok(())
+}
+
+#[cfg(unix)]
+async fn shutdown_signal() {
+    use tokio::signal::unix::{signal, SignalKind};
+    match (
+        signal(SignalKind::terminate()),
+        signal(SignalKind::interrupt()),
+    ) {
+        (Ok(mut sigterm), Ok(mut sigint)) => {
+            tokio::select! {
+                _ = sigterm.recv() => {}
+                _ = sigint.recv() => {}
+            }
+        }
+        _ => {
+            tracing::warn!(
+                "Failed to install signal handlers; daemon can only stop on token expiry"
+            );
+            std::future::pending::<()>().await;
+        }
+    }
+}
+
+#[cfg(not(unix))]
+async fn shutdown_signal() {
+    let _ = tokio::signal::ctrl_c().await;
+}

--- a/src/apps/cli/src/daemon/service.rs
+++ b/src/apps/cli/src/daemon/service.rs
@@ -1,0 +1,334 @@
+//! Auto-start service integration for the CLI daemon.
+//!
+//! Linux: systemd user unit + `loginctl enable-linger` so the daemon starts at
+//! boot and keeps running without an interactive login session.
+//! macOS: LaunchAgent (`launchctl bootstrap`).
+//! Other platforms: explicit unsupported error.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, Context, Result};
+
+#[cfg(target_os = "macos")]
+const LAUNCH_AGENT_LABEL: &str = "com.bitfun.cli.daemon";
+
+#[cfg(all(unix, not(target_os = "macos")))]
+const SYSTEMD_UNIT_NAME: &str = "bitfun-cli-daemon.service";
+
+fn current_exe_path() -> Result<PathBuf> {
+    std::env::current_exe().context("resolve current executable path")
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn systemd_unit_path() -> Result<PathBuf> {
+    let config_home = std::env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|home| home.join(".config")))
+        .ok_or_else(|| anyhow!("cannot determine config directory"))?;
+    Ok(config_home.join("systemd/user").join(SYSTEMD_UNIT_NAME))
+}
+
+#[cfg(any(test, all(unix, not(target_os = "macos"))))]
+fn render_systemd_unit(executable: &Path) -> String {
+    format!(
+        "[Unit]\n\
+         Description=BitFun CLI account device host\n\
+         After=network-online.target\n\
+         Wants=network-online.target\n\
+         \n\
+         [Service]\n\
+         Type=simple\n\
+         ExecStart={} daemon run\n\
+         Restart=on-failure\n\
+         RestartSec=5\n\
+         \n\
+         [Install]\n\
+         WantedBy=default.target\n",
+        executable.display()
+    )
+}
+
+#[cfg(target_os = "macos")]
+fn launch_agent_path() -> Result<PathBuf> {
+    let home = dirs::home_dir().ok_or_else(|| anyhow!("cannot determine home directory"))?;
+    Ok(home
+        .join("Library/LaunchAgents")
+        .join(format!("{LAUNCH_AGENT_LABEL}.plist")))
+}
+
+#[cfg(target_os = "macos")]
+fn render_launch_agent(executable: &Path) -> String {
+    format!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+         <!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \
+         \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n\
+         <plist version=\"1.0\">\n\
+         <dict>\n\
+         \t<key>Label</key>\n\
+         \t<string>{LAUNCH_AGENT_LABEL}</string>\n\
+         \t<key>ProgramArguments</key>\n\
+         \t<array>\n\
+         \t\t<string>{}</string>\n\
+         \t\t<string>daemon</string>\n\
+         \t\t<string>run</string>\n\
+         \t</array>\n\
+         \t<key>RunAtLoad</key>\n\
+         \t<true/>\n\
+         \t<key>KeepAlive</key>\n\
+         \t<dict>\n\
+         \t\t<key>Crashed</key>\n\
+         \t\t<true/>\n\
+         \t</dict>\n\
+         </dict>\n\
+         </plist>\n",
+        executable.display()
+    )
+}
+
+fn run_command(program: &str, args: &[&str]) -> Result<std::process::Output> {
+    std::process::Command::new(program)
+        .args(args)
+        .output()
+        .with_context(|| format!("run `{program} {}`", args.join(" ")))
+}
+
+fn ensure_success(program: &str, args: &[&str]) -> Result<()> {
+    let output = run_command(program, args)?;
+    if output.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    Err(anyhow!(
+        "`{program} {}` failed: {}",
+        args.join(" "),
+        stderr.trim()
+    ))
+}
+
+/// Whether the auto-start service unit file exists.
+fn service_unit_installed() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        launch_agent_path().is_ok_and(|path| path.exists())
+    }
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        systemd_unit_path().is_ok_and(|path| path.exists())
+    }
+    #[cfg(not(unix))]
+    {
+        false
+    }
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn install_platform_service(executable: &Path) -> Result<String> {
+    let unit_path = systemd_unit_path()?;
+    if let Some(parent) = unit_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create systemd user directory {}", parent.display()))?;
+    }
+    std::fs::write(&unit_path, render_systemd_unit(executable))
+        .with_context(|| format!("write systemd unit {}", unit_path.display()))?;
+
+    ensure_success("systemctl", &["--user", "daemon-reload"])?;
+    ensure_success(
+        "systemctl",
+        &["--user", "enable", "--now", SYSTEMD_UNIT_NAME],
+    )?;
+
+    // Linger keeps the user manager (and therefore the daemon) running without
+    // an interactive login session, and starts it at boot. This is what makes
+    // the device reachable right after a server reboot.
+    let linger_note = match run_command("loginctl", &["enable-linger"]) {
+        Ok(output) if output.status.success() => {
+            "Linger enabled: the daemon starts at boot without login.".to_string()
+        }
+        _ => format!(
+            "Warning: could not enable linger automatically; run `loginctl enable-linger {}` so the daemon starts at boot.",
+            std::env::var("USER").unwrap_or_else(|_| "<user>".to_string())
+        ),
+    };
+
+    Ok(format!(
+        "Installed and started systemd user service {SYSTEMD_UNIT_NAME} ({}).\n{linger_note}",
+        unit_path.display()
+    ))
+}
+
+#[cfg(target_os = "macos")]
+fn install_platform_service(executable: &Path) -> Result<String> {
+    let plist_path = launch_agent_path()?;
+    if let Some(parent) = plist_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create LaunchAgents directory {}", parent.display()))?;
+    }
+    std::fs::write(&plist_path, render_launch_agent(executable))
+        .with_context(|| format!("write LaunchAgent {}", plist_path.display()))?;
+
+    let uid = unsafe { libc::getuid() };
+    let domain = format!("gui/{uid}");
+    // Best-effort bootout first so reinstall is idempotent.
+    let _ = run_command(
+        "launchctl",
+        &["bootout", &format!("{domain}/{LAUNCH_AGENT_LABEL}")],
+    );
+    ensure_success(
+        "launchctl",
+        &["bootstrap", &domain, &plist_path.to_string_lossy()],
+    )?;
+
+    Ok(format!(
+        "Installed and started LaunchAgent {LAUNCH_AGENT_LABEL} ({}).",
+        plist_path.display()
+    ))
+}
+
+#[cfg(not(unix))]
+fn install_platform_service(_executable: &Path) -> Result<String> {
+    Err(anyhow!(
+        "daemon auto-start service is not supported on this platform; run `bitfun-cli daemon run` in a terminal instead"
+    ))
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn uninstall_platform_service() -> Result<String> {
+    let unit_path = systemd_unit_path()?;
+    if !unit_path.exists() {
+        return Ok("Auto-start service is not installed.".to_string());
+    }
+    // disable --now stops and disables; ignore failure when already stopped.
+    let _ = run_command(
+        "systemctl",
+        &["--user", "disable", "--now", SYSTEMD_UNIT_NAME],
+    );
+    std::fs::remove_file(&unit_path)
+        .with_context(|| format!("remove systemd unit {}", unit_path.display()))?;
+    let _ = run_command("systemctl", &["--user", "daemon-reload"]);
+    Ok("Stopped and removed the systemd user service.".to_string())
+}
+
+#[cfg(target_os = "macos")]
+fn uninstall_platform_service() -> Result<String> {
+    let plist_path = launch_agent_path()?;
+    if !plist_path.exists() {
+        return Ok("Auto-start service is not installed.".to_string());
+    }
+    let uid = unsafe { libc::getuid() };
+    let _ = run_command(
+        "launchctl",
+        &["bootout", &format!("gui/{uid}/{LAUNCH_AGENT_LABEL}")],
+    );
+    std::fs::remove_file(&plist_path)
+        .with_context(|| format!("remove LaunchAgent {}", plist_path.display()))?;
+    Ok("Stopped and removed the LaunchAgent.".to_string())
+}
+
+#[cfg(not(unix))]
+fn uninstall_platform_service() -> Result<String> {
+    Err(anyhow!(
+        "daemon auto-start service is not supported on this platform"
+    ))
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn platform_service_active() -> Option<bool> {
+    let output = run_command("systemctl", &["--user", "is-active", SYSTEMD_UNIT_NAME]).ok()?;
+    Some(output.status.success())
+}
+
+#[cfg(target_os = "macos")]
+fn platform_service_active() -> Option<bool> {
+    let uid = unsafe { libc::getuid() };
+    let output = run_command(
+        "launchctl",
+        &["print", &format!("gui/{uid}/{LAUNCH_AGENT_LABEL}")],
+    )
+    .ok()?;
+    Some(output.status.success())
+}
+
+#[cfg(not(unix))]
+fn platform_service_active() -> Option<bool> {
+    None
+}
+
+/// Install and start the auto-start service. Requires a persisted account
+/// session (the daemon logs in from `~/.bitfun/account_session.enc`).
+pub(crate) fn install_service() -> Result<()> {
+    match bitfun_core::service::remote_connect::session_store::load_session() {
+        Ok(Some(_)) => {}
+        Ok(None) => {
+            return Err(anyhow!(
+                "not logged in; run `bitfun-cli`, log in with `/login`, then re-run `bitfun-cli daemon install`"
+            ));
+        }
+        Err(error) => return Err(anyhow!("read account session: {error}")),
+    }
+
+    let executable = current_exe_path()?;
+    let message = install_platform_service(&executable)?;
+    println!("{message}");
+    Ok(())
+}
+
+/// Stop and remove the auto-start service.
+pub(crate) fn uninstall_service() -> Result<()> {
+    let message = uninstall_platform_service()?;
+    println!("{message}");
+    Ok(())
+}
+
+/// Print daemon liveness and auto-start service status.
+pub(crate) fn print_status() -> Result<()> {
+    let running = super::pid::is_daemon_running();
+    let installed = service_unit_installed();
+    let active = platform_service_active();
+
+    println!(
+        "daemon process: {}",
+        if running { "running" } else { "not running" }
+    );
+    println!(
+        "auto-start service: {}",
+        if installed {
+            "installed"
+        } else {
+            "not installed"
+        }
+    );
+    if let Some(active) = active {
+        println!(
+            "service state: {}",
+            if active { "active" } else { "inactive" }
+        );
+    }
+    if !installed && !running {
+        println!("hint: `bitfun-cli daemon install` keeps this device reachable after reboot");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn systemd_unit_runs_daemon_run_and_restarts_on_failure() {
+        let unit = render_systemd_unit(Path::new("/home/u/.local/bin/bitfun-cli"));
+        assert!(unit.contains("ExecStart=/home/u/.local/bin/bitfun-cli daemon run"));
+        assert!(unit.contains("Restart=on-failure"));
+        assert!(unit.contains("WantedBy=default.target"));
+        assert!(unit.contains("After=network-online.target"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn launch_agent_runs_daemon_run_at_load() {
+        let plist = render_launch_agent(Path::new("/usr/local/bin/bitfun-cli"));
+        assert!(plist.contains("<string>/usr/local/bin/bitfun-cli</string>"));
+        assert!(plist.contains("<string>run</string>"));
+        assert!(plist.contains("<key>RunAtLoad</key>"));
+        assert!(plist.contains(LAUNCH_AGENT_LABEL));
+    }
+}

--- a/src/apps/cli/src/daemon/service.rs
+++ b/src/apps/cli/src/daemon/service.rs
@@ -122,7 +122,21 @@ fn service_unit_installed() -> bool {
 }
 
 #[cfg(all(unix, not(target_os = "macos")))]
+fn ensure_systemd_user_available() -> Result<()> {
+    match run_command("systemctl", &["--user", "show-environment"]) {
+        Ok(output) if output.status.success() => Ok(()),
+        _ => Err(anyhow!(
+            "systemd user session is not available (no user bus; common in containers, WSL, or SSH sessions without systemd --user).\n\
+             Enable a systemd user session for this account, or run the daemon under your own supervisor instead:\n\
+             \x20 bitfun-cli daemon run"
+        )),
+    }
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
 fn install_platform_service(executable: &Path) -> Result<String> {
+    ensure_systemd_user_available()?;
+
     let unit_path = systemd_unit_path()?;
     if let Some(parent) = unit_path.parent() {
         std::fs::create_dir_all(parent)

--- a/src/apps/cli/src/main.rs
+++ b/src/apps/cli/src/main.rs
@@ -12,6 +12,7 @@ mod agent;
 #[allow(dead_code)]
 mod chat_state;
 mod config;
+mod daemon;
 mod diagnostics;
 mod logging;
 mod management;
@@ -182,6 +183,16 @@ enum Commands {
 
     /// Health check
     Health,
+
+    /// Manage the always-on account device host daemon
+    ///
+    /// The daemon holds the relay device-routing connection in a headless
+    /// process so this device stays reachable by account peers whenever the
+    /// machine is up, even without an interactive CLI running.
+    Daemon {
+        #[command(subcommand)]
+        action: DaemonAction,
+    },
 
     /// Start or inspect the Agent Client Protocol (ACP) server
     Acp {
@@ -390,6 +401,18 @@ enum ConfigAction {
     Reset,
 }
 
+#[derive(Subcommand)]
+enum DaemonAction {
+    /// Run the daemon in the foreground (used by the service manager)
+    Run,
+    /// Install and start the auto-start service (systemd user unit / LaunchAgent)
+    Install,
+    /// Stop and remove the auto-start service
+    Uninstall,
+    /// Show daemon and auto-start service status
+    Status,
+}
+
 // ======================== System Initialization ========================
 
 /// Return the current project path. CLI session scope is intentionally cwd-only.
@@ -586,10 +609,18 @@ async fn run_interactive(
     if let Some(user_id) = account::try_restore_session().await {
         tracing::info!("Restored account session for user {user_id}");
         // Re-establish device routing so the CLI becomes RPC-controllable.
-        let device =
-            DeviceIdentity::from_current_machine().map_err(|e| anyhow!("detect device: {e}"))?;
-        if let Err(e) = account::restore_device_routing(&device.device_name).await {
-            tracing::warn!("Failed to restore device routing: {e}");
+        // The daemon owns device routing when it is running: same-machine
+        // processes share one device_id and last AuthConnect wins.
+        if daemon::is_daemon_running() {
+            tracing::info!(
+                "CLI daemon is running; skipping in-process device routing (daemon owns it)"
+            );
+        } else {
+            let device = DeviceIdentity::from_current_machine()
+                .map_err(|e| anyhow!("detect device: {e}"))?;
+            if let Err(e) = account::restore_device_routing(&device.device_name).await {
+                tracing::warn!("Failed to restore device routing: {e}");
+            }
         }
     }
 
@@ -678,6 +709,12 @@ async fn run_cli() -> Result<()> {
 
     let is_tui_mode = matches!(cli.command, None | Some(Commands::Chat { .. }));
     let is_exec_mode = matches!(cli.command, Some(Commands::Exec { .. }));
+    let is_daemon_run = matches!(
+        cli.command,
+        Some(Commands::Daemon {
+            action: DaemonAction::Run,
+        })
+    );
     let file_log_level = logging::default_log_level(cli.verbose);
     let stderr_log_level = if cli.verbose {
         tracing::Level::TRACE
@@ -685,7 +722,7 @@ async fn run_cli() -> Result<()> {
         tracing::Level::ERROR
     };
 
-    if is_tui_mode || is_exec_mode {
+    if is_tui_mode || is_exec_mode || is_daemon_run {
         logging::init_file_logging(file_log_level);
     } else {
         tracing_subscriber::fmt()
@@ -850,6 +887,13 @@ async fn run_cli() -> Result<()> {
         Some(Commands::Health) => {
             root_handlers::handle_health_command()?;
         }
+
+        Some(Commands::Daemon { action }) => match action {
+            DaemonAction::Run => daemon::run_daemon().await?,
+            DaemonAction::Install => daemon::install_service()?,
+            DaemonAction::Uninstall => daemon::uninstall_service()?,
+            DaemonAction::Status => daemon::print_status()?,
+        },
 
         Some(Commands::Acp {
             action: None | Some(AcpAction::Serve),

--- a/src/web-ui/src/app/components/AccountLoginDialog/AccountLoginDialog.tsx
+++ b/src/web-ui/src/app/components/AccountLoginDialog/AccountLoginDialog.tsx
@@ -242,19 +242,10 @@ export const AccountLoginDialog: React.FC<AccountLoginDialogProps> = ({
         }
       },
     );
-    const unlistenSettings = api.listen('account://settings-applied', async () => {
-      try {
-        await configAPI.reloadConfig();
-        configManager.clearCache();
-      } catch (e) {
-        log.warn('Failed to apply settings-applied event', e);
-      }
-    });
 
     return () => {
       if (refreshTimer.current) { clearInterval(refreshTimer.current); refreshTimer.current = null; }
       unlistenPresence();
-      unlistenSettings();
     };
   }, [
     isOpen,

--- a/src/web-ui/src/features/ssh-remote/SSHRemoteProvider.test.tsx
+++ b/src/web-ui/src/features/ssh-remote/SSHRemoteProvider.test.tsx
@@ -8,8 +8,15 @@ import { WorkspaceKind, WorkspaceType } from '@/shared/types/global-state';
 import { notificationService } from '@/shared/notification-system';
 
 import { SSHRemoteProvider } from './SSHRemoteProvider';
+import { SSHContext, type ConnectionStatus } from './SSHRemoteContext';
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const peerModeFlagMock = vi.hoisted(() => ({ active: false }));
+
+vi.mock('@/infrastructure/peer-device/peerModeFlag', () => ({
+  isPeerDeviceModeActive: () => peerModeFlagMock.active,
+}));
 
 const workspaceManagerMock = vi.hoisted(() => ({
   getState: vi.fn(),
@@ -194,5 +201,201 @@ describe('SSHRemoteProvider startup restore', () => {
       'Remote workspace could not reconnect within 180 seconds and was removed: /root/repos',
       { duration: 8000 }
     );
+  });
+});
+
+describe('SSHRemoteProvider peer device mode', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let latestStatuses: Record<string, ConnectionStatus>;
+
+  function StatusProbe() {
+    const ctx = React.useContext(SSHContext);
+    latestStatuses = ctx?.workspaceStatuses ?? {};
+    return null;
+  }
+
+  function createRemoteWorkspace() {
+    return {
+      id: 'ws-remote-1',
+      name: 'repos',
+      rootPath: '/root/repos',
+      workspaceType: WorkspaceType.SingleProject,
+      workspaceKind: WorkspaceKind.Remote,
+      languages: [] as string[],
+      openedAt: new Date().toISOString(),
+      lastAccessed: new Date().toISOString(),
+      tags: [] as string[],
+      connectionId: 'conn-1',
+      connectionName: 'dev-box',
+      sshHost: 'example.com',
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    peerModeFlagMock.active = false;
+    latestStatuses = {};
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    workspaceManagerMock.getState.mockReturnValue({
+      loading: false,
+      openedWorkspaces: new Map(),
+      activeWorkspaceId: null,
+    });
+    workspaceManagerMock.addEventListener.mockReturnValue(() => undefined);
+    workspaceManagerMock.consumeStartupLegacyRemoteWorkspaceSnapshot.mockReturnValue({
+      available: true,
+      workspace: null,
+    });
+    sshApiMock.getWorkspaceInfo.mockResolvedValue(null);
+    sshApiMock.listSavedConnections.mockResolvedValue([]);
+    sshApiMock.isConnected.mockResolvedValue(false);
+    sshApiMock.connect.mockResolvedValue({ success: false, error: 'connection refused' });
+    sshApiMock.openWorkspace.mockResolvedValue(undefined);
+    sshApiMock.removeWorkspace.mockResolvedValue(undefined);
+    workspaceManagerMock.removeRemoteWorkspace.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    peerModeFlagMock.active = false;
+    vi.useRealTimers();
+  });
+
+  async function renderProvider(): Promise<void> {
+    await act(async () => {
+      root.render(
+        <SSHRemoteProvider>
+          <StatusProbe />
+        </SSHRemoteProvider>
+      );
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+
+  function emitWorkspaceManagerEvent(event: unknown): void {
+    const handlers = workspaceManagerMock.addEventListener.mock.calls.map(call => call[0]);
+    act(() => {
+      for (const handler of handlers) {
+        handler(event);
+      }
+    });
+  }
+
+  it('mirrors peer-owned remote workspaces as connected without starting the reconnect timeout', async () => {
+    vi.useFakeTimers();
+    peerModeFlagMock.active = true;
+
+    const remoteWorkspace = createRemoteWorkspace();
+    workspaceManagerMock.getState.mockReturnValue({
+      loading: false,
+      openedWorkspaces: new Map([[remoteWorkspace.id, remoteWorkspace]]),
+      activeWorkspaceId: remoteWorkspace.id,
+    });
+
+    await renderProvider();
+
+    // The peer-mode snapshot must not trigger controller-side reconnect logic.
+    expect(sshApiMock.listSavedConnections).not.toHaveBeenCalled();
+
+    emitWorkspaceManagerEvent({ type: 'workspace:opened', workspace: remoteWorkspace });
+
+    expect(latestStatuses['conn-1']).toBe('connected');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200_000);
+    });
+
+    expect(workspaceManagerMock.removeRemoteWorkspace).not.toHaveBeenCalled();
+    expect(sshApiMock.removeWorkspace).not.toHaveBeenCalled();
+    expect(notificationService.error).not.toHaveBeenCalled();
+  });
+
+  it('cancels the pending reconnect timeout when peer device mode activates', async () => {
+    vi.useFakeTimers();
+
+    const remoteWorkspace = createRemoteWorkspace();
+    await renderProvider();
+
+    // No remote workspaces in local state yet, so the workspace event listener
+    // owns the 'connecting' transition and its 180s removal timeout.
+    emitWorkspaceManagerEvent({ type: 'workspace:opened', workspace: remoteWorkspace });
+    expect(latestStatuses['conn-1']).toBe('connecting');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+
+    // Enter Peer Device Mode mid-timeout: the peer now owns SSH lifecycle.
+    peerModeFlagMock.active = true;
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('peer-mode:changed', { detail: { active: true, deviceId: 'device-b' } })
+      );
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200_000);
+    });
+
+    expect(workspaceManagerMock.removeRemoteWorkspace).not.toHaveBeenCalled();
+    expect(sshApiMock.removeWorkspace).not.toHaveBeenCalled();
+    expect(notificationService.error).not.toHaveBeenCalled();
+  });
+
+  it('does not remove the workspace when an in-flight reconnect budget ends after entering peer mode', async () => {
+    vi.useFakeTimers();
+
+    const remoteWorkspace = createRemoteWorkspace();
+    workspaceManagerMock.getState.mockReturnValue({
+      loading: false,
+      openedWorkspaces: new Map([[remoteWorkspace.id, remoteWorkspace]]),
+      activeWorkspaceId: remoteWorkspace.id,
+    });
+    sshApiMock.listSavedConnections.mockResolvedValue([
+      {
+        id: 'conn-1',
+        name: 'dev-box',
+        host: 'example.com',
+        port: 22,
+        username: 'root',
+        authType: { type: 'PrivateKey', keyPath: '/tmp/id_rsa' },
+      },
+    ]);
+
+    await renderProvider();
+
+    // Local reconnect loop is running with fast-failing connect attempts.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+    expect(sshApiMock.connect.mock.calls.length).toBeGreaterThan(1);
+    const connectCallsBeforePeerMode = sshApiMock.connect.mock.calls.length;
+
+    peerModeFlagMock.active = true;
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('peer-mode:changed', { detail: { active: true, deviceId: 'device-b' } })
+      );
+    });
+
+    // Budget (180s from reconnect start) ends while peer mode is active.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200_000);
+    });
+
+    // No new SSH connects using controller credentials on the peer, no removal,
+    // and no spurious failure notification.
+    expect(sshApiMock.connect.mock.calls.length).toBe(connectCallsBeforePeerMode);
+    expect(workspaceManagerMock.removeRemoteWorkspace).not.toHaveBeenCalled();
+    expect(sshApiMock.removeWorkspace).not.toHaveBeenCalled();
+    expect(notificationService.error).not.toHaveBeenCalled();
   });
 });

--- a/src/web-ui/src/features/ssh-remote/SSHRemoteProvider.tsx
+++ b/src/web-ui/src/features/ssh-remote/SSHRemoteProvider.tsx
@@ -160,6 +160,17 @@ export const SSHRemoteProvider: React.FC<SSHRemoteProviderProps> = ({ children }
     if (st === 'connecting') {
       const timeoutId = window.setTimeout(() => {
         workspaceStatusTimeouts.current.delete(connId);
+
+        // Peer Device Mode: the peer owns SSH connections. Never run the
+        // controller-side timeout removal — it would route removal invokes to
+        // the peer and delete its workspaces.
+        if (isPeerDeviceModeActive()) {
+          setWorkspaceStatuses(prev =>
+            prev[connId] === 'connecting' ? { ...prev, [connId]: 'connected' } : prev
+          );
+          return;
+        }
+
         if (workspaceStatusesRef.current[connId] !== 'connecting') {
           return;
         }
@@ -239,6 +250,15 @@ export const SSHRemoteProvider: React.FC<SSHRemoteProviderProps> = ({ children }
   }, []);
 
   const forgetRemoteWorkspace = useCallback(async (workspace: RemoteWorkspace) => {
+    if (isPeerDeviceModeActive()) {
+      // Removal invokes route to the peer while controlling it; the peer owns
+      // its remote workspaces, so the controller must never delete them.
+      log.info('Skipping remote workspace removal while peer device mode is active', {
+        connectionId: workspace.connectionId,
+        remotePath: workspace.remotePath,
+      });
+      return;
+    }
     log.info('Forgetting remote workspace restore entry', {
       connectionId: workspace.connectionId,
       remotePath: workspace.remotePath,
@@ -251,6 +271,9 @@ export const SSHRemoteProvider: React.FC<SSHRemoteProviderProps> = ({ children }
   }, [clearWorkspaceStatus]);
 
   const reportRemoteWorkspaceReconnectFailure = useCallback((workspace: RemoteWorkspace) => {
+    if (isPeerDeviceModeActive()) {
+      return;
+    }
     const path = normalizeRemoteWorkspacePath(workspace.remotePath);
     notificationService.error(
       `Remote workspace could not reconnect within ${RECONNECT_TIMEOUT_SECONDS} seconds and was removed: ${path}`,
@@ -309,6 +332,11 @@ export const SSHRemoteProvider: React.FC<SSHRemoteProviderProps> = ({ children }
     return reconnectUntilDeadline({
       totalTimeoutMs: timeoutMs,
       attempt: async (attemptTimeoutMs, attempt) => {
+        if (isPeerDeviceModeActive()) {
+          // Abort controller-side reconnects: connecting now would open an SSH
+          // session on the peer with controller-local credentials.
+          throw new Error('Peer device mode activated');
+        }
         log.info(`Attempting to reconnect (attempt ${attempt})`, {
           connectionId: workspace.connectionId,
           host: reconnectConfig.host,
@@ -637,9 +665,17 @@ export const SSHRemoteProvider: React.FC<SSHRemoteProviderProps> = ({ children }
   useEffect(() => {
     const onPeerModeChanged = (event: Event) => {
       const detail = (event as CustomEvent<{ active?: boolean }>).detail;
-      if (detail?.active === true && heartbeatInterval.current) {
-        clearInterval(heartbeatInterval.current);
-        heartbeatInterval.current = null;
+      if (detail?.active === true) {
+        if (heartbeatInterval.current) {
+          clearInterval(heartbeatInterval.current);
+          heartbeatInterval.current = null;
+        }
+        // Cancel pending controller-side reconnect timeouts; the peer owns the
+        // SSH lifecycle now, so these must never fire their removal path.
+        for (const timeoutId of workspaceStatusTimeouts.current.values()) {
+          window.clearTimeout(timeoutId);
+        }
+        workspaceStatusTimeouts.current.clear();
         log.info('Paused SSH heartbeat while peer device mode is active');
       }
     };
@@ -657,7 +693,20 @@ export const SSHRemoteProvider: React.FC<SSHRemoteProviderProps> = ({ children }
         return;
       }
       const connId = workspace.connectionId?.trim();
-      if (connId && !workspaceStatusesRef.current[connId]) {
+      if (!connId) {
+        return;
+      }
+      if (isPeerDeviceModeActive()) {
+        // Peer Device Mode: the peer owns the SSH connection lifecycle. Mirror
+        // its opened remote workspaces as connected and never run the
+        // controller-side reconnect/timeout removal path — those invokes route
+        // to the peer and would delete the peer's workspace.
+        if (workspaceStatusesRef.current[connId] !== 'connected') {
+          setWorkspaceStatus(connId, 'connected');
+        }
+        return;
+      }
+      if (!workspaceStatusesRef.current[connId]) {
         setWorkspaceStatus(connId, 'connecting');
       }
       void checkRemoteWorkspaceRef.current();

--- a/src/web-ui/src/infrastructure/account/settingsAppliedListener.test.ts
+++ b/src/web-ui/src/infrastructure/account/settingsAppliedListener.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  listen: vi.fn(),
+  reloadConfig: vi.fn(),
+  applyExternalReload: vi.fn(),
+}));
+
+vi.mock('@/infrastructure/api/service-api/ApiClient', () => ({
+  api: { listen: mocks.listen },
+}));
+
+vi.mock('@/infrastructure/api/service-api/ConfigAPI', () => ({
+  configAPI: { reloadConfig: mocks.reloadConfig },
+}));
+
+vi.mock('@/infrastructure/config/services/ConfigManager', () => ({
+  configManager: { applyExternalReload: mocks.applyExternalReload },
+}));
+
+vi.mock('@/shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+describe('settingsAppliedListener', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mocks.listen.mockReturnValue(() => undefined);
+    mocks.reloadConfig.mockResolvedValue(undefined);
+    mocks.applyExternalReload.mockResolvedValue(undefined);
+  });
+
+  it('refreshes the config cache when the backend applies cloud settings', async () => {
+    const { ensureSettingsAppliedListener } = await import('./settingsAppliedListener');
+    ensureSettingsAppliedListener();
+
+    expect(mocks.listen).toHaveBeenCalledTimes(1);
+    const [event, handler] = mocks.listen.mock.calls[0];
+    expect(event).toBe('account://settings-applied');
+
+    handler({ applied: true });
+
+    await vi.waitFor(() => {
+      expect(mocks.reloadConfig).toHaveBeenCalledTimes(1);
+      expect(mocks.applyExternalReload).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('registers the listener only once', async () => {
+    const { ensureSettingsAppliedListener } = await import('./settingsAppliedListener');
+    ensureSettingsAppliedListener();
+    ensureSettingsAppliedListener();
+
+    expect(mocks.listen).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/web-ui/src/infrastructure/account/settingsAppliedListener.ts
+++ b/src/web-ui/src/infrastructure/account/settingsAppliedListener.ts
@@ -1,0 +1,39 @@
+/**
+ * Resident listener for account cloud-sync settings application.
+ *
+ * The desktop backend emits `account://settings-applied` after importing a
+ * newer cloud settings blob (login auto-sync and the periodic pull reconcile).
+ * Registered once at app startup so the frontend config cache and
+ * config-driven UI refresh even while the account dialog is closed.
+ */
+import { api } from '@/infrastructure/api/service-api/ApiClient';
+import { configAPI } from '@/infrastructure/api/service-api/ConfigAPI';
+import { configManager } from '@/infrastructure/config/services/ConfigManager';
+import { createLogger } from '@/shared/utils/logger';
+
+const log = createLogger('SettingsAppliedListener');
+
+let settingsAppliedUnlisten: (() => void) | null = null;
+
+async function applyCloudSyncedSettings(): Promise<void> {
+  try {
+    await configAPI.reloadConfig();
+    await configManager.applyExternalReload();
+  } catch (error) {
+    log.warn('Failed to apply cloud-synced settings', error);
+  }
+}
+
+/** Register once so config refresh works while the account dialog is closed. */
+export function ensureSettingsAppliedListener(): void {
+  if (settingsAppliedUnlisten) {
+    return;
+  }
+  try {
+    settingsAppliedUnlisten = api.listen('account://settings-applied', () => {
+      void applyCloudSyncedSettings();
+    });
+  } catch (error) {
+    log.warn('Failed to register settings-applied listener', error);
+  }
+}

--- a/src/web-ui/src/infrastructure/config/services/ConfigManager.test.ts
+++ b/src/web-ui/src/infrastructure/config/services/ConfigManager.test.ts
@@ -331,4 +331,69 @@ describe('ConfigManager', () => {
     expect(migrated[2].metadata.provider_instance_id).not.toBe(firstProviderId);
     expect(configApiMocks.setConfig).toHaveBeenCalledWith('ai.models', migrated);
   });
+
+  it('applyExternalReload notifies listeners only for paths whose value changed', async () => {
+    configApiMocks.getConfig.mockImplementation(async (path?: string) => {
+      if (path === 'editor') return { fontSize: 14 };
+      if (path === 'app.window.mode') return 'compact';
+      return undefined;
+    });
+    await configManager.getConfig('editor');
+    await configManager.getConfig('app.window.mode');
+
+    const changes: Array<{ path: string; oldValue: unknown; newValue: unknown }> = [];
+    const unsubscribe = configManager.onConfigChange((path, oldValue, newValue) => {
+      changes.push({ path, oldValue, newValue });
+    });
+    const watchedPaths: string[] = [];
+    const unwatchKeybindings = configManager.watch('app.keybindings', () => {
+      watchedPaths.push('app.keybindings');
+    });
+    const unwatchEditor = configManager.watch('editor', () => {
+      watchedPaths.push('editor');
+    });
+
+    // Cloud sync changed `editor` only; other tracked paths stay identical.
+    configApiMocks.getConfigs.mockResolvedValueOnce({
+      editor: { fontSize: 16 },
+      'app.window.mode': 'compact',
+      'app.keybindings': undefined,
+    });
+
+    await configManager.applyExternalReload();
+
+    expect(configApiMocks.getConfigs).toHaveBeenCalledTimes(1);
+    expect(changes).toEqual([
+      { path: 'editor', oldValue: { fontSize: 14 }, newValue: { fontSize: 16 } },
+    ]);
+    expect(watchedPaths).toEqual(['editor']);
+    expect(configManager.get('editor')).toEqual({ fontSize: 16 });
+    expect(configManager.get('app.window.mode')).toBe('compact');
+
+    unwatchEditor();
+    unwatchKeybindings();
+    unsubscribe();
+  });
+
+  it('applyExternalReload clears the cache without notifying when the re-read fails', async () => {
+    configApiMocks.getConfig.mockResolvedValueOnce({ fontSize: 14 });
+    await configManager.getConfig('editor');
+
+    const changes: string[] = [];
+    const unsubscribe = configManager.onConfigChange(path => {
+      changes.push(path);
+    });
+
+    configApiMocks.getConfigs.mockRejectedValueOnce(new Error('ipc down'));
+    await configManager.applyExternalReload();
+
+    expect(changes).toEqual([]);
+
+    // Cache was cleared, so the next read fetches the fresh value from the backend.
+    configApiMocks.getConfig.mockResolvedValueOnce({ fontSize: 16 });
+    await expect(configManager.getConfig('editor')).resolves.toEqual({ fontSize: 16 });
+    expect(configApiMocks.getConfig).toHaveBeenCalledWith('editor');
+
+    unsubscribe();
+  });
 });

--- a/src/web-ui/src/infrastructure/config/services/ConfigManager.ts
+++ b/src/web-ui/src/infrastructure/config/services/ConfigManager.ts
@@ -49,6 +49,34 @@ function legacyProviderGroupSeed(model: Record<string, unknown>, index: number):
   return id ? `id:${id}` : `index:${index}`;
 }
 
+/** Structural equality for JSON-shaped config values. */
+function configValuesEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) {
+    return true;
+  }
+  if (typeof a !== typeof b || typeof a !== 'object' || a === null || b === null) {
+    return false;
+  }
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) {
+      return false;
+    }
+    return a.every((item, index) => configValuesEqual(item, b[index]));
+  }
+  const aRecord = a as Record<string, unknown>;
+  const bRecord = b as Record<string, unknown>;
+  const aKeys = Object.keys(aRecord);
+  const bKeys = Object.keys(bRecord);
+  return (
+    aKeys.length === bKeys.length &&
+    aKeys.every(
+      key =>
+        Object.prototype.hasOwnProperty.call(bRecord, key) &&
+        configValuesEqual(aRecord[key], bRecord[key])
+    )
+  );
+}
+
 class ConfigManagerImpl implements IConfigManager {
   
   private configCache: Map<string, any> = new Map();
@@ -545,6 +573,46 @@ class ConfigManagerImpl implements IConfigManager {
     } catch (error) {
       log.error('Failed to reload config', error);
       throw error;
+    }
+  }
+
+  /**
+   * Re-read every cached/watched path after the backend applied an external
+   * config change (e.g. account cloud sync), then notify listeners only for
+   * paths whose value actually changed so config-driven UI refreshes.
+   */
+  async applyExternalReload(): Promise<void> {
+    const trackedPaths = new Set<string>([
+      ...this.configCache.keys(),
+      ...this.pathListeners.keys(),
+    ]);
+
+    const previousValues = new Map<string, unknown>();
+    for (const path of trackedPaths) {
+      if (this.configCache.has(path)) {
+        previousValues.set(path, this.configCache.get(path));
+      }
+    }
+
+    this.clearCache();
+
+    if (trackedPaths.size > 0) {
+      try {
+        await this.readConfigs([...trackedPaths]);
+      } catch (error) {
+        // The cache is already cleared, so later reads still pick up fresh
+        // values; only listener notification is skipped.
+        log.error('Failed to re-read config after external change', error);
+        return;
+      }
+    }
+
+    for (const path of trackedPaths) {
+      const oldValue = previousValues.get(path);
+      const newValue = this.configCache.get(path);
+      if (!configValuesEqual(oldValue, newValue)) {
+        this.notifyConfigChange(path, oldValue, newValue);
+      }
     }
   }
 }

--- a/src/web-ui/src/main.tsx
+++ b/src/web-ui/src/main.tsx
@@ -267,6 +267,12 @@ async function initializeAfterRender(): Promise<void> {
       await installFrontendLogLevelConfigWatcher();
     })(),
     (async () => {
+      const { ensureSettingsAppliedListener } = await import(
+        './infrastructure/account/settingsAppliedListener'
+      );
+      ensureSettingsAppliedListener();
+    })(),
+    (async () => {
       const { themeService } = await import('./infrastructure/theme');
       await themeService.ensureUserThemesLoaded();
     })(),
@@ -299,6 +305,7 @@ async function initializeAfterRender(): Promise<void> {
     const names = [
       'EditorConfigPreload',
       'LogLevelConfigWatcher',
+      'SettingsAppliedListener',
       'UserThemes',
       'DefaultContextTypes',
       'RecommendationProviders',


### PR DESCRIPTION
## Summary

Three account multi-device improvements, each in its own self-contained commit:

1. **`feat(cli)`: always-on account device host daemon** — `bitfun-cli daemon run|install|uninstall|status`. A headless peer host that restores the persisted account session (`~/.bitfun/account_session.enc`) and holds the relay device-routing connection, so a server stays reachable by account peers whenever the machine is up — no interactive CLI required. `daemon install` registers auto-start via a systemd user unit (+ linger) on Linux or a LaunchAgent on macOS, with a fast, actionable error when no systemd user bus exists (containers/WSL) and an explicit unsupported message elsewhere.
2. **`fix(web-ui)`: skip controller-side SSH reconnect and removal in peer device mode** — while controlling a peer, the controller mirrored the peer's remote workspaces as `connecting` and started the 180s removal timeout, but the reconnect path is intentionally paused in peer mode. The timeout then reported a spurious failure and routed removal invokes to the peer, deleting the peer's real remote workspaces.
3. **`feat(account)`: refresh frontend config when cloud settings are applied** — the backend emits `account://settings-applied` after importing a newer cloud settings blob, but the only frontend listener lived in the account dialog while it was open, so config-driven UI stayed stale after a background pull reconcile.

Fixes #

## Type and Areas

Type: Feature, bug fix, docs

Areas: CLI (`src/apps/cli`), web UI (`src/web-ui`), docs

## Motivation / Impact

- **Server multi-device access**: account device presence equals "who holds the relay WebSocket", so a server without a running CLI appeared offline and rejected peer RPCs (HTTP 404). With the daemon, the device is reachable after CLI exit and after reboot (linger starts it before any login). The daemon is a full Peer Device Mode host (reuses `peer_host` + `initialize_core_services`), not a presence placeholder.
- **Peer mode data loss**: controlling a device that had connected SSH remote workspaces would, after 180s, show "Remote workspace connection timed out" and actually close/remove the peer's workspaces and cancel running sessions. The controller now mirrors peer-owned remote workspaces as connected and never runs the reconnect/timeout/removal path in peer mode.
- **Config sync UX**: after another device pushed config changes, the local UI now refreshes immediately when the periodic pull applies them (per-path change notification), instead of staying stale until reload.

## Verification

- `cargo check -p bitfun-cli` — clean, no warnings (macOS and Linux cfg paths).
- `cargo test -p bitfun-cli` — 200 tests pass, including 5 new daemon tests (pid file roundtrip/garbage/liveness, systemd unit and LaunchAgent plist rendering).
- `src/web-ui`: `tsc --noEmit` clean; `vitest run` — SSHRemoteProvider (6, incl. 3 new peer-mode cases), ConfigManager (16, incl. 2 new `applyExternalReload` cases), settingsAppliedListener (2) all pass.
- Live deployment on an Ubuntu server: `daemon install` created and started the systemd user service, linger enabled; logs confirm `CLI peer host services ready`, session restore, and `Device routing auth ok`; `daemon status` reports running/installed/active. Service restart with the new binary verified.
- `bash -n src/apps/cli/install.sh` — syntax clean.

## Reviewer Notes

- The commits are intentionally separable for review: each compiles and tests pass at every commit.
- Daemon/device_id coordination: same-machine processes share one `device_id` (last AuthConnect wins), so the daemon is the single device-routing owner. The interactive CLI and `/login` skip their own relay connection while a daemon runs; `/logout` SIGTERMs the daemon so the device goes offline immediately instead of lingering with a revoked token; a daemon whose token is rejected exits 0 so `Restart=on-failure` does not loop.
- No relay protocol or relay-service changes; presence semantics unchanged. Windows auto-start is explicitly unsupported (`daemon run` still works in a terminal).
- Peer mode fix keeps the existing design where the peer owns the SSH lifecycle; the controller only mirrors state for UI (status dot, FlowChat init key).

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.
