### PR TITLE
fix(settings): prevent Subagent model gear click from freezing UI

### DIFF
--- a/src/web-ui/src/app/scenes/settings/settingsTabSearchContent.ts
+++ b/src/web-ui/src/app/scenes/settings/settingsTabSearchContent.ts
@@ -42,6 +42,7 @@ export const SETTINGS_TAB_SEARCH_CONTENT: Record<ConfigTab, readonly SettingsTab
     { ns: 'settings/default-model', key: 'tabs.models' },
     { ns: 'settings/ai-model', key: 'subtitle' },
     { ns: 'settings/ai-model', key: 'subagentModels.title' },
+    { ns: 'settings/ai-model', key: 'subagentModels.default.description' },
     { ns: 'settings/ai-model', key: 'sessionTitle.title' },
     { ns: 'settings/ai-model', key: 'sessionTitle.subtitle' },
     { ns: 'settings/default-model', key: 'tabs.proxy' },

--- a/src/web-ui/src/infrastructure/config/components/SessionTitleConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/SessionTitleConfig.tsx
@@ -16,7 +16,7 @@ const AGENT_SESSION_TITLE = 'session-title-func-agent';
 
 export const SessionTitleConfig: React.FC = () => {
   const { t } = useTranslation('settings/ai-model');
-  const notification = useNotification();
+  const { success: notifySuccess, error: notifyError } = useNotification();
   const [isLoading, setIsLoading] = useState(true);
   const [settings, setSettings] = useState<AIExperienceSettings | null>(null);
   const [models, setModels] = useState<AIModelConfig[]>([]);
@@ -35,11 +35,11 @@ export const SessionTitleConfig: React.FC = () => {
       setFuncAgentModels(funcAgentModelsData ?? {});
     } catch (error) {
       log.error('Failed to load session title config', error);
-      notification.error(t('sessionTitle.loadFailed'));
+      notifyError(t('sessionTitle.loadFailed'));
     } finally {
       setIsLoading(false);
     }
-  }, [notification, t]);
+  }, [notifyError, t]);
 
   useEffect(() => {
     void loadData();
@@ -65,10 +65,10 @@ export const SessionTitleConfig: React.FC = () => {
     setSettings(next);
     try {
       await aiExperienceConfigService.saveSettings(next);
-      notification.success(t('sessionTitle.messages.saveSuccess'));
+      notifySuccess(t('sessionTitle.messages.saveSuccess'));
     } catch (error) {
       log.error('Failed to save session title enable setting', error);
-      notification.error(t('sessionTitle.messages.saveFailed'));
+      notifyError(t('sessionTitle.messages.saveFailed'));
       setSettings(previous);
     }
   };

--- a/src/web-ui/src/infrastructure/config/components/SubagentModelConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/SubagentModelConfig.tsx
@@ -92,7 +92,9 @@ export const SubagentModelConfig: React.FC = () => {
     }
   }, [notifyError, t]);
 
-  const openSubagentCustomization = useCallback(() => {
+  const openSubagentCustomization = useCallback((event: React.MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
     openScene('agents');
   }, [openScene]);
 
@@ -117,6 +119,7 @@ export const SubagentModelConfig: React.FC = () => {
           </IconButton>
         </span>
       )}
+      description={t('subagentModels.default.description')}
       align="center"
     >
       <Select

--- a/src/web-ui/src/infrastructure/config/components/common/ConfigPageLayout.tsx
+++ b/src/web-ui/src/infrastructure/config/components/common/ConfigPageLayout.tsx
@@ -135,10 +135,11 @@ export const ConfigPageRow: React.FC<ConfigPageRowProps> = ({
   return (
     <div className={cls} style={gridStyle}>
       <div className="bitfun-config-page-row__meta">
-        <p className="bitfun-config-page-row__label">{label}</p>
-        {description && (
-          <p className="bitfun-config-page-row__description">{description}</p>
-        )}
+        {/* div (not p): label may contain buttons; button-in-p freezes React event path */}
+        <div className="bitfun-config-page-row__label">{label}</div>
+        {description ? (
+          <div className="bitfun-config-page-row__description">{description}</div>
+        ) : null}
       </div>
       <div className="bitfun-config-page-row__control">
         {children}

--- a/src/web-ui/src/locales/en-US/settings/ai-model.json
+++ b/src/web-ui/src/locales/en-US/settings/ai-model.json
@@ -12,6 +12,7 @@
     "title": "Subagent Models",
     "default": {
       "label": "Default Subagent Model",
+      "description": "Default model used by subagents when none is set individually",
       "configureTooltip": "Sets the default model for subagents. Open Customize > Agents to configure each subagent separately",
       "updateFailed": "Failed to update the default Subagent model"
     },

--- a/src/web-ui/src/locales/zh-CN/settings/ai-model.json
+++ b/src/web-ui/src/locales/zh-CN/settings/ai-model.json
@@ -12,6 +12,7 @@
     "title": "Subagent 模型",
     "default": {
       "label": "Subagent 默认模型",
+      "description": "未单独指定时，Subagent 使用的默认模型",
       "configureTooltip": "设置 Subagent 的默认模型。前往“定制 > 专业智能体”可为每个 Subagent 单独配置模型",
       "updateFailed": "更新 Subagent 默认模型失败"
     },

--- a/src/web-ui/src/locales/zh-TW/settings/ai-model.json
+++ b/src/web-ui/src/locales/zh-TW/settings/ai-model.json
@@ -12,6 +12,7 @@
     "title": "Subagent 模型",
     "default": {
       "label": "Subagent 預設模型",
+      "description": "未單獨指定時，Subagent 使用的預設模型",
       "configureTooltip": "設定 Subagent 的預設模型。前往「定製 > 專業智能體」可為每個 Subagent 個別設定模型",
       "updateFailed": "更新 Subagent 預設模型失敗"
     },


### PR DESCRIPTION
## Summary
- Fix UI freeze when clicking the Subagent default model settings gear by changing `ConfigPageRow` label/description wrappers from `<p>` to `<div>` (invalid `button`-in-`<p>` nesting could hang React's event path).
- Add a one-line description under Subagent default model, matching the default model rows.
- Stabilize `SessionTitleConfig` notification callback dependencies to avoid reload loops.

## Test plan
- [ ] Open Settings → Models
- [ ] Confirm Subagent default model shows the description subtitle
- [ ] Click the gear next to Subagent default model and confirm BitFun navigates to Agents without freezing
- [ ] Toggle session title enable/model and confirm settings still save normally