### PR TITLE
polish(settings): simplify models section chrome and clarify Subagent default copy

### DIFF
--- a/src/web-ui/src/infrastructure/config/components/AIModelConfig.scss
+++ b/src/web-ui/src/infrastructure/config/components/AIModelConfig.scss
@@ -64,6 +64,15 @@
     }
   }
 
+  // Model list owns its own provider-group cards; drop the section body chrome.
+  &__models-section {
+    > .bitfun-config-page-section__body {
+      border: 0;
+      border-radius: 0;
+      background: transparent;
+    }
+  }
+
   &__collection {
     display: flex;
     flex-direction: column;

--- a/src/web-ui/src/infrastructure/config/components/AIModelConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/AIModelConfig.tsx
@@ -2660,6 +2660,7 @@ const AIModelConfig: React.FC = () => {
         </ConfigPageSection>
 
         <ConfigPageSection
+          className="bitfun-ai-model-config__models-section"
           title={tDefault('tabs.models')}
           description={t('subtitle')}
           extra={(

--- a/src/web-ui/src/locales/zh-CN/settings/ai-model.json
+++ b/src/web-ui/src/locales/zh-CN/settings/ai-model.json
@@ -12,7 +12,7 @@
     "title": "Subagent 模型",
     "default": {
       "label": "Subagent 默认模型",
-      "description": "未单独指定时，Subagent 使用的默认模型",
+      "description": "Subagent 未单独配置模型时，统一使用此模型",
       "configureTooltip": "设置 Subagent 的默认模型。前往“定制 > 专业智能体”可为每个 Subagent 单独配置模型",
       "updateFailed": "更新 Subagent 默认模型失败"
     },

--- a/src/web-ui/src/locales/zh-TW/settings/ai-model.json
+++ b/src/web-ui/src/locales/zh-TW/settings/ai-model.json
@@ -12,7 +12,7 @@
     "title": "Subagent 模型",
     "default": {
       "label": "Subagent 預設模型",
-      "description": "未單獨指定時，Subagent 使用的預設模型",
+      "description": "Subagent 未單獨設定模型時，統一使用此模型",
       "configureTooltip": "設定 Subagent 的預設模型。前往「定製 > 專業智能體」可為每個 Subagent 個別設定模型",
       "updateFailed": "更新 Subagent 預設模型失敗"
     },


### PR DESCRIPTION
## Summary
- Remove nested section body chrome on the AI Models settings page so provider-group cards are the only visual containers.
- Clarify zh-CN / zh-TW copy for the Subagent default model description.

## Test plan
- [ ] Open Settings → AI Models and confirm the models section no longer shows an extra bordered panel around provider groups.
- [ ] Switch to zh-CN / zh-TW and confirm the Subagent default model description reads clearly.
- [x] `pnpm run type-check:web`
- [x] `pnpm run i18n:audit`