### PR TITLE
fix(account): restore This device badge when device_id drifts

### DIFF
--- a/src/apps/cli/src/account.rs
+++ b/src/apps/cli/src/account.rs
@@ -68,15 +68,21 @@ pub(crate) async fn is_logged_in() -> bool {
 /// Attempt to restore a persisted session from disk.  Called at startup.
 /// Returns `Some(user_id)` if a session was restored.
 pub(crate) async fn try_restore_session() -> Option<String> {
-    match session_store::load_session() {
-        Ok(Some((token, user_id, master_key, relay_url))) => {
+    match session_store::load_session_detailed() {
+        Ok(Some(loaded)) => {
+            let user_id = loaded.user_id.clone();
+            if let Some(device_id) = loaded.device_id.as_deref() {
+                if let Err(e) = DeviceIdentity::adopt_account_device_id(device_id) {
+                    tracing::warn!("Failed to adopt restored session device_id: {e}");
+                }
+            }
             let session = AccountSession {
-                token,
+                token: loaded.token,
                 user_id: user_id.clone(),
-                master_key,
+                master_key: loaded.master_key,
             };
             *account_session().write().await = Some(session);
-            *account_relay_url().write().await = Some(relay_url);
+            *account_relay_url().write().await = Some(loaded.relay_url);
             tracing::info!("Restored account session for user {user_id}");
             Some(user_id)
         }
@@ -157,7 +163,13 @@ pub(crate) async fn login_with_credentials(
     *account_session().write().await = Some(session);
     *account_relay_url().write().await = Some(relay_url.to_string());
 
-    if let Err(e) = session_store::save_session(&token, &user_id, &master_key, relay_url) {
+    if let Err(e) = session_store::save_session_with_device(
+        &token,
+        &user_id,
+        &master_key,
+        relay_url,
+        Some(device.device_id.as_str()),
+    ) {
         tracing::warn!("Failed to persist session: {e}");
     }
     session_store::save_credential_hint(username, relay_url);
@@ -313,6 +325,21 @@ async fn handle_relay_event(
     match event {
         RelayEvent::AuthOk { user_id, device_id } => {
             tracing::info!("Device routing auth ok: user={user_id} device={device_id}");
+            if let Err(e) = DeviceIdentity::adopt_account_device_id(&device_id) {
+                tracing::warn!("Failed to adopt AuthOk device_id: {e}");
+            } else if let Some(session) = session_arc.read().await.clone() {
+                if let Some(relay_url) = account_relay_url().read().await.clone() {
+                    if let Err(e) = session_store::save_session_with_device(
+                        &session.token,
+                        &session.user_id,
+                        &session.master_key,
+                        &relay_url,
+                        Some(device_id.as_str()),
+                    ) {
+                        tracing::warn!("Failed to persist AuthOk device_id into session: {e}");
+                    }
+                }
+            }
         }
         RelayEvent::AuthError { message } => {
             tracing::warn!("Device routing auth error: {message}");

--- a/src/apps/desktop/src/api/remote_connect_api.rs
+++ b/src/apps/desktop/src/api/remote_connect_api.rs
@@ -421,12 +421,19 @@ pub fn init_on_startup() {
     tokio::spawn(async {
         // Restore persisted account session (if any) before anything else
         // so that auto-sync, device routing, and bot delegation work on restart.
-        match session_store::load_session() {
-            Ok(Some((token, user_id, master_key, relay_url))) => {
+        match session_store::load_session_detailed() {
+            Ok(Some(loaded)) => {
+                let user_id = loaded.user_id.clone();
+                let relay_url = loaded.relay_url.clone();
+                if let Some(device_id) = loaded.device_id.as_deref() {
+                    if let Err(e) = DeviceIdentity::adopt_account_device_id(device_id) {
+                        log::warn!("Failed to adopt restored session device_id: {e}");
+                    }
+                }
                 let session = AccountSession {
-                    token,
+                    token: loaded.token,
                     user_id: user_id.clone(),
-                    master_key,
+                    master_key: loaded.master_key,
                 };
                 *get_account_session().write().await = Some(session);
                 *get_account_relay_url().write().await = Some(relay_url.clone());
@@ -829,14 +836,13 @@ fn is_ipv4(s: &str) -> bool {
 #[tauri::command]
 pub async fn remote_connect_get_device_info() -> Result<DeviceInfo, String> {
     ensure_service().await?;
-    let holder = get_service_holder();
-    let guard = holder.read().await;
-    let service = guard.as_ref().ok_or("service not initialized")?;
-    let id = service.device_identity();
+    // Always read the persisted/account-adopted identity — not a stale copy
+    // captured when RemoteConnectService was first constructed.
+    let id = DeviceIdentity::from_current_machine().map_err(|e| format!("detect device: {e}"))?;
     Ok(DeviceInfo {
-        device_id: id.device_id.clone(),
-        device_name: id.device_name.clone(),
-        mac_address: id.mac_address.clone(),
+        device_id: id.device_id,
+        device_name: id.device_name,
+        mac_address: id.mac_address,
     })
 }
 
@@ -1227,11 +1233,12 @@ pub async fn account_login(request: AccountAuthRequest) -> Result<AccountLoginRe
     save_credential_hint(&request.username, &request.relay_url);
     // Persist the full session (token + master_key, encrypted) so the
     // user stays logged in across app restarts.
-    if let Err(e) = session_store::save_session(
+    if let Err(e) = session_store::save_session_with_device(
         &result.token,
         &result.user_id,
         &master_key,
         &request.relay_url,
+        Some(device.device_id.as_str()),
     ) {
         log::warn!("Failed to persist session: {e}");
     }
@@ -1299,24 +1306,36 @@ pub async fn account_connect_devices() -> Result<Vec<OnlineDeviceInfo>, String> 
         .as_ref()
         .ok_or_else(|| "remote connect service not initialized".to_string())?;
 
-    // Skip reconnecting if the device WS is already active.  Repeated calls
-    // (e.g. dialog re-open) should not tear down an existing connection.
+    // Skip reconnecting if the device WS is already active AND local identity
+    // already matches an online device. Otherwise reconnect so AuthOk can heal
+    // a drifted MAC-derived device_id (AuthOk is consumed inside start_device_connection).
     if service.is_device_connected().await {
         let devices = service.online_devices().await;
-        return Ok(devices
-            .into_iter()
-            .map(|d| OnlineDeviceInfo {
-                device_id: d.device_id,
-                device_name: d.device_name,
-            })
-            .collect());
+        let local_id = DeviceIdentity::from_current_machine()
+            .ok()
+            .map(|d| d.device_id);
+        let local_known = local_id
+            .as_ref()
+            .is_some_and(|id| devices.iter().any(|d| d.device_id == *id));
+        if local_known {
+            return Ok(devices
+                .into_iter()
+                .map(|d| OnlineDeviceInfo {
+                    device_id: d.device_id,
+                    device_name: d.device_name,
+                })
+                .collect());
+        }
+        log::info!(
+            "Device WS connected but local device_id not in online set; reconnecting to heal identity"
+        );
     }
 
-    let mut event_rx = match service
+    let (mut event_rx, auth_device_id) = match service
         .start_device_connection(&relay_url, &session.token, &device_name)
         .await
     {
-        Ok(rx) => rx,
+        Ok(result) => result,
         Err(e) => {
             let msg = format!("{e}");
             drop(holder);
@@ -1327,14 +1346,28 @@ pub async fn account_connect_devices() -> Result<Vec<OnlineDeviceInfo>, String> 
         }
     };
 
+    if let Err(e) = session_store::save_session_with_device(
+        &session.token,
+        &session.user_id,
+        &session.master_key,
+        &relay_url,
+        Some(auth_device_id.as_str()),
+    ) {
+        log::warn!("Failed to persist AuthOk device_id into session: {e}");
+    }
+
     // Background task: consume events (presence / device messages / auth errors)
+    // Note: AuthOk is consumed inside start_device_connection (adopt happens there).
     let session_arc = get_account_session().clone();
     tokio::spawn(async move {
         use bitfun_core::service::remote_connect::relay_client::RelayEvent;
         while let Some(event) = event_rx.recv().await {
             match event {
                 RelayEvent::AuthOk { user_id, device_id } => {
-                    log::info!("Device routing auth ok: user={user_id} device={device_id}");
+                    // Should not normally arrive — start_device_connection consumes AuthOk.
+                    log::info!(
+                        "Device routing auth ok (forwarded unexpectedly): user={user_id} device={device_id}"
+                    );
                 }
                 RelayEvent::AuthError { message } => {
                     log::warn!("Device routing auth error: {message}");

--- a/src/crates/assembly/core/src/service/remote_connect/mod.rs
+++ b/src/crates/assembly/core/src/service/remote_connect/mod.rs
@@ -1210,12 +1210,20 @@ impl RemoteConnectService {
         )
     }
 
+    /// Start account device routing. Returns `(event_rx, authenticated_device_id)`.
+    ///
+    /// `AuthOk` is consumed here (not forwarded) so callers must use the returned
+    /// `authenticated_device_id` — and this method adopts it into the persisted
+    /// local `DeviceIdentity` before returning.
     pub async fn start_device_connection(
         &self,
         relay_url: &str,
         token: &str,
         device_name: &str,
-    ) -> Result<tokio::sync::mpsc::UnboundedReceiver<relay_client::RelayEvent>> {
+    ) -> Result<(
+        tokio::sync::mpsc::UnboundedReceiver<relay_client::RelayEvent>,
+        String,
+    )> {
         // Disconnect previous device connection if any.
         self.stop_device_connection().await;
 
@@ -1238,13 +1246,18 @@ impl RemoteConnectService {
         // The relay client may emit other events first (e.g. `Connected`),
         // so we loop until we see AuthOk/AuthError or time out.
         let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
-        let mut got_auth = false;
+        let mut authenticated_device_id: Option<String> = None;
         let mut auth_error: Option<String> = None;
-        while !got_auth && auth_error.is_none() {
+        while authenticated_device_id.is_none() && auth_error.is_none() {
             match tokio::time::timeout_at(deadline, event_rx.recv()).await {
                 Ok(Some(relay_client::RelayEvent::AuthOk { user_id, device_id })) => {
                     log::info!("Device connection auth ok: user={user_id} device={device_id}");
-                    got_auth = true;
+                    // AuthOk is consumed here and never forwarded. Adopt immediately
+                    // so getDeviceInfo / 本机 marking match the token-bound device.
+                    if let Err(e) = DeviceIdentity::adopt_account_device_id(&device_id) {
+                        log::warn!("Failed to adopt AuthOk device_id: {e}");
+                    }
+                    authenticated_device_id = Some(device_id);
                 }
                 Ok(Some(relay_client::RelayEvent::AuthError { message })) => {
                     auth_error = Some(message);
@@ -1266,6 +1279,8 @@ impl RemoteConnectService {
         if let Some(msg) = auth_error {
             anyhow::bail!("relay auth error: {msg}");
         }
+        let authenticated_device_id = authenticated_device_id
+            .ok_or_else(|| anyhow::anyhow!("relay auth completed without device_id"))?;
 
         let online_arc = self.online_devices.clone();
         let device_client_arc = self.device_relay_client.clone();
@@ -1288,7 +1303,7 @@ impl RemoteConnectService {
         });
 
         *device_client_arc.write().await = Some(client);
-        Ok(forward_rx)
+        Ok((forward_rx, authenticated_device_id))
     }
 
     /// Disconnect the account-authenticated device-routing connection.

--- a/src/crates/services/services-integrations/src/remote_connect/device.rs
+++ b/src/crates/services/services-integrations/src/remote_connect/device.rs
@@ -1,12 +1,16 @@
-//! Device identity for Remote Connect pairing.
+//! Device identity for Remote Connect pairing and account device routing.
 //!
-//! Generates a stable `device_id` from `SHA-256(hostname + MAC address)`.
-//! Falls back gracefully when MAC or hostname are unavailable.
+//! `device_id` is generated once and persisted under `~/.bitfun/device_identity.json`.
+//! Hostname/MAC are refreshed for display only — they must not rewrite `device_id`,
+//! because macOS private Wi‑Fi addresses and interface order make MAC unstable.
 
-use anyhow::Result;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use anyhow::{anyhow, Context, Result};
 use sha2::{Digest, Sha256};
 
-/// Represents a device's identity used for pairing.
+/// Represents a device's identity used for pairing and account routing.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct DeviceIdentity {
     pub device_id: String,
@@ -14,27 +18,136 @@ pub struct DeviceIdentity {
     pub mac_address: String,
 }
 
+static CACHED_IDENTITY: Mutex<Option<DeviceIdentity>> = Mutex::new(None);
+
+#[cfg(test)]
+thread_local! {
+    static TEST_IDENTITY_PATH: std::cell::RefCell<Option<PathBuf>> = const { std::cell::RefCell::new(None) };
+}
+
 impl DeviceIdentity {
-    /// Build the device identity from the current machine.
+    /// Load the stable machine identity (persisted), creating it on first use.
     pub fn from_current_machine() -> Result<Self> {
-        let device_name = get_hostname();
-        let mac_address = get_mac_address();
+        if let Ok(guard) = CACHED_IDENTITY.lock() {
+            if let Some(cached) = guard.as_ref() {
+                let mut identity = cached.clone();
+                identity.device_name = get_hostname();
+                identity.mac_address = get_mac_address();
+                return Ok(identity);
+            }
+        }
 
-        let mut hasher = Sha256::new();
-        hasher.update(device_name.as_bytes());
-        hasher.update(b":");
-        hasher.update(mac_address.as_bytes());
-        let hash = hasher.finalize();
-        let device_id = hash[..16]
-            .iter()
-            .map(|b| format!("{b:02x}"))
-            .collect::<String>();
+        let mut identity = load_persisted()?.unwrap_or_else(compute_initial_identity);
+        identity.device_name = get_hostname();
+        identity.mac_address = get_mac_address();
+        save_persisted(&identity)?;
+        cache_identity(identity.clone());
+        Ok(identity)
+    }
 
-        Ok(Self {
+    /// Align the local identity with the account-bound `device_id` from a
+    /// login token / `AuthOk`. Needed when a prior MAC-derived id drifted
+    /// while an existing session still authenticates as the old id.
+    pub fn adopt_account_device_id(device_id: &str) -> Result<Self> {
+        let device_id = device_id.trim();
+        if !is_valid_device_id(device_id) {
+            return Err(anyhow!("invalid account device_id"));
+        }
+
+        let mut identity = Self::from_current_machine()?;
+        if identity.device_id == device_id {
+            return Ok(identity);
+        }
+
+        log::info!(
+            "Adopting account device_id {} (was {})",
             device_id,
-            device_name,
-            mac_address,
-        })
+            identity.device_id
+        );
+        identity.device_id = device_id.to_string();
+        identity.device_name = get_hostname();
+        identity.mac_address = get_mac_address();
+        save_persisted(&identity)?;
+        cache_identity(identity.clone());
+        Ok(identity)
+    }
+}
+
+fn is_valid_device_id(device_id: &str) -> bool {
+    device_id.len() == 32 && device_id.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+fn compute_initial_identity() -> DeviceIdentity {
+    let device_name = get_hostname();
+    let mac_address = get_mac_address();
+
+    let mut hasher = Sha256::new();
+    hasher.update(device_name.as_bytes());
+    hasher.update(b":");
+    hasher.update(mac_address.as_bytes());
+    let hash = hasher.finalize();
+    let device_id = hash[..16]
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect::<String>();
+
+    DeviceIdentity {
+        device_id,
+        device_name,
+        mac_address,
+    }
+}
+
+fn identity_file_path() -> Result<PathBuf> {
+    #[cfg(test)]
+    {
+        let override_path = TEST_IDENTITY_PATH.with(|cell| cell.borrow().clone());
+        if let Some(path) = override_path {
+            return Ok(path);
+        }
+    }
+
+    if let Ok(path) = std::env::var("BITFUN_DEVICE_IDENTITY_PATH") {
+        let path = path.trim();
+        if !path.is_empty() {
+            return Ok(PathBuf::from(path));
+        }
+    }
+
+    let home = dirs::home_dir().ok_or_else(|| anyhow!("cannot determine home directory"))?;
+    Ok(home.join(".bitfun").join("device_identity.json"))
+}
+
+fn load_persisted() -> Result<Option<DeviceIdentity>> {
+    let path = identity_file_path()?;
+    let json = match std::fs::read_to_string(&path) {
+        Ok(data) => data,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => {
+            return Err(anyhow!("read device identity: {e}").context(path.display().to_string()))
+        }
+    };
+    let identity: DeviceIdentity =
+        serde_json::from_str(&json).context("parse device identity file")?;
+    if !is_valid_device_id(&identity.device_id) {
+        return Err(anyhow!("persisted device_id is invalid"));
+    }
+    Ok(Some(identity))
+}
+
+fn save_persisted(identity: &DeviceIdentity) -> Result<()> {
+    let path = identity_file_path()?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).context("create device identity dir")?;
+    }
+    let json = serde_json::to_string_pretty(identity).context("serialize device identity")?;
+    std::fs::write(&path, json).context("write device identity file")?;
+    Ok(())
+}
+
+fn cache_identity(identity: DeviceIdentity) {
+    if let Ok(mut guard) = CACHED_IDENTITY.lock() {
+        *guard = Some(identity);
     }
 }
 
@@ -56,19 +169,84 @@ fn get_mac_address() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
 
-    #[test]
-    fn test_device_identity_creation() {
-        let identity = DeviceIdentity::from_current_machine().unwrap();
-        assert!(!identity.device_id.is_empty());
-        assert!(!identity.device_name.is_empty());
-        assert_eq!(identity.device_id.len(), 32); // 16 bytes hex = 32 chars
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_temp_identity_path<F: FnOnce()>(f: F) {
+        let _guard = TEST_LOCK.lock().unwrap();
+        let path = std::env::temp_dir().join(format!(
+            "bitfun-device-identity-{}-{}.json",
+            std::process::id(),
+            uuid_like()
+        ));
+        let _ = std::fs::remove_file(&path);
+        TEST_IDENTITY_PATH.with(|cell| *cell.borrow_mut() = Some(path.clone()));
+        if let Ok(mut cache) = CACHED_IDENTITY.lock() {
+            *cache = None;
+        }
+        f();
+        let _ = std::fs::remove_file(&path);
+        TEST_IDENTITY_PATH.with(|cell| *cell.borrow_mut() = None);
+        if let Ok(mut cache) = CACHED_IDENTITY.lock() {
+            *cache = None;
+        }
+    }
+
+    fn uuid_like() -> String {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        format!("{nanos:x}")
     }
 
     #[test]
-    fn test_device_identity_stable() {
-        let id1 = DeviceIdentity::from_current_machine().unwrap();
-        let id2 = DeviceIdentity::from_current_machine().unwrap();
-        assert_eq!(id1.device_id, id2.device_id);
+    fn test_device_identity_creation() {
+        with_temp_identity_path(|| {
+            let identity = DeviceIdentity::from_current_machine().unwrap();
+            assert!(!identity.device_id.is_empty());
+            assert!(!identity.device_name.is_empty());
+            assert_eq!(identity.device_id.len(), 32);
+        });
+    }
+
+    #[test]
+    fn test_device_identity_stable_across_calls() {
+        with_temp_identity_path(|| {
+            let id1 = DeviceIdentity::from_current_machine().unwrap();
+            let id2 = DeviceIdentity::from_current_machine().unwrap();
+            assert_eq!(id1.device_id, id2.device_id);
+        });
+    }
+
+    #[test]
+    fn test_device_identity_persists_across_cache_clear() {
+        with_temp_identity_path(|| {
+            let id1 = DeviceIdentity::from_current_machine().unwrap();
+            if let Ok(mut cache) = CACHED_IDENTITY.lock() {
+                *cache = None;
+            }
+            let id2 = DeviceIdentity::from_current_machine().unwrap();
+            assert_eq!(id1.device_id, id2.device_id);
+        });
+    }
+
+    #[test]
+    fn test_adopt_account_device_id_rewrites_persisted_id() {
+        with_temp_identity_path(|| {
+            let original = DeviceIdentity::from_current_machine().unwrap();
+            let adopted_id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+            let adopted = DeviceIdentity::adopt_account_device_id(adopted_id).unwrap();
+            assert_eq!(adopted.device_id, adopted_id);
+            assert_ne!(adopted.device_id, original.device_id);
+
+            if let Ok(mut cache) = CACHED_IDENTITY.lock() {
+                *cache = None;
+            }
+            let reloaded = DeviceIdentity::from_current_machine().unwrap();
+            assert_eq!(reloaded.device_id, adopted_id);
+        });
     }
 }

--- a/src/crates/services/services-integrations/src/remote_connect/session_store.rs
+++ b/src/crates/services/services-integrations/src/remote_connect/session_store.rs
@@ -29,6 +29,10 @@ struct SessionPayload {
     /// Base64-encoded 32-byte master key.
     master_key_b64: String,
     relay_url: String,
+    /// Account-bound device id used when the session token was issued.
+    /// Optional for backward compatibility with sessions saved before this field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    device_id: Option<String>,
 }
 
 /// Resolve the persistent session file path.
@@ -121,11 +125,26 @@ pub fn save_session(
     master_key: &[u8; 32],
     relay_url: &str,
 ) -> Result<()> {
+    save_session_with_device(token, user_id, master_key, relay_url, None)
+}
+
+/// Persist the session including the account-bound `device_id`.
+pub fn save_session_with_device(
+    token: &str,
+    user_id: &str,
+    master_key: &[u8; 32],
+    relay_url: &str,
+    device_id: Option<&str>,
+) -> Result<()> {
     let payload = SessionPayload {
         token: token.to_string(),
         user_id: user_id.to_string(),
         master_key_b64: BASE64.encode(master_key),
         relay_url: relay_url.to_string(),
+        device_id: device_id
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+            .map(str::to_string),
     };
     let json = serde_json::to_string(&payload).context("serialize session payload")?;
 
@@ -156,9 +175,24 @@ pub fn save_session(
     Ok(())
 }
 
+/// Loaded account session fields from disk.
+#[derive(Debug, Clone)]
+pub struct LoadedSession {
+    pub token: String,
+    pub user_id: String,
+    pub master_key: [u8; 32],
+    pub relay_url: String,
+    pub device_id: Option<String>,
+}
+
 /// Load and decrypt the session from disk.
 /// Returns `Ok(None)` if the file doesn't exist (not an error).
 pub fn load_session() -> Result<Option<(String, String, [u8; 32], String)>> {
+    Ok(load_session_detailed()?.map(|s| (s.token, s.user_id, s.master_key, s.relay_url)))
+}
+
+/// Load and decrypt the session, including optional account-bound `device_id`.
+pub fn load_session_detailed() -> Result<Option<LoadedSession>> {
     let path = session_file_path()?;
     let encoded = match std::fs::read_to_string(&path) {
         Ok(data) => data,
@@ -200,12 +234,13 @@ pub fn load_session() -> Result<Option<(String, String, [u8; 32], String)>> {
     }
     master_key.copy_from_slice(&master_key_bytes);
 
-    Ok(Some((
-        payload.token,
-        payload.user_id,
+    Ok(Some(LoadedSession {
+        token: payload.token,
+        user_id: payload.user_id,
         master_key,
-        payload.relay_url,
-    )))
+        relay_url: payload.relay_url,
+        device_id: payload.device_id,
+    }))
 }
 
 /// Remove the persisted session file (called on logout).

--- a/src/web-ui/src/app/components/AccountLoginDialog/AccountLoginDialog.tsx
+++ b/src/web-ui/src/app/components/AccountLoginDialog/AccountLoginDialog.tsx
@@ -221,6 +221,13 @@ export const AccountLoginDialog: React.FC<AccountLoginDialogProps> = ({
         setView('devices');
         try {
           await remoteConnectAPI.accountConnectDevices();
+          // Re-read after AuthOk may have adopted the account-bound device_id.
+          try {
+            const info = await remoteConnectAPI.getDeviceInfo();
+            setLocalDeviceId(info.device_id);
+          } catch (e) {
+            log.warn('getDeviceInfo after connect failed', e);
+          }
         } catch (err) {
           log.warn('accountConnectDevices failed', err);
           if (isAccountAuthFailure(err)) {


### PR DESCRIPTION
## Summary
- Persist a stable local `device_id` under `~/.bitfun/device_identity.json` so hostname/MAC changes no longer rewrite identity.
- Adopt the AuthOk / session-bound `device_id` when connecting (AuthOk is consumed inside `start_device_connection`), and heal by reconnecting if the WS is up but the local id is missing from the online set.
- Desktop and CLI both refresh account session persistence with `device_id`; the Online Devices UI re-reads local identity after connect so the This device badge matches again.

## Test plan
- [ ] Log in on Desktop, open Online Devices, confirm the current machine shows the This device badge and no remove control.
- [ ] Restart Desktop with an existing session; badge still appears without re-login.
- [ ] On macOS with private Wi‑Fi MAC, confirm `~/.bitfun/device_identity.json` keeps a stable `device_id` across restarts.
- [ ] Optional: rename hostname, reconnect device routing, confirm other devices see the updated device name.
- [ ] `cargo test -p bitfun-services-integrations --features remote-connect device::tests --lib`