### PR TITLE
fix(ai): use registered OAuth loopback redirects

### DIFF
--- a/src/crates/adapters/ai-adapters/src/subscription_auth/antigravity.rs
+++ b/src/crates/adapters/ai-adapters/src/subscription_auth/antigravity.rs
@@ -323,3 +323,20 @@ pub(crate) async fn resolve() -> Result<ResolvedCredential> {
 pub(crate) fn suggested() -> (&'static str, &'static str, &'static str) {
     ("gemini-code-assist", CODE_ASSIST_BASE_URL, DEFAULT_MODEL)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{build_authorize_url, redirect_uri};
+    use crate::subscription_auth::pkce::Pkce;
+
+    #[test]
+    fn uses_registered_localhost_redirect_uri() {
+        let redirect_uri = redirect_uri();
+        assert_eq!(redirect_uri, "http://localhost:51121/oauth-callback");
+
+        let authorize_url = build_authorize_url(&Pkce::generate(), "state", &redirect_uri);
+        assert!(
+            authorize_url.contains("redirect_uri=http%3A%2F%2Flocalhost%3A51121%2Foauth-callback")
+        );
+    }
+}

--- a/src/crates/adapters/ai-adapters/src/subscription_auth/codex.rs
+++ b/src/crates/adapters/ai-adapters/src/subscription_auth/codex.rs
@@ -1,7 +1,7 @@
 //! Codex (ChatGPT) subscription login and credential resolution.
 //!
 //! Aligned with OpenCode's `plugin/openai/codex.ts`: browser PKCE login against
-//! `auth.openai.com` on the fixed loopback port `1455`, then Bearer access to
+//! `auth.openai.com` on registered loopback ports, then Bearer access to
 //! `chatgpt.com/backend-api/codex/responses`.
 
 use super::store::{self, StoredCredential};
@@ -16,6 +16,9 @@ const CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
 const ISSUER: &str = "https://auth.openai.com";
 const CALLBACK_PATH: &str = "/auth/callback";
 const CALLBACK_PORT: u16 = 1455;
+// Keep in sync with the Codex CLI OAuth redirect URI allow-list.
+const CALLBACK_FALLBACK_PORT: u16 = 1457;
+const CALLBACK_PORTS: &[u16] = &[CALLBACK_PORT, CALLBACK_FALLBACK_PORT];
 const SCOPE: &str = "openid profile email offline_access";
 const CHATGPT_BASE_URL: &str = "https://chatgpt.com/backend-api/codex";
 const CHATGPT_REQUEST_URL: &str = "https://chatgpt.com/backend-api/codex/responses";
@@ -23,8 +26,8 @@ const DEFAULT_MODEL: &str = "gpt-5-codex";
 const REFRESH_LEEWAY_MS: i64 = 5 * 60 * 1000;
 const STORE_KEY: &str = "codex";
 
-fn redirect_uri() -> String {
-    oauth_server::loopback_redirect_uri(CALLBACK_PORT, CALLBACK_PATH)
+fn redirect_uri(port: u16) -> String {
+    oauth_server::loopback_redirect_uri(port, CALLBACK_PATH)
 }
 
 #[derive(Debug, Deserialize)]
@@ -170,9 +173,9 @@ async fn persist_tokens(tokens: TokenResponse) -> Result<()> {
 pub(crate) async fn begin_login(cancel: CancellationToken) -> Result<StartedLogin> {
     let pkce = Pkce::generate();
     let state = super::pkce::random_state();
-    let redirect_uri = redirect_uri();
+    let (listener, callback_port) = oauth_server::bind_loopback_ports(CALLBACK_PORTS).await?;
+    let redirect_uri = redirect_uri(callback_port);
     let authorization_url = build_authorize_url(&pkce, &state, &redirect_uri);
-    let listener = oauth_server::bind_loopback(CALLBACK_PORT).await?;
     let verifier = pkce.verifier.clone();
 
     let runner = async move {
@@ -322,7 +325,26 @@ pub(crate) fn suggested() -> (&'static str, &'static str, &'static str) {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_codex_cli_version;
+    use super::{
+        build_authorize_url, parse_codex_cli_version, redirect_uri, CALLBACK_FALLBACK_PORT,
+        CALLBACK_PORT,
+    };
+    use crate::subscription_auth::pkce::Pkce;
+
+    #[test]
+    fn uses_registered_localhost_redirect_uri() {
+        let primary_redirect_uri = redirect_uri(CALLBACK_PORT);
+        assert_eq!(primary_redirect_uri, "http://localhost:1455/auth/callback");
+        assert_eq!(
+            redirect_uri(CALLBACK_FALLBACK_PORT),
+            "http://localhost:1457/auth/callback"
+        );
+
+        let authorize_url = build_authorize_url(&Pkce::generate(), "state", &primary_redirect_uri);
+        assert!(
+            authorize_url.contains("redirect_uri=http%3A%2F%2Flocalhost%3A1455%2Fauth%2Fcallback")
+        );
+    }
 
     #[test]
     fn parses_codex_cli_version_output() {

--- a/src/crates/adapters/ai-adapters/src/subscription_auth/oauth_server.rs
+++ b/src/crates/adapters/ai-adapters/src/subscription_auth/oauth_server.rs
@@ -1,6 +1,6 @@
 //! Minimal loopback HTTP server used to capture browser OAuth redirects.
 //!
-//! Providers pre-bind a `TcpListener` on their fixed port and hand it to
+//! Providers pre-bind a `TcpListener` on a registered port and hand it to
 //! [`wait_for_callback`], which accepts connections, parses the redirect query
 //! string, validates the `state`, serves an HTML result page, and returns the
 //! query parameters.
@@ -10,32 +10,75 @@ use std::collections::HashMap;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 
-/// Loopback host used in both the OAuth `redirect_uri` and the TCP bind.
-///
-/// Prefer `127.0.0.1` over `localhost` so the browser and the listener always
-/// agree on IPv4. On macOS, `localhost` often resolves to `::1`, which would
-/// miss a listener bound only to `127.0.0.1` (and vice versa).
-pub(crate) const LOOPBACK_HOST: &str = "127.0.0.1";
+/// IPv4 loopback address used for the TCP listener.
+pub(crate) const LOOPBACK_BIND_HOST: &str = "127.0.0.1";
 
-/// Builds `http://127.0.0.1:{port}{path}` for authorize/token exchange.
+/// Hostname used by provider-registered OAuth redirect URIs.
+///
+/// OAuth servers compare redirect URIs exactly. Codex and Antigravity register
+/// `localhost`, while binding the local listener to IPv4 avoids macOS resolving
+/// `localhost` to `::1` and missing a listener bound only on `127.0.0.1`.
+pub(crate) const LOOPBACK_REDIRECT_HOST: &str = "localhost";
+
+/// Builds a provider-registered `http://localhost:{port}{path}` redirect URI.
 pub(crate) fn loopback_redirect_uri(port: u16, path: &str) -> String {
     let path = if path.starts_with('/') {
         path.to_string()
     } else {
         format!("/{path}")
     };
-    format!("http://{LOOPBACK_HOST}:{port}{path}")
+    format!("http://{LOOPBACK_REDIRECT_HOST}:{port}{path}")
 }
 
-/// Binds the OAuth callback listener on [`LOOPBACK_HOST`].
+/// Binds the OAuth callback listener on [`LOOPBACK_BIND_HOST`].
 pub(crate) async fn bind_loopback(port: u16) -> Result<TcpListener> {
-    TcpListener::bind((LOOPBACK_HOST, port))
+    TcpListener::bind((LOOPBACK_BIND_HOST, port))
         .await
         .with_context(|| {
             format!(
-                "bind OAuth callback on {LOOPBACK_HOST}:{port} (is another app using this port?)"
+                "bind OAuth callback on {LOOPBACK_BIND_HOST}:{port} (is another app using this port?)"
             )
         })
+}
+
+/// Binds the first available registered callback port.
+///
+/// Fallback is attempted only when a preferred port is already in use. The
+/// returned port must be used to construct both the authorize and token
+/// exchange redirect URI.
+pub(crate) async fn bind_loopback_ports(ports: &[u16]) -> Result<(TcpListener, u16)> {
+    let Some(preferred_port) = ports.first().copied() else {
+        return Err(anyhow!("OAuth callback port list is empty"));
+    };
+
+    for (index, port) in ports.iter().copied().enumerate() {
+        match TcpListener::bind((LOOPBACK_BIND_HOST, port)).await {
+            Ok(listener) => {
+                let actual_port = listener
+                    .local_addr()
+                    .context("read OAuth callback listener address")?
+                    .port();
+                if index > 0 {
+                    log::warn!(
+                        "OAuth callback port {preferred_port} is unavailable; using registered fallback port {actual_port}"
+                    );
+                }
+                return Ok((listener, actual_port));
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::AddrInUse && index + 1 < ports.len() => {
+                continue;
+            }
+            Err(err) => {
+                return Err(err).with_context(|| {
+                    format!(
+                        "bind OAuth callback on {LOOPBACK_BIND_HOST}:{port} (is another app using this port?)"
+                    )
+                });
+            }
+        }
+    }
+
+    unreachable!("a non-empty callback port list always returns from the loop")
 }
 
 /// Accepts loopback connections until the OAuth redirect arrives on
@@ -173,7 +216,10 @@ fn escape_html(text: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{escape_html, loopback_redirect_uri, LOOPBACK_HOST};
+    use super::{
+        bind_loopback_ports, escape_html, loopback_redirect_uri, LOOPBACK_BIND_HOST,
+        LOOPBACK_REDIRECT_HOST,
+    };
 
     #[test]
     fn escapes_html_injection() {
@@ -184,18 +230,29 @@ mod tests {
     }
 
     #[test]
-    fn loopback_redirect_uri_uses_ipv4_literal() {
+    fn loopback_redirect_uri_uses_registered_localhost() {
         assert_eq!(
             loopback_redirect_uri(1455, "/auth/callback"),
-            format!("http://{LOOPBACK_HOST}:1455/auth/callback")
+            format!("http://{LOOPBACK_REDIRECT_HOST}:1455/auth/callback")
         );
         assert_eq!(
             loopback_redirect_uri(51121, "oauth-callback"),
-            format!("http://{LOOPBACK_HOST}:51121/oauth-callback")
+            format!("http://{LOOPBACK_REDIRECT_HOST}:51121/oauth-callback")
         );
-        assert!(
-            !loopback_redirect_uri(1455, "/auth/callback").contains("localhost"),
-            "must not use localhost (macOS often resolves it to ::1)"
-        );
+        assert_eq!(LOOPBACK_BIND_HOST, "127.0.0.1");
+        assert_eq!(LOOPBACK_REDIRECT_HOST, "localhost");
+    }
+
+    #[tokio::test]
+    async fn falls_back_when_preferred_callback_port_is_occupied() {
+        let occupied = tokio::net::TcpListener::bind((LOOPBACK_BIND_HOST, 0))
+            .await
+            .unwrap();
+        let occupied_port = occupied.local_addr().unwrap().port();
+
+        let (fallback, actual_port) = bind_loopback_ports(&[occupied_port, 0]).await.unwrap();
+
+        assert_ne!(actual_port, occupied_port);
+        assert_eq!(fallback.local_addr().unwrap().port(), actual_port);
     }
 }


### PR DESCRIPTION
## Summary
- advertise the provider-registered `localhost` callback URIs for Codex and Antigravity while continuing to bind the local listener on IPv4 loopback
- fall back from Codex port `1455` to the registered port `1457` when the preferred port is occupied, and use the selected URI for both authorization and token exchange
- add regression coverage for registered redirect URIs and callback-port fallback

## Why
OAuth providers compare redirect URIs exactly, so advertising `127.0.0.1` can be rejected when the registered URI uses `localhost`. Binding the server itself to `127.0.0.1` still avoids the macOS IPv6 resolution mismatch. A second registered Codex port also prevents another local Codex process from blocking sign-in.

## Test plan
- [x] `cargo test -p bitfun-ai-adapters --features subscription-auth subscription_auth`
- [x] `cargo check --workspace`
- [x] `git diff --check`

AI-assisted: yes. Testing level: fully tested with automated Rust checks.