### PR TITLE
fix(ai): strengthen exponential backoff for 429 rate-limit retries

### DIFF
--- a/src/crates/adapters/ai-adapters/src/client.rs
+++ b/src/crates/adapters/ai-adapters/src/client.rs
@@ -28,6 +28,10 @@ use tokio::sync::mpsc;
 const SEND_MESSAGE_STREAM_ATTEMPTS: usize = 10;
 const TEST_CONNECTION_STREAM_ATTEMPTS: usize = 5;
 const SEND_MESSAGE_RETRY_BASE_DELAY_MS: u64 = 500;
+const SEND_MESSAGE_RATE_LIMIT_RETRY_BASE_DELAY_MS: u64 = 2_000;
+const SEND_MESSAGE_MAX_EXPONENTIAL_DELAY_MS: u64 = 30_000;
+const SEND_MESSAGE_MAX_RATE_LIMIT_DELAY_MS: u64 = 60_000;
+const SEND_MESSAGE_MAX_RETRY_EXPONENT_SHIFT: u32 = 6;
 
 /// Streamed response result with the parsed stream and optional raw SSE receiver.
 pub struct StreamResponse {
@@ -249,7 +253,7 @@ impl AIClient {
                         &error.to_string(),
                     )
                     .await;
-                    let delay_ms = send_message_retry_delay_ms(attempt);
+                    let delay_ms = send_message_retry_delay_ms(attempt, &error.to_string());
                     warn!(
                         "Retrying aggregated AI stream after transient error: attempt={}/{}, delay_ms={}, error={}",
                         attempt + 1,
@@ -344,8 +348,23 @@ impl AIClient {
     }
 }
 
-fn send_message_retry_delay_ms(attempt_index: usize) -> u64 {
-    SEND_MESSAGE_RETRY_BASE_DELAY_MS * (1u64 << attempt_index.min(3))
+fn send_message_retry_delay_ms(attempt_index: usize, error_message: &str) -> u64 {
+    let shift = u32::try_from(attempt_index)
+        .unwrap_or(u32::MAX)
+        .min(SEND_MESSAGE_MAX_RETRY_EXPONENT_SHIFT);
+    let msg = error_message.to_lowercase();
+    let is_rate_limit =
+        msg.contains("429") || msg.contains("rate limit") || msg.contains("too many requests");
+
+    if is_rate_limit {
+        SEND_MESSAGE_RATE_LIMIT_RETRY_BASE_DELAY_MS
+            .saturating_mul(1u64 << shift)
+            .min(SEND_MESSAGE_MAX_RATE_LIMIT_DELAY_MS)
+    } else {
+        SEND_MESSAGE_RETRY_BASE_DELAY_MS
+            .saturating_mul(1u64 << shift)
+            .min(SEND_MESSAGE_MAX_EXPONENTIAL_DELAY_MS)
+    }
 }
 
 fn is_transient_stream_error(error_message: &str) -> bool {
@@ -485,7 +504,7 @@ fn gemini_response_to_trace(response: &GeminiResponse) -> ModelExchangeResponseT
 
 #[cfg(test)]
 mod tests {
-    use super::{is_transient_stream_error, AIClient};
+    use super::{is_transient_stream_error, send_message_retry_delay_ms, AIClient};
     use crate::providers::{anthropic, gemini, gemini::GeminiMessageConverter, openai};
     use crate::types::ReasoningMode;
     use crate::types::{AIConfig, ToolDefinition};
@@ -1472,6 +1491,28 @@ mod tests {
                 "expected transient stream error: {msg}"
             );
         }
+    }
+
+    #[test]
+    fn aggregated_retry_delay_grows_beyond_previous_four_second_cap() {
+        assert_eq!(send_message_retry_delay_ms(0, "connection reset"), 500);
+        assert_eq!(send_message_retry_delay_ms(3, "connection reset"), 4_000);
+        assert_eq!(send_message_retry_delay_ms(5, "connection reset"), 16_000);
+        assert_eq!(send_message_retry_delay_ms(6, "connection reset"), 30_000);
+        assert_eq!(send_message_retry_delay_ms(9, "connection reset"), 30_000);
+    }
+
+    #[test]
+    fn aggregated_rate_limit_retry_delay_uses_longer_ladder() {
+        assert_eq!(
+            send_message_retry_delay_ms(0, "Anthropic Streaming API error 429"),
+            2_000
+        );
+        assert_eq!(
+            send_message_retry_delay_ms(3, "rate limit exceeded"),
+            16_000
+        );
+        assert_eq!(send_message_retry_delay_ms(5, "too many requests"), 60_000);
     }
 
     #[test]

--- a/src/crates/adapters/ai-adapters/src/client/sse.rs
+++ b/src/crates/adapters/ai-adapters/src/client/sse.rs
@@ -21,7 +21,18 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use tokio_util::sync::CancellationToken;
 
 const BASE_RETRY_DELAY_MS: u64 = 500;
-/// Maximum delay applied to a `Retry-After` header value.
+/// Base delay for HTTP 429 / rate-limit retries when `Retry-After` is absent.
+///
+/// Providers frequently omit `Retry-After` (or send a useless 1s value). The
+/// previous general backoff capped at 4s (`attempt.min(3)`), so 10 attempts
+/// finished in ~90s and never waited for TPM / RPM windows to recover —
+/// especially painful when multiple subagents retry in parallel.
+const RATE_LIMIT_BASE_RETRY_DELAY_MS: u64 = 2_000;
+/// Cap for the general (non-429) exponential backoff ladder.
+const MAX_EXPONENTIAL_DELAY_MS: u64 = 30_000;
+/// Maximum exponent shift applied to retry delays (`2^n` multiplier).
+const MAX_RETRY_EXPONENT_SHIFT: u32 = 6;
+/// Maximum delay applied to a `Retry-After` header value / rate-limit backoff.
 ///
 /// Some providers (especially TPM-based rate limits on aggregator platforms
 /// like NVIDIA's integrate API) return large `Retry-After` values of 30-60
@@ -94,7 +105,21 @@ fn is_retryable_http_status(status: StatusCode) -> bool {
 }
 
 fn exponential_retry_delay_ms(attempt: usize) -> u64 {
-    BASE_RETRY_DELAY_MS * (1 << attempt.min(3))
+    let shift = u32::try_from(attempt)
+        .unwrap_or(u32::MAX)
+        .min(MAX_RETRY_EXPONENT_SHIFT);
+    BASE_RETRY_DELAY_MS
+        .saturating_mul(1u64 << shift)
+        .min(MAX_EXPONENTIAL_DELAY_MS)
+}
+
+fn rate_limit_retry_delay_ms(attempt: usize) -> u64 {
+    let shift = u32::try_from(attempt)
+        .unwrap_or(u32::MAX)
+        .min(MAX_RETRY_EXPONENT_SHIFT);
+    RATE_LIMIT_BASE_RETRY_DELAY_MS
+        .saturating_mul(1u64 << shift)
+        .min(MAX_RETRY_AFTER_DELAY_MS)
 }
 
 fn retry_after_delay_ms(headers: &HeaderMap) -> Option<u64> {
@@ -121,8 +146,22 @@ fn retry_after_delay_ms(headers: &HeaderMap) -> Option<u64> {
     .map(|delay| delay.min(MAX_RETRY_AFTER_DELAY_MS))
 }
 
-fn retry_delay_ms(attempt: usize, headers: &HeaderMap) -> u64 {
-    retry_after_delay_ms(headers).unwrap_or_else(|| exponential_retry_delay_ms(attempt))
+fn retry_delay_ms(attempt: usize, headers: &HeaderMap, status: StatusCode) -> u64 {
+    let fallback = if status == StatusCode::TOO_MANY_REQUESTS {
+        rate_limit_retry_delay_ms(attempt)
+    } else {
+        exponential_retry_delay_ms(attempt)
+    };
+
+    match retry_after_delay_ms(headers) {
+        // Honor Retry-After, but never let a tiny/zero value defeat the
+        // rate-limit ladder (common with aggregator "Retry-After: 1" responses).
+        Some(retry_after) if status == StatusCode::TOO_MANY_REQUESTS => {
+            retry_after.max(fallback).min(MAX_RETRY_AFTER_DELAY_MS)
+        }
+        Some(retry_after) if retry_after > 0 => retry_after,
+        Some(_) | None => fallback,
+    }
 }
 
 struct ManagedResponseStream {
@@ -260,7 +299,7 @@ where
                     }
 
                     if attempt < max_tries - 1 {
-                        let delay_ms = retry_delay_ms(attempt, &headers);
+                        let delay_ms = retry_delay_ms(attempt, &headers, status);
                         debug!(
                             "Retrying {} after {}ms (attempt {}, status {})",
                             label,
@@ -457,8 +496,59 @@ mod tests {
     fn retry_delay_falls_back_to_exponential_backoff() {
         let headers = HeaderMap::new();
 
-        assert_eq!(retry_delay_ms(0, &headers), 500);
-        assert_eq!(retry_delay_ms(1, &headers), 1000);
-        assert_eq!(retry_delay_ms(4, &headers), 4000);
+        assert_eq!(retry_delay_ms(0, &headers, StatusCode::BAD_GATEWAY), 500);
+        assert_eq!(retry_delay_ms(1, &headers, StatusCode::BAD_GATEWAY), 1000);
+        assert_eq!(retry_delay_ms(4, &headers, StatusCode::BAD_GATEWAY), 8_000);
+        assert_eq!(retry_delay_ms(6, &headers, StatusCode::BAD_GATEWAY), 30_000);
+        assert_eq!(retry_delay_ms(8, &headers, StatusCode::BAD_GATEWAY), 30_000);
+    }
+
+    #[test]
+    fn rate_limit_retry_uses_longer_exponential_backoff() {
+        let headers = HeaderMap::new();
+
+        assert_eq!(
+            retry_delay_ms(0, &headers, StatusCode::TOO_MANY_REQUESTS),
+            2_000
+        );
+        assert_eq!(
+            retry_delay_ms(1, &headers, StatusCode::TOO_MANY_REQUESTS),
+            4_000
+        );
+        assert_eq!(
+            retry_delay_ms(3, &headers, StatusCode::TOO_MANY_REQUESTS),
+            16_000
+        );
+        assert_eq!(
+            retry_delay_ms(5, &headers, StatusCode::TOO_MANY_REQUESTS),
+            60_000
+        );
+        assert_eq!(
+            retry_delay_ms(9, &headers, StatusCode::TOO_MANY_REQUESTS),
+            60_000
+        );
+    }
+
+    #[test]
+    fn rate_limit_retry_after_never_undercuts_exponential_floor() {
+        let mut headers = HeaderMap::new();
+        headers.insert(RETRY_AFTER, HeaderValue::from_static("1"));
+
+        // Retry-After: 1s must not collapse attempt 3 back to a 1s storm.
+        assert_eq!(
+            retry_delay_ms(3, &headers, StatusCode::TOO_MANY_REQUESTS),
+            16_000
+        );
+    }
+
+    #[test]
+    fn rate_limit_honors_longer_retry_after() {
+        let mut headers = HeaderMap::new();
+        headers.insert(RETRY_AFTER, HeaderValue::from_static("45"));
+
+        assert_eq!(
+            retry_delay_ms(0, &headers, StatusCode::TOO_MANY_REQUESTS),
+            45_000
+        );
     }
 }

--- a/src/crates/assembly/core/src/agentic/execution/round_executor.rs
+++ b/src/crates/assembly/core/src/agentic/execution/round_executor.rs
@@ -78,6 +78,10 @@ pub struct RoundExecutor {
 impl RoundExecutor {
     const MAX_STREAM_ATTEMPTS: usize = 10;
     const RETRY_BASE_DELAY_MS: u64 = 500;
+    const RATE_LIMIT_RETRY_BASE_DELAY_MS: u64 = 2_000;
+    const MAX_EXPONENTIAL_DELAY_MS: u64 = 30_000;
+    const MAX_RATE_LIMIT_DELAY_MS: u64 = 60_000;
+    const MAX_RETRY_EXPONENT_SHIFT: u32 = 6;
 
     fn has_user_visible_assistant_text(text: &str) -> bool {
         !text.trim().is_empty()
@@ -235,7 +239,7 @@ impl RoundExecutor {
                     if Self::is_transient_network_error(&err_msg)
                         && attempt_index < max_attempts - 1
                     {
-                        let delay_ms = Self::retry_delay_ms(attempt_index);
+                        let delay_ms = Self::retry_delay_ms_for_error(attempt_index, &err_msg);
                         warn!(
                             "Retrying AI request after connection failure: session_id={}, round_id={}, attempt={}/{}, delay_ms={}, error={}",
                             context.session_id,
@@ -339,7 +343,7 @@ impl RoundExecutor {
                                 Self::trace_response_from_stream_result("partial", &result),
                             )
                             .await;
-                            let delay_ms = Self::retry_delay_ms(attempt_index);
+                            let delay_ms = Self::retry_delay_ms_for_error(attempt_index, &err_msg);
                             warn!(
                                 "Retrying stream because tool arguments were interrupted before valid JSON completed: session_id={}, round_id={}, attempt={}/{}, delay_ms={}, invalid_tool_calls={}, error={}",
                                 context.session_id,
@@ -430,7 +434,8 @@ impl RoundExecutor {
                             Self::trace_response_from_stream_result("partial", &result),
                         )
                         .await;
-                        let delay_ms = Self::retry_delay_ms(attempt_index);
+                        let delay_ms =
+                            Self::retry_delay_ms_for_error(attempt_index, partial_recovery_reason);
                         warn!(
                             "Retrying stream because tool calls arrived on an interrupted network stream without assistant text: session_id={}, round_id={}, attempt={}/{}, delay_ms={}, tool_calls={}, reason={}",
                             context.session_id,
@@ -554,7 +559,7 @@ impl RoundExecutor {
                     )
                     .await;
                     if can_retry {
-                        let delay_ms = Self::retry_delay_ms(attempt_index);
+                        let delay_ms = Self::retry_delay_ms_for_error(attempt_index, &err_msg);
                         warn!(
                             "Retrying stream after transient error with no effective output: session_id={}, round_id={}, attempt={}/{}, delay_ms={}, error={}",
                             context.session_id,
@@ -1238,7 +1243,26 @@ impl RoundExecutor {
     }
 
     fn retry_delay_ms(attempt_index: usize) -> u64 {
-        Self::RETRY_BASE_DELAY_MS * (1u64 << attempt_index.min(3))
+        Self::retry_delay_ms_for_error(attempt_index, "")
+    }
+
+    fn retry_delay_ms_for_error(attempt_index: usize, error_message: &str) -> u64 {
+        let shift = u32::try_from(attempt_index)
+            .unwrap_or(u32::MAX)
+            .min(Self::MAX_RETRY_EXPONENT_SHIFT);
+        let msg = error_message.to_lowercase();
+        let is_rate_limit =
+            msg.contains("429") || msg.contains("rate limit") || msg.contains("too many requests");
+
+        if is_rate_limit {
+            Self::RATE_LIMIT_RETRY_BASE_DELAY_MS
+                .saturating_mul(1u64 << shift)
+                .min(Self::MAX_RATE_LIMIT_DELAY_MS)
+        } else {
+            Self::RETRY_BASE_DELAY_MS
+                .saturating_mul(1u64 << shift)
+                .min(Self::MAX_EXPONENTIAL_DELAY_MS)
+        }
     }
 
     /// Check whether an error message represents a transient (retryable) condition.
@@ -1704,6 +1728,32 @@ mod tests {
         assert!(RoundExecutor::is_transient_network_error(
             "rate limit exceeded"
         ));
+    }
+
+    #[test]
+    fn retry_delay_grows_beyond_previous_four_second_cap() {
+        assert_eq!(RoundExecutor::retry_delay_ms(0), 500);
+        assert_eq!(RoundExecutor::retry_delay_ms(3), 4_000);
+        assert_eq!(RoundExecutor::retry_delay_ms(5), 16_000);
+        assert_eq!(RoundExecutor::retry_delay_ms(6), 30_000);
+        assert_eq!(RoundExecutor::retry_delay_ms(9), 30_000);
+    }
+
+    #[test]
+    fn rate_limit_retry_delay_uses_longer_ladder() {
+        assert_eq!(
+            RoundExecutor::retry_delay_ms_for_error(0, "error 429 Too Many Requests"),
+            2_000
+        );
+        assert_eq!(
+            RoundExecutor::retry_delay_ms_for_error(3, "rate limit exceeded"),
+            16_000
+        );
+        assert_eq!(
+            RoundExecutor::retry_delay_ms_for_error(5, "too many requests"),
+            60_000
+        );
+        assert_eq!(RoundExecutor::retry_delay_ms_for_error(9, "429"), 60_000);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Raise AI stream retry backoff so 429 / rate-limit responses no longer burn through 10 attempts in ~90s with a 4s ceiling.
- Use a dedicated rate-limit ladder (2s → 60s), raise the general exponential cap to 30s, and take `max(Retry-After, ladder)` so tiny `Retry-After` values cannot restart a retry storm.
- Align the same policy across SSE transport, aggregated `send_message`, and `RoundExecutor` so OpenAI / Anthropic / Gemini streaming agent paths share the stronger backoff.

## Test plan
- [x] `cargo test -p bitfun-ai-adapters`
- [x] `cargo test -p bitfun-core retry_delay`
- [x] `cargo test -p bitfun-core is_transient_error`
- [ ] Reproduce parallel subagent 429 under a rate-limited provider and confirm waits grow (2s/4s/8s/…/60s) instead of finishing near 90s