### PR TITLE
fix(account-sync): continuous settings sync for CLI/daemon via shared engine

### DIFF
--- a/docs/architecture/peer-device-mode.md
+++ b/docs/architecture/peer-device-mode.md
@@ -25,6 +25,13 @@ Do **not** treat cloud session blobs as the Remote data plane. Do **not** merge
 cloud session metadata into local disk on login or periodic pull — that pollutes
 A and conflicts with Peer Mode.
 
+Settings sync is continuous on every logged-in host (Desktop, interactive CLI,
+and the CLI daemon): local changes upload after a ~5s debounce (content-hash
+deduped); cloud changes are pulled at process start and then every ~30s. After
+applying or uploading settings, a host fans out `account://settings-applied`
+to attached controllers; the controller re-emits it locally so the frontend
+config cache and model selectors refresh without reconnecting.
+
 SSH `WorkspaceKind.Remote` remains a separate path (local session mirror + remote
 FS) and must not be mixed with Peer Device Mode.
 
@@ -114,6 +121,11 @@ Still use normal `openWorkspace` / create-workspace flows (not SSH
   webview bridge). Device routing in `src/apps/cli/src/account.rs` special-cases
   `HostInvoke` / `DeviceEvent`. Same machine Desktop+CLI share one `device_id`;
   last `AuthConnect` wins.
+- Shared account settings sync engine:
+  `src/crates/assembly/core/src/service/remote_connect/settings_sync.rs`
+  (debounced push, 30s pull, persisted cursor); app wiring in
+  `src/apps/desktop/src/api/remote_connect_api.rs` and
+  `src/apps/cli/src/account_sync.rs`.
 - Frontend mode + transport: `src/web-ui/src/infrastructure/peer-device/`,
   `adapters/peer-device-adapter.ts`
 - Peer directory picker: `pickWorkspaceDirectory.ts`, `PeerDirectoryBrowser.tsx`,

--- a/src/apps/cli/README.md
+++ b/src/apps/cli/README.md
@@ -91,6 +91,30 @@ bitfun-cli daemon run         # foreground mode (used by the service manager; al
 - Logging out (`/logout`) signals the daemon to shut down so the device goes offline immediately;
   a daemon whose token is rejected by the relay exits on its own instead of staying "online" with
   a doomed token.
