### PR TITLE
feat(remote-connect): merge account login into remote connect dialog

### DIFF
--- a/BitFun-Installer/src/i18n/generatedLocaleContract.ts
+++ b/BitFun-Installer/src/i18n/generatedLocaleContract.ts
@@ -61,8 +61,7 @@ export const SHARED_TERMS_BY_APP_LANGUAGE = {
       "codeAgent": "Code Agent",
       "deepReview": "Review: Strict",
       "settings": "Settings",
-      "workspace": "Workspace",
-      "accountLogin": "Account Login"
+      "workspace": "Workspace"
     },
     "modes": {
       "agentic": "Agentic Mode",
@@ -112,8 +111,7 @@ export const SHARED_TERMS_BY_APP_LANGUAGE = {
       "codeAgent": "代码助手",
       "deepReview": "严格审查",
       "settings": "设置",
-      "workspace": "工作区",
-      "accountLogin": "账户登录"
+      "workspace": "工作区"
     },
     "modes": {
       "agentic": "代理模式",
@@ -163,8 +161,7 @@ export const SHARED_TERMS_BY_APP_LANGUAGE = {
       "codeAgent": "程式碼助手",
       "deepReview": "嚴格審查",
       "settings": "設定",
-      "workspace": "工作區",
-      "accountLogin": "帳號登入"
+      "workspace": "工作區"
     },
     "modes": {
       "agentic": "代理模式",

--- a/src/crates/assembly/core/src/service/i18n/generated_locale_contract.rs
+++ b/src/crates/assembly/core/src/service/i18n/generated_locale_contract.rs
@@ -124,11 +124,6 @@ pub const GENERATED_SHARED_TERMS: &[GeneratedSharedTermEntry] = &[
     },
     GeneratedSharedTermEntry {
         locale: LocaleId::ZhCN,
-        key: "features.accountLogin",
-        value: "账户登录",
-    },
-    GeneratedSharedTermEntry {
-        locale: LocaleId::ZhCN,
         key: "features.codeAgent",
         value: "代码助手",
     },
@@ -299,11 +294,6 @@ pub const GENERATED_SHARED_TERMS: &[GeneratedSharedTermEntry] = &[
     },
     GeneratedSharedTermEntry {
         locale: LocaleId::ZhTW,
-        key: "features.accountLogin",
-        value: "帳號登入",
-    },
-    GeneratedSharedTermEntry {
-        locale: LocaleId::ZhTW,
         key: "features.codeAgent",
         value: "程式碼助手",
     },
@@ -471,11 +461,6 @@ pub const GENERATED_SHARED_TERMS: &[GeneratedSharedTermEntry] = &[
         locale: LocaleId::EnUS,
         key: "connectionMethods.ngrok",
         value: "Ngrok",
-    },
-    GeneratedSharedTermEntry {
-        locale: LocaleId::EnUS,
-        key: "features.accountLogin",
-        value: "Account Login",
     },
     GeneratedSharedTermEntry {
         locale: LocaleId::EnUS,

--- a/src/mobile-web/src/i18n/generatedLocaleContract.ts
+++ b/src/mobile-web/src/i18n/generatedLocaleContract.ts
@@ -45,8 +45,7 @@ export const SHARED_TERMS_BY_LOCALE = {
       "codeAgent": "代码助手",
       "deepReview": "严格审查",
       "settings": "设置",
-      "workspace": "工作区",
-      "accountLogin": "账户登录"
+      "workspace": "工作区"
     },
     "modes": {
       "agentic": "代理模式",
@@ -96,8 +95,7 @@ export const SHARED_TERMS_BY_LOCALE = {
       "codeAgent": "程式碼助手",
       "deepReview": "嚴格審查",
       "settings": "設定",
-      "workspace": "工作區",
-      "accountLogin": "帳號登入"
+      "workspace": "工作區"
     },
     "modes": {
       "agentic": "代理模式",
@@ -147,8 +145,7 @@ export const SHARED_TERMS_BY_LOCALE = {
       "codeAgent": "Code Agent",
       "deepReview": "Review: Strict",
       "settings": "Settings",
-      "workspace": "Workspace",
-      "accountLogin": "Account Login"
+      "workspace": "Workspace"
     },
     "modes": {
       "agentic": "Agentic Mode",

--- a/src/shared/i18n/resources/shared/en-US/terms.json
+++ b/src/shared/i18n/resources/shared/en-US/terms.json
@@ -8,8 +8,7 @@
     "codeAgent": "Code Agent",
     "deepReview": "Review: Strict",
     "settings": "Settings",
-    "workspace": "Workspace",
-    "accountLogin": "Account Login"
+    "workspace": "Workspace"
   },
   "modes": {
     "agentic": "Agentic Mode",

--- a/src/shared/i18n/resources/shared/zh-CN/terms.json
+++ b/src/shared/i18n/resources/shared/zh-CN/terms.json
@@ -8,8 +8,7 @@
     "codeAgent": "代码助手",
     "deepReview": "严格审查",
     "settings": "设置",
-    "workspace": "工作区",
-    "accountLogin": "账户登录"
+    "workspace": "工作区"
   },
   "modes": {
     "agentic": "代理模式",

--- a/src/shared/i18n/resources/shared/zh-TW/terms.json
+++ b/src/shared/i18n/resources/shared/zh-TW/terms.json
@@ -8,8 +8,7 @@
     "codeAgent": "程式碼助手",
     "deepReview": "嚴格審查",
     "settings": "設定",
-    "workspace": "工作區",
-    "accountLogin": "帳號登入"
+    "workspace": "工作區"
   },
   "modes": {
     "agentic": "代理模式",

--- a/src/web-ui/AGENTS-CN.md
+++ b/src/web-ui/AGENTS-CN.md
@@ -24,11 +24,11 @@
 - `src/locales/`：多语言文案
 
 Peer Device Mode（同账号远程完整客户端）的边界见 `docs/architecture/peer-device-mode.md`。
-前端不变量见 `src/infrastructure/peer-device/README.md`。不要重新引入
-`AccountLoginDialog` 内嵌会话/聊天壳；应从设备列表进入 peer mode。
+前端不变量见 `src/infrastructure/peer-device/README.md`。不要重新引入内嵌会话/聊天壳；
+应从设备列表（Remote Connect 的「我的设备」组）进入 peer mode。
 
-一键部署 Relay：`src/features/relay-deploy/`（见其 README）。账户登录与 Remote
-Connect Self-Hosted 入口必须打开 `RelayDeployWizard`，不要改成外链 README。
+一键部署 Relay：`src/features/relay-deploy/`（见其 README）。Remote Connect「我的设备」
+登录表单与 Self-Hosted 入口必须打开 `RelayDeployWizard`，不要改成外链 README。
 
 ## 本模块规则
 

--- a/src/web-ui/AGENTS.md
+++ b/src/web-ui/AGENTS.md
@@ -25,12 +25,13 @@ Most changes start in:
 
 Peer Device Mode (same-account remote full client) is documented in
 `docs/architecture/peer-device-mode.md`. Frontend invariants:
-`src/infrastructure/peer-device/README.md`. Do not reintroduce AccountLoginDialog
-nested sessions/chat shells; enter peer mode from the device list instead.
+`src/infrastructure/peer-device/README.md`. Do not reintroduce nested
+sessions/chat shells; enter peer mode from the device list (Remote Connect →
+My Devices) instead.
 
 One-click relay deploy wizard: `src/features/relay-deploy/` (see its README).
-Account Login and Remote Connect Self-Hosted entries must open
-`RelayDeployWizard`, not an external README.
+The Remote Connect account group (My Devices) login form and the Remote Connect
+Self-Hosted entries must open `RelayDeployWizard`, not an external README.
 
 ## Local rules
 

--- a/src/web-ui/src/app/components/AccountLoginDialog/index.ts
+++ b/src/web-ui/src/app/components/AccountLoginDialog/index.ts
@@ -1,2 +1,0 @@
-export { AccountLoginDialog } from './AccountLoginDialog';
-export { AccountLoginDialog as default } from './AccountLoginDialog';

--- a/src/web-ui/src/app/components/NavPanel/NavPanel.scss
+++ b/src/web-ui/src/app/components/NavPanel/NavPanel.scss
@@ -1777,6 +1777,22 @@ $_section-header-height: 24px;
   }
 }
 
+.bitfun-nav-panel__footer-menu-item-label {
+  flex: 1;
+  min-width: 0;
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.bitfun-nav-panel__footer-menu-item-dot {
+  flex-shrink: 0;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--color-success);
+}
+
 .bitfun-nav-panel__remote-disclaimer {
   display: flex;
   flex-direction: column;

--- a/src/web-ui/src/app/components/NavPanel/components/PersistentFooterActions.tsx
+++ b/src/web-ui/src/app/components/NavPanel/components/PersistentFooterActions.tsx
@@ -11,7 +11,6 @@ import {
   ExternalLink,
   BarChart3,
   ChevronUp,
-  LogIn,
 } from 'lucide-react';
 import { Tooltip, Modal } from '@/component-library';
 import { useI18n } from '@/infrastructure/i18n/hooks/useI18n';
@@ -20,8 +19,8 @@ import { useNavSceneStore } from '../../../stores/navSceneStore';
 import { useSceneStore } from '../../../stores/sceneStore';
 import { useCanvasStore } from '@/app/components/panels/content-canvas/stores';
 import { useToolbarModeContext } from '@/flow_chat/components/toolbar-mode/ToolbarModeContext';
-import { useCurrentWorkspace } from '@/infrastructure/contexts/WorkspaceContext';
 import { useNotification } from '@/shared/notification-system';
+import { useAccountLoginState } from '@/infrastructure/account/useAccountLoginState';
 import { remoteConnectAPI } from '@/infrastructure/api/service-api/RemoteConnectAPI';
 import NotificationButton from '../../TitleBar/NotificationButton';
 import {
@@ -33,7 +32,6 @@ import {
 } from '../../RemoteConnectDialog/remoteConnectDisclaimerStorage';
 
 const RemoteConnectDialog = lazy(() => import('../../RemoteConnectDialog'));
-const AccountLoginDialog = lazy(() => import('../../AccountLoginDialog'));
 const AboutDialog = lazy(() =>
   import('../../AboutDialog').then(module => ({ default: module.AboutDialog }))
 );
@@ -53,8 +51,8 @@ const PersistentFooterActions: React.FC = () => {
     return activeTab?.content.type === 'browser';
   });
   const { enableToolbarMode } = useToolbarModeContext();
-  const { hasWorkspace } = useCurrentWorkspace();
   const { warning } = useNotification();
+  const { loggedIn: accountLoggedIn, deviceName: accountDeviceName } = useAccountLoginState();
 
   useEffect(() => {
     const onAutoExit = (event: Event) => {
@@ -73,18 +71,20 @@ const PersistentFooterActions: React.FC = () => {
   const [menuOpen, setMenuOpen] = useState(false);
   const [menuClosing, setMenuClosing] = useState(false);
   const [showAbout, setShowAbout] = useState(false);
-  const [showAccountLogin, setShowAccountLogin] = useState(false);
   const [showRemoteConnect, setShowRemoteConnect] = useState(false);
+  const [remoteInitialGroup, setRemoteInitialGroup] = useState<'network' | 'bot' | 'account' | undefined>(undefined);
   const [showRemoteDisclaimer, setShowRemoteDisclaimer] = useState(false);
   const [hasAgreedRemoteDisclaimer, setHasAgreedRemoteDisclaimer] = useState<boolean>(() => getRemoteConnectDisclaimerAgreed());
 
-  // Periodic token-expiry check. Only auto-open the login dialog if the
-  // token has actually expired while the app is running — not on startup.
+  // Periodic token-expiry check. Only auto-open the dialog if the token has
+  // actually expired while the app is running — not on startup. Lands on the
+  // account group so the user can sign in again right away.
   useEffect(() => {
     const expiryCheck = setInterval(() => {
       remoteConnectAPI.accountTokenExpired().then((expired) => {
         if (expired) {
-          setShowAccountLogin(true);
+          setRemoteInitialGroup('account');
+          setShowRemoteConnect(true);
         }
       });
     }, 60000);
@@ -152,32 +152,24 @@ const PersistentFooterActions: React.FC = () => {
     enableToolbarMode();
   };
 
-  const handleAccountLogin = () => {
-    closeMenu();
-    setShowAccountLogin(true);
-  };
-
   const handleRemoteConnect = useCallback(async () => {
-    if (!hasWorkspace) {
-      warning(t('header.remoteConnectRequiresWorkspace'));
-      return;
-    }
-
     closeMenu();
 
     if (hasAgreedRemoteDisclaimer || getRemoteConnectDisclaimerAgreed()) {
       setHasAgreedRemoteDisclaimer(true);
+      setRemoteInitialGroup(undefined);
       setShowRemoteConnect(true);
       return;
     }
 
     setShowRemoteDisclaimer(true);
-  }, [hasWorkspace, warning, t, closeMenu, hasAgreedRemoteDisclaimer]);
+  }, [closeMenu, hasAgreedRemoteDisclaimer]);
 
   const handleAgreeDisclaimer = useCallback(() => {
     setRemoteConnectDisclaimerAgreed();
     setHasAgreedRemoteDisclaimer(true);
     setShowRemoteDisclaimer(false);
+    setRemoteInitialGroup(undefined);
     setShowRemoteConnect(true);
   }, []);
 
@@ -224,29 +216,18 @@ const PersistentFooterActions: React.FC = () => {
                     type="button"
                     className="bitfun-nav-panel__footer-menu-item"
                     role="menuitem"
-                    onClick={handleAccountLogin}
-                    data-testid="nav-footer-account-login-item"
+                    onClick={handleRemoteConnect}
                   >
-                    <LogIn size={14} />
-                    <span>{t('shared:features.accountLogin')}</span>
+                    <Smartphone size={14} />
+                    <span className="bitfun-nav-panel__footer-menu-item-label">
+                      {accountLoggedIn && accountDeviceName
+                        ? accountDeviceName
+                        : t('shared:features.remoteControl')}
+                    </span>
+                    {accountLoggedIn && (
+                      <span className="bitfun-nav-panel__footer-menu-item-dot" />
+                    )}
                   </button>
-                  <div className="bitfun-nav-panel__footer-menu-divider" />
-                  <Tooltip
-                    content={t('header.remoteConnectRequiresWorkspace')}
-                    placement="right"
-                    disabled={hasWorkspace}
-                  >
-                    <button
-                      type="button"
-                      className={`bitfun-nav-panel__footer-menu-item${!hasWorkspace ? ' is-disabled' : ''}`}
-                      role="menuitem"
-                      aria-disabled={!hasWorkspace}
-                      onClick={handleRemoteConnect}
-                    >
-                      <Smartphone size={14} />
-                      <span>{t('shared:features.remoteControl')}</span>
-                    </button>
-                  </Tooltip>
                   <div className="bitfun-nav-panel__footer-menu-divider" />
                   <button
                     type="button"
@@ -333,14 +314,13 @@ const PersistentFooterActions: React.FC = () => {
           <AboutDialog isOpen={showAbout} onClose={() => setShowAbout(false)} />
         </Suspense>
       )}
-      {showAccountLogin && (
-        <Suspense fallback={null}>
-          <AccountLoginDialog isOpen={showAccountLogin} onClose={() => setShowAccountLogin(false)} />
-        </Suspense>
-      )}
       {showRemoteConnect && (
         <Suspense fallback={null}>
-          <RemoteConnectDialog isOpen={showRemoteConnect} onClose={() => setShowRemoteConnect(false)} />
+          <RemoteConnectDialog
+            isOpen={showRemoteConnect}
+            onClose={() => setShowRemoteConnect(false)}
+            initialGroup={remoteInitialGroup}
+          />
         </Suspense>
       )}
       <Modal

--- a/src/web-ui/src/app/components/RemoteConnectDialog/AccountPanel.scss
+++ b/src/web-ui/src/app/components/RemoteConnectDialog/AccountPanel.scss
@@ -1,9 +1,10 @@
 /**
- * Account Login Dialog Styles
+ * Account ("My Devices") panel styles — embedded in the Remote Connect dialog.
  * Mirrors the SSH connection dialog visual style.
  */
 
-.account-login-dialog {
+.account-panel {
+  position: relative;
   display: flex;
   flex-direction: column;
   flex: 1;
@@ -27,6 +28,13 @@
     min-height: 0;
     overflow-y: auto;
     padding: 10px 0 6px;
+  }
+
+  &__value-prop {
+    margin: 2px 16px 12px;
+    font-size: 12px;
+    line-height: 1.5;
+    color: var(--color-text-secondary);
   }
 
   &__form {
@@ -125,40 +133,11 @@
     }
   }
 
-  &__devices {
-    margin: 12px 16px 4px;
-    padding: 8px;
-    border: 1px solid var(--border-subtle);
-    border-radius: 6px;
-    background: var(--color-bg-secondary);
-  }
-
-  &__devices-header {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    font-size: 11px;
-    font-weight: 600;
-    color: var(--color-text-secondary);
-    margin-bottom: 6px;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-  }
-
   &__device-list {
     display: flex;
     flex-direction: column;
     gap: 4px;
-  }
-
-  &__device-item {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 4px 6px;
-    border-radius: 4px;
-    background: var(--color-bg-primary);
-    font-size: 12px;
+    padding: 0 16px;
   }
 
   &__device-name {
@@ -199,11 +178,6 @@
       font-size: 13px;
       line-height: 1.5;
     }
-  }
-
-  &__overwrite-detail {
-    color: var(--color-text-secondary);
-    font-size: 12px !important;
   }
 
   &__sync-options {
@@ -352,7 +326,7 @@
       background: color-mix(in srgb, var(--color-accent-500) 8%, var(--color-bg-primary));
     }
 
-    .account-login-dialog__device-info {
+    .account-panel__device-info {
       flex: 1;
       display: flex;
       flex-direction: column;
@@ -403,163 +377,6 @@
     color: var(--color-static-white);
     font-size: 12px;
     border-radius: inherit;
-  }
-
-  &__back-bar-right {
-    display: flex;
-    gap: 4px;
-  }
-
-  &__workspace-section {
-    margin-bottom: 8px;
-  }
-
-  &__workspace-label {
-    font-size: 10px;
-    font-weight: 600;
-    color: var(--color-text-muted);
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    margin-bottom: 4px;
-  }
-
-  &__workspace-chips {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 4px;
-  }
-
-  &__workspace-chip {
-    padding: 3px 8px;
-    border-radius: 4px;
-    background: var(--color-bg-primary);
-    border: 1px solid var(--border-subtle);
-    font-size: 11px;
-    cursor: pointer;
-    transition: all 0.15s;
-    max-width: 150px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-
-    &:hover { border-color: var(--color-accent-500); }
-    &.active { background: var(--color-accent-500); color: var(--color-static-white); border-color: var(--color-accent-500); }
-  }
-
-  &__new-workspace {
-    display: flex;
-    gap: 6px;
-    align-items: center;
-    margin: 8px 0;
-    padding: 6px;
-    border-radius: 6px;
-    background: var(--color-bg-secondary);
-
-    .input-wrapper { flex: 1; }
-  }
-
-  &__back-bar {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 0 0 8px;
-  }
-
-  &__workspace-info {
-    font-size: 11px;
-    color: var(--color-text-secondary);
-    padding: 4px 0 8px;
-    font-family: var(--font-family-mono);
-  }
-
-  &__session-list {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-  }
-
-  &__session-item {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 8px 10px;
-    border-radius: 6px;
-    background: var(--color-bg-primary);
-    border: 1px solid var(--border-subtle);
-    cursor: pointer;
-    transition: border-color 0.15s;
-
-    &:hover { border-color: var(--color-accent-500); }
-  }
-
-  &__session-info {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-  }
-
-  &__session-name {
-    font-size: 13px;
-    font-weight: 500;
-    color: var(--color-text-primary);
-  }
-
-  &__session-meta {
-    font-size: 10px;
-    color: var(--color-text-muted);
-  }
-
-  &__messages {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    padding: 4px 0 12px;
-    max-height: 300px;
-    overflow-y: auto;
-  }
-
-  &__message {
-    padding: 6px 10px;
-    border-radius: 8px;
-    font-size: 12px;
-    max-width: 90%;
-
-    &--user {
-      background: var(--color-bg-secondary);
-      align-self: flex-end;
-      text-align: right;
-    }
-
-    &--assistant {
-      background: var(--color-bg-primary);
-      border: 1px solid var(--border-subtle);
-      align-self: flex-start;
-    }
-  }
-
-  &__message-role {
-    font-size: 10px;
-    font-weight: 600;
-    color: var(--color-text-muted);
-    text-transform: uppercase;
-    margin-bottom: 2px;
-  }
-
-  &__message-content {
-    white-space: pre-wrap;
-    word-break: break-word;
-    line-height: 1.4;
-  }
-
-  &__message-input {
-    display: flex;
-    gap: 8px;
-    align-items: center;
-    padding-top: 8px;
-    border-top: 1px solid var(--border-subtle);
-
-    .input-wrapper { flex: 1; }
   }
 }
 

--- a/src/web-ui/src/app/components/RemoteConnectDialog/AccountPanel.tsx
+++ b/src/web-ui/src/app/components/RemoteConnectDialog/AccountPanel.tsx
@@ -1,23 +1,23 @@
 /**
- * Account Login + Online Devices
+ * Account ("My Devices") panel inside the Remote Connect dialog.
  *
  * Views: login → overwrite (optional) → devices
- * After login / overwrite choice the dialog closes immediately while cloud
- * sync continues in the background; reopening Online Devices shows progress.
- * Clicking an online peer device enters Peer Device Mode and closes the dialog.
+ * Unlike the old standalone dialog, a successful login keeps the panel open
+ * and lands on the devices view so sync progress stays visible in place.
  *
  * Sync-choice invariants (do not regress):
  * - When the relay already has cloud settings, `account_login` keeps the
- *   session memory-only until `account_finalize_login`. Closing / canceling
- *   the overwrite view must logout so a killed process does not restore login.
- * - One-click deploy opens `RelayDeployWizard` (same feature as Remote Connect),
- *   not an external README. See `src/features/relay-deploy/README.md`.
+ *   session memory-only until `account_finalize_login`. Canceling the
+ *   overwrite view, switching away from this panel, or closing the dialog
+ *   must logout so a killed process does not restore login.
+ * - One-click deploy opens `RelayDeployWizard` (same feature as the Network
+ *   group), not an external README. See `src/features/relay-deploy/README.md`.
  */
 
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { useI18n } from '@/infrastructure/i18n';
 import { useCurrentWorkspace } from '@/infrastructure/contexts/WorkspaceContext';
-import { Modal, Button, Input, Alert } from '@/component-library';
+import { Button, Input, Alert } from '@/component-library';
 import {
   User, Lock, Server, LogIn, Monitor, CloudDownload, Upload,
   ChevronRight, RefreshCw, Eye, EyeOff, X, Rocket, Copy, Check,
@@ -35,9 +35,9 @@ import type { AccountSyncPhase } from '@/infrastructure/account/accountSyncStore
 import { isAccountAuthFailure } from '@/infrastructure/account/accountErrorUtils';
 import { useNotification } from '@/shared/notification-system';
 import { createLogger } from '@/shared/utils/logger';
-import './AccountLoginDialog.scss';
+import './AccountPanel.scss';
 
-const log = createLogger('AccountLoginDialog');
+const log = createLogger('AccountPanel');
 
 const DEVICE_POLL_FALLBACK_MS = 30_000;
 
@@ -73,16 +73,15 @@ function syncPhaseLabel(
   }
 }
 
-interface AccountLoginDialogProps {
-  isOpen: boolean;
-  onClose: () => void;
+interface AccountPanelProps {
+  /** Close the whole Remote Connect dialog (used when entering peer mode). */
+  onCloseDialog: () => void;
 }
 
 type View = 'login' | 'overwrite' | 'devices';
 
-export const AccountLoginDialog: React.FC<AccountLoginDialogProps> = ({
-  isOpen,
-  onClose,
+export const AccountPanel: React.FC<AccountPanelProps> = ({
+  onCloseDialog,
 }) => {
   const { t } = useI18n('common');
   const { success, info, warning } = useNotification();
@@ -114,6 +113,9 @@ export const AccountLoginDialog: React.FC<AccountLoginDialogProps> = ({
   const refreshTimer = useRef<ReturnType<typeof setInterval> | null>(null);
   /** Prevent overlapping background syncs from rapid clicks. */
   const syncInFlightRef = useRef(false);
+  /** Track the overwrite view for the unmount logout invariant. */
+  const viewRef = useRef<View>(view);
+  viewRef.current = view;
 
   const resetState = useCallback(() => {
     setDevices([]);
@@ -217,25 +219,62 @@ export const AccountLoginDialog: React.FC<AccountLoginDialogProps> = ({
     });
   }, []);
 
+  /** Latest refreshDevices for the polling interval (avoids stale closures). */
+  const refreshDevicesRef = useRef(refreshDevices);
+  refreshDevicesRef.current = refreshDevices;
+
   const startDevicePolling = useCallback(() => {
     if (refreshTimer.current) {
       clearInterval(refreshTimer.current);
     }
-    refreshTimer.current = setInterval(refreshDevices, DEVICE_POLL_FALLBACK_MS);
-  }, [refreshDevices]);
+    refreshTimer.current = setInterval(
+      () => { void refreshDevicesRef.current(); },
+      DEVICE_POLL_FALLBACK_MS,
+    );
+  }, []);
+
+  /** Connect presence + load the device list for an active account session. */
+  const initializeDevices = useCallback(async () => {
+    try {
+      await remoteConnectAPI.accountConnectDevices();
+      // Re-read after AuthOk may have adopted the account-bound device_id.
+      try {
+        const info = await remoteConnectAPI.getDeviceInfo();
+        setLocalDeviceId(info.device_id);
+      } catch (e) {
+        log.warn('getDeviceInfo after connect failed', e);
+      }
+    } catch (err) {
+      log.warn('accountConnectDevices failed', err);
+      if (isAccountAuthFailure(err)) {
+        await handleSessionExpired(err);
+        return;
+      }
+      markRelayUnreachable();
+    }
+    void refreshDevices();
+    startDevicePolling();
+  }, [handleSessionExpired, markRelayUnreachable, refreshDevices, startDevicePolling]);
 
   useEffect(() => {
     ensureAccountSyncProgressListener();
   }, []);
 
+  // Unmounting (dialog close or group switch) during the sync-choice step
+  // abandons the incomplete login — pair with `account_finalize_login`.
+  // The dialog tree unmounts this panel directly, so this must be a cleanup,
+  // not an effect gated on a prop flip.
   useEffect(() => {
-    if (!isOpen) {
-      setUsername(''); setPassword(''); setAuthServer('');
-      setError(null); setLoading(false); setView('login');
-      resetState();
-      return;
-    }
+    return () => {
+      if (viewRef.current === 'overwrite') {
+        void remoteConnectAPI.accountLogout().catch((e) => {
+          log.warn('logout on overwrite abandon failed', e);
+        });
+      }
+    };
+  }, []);
 
+  useEffect(() => {
     remoteConnectAPI.getDeviceInfo().then((info) => {
       setLocalDeviceId(info.device_id);
     }).catch((e) => { log.warn('getDeviceInfo failed', e); });
@@ -245,25 +284,7 @@ export const AccountLoginDialog: React.FC<AccountLoginDialogProps> = ({
     remoteConnectAPI.accountStatus().then(async (status) => {
       if (status.logged_in && status.user_id) {
         setView('devices');
-        try {
-          await remoteConnectAPI.accountConnectDevices();
-          // Re-read after AuthOk may have adopted the account-bound device_id.
-          try {
-            const info = await remoteConnectAPI.getDeviceInfo();
-            setLocalDeviceId(info.device_id);
-          } catch (e) {
-            log.warn('getDeviceInfo after connect failed', e);
-          }
-        } catch (err) {
-          log.warn('accountConnectDevices failed', err);
-          if (isAccountAuthFailure(err)) {
-            await handleSessionExpired(err);
-            return;
-          }
-          markRelayUnreachable();
-        }
-        void refreshDevices();
-        startDevicePolling();
+        await initializeDevices();
       }
     });
 
@@ -281,13 +302,8 @@ export const AccountLoginDialog: React.FC<AccountLoginDialogProps> = ({
       unlistenPresence();
     };
   }, [
-    isOpen,
-    refreshDevices,
-    resetState,
-    startDevicePolling,
     applyPresenceOnline,
-    handleSessionExpired,
-    markRelayUnreachable,
+    initializeDevices,
   ]);
 
   const validate = useCallback(() => {
@@ -300,8 +316,8 @@ export const AccountLoginDialog: React.FC<AccountLoginDialogProps> = ({
   }, [username, password, authServer, t]);
 
   /**
-   * Run cloud sync + device connect in the background. Dialog can close
-   * immediately; progress is visible when Online Devices is reopened.
+   * Run cloud sync + device connect in the background. Progress is visible
+   * in the devices view while it continues.
    */
   const startBackgroundSync = useCallback((isFirstLogin: boolean) => {
     if (syncInFlightRef.current) {
@@ -313,7 +329,7 @@ export const AccountLoginDialog: React.FC<AccountLoginDialogProps> = ({
     setSyncing();
     info(t('accountLogin.syncStarted'));
 
-    // Connect device presence immediately so Online Devices can populate
+    // Connect device presence immediately so the device list can populate
     // while the heavier settings/session sync continues.
     void remoteConnectAPI.accountConnectDevices().catch((err) => {
       log.warn('accountConnectDevices failed at sync start', err);
@@ -392,6 +408,14 @@ export const AccountLoginDialog: React.FC<AccountLoginDialogProps> = ({
     workspacePath,
   ]);
 
+  /** Landing path after a completed login: devices view + background sync. */
+  const completeLogin = useCallback((relayUrl: string, isFirstLogin: boolean) => {
+    setAccountRelayUrl(relayUrl);
+    setView('devices');
+    void initializeDevices();
+    startBackgroundSync(isFirstLogin);
+  }, [initializeDevices, startBackgroundSync]);
+
   const performLogin = useCallback(async (server: string, user: string, pass: string) => {
     setLoading(true); setError(null);
     try {
@@ -402,13 +426,11 @@ export const AccountLoginDialog: React.FC<AccountLoginDialogProps> = ({
         return;
       }
       success(t('accountLogin.loginSuccess', { user_id: result.user_id }));
-      setAccountRelayUrl(server);
-      startBackgroundSync(true);
-      onClose();
+      completeLogin(server, true);
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : String(e));
     } finally { setLoading(false); }
-  }, [startBackgroundSync, success, t, onClose]);
+  }, [completeLogin, success, t]);
 
   const handleLogin = useCallback(async () => {
     if (!validate()) return;
@@ -433,8 +455,7 @@ export const AccountLoginDialog: React.FC<AccountLoginDialogProps> = ({
     try {
       await remoteConnectAPI.accountFinalizeLogin();
       success(t('accountLogin.loginSuccess', { user_id: username }));
-      startBackgroundSync(isFirstLogin);
-      onClose();
+      completeLogin(authServer.trim(), isFirstLogin);
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : String(e));
       try { await remoteConnectAPI.accountLogout(); } catch (logoutErr) {
@@ -445,7 +466,7 @@ export const AccountLoginDialog: React.FC<AccountLoginDialogProps> = ({
     } finally {
       setLoading(false);
     }
-  }, [onClose, resetState, startBackgroundSync, success, t, username]);
+  }, [authServer, completeLogin, resetState, success, t, username]);
 
   const handleConfirmOverwrite = useCallback(() => {
     void finalizeAndSync(false);
@@ -459,17 +480,7 @@ export const AccountLoginDialog: React.FC<AccountLoginDialogProps> = ({
     try { await remoteConnectAPI.accountLogout(); } catch (e) { log.warn('logout failed', e); }
     resetState();
     setView('login');
-    onClose();
-  }, [onClose, resetState]);
-
-  /** Closing the dialog during the sync-choice step abandons the incomplete login. */
-  const handleDialogClose = useCallback(() => {
-    if (view === 'overwrite') {
-      void handleCancelOverwrite();
-      return;
-    }
-    onClose();
-  }, [handleCancelOverwrite, onClose, view]);
+  }, [resetState]);
 
   const handleLogout = useCallback(async () => {
     setLoading(true);
@@ -505,46 +516,41 @@ export const AccountLoginDialog: React.FC<AccountLoginDialogProps> = ({
     try {
       await enterPeerMode(device.device_id, device.device_name);
       success(t('accountLogin.enteredPeerMode', { name: device.device_name }));
-      onClose();
+      onCloseDialog();
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
       setLoading(false);
     }
-  }, [enterPeerMode, info, localDeviceId, onClose, success, syncStatus, t]);
-
-  const title = view === 'login' || view === 'overwrite'
-    ? t('shared:features.accountLogin')
-    : t('accountLogin.devices');
+  }, [enterPeerMode, info, localDeviceId, onCloseDialog, success, syncStatus, t]);
 
   return (
     <>
-      <Modal isOpen={isOpen} onClose={handleDialogClose} title={title} size="medium"
-        showCloseButton closeOnOverlayClick={false} contentClassName="modal__content--fill-flex">
-      <div className="account-login-dialog">
+      <div className="account-panel">
         {error && (
-          <div className="account-login-dialog__error-banner">
+          <div className="account-panel__error-banner">
             <Alert type="error" message={error} closable onClose={() => setError(null)}
-              className="account-login-dialog__error-alert" />
+              className="account-panel__error-alert" />
           </div>
         )}
 
         {loading && view === 'devices' && (
-          <div className="account-login-dialog__loading-overlay">
+          <div className="account-panel__loading-overlay">
             <RefreshCw size={20} className="spinning" />
             <span>{t('accountLogin.processing')}</span>
           </div>
         )}
 
         {view === 'login' && (
-          <div className="account-login-dialog__scroll">
-            <div className="account-login-dialog__form">
-              <div className="account-login-dialog__field">
+          <div className="account-panel__scroll">
+            <p className="account-panel__value-prop">{t('accountLogin.loginValueProp')}</p>
+            <div className="account-panel__form">
+              <div className="account-panel__field">
                 <Input label={t('accountLogin.username')} type="text" value={username}
                   onChange={(e) => setUsername(e.target.value)} prefix={<User size={16} />}
                   size="medium" disabled={loading} />
               </div>
-              <div className="account-login-dialog__field">
+              <div className="account-panel__field">
                 <Input label={t('accountLogin.password')} type={showPassword ? 'text' : 'password'} value={password}
                   onChange={(e) => setPassword(e.target.value)} prefix={<Lock size={16} />}
                   size="medium" disabled={loading}
@@ -554,17 +560,17 @@ export const AccountLoginDialog: React.FC<AccountLoginDialogProps> = ({
                     </button>
                   } />
               </div>
-              <div className="account-login-dialog__field">
+              <div className="account-panel__field">
                 <Input label={t('accountLogin.authServer')} type="url" value={authServer}
                   onChange={(e) => setAuthServer(e.target.value)}
                   placeholder={t('accountLogin.authServerPlaceholder')}
                   prefix={<Server size={16} />} size="medium" disabled={loading} />
               </div>
-              <div className="account-login-dialog__deploy-entry">
+              <div className="account-panel__deploy-entry">
                 <span>{t('relayDeploy.entryHint')}</span>
                 <button
                   type="button"
-                  className="account-login-dialog__deploy-link"
+                  className="account-panel__deploy-link"
                   onClick={() => setShowRelayDeploy(true)}
                   disabled={loading}
                 >
@@ -573,10 +579,7 @@ export const AccountLoginDialog: React.FC<AccountLoginDialogProps> = ({
                 </button>
               </div>
             </div>
-            <div className="account-login-dialog__actions">
-              <Button variant="secondary" size="small" onClick={onClose} disabled={loading}>
-                {t('accountLogin.cancel')}
-              </Button>
+            <div className="account-panel__actions">
               <Button variant="primary" size="small" onClick={handleLogin} disabled={loading}>
                 <LogIn size={14} />
                 {loading ? t('accountLogin.processing') : t('accountLogin.login')}
@@ -586,36 +589,36 @@ export const AccountLoginDialog: React.FC<AccountLoginDialogProps> = ({
         )}
 
         {view === 'overwrite' && (
-          <div className="account-login-dialog__scroll">
-            <div className="account-login-dialog__overwrite-notice">
+          <div className="account-panel__scroll">
+            <div className="account-panel__overwrite-notice">
               <CloudDownload size={32} />
               <p>{t('accountLogin.cloudOverwriteWarning')}</p>
             </div>
-            <div className="account-login-dialog__sync-options">
+            <div className="account-panel__sync-options">
               <button
-                className="account-login-dialog__sync-option"
+                className="account-panel__sync-option"
                 onClick={handleUseLocalOverwrite}
                 disabled={loading}
               >
                 <Upload size={20} />
-                <div className="account-login-dialog__sync-option-text">
-                  <span className="account-login-dialog__sync-option-title">{t('accountLogin.useLocalTitle')}</span>
-                  <span className="account-login-dialog__sync-option-desc">{t('accountLogin.useLocalDesc')}</span>
+                <div className="account-panel__sync-option-text">
+                  <span className="account-panel__sync-option-title">{t('accountLogin.useLocalTitle')}</span>
+                  <span className="account-panel__sync-option-desc">{t('accountLogin.useLocalDesc')}</span>
                 </div>
               </button>
               <button
-                className="account-login-dialog__sync-option"
+                className="account-panel__sync-option"
                 onClick={handleConfirmOverwrite}
                 disabled={loading}
               >
                 <CloudDownload size={20} />
-                <div className="account-login-dialog__sync-option-text">
-                  <span className="account-login-dialog__sync-option-title">{t('accountLogin.useCloudTitle')}</span>
-                  <span className="account-login-dialog__sync-option-desc">{t('accountLogin.useCloudDesc')}</span>
+                <div className="account-panel__sync-option-text">
+                  <span className="account-panel__sync-option-title">{t('accountLogin.useCloudTitle')}</span>
+                  <span className="account-panel__sync-option-desc">{t('accountLogin.useCloudDesc')}</span>
                 </div>
               </button>
             </div>
-            <div className="account-login-dialog__actions">
+            <div className="account-panel__actions">
               <Button variant="secondary" size="small" onClick={handleCancelOverwrite} disabled={loading}>
                 {t('accountLogin.disagree')}
               </Button>
@@ -624,16 +627,16 @@ export const AccountLoginDialog: React.FC<AccountLoginDialogProps> = ({
         )}
 
         {view === 'devices' && (
-          <div className="account-login-dialog__scroll">
+          <div className="account-panel__scroll">
             {accountRelayUrl && (
-              <div className="account-login-dialog__server-line">
+              <div className="account-panel__server-line">
                 <Server size={13} />
-                <span className="account-login-dialog__server-url" title={accountRelayUrl}>
+                <span className="account-panel__server-url" title={accountRelayUrl}>
                   {accountRelayUrl}
                 </span>
                 <button
                   type="button"
-                  className="account-login-dialog__copy-btn"
+                  className="account-panel__copy-btn"
                   onClick={handleCopyRelayUrl}
                   title={t('accountLogin.copyServerUrl')}
                 >
@@ -642,12 +645,12 @@ export const AccountLoginDialog: React.FC<AccountLoginDialogProps> = ({
               </div>
             )}
             {syncStatus !== 'idle' && !relayError && (
-              <div className={`account-login-dialog__sync-indicator ${syncStatus}`}>
-                <div className="account-login-dialog__sync-indicator-row">
+              <div className={`account-panel__sync-indicator ${syncStatus}`}>
+                <div className="account-panel__sync-indicator-row">
                   {syncStatus === 'syncing' && <RefreshCw size={14} className="spinning" />}
                   {syncStatus === 'done' && <span>✓</span>}
                   {syncStatus === 'failed' && <span>⚠</span>}
-                  <span className="account-login-dialog__sync-indicator-text">
+                  <span className="account-panel__sync-indicator-text">
                     {syncStatus === 'syncing' && syncPhaseLabel(
                       t,
                       syncProgress.phase,
@@ -658,21 +661,21 @@ export const AccountLoginDialog: React.FC<AccountLoginDialogProps> = ({
                     {syncStatus === 'failed' && t('accountLogin.syncFailed')}
                   </span>
                   {syncStatus === 'syncing' && (
-                    <span className="account-login-dialog__sync-indicator-percent">
+                    <span className="account-panel__sync-indicator-percent">
                       {t('accountLogin.syncProgressPercent', { percent: syncProgress.percent })}
                     </span>
                   )}
                 </div>
                 {syncStatus === 'syncing' && (
                   <div
-                    className="account-login-dialog__sync-progress-track"
+                    className="account-panel__sync-progress-track"
                     role="progressbar"
                     aria-valuemin={0}
                     aria-valuemax={100}
                     aria-valuenow={syncProgress.percent}
                   >
                     <div
-                      className="account-login-dialog__sync-progress-fill"
+                      className="account-panel__sync-progress-fill"
                       style={{ width: `${Math.max(2, syncProgress.percent)}%` }}
                     />
                   </div>
@@ -680,35 +683,35 @@ export const AccountLoginDialog: React.FC<AccountLoginDialogProps> = ({
               </div>
             )}
             {relayError && (
-              <div className="account-login-dialog__error-banner">
+              <div className="account-panel__error-banner">
                 <Alert
                   type="error"
                   message={relayError}
-                  className="account-login-dialog__error-alert"
+                  className="account-panel__error-alert"
                 />
               </div>
             )}
-            <div className="account-login-dialog__device-list">
+            <div className="account-panel__device-list">
               {!relayError && devicesReady && devices.length === 0 && (
-                <div className="account-login-dialog__empty">{t('accountLogin.noDevices')}</div>
+                <div className="account-panel__empty">{t('accountLogin.noDevices')}</div>
               )}
               {!relayError && devices.map((d) => {
                 const isLocal = localDeviceId === d.device_id;
                 return (
                 <div key={d.device_id}
-                  className={`account-login-dialog__device-card ${d.online ? '' : 'offline'} ${isLocal ? 'current' : ''} ${syncStatus === 'syncing' && !isLocal ? 'syncing' : ''}`}
+                  className={`account-panel__device-card ${d.online ? '' : 'offline'} ${isLocal ? 'current' : ''} ${syncStatus === 'syncing' && !isLocal ? 'syncing' : ''}`}
                   onClick={() => !isLocal && selectDevice(d)}>
                   <Monitor size={16} />
-                  <div className="account-login-dialog__device-info">
-                    <span className="account-login-dialog__device-name">
+                  <div className="account-panel__device-info">
+                    <span className="account-panel__device-name">
                       {d.device_name}
-                      {isLocal && <span className="account-login-dialog__device-badge">{t('accountLogin.thisDevice')}</span>}
+                      {isLocal && <span className="account-panel__device-badge">{t('accountLogin.thisDevice')}</span>}
                     </span>
-                    <span className="account-login-dialog__device-meta">
-                      <span className="account-login-dialog__device-id">
+                    <span className="account-panel__device-meta">
+                      <span className="account-panel__device-id">
                         {d.device_id.slice(0, 8)}
                       </span>
-                      <span className="account-login-dialog__device-status">
+                      <span className="account-panel__device-status">
                         {' · '}
                         {d.online ? t('accountLogin.online') : t('accountLogin.offline')}
                       </span>
@@ -721,7 +724,7 @@ export const AccountLoginDialog: React.FC<AccountLoginDialogProps> = ({
                         {d.online && syncStatus === 'syncing' && (
                           <RefreshCw size={14} className="spinning" aria-label={t('accountLogin.syncing')} />
                         )}
-                        <button className="account-login-dialog__device-remove"
+                        <button className="account-panel__device-remove"
                           onClick={(e) => { e.stopPropagation(); handleDeleteDevice(d.device_id, d.device_name); }}
                           title={t('accountLogin.removeDevice')}
                           tabIndex={-1}>
@@ -732,7 +735,7 @@ export const AccountLoginDialog: React.FC<AccountLoginDialogProps> = ({
                 );
               })}
             </div>
-            <div className="account-login-dialog__actions">
+            <div className="account-panel__actions">
               {relayError && (
                 <Button variant="primary" size="small" onClick={handleRetryConnect} disabled={loading}>
                   <RefreshCw size={14} />
@@ -746,7 +749,6 @@ export const AccountLoginDialog: React.FC<AccountLoginDialogProps> = ({
           </div>
         )}
       </div>
-      </Modal>
 
       {showRelayDeploy && (
         <RelayDeployWizard
@@ -759,4 +761,4 @@ export const AccountLoginDialog: React.FC<AccountLoginDialogProps> = ({
   );
 };
 
-export default AccountLoginDialog;
+export default AccountPanel;

--- a/src/web-ui/src/app/components/RemoteConnectDialog/RemoteConnectDialog.tsx
+++ b/src/web-ui/src/app/components/RemoteConnectDialog/RemoteConnectDialog.tsx
@@ -1,17 +1,22 @@
 /**
- * Remote Connect dialog with two independent groups:
+ * Remote Connect dialog with three groups:
  *   - Network (LAN / Ngrok / BitFun Server / Custom Server) – mutually exclusive
  *   - IM Bot (Telegram / Feishu / WeChat) – mutually exclusive
- * Both groups can be active simultaneously.
+ *   - Account / My Devices (login, cloud sync, peer device control)
+ * Network and Bot require an open workspace and can be active simultaneously;
+ * the Account group works without a workspace.
  */
 
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { QRCodeSVG } from 'qrcode.react';
 import { useI18n } from '@/infrastructure/i18n';
 import { getLocaleFallbackChain, type LocaleId } from '@/infrastructure/i18n/presets';
-import { Modal, Badge, Input, Select } from '@/component-library';
+import { Modal, Badge, Input, Select, Tooltip } from '@/component-library';
 import { systemAPI } from '@/infrastructure/api/service-api/SystemAPI';
 import { api } from '@/infrastructure/api/service-api/ApiClient';
+import { useCurrentWorkspace } from '@/infrastructure/contexts/WorkspaceContext';
+import { useAccountLoginState } from '@/infrastructure/account/useAccountLoginState';
+import { AccountPanel } from './AccountPanel';
 import {
   remoteConnectAPI,
   type ConnectionResult,
@@ -31,7 +36,7 @@ import './RemoteConnectDialog.scss';
 
 // ── Types ────────────────────────────────────────────────────────────
 
-type ActiveGroup = 'network' | 'bot';
+type ActiveGroup = 'network' | 'bot' | 'account';
 type NetworkTab = 'lan' | 'ngrok' | 'bitfun_server' | 'custom_server';
 type BotTab = 'telegram' | 'feishu' | 'weixin';
 
@@ -102,15 +107,26 @@ const botInfoToBotTab = (info: string | null | undefined): BotTab | null => {
 interface RemoteConnectDialogProps {
   isOpen: boolean;
   onClose: () => void;
+  /**
+   * Group to show when no active connection is detected (e.g. the menu opens
+   * the account group after a token expiry). Active relay/bot connections
+   * still take precedence and switch to their own group.
+   */
+  initialGroup?: ActiveGroup;
 }
 
 export const RemoteConnectDialog: React.FC<RemoteConnectDialogProps> = ({
   isOpen,
   onClose,
+  initialGroup,
 }) => {
   const { t, currentLanguage } = useI18n('common');
+  const { hasWorkspace } = useCurrentWorkspace();
+  const { loggedIn: accountLoggedIn } = useAccountLoginState();
 
-  const [activeGroup, setActiveGroup] = useState<ActiveGroup>('network');
+  const [activeGroup, setActiveGroup] = useState<ActiveGroup>(
+    initialGroup ?? (hasWorkspace ? 'network' : 'account'),
+  );
   const [networkTab, setNetworkTab] = useState<NetworkTab>(NETWORK_TABS[0].id);
   const [botTab, setBotTab] = useState<BotTab>(BOT_TABS[0].id);
 
@@ -998,29 +1014,50 @@ export const RemoteConnectDialog: React.FC<RemoteConnectDialogProps> = ({
         <div className="bitfun-remote-connect">
           {/* ── Group tabs ── */}
           <div className="bitfun-remote-connect__groups">
-            <button
-              type="button"
-              className={`bitfun-remote-connect__group-btn${activeGroup === 'network' ? ' is-active' : ''}`}
-              onClick={() => { setActiveGroup('network'); setConnectionResult(null); setError(null); }}
-              disabled={isBotConnecting}
+            <Tooltip
+              content={t('header.remoteConnectRequiresWorkspace')}
+              placement="bottom"
+              disabled={hasWorkspace}
             >
-              {t('remoteConnect.groupNetwork')}
-              {isRelayConnected && <span className="bitfun-remote-connect__dot" />}
-            </button>
+              <button
+                type="button"
+                className={`bitfun-remote-connect__group-btn${activeGroup === 'network' ? ' is-active' : ''}`}
+                onClick={() => { setActiveGroup('network'); setConnectionResult(null); setError(null); }}
+                disabled={isBotConnecting || !hasWorkspace}
+              >
+                {t('remoteConnect.groupNetwork')}
+                {isRelayConnected && <span className="bitfun-remote-connect__dot" />}
+              </button>
+            </Tooltip>
+            <span className="bitfun-remote-connect__group-divider" />
+            <Tooltip
+              content={t('header.remoteConnectRequiresWorkspace')}
+              placement="bottom"
+              disabled={hasWorkspace}
+            >
+              <button
+                type="button"
+                className={`bitfun-remote-connect__group-btn${activeGroup === 'bot' ? ' is-active' : ''}`}
+                onClick={() => { setActiveGroup('bot'); setConnectionResult(null); setError(null); }}
+                disabled={isNetworkConnecting || !hasWorkspace}
+              >
+                {t('remoteConnect.groupBot')}
+                {isBotConnected && <span className="bitfun-remote-connect__dot" />}
+              </button>
+            </Tooltip>
             <span className="bitfun-remote-connect__group-divider" />
             <button
               type="button"
-              className={`bitfun-remote-connect__group-btn${activeGroup === 'bot' ? ' is-active' : ''}`}
-              onClick={() => { setActiveGroup('bot'); setConnectionResult(null); setError(null); }}
-              disabled={isNetworkConnecting}
+              className={`bitfun-remote-connect__group-btn${activeGroup === 'account' ? ' is-active' : ''}`}
+              onClick={() => { setActiveGroup('account'); setError(null); }}
             >
-              {t('remoteConnect.groupBot')}
-              {isBotConnected && <span className="bitfun-remote-connect__dot" />}
+              {t('remoteConnect.groupAccount')}
+              {accountLoggedIn && <span className="bitfun-remote-connect__dot" />}
             </button>
           </div>
 
           {/* ── Sub-tabs ── */}
-          {activeGroup === 'network' ? (
+          {activeGroup === 'account' ? null : activeGroup === 'network' ? (
             <div className="bitfun-remote-connect__subtabs">
               {NETWORK_TABS.map((tab, i) => (
                 <React.Fragment key={tab.id}>
@@ -1061,7 +1098,13 @@ export const RemoteConnectDialog: React.FC<RemoteConnectDialogProps> = ({
           )}
 
           {/* ── Content ── */}
-          {activeGroup === 'network' ? renderNetworkContent() : renderBotContent()}
+          {activeGroup === 'account' ? (
+            <AccountPanel onCloseDialog={onClose} />
+          ) : activeGroup === 'network' ? (
+            renderNetworkContent()
+          ) : (
+            renderBotContent()
+          )}
         </div>
       </Modal>
 

--- a/src/web-ui/src/features/relay-deploy/README.md
+++ b/src/web-ui/src/features/relay-deploy/README.md
@@ -5,7 +5,7 @@ Desktop wizard that SSHes to a user-owned Linux host and deploys
 
 Entry points:
 
-- Account Login → “一键部署到自己的服务器”
+- Remote Connect → My Devices → login form → “一键部署到自己的服务器”
 - Remote Connect → Network Relay → Self-Hosted → same action (must open this
   wizard, not an external README)
 

--- a/src/web-ui/src/features/relay-deploy/RelayDeployWizard.scss
+++ b/src/web-ui/src/features/relay-deploy/RelayDeployWizard.scss
@@ -215,6 +215,39 @@
     }
   }
 
+  &__reg-mode {
+    display: flex;
+    gap: 8px;
+    margin: 0 16px 12px;
+  }
+
+  &__reg-mode-btn {
+    flex: 1;
+    padding: 6px 10px;
+    border-radius: 6px;
+    border: 1px solid var(--border-subtle);
+    background: var(--color-bg-secondary);
+    color: var(--color-text-secondary);
+    font-size: 12px;
+    cursor: pointer;
+    transition: border-color 0.15s, color 0.15s;
+
+    &:hover:not(:disabled) {
+      color: var(--color-text-primary);
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    &.is-active {
+      border-color: var(--color-accent-500);
+      color: var(--color-accent-500);
+      font-weight: 600;
+    }
+  }
+
   &__row {
     display: flex;
     gap: 8px;

--- a/src/web-ui/src/features/relay-deploy/RelayDeployWizard.tsx
+++ b/src/web-ui/src/features/relay-deploy/RelayDeployWizard.tsx
@@ -162,6 +162,12 @@ export const RelayDeployWizard: React.FC<RelayDeployWizardProps> = ({
   const [regConfirm, setRegConfirm] = useState('');
   const [regLoading, setRegLoading] = useState(false);
   const [showRegPassword, setShowRegPassword] = useState(false);
+  /**
+   * Redeploys keep the relay database, so account creation can fail with
+   * "already exists". `existing` skips provisioning and hands the typed
+   * credentials straight to the caller's real login.
+   */
+  const [regMode, setRegMode] = useState<'create' | 'existing'>('create');
 
   // ── done ─────────────────────────────────────────────────────────────────
   const [verify, setVerify] = useState<RelayVerifyResult | null>(null);
@@ -268,6 +274,7 @@ export const RelayDeployWizard: React.FC<RelayDeployWizardProps> = ({
       setRegPassword('');
       setRegConfirm('');
       setRegLoading(false);
+      setRegMode('create');
       setVerify(null);
       return;
     }
@@ -603,10 +610,23 @@ export const RelayDeployWizard: React.FC<RelayDeployWizardProps> = ({
       setVerify(v);
       setStep('done');
     } catch (e) {
-      setError(errMsg(e));
+      const msg = errMsg(e);
+      // Redeploy keeps the database — point the user at the existing-account
+      // mode instead of leaving a raw relay error.
+      setError(/already exists/i.test(msg)
+        ? `${msg} — ${t('relayDeploy.accountExistsHint')}`
+        : msg);
     } finally {
       setRegLoading(false);
     }
+  };
+
+  /** Existing-account mode: no provisioning; the caller performs the login. */
+  const handleUseExisting = () => {
+    if (!regUsername.trim()) { setError(t('relayDeploy.usernameRequired')); return; }
+    if (!regPassword) { setError(t('accountLogin.emptyFields')); return; }
+    setError(null);
+    onRegistered({ relayUrl, username: regUsername.trim(), password: regPassword });
   };
 
   const handleFinish = () => {
@@ -1187,11 +1207,33 @@ export const RelayDeployWizard: React.FC<RelayDeployWizardProps> = ({
         <Server size={14} />
         <span>{relayUrl}</span>
       </div>
+      <div className="relay-deploy-wizard__reg-mode">
+        <button
+          type="button"
+          className={`relay-deploy-wizard__reg-mode-btn${regMode === 'create' ? ' is-active' : ''}`}
+          onClick={() => { setRegMode('create'); setError(null); }}
+          disabled={regLoading}
+        >
+          {t('relayDeploy.regModeCreate')}
+        </button>
+        <button
+          type="button"
+          className={`relay-deploy-wizard__reg-mode-btn${regMode === 'existing' ? ' is-active' : ''}`}
+          onClick={() => { setRegMode('existing'); setError(null); }}
+          disabled={regLoading}
+        >
+          {t('relayDeploy.regModeExisting')}
+        </button>
+      </div>
       <div className="relay-deploy-wizard__notice relay-deploy-wizard__notice--info">
         <User size={18} />
         <div className="relay-deploy-wizard__notice-text">
-          <span className="relay-deploy-wizard__notice-title">{t('relayDeploy.registerTitle')}</span>
-          <span className="relay-deploy-wizard__notice-desc">{t('relayDeploy.registerDesc')}</span>
+          <span className="relay-deploy-wizard__notice-title">
+            {regMode === 'create' ? t('relayDeploy.registerTitle') : t('relayDeploy.registerExistingTitle')}
+          </span>
+          <span className="relay-deploy-wizard__notice-desc">
+            {regMode === 'create' ? t('relayDeploy.registerDesc') : t('relayDeploy.registerExistingDesc')}
+          </span>
         </div>
       </div>
       <div className="relay-deploy-wizard__form">
@@ -1210,25 +1252,35 @@ export const RelayDeployWizard: React.FC<RelayDeployWizardProps> = ({
               </button>
             } />
         </div>
-        <div className="relay-deploy-wizard__field">
-          <Input label={t('relayDeploy.confirmPassword')} type={showRegPassword ? 'text' : 'password'}
-            value={regConfirm} onChange={(e) => setRegConfirm(e.target.value)}
-            prefix={<Lock size={16} />} size="medium" disabled={regLoading} />
-        </div>
+        {regMode === 'create' && (
+          <div className="relay-deploy-wizard__field">
+            <Input label={t('relayDeploy.confirmPassword')} type={showRegPassword ? 'text' : 'password'}
+              value={regConfirm} onChange={(e) => setRegConfirm(e.target.value)}
+              prefix={<Lock size={16} />} size="medium" disabled={regLoading} />
+          </div>
+        )}
       </div>
       <div className="relay-deploy-wizard__actions">
         <Button variant="secondary" size="small" onClick={handleBackToPreflight} disabled={regLoading}>
           <ChevronLeft size={14} />
           {t('relayDeploy.back')}
         </Button>
-        <Button variant="primary" size="small" onClick={handleRegister}
-          disabled={regLoading || !regUsername.trim() || !regPassword || !regConfirm}>
-          {regLoading ? (
-            <><Loader2 size={14} className="spinning" />{t('relayDeploy.creatingAccount')}</>
-          ) : (
-            <><User size={14} />{t('relayDeploy.createAccount')}</>
-          )}
-        </Button>
+        {regMode === 'create' ? (
+          <Button variant="primary" size="small" onClick={handleRegister}
+            disabled={regLoading || !regUsername.trim() || !regPassword || !regConfirm}>
+            {regLoading ? (
+              <><Loader2 size={14} className="spinning" />{t('relayDeploy.creatingAccount')}</>
+            ) : (
+              <><User size={14} />{t('relayDeploy.createAccount')}</>
+            )}
+          </Button>
+        ) : (
+          <Button variant="primary" size="small" onClick={handleUseExisting}
+            disabled={regLoading || !regUsername.trim() || !regPassword}>
+            <CheckCircle2 size={14} />
+            {t('relayDeploy.finishAndLogin')}
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/src/web-ui/src/infrastructure/account/accountSyncStore.ts
+++ b/src/web-ui/src/infrastructure/account/accountSyncStore.ts
@@ -68,7 +68,7 @@ function normalizePhase(phase: string): AccountSyncPhase {
 }
 
 /**
- * Survives AccountLoginDialog close/reopen so users can reopen Online Devices
+ * Survives Remote Connect dialog close/reopen so users can reopen My Devices
  * and still see in-progress cloud sync after choosing local/cloud overwrite.
  */
 export const useAccountSyncStore = create<AccountSyncState>((set) => ({

--- a/src/web-ui/src/infrastructure/account/useAccountLoginState.ts
+++ b/src/web-ui/src/infrastructure/account/useAccountLoginState.ts
@@ -1,0 +1,67 @@
+/**
+ * Shared account login state for UI chrome (menu items, tab badges).
+ *
+ * Initial state comes from `account_status`; afterwards the backend pushes
+ * `account://login-state` on login / logout / finalize. Token expiry clears
+ * the session without an event, so a slow poll keeps the state honest.
+ * Components that need the full device list or relay details should still
+ * query the API directly.
+ */
+
+import { useEffect, useState } from 'react';
+import { api } from '@/infrastructure/api/service-api/ApiClient';
+import { remoteConnectAPI } from '@/infrastructure/api/service-api/RemoteConnectAPI';
+
+const STATUS_POLL_MS = 60_000;
+
+export interface AccountLoginState {
+  loggedIn: boolean;
+  /** Friendly name of this device, shown as the logged-in label. */
+  deviceName: string | null;
+}
+
+export function useAccountLoginState(): AccountLoginState {
+  const [state, setState] = useState<AccountLoginState>({ loggedIn: false, deviceName: null });
+
+  useEffect(() => {
+    let cancelled = false;
+    const refresh = async () => {
+      const status = await remoteConnectAPI.accountStatus();
+      if (!status.logged_in) {
+        if (!cancelled) setState({ loggedIn: false, deviceName: null });
+        return;
+      }
+      // accountStatus only exposes a UUID user_id; the menu label needs the
+      // human-readable device name instead.
+      let deviceName: string | null = null;
+      try {
+        const info = await remoteConnectAPI.getDeviceInfo();
+        deviceName = info.device_name || null;
+      } catch {
+        deviceName = null;
+      }
+      if (!cancelled) {
+        setState({ loggedIn: true, deviceName });
+      }
+    };
+    void refresh();
+
+    const unlisten = api.listen<{ logged_in: boolean }>(
+      'account://login-state',
+      () => {
+        // The event payload does not carry the device name; re-read the status
+        // so the label always reflects the persisted account session.
+        void refresh();
+      },
+    );
+    const poll = setInterval(() => { void refresh(); }, STATUS_POLL_MS);
+
+    return () => {
+      cancelled = true;
+      unlisten();
+      clearInterval(poll);
+    };
+  }, []);
+
+  return state;
+}

--- a/src/web-ui/src/infrastructure/i18n/presets/generatedLocaleContract.ts
+++ b/src/web-ui/src/infrastructure/i18n/presets/generatedLocaleContract.ts
@@ -39,8 +39,7 @@ export const SHARED_TERMS_BY_LOCALE = {
       "codeAgent": "代码助手",
       "deepReview": "严格审查",
       "settings": "设置",
-      "workspace": "工作区",
-      "accountLogin": "账户登录"
+      "workspace": "工作区"
     },
     "modes": {
       "agentic": "代理模式",
@@ -90,8 +89,7 @@ export const SHARED_TERMS_BY_LOCALE = {
       "codeAgent": "Code Agent",
       "deepReview": "Review: Strict",
       "settings": "Settings",
-      "workspace": "Workspace",
-      "accountLogin": "Account Login"
+      "workspace": "Workspace"
     },
     "modes": {
       "agentic": "Agentic Mode",
@@ -141,8 +139,7 @@ export const SHARED_TERMS_BY_LOCALE = {
       "codeAgent": "程式碼助手",
       "deepReview": "嚴格審查",
       "settings": "設定",
-      "workspace": "工作區",
-      "accountLogin": "帳號登入"
+      "workspace": "工作區"
     },
     "modes": {
       "agentic": "代理模式",

--- a/src/web-ui/src/locales/en-US/common.json
+++ b/src/web-ui/src/locales/en-US/common.json
@@ -546,7 +546,8 @@
     "syncPhaseSettingsDone": "Settings synced",
     "syncPhaseListingSessions": "Scanning local sessions…",
     "syncPhaseExportingSessions": "Backing up sessions {{current}}/{{total}}",
-    "copyServerUrl": "Copy server address"
+    "copyServerUrl": "Copy server address",
+    "loginValueProp": "Log in to link your devices: control one from another and keep settings & sessions in sync."
   },
   "relayDeploy": {
     "entryHint": "No relay server yet?",
@@ -617,6 +618,11 @@
     "passwordMismatch": "Passwords do not match",
     "createAccount": "Create Account",
     "creatingAccount": "Creating account…",
+    "regModeCreate": "Create new account",
+    "regModeExisting": "Use existing account",
+    "registerExistingTitle": "Use an existing account",
+    "registerExistingDesc": "Redeploying keeps the relay database. Enter your existing credentials to finish and log in — no new account is created.",
+    "accountExistsHint": "This username already exists — switch to \"Use existing account\" to log in.",
     "doneTitle": "Your relay is ready",
     "verifyOk": "Reachable from this device",
     "verifyFailed": "Not reachable from this device. Check the cloud firewall / security group for this inbound port — or continue and fix it later.",
@@ -628,6 +634,7 @@
     "tabBot": "IM Bot",
     "groupNetwork": "Network Relay",
     "groupBot": "IM Bot",
+    "groupAccount": "My Devices",
     "connect": "Connect",
     "connecting": "Connecting...",
     "disconnect": "Disconnect",

--- a/src/web-ui/src/locales/zh-CN/common.json
+++ b/src/web-ui/src/locales/zh-CN/common.json
@@ -546,7 +546,8 @@
     "syncPhaseSettingsDone": "配置已同步",
     "syncPhaseListingSessions": "正在扫描本地会话…",
     "syncPhaseExportingSessions": "正在备份会话 {{current}}/{{total}}",
-    "copyServerUrl": "复制服务器地址"
+    "copyServerUrl": "复制服务器地址",
+    "loginValueProp": "登录以关联你的多台设备：互相远程控制，并云同步设置与会话。"
   },
   "relayDeploy": {
     "entryHint": "还没有中继服务器？",
@@ -617,6 +618,11 @@
     "passwordMismatch": "两次输入的密码不一致",
     "createAccount": "创建账户",
     "creatingAccount": "正在创建账户…",
+    "regModeCreate": "创建新账户",
+    "regModeExisting": "使用已有账户",
+    "registerExistingTitle": "使用已有账户",
+    "registerExistingDesc": "重新部署会保留 relay 数据库。输入已有账号密码即可完成登录，不会创建新账户。",
+    "accountExistsHint": "该用户名已存在，可切换到「使用已有账户」直接登录。",
     "doneTitle": "你的 relay 已就绪",
     "verifyOk": "从本机访问正常",
     "verifyFailed": "无法从本机访问。请检查云服务器安全组 / 防火墙是否放行该端口——也可以先继续，稍后修复。",
@@ -628,6 +634,7 @@
     "tabBot": "IM机器人",
     "groupNetwork": "网络中继",
     "groupBot": "IM机器人",
+    "groupAccount": "我的设备",
     "connect": "连接",
     "connecting": "连接中...",
     "disconnect": "断开连接",

--- a/src/web-ui/src/locales/zh-TW/common.json
+++ b/src/web-ui/src/locales/zh-TW/common.json
@@ -546,7 +546,8 @@
     "syncPhaseSettingsDone": "設定已同步",
     "syncPhaseListingSessions": "正在掃描本地工作階段…",
     "syncPhaseExportingSessions": "正在備份工作階段 {{current}}/{{total}}",
-    "copyServerUrl": "複製伺服器位址"
+    "copyServerUrl": "複製伺服器位址",
+    "loginValueProp": "登入以關聯你的多台裝置：互相遠端控制，並雲端同步設定與工作階段。"
   },
   "relayDeploy": {
     "entryHint": "還沒有中繼伺服器？",
@@ -617,6 +618,11 @@
     "passwordMismatch": "兩次輸入的密碼不一致",
     "createAccount": "建立帳戶",
     "creatingAccount": "正在建立帳戶…",
+    "regModeCreate": "建立新帳戶",
+    "regModeExisting": "使用已有帳號",
+    "registerExistingTitle": "使用已有帳號",
+    "registerExistingDesc": "重新部署會保留 relay 資料庫。輸入已有帳號密碼即可完成登入，不會建立新帳戶。",
+    "accountExistsHint": "該使用者名稱已存在，可切換到「使用已有帳號」直接登入。",
     "doneTitle": "你的 relay 已就緒",
     "verifyOk": "從本機存取正常",
     "verifyFailed": "無法從本機存取。請檢查雲端伺服器安全群組 / 防火牆是否放行該連接埠——也可以先繼續，稍後修復。",
@@ -628,6 +634,7 @@
     "tabBot": "IM機器人",
     "groupNetwork": "網絡中繼",
     "groupBot": "IM機器人",
+    "groupAccount": "我的裝置",
     "connect": "連接",
     "connecting": "連接中...",
     "disconnect": "斷開連接",


### PR DESCRIPTION
## Why

Remote Control and Account Login were two separate menu entries backed by the same relay infrastructure. Most remote-control features work without an account, so the standalone Account Login entry fragmented the mental model and hid the login state entirely (no avatar / persistent indicator anywhere).

## What

**Remote Connect dialog gains a third group, "My Devices"** (account)
- Logged out: inline login card with a value proposition ("link your devices: control one from another, sync settings & sessions") instead of an abstract login entry
- Logged in: device list + cloud sync progress (the previous AccountLoginDialog devices view)
- Successful login stays in the dialog and lands on the devices view instead of closing it, so sync progress remains visible in place
- The sync-choice invariant is preserved: leaving the overwrite view (group switch or dialog close) abandons the memory-only login via an unmount cleanup, pairing with `account_finalize_login`

**Nav footer menu becomes stateful**
- The separate "Account Login" entry is removed (6 items → 5)
- The Remote Control entry shows the device name + a status dot when logged in; token expiry auto-opens the dialog on the account group
- New shared hook `useAccountLoginState` (event-driven + slow poll, since backend token invalidation clears the session without emitting an event)

**Workspace gating moves into the dialog**
- The menu entry no longer requires an open workspace; the network/IM-bot groups are disabled with a hint inside the dialog, while the account group stays usable

**Relay deploy wizard: existing-account mode**
- Redeploying keeps the relay database, but the account step only offered "create account", which fails with `username already exists`. The step now has a "Use existing account" mode that hands the credentials to the caller's real login, and the creation error hints at it

**Cleanup**
- `AccountLoginDialog/` deleted; unused shared term `features.accountLogin` removed from the i18n contract

## Verification

- `pnpm run type-check:web`, eslint on touched files
- Web UI tests: 1732 passed (incl. startup performance contract)
- `pnpm run i18n:contract:test`, `pnpm run i18n:audit`, `pnpm run theme:color-audit:all`
- Independent adversarial code review of the diff; its high-severity finding (overwrite-abandon logout never firing under conditional-render unmount) was fixed before this PR