### PR TITLE
feat(settings): move session title config into Models settings

### DIFF
--- a/src/apps/desktop/tauri.dev.conf.json
+++ b/src/apps/desktop/tauri.dev.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "BitFun",
-  "identifier": "com.bitfun.desktop",
+  "identifier": "com.bitfun.desktop.dev",
   "build": {
     "beforeDevCommand": "pnpm run dev:web",
     "devUrl": "http://localhost:1422",

--- a/src/web-ui/src/app/scenes/settings/settingsConfig.ts
+++ b/src/web-ui/src/app/scenes/settings/settingsConfig.ts
@@ -96,6 +96,9 @@ export const SETTINGS_CATEGORIES: ConfigCategoryDef[] = [
           'model',
           'temperature',
           'token',
+          'session title',
+          'auto title',
+          'subagent',
         ],
       },
       {
@@ -135,7 +138,6 @@ export const SETTINGS_CATEGORIES: ConfigCategoryDef[] = [
         descriptionKey: 'configCenter.tabDescriptions.sessionPersonalization',
         keywords: [
           'session',
-          'title',
           'companion',
           'agent',
           'pixel',

--- a/src/web-ui/src/app/scenes/settings/settingsTabSearchContent.ts
+++ b/src/web-ui/src/app/scenes/settings/settingsTabSearchContent.ts
@@ -41,6 +41,9 @@ export const SETTINGS_TAB_SEARCH_CONTENT: Record<ConfigTab, readonly SettingsTab
     { ns: 'settings/default-model', key: 'subtitle' },
     { ns: 'settings/default-model', key: 'tabs.models' },
     { ns: 'settings/ai-model', key: 'subtitle' },
+    { ns: 'settings/ai-model', key: 'subagentModels.title' },
+    { ns: 'settings/ai-model', key: 'sessionTitle.title' },
+    { ns: 'settings/ai-model', key: 'sessionTitle.subtitle' },
     { ns: 'settings/default-model', key: 'tabs.proxy' },
     { ns: 'settings/ai-model', key: 'proxy.enableHint' },
   ],
@@ -56,11 +59,8 @@ export const SETTINGS_TAB_SEARCH_CONTENT: Record<ConfigTab, readonly SettingsTab
   'session-personalization': [
     { ns: 'settings/session-config', key: 'personalizationPage.title' },
     { ns: 'settings/session-config', key: 'personalizationPage.subtitle' },
-    { ns: 'settings/session-config', key: 'features.sessionTitle.title' },
-    { ns: 'settings/session-config', key: 'features.sessionTitle.subtitle' },
     { ns: 'settings/session-config', key: 'features.agentCompanion.title' },
     { ns: 'settings/session-config', key: 'features.agentCompanion.subtitle' },
-    { ns: 'settings/session-config', key: 'models.empty' },
   ],
 
   'session-permissions': [

--- a/src/web-ui/src/infrastructure/config/components/AIModelConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/AIModelConfig.tsx
@@ -18,6 +18,7 @@ import { useNotification } from '@/shared/notification-system';
 import { ConfigPageHeader, ConfigPageLayout, ConfigPageContent, ConfigPageSection, ConfigPageRow, ConfigCollectionItem } from './common';
 import DefaultModelConfig from './DefaultModelConfig';
 import SubagentModelConfig from './SubagentModelConfig';
+import SessionTitleConfig from './SessionTitleConfig';
 import { createLogger } from '@/shared/utils/logger';
 import { translateConnectionTestMessage } from '@/shared/utils/aiConnectionTestMessages';
 import { i18nService } from '@/infrastructure/i18n';
@@ -2584,6 +2585,8 @@ const AIModelConfig: React.FC = () => {
         <ConfigPageSection title={t('subagentModels.title')}>
           <SubagentModelConfig />
         </ConfigPageSection>
+
+        <SessionTitleConfig />
 
         <ConfigPageSection
           title={t('cliAuth.sectionTitle')}

--- a/src/web-ui/src/infrastructure/config/components/SessionConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/SessionConfig.tsx
@@ -29,14 +29,13 @@ import {
 import { configManager } from '../services/ConfigManager';
 import { systemAPI } from '@/infrastructure/api/service-api/SystemAPI';
 import { useNotification, notificationService } from '@/shared/notification-system';
-import type { AIModelConfig, DebugModeConfig, LanguageDebugTemplate } from '../types';
+import type { DebugModeConfig, LanguageDebugTemplate } from '../types';
 import {
   LANGUAGE_TEMPLATE_LABELS,
   DEFAULT_DEBUG_MODE_CONFIG,
   ALL_LANGUAGES,
   DEFAULT_LANGUAGE_TEMPLATES,
 } from '../types';
-import { ModelSelectionRadio } from './ModelSelectionRadio';
 import { ChatInputPixelPet } from '@/flow_chat/components/ChatInputPixelPet';
 import { ask, open } from '@tauri-apps/plugin-dialog';
 import { createLogger } from '@/shared/utils/logger';
@@ -46,8 +45,6 @@ import './DebugConfig.scss';
 const log = createLogger('SessionSettingsPanels');
 
 const IS_TAURI_DESKTOP = typeof window !== 'undefined' && '__TAURI__' in window;
-
-const AGENT_SESSION_TITLE = 'session-title-func-agent';
 
 type ComputerUseStatusPayload = {
   computerUseEnabled: boolean;
@@ -103,8 +100,6 @@ const SessionSettingsPanels: React.FC<SessionSettingsPanelsProps> = ({ variant }
   const [companionPetImporting, setCompanionPetImporting] = useState(false);
   const [companionPetDeletingPath, setCompanionPetDeletingPath] = useState<string | null>(null);
   const [companionPetListExpanded, setCompanionPetListExpanded] = useState(false);
-  const [models, setModels] = useState<AIModelConfig[]>([]);
-  const [funcAgentModels, setFuncAgentModels] = useState<Record<string, string>>({});
   const [skipToolConfirmation, setSkipToolConfirmation] = useState(true);
   const [enableDeferredToolLoading, setEnableDeferredToolLoading] = useState(true);
   const [subagentMaxConcurrency, setSubagentMaxConcurrency] = useState(DEFAULT_SUBAGENT_MAX_CONCURRENCY);
@@ -209,8 +204,6 @@ const SessionSettingsPanels: React.FC<SessionSettingsPanelsProps> = ({ variant }
     try {
       const [
         loadedSettings,
-        allModels,
-        funcAgentModelsData,
         skipConfirm,
         deferredToolLoadingEnabled,
         loadedSubagentMaxConcurrency,
@@ -223,8 +216,6 @@ const SessionSettingsPanels: React.FC<SessionSettingsPanelsProps> = ({ variant }
         loadedCompanionPets,
       ] = await Promise.all([
         aiExperienceConfigService.getSettingsAsync(),
-        configManager.getConfig<AIModelConfig[]>('ai.models') || [],
-        configManager.getConfig<Record<string, string>>('ai.func_agent_models') || {},
         configManager.getConfig<boolean>('ai.skip_tool_confirmation'),
         configManager.getConfig<boolean>('ai.enable_deferred_tool_loading'),
         configManager.getConfig<number | null>('ai.subagent_max_concurrency'),
@@ -239,8 +230,6 @@ const SessionSettingsPanels: React.FC<SessionSettingsPanelsProps> = ({ variant }
 
       setSettings(loadedSettings);
       setCompanionPets(loadedCompanionPets);
-      setModels(allModels as AIModelConfig[]);
-      setFuncAgentModels(funcAgentModelsData as Record<string, string>);
       setSkipToolConfirmation(skipConfirm ?? true);
       setEnableDeferredToolLoading(deferredToolLoadingEnabled ?? true);
       setSubagentMaxConcurrency(loadedSubagentMaxConcurrency != null
@@ -429,37 +418,6 @@ const SessionSettingsPanels: React.FC<SessionSettingsPanelsProps> = ({ variant }
       spritesheetMimeType: pet.spritesheetMimeType,
     });
     setCompanionPetListExpanded(false);
-  };
-
-  const getModelName = useCallback((modelId: string | null | undefined): string | undefined => {
-    if (!modelId) return undefined;
-    return models.find(m => m.id === modelId)?.name;
-  }, [models]);
-
-  const handleAgentModelChange = async (agentKey: string, featureTitleKey: string, modelId: string) => {
-    try {
-      const current = await configManager.getConfig<Record<string, string>>('ai.func_agent_models') || {};
-      const updated = { ...current, [agentKey]: modelId };
-      await configManager.setConfig('ai.func_agent_models', updated);
-      setFuncAgentModels(updated);
-
-      let modelDesc = '';
-      if (modelId === 'primary') {
-        modelDesc = t('model.primary');
-      } else if (modelId === 'fast') {
-        modelDesc = t('model.fast');
-      } else {
-        modelDesc = getModelName(modelId) || modelId || '';
-      }
-
-      notificationService.success(
-        t('models.updateSuccess', { agentName: t(featureTitleKey), modelName: modelDesc }),
-        { duration: 2000 }
-      );
-    } catch (error) {
-      log.error('Failed to update agent model', { agentKey, modelId, error });
-      notificationService.error(t('messages.updateFailed'), { duration: 3000 });
-    }
   };
 
   const handleSkipToolConfirmationChange = async (checked: boolean) => {
@@ -812,8 +770,6 @@ const SessionSettingsPanels: React.FC<SessionSettingsPanelsProps> = ({ variant }
 
   // ── Derived values ───────────────────────────────────────────────────────
 
-  const enabledModels = models.filter((m: AIModelConfig) => m.enabled);
-  const sessionTitleModelId = funcAgentModels[AGENT_SESSION_TITLE] || 'fast';
   const templateEntries = getTemplateEntries();
   const computerUseAccessLabel = computerUseStatusLoading
     ? t('loading.text')
@@ -856,38 +812,6 @@ const SessionSettingsPanels: React.FC<SessionSettingsPanelsProps> = ({ variant }
 
         {variant === 'personalization' ? (
           <>
-
-        {/* ── Auto session title ─────────────────────────────────── */}
-        <ConfigPageSection
-          title={t('features.sessionTitle.title')}
-          description={t('features.sessionTitle.subtitle')}
-        >
-          <ConfigPageRow label={t('common.enable')} align="center">
-            <div className="bitfun-func-agent-config__row-control">
-              <Switch
-                checked={settings.enable_session_title_generation}
-                onChange={(e) => updateSetting('enable_session_title_generation', e.target.checked)}
-                size="small"
-              />
-            </div>
-          </ConfigPageRow>
-          <ConfigPageRow
-            className="bitfun-func-agent-config__model-row"
-            label={t('model.label')}
-            description={enabledModels.length === 0 ? t('models.empty') : undefined}
-            align="center"
-          >
-            <div className="bitfun-func-agent-config__row-control bitfun-func-agent-config__row-control--model">
-              <ModelSelectionRadio
-                value={sessionTitleModelId}
-                models={enabledModels}
-                onChange={(modelId) => handleAgentModelChange(AGENT_SESSION_TITLE, 'features.sessionTitle.title', modelId)}
-                layout="horizontal"
-                size="small"
-              />
-            </div>
-          </ConfigPageRow>
-        </ConfigPageSection>
 
         {/* ── Agent companion (collapsed input) ─────────────────── */}
         <ConfigPageSection

--- a/src/web-ui/src/infrastructure/config/components/SessionTitleConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/SessionTitleConfig.tsx
@@ -1,0 +1,147 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Switch } from '@/component-library';
+import { useNotification, notificationService } from '@/shared/notification-system';
+import { createLogger } from '@/shared/utils/logger';
+import { aiExperienceConfigService, type AIExperienceSettings } from '../services/AIExperienceConfigService';
+import { configManager } from '../services/ConfigManager';
+import type { AIModelConfig } from '../types';
+import { ConfigPageRow, ConfigPageSection } from './common';
+import { ModelSelectionRadio } from './ModelSelectionRadio';
+import './AIFeaturesConfig.scss';
+
+const log = createLogger('SessionTitleConfig');
+
+const AGENT_SESSION_TITLE = 'session-title-func-agent';
+
+export const SessionTitleConfig: React.FC = () => {
+  const { t } = useTranslation('settings/ai-model');
+  const notification = useNotification();
+  const [isLoading, setIsLoading] = useState(true);
+  const [settings, setSettings] = useState<AIExperienceSettings | null>(null);
+  const [models, setModels] = useState<AIModelConfig[]>([]);
+  const [funcAgentModels, setFuncAgentModels] = useState<Record<string, string>>({});
+
+  const loadData = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const [loadedSettings, allModels, funcAgentModelsData] = await Promise.all([
+        aiExperienceConfigService.getSettingsAsync(),
+        configManager.getConfig<AIModelConfig[]>('ai.models') || [],
+        configManager.getConfig<Record<string, string>>('ai.func_agent_models') || {},
+      ]);
+      setSettings(loadedSettings);
+      setModels(allModels ?? []);
+      setFuncAgentModels(funcAgentModelsData ?? {});
+    } catch (error) {
+      log.error('Failed to load session title config', error);
+      notification.error(t('sessionTitle.loadFailed'));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [notification, t]);
+
+  useEffect(() => {
+    void loadData();
+    const unwatchModels = configManager.watch('ai.models', () => void loadData());
+    const unwatchFuncAgentModels = configManager.watch('ai.func_agent_models', () => void loadData());
+    const unwatchSettings = aiExperienceConfigService.addChangeListener((next) => {
+      setSettings(next);
+    });
+    return () => {
+      unwatchModels();
+      unwatchFuncAgentModels();
+      unwatchSettings();
+    };
+  }, [loadData]);
+
+  const enabledModels = models.filter((model) => model.enabled);
+  const sessionTitleModelId = funcAgentModels[AGENT_SESSION_TITLE] || 'fast';
+
+  const updateEnabled = async (checked: boolean) => {
+    if (!settings) return;
+    const previous = settings;
+    const next = { ...settings, enable_session_title_generation: checked };
+    setSettings(next);
+    try {
+      await aiExperienceConfigService.saveSettings(next);
+      notification.success(t('sessionTitle.messages.saveSuccess'));
+    } catch (error) {
+      log.error('Failed to save session title enable setting', error);
+      notification.error(t('sessionTitle.messages.saveFailed'));
+      setSettings(previous);
+    }
+  };
+
+  const getModelName = useCallback((modelId: string | null | undefined): string | undefined => {
+    if (!modelId) return undefined;
+    return models.find((model) => model.id === modelId)?.name;
+  }, [models]);
+
+  const handleModelChange = async (modelId: string) => {
+    try {
+      const current = await configManager.getConfig<Record<string, string>>('ai.func_agent_models') || {};
+      const updated = { ...current, [AGENT_SESSION_TITLE]: modelId };
+      await configManager.setConfig('ai.func_agent_models', updated);
+      setFuncAgentModels(updated);
+
+      let modelDesc = '';
+      if (modelId === 'primary') {
+        modelDesc = t('sessionTitle.model.primary');
+      } else if (modelId === 'fast') {
+        modelDesc = t('sessionTitle.model.fast');
+      } else {
+        modelDesc = getModelName(modelId) || modelId || '';
+      }
+
+      notificationService.success(
+        t('sessionTitle.models.updateSuccess', {
+          agentName: t('sessionTitle.title'),
+          modelName: modelDesc,
+        }),
+        { duration: 2000 },
+      );
+    } catch (error) {
+      log.error('Failed to update session title model', { modelId, error });
+      notificationService.error(t('sessionTitle.messages.updateFailed'), { duration: 3000 });
+    }
+  };
+
+  return (
+    <ConfigPageSection
+      className="bitfun-func-agent-config"
+      title={t('sessionTitle.title')}
+      description={t('sessionTitle.subtitle')}
+    >
+      <ConfigPageRow label={t('sessionTitle.enable')} align="center">
+        <div className="bitfun-func-agent-config__row-control">
+          <Switch
+            checked={settings?.enable_session_title_generation ?? false}
+            onChange={(e) => void updateEnabled(e.target.checked)}
+            size="small"
+            disabled={isLoading || !settings}
+          />
+        </div>
+      </ConfigPageRow>
+      <ConfigPageRow
+        className="bitfun-func-agent-config__model-row"
+        label={t('sessionTitle.model.label')}
+        description={enabledModels.length === 0 ? t('sessionTitle.models.empty') : undefined}
+        align="center"
+      >
+        <div className="bitfun-func-agent-config__row-control bitfun-func-agent-config__row-control--model">
+          <ModelSelectionRadio
+            value={sessionTitleModelId}
+            models={enabledModels}
+            onChange={(modelId) => void handleModelChange(modelId)}
+            layout="horizontal"
+            size="small"
+            disabled={isLoading}
+          />
+        </div>
+      </ConfigPageRow>
+    </ConfigPageSection>
+  );
+};
+
+export default SessionTitleConfig;

--- a/src/web-ui/src/locales/en-US/settings.json
+++ b/src/web-ui/src/locales/en-US/settings.json
@@ -17,8 +17,8 @@
     "tabDescriptions": {
       "basics": "Logging, terminal shell, notifications, and launch at login.",
       "appearance": "Language, theme, and UI font size.",
-      "models": "AI models, API keys, providers, and proxy.",
-      "sessionPersonalization": "Session title and Agent companion.",
+      "models": "AI models, API keys, providers, proxy, and session title.",
+      "sessionPersonalization": "Agent companion.",
       "sessionPermissions": "Accelerated workspace search, tool confirmation, Computer use, browser, and debug.",
       "quickActions": "One-click AI actions after coding. Built-in and customizable prompts.",
       "review": "Review strategy, coverage depth, capacity, cost, and latency controls.",

--- a/src/web-ui/src/locales/en-US/settings/ai-model.json
+++ b/src/web-ui/src/locales/en-US/settings/ai-model.json
@@ -23,6 +23,26 @@
     },
     "loadFailed": "Failed to load Subagent model settings"
   },
+  "sessionTitle": {
+    "title": "Auto Session Title",
+    "subtitle": "AI automatically generates concise titles for new conversations",
+    "enable": "Enable",
+    "loadFailed": "Failed to load session title settings",
+    "model": {
+      "label": "Model",
+      "primary": "Primary Model",
+      "fast": "Fast Model"
+    },
+    "models": {
+      "empty": "No available models. Please add models in \"Models\" first.",
+      "updateSuccess": "{{agentName}} will use {{modelName}}"
+    },
+    "messages": {
+      "saveSuccess": "Settings saved",
+      "saveFailed": "Save failed",
+      "updateFailed": "Update failed"
+    }
+  },
   "cliAuth": {
     "sectionTitle": "Local CLI accounts",
     "sectionDescription": "Import Codex CLI / Gemini CLI accounts already signed in on this machine and use them as models",

--- a/src/web-ui/src/locales/en-US/settings/session-config.json
+++ b/src/web-ui/src/locales/en-US/settings/session-config.json
@@ -1,18 +1,13 @@
 {
   "personalizationPage": {
     "title": "Personalization",
-    "subtitle": "Auto session title and Agent companion"
+    "subtitle": "Personalize your BitFun"
   },
   "permissionsPage": {
     "title": "Permission management",
     "subtitle": "Accelerated workspace search, tool execution, tool definition loading, Computer use, browser control, and debug mode"
   },
   "features": {
-    "sessionTitle": {
-      "title": "Auto Session Title",
-      "subtitle": "AI automatically generates concise titles for new conversations",
-      "warning": "Session title will use first 20 characters of user message"
-    },
     "agentCompanion": {
       "title": "Agent companion",
       "subtitle": "Control where the BitFun companion appears.",
@@ -101,17 +96,8 @@
     "createLauncherDesc": "Create a browser shortcut with the debug port enabled.",
     "tabs": "tabs"
   },
-  "model": {
-    "label": "Model",
-    "primary": "Primary Model",
-    "fast": "Fast Model"
-  },
   "common": {
     "enable": "Enable"
-  },
-  "models": {
-    "empty": "No available models. Please add models in \"Models\" first.",
-    "updateSuccess": "{{agentName}} will use {{modelName}}"
   },
   "loading": {
     "text": "Loading configuration..."

--- a/src/web-ui/src/locales/zh-CN/settings.json
+++ b/src/web-ui/src/locales/zh-CN/settings.json
@@ -38,8 +38,8 @@
     "tabDescriptions": {
       "basics": "日志、终端 Shell、通知与开机启动。",
       "appearance": "语言、主题与界面字体大小。",
-      "models": "AI 模型、API 密钥、供应商与代理。",
-      "sessionPersonalization": "会话标题与 Agent 伙伴。",
+      "models": "AI 模型、API 密钥、供应商、代理与会话标题。",
+      "sessionPersonalization": "Agent 伙伴。",
       "sessionPermissions": "加速工作区搜索、工具确认与超时、Computer use、浏览器与调试。",
       "quickActions": "代码完成后的一键 AI 动作，支持内置和自定义指令。",
       "review": "Review 策略、覆盖深度、容量、成本和耗时控制。",

--- a/src/web-ui/src/locales/zh-CN/settings/ai-model.json
+++ b/src/web-ui/src/locales/zh-CN/settings/ai-model.json
@@ -23,6 +23,26 @@
     },
     "loadFailed": "加载 Subagent 模型配置失败"
   },
+  "sessionTitle": {
+    "title": "会话标题自动生成",
+    "subtitle": "新对话时 AI 自动生成简洁标题",
+    "enable": "启用",
+    "loadFailed": "加载会话标题配置失败",
+    "model": {
+      "label": "模型",
+      "primary": "主力模型",
+      "fast": "快速模型"
+    },
+    "models": {
+      "empty": "暂无可用模型，请先在「模型」中添加模型。",
+      "updateSuccess": "{{agentName}} 将使用 {{modelName}}"
+    },
+    "messages": {
+      "saveSuccess": "设置已保存",
+      "saveFailed": "保存失败",
+      "updateFailed": "设置失败"
+    }
+  },
   "cliAuth": {
     "sectionTitle": "本机已登录账号",
     "sectionDescription": "可直接导入本机 Codex CLI / Gemini CLI 已登录账号作为模型使用",

--- a/src/web-ui/src/locales/zh-CN/settings/session-config.json
+++ b/src/web-ui/src/locales/zh-CN/settings/session-config.json
@@ -1,18 +1,13 @@
 {
   "personalizationPage": {
     "title": "个性化",
-    "subtitle": "会话标题自动生成、Agent 伙伴"
+    "subtitle": "个性化配置你的 BitFun"
   },
   "permissionsPage": {
     "title": "权限管理",
     "subtitle": "加速工作区搜索、工具执行、工具定义加载、Computer use、浏览器控制与调试模式"
   },
   "features": {
-    "sessionTitle": {
-      "title": "会话标题自动生成",
-      "subtitle": "新对话时 AI 自动生成简洁标题",
-      "warning": "会话标题将使用用户消息的前 20 个字符"
-    },
     "agentCompanion": {
       "title": "Agent 伙伴",
       "subtitle": "控制 BitFun 伙伴的显示方式。",
@@ -101,17 +96,8 @@
     "createLauncherDesc": "创建带调试端口的浏览器快捷方式。",
     "tabs": "个标签页"
   },
-  "model": {
-    "label": "模型",
-    "primary": "主力模型",
-    "fast": "快速模型"
-  },
   "common": {
     "enable": "启用"
-  },
-  "models": {
-    "empty": "暂无可用模型，请先在「模型」中添加模型。",
-    "updateSuccess": "{{agentName}} 将使用 {{modelName}}"
   },
   "loading": {
     "text": "加载配置中..."

--- a/src/web-ui/src/locales/zh-TW/settings.json
+++ b/src/web-ui/src/locales/zh-TW/settings.json
@@ -38,8 +38,8 @@
     "tabDescriptions": {
       "basics": "日誌、終端 Shell、通知與開機啟動。",
       "appearance": "語言、主題與介面字體大小。",
-      "models": "AI 模型、API 密鑰、供應商與代理。",
-      "sessionPersonalization": "會話標題與 Agent 夥伴。",
+      "models": "AI 模型、API 密鑰、供應商、代理與會話標題。",
+      "sessionPersonalization": "Agent 夥伴。",
       "sessionPermissions": "加速工作區搜尋、工具確認與逾時、Computer use、瀏覽器與偵錯。",
       "review": "Review 策略、覆蓋深度、容量、成本和耗時控制。",
       "memories": "自動記憶生成、注入、整理窗口與記憶模型。",

--- a/src/web-ui/src/locales/zh-TW/settings/ai-model.json
+++ b/src/web-ui/src/locales/zh-TW/settings/ai-model.json
@@ -23,6 +23,26 @@
     },
     "loadFailed": "載入 Subagent 模型設定失敗"
   },
+  "sessionTitle": {
+    "title": "會話標題自動生成",
+    "subtitle": "新對話時 AI 自動生成簡潔標題",
+    "enable": "啟用",
+    "loadFailed": "載入會話標題設定失敗",
+    "model": {
+      "label": "模型",
+      "primary": "主力模型",
+      "fast": "快速模型"
+    },
+    "models": {
+      "empty": "暫無可用模型，請先在「模型」中新增模型。",
+      "updateSuccess": "{{agentName}} 將使用 {{modelName}}"
+    },
+    "messages": {
+      "saveSuccess": "設定已儲存",
+      "saveFailed": "儲存失敗",
+      "updateFailed": "設定失敗"
+    }
+  },
   "cliAuth": {
     "sectionTitle": "本機已登錄賬號",
     "sectionDescription": "可直接匯入本機 Codex CLI / Gemini CLI 已登錄賬號作為模型使用",

--- a/src/web-ui/src/locales/zh-TW/settings/session-config.json
+++ b/src/web-ui/src/locales/zh-TW/settings/session-config.json
@@ -1,18 +1,13 @@
 {
   "personalizationPage": {
     "title": "個性化",
-    "subtitle": "會話標題自動生成、Agent 夥伴"
+    "subtitle": "個性化配置你的 BitFun"
   },
   "permissionsPage": {
     "title": "權限管理",
     "subtitle": "加速工作區搜尋、工具執行、工具定義載入、Computer use、瀏覽器控制與偵錯模式"
   },
   "features": {
-    "sessionTitle": {
-      "title": "會話標題自動生成",
-      "subtitle": "新對話時 AI 自動生成簡潔標題",
-      "warning": "會話標題將使用用戶消息的前 20 個字符"
-    },
     "agentCompanion": {
       "title": "Agent 夥伴",
       "subtitle": "控制 BitFun 夥伴的顯示方式。",
@@ -101,17 +96,8 @@
     "preferredBrowserDesc": "選擇要由 BitFun 透過 CDP 控制的瀏覽器；預設表示跟隨系統預設瀏覽器。",
     "notInstalled": "未安裝"
   },
-  "model": {
-    "label": "模型",
-    "primary": "主力模型",
-    "fast": "快速模型"
-  },
   "common": {
     "enable": "啟用"
-  },
-  "models": {
-    "empty": "暫無可用模型，請先在「模型」中新增模型。",
-    "updateSuccess": "{{agentName}} 將使用 {{modelName}}"
   },
   "loading": {
     "text": "載入設定中..."


### PR DESCRIPTION
## Summary
- Move auto session title enablement and model selection from Session Personalization into the Models settings page.
- Extract a dedicated `SessionTitleConfig` component and update settings search/keywords plus en-US / zh-CN / zh-TW copy accordingly.
- Leave Session Personalization focused on Agent companion.

## Test plan
- [ ] Open Settings → Models and confirm Auto Session Title appears with enable toggle and model selector.
- [ ] Toggle enable and change the title model; reload settings and verify persistence.
- [ ] Open Settings → Session Personalization and confirm session title UI is gone; Agent companion still works.
- [ ] Search settings for "session title" / "auto title" and land on Models.
- [ ] Switch locale among en-US / zh-CN / zh-TW and verify labels.