+- Logs land in `~/.config/bitfun/cli-logs/<session-timestamp>/app.log` (the daemon starts a new
+  session directory per process start).
+
+### Account settings sync
+
+Both the interactive CLI and the daemon continuously sync account settings (model configs,
+default model, agent preferences, ...) with the account cloud:
+
+- Local changes (TUI model picker / model forms, `bitfun-cli models set-default`, or a peer
+  controller's `set_config`) upload after a ~5s debounce, deduped by content hash.
+- Cloud changes from other devices are pulled right after process start, then every ~30s, and
+  applied to the running process (AI client cache invalidated, config reloaded).
+- While a desktop controller is attached (Peer Device Mode), the host fans out
+  `account://settings-applied` after applying or uploading settings, so the controller's
+  model list / settings UI refreshes without reconnecting.
+- The sync cursor persists at `~/.bitfun/account_sync/<user>.settings.json`, so restarts do not
+  re-apply unchanged settings.
+
+### Upgrading
+
+Re-run `bash src/apps/cli/install.sh`. It installs the new binary and restarts the daemon's
+auto-start service when one is installed (a running daemon otherwise keeps executing the old
+binary). If you supervise the daemon yourself (`daemon run` under tmux/nohup/a custom unit),
+restart it manually after upgrading.
 
 ## One-click install (Linux / macOS, amd64 + arm64)
 

--- a/src/apps/cli/install.sh
+++ b/src/apps/cli/install.sh
@@ -10,6 +10,8 @@
 #   2. Install binary to ~/.local/bin/bitfun-cli (override with BITFUN_CLI_BIN_DIR)
 #   3. Idempotently append a PATH block to ~/.bashrc and ~/.zshrc
 #   4. Source the matching rc for the current shell when interactive
+#   5. Restart the account daemon's auto-start service when installed, so
+#      upgrades take effect (a running daemon keeps the old binary otherwise)
 #
 # Supported hosts: Linux/macOS on amd64 (x86_64) and arm64 (aarch64).
 #
@@ -165,6 +167,52 @@ maybe_source_shellrc() {
   esac
 }
 
+# A running daemon keeps executing the previous binary (old inode) until it is
+# restarted; `systemctl enable --now` does NOT restart an already-active
+# service either. Restart the installed auto-start service so upgrades take
+# effect. Best-effort: skips cleanly when nothing is installed.
+restart_daemon_for_upgrade() {
+  local os unit_name agent_label config_home plist uid
+  os="$(uname -s)"
+  unit_name="bitfun-cli-daemon.service"
+  agent_label="com.bitfun.cli.daemon"
+
+  case "$os" in
+    Linux)
+      config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
+      if [ -f "$config_home/systemd/user/$unit_name" ]; then
+        if command -v systemctl >/dev/null 2>&1 && systemctl --user try-restart "$unit_name" 2>/dev/null; then
+          echo "Restarted $unit_name to pick up the new binary."
+        else
+          echo "Note: daemon service installed but could not be restarted from this shell."
+          echo "Run: systemctl --user restart $unit_name"
+        fi
+        return 0
+      fi
+      ;;
+    Darwin)
+      plist="$HOME/Library/LaunchAgents/${agent_label}.plist"
+      if [ -f "$plist" ]; then
+        uid="$(id -u)"
+        if launchctl kickstart -k "gui/${uid}/${agent_label}" 2>/dev/null; then
+          echo "Restarted LaunchAgent ${agent_label} to pick up the new binary."
+        else
+          echo "Note: daemon LaunchAgent installed but could not be restarted."
+          echo "Run: launchctl kickstart -k gui/${uid}/${agent_label}"
+        fi
+        return 0
+      fi
+      ;;
+  esac
+
+  # No auto-start service installed — warn only when a manually supervised
+  # daemon is still running the old binary.
+  if "${BIN_DIR}/bitfun-cli" daemon status 2>/dev/null | grep -q "daemon process: running"; then
+    echo "Note: a running daemon was detected (not service-managed); restart it"
+    echo "so it picks up the new binary."
+  fi
+}
+
 usage() {
   cat <<'EOF'
 BitFun CLI install script
@@ -215,7 +263,7 @@ require_cargo
 mkdir -p "$BIN_DIR"
 
 echo ""
-echo "[1/3] Building bitfun-cli (release)..."
+echo "[1/4] Building bitfun-cli (release)..."
 cd "$REPO_ROOT"
 # Build from workspace root so path deps resolve.
 cargo build -p bitfun-cli --release
@@ -228,13 +276,13 @@ if [ ! -x "$BUILT_BIN" ]; then
 fi
 
 echo ""
-echo "[2/3] Installing binary..."
+echo "[2/4] Installing binary..."
 install -m 755 "$BUILT_BIN" "${BIN_DIR}/bitfun-cli"
 echo "Installed: ${BIN_DIR}/bitfun-cli"
 "${BIN_DIR}/bitfun-cli" --version 2>/dev/null || "${BIN_DIR}/bitfun-cli" -V 2>/dev/null || true
 
 echo ""
-echo "[3/3] Configuring shell PATH..."
+echo "[3/4] Configuring shell PATH..."
 if [ "${BITFUN_CLI_SKIP_SHELLRC:-0}" = "1" ]; then
   echo "Skipped shell rc edits (BITFUN_CLI_SKIP_SHELLRC=1)."
   case ":${PATH}:" in
@@ -246,6 +294,10 @@ else
   upsert_shellrc_path "${HOME}/.zshrc" "$BIN_DIR"
   maybe_source_shellrc "$BIN_DIR"
 fi
+
+echo ""
+echo "[4/4] Restarting account daemon (if installed)..."
+restart_daemon_for_upgrade
 
 echo ""
 echo "=== Install complete ==="

--- a/src/apps/cli/src/account.rs
+++ b/src/apps/cli/src/account.rs
@@ -94,6 +94,12 @@ pub(crate) fn is_token_expired() -> bool {
     TOKEN_EXPIRED.load(Ordering::Relaxed)
 }
 
+/// Mark the account token as rejected by the relay (expired / revoked).
+/// Called by the settings sync engine when a sync request gets a 401.
+pub(crate) fn mark_token_expired() {
+    TOKEN_EXPIRED.store(true, Ordering::Relaxed);
+}
+
 /// Resolve the current device identity (machine-based).
 fn current_device_identity() -> Result<DeviceIdentity> {
     DeviceIdentity::from_current_machine().map_err(|e| anyhow!("detect device: {e}"))

--- a/src/apps/cli/src/account_sync.rs
+++ b/src/apps/cli/src/account_sync.rs
@@ -12,11 +12,59 @@ use tokio::sync::RwLock;
 
 use bitfun_core::product_runtime::CoreAgentRuntimeCompatibility;
 use bitfun_core::service::config::get_global_config_service;
+use bitfun_core::service::remote_connect::settings_sync;
 use bitfun_core::service::remote_connect::{sync_state, AccountClient};
 
 use crate::account::read_account_context;
 
 const UPLOAD_CONCURRENCY_CHUNK: usize = 5;
+
+/// Start the continuous settings sync loop (debounced push + 30s pull).
+/// Started once per process (interactive TUI and daemon); every cycle
+/// silently skips while logged out and converges as soon as an account
+/// session exists. Peer Mode controllers are notified via DeviceEvent when
+/// this host's effective settings change.
+pub(crate) fn start_settings_sync_loop() {
+    let hooks = settings_sync::SettingsSyncHooks {
+        account_context: Some(Arc::new(|| {
+            Box::pin(async { read_account_context().await })
+        })),
+        on_settings_applied: Some(Arc::new(|| {
+            crate::peer_host::notify_controllers_settings_changed();
+        })),
+        on_settings_pushed: Some(Arc::new(|| {
+            crate::peer_host::notify_controllers_settings_changed();
+        })),
+        on_token_expired: Some(Arc::new(|| crate::account::mark_token_expired())),
+        ..Default::default()
+    };
+    settings_sync::start_settings_sync_engine(hooks);
+}
+
+/// Notify the sync loop that local settings changed (TUI edits, peer
+/// `set_config`). Upload is debounced and content-hash deduped.
+pub(crate) fn notify_local_settings_changed() {
+    settings_sync::notify_settings_changed();
+}
+
+/// Best-effort one-shot settings push for short-lived management commands
+/// (e.g. `bitfun models set-default`) where the sync loop never starts.
+/// Silently no-ops when logged out; failures are logged, not fatal.
+pub(crate) async fn push_settings_after_local_change() {
+    // Management commands never restore the persisted account session into
+    // memory — do it on demand so the push can authenticate.
+    if read_account_context().await.is_err() {
+        crate::account::try_restore_session().await;
+    }
+    let Ok((account, relay_url)) = read_account_context().await else {
+        return;
+    };
+    match settings_sync::push_settings_now(&account, &relay_url).await {
+        Ok(true) => tracing::info!("Settings pushed to account cloud"),
+        Ok(false) => {}
+        Err(e) => tracing::warn!("Settings push failed: {e}"),
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SyncStatus {
@@ -184,8 +232,7 @@ pub(crate) async fn run_auto_sync(
             .map_err(|e| anyhow!("export config: {e}"))?;
         let config_json =
             serde_json::to_string(&exported).map_err(|e| anyhow!("serialize config: {e}"))?;
-        client
-            .upload_settings(&relay_url, &acct_session, &config_json)
+        settings_sync::upload_settings_payload(&acct_session, &relay_url, &config_json)
             .await
             .map_err(|e| anyhow!("upload settings: {e}"))?;
         emit_progress("settings_done", 15, None, None, None).await;
@@ -198,25 +245,11 @@ pub(crate) async fn run_auto_sync(
             .map_err(|e| anyhow!("fetch settings: {e}"))?;
         if let Some(blob) = cloud {
             emit_progress("applying_settings", 10, None, None, None).await;
-            let config_value: serde_json::Value = serde_json::from_str(&blob.plaintext)
-                .map_err(|e| anyhow!("parse cloud config: {e}"))?;
-            let inner_config = config_value.get("config").cloned().unwrap_or(config_value);
-            let config_service = get_global_config_service()
+            // Explicit user choice ("use cloud") — always apply, even when the
+            // cursor says this device already has this version.
+            settings_sync::apply_settings_blob(&acct_session, &blob, true)
                 .await
-                .map_err(|e| anyhow!("config service: {e}"))?;
-            let import_result = config_service
-                .import_config_data(inner_config)
-                .await
-                .map_err(|e| anyhow!("import cloud config: {e}"))?;
-            if !import_result.success {
-                return Err(anyhow!(
-                    "import cloud config failed: {}",
-                    import_result.errors.join("; ")
-                ));
-            }
-            if let Err(e) = config_service.reload().await {
-                tracing::warn!("reload after cloud config import failed: {e}");
-            }
+                .map_err(|e| anyhow!("apply cloud config: {e}"))?;
             emit_progress("settings_done", 15, None, None, None).await;
             true
         } else {

--- a/src/apps/cli/src/daemon/runner.rs
+++ b/src/apps/cli/src/daemon/runner.rs
@@ -45,6 +45,11 @@ pub(crate) async fn run_daemon() -> Result<()> {
         DeviceIdentity::from_current_machine().map_err(|e| anyhow!("detect device: {e}"))?;
     account::restore_device_routing(&device.device_name).await?;
 
+    // Continuous account settings sync (30s pull + debounced push) so this
+    // always-on host converges with cloud changes made on other devices and
+    // attached controllers see fresh config without reconnecting.
+    crate::account_sync::start_settings_sync_loop();
+
     pid::write_pid_file()?;
     tracing::info!("bitfun-cli daemon running (pid {})", std::process::id());
 

--- a/src/apps/cli/src/main.rs
+++ b/src/apps/cli/src/main.rs
@@ -625,6 +625,10 @@ async fn run_interactive(
         }
     }
 
+    // 3.6 Continuous account settings sync (30s pull + debounced push).
+    // Safe to start before login: cycles skip while logged out.
+    account_sync::start_settings_sync_loop();
+
     // 4. Show startup page (with full command support)
     let mut startup_page = StartupPage::new(
         config,

--- a/src/apps/cli/src/management.rs
+++ b/src/apps/cli/src/management.rs
@@ -174,6 +174,10 @@ pub(crate) async fn set_default_model(model_id: &str) -> Result<()> {
         .await?;
 
     println!("Default model set to: {}", model_id);
+
+    // Short-lived management process: the sync loop never runs here, so push
+    // the change directly (no-op when logged out).
+    crate::account_sync::push_settings_after_local_change().await;
     Ok(())
 }
 

--- a/src/apps/cli/src/modes/chat/provider_models.rs
+++ b/src/apps/cli/src/modes/chat/provider_models.rs
@@ -123,6 +123,7 @@ impl ChatMode {
             chat_view.set_status(Some(format!("Model added: {}", result.name)));
             chat_state.current_model_name = format!("{} / {}", result.model_name, result.name);
             tracing::info!("Added new AI model: {} ({})", model_id, result.model_name);
+            crate::account_sync::notify_local_settings_changed();
         } else {
             chat_view.set_status(Some("Failed to add model".to_string()));
         }
@@ -252,6 +253,7 @@ impl ChatMode {
             chat_view.set_status(Some(format!("Model updated: {}", result.name)));
             chat_state.current_model_name = format!("{} / {}", result.model_name, result.name);
             tracing::info!("Updated AI model: {}", model_id);
+            crate::account_sync::notify_local_settings_changed();
         } else {
             chat_view.set_status(Some("Failed to update model".to_string()));
         }

--- a/src/apps/cli/src/modes/chat/selection.rs
+++ b/src/apps/cli/src/modes/chat/selection.rs
@@ -430,18 +430,15 @@ impl ChatMode {
                     };
                 }
 
+                crate::account_sync::notify_local_settings_changed();
+
                 ModelSelectionApplyOutcome::Applied {
                     default_persist_error: None,
                 }
             })
         });
 
-        apply_model_selection_feedback(
-            chat_state,
-            &selected_display_name,
-            &selected_id,
-            outcome,
-        );
+        apply_model_selection_feedback(chat_state, &selected_display_name, &selected_id, outcome);
     }
 
     /// Show agent selector popup with all available agent modes
@@ -493,5 +490,4 @@ impl ChatMode {
     }
 
     // ============ MCP management ============
-
 }

--- a/src/apps/cli/src/peer_host/commands/config.rs
+++ b/src/apps/cli/src/peer_host/commands/config.rs
@@ -108,6 +108,10 @@ pub(crate) async fn set_config(args: &Value) -> Result<Value, String> {
         format!("Failed to set config: {e}")
     })?;
 
+    // Config changed on this host via a peer controller — schedule the cloud
+    // push so other same-account devices converge.
+    crate::account_sync::notify_local_settings_changed();
+
     Ok(json!("Configuration set successfully"))
 }
 

