### PR TITLE
fix(dev): stop target GC from forcing cold Cargo rebuilds

### DIFF
--- a/docs/superpowers/specs/2026-07-22-cargo-target-latest-only-gc-design.md
+++ b/docs/superpowers/specs/2026-07-22-cargo-target-latest-only-gc-design.md
@@ -18,7 +18,7 @@ After a desktop dev session exits or a desktop build finishes, keep only the lat
 
 - Changing default `profile.dev` debuginfo (optional later).
 - GC on every incremental rebuild during a live `tauri dev` session.
-- Guaranteeing a single hash per third-party crate when Cargo legitimately needs two units (lib vs build-dep).
+- Pruning `.fingerprint` directories by keep-newest-N (unsafe; caused full cold rebuilds).
 
 ## Design
 
@@ -40,8 +40,8 @@ Skip when another `cargo` / `rustc` process still appears active (avoid deleting
 For `target/<triple?>/<profile>/` (default host triple omitted; profile `debug` for dev, build profile from argv):
 
 1. **incremental** — group directories by crate prefix (name before final `-`); keep the newest mtime; delete older roots. Inside a kept root, keep the newest finalized `s-*` session when multiple remain.
-2. **.fingerprint** — group by package stem; keep newest **1** for `bitfun_*` / workspace-app stems, newest **2** for other packages (build-dep dual units). Delete older groups.
-3. **deps** — delete artifacts whose trailing hash no longer appears in any remaining fingerprint directory name. Do not delete by “crate name latest only” (unsafe for dual feature units).
+2. **.fingerprint** — **do not mtime-prune**. Cargo may keep multiple concurrent units per package (lib / build-script / feature variants). Deleting a still-referenced fingerprint forces a cold rebuild on the next `desktop:dev`.
+3. **deps** — delete artifacts whose trailing hash no longer appears in **any existing** fingerprint directory name (true orphans only). Never delete deps solely because another fingerprint for the same stem is newer.
 
 ### Safety
 

--- a/scripts/cargo-target-gc.mjs
+++ b/scripts/cargo-target-gc.mjs
@@ -1,7 +1,11 @@
 #!/usr/bin/env node
 /**
- * Prune Cargo target caches so each crate/package keeps only the latest useful
- * artifacts for a profile. Used after desktop:dev exits and desktop:build ends.
+ * Prune Cargo target caches after desktop:dev exits and desktop:build ends.
+ *
+ * Safe policy:
+ * - incremental: keep latest crate root (+ latest session)
+ * - .fingerprint: never mtime-prune (Cargo needs multiple concurrent units)
+ * - deps: delete only hashes with no remaining fingerprint directory
  *
  * Env:
  *   BITFUN_TARGET_GC=0          disable
@@ -49,14 +53,6 @@ export function splitFingerprintDir(name) {
 export function extractDepsArtifactHash(filename) {
   const match = DEPS_HASH_RE.exec(filename);
   return match ? match[1] : null;
-}
-
-export function fingerprintKeepCount(stem) {
-  if (stem.startsWith('bitfun-') || stem.startsWith('bitfun_')) {
-    return 1;
-  }
-  // Third-party crates may need lib + build-dep units with different hashes.
-  return 2;
 }
 
 function safeStatMtimeMs(path) {
@@ -153,39 +149,24 @@ export function planIncrementalPrune(incrementalDir, { keepSessions = 1 } = {}) 
   return toDelete;
 }
 
+/**
+ * Collect fingerprint metadata hashes that still exist on disk.
+ *
+ * Important: do NOT delete fingerprint directories by "keep newest N per stem".
+ * Cargo routinely keeps multiple concurrent units for one package (lib,
+ * build-script, feature variants). mtime is not a valid liveness signal, and
+ * deleting a still-referenced fingerprint + its deps forces a cold rebuild of
+ * that crate (and often a large share of the graph) on the next desktop:dev.
+ */
 export function planFingerprintPrune(fingerprintDir) {
-  const toDelete = [];
-  const groups = new Map();
-
+  const keptHashes = new Set();
   for (const name of listDirs(fingerprintDir)) {
     const split = splitFingerprintDir(name);
-    if (!split) {
-      continue;
-    }
-    const path = join(fingerprintDir, name);
-    const list = groups.get(split.stem) || [];
-    list.push({
-      path,
-      mtimeMs: safeStatMtimeMs(path),
-      hash: split.hash,
-      stem: split.stem,
-    });
-    groups.set(split.stem, list);
-  }
-
-  const keptHashes = new Set();
-  for (const [stem, entries] of groups.entries()) {
-    const keep = fingerprintKeepCount(stem);
-    const sorted = [...entries].sort((a, b) => b.mtimeMs - a.mtimeMs);
-    for (const entry of sorted.slice(0, keep)) {
-      keptHashes.add(entry.hash);
-    }
-    for (const entry of sorted.slice(keep)) {
-      toDelete.push(entry.path);
+    if (split) {
+      keptHashes.add(split.hash);
     }
   }
-
-  return { toDelete, keptHashes };
+  return { toDelete: [], keptHashes };
 }
 
 export function planDepsOrphanPrune(depsDir, keptHashes) {

--- a/scripts/cargo-target-gc.test.mjs
+++ b/scripts/cargo-target-gc.test.mjs
@@ -6,7 +6,6 @@ import test from 'node:test';
 import {
   collectGcPlan,
   extractDepsArtifactHash,
-  fingerprintKeepCount,
   profileFromTauriBuildArgs,
   runCargoTargetGc,
   selectStaleByMtime,
@@ -51,8 +50,6 @@ test('split helpers parse cargo cache names', () => {
     extractDepsArtifactHash('bitfun_core-023db5b6b08d0150.02dradpmwvb53dgn1eck0186y.rcgu.o'),
     '023db5b6b08d0150'
   );
-  assert.equal(fingerprintKeepCount('bitfun-core'), 1);
-  assert.equal(fingerprintKeepCount('syn'), 2);
 });
 
 test('selectStaleByMtime keeps newest entries', () => {
@@ -67,7 +64,7 @@ test('selectStaleByMtime keeps newest entries', () => {
   assert.deepEqual(new Set(stale), new Set(['a', 'c']));
 });
 
-test('collectGcPlan keeps latest incremental and fingerprint caches', () => {
+test('collectGcPlan prunes incremental only and never drops live fingerprints', () => {
   const { root, cleanup } = fixtureRoot();
   try {
     const profileDir = join(root, 'debug');
@@ -84,6 +81,8 @@ test('collectGcPlan keeps latest incremental and fingerprint caches', () => {
       now
     );
 
+    // Multiple fingerprint units for the same stem can all be live for Cargo
+    // (lib / build-script / feature variants). GC must not mtime-prune them.
     touchDir(join(profileDir, '.fingerprint', 'bitfun-core-aaaaaaaaaaaaaaaa'), now - 3_000);
     touchDir(join(profileDir, '.fingerprint', 'bitfun-core-bbbbbbbbbbbbbbbb'), now);
     touchDir(join(profileDir, '.fingerprint', 'syn-1111111111111111'), now - 4_000);
@@ -95,28 +94,31 @@ test('collectGcPlan keeps latest incremental and fingerprint caches', () => {
     touchFile(join(profileDir, 'deps', 'libsyn-1111111111111111.rlib'), now - 4_000);
     touchFile(join(profileDir, 'deps', 'libsyn-2222222222222222.rlib'), now - 2_000);
     touchFile(join(profileDir, 'deps', 'libsyn-3333333333333333.rlib'), now);
+    // True orphan: no matching fingerprint directory remains.
+    touchFile(join(profileDir, 'deps', 'liborphan-ffffffffffffffff.rlib'), now - 5_000);
 
     const plan = collectGcPlan(profileDir);
 
     assert.ok(plan.incremental.some((path) => path.endsWith('bitfun_core-oldhash1')));
-    assert.ok(plan.incremental.some((path) => path.includes(`${join('bitfun_core-newhash2', 's-old-session')}`)));
     assert.ok(
-      plan.fingerprint.some((path) => path.endsWith('bitfun-core-aaaaaaaaaaaaaaaa'))
+      plan.incremental.some((path) =>
+        path.includes(`${join('bitfun_core-newhash2', 's-old-session')}`)
+      )
     );
-    assert.ok(plan.fingerprint.some((path) => path.endsWith('syn-1111111111111111')));
-    assert.ok(!plan.fingerprint.some((path) => path.endsWith('syn-2222222222222222')));
-    assert.ok(!plan.fingerprint.some((path) => path.endsWith('syn-3333333333333333')));
-
-    assert.ok(plan.deps.some((path) => path.endsWith('libbitfun_core-aaaaaaaaaaaaaaaa.rlib')));
-    assert.ok(plan.deps.some((path) => path.endsWith('libsyn-1111111111111111.rlib')));
+    assert.equal(plan.fingerprint.length, 0);
+    assert.ok(
+      !plan.deps.some((path) => path.endsWith('libbitfun_core-aaaaaaaaaaaaaaaa.rlib'))
+    );
+    assert.ok(!plan.deps.some((path) => path.endsWith('libsyn-1111111111111111.rlib')));
     assert.ok(!plan.deps.some((path) => path.endsWith('libsyn-2222222222222222.rlib')));
-    assert.ok(!plan.deps.some((path) => path.endsWith('libbitfun_core-bbbbbbbbbbbbbbbb.rlib')));
+    assert.ok(!plan.deps.some((path) => path.endsWith('libsyn-3333333333333333.rlib')));
+    assert.ok(plan.deps.some((path) => path.endsWith('liborphan-ffffffffffffffff.rlib')));
   } finally {
     cleanup();
   }
 });
 
-test('runCargoTargetGc removes planned paths and respects dry-run', () => {
+test('runCargoTargetGc keeps fingerprint-backed deps so next cargo can reuse them', () => {
   const { root, cleanup } = fixtureRoot();
   try {
     const targetDir = join(root, 'target');
@@ -128,6 +130,7 @@ test('runCargoTargetGc removes planned paths and respects dry-run', () => {
     touchDir(join(profileDir, '.fingerprint', 'bitfun-demo-bbbbbbbbbbbbbbbb'), now);
     touchFile(join(profileDir, 'deps', 'libbitfun_demo-aaaaaaaaaaaaaaaa.rlib'), now - 1_000);
     touchFile(join(profileDir, 'deps', 'libbitfun_demo-bbbbbbbbbbbbbbbb.rlib'), now);
+    touchFile(join(profileDir, 'deps', 'libghost-cccccccccccccccc.rlib'), now - 2_000);
 
     const dry = runCargoTargetGc({
       rootDir: root,
@@ -153,13 +156,18 @@ test('runCargoTargetGc removes planned paths and respects dry-run', () => {
     assert.equal(existsSync(join(profileDir, 'incremental', 'bitfun_demo-old')), false);
     assert.equal(existsSync(join(profileDir, 'incremental', 'bitfun_demo-new')), true);
     assert.equal(
+      existsSync(join(profileDir, '.fingerprint', 'bitfun-demo-aaaaaaaaaaaaaaaa')),
+      true
+    );
+    assert.equal(
       existsSync(join(profileDir, 'deps', 'libbitfun_demo-aaaaaaaaaaaaaaaa.rlib')),
-      false
+      true
     );
     assert.equal(
       existsSync(join(profileDir, 'deps', 'libbitfun_demo-bbbbbbbbbbbbbbbb.rlib')),
       true
     );
+    assert.equal(existsSync(join(profileDir, 'deps', 'libghost-cccccccccccccccc.rlib')), false);
   } finally {
     cleanup();
   }

--- a/src/apps/desktop/AGENTS-CN.md
+++ b/src/apps/desktop/AGENTS-CN.md
@@ -55,7 +55,7 @@ pnpm run desktop:build:fast
 
 ## Target 缓存 GC
 
-`desktop:dev`（退出时）、`desktop:preview:debug`（关闭时）以及 `desktop:build*` 会裁剪过期的 `target/<profile>/{incremental,.fingerprint,deps}`，每种缓存只保留最新可用副本，避免跨会话堆积。手动执行：`pnpm run target:gc -- --profile debug`。禁用：`BITFUN_TARGET_GC=0`；演练：`BITFUN_TARGET_GC_DRY_RUN=1`。
+`desktop:dev`（退出时）、`desktop:preview:debug`（关闭时）以及 `desktop:build*` 会裁剪过期的 `target/<profile>/incremental`（每个 crate 只留最新根）以及已无对应 `.fingerprint` 的孤儿 `deps`。**不会**按 mtime 删除 fingerprint（否则下次 `desktop:dev` 会冷编译）。手动执行：`pnpm run target:gc -- --profile debug`。禁用：`BITFUN_TARGET_GC=0`；演练：`BITFUN_TARGET_GC_DRY_RUN=1`。
 
 `release-fast` profile（`Cargo.toml`）：继承 `release`，但关闭 LTO、`codegen-units` 提高到 16、启用增量编译。编译速度显著提升，代价是二进制体积增大和边际运行时性能下降。
 

--- a/src/apps/desktop/AGENTS.md
+++ b/src/apps/desktop/AGENTS.md
@@ -63,7 +63,7 @@ pnpm run desktop:build:fast
 
 ## Target cache GC
 
-`desktop:dev` (on exit), `desktop:preview:debug` (on shutdown), and `desktop:build*` run a latest-only prune of stale `target/<profile>/{incremental,.fingerprint,deps}` artifacts so caches do not accumulate across sessions. Manual: `pnpm run target:gc -- --profile debug`. Disable with `BITFUN_TARGET_GC=0`; dry-run with `BITFUN_TARGET_GC_DRY_RUN=1`.
+`desktop:dev` (on exit), `desktop:preview:debug` (on shutdown), and `desktop:build*` prune stale `target/<profile>/incremental` roots (keep latest per crate) and true-orphan `deps` hashes with no matching `.fingerprint` directory. Fingerprints are never mtime-pruned (that forced cold rebuilds). Manual: `pnpm run target:gc -- --profile debug`. Disable with `BITFUN_TARGET_GC=0`; dry-run with `BITFUN_TARGET_GC_DRY_RUN=1`.
 
 `release-fast` profile (`Cargo.toml`): inherits `release` but disables LTO, increases `codegen-units` to 16, enables incremental compilation. Significantly faster at the cost of binary size and marginal runtime performance.
 


### PR DESCRIPTION
## Summary
- Root cause: target GC mtime-pruned `.fingerprint` dirs (keep 1/2 per stem) and then deleted the matching `deps`, so the next `pnpm run desktop:dev` cold-recompiled the graph (e.g. `proc-macro2` onward).
- Fix: never mtime-prune fingerprints; only keep-latest `incremental` roots/sessions and delete true-orphan `deps` whose hash has no remaining fingerprint directory.
- Update unit tests and desktop AGENTS notes to lock the safer policy.

## Test plan
- [x] `node --test scripts/cargo-target-gc.test.mjs`
- [ ] Exit `pnpm run desktop:dev`, confirm GC log, then start again and verify Cargo reuses cache (no full third-party recompile)
- [ ] `BITFUN_TARGET_GC_DRY_RUN=1 pnpm run target:gc -- --profile debug`