### PR TITLE
fix(ai): harden subscription OAuth login (OpenCode/Codex/Antigravity)

### DIFF
--- a/src/crates/adapters/ai-adapters/src/subscription_auth/antigravity.rs
+++ b/src/crates/adapters/ai-adapters/src/subscription_auth/antigravity.rs
@@ -10,11 +10,9 @@ use super::{jwt, oauth_server, pkce, pkce::Pkce, ResolvedCredential, StartedLogi
 use anyhow::{anyhow, Context, Result};
 use serde::Deserialize;
 use std::collections::HashMap;
-use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 
 const CLIENT_ID: &str = "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com";
-const REDIRECT_URI: &str = "http://localhost:51121/oauth-callback";
 const CALLBACK_PATH: &str = "/oauth-callback";
 const CALLBACK_PORT: u16 = 51121;
 const AUTHORIZE_URL: &str = "https://accounts.google.com/o/oauth2/v2/auth";
@@ -27,6 +25,10 @@ const GOOG_API_CLIENT: &str = "google-cloud-sdk vscode_cloudshelleditor/0.1";
 const DEFAULT_MODEL: &str = "gemini-3-pro-high";
 const REFRESH_LEEWAY_MS: i64 = 5 * 60 * 1000;
 const STORE_KEY: &str = "antigravity";
+
+fn redirect_uri() -> String {
+    oauth_server::loopback_redirect_uri(CALLBACK_PORT, CALLBACK_PATH)
+}
 
 const SCOPES: &[&str] = &[
     "https://www.googleapis.com/auth/cloud-platform",
@@ -73,12 +75,12 @@ struct TokenResponse {
     expires_in: Option<i64>,
 }
 
-fn build_authorize_url(pkce: &Pkce, state: &str) -> String {
+fn build_authorize_url(pkce: &Pkce, state: &str, redirect_uri: &str) -> String {
     let scope = SCOPES.join(" ");
     let params = [
         ("response_type", "code"),
         ("client_id", CLIENT_ID),
-        ("redirect_uri", REDIRECT_URI),
+        ("redirect_uri", redirect_uri),
         ("scope", scope.as_str()),
         ("code_challenge", pkce.challenge.as_str()),
         ("code_challenge_method", "S256"),
@@ -101,13 +103,13 @@ fn http_client() -> Result<reqwest::Client> {
         .context("build antigravity http client")
 }
 
-async fn exchange_code(code: &str, verifier: &str) -> Result<TokenResponse> {
+async fn exchange_code(code: &str, verifier: &str, redirect_uri: &str) -> Result<TokenResponse> {
     let client = http_client()?;
     let secret = client_secret();
     let params = [
         ("grant_type", "authorization_code"),
         ("code", code),
-        ("redirect_uri", REDIRECT_URI),
+        ("redirect_uri", redirect_uri),
         ("client_id", CLIENT_ID),
         ("client_secret", secret.as_str()),
         ("code_verifier", verifier),
@@ -212,12 +214,9 @@ async fn persist_tokens(tokens: TokenResponse) -> Result<()> {
 pub(crate) async fn begin_login(cancel: CancellationToken) -> Result<StartedLogin> {
     let pkce = Pkce::generate();
     let state = pkce::random_state();
-    let authorization_url = build_authorize_url(&pkce, &state);
-    let listener = TcpListener::bind(("127.0.0.1", CALLBACK_PORT))
-        .await
-        .with_context(|| {
-            format!("bind antigravity callback server on 127.0.0.1:{CALLBACK_PORT}")
-        })?;
+    let redirect_uri = redirect_uri();
+    let authorization_url = build_authorize_url(&pkce, &state, &redirect_uri);
+    let listener = oauth_server::bind_loopback(CALLBACK_PORT).await?;
     let verifier = pkce.verifier.clone();
 
     let runner = async move {
@@ -230,7 +229,7 @@ pub(crate) async fn begin_login(cancel: CancellationToken) -> Result<StartedLogi
                     .get("code")
                     .cloned()
                     .ok_or_else(|| anyhow!("antigravity callback missing code"))?;
-                let tokens = exchange_code(&code, &verifier).await?;
+                let tokens = exchange_code(&code, &verifier, &redirect_uri).await?;
                 persist_tokens(tokens).await
             } => result,
         }

--- a/src/crates/adapters/ai-adapters/src/subscription_auth/codex.rs
+++ b/src/crates/adapters/ai-adapters/src/subscription_auth/codex.rs
@@ -9,13 +9,11 @@ use super::{jwt, oauth_server, pkce::Pkce, ResolvedCredential, StartedLogin};
 use anyhow::{anyhow, Context, Result};
 use serde::Deserialize;
 use std::collections::HashMap;
-use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 const CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
 const ISSUER: &str = "https://auth.openai.com";
-const REDIRECT_URI: &str = "http://localhost:1455/auth/callback";
 const CALLBACK_PATH: &str = "/auth/callback";
 const CALLBACK_PORT: u16 = 1455;
 const SCOPE: &str = "openid profile email offline_access";
@@ -24,6 +22,10 @@ const CHATGPT_REQUEST_URL: &str = "https://chatgpt.com/backend-api/codex/respons
 const DEFAULT_MODEL: &str = "gpt-5-codex";
 const REFRESH_LEEWAY_MS: i64 = 5 * 60 * 1000;
 const STORE_KEY: &str = "codex";
+
+fn redirect_uri() -> String {
+    oauth_server::loopback_redirect_uri(CALLBACK_PORT, CALLBACK_PATH)
+}
 
 #[derive(Debug, Deserialize)]
 struct TokenResponse {
@@ -37,11 +39,11 @@ struct TokenResponse {
     expires_in: Option<i64>,
 }
 
-fn build_authorize_url(pkce: &Pkce, state: &str) -> String {
+fn build_authorize_url(pkce: &Pkce, state: &str, redirect_uri: &str) -> String {
     let params = [
         ("response_type", "code"),
         ("client_id", CLIENT_ID),
-        ("redirect_uri", REDIRECT_URI),
+        ("redirect_uri", redirect_uri),
         ("scope", SCOPE),
         ("code_challenge", pkce.challenge.as_str()),
         ("code_challenge_method", "S256"),
@@ -65,12 +67,12 @@ fn http_client() -> Result<reqwest::Client> {
         .context("build codex http client")
 }
 
-async fn exchange_code(code: &str, verifier: &str) -> Result<TokenResponse> {
+async fn exchange_code(code: &str, verifier: &str, redirect_uri: &str) -> Result<TokenResponse> {
     let client = http_client()?;
     let params = [
         ("grant_type", "authorization_code"),
         ("code", code),
-        ("redirect_uri", REDIRECT_URI),
+        ("redirect_uri", redirect_uri),
         ("client_id", CLIENT_ID),
         ("code_verifier", verifier),
     ];
@@ -168,10 +170,9 @@ async fn persist_tokens(tokens: TokenResponse) -> Result<()> {
 pub(crate) async fn begin_login(cancel: CancellationToken) -> Result<StartedLogin> {
     let pkce = Pkce::generate();
     let state = super::pkce::random_state();
-    let authorization_url = build_authorize_url(&pkce, &state);
-    let listener = TcpListener::bind(("127.0.0.1", CALLBACK_PORT))
-        .await
-        .with_context(|| format!("bind codex callback server on 127.0.0.1:{CALLBACK_PORT}"))?;
+    let redirect_uri = redirect_uri();
+    let authorization_url = build_authorize_url(&pkce, &state, &redirect_uri);
+    let listener = oauth_server::bind_loopback(CALLBACK_PORT).await?;
     let verifier = pkce.verifier.clone();
 
     let runner = async move {
@@ -184,7 +185,7 @@ pub(crate) async fn begin_login(cancel: CancellationToken) -> Result<StartedLogi
                     .get("code")
                     .cloned()
                     .ok_or_else(|| anyhow!("codex callback missing code"))?;
-                let tokens = exchange_code(&code, &verifier).await?;
+                let tokens = exchange_code(&code, &verifier, &redirect_uri).await?;
                 persist_tokens(tokens).await
             } => result,
         }

--- a/src/crates/adapters/ai-adapters/src/subscription_auth/mod.rs
+++ b/src/crates/adapters/ai-adapters/src/subscription_auth/mod.rs
@@ -263,6 +263,14 @@ pub async fn start_login(provider: SubscriptionProvider) -> Result<LoginStartRes
     }?;
 
     let authorization_url = started.authorization_url.clone();
+    // Desktop opener rejects relative URLs ("Not allowed to open url /...").
+    // Every provider must return an absolute http(s) authorization URL.
+    if !(authorization_url.starts_with("https://") || authorization_url.starts_with("http://")) {
+        cancel.cancel();
+        return Err(anyhow!(
+            "subscription login returned a non-absolute authorization URL: {authorization_url}"
+        ));
+    }
     let user_code = started.user_code.clone();
     let instructions = started.instructions.clone();
     let generation = next_generation();

--- a/src/crates/adapters/ai-adapters/src/subscription_auth/oauth_server.rs
+++ b/src/crates/adapters/ai-adapters/src/subscription_auth/oauth_server.rs
@@ -5,10 +5,38 @@
 //! string, validates the `state`, serves an HTML result page, and returns the
 //! query parameters.
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use std::collections::HashMap;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
+
+/// Loopback host used in both the OAuth `redirect_uri` and the TCP bind.
+///
+/// Prefer `127.0.0.1` over `localhost` so the browser and the listener always
+/// agree on IPv4. On macOS, `localhost` often resolves to `::1`, which would
+/// miss a listener bound only to `127.0.0.1` (and vice versa).
+pub(crate) const LOOPBACK_HOST: &str = "127.0.0.1";
+
+/// Builds `http://127.0.0.1:{port}{path}` for authorize/token exchange.
+pub(crate) fn loopback_redirect_uri(port: u16, path: &str) -> String {
+    let path = if path.starts_with('/') {
+        path.to_string()
+    } else {
+        format!("/{path}")
+    };
+    format!("http://{LOOPBACK_HOST}:{port}{path}")
+}
+
+/// Binds the OAuth callback listener on [`LOOPBACK_HOST`].
+pub(crate) async fn bind_loopback(port: u16) -> Result<TcpListener> {
+    TcpListener::bind((LOOPBACK_HOST, port))
+        .await
+        .with_context(|| {
+            format!(
+                "bind OAuth callback on {LOOPBACK_HOST}:{port} (is another app using this port?)"
+            )
+        })
+}
 
 /// Accepts loopback connections until the OAuth redirect arrives on
 /// `callback_path`, then returns its query parameters.
@@ -145,13 +173,29 @@ fn escape_html(text: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::escape_html;
+    use super::{escape_html, loopback_redirect_uri, LOOPBACK_HOST};
 
     #[test]
     fn escapes_html_injection() {
         assert_eq!(
             escape_html("<script>alert(\"x\")</script>&'"),
             "&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;&amp;&#39;"
+        );
+    }
+
+    #[test]
+    fn loopback_redirect_uri_uses_ipv4_literal() {
+        assert_eq!(
+            loopback_redirect_uri(1455, "/auth/callback"),
+            format!("http://{LOOPBACK_HOST}:1455/auth/callback")
+        );
+        assert_eq!(
+            loopback_redirect_uri(51121, "oauth-callback"),
+            format!("http://{LOOPBACK_HOST}:51121/oauth-callback")
+        );
+        assert!(
+            !loopback_redirect_uri(1455, "/auth/callback").contains("localhost"),
+            "must not use localhost (macOS often resolves it to ::1)"
         );
     }
 }

--- a/src/crates/adapters/ai-adapters/src/subscription_auth/opencode.rs
+++ b/src/crates/adapters/ai-adapters/src/subscription_auth/opencode.rs
@@ -221,6 +221,21 @@ async fn refresh(refresh_token: &str) -> Result<TokenResponse> {
     resp.json().await.context("parse opencode token response")
 }
 
+/// Resolves OpenCode's device verification URI to an absolute URL.
+///
+/// The console API returns a path such as `/device?user_code=...` (same as
+/// OpenCode's own client, which prefixes `https://console.opencode.ai`).
+fn absolute_verification_url(uri: &str) -> String {
+    let trimmed = uri.trim();
+    if trimmed.starts_with("https://") || trimmed.starts_with("http://") {
+        return trimmed.to_string();
+    }
+    if trimmed.starts_with('/') {
+        return format!("{SERVER}{trimmed}");
+    }
+    format!("{SERVER}/{trimmed}")
+}
+
 /// Starts the device-code login flow. The verification URL and user code are
 /// returned immediately; the runner polls in the background.
 pub(crate) async fn begin_login(cancel: CancellationToken) -> Result<StartedLogin> {
@@ -228,6 +243,7 @@ pub(crate) async fn begin_login(cancel: CancellationToken) -> Result<StartedLogi
     let interval = device.interval.unwrap_or(5).max(1);
     let device_code = device.device_code.clone();
     let user_code = device.user_code.clone();
+    let authorization_url = absolute_verification_url(&device.verification_uri_complete);
 
     let runner = async move {
         tokio::select! {
@@ -253,7 +269,7 @@ pub(crate) async fn begin_login(cancel: CancellationToken) -> Result<StartedLogi
     };
 
     Ok(StartedLogin {
-        authorization_url: device.verification_uri_complete,
+        authorization_url,
         user_code: Some(user_code),
         instructions: "Open the verification link and enter the code, then return to BitFun."
             .to_string(),
@@ -317,4 +333,27 @@ pub(crate) async fn resolve() -> Result<ResolvedCredential> {
 /// Provider metadata used to seed a new model entry.
 pub(crate) fn suggested() -> (&'static str, &'static str, &'static str) {
     ("openai", ZEN_BASE_URL, DEFAULT_MODEL)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::absolute_verification_url;
+
+    #[test]
+    fn prefixes_relative_device_verification_path() {
+        assert_eq!(
+            absolute_verification_url("/device?user_code=FBPH-VLFC&client_id=opencode-cli"),
+            "https://console.opencode.ai/device?user_code=FBPH-VLFC&client_id=opencode-cli"
+        );
+    }
+
+    #[test]
+    fn keeps_absolute_verification_url() {
+        assert_eq!(
+            absolute_verification_url(
+                "https://console.opencode.ai/device?user_code=ABCD-1234&client_id=opencode-cli"
+            ),
+            "https://console.opencode.ai/device?user_code=ABCD-1234&client_id=opencode-cli"
+        );
+    }
 }

--- a/src/web-ui/src/infrastructure/config/components/AIModelConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/AIModelConfig.tsx
@@ -982,7 +982,21 @@ const AIModelConfig: React.FC = () => {
     try {
       const started = await aiApi.startSubscriptionLogin(provider);
       if (started.authorization_url) {
-        await systemAPI.openExternal(started.authorization_url);
+        try {
+          await systemAPI.openExternal(started.authorization_url);
+        } catch (openError) {
+          // Keep polling: the backend login session is already running. Surface
+          // the URL so the user can open it manually (relative URLs / opener
+          // policy failures must not abort an otherwise valid login).
+          log.warn('Failed to open subscription authorization URL', {
+            provider,
+            url: started.authorization_url,
+            error: String(openError),
+          });
+          notification.info(
+            t('subscriptionAuth.openUrlManually', { url: started.authorization_url }),
+          );
+        }
       }
       if (started.user_code) {
         notification.info(t('subscriptionAuth.userCodeHint', { code: started.user_code }));

--- a/src/web-ui/src/locales/en-US/settings/ai-model.json
+++ b/src/web-ui/src/locales/en-US/settings/ai-model.json
@@ -61,6 +61,7 @@
     "logoutSuccess": "Signed out",
     "logoutFailed": "Sign-out failed: {{error}}",
     "userCodeHint": "Enter this code in the browser: {{code}}",
+    "openUrlManually": "Could not open the browser automatically. Open this URL manually: {{url}}",
     "expiresAt": "Token valid until {{time}}",
     "tokenValid": "Token ready",
     "notSignedIn": "Not signed in",

--- a/src/web-ui/src/locales/zh-CN/settings/ai-model.json
+++ b/src/web-ui/src/locales/zh-CN/settings/ai-model.json
@@ -61,6 +61,7 @@
     "logoutSuccess": "已退出登录",
     "logoutFailed": "退出登录失败：{{error}}",
     "userCodeHint": "请在浏览器中输入验证码：{{code}}",
+    "openUrlManually": "无法自动打开浏览器，请手动访问：{{url}}",
     "expiresAt": "Token 有效期至 {{time}}",
     "tokenValid": "Token 已就绪",
     "notSignedIn": "未登录",

--- a/src/web-ui/src/locales/zh-TW/settings/ai-model.json
+++ b/src/web-ui/src/locales/zh-TW/settings/ai-model.json
@@ -61,6 +61,7 @@
     "logoutSuccess": "已登出",
     "logoutFailed": "登出失敗：{{error}}",
     "userCodeHint": "請在瀏覽器中輸入驗證碼：{{code}}",
+    "openUrlManually": "無法自動開啟瀏覽器，請手動造訪：{{url}}",
     "expiresAt": "Token 有效期至 {{time}}",
     "tokenValid": "Token 已就緒",
     "notSignedIn": "未登入",


### PR DESCRIPTION
## Summary
- **OpenCode**: absolutize relative device verification paths (`/device?...` → `https://console.opencode.ai/device?...`).
- **Codex / Antigravity**: bind and advertise the OAuth callback as `http://127.0.0.1:<port>/...` so browser redirects cannot miss a listener bound only on IPv4 while `localhost` resolves to `::1` on macOS.
- **UI**: if the desktop opener cannot open the authorization URL, show it for manual open and keep polling the in-flight login session.

## Test plan
- [x] `cargo test -p bitfun-ai-adapters --features subscription-auth subscription_auth`
- [x] `pnpm run type-check:web && pnpm run i18n:audit`
- [ ] Desktop: OpenCode Zen sign-in opens `https://console.opencode.ai/device?...`
- [ ] Desktop: Codex sign-in completes callback on `127.0.0.1:1455`
- [ ] Desktop: Antigravity sign-in completes callback on `127.0.0.1:51121`