--- a/src/apps/cli/src/peer_host/mod.rs
+++ b/src/apps/cli/src/peer_host/mod.rs
@@ -17,6 +17,19 @@ mod workspace_dto;
 pub(crate) use bootstrap::ensure_peer_host_ready;
 pub(crate) use dispatch::{handle_device_event_command, handle_host_invoke};
 
+/// Fan out an `account://settings-applied` DeviceEvent to attached Peer Mode
+/// controllers so they refresh their config cache after this host's settings
+/// changed (cloud pull or local edit). No-op when no controller is attached.
+pub(crate) fn notify_controllers_settings_changed() {
+    tokio::spawn(async {
+        fanout::fanout_peer_device_event(
+            "account://settings-applied".to_string(),
+            serde_json::json!({ "applied": true }),
+        )
+        .await;
+    });
+}
+
 pub(crate) async fn update_controller_presence(online_device_ids: Vec<String>) {
     let lost_last_controller =
         control::retain_online_controllers(online_device_ids.iter().map(String::as_str)).await;

--- a/src/apps/cli/src/ui/startup.rs
+++ b/src/apps/cli/src/ui/startup.rs
@@ -1434,6 +1434,7 @@ impl StartupPage {
         if success {
             self.model_display_name = selected_display_name.clone();
             self.status = Some(format!("Model switched to: {}", selected_display_name));
+            crate::account_sync::notify_local_settings_changed();
         } else {
             self.status = Some("Failed to switch model".to_string());
         }
@@ -1559,6 +1560,7 @@ impl StartupPage {
             self.model_display_name = result_model_display;
             self.status = Some(format!("Model added: {}", result_name));
             tracing::info!("Added new AI model: {}", model_id);
+            crate::account_sync::notify_local_settings_changed();
             // Reload model name display
             self.load_current_model_name();
         } else {
@@ -1682,6 +1684,7 @@ impl StartupPage {
             self.model_display_name = result_model_display;
             self.status = Some(format!("Model updated: {}", result_name));
             tracing::info!("Updated AI model: {}", model_id);
+            crate::account_sync::notify_local_settings_changed();
             self.load_current_model_name();
         } else {
             self.status = Some("Failed to update model".to_string());

--- a/src/apps/desktop/src/api/remote_connect_api.rs
+++ b/src/apps/desktop/src/api/remote_connect_api.rs
@@ -11,6 +11,7 @@ use bitfun_core::service::remote_connect::{
     ConnectionResult, DeviceIdentity, PairingState, RemoteConnectConfig, RemoteConnectService,
 };
 use bitfun_core::service::session::{DialogTurnData, SessionMetadata};
+use bitfun_services_integrations::remote_connect::account::error_indicates_expired_token;
 use futures::stream::{self, StreamExt};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -298,15 +299,6 @@ static TOKEN_EXPIRED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicB
 #[tauri::command]
 pub async fn account_token_expired() -> bool {
     TOKEN_EXPIRED.load(std::sync::atomic::Ordering::Relaxed)
-}
-
-/// Internal helper: check if an error message indicates an invalid/expired token.
-fn error_indicates_expired_token(msg: &str) -> bool {
-    let lower = msg.to_ascii_lowercase();
-    lower.contains("http 401")
-        || lower.contains("unauthorized")
-        || lower.contains("invalid or expired token")
-        || lower.contains("relay auth error")
 }
 
 /// Internal helper: check if an error message indicates HTTP 401.
@@ -1633,10 +1625,14 @@ pub async fn account_delete_synced_session(session_id: String) -> Result<(), Str
 #[tauri::command]
 pub async fn account_sync_settings(settings_json: String) -> Result<(), String> {
     let (session, relay_url) = read_account_context().await?;
-    AccountClient::new()
-        .upload_settings(&relay_url, &session, &settings_json)
-        .await
-        .map_err(|e| format!("{e}"))
+    bitfun_core::service::remote_connect::settings_sync::upload_settings_payload(
+        &session,
+        &relay_url,
+        &settings_json,
+    )
+    .await
+    .map_err(|e| format!("{e}"))?;
+    Ok(())
 }
 
 /// Fetch and decrypt the settings blob. Returns null if none exists.
@@ -2106,17 +2102,14 @@ pub async fn account_auto_sync(
     app_state: State<'_, crate::api::app_state::AppState>,
     path_manager: State<'_, Arc<bitfun_core::infrastructure::PathManager>>,
 ) -> Result<AutoSyncResult, String> {
-    AUTO_SYNC_IN_FLIGHT.store(true, std::sync::atomic::Ordering::SeqCst);
-    let sync_result = account_auto_sync_inner(
+    account_auto_sync_inner(
         is_first_login,
         workspace_path,
         config_json,
         app_state,
         path_manager,
     )
-    .await;
-    AUTO_SYNC_IN_FLIGHT.store(false, std::sync::atomic::Ordering::SeqCst);
-    sync_result
+    .await
 }
 
 async fn account_auto_sync_inner(
@@ -2131,18 +2124,14 @@ async fn account_auto_sync_inner(
     }
     let (acct_session, relay_url) = read_account_context().await?;
     let client = AccountClient::new();
+    use bitfun_core::service::remote_connect::settings_sync;
 
     // 1. Settings sync
     let settings_synced = if is_first_login {
         emit_sync_progress("uploading_settings", 5, None, None, None);
-        client
-            .upload_settings(&relay_url, &acct_session, &config_json)
+        settings_sync::upload_settings_payload(&acct_session, &relay_url, &config_json)
             .await
             .map_err(|e| format!("upload settings: {e}"))?;
-        LAST_SETTINGS_VERSION.store(
-            chrono::Utc::now().timestamp_millis(),
-            std::sync::atomic::Ordering::Relaxed,
-        );
         log::info!("First login: uploaded local settings to cloud");
         emit_sync_progress("settings_done", 15, None, None, None);
         true
@@ -2154,30 +2143,13 @@ async fn account_auto_sync_inner(
             .map_err(|e| format!("fetch settings: {e}"))?;
         if let Some(blob) = cloud {
             emit_sync_progress("applying_settings", 10, None, None, None);
-            let config_value: serde_json::Value = serde_json::from_str(&blob.plaintext)
-                .map_err(|e| format!("parse cloud config: {e}"))?;
-            // Extract the .config field from the ConfigExport wrapper —
-            // the upload path stores the full ConfigExport JSON which has
-            // { config: GlobalConfig, export_timestamp, version }, but
-            // import_config_data expects the inner GlobalConfig directly.
-            let inner_config = config_value.get("config").cloned().unwrap_or(config_value);
-            let import_result = app_state
-                .config_service
-                .import_config_data(inner_config)
+            // Explicit user choice — always apply, even when the cursor says
+            // this device already has this version. Applies into the global
+            // config service, invalidates the AI client cache, reloads, and
+            // emits `account://settings-applied`.
+            settings_sync::apply_settings_blob(&acct_session, &blob, true)
                 .await
-                .map_err(|e| format!("import cloud config: {e}"))?;
-            if !import_result.success {
-                return Err(format!(
-                    "import cloud config failed: {}",
-                    import_result.errors.join("; ")
-                ));
-            }
-            app_state.ai_client_factory.invalidate_cache();
-            if let Err(e) = app_state.config_service.reload().await {
-                log::warn!("reload after cloud config import failed: {e}");
-            }
-            emit_settings_applied();
-            LAST_SETTINGS_VERSION.store(blob.version, std::sync::atomic::Ordering::Relaxed);
+                .map_err(|e| format!("apply cloud config: {e}"))?;
             log::info!(
                 "Applied cloud settings to local device (version={})",
                 blob.version
@@ -2304,22 +2276,15 @@ async fn account_auto_sync_inner(
     })
 }
 
-// ── Auto-sync: debounced upload on session/config changes ──────────────────
+// ── Auto-sync: debounced upload on session changes ─────────────────────────
+//
+// Settings sync (debounced push + 30s pull) is owned by the shared engine in
+// `bitfun_core::service::remote_connect::settings_sync`; this module only
+// keeps the desktop-specific session backup loop and wires engine hooks.
 
 use std::time::Duration;
 use tokio::sync::mpsc;
 
-/// Tracks the last-known cloud settings version so the periodic pull can
-/// skip re-applying unchanged settings. Updated by both the push path
-/// (after upload) and the pull path (after fetch).
-static LAST_SETTINGS_VERSION: std::sync::atomic::AtomicI64 = std::sync::atomic::AtomicI64::new(0);
-
-/// True while `account_auto_sync` is running — periodic pull must not apply
-/// settings we just uploaded (causes mid-sync UI reload).
-static AUTO_SYNC_IN_FLIGHT: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
-
-/// What to sync. `Session` carries the session_id + workspace_path.
 /// What to sync. Each variant maps to a single relay operation.
 #[derive(Debug, Clone)]
 enum SyncRequest {
@@ -2330,18 +2295,49 @@ enum SyncRequest {
     },
     /// Tombstone a session on the relay — fired on delete. Prevents re-import.
     SessionDelete { session_id: String },
-    /// Upload config blob — fired on set_config/import_config/reset_config.
-    Settings,
 }
 
 /// Global channel for notifying the sync background task.
 static SYNC_TX: OnceLock<mpsc::UnboundedSender<SyncRequest>> = OnceLock::new();
 
-/// Called once at app startup to start the debounced sync background task.
+/// Called once at app startup to start the settings sync engine and the
+/// debounced session sync background task.
 pub fn init_auto_sync() {
+    start_settings_sync_engine();
     let (tx, rx) = mpsc::unbounded_channel::<SyncRequest>();
     let _ = SYNC_TX.set(tx);
     tokio::spawn(sync_background_loop(rx));
+}
+
+/// Start the shared settings sync engine with desktop hooks.
+fn start_settings_sync_engine() {
+    use bitfun_core::service::remote_connect::settings_sync;
+    let hooks = settings_sync::SettingsSyncHooks {
+        account_context: Some(std::sync::Arc::new(|| {
+            Box::pin(async { read_account_context().await.map_err(anyhow::Error::msg) })
+        })),
+        should_pause: Some(std::sync::Arc::new(|| {
+            crate::api::peer_host_invoke::is_peer_controller_active()
+        })),
+        on_settings_applied: Some(std::sync::Arc::new(|| {
+            emit_settings_applied();
+            fanout_peer_device_event(
+                "account://settings-applied".to_string(),
+                serde_json::json!({ "applied": true }),
+            );
+        })),
+        on_settings_pushed: Some(std::sync::Arc::new(|| {
+            fanout_peer_device_event(
+                "account://settings-applied".to_string(),
+                serde_json::json!({ "applied": true }),
+            );
+        })),
+        on_token_expired: Some(std::sync::Arc::new(|| {
+            TOKEN_EXPIRED.store(true, std::sync::atomic::Ordering::Relaxed);
+        })),
+        ..Default::default()
+    };
+    settings_sync::start_settings_sync_engine(hooks);
 }
 
 /// Non-blocking notification that a session was created/modified. Called from
@@ -2368,82 +2364,65 @@ pub fn notify_session_deleted(session_id: &str) {
 }
 
 /// Non-blocking notification that config was changed. Called from `set_config`.
+/// Forwards to the shared settings sync engine (debounced + hash-deduped).
 pub fn notify_settings_changed() {
-    if let Some(tx) = SYNC_TX.get() {
-        let _ = tx.send(SyncRequest::Settings);
-    }
+    bitfun_core::service::remote_connect::settings_sync::notify_settings_changed();
 }
 
-/// Background loop: collects sync requests, debounces 5 seconds, then uploads.
+/// Background loop: collects session sync requests, debounces 5 seconds,
+/// then uploads. Settings push/pull is handled by the settings sync engine.
 async fn sync_background_loop(mut rx: mpsc::UnboundedReceiver<SyncRequest>) {
     let debounce = Duration::from_secs(5);
-    let pull_interval = Duration::from_secs(30);
-    let mut next_pull = tokio::time::Instant::now() + pull_interval;
     loop {
-        // Wait for either a sync request (push) or the pull timer
-        let pull_deadline = tokio::time::sleep_until(next_pull);
-        tokio::pin!(pull_deadline);
+        // Wait for the next session sync request, then drain during the
+        // debounce window.
+        let Some(first) = rx.recv().await else {
+            return;
+        };
+        let mut pending_upserts: HashMap<String, String> = HashMap::new();
+        let mut pending_deletes: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
+        match first {
+            SyncRequest::SessionUpsert {
+                session_id,
+                workspace_path,
+            } => {
+                pending_upserts.insert(session_id, workspace_path);
+            }
+            SyncRequest::SessionDelete { session_id } => {
+                pending_deletes.insert(session_id);
+            }
+        }
 
-        tokio::select! {
-            // Push path: collect and debounce
-            Some(first) = rx.recv() => {
-                let mut pending_upserts: HashMap<String, String> = HashMap::new();
-                let mut pending_deletes: std::collections::HashSet<String> =
-                    std::collections::HashSet::new();
-                let mut pending_settings = false;
-                match first {
-                    SyncRequest::SessionUpsert { session_id, workspace_path } => {
-                        pending_upserts.insert(session_id, workspace_path);
-                    }
-                    SyncRequest::SessionDelete { session_id } => {
-                        pending_deletes.insert(session_id);
-                    }
-                    SyncRequest::Settings => {
-                        pending_settings = true;
-                    }
-                }
-
-                // Drain during debounce window
-                let deadline = tokio::time::sleep(debounce);
-                tokio::pin!(deadline);
-                loop {
-                    tokio::select! {
-                        _ = &mut deadline => break,
-                        Some(req) = rx.recv() => {
-                            match req {
-                                SyncRequest::SessionUpsert { session_id, workspace_path } => {
-                                    pending_deletes.remove(&session_id);
-                                    pending_upserts.insert(session_id, workspace_path);
-                                }
-                                SyncRequest::SessionDelete { session_id } => {
-                                    pending_upserts.remove(&session_id);
-                                    pending_deletes.insert(session_id);
-                                }
-                                SyncRequest::Settings => {
-                                    pending_settings = true;
-                                }
-                            }
+        let deadline = tokio::time::sleep(debounce);
+        tokio::pin!(deadline);
+        loop {
+            tokio::select! {
+                _ = &mut deadline => break,
+                Some(req) = rx.recv() => {
+                    match req {
+                        SyncRequest::SessionUpsert { session_id, workspace_path } => {
+                            pending_deletes.remove(&session_id);
+                            pending_upserts.insert(session_id, workspace_path);
+                        }
+                        SyncRequest::SessionDelete { session_id } => {
+                            pending_upserts.remove(&session_id);
+                            pending_deletes.insert(session_id);
                         }
                     }
                 }
-
-                execute_debounced_sync(pending_upserts, pending_deletes, pending_settings).await;
-            }
-            // Pull path: periodic remote fetch + reconcile
-            _ = &mut pull_deadline => {
-                next_pull = tokio::time::Instant::now() + pull_interval;
-                pull_and_reconcile().await;
             }
         }
+
+        execute_debounced_sync(pending_upserts, pending_deletes).await;
     }
 }
 
 /// Execute the debounced sync: upload changed sessions, tombstone deleted
-/// sessions, optionally upload settings.
+/// sessions.
 async fn execute_debounced_sync(
     upserts: HashMap<String, String>,
     deletes: std::collections::HashSet<String>,
-    sync_settings: bool,
 ) {
     if crate::api::peer_host_invoke::is_peer_controller_active() {
         log::debug!("Debounced sync skipped while peer controller mode is active");
@@ -2522,38 +2501,6 @@ async fn execute_debounced_sync(
         }
     }
     let _ = sync_state::save(&acct_session.user_id, &sync_state_local);
-
-    // Upload settings if changed
-    if sync_settings {
-        if let Ok(config_service) = bitfun_core::service::config::get_global_config_service().await
-        {
-            match config_service.export_config().await {
-                Ok(export_data) => {
-                    let json = serde_json::to_string(&export_data).unwrap_or_else(|_| "{}".into());
-                    if let Err(e) = client
-                        .upload_settings(&relay_url, &acct_session, &json)
-                        .await
-                    {
-                        if is_token_expired_error(&e) {
-                            TOKEN_EXPIRED.store(true, std::sync::atomic::Ordering::Relaxed);
-                        }
-                        log::warn!("Auto-sync settings failed: {e}");
-                    } else {
-                        // Record the version we just uploaded so the pull path
-                        // doesn't immediately re-apply our own upload.
-                        LAST_SETTINGS_VERSION.store(
-                            chrono::Utc::now().timestamp_millis(),
-                            std::sync::atomic::Ordering::Relaxed,
-                        );
-                        log::debug!("Auto-synced settings");
-                    }
-                }
-                Err(e) => {
-                    log::warn!("Auto-sync: export config failed: {e}");
-                }
-            }
-        }
-    }
 }
 
 /// Load a single session from disk, serialize to bundle, and upload.
@@ -2763,96 +2710,23 @@ async fn import_session_bundle(bundle_json: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Periodic pull: fetch all remote sessions, import any that don't exist
-/// locally anywhere. Does NOT delete local sessions based on remote
-/// absence — that would risk deleting locally-created sessions that
-/// haven't been uploaded yet. Deletion propagation is handled by the
-/// explicit tombstone call in the SessionDelete sync path (the relay
-/// marks deleted=1, and future pulls simply won't return that session,
-/// so it won't be re-imported).
-///
-/// To avoid cross-workspace duplication, we first collect ALL local
-/// session IDs across ALL workspaces, then only import a remote session
-/// if it doesn't exist in ANY workspace.
+/// One-shot cloud settings pull, triggered when another same-account device
+/// comes online. The periodic pull lives in the shared settings sync engine.
 async fn pull_and_reconcile() {
     if crate::api::peer_host_invoke::is_peer_controller_active() {
         log::debug!("Pull: skip while peer controller mode is active");
         return;
     }
-    let (acct_session, relay_url) = match read_account_context().await {
-        Ok(ctx) => ctx,
-        Err(_) => return,
+    let Ok((acct_session, relay_url)) = read_account_context().await else {
+        return;
     };
-    let client = AccountClient::new();
-
-    // ── Settings pull ──
-    // Fetch the cloud settings blob; if the version changed since our last
-    // known version, apply it locally. Skip while login auto-sync is running —
-    // otherwise we re-apply the settings we just uploaded and flash the UI.
-    if AUTO_SYNC_IN_FLIGHT.load(std::sync::atomic::Ordering::SeqCst) {
-        log::debug!("Pull: skip settings apply while account_auto_sync in flight");
-    } else {
-        match client
-            .fetch_settings_with_version(&relay_url, &acct_session)
-            .await
-        {
-            Ok(Some(blob)) => {
-                let known = LAST_SETTINGS_VERSION.load(std::sync::atomic::Ordering::Relaxed);
-                if blob.version != known {
-                    if let Ok(config_value) =
-                        serde_json::from_str::<serde_json::Value>(&blob.plaintext)
-                    {
-                        let inner_config =
-                            config_value.get("config").cloned().unwrap_or(config_value);
-                        if let Ok(config_service) =
-                            bitfun_core::service::config::get_global_config_service().await
-                        {
-                            match config_service.import_config_data(inner_config).await {
-                                Ok(result) if result.success => {
-                                    LAST_SETTINGS_VERSION
-                                        .store(blob.version, std::sync::atomic::Ordering::Relaxed);
-                                    if let Ok(factory) =
-                                    bitfun_core::infrastructure::ai::AIClientFactory::get_global()
-                                        .await
-                                {
-                                    factory.invalidate_cache();
-                                }
-                                    if let Err(e) = config_service.reload().await {
-                                        log::warn!("Pull: reload after config import failed: {e}");
-                                    }
-                                    emit_settings_applied();
-                                    log::info!(
-                                        "Pull: applied cloud settings (version={})",
-                                        blob.version
-                                    );
-                                }
-                                Ok(result) => {
-                                    log::warn!(
-                                        "Pull: import config unsuccessful: {}",
-                                        result.errors.join("; ")
-                                    );
-                                }
-                                Err(e) => {
-                                    log::warn!("Pull: import config failed: {e}");
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            Ok(None) => {} // no cloud settings yet
-            Err(e) => {
-                if is_token_expired_error(&e) {
-                    TOKEN_EXPIRED.store(true, std::sync::atomic::Ordering::Relaxed);
-                }
-                log::debug!("Pull: fetch_settings failed: {e}");
-            }
+    use bitfun_core::service::remote_connect::settings_sync;
+    if let Err(e) = settings_sync::pull_and_apply_settings(&acct_session, &relay_url).await {
+        if is_token_expired_error(&e) {
+            TOKEN_EXPIRED.store(true, std::sync::atomic::Ordering::Relaxed);
         }
-    } // end AUTO_SYNC_IN_FLIGHT settings guard
-
-    // Session cloud import into local disk is intentionally disabled.
-    // Peer Remote Mode reads the peer device's live session store via HostInvoke;
-    // merging cloud session metadata into this machine pollutes local UX.
+        log::debug!("Pull: fetch_settings failed: {e}");
+    }
 }
 
 #[cfg(test)]

--- a/src/crates/assembly/core/src/service/remote_connect/mod.rs
+++ b/src/crates/assembly/core/src/service/remote_connect/mod.rs
@@ -13,6 +13,7 @@ pub mod embedded_relay;
 pub mod lan;
 pub mod ngrok;
 pub mod remote_server;
+pub mod settings_sync;
 
 pub mod device {
     pub use bitfun_services_integrations::remote_connect::device::*;

--- a/src/crates/assembly/core/src/service/remote_connect/settings_sync.rs
+++ b/src/crates/assembly/core/src/service/remote_connect/settings_sync.rs
@@ -1,0 +1,396 @@
+//! Account cloud settings sync engine, shared by Desktop and CLI.
+//!
+//! Owns the full settings sync lifecycle for one process:
+//! - **Push**: `notify_changed()` marks local settings dirty; a 5s debounce
+//!   later the engine exports the config and uploads it to the relay. Uploads
+//!   are content-hash deduped so identical content is never re-uploaded.
+//! - **Pull**: an immediate pull on start, then every 30s, fetches the cloud
+//!   settings blob and applies it when the relay version differs from the
+//!   last version this device uploaded or applied.
+//! - **Apply**: import into the global config service, reload, invalidate the
+//!   AI client cache, then fire `on_settings_applied` so the host app can
+//!   refresh UI / notify peer controllers.
+//!
+//! The cursor (`version` + content `hash` of the last uploaded/applied blob)
+//! is persisted in `~/.bitfun/account_sync/<user>.settings.json`, separate
+//! from the session sync state, so restarts do not re-apply unchanged blobs
+//! and co-located processes (e.g. CLI daemon + interactive CLI) share one
+//! cursor without racing the session backup writer.
+//!
+//! Apps wire platform behavior through [`SettingsSyncHooks`]; the engine
+//! itself is platform-agnostic.
+
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+
+use anyhow::{anyhow, Result};
+use log::{debug, warn};
+use tokio::sync::mpsc;
+
+use bitfun_services_integrations::remote_connect::account::{
+    error_indicates_expired_token, AccountClient, AccountSession, SettingsBlob,
+};
+use bitfun_services_integrations::remote_connect::sync_state;
+
+/// How often the engine pulls cloud settings.
+pub const SETTINGS_PULL_INTERVAL: Duration = Duration::from_secs(30);
+/// Debounce window between the last local change and the settings upload.
+pub const SETTINGS_PUSH_DEBOUNCE: Duration = Duration::from_secs(5);
+
+/// Account context needed for every relay call: the session (token +
+/// master_key) and the relay base URL.
+pub type AccountContext = (AccountSession, String);
+
+type AccountContextFn = dyn Fn() -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<AccountContext>> + Send>>
+    + Send
+    + Sync;
+
+/// Platform wiring for the settings sync engine. All hooks have no-op
+/// defaults so apps only register what they need.
+#[derive(Default)]
+pub struct SettingsSyncHooks {
+    /// Returns the current account session + relay URL, or an error when
+    /// logged out. Required for the background loop; one-shot helpers take
+    /// the context explicitly.
+    pub account_context: Option<Arc<AccountContextFn>>,
+    /// When true, push and pull are paused (Desktop: Peer controller mode).
+    pub should_pause: Option<Arc<dyn Fn() -> bool + Send + Sync>>,
+    /// Fired after cloud settings were applied to the local config.
+    pub on_settings_applied: Option<Arc<dyn Fn() + Send + Sync>>,
+    /// Fired after local settings were uploaded to the cloud.
+    pub on_settings_pushed: Option<Arc<dyn Fn() + Send + Sync>>,
+    /// Fired when the relay rejected the account token.
+    pub on_token_expired: Option<Arc<dyn Fn() + Send + Sync>>,
+}
+
+static HOOKS: OnceLock<SettingsSyncHooks> = OnceLock::new();
+static STARTED: AtomicBool = AtomicBool::new(false);
+static PUSH_TX: OnceLock<mpsc::UnboundedSender<()>> = OnceLock::new();
+/// Number of uploads/applies currently running (one-shot login sync, loop
+/// push, or loop pull apply). The periodic pull skips while non-zero so it
+/// never re-applies a blob that is mid-upload or fights an explicit
+/// user-chosen direction. A counter (not a flag) so concurrent ops do not
+/// clear each other's in-flight state on completion.
+static SYNC_OPS_IN_FLIGHT: AtomicUsize = AtomicUsize::new(0);
+
+/// RAII guard that marks a sync upload/apply as in flight.
+struct SyncOpGuard;
+impl SyncOpGuard {
+    fn begin() -> Self {
+        SYNC_OPS_IN_FLIGHT.fetch_add(1, Ordering::SeqCst);
+        Self
+    }
+}
+impl Drop for SyncOpGuard {
+    fn drop(&mut self) {
+        SYNC_OPS_IN_FLIGHT.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+fn hooks() -> &'static SettingsSyncHooks {
+    static DEFAULT: SettingsSyncHooks = SettingsSyncHooks {
+        account_context: None,
+        should_pause: None,
+        on_settings_applied: None,
+        on_settings_pushed: None,
+        on_token_expired: None,
+    };
+    HOOKS.get().unwrap_or(&DEFAULT)
+}
+
+fn should_pause() -> bool {
+    hooks().should_pause.as_ref().map(|f| f()).unwrap_or(false)
+}
+
+fn fire_settings_applied() {
+    if let Some(f) = hooks().on_settings_applied.as_ref() {
+        f();
+    }
+}
+
+fn fire_settings_pushed() {
+    if let Some(f) = hooks().on_settings_pushed.as_ref() {
+        f();
+    }
+}
+
+fn fire_token_expired() {
+    if let Some(f) = hooks().on_token_expired.as_ref() {
+        f();
+    }
+}
+
+/// Start the background settings sync loop. Idempotent: later calls are
+/// ignored. Safe to call before login — every cycle silently skips while the
+/// account context is unavailable, and picks up once the user logs in.
+pub fn start_settings_sync_engine(hooks: SettingsSyncHooks) {
+    if STARTED.swap(true, Ordering::SeqCst) {
+        debug!("Settings sync engine already started; ignoring duplicate start");
+        return;
+    }
+    let _ = HOOKS.set(hooks);
+    let (tx, rx) = mpsc::unbounded_channel::<()>();
+    let _ = PUSH_TX.set(tx);
+    tokio::spawn(settings_sync_loop(rx));
+}
+
+/// Notify the engine that local settings changed (config set / import /
+/// reset). Cheap and non-blocking; the upload is debounced and deduped.
+pub fn notify_settings_changed() {
+    if let Some(tx) = PUSH_TX.get() {
+        let _ = tx.send(());
+    }
+}
+
+/// Extract the inner `config` object from a settings payload, tolerating both
+/// the `ConfigExport` wrapper (`{ config, export_timestamp, version }`) and a
+/// bare `GlobalConfig` JSON.
+fn inner_config_value(payload: &str) -> Result<serde_json::Value> {
+    let value: serde_json::Value =
+        serde_json::from_str(payload).map_err(|e| anyhow!("parse settings payload: {e}"))?;
+    Ok(value.get("config").cloned().unwrap_or(value))
+}
+
+/// Hash the canonical config content of a settings payload, ignoring volatile
+/// wrapper fields such as `export_timestamp`.
+fn settings_content_hash(payload: &str) -> Result<String> {
+    let inner = inner_config_value(payload)?;
+    let canonical = serde_json::to_string(&inner)
+        .map_err(|e| anyhow!("serialize settings for hashing: {e}"))?;
+    Ok(sync_state::content_hash(&canonical))
+}
+
+/// Record the settings cursor after a successful upload or apply.
+fn record_settings_cursor(user_id: &str, version: i64, hash: String) {
+    let cursor = sync_state::SettingsCursor { version, hash };
+    if let Err(e) = sync_state::save_settings_cursor(user_id, &cursor) {
+        warn!("Settings sync: failed to persist settings cursor: {e}");
+    }
+}
+
+fn note_relay_error(error: &anyhow::Error, context: &str) {
+    if error_indicates_expired_token(&error.to_string()) {
+        fire_token_expired();
+    }
+    warn!("Settings sync: {context} failed: {error}");
+}
+
+/// Upload a settings payload to the relay and record the cursor.
+/// Returns the version assigned to the upload.
+pub async fn upload_settings_payload(
+    account: &AccountSession,
+    relay_url: &str,
+    payload: &str,
+) -> Result<i64> {
+    let _op = SyncOpGuard::begin();
+    let client = AccountClient::new();
+    // The version returned here is the exact one stored on the relay —
+    // recording it keeps the next pull from re-applying our own upload.
+    let version = client.upload_settings(relay_url, account, payload).await?;
+    let hash = settings_content_hash(payload).unwrap_or_default();
+    record_settings_cursor(&account.user_id, version, hash);
+    debug!("Settings sync: uploaded settings (version={version})");
+    fire_settings_pushed();
+    Ok(version)
+}
+
+/// Export the current config and upload it when the content differs from the
+/// last uploaded/applied blob. Returns `true` when an upload happened.
+pub async fn push_settings_now(account: &AccountSession, relay_url: &str) -> Result<bool> {
+    let config_service = crate::service::config::get_global_config_service()
+        .await
+        .map_err(|e| anyhow!("config service: {e}"))?;
+    let exported = config_service
+        .export_config()
+        .await
+        .map_err(|e| anyhow!("export config: {e}"))?;
+    let payload = serde_json::to_string(&exported).map_err(|e| anyhow!("serialize config: {e}"))?;
+
+    let hash = settings_content_hash(&payload)?;
+    let known = sync_state::load_settings_cursor(&account.user_id);
+    if known.hash == hash && known.version != 0 {
+        debug!("Settings sync: push skipped, content unchanged");
+        return Ok(false);
+    }
+
+    upload_settings_payload(account, relay_url, &payload).await?;
+    Ok(true)
+}
+
+/// Apply a fetched cloud settings blob when its version is newer than the
+/// recorded cursor. Pass `force = true` for explicit user choices (login
+/// "use cloud") so the blob applies even when the version matches the cursor.
+/// Returns `true` when the blob was applied.
+pub async fn apply_settings_blob(
+    account: &AccountSession,
+    blob: &SettingsBlob,
+    force: bool,
+) -> Result<bool> {
+    if !force {
+        let known = sync_state::load_settings_cursor(&account.user_id);
+        if blob.version == known.version {
+            return Ok(false);
+        }
+    }
+    let _op = SyncOpGuard::begin();
+
+    let inner_config = inner_config_value(&blob.plaintext)?;
+    let config_service = crate::service::config::get_global_config_service()
+        .await
+        .map_err(|e| anyhow!("config service: {e}"))?;
+    let import_result = config_service
+        .import_config_data(inner_config)
+        .await
+        .map_err(|e| anyhow!("import cloud config: {e}"))?;
+    if !import_result.success {
+        return Err(anyhow!(
+            "import cloud config failed: {}",
+            import_result.errors.join("; ")
+        ));
+    }
+    if let Ok(factory) = crate::infrastructure::ai::AIClientFactory::get_global().await {
+        factory.invalidate_cache();
+    }
+    // A failed reload leaves in-memory config stale; bail without recording
+    // the cursor so the next pull retries the apply.
+    config_service
+        .reload()
+        .await
+        .map_err(|e| anyhow!("reload after config import: {e}"))?;
+
+    let hash = settings_content_hash(&blob.plaintext).unwrap_or_default();
+    record_settings_cursor(&account.user_id, blob.version, hash);
+    debug!(
+        "Settings sync: applied cloud settings (version={})",
+        blob.version
+    );
+    fire_settings_applied();
+    Ok(true)
+}
+
+/// Fetch the cloud settings blob and apply it when changed. Returns `true`
+/// when new settings were applied; `Ok(false)` also when no cloud settings
+/// exist yet.
+pub async fn pull_and_apply_settings(account: &AccountSession, relay_url: &str) -> Result<bool> {
+    let client = AccountClient::new();
+    let Some(blob) = client
+        .fetch_settings_with_version(relay_url, account)
+        .await?
+    else {
+        return Ok(false);
+    };
+    apply_settings_blob(account, &blob, false).await
+}
+
+async fn account_context() -> Result<AccountContext> {
+    let provider = hooks()
+        .account_context
+        .as_ref()
+        .ok_or_else(|| anyhow!("account context provider not registered"))?;
+    provider().await
+}
+
+async fn push_from_loop() {
+    if should_pause() {
+        debug!("Settings sync: push paused by host app");
+        return;
+    }
+    let (account, relay_url) = match account_context().await {
+        Ok(ctx) => ctx,
+        Err(_) => return, // logged out — silently skip
+    };
+    if let Err(e) = push_settings_now(&account, &relay_url).await {
+        note_relay_error(&e, "push");
+    }
+}
+
+async fn pull_from_loop() {
+    if should_pause() {
+        debug!("Settings sync: pull paused by host app");
+        return;
+    }
+    if SYNC_OPS_IN_FLIGHT.load(Ordering::SeqCst) > 0 {
+        debug!("Settings sync: pull skipped while an upload/apply is in flight");
+        return;
+    }
+    let (account, relay_url) = match account_context().await {
+        Ok(ctx) => ctx,
+        Err(_) => return, // logged out — silently skip
+    };
+    if let Err(e) = pull_and_apply_settings(&account, &relay_url).await {
+        note_relay_error(&e, "pull");
+    }
+}
+
+/// Background loop: debounced push on local change + periodic pull.
+/// The first pull runs immediately so a long-running process (CLI daemon)
+/// converges right after start instead of one interval later.
+async fn settings_sync_loop(mut rx: mpsc::UnboundedReceiver<()>) {
+    let mut next_pull = tokio::time::Instant::now();
+    loop {
+        let pull_deadline = tokio::time::sleep_until(next_pull);
+        tokio::pin!(pull_deadline);
+
+        tokio::select! {
+            Some(()) = rx.recv() => {
+                // Drain further notifications during the debounce window.
+                let deadline = tokio::time::sleep(SETTINGS_PUSH_DEBOUNCE);
+                tokio::pin!(deadline);
+                loop {
+                    tokio::select! {
+                        _ = &mut deadline => break,
+                        Some(()) = rx.recv() => {}
+                    }
+                }
+                push_from_loop().await;
+            }
+            _ = &mut pull_deadline => {
+                next_pull = tokio::time::Instant::now() + SETTINGS_PULL_INTERVAL;
+                pull_from_loop().await;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn content_hash_ignores_export_wrapper_fields() {
+        let a = r#"{"config":{"ai":{"models":[{"id":"m1"}]}},"export_timestamp":"2026-01-01T00:00:00Z","version":"1"}"#;
+        let b = r#"{"config":{"ai":{"models":[{"id":"m1"}]}},"export_timestamp":"2026-02-02T00:00:00Z","version":"2"}"#;
+        assert_eq!(
+            settings_content_hash(a).unwrap(),
+            settings_content_hash(b).unwrap()
+        );
+    }
+
+    #[test]
+    fn content_hash_changes_with_config_content() {
+        let a = r#"{"config":{"ai":{"models":[{"id":"m1"}]}}}"#;
+        let b = r#"{"config":{"ai":{"models":[{"id":"m2"}]}}}"#;
+        assert_ne!(
+            settings_content_hash(a).unwrap(),
+            settings_content_hash(b).unwrap()
+        );
+    }
+
+    #[test]
+    fn content_hash_accepts_bare_config_payload() {
+        let wrapped = r#"{"config":{"ai":{"models":[{"id":"m1"}]}},"export_timestamp":"t"}"#;
+        let bare = r#"{"ai":{"models":[{"id":"m1"}]}}"#;
+        assert_eq!(
+            settings_content_hash(wrapped).unwrap(),
+            settings_content_hash(bare).unwrap()
+        );
+    }
+
+    #[test]
+    fn inner_config_unwraps_export_wrapper() {
+        let payload = r#"{"config":{"a":1},"export_timestamp":"t","version":"v"}"#;
+        let inner = inner_config_value(payload).unwrap();
+        assert_eq!(inner, serde_json::json!({"a": 1}));
+    }
+}

--- a/src/crates/services/services-integrations/src/remote_connect/account.rs
+++ b/src/crates/services/services-integrations/src/remote_connect/account.rs
@@ -183,6 +183,17 @@ pub struct AccountClient {
     http: reqwest::Client,
 }
 
+/// Check whether an account/relay error message indicates an invalid or
+/// expired account token (relay auth failure). Shared by Desktop, CLI, and
+/// the settings sync engine so they all react to the same relay wording.
+pub fn error_indicates_expired_token(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+    lower.contains("http 401")
+        || lower.contains("unauthorized")
+        || lower.contains("invalid or expired token")
+        || lower.contains("relay auth error")
+}
+
 impl Default for AccountClient {
     fn default() -> Self {
         Self::new()
@@ -477,17 +488,20 @@ impl AccountClient {
     }
 
     /// Upload an encrypted settings blob (keyed by the user, not per-device).
+    /// Returns the version sent with the upload so callers can record a sync
+    /// cursor that matches what the relay actually stored.
     pub async fn upload_settings(
         &self,
         relay_url: &str,
         session: &AccountSession,
         plaintext: &str,
-    ) -> Result<()> {
+    ) -> Result<i64> {
         let (data, nonce) = Self::seal(session, plaintext)?;
+        let version = chrono::Utc::now().timestamp_millis();
         let body = serde_json::json!({
             "encrypted_data": data,
             "nonce": nonce,
-            "version": chrono::Utc::now().timestamp_millis(),
+            "version": version,
         });
         let resp = self
             .http
@@ -499,7 +513,7 @@ impl AccountClient {
         if !resp.status().is_success() {
             return Err(Self::into_error(resp).await);
         }
-        Ok(())
+        Ok(version)
     }
 
     /// Fetch and decrypt the settings blob. Returns `None` if no settings exist.

--- a/src/crates/services/services-integrations/src/remote_connect/sync_state.rs
+++ b/src/crates/services/services-integrations/src/remote_connect/sync_state.rs
@@ -3,6 +3,11 @@
 //! Persists per-user state under `~/.bitfun/account_sync/` so incremental
 //! `?since=` pulls and upload dedupe survive app restarts. Not secret —
 //! hashes are of plaintext session bundles; cursors are relay version ints.
+//!
+//! Session sync state (`<user>.json`) and the settings sync cursor
+//! (`<user>.settings.json`) live in separate files on purpose: the session
+//! backup loop and the settings sync engine are independent writers, so a
+//! shared read-modify-write file could drop one writer's update.
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -22,6 +27,18 @@ pub struct AccountSyncState {
     pub uploaded_hashes: HashMap<String, String>,
 }
 
+/// Settings sync progress for one account: the cloud settings blob version
+/// this device last uploaded or applied, plus the content hash of that blob.
+/// Lets the periodic pull skip unchanged blobs across restarts and the push
+/// path skip unchanged content.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SettingsCursor {
+    #[serde(default)]
+    pub version: i64,
+    #[serde(default)]
+    pub hash: String,
+}
+
 /// SHA-256 hex digest of session bundle plaintext (stable skip key).
 pub fn content_hash(plaintext: &str) -> String {
     let digest = Sha256::digest(plaintext.as_bytes());
@@ -33,8 +50,8 @@ fn sync_dir() -> Result<PathBuf> {
     Ok(home.join(".bitfun").join("account_sync"))
 }
 
-fn sync_state_path(user_id: &str) -> Result<PathBuf> {
-    let safe: String = user_id
+fn safe_user_id(user_id: &str) -> String {
+    user_id
         .chars()
         .map(|c| {
             if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
@@ -43,8 +60,15 @@ fn sync_state_path(user_id: &str) -> Result<PathBuf> {
                 '_'
             }
         })
-        .collect();
-    Ok(sync_dir()?.join(format!("{safe}.json")))
+        .collect()
+}
+
+fn sync_state_path(user_id: &str) -> Result<PathBuf> {
+    Ok(sync_dir()?.join(format!("{}.json", safe_user_id(user_id))))
+}
+
+fn settings_cursor_path(user_id: &str) -> Result<PathBuf> {
+    Ok(sync_dir()?.join(format!("{}.settings.json", safe_user_id(user_id))))
 }
 
 /// Load sync state for `user_id`, or a default empty state if missing/corrupt.
@@ -65,6 +89,30 @@ pub fn save(user_id: &str, state: &AccountSyncState) -> Result<()> {
     std::fs::create_dir_all(&dir)?;
     let path = sync_state_path(user_id)?;
     let raw = serde_json::to_string_pretty(state)?;
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, raw)?;
+    std::fs::rename(&tmp, &path)?;
+    Ok(())
+}
+
+/// Load the settings cursor for `user_id`, defaulting when missing/corrupt.
+pub fn load_settings_cursor(user_id: &str) -> SettingsCursor {
+    let path = match settings_cursor_path(user_id) {
+        Ok(p) => p,
+        Err(_) => return SettingsCursor::default(),
+    };
+    match std::fs::read_to_string(&path) {
+        Ok(raw) => serde_json::from_str(&raw).unwrap_or_default(),
+        Err(_) => SettingsCursor::default(),
+    }
+}
+
+/// Persist the settings cursor for `user_id`.
+pub fn save_settings_cursor(user_id: &str, cursor: &SettingsCursor) -> Result<()> {
+    let dir = sync_dir()?;
+    std::fs::create_dir_all(&dir)?;
+    let path = settings_cursor_path(user_id)?;
+    let raw = serde_json::to_string_pretty(cursor)?;
     let tmp = path.with_extension("json.tmp");
     std::fs::write(&tmp, raw)?;
     std::fs::rename(&tmp, &path)?;
@@ -93,5 +141,37 @@ impl AccountSyncState {
             }
         }
         self.last_session_since = max_v;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_state_deserializes() {
+        let legacy = r#"{"last_session_since":7,"uploaded_hashes":{"s1":"abc"}}"#;
+        let state: AccountSyncState = serde_json::from_str(legacy).unwrap();
+        assert_eq!(state.last_session_since, 7);
+        assert_eq!(state.uploaded_hash("s1"), Some("abc"));
+    }
+
+    #[test]
+    fn settings_cursor_round_trips() {
+        let cursor = SettingsCursor {
+            version: 42,
+            hash: "deadbeef".to_string(),
+        };
+        let raw = serde_json::to_string(&cursor).unwrap();
+        let back: SettingsCursor = serde_json::from_str(&raw).unwrap();
+        assert_eq!(back.version, 42);
+        assert_eq!(back.hash, "deadbeef");
+    }
+
+    #[test]
+    fn settings_cursor_defaults_when_missing_fields() {
+        let cursor: SettingsCursor = serde_json::from_str("{}").unwrap();
+        assert_eq!(cursor.version, 0);
+        assert!(cursor.hash.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Only the Desktop app had a settings sync loop (5s debounced push + 30s pull). The interactive CLI synced settings **once at login**, and the always-on CLI daemon **never synced at all** — so a desktop connecting to a server-side CLI via Peer Device Mode saw stale model configs until the CLI process restarted. This unifies both apps on one shared sync engine.

- New shared `SettingsSyncEngine` in `bitfun_core`: debounced content-hash-deduped push, immediate + 30s periodic pull, persisted settings cursor (`~/.bitfun/account_sync/<user>.settings.json`), in-flight guard, token-expiry + pause hooks.
- **CLI**: engine runs in the interactive TUI and the daemon; local changes (TUI model picker/forms, peer `set_config`, `models set-default`) upload; applied settings invalidate the AI client cache; hosts fan out `account://settings-applied` to peer controllers so connected desktops refresh without reconnecting.
- **Desktop**: migrated to the same engine (session backup loop unchanged); fixes version-cursor persistence (no more re-apply flash after restart) and records the exact relay-stored version on upload (no more re-applying own uploads).
- `install.sh` restarts the daemon's auto-start service on upgrade (a running daemon otherwise keeps the old binary; `systemctl enable --now` does not restart an active service); README + peer-device-mode docs updated.

## Type and Areas

Type: bug fix

Areas: Rust core (assembly/core settings sync engine), CLI, desktop/Tauri, docs

## Motivation / Impact

After configuring models (or any synced settings) on one device, other logged-in devices — including always-on CLI daemons on servers — converge within ~30s, and Peer Mode model selectors refresh live without reconnecting. Previously CLI hosts only synced at login and the daemon never synced, so Peer Mode showed stale configs indefinitely.

## Verification

- `cargo check --workspace` — 0 errors; `format-changed-rust.mjs --check` clean.
- New unit tests: engine hash/canonicalization (4), sync-state cursor serde compatibility (3); desktop remote_connect tests (2); CLI suite (213) — all pass.
- Live end-to-end on a real Linux server: built + deployed via `install.sh` and `bitfun-cli daemon install`; added a model on the desktop client; the server daemon applied the cloud settings ~2s after upload (30s pull cadence confirmed in daemon logs, first pull immediate at process start); `bitfun-cli models` on the server lists the new model; the settings cursor file persisted the version.
- Pre-existing failure unrelated to this PR: `interactive_startup_survives_resize_multiline_input_and_emits_cleanup` also fails on the base commit.

AI-assisted: yes (implementation, tests, docs). Testing level: fully tested — unit tests + live end-to-end against a real server daemon. Note: the migrated desktop engine build was verified by compile/unit tests and call-site review; it has not yet been run as a GUI app (the session-backup loop and hook wiring are unchanged in behavior).

## Reviewer Notes

- The first pull now runs immediately at process start (desktop previously waited 30s); with the persisted cursor this is normally a no-op skip.
- Desktop session backup sync (session upload/tombstone) is intentionally unchanged.
- `AccountClient::upload_settings` now returns the relay-stored version so the cursor matches the server exactly.
- `docs/superpowers/specs/2026-07-14-cli-account-sync-panel-design.md` listed this continuous sync as a follow-up; this PR implements it.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.