### PR TITLE
fix(ui): prevent subscription account text overlap

### DIFF
--- a/src/web-ui/src/infrastructure/config/components/AIModelConfig.scss
+++ b/src/web-ui/src/infrastructure/config/components/AIModelConfig.scss
@@ -2044,6 +2044,14 @@
     }
   }
 
+  &__cli-account {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  &__cli-description-line {
+    display: block;
+  }
+
   &__cli-actions {
     display: inline-flex;
     align-items: center;
@@ -2056,7 +2064,21 @@
       flex-shrink: 0;
     }
   }
+
+  @container config-panel (max-width: 760px) {
+    &__cli-account {
+      grid-template-columns: minmax(0, 1fr);
+      align-items: flex-start;
+
+      .bitfun-config-page-row__control {
+        justify-content: flex-start;
+      }
+    }
+
+    &__cli-actions {
+      justify-content: flex-start;
+      flex-wrap: wrap;
+    }
+  }
 }
-
-
 

--- a/src/web-ui/src/infrastructure/config/components/AIModelConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/AIModelConfig.tsx
@@ -2752,7 +2752,15 @@ const AIModelConfig: React.FC = () => {
                 <ConfigPageRow
                   key={account.provider}
                   label={account.display_label}
-                  description={descriptionParts.join(' · ')}
+                  description={descriptionParts.map((part) => (
+                    <span
+                      key={part}
+                      className="bitfun-ai-model-config__cli-description-line"
+                    >
+                      {part}
+                    </span>
+                  ))}
+                  className="bitfun-ai-model-config__cli-account"
                   align="center"
                 >
                   <div className="bitfun-ai-model-config__cli-actions">


### PR DESCRIPTION
## Summary

- reserve intrinsic width for subscription account action buttons
- show account identity and token expiry on separate lines
- stack and wrap account actions in narrow settings panels

## Verification

- pnpm run type-check:web