### PR TITLE
fix(peer): raise mutual-control caps to i32::MAX

### DIFF
--- a/docs/architecture/peer-device-mode.md
+++ b/docs/architecture/peer-device-mode.md
@@ -49,12 +49,13 @@ FS) and must not be mixed with Peer Device Mode.
 
 - Controller: `PeerDeviceTransportAdapter` wraps product `invoke` as
   `RemoteCommand::HostInvoke` over `account_device_rpc`.
-- HostInvoke on the controller is **priority-queued** (max 2 in flight). Session
-  restore / session-list / dialog / workspace-startup commands outrank background
-  `git_*` / `ssh_*` / `lsp_*` / `search_*` / FS / canvas / editor RPCs so hydrate
-  is not starved into relay HTTP 504s. Terminal commands are always interactive
-  priority, and one slot is kept free from low-priority background work so input
-  cannot be trapped behind two slow polling requests.
+- HostInvoke on the controller is **priority-queued** (effectively unbounded
+  concurrency, `i32::MAX` in flight). Session restore / session-list / dialog /
+  workspace-startup commands outrank background `git_*` / `ssh_*` / `lsp_*` /
+  `search_*` / FS / canvas / editor RPCs so hydrate is not starved into relay
+  HTTP 504s. Terminal commands are always interactive priority, and one slot is
+  kept free from low-priority background work so input cannot be trapped behind
+  slow polling requests.
 - While Peer Mode is active, background noise is reduced further:
   - controller-local SSH heartbeats and remote-workspace auto-reconnect pause
   - Git / FilesPanel window-focus refresh pauses

--- a/src/apps/cli/src/peer_host/control.rs
+++ b/src/apps/cli/src/peer_host/control.rs
@@ -21,7 +21,7 @@ pub(crate) struct ControllerLease {
 
 static CONTROL_SUBSCRIBERS: OnceLock<Mutex<ControllerRegistry>> = OnceLock::new();
 static CONTROLLER_DELIVERY: OnceLock<RwLock<()>> = OnceLock::new();
-const MAX_ATTACHED_CONTROLLERS: usize = 64;
+const MAX_ATTACHED_CONTROLLERS: usize = i32::MAX as usize;
 
 fn control_subscribers() -> &'static Mutex<ControllerRegistry> {
     CONTROL_SUBSCRIBERS.get_or_init(|| Mutex::new(ControllerRegistry::default()))

--- a/src/apps/cli/src/peer_host/fanout.rs
+++ b/src/apps/cli/src/peer_host/fanout.rs
@@ -15,7 +15,7 @@ use crate::account::PeerFanoutOwner;
 use super::control::{attached_controllers, controller_delivery_lease};
 use super::state::{PeerHostState, PeerTurnKey};
 
-const PEER_EVENT_DELIVERY_CAPACITY: usize = 512;
+const PEER_EVENT_DELIVERY_CAPACITY: usize = i32::MAX as usize;
 
 struct QueuedPeerDeviceEvent {
     owner: PeerFanoutOwner,

--- a/src/apps/cli/src/peer_host/state.rs
+++ b/src/apps/cli/src/peer_host/state.rs
@@ -12,9 +12,9 @@ use bitfun_runtime_ports::{AgentSubmissionSource, AgentTurnCancellationRequest};
 
 use crate::runtime::events::CliAgentEventSource;
 
-const MAX_TRACKED_PEER_TURNS: usize = 256;
-const MAX_BACKGROUND_PEER_AUTHORIZATIONS: usize = 256;
-const MAX_PENDING_PEER_TASK_CANCELLATIONS: usize = 256;
+const MAX_TRACKED_PEER_TURNS: usize = i32::MAX as usize;
+const MAX_BACKGROUND_PEER_AUTHORIZATIONS: usize = i32::MAX as usize;
+const MAX_PENDING_PEER_TASK_CANCELLATIONS: usize = i32::MAX as usize;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub(crate) struct PeerTurnKey {
@@ -927,7 +927,7 @@ impl PeerHostState {
         drain: PeerTurnDrain,
         reason: &'static str,
     ) -> Result<(), String> {
-        const MAX_CONCURRENT_CANCELLATIONS: usize = 32;
+        const MAX_CONCURRENT_CANCELLATIONS: usize = i32::MAX as usize;
 
         let mut failure_count = 0usize;
         let mut pending_background = drain.background_subagents.into_iter();
@@ -1359,10 +1359,20 @@ mod tests {
     }
 
     #[test]
+    fn peer_tracking_capacities_are_effectively_unbounded() {
+        assert_eq!(super::MAX_TRACKED_PEER_TURNS, i32::MAX as usize);
+        assert_eq!(super::MAX_BACKGROUND_PEER_AUTHORIZATIONS, i32::MAX as usize);
+        assert_eq!(
+            super::MAX_PENDING_PEER_TASK_CANCELLATIONS,
+            i32::MAX as usize
+        );
+    }
+
+    #[test]
     fn completed_background_authorizations_do_not_reduce_live_turn_capacity() {
         let tracker = PeerTurnTracker::new();
         tracker.mark_event_stream_ready();
-        for index in 0..super::MAX_BACKGROUND_PEER_AUTHORIZATIONS {
+        for index in 0..16 {
             let root = PeerTurnKey::new(format!("parent-{index}"), format!("root-{index}"));
             let child = PeerTurnKey::new(format!("child-{index}"), format!("child-turn-{index}"));
             tracker.register_root(root.clone()).expect("register root");
@@ -1371,8 +1381,7 @@ mod tests {
             tracker.finish_turn(&root);
         }
 
-        let mut live_roots = Vec::new();
-        for index in 0..super::MAX_TRACKED_PEER_TURNS {
+        for index in 0..16 {
             let root = PeerTurnKey::new(
                 format!("live-session-{index}"),
                 format!("live-turn-{index}"),
@@ -1380,50 +1389,25 @@ mod tests {
             tracker
                 .register_root(root.clone())
                 .expect("background history must not reduce live capacity");
-            live_roots.push(root);
-        }
-        assert!(tracker
-            .record_background_task_call(&live_roots[0], "overflow-task".to_string())
-            .expect_err("the next background authorization must fail closed")
-            .contains("background authorization capacity"));
-    }
-
-    #[test]
-    fn active_capacity_rejects_a_new_root_without_requesting_a_reset() {
-        let tracker = PeerTurnTracker::new();
-        tracker.mark_event_stream_ready();
-        for index in 0..super::MAX_TRACKED_PEER_TURNS {
             tracker
-                .register_root(PeerTurnKey::new(
-                    format!("session-{index}"),
-                    format!("turn-{index}"),
-                ))
-                .expect("register active root");
+                .record_background_task_call(&root, format!("live-task-{index}"))
+                .expect("live background authorization must remain available");
         }
-
-        assert!(tracker
-            .register_root(PeerTurnKey::new("overflow-session", "overflow-turn"))
-            .expect_err("live capacity must reject one more root")
-            .contains("capacity is exhausted"));
     }
 
     #[test]
-    fn unlinked_background_and_cancellation_task_markers_are_bounded() {
+    fn unlinked_background_and_cancellation_task_markers_accept_many_entries() {
         let tracker = PeerTurnTracker::new();
         tracker.mark_event_stream_ready();
         let root = PeerTurnKey::new("session", "turn");
         tracker.register_root(root.clone()).expect("register root");
-        for index in 0..super::MAX_BACKGROUND_PEER_AUTHORIZATIONS {
+        for index in 0..64 {
             tracker
                 .record_background_task_call(&root, format!("background-{index}"))
                 .expect("reserve background authorization");
         }
-        assert!(tracker
-            .record_background_task_call(&root, "background-overflow".to_string())
-            .expect_err("unlinked background calls must be bounded")
-            .contains("background authorization capacity"));
 
-        for index in 0..super::MAX_PENDING_PEER_TASK_CANCELLATIONS {
+        for index in 0..64 {
             tracker
                 .record_background_task_cancellation(
                     &root,
@@ -1432,21 +1416,13 @@ mod tests {
                 )
                 .expect("track Task cancellation");
         }
-        assert!(tracker
-            .record_background_task_cancellation(
-                &root,
-                "cancel-overflow".to_string(),
-                "subagent-overflow".to_string(),
-            )
-            .expect_err("Task cancellation markers must be bounded")
-            .contains("cancellation tracking capacity"));
     }
 
     #[test]
     fn foreground_children_do_not_consume_background_lineage_capacity() {
         let tracker = PeerTurnTracker::new();
         tracker.mark_event_stream_ready();
-        for index in 0..(super::MAX_TRACKED_PEER_TURNS * 2) {
+        for index in 0..64 {
             let root = PeerTurnKey::new(format!("parent-{index}"), format!("root-{index}"));
             let child = PeerTurnKey::new(format!("child-{index}"), format!("child-turn-{index}"));
             tracker.register_root(root.clone()).expect("register root");
@@ -1758,7 +1734,7 @@ mod tests {
             .register_root(parent.clone())
             .expect("register parent");
 
-        for index in 0..(super::MAX_BACKGROUND_PEER_AUTHORIZATIONS * 2) {
+        for index in 0..64 {
             let tool_call_id = format!("task-tool-{index}");
             let background_task_id = format!("background-task-{index}");
             let source = PeerTurnKey::new("subagent-session", format!("subagent-turn-{index}"));
@@ -1784,7 +1760,7 @@ mod tests {
         tracker.interrupt_event_stream(false);
         tracker.mark_event_stream_ready();
 
-        for index in 0..super::MAX_TRACKED_PEER_TURNS {
+        for index in 0..64 {
             tracker
                 .register_root(PeerTurnKey::new(
                     format!("session-{index}"),

--- a/src/crates/services/relay-service/src/relay/device_manager.rs
+++ b/src/crates/services/relay-service/src/relay/device_manager.rs
@@ -20,7 +20,7 @@ use tracing::{debug, info};
 
 use crate::relay::room::{ConnId, OutboundMessage};
 
-pub const MAX_PENDING_DEVICE_RPCS: usize = 1024;
+pub const MAX_PENDING_DEVICE_RPCS: usize = i32::MAX as usize;
 
 /// An online device connection belonging to a user.
 struct DeviceConn {
@@ -766,18 +766,16 @@ mod tests {
     }
 
     #[test]
-    fn pending_device_rpcs_are_bounded_and_permits_are_reclaimed() {
+    fn pending_device_rpcs_are_effectively_unbounded_and_permits_are_reclaimed() {
+        assert_eq!(MAX_PENDING_DEVICE_RPCS, i32::MAX as usize);
         let mgr = DeviceManager::new();
         let mut receivers = Vec::new();
-        for index in 0..MAX_PENDING_DEVICE_RPCS {
+        for index in 0..64 {
             receivers.push(
                 mgr.register_rpc(&format!("corr-{index}"), "user-1", "desktop-1")
                     .expect("registration within global limit"),
             );
         }
-        assert!(mgr
-            .register_rpc("overflow", "user-1", "desktop-1")
-            .is_none());
 
         mgr.cancel_rpc("corr-0");
         assert!(mgr

--- a/src/crates/services/relay-service/src/relay/room.rs
+++ b/src/crates/services/relay-service/src/relay/room.rs
@@ -13,9 +13,9 @@ use tokio::sync::{mpsc, oneshot, OwnedSemaphorePermit, Semaphore};
 use tracing::{debug, info, warn};
 
 pub type ConnId = u64;
-pub const MAX_PENDING_REQUESTS: usize = 1024;
-pub const MAX_PENDING_REQUESTS_PER_ROOM: usize = 128;
-pub const MAX_ACTIVE_ROOMS: usize = 10_000;
+pub const MAX_PENDING_REQUESTS: usize = i32::MAX as usize;
+pub const MAX_PENDING_REQUESTS_PER_ROOM: usize = i32::MAX as usize;
+pub const MAX_ACTIVE_ROOMS: usize = i32::MAX as usize;
 
 /// Room IDs cross an untrusted WebSocket boundary and later become asset
 /// namespace names. Keep them to one portable path segment so they can never
@@ -464,42 +464,31 @@ mod tests {
     }
 
     #[test]
-    fn pending_registration_is_bounded() {
+    fn pending_registration_capacity_is_effectively_unbounded() {
+        assert_eq!(MAX_PENDING_REQUESTS, i32::MAX as usize);
+        assert_eq!(MAX_PENDING_REQUESTS_PER_ROOM, i32::MAX as usize);
+        assert_eq!(MAX_ACTIVE_ROOMS, i32::MAX as usize);
+
         let manager = RoomManager::new();
         let mut guards = Vec::new();
-
-        for index in 0..MAX_PENDING_REQUESTS {
+        for index in 0..64 {
             let room_id = format!("room-{index}");
             let (guard, _rx) = manager
                 .try_register_pending(&room_id, format!("pending-{index}"))
                 .expect("pending registration within limit");
             guards.push(guard);
         }
-
-        assert!(manager
-            .try_register_pending("overflow-room", "overflow".to_string())
-            .is_none());
         drop(guards.pop());
         assert!(manager
             .try_register_pending("after-cancel-room", "after-cancel".to_string())
             .is_some());
-    }
 
-    #[test]
-    fn pending_registration_is_bounded_per_room_without_starving_other_rooms() {
-        let manager = RoomManager::new();
-        let mut guards = Vec::new();
-
-        for index in 0..MAX_PENDING_REQUESTS_PER_ROOM {
+        for index in 0..64 {
             let (guard, _rx) = manager
                 .try_register_pending("room-a", format!("room-a-{index}"))
                 .expect("room-a pending registration within per-room limit");
             guards.push(guard);
         }
-
-        assert!(manager
-            .try_register_pending("room-a", "room-a-overflow".to_string())
-            .is_none());
         assert!(manager
             .try_register_pending("room-b", "room-b-still-healthy".to_string())
             .is_some());

--- a/src/crates/services/relay-service/src/routes/websocket.rs
+++ b/src/crates/services/relay-service/src/routes/websocket.rs
@@ -28,7 +28,7 @@ use tracing::{debug, error, info, warn};
 use crate::relay::room::{send_outbound_message, ConnId, OutboundMessage, ResponsePayload};
 use crate::routes::api::AppState;
 
-const OUTBOUND_QUEUE_CAPACITY: usize = 256;
+const OUTBOUND_QUEUE_CAPACITY: usize = i32::MAX as usize;
 const MAX_WS_MESSAGE_BYTES: usize = 64 * 1024 * 1024;
 const MAX_ENCRYPTED_PAYLOAD_BYTES: usize = 48 * 1024 * 1024;
 const MAX_IDENTIFIER_BYTES: usize = 128;
@@ -36,7 +36,7 @@ const MAX_DEVICE_NAME_BYTES: usize = 256;
 const MAX_PUBLIC_KEY_BYTES: usize = 512;
 const MAX_NONCE_BYTES: usize = 256;
 const RATE_LIMIT_WINDOW: Duration = Duration::from_secs(60);
-const MAX_MESSAGES_PER_WINDOW: u32 = 600;
+const MAX_MESSAGES_PER_WINDOW: u32 = i32::MAX as u32;
 const DEVICE_TOKEN_REVALIDATION_INTERVAL: Duration = Duration::from_secs(5);
 
 struct ConnectionRateLimiter {
@@ -965,12 +965,12 @@ mod tests {
     }
 
     #[test]
-    fn websocket_message_rate_is_bounded() {
+    fn websocket_message_rate_is_effectively_unbounded() {
+        assert_eq!(MAX_MESSAGES_PER_WINDOW, i32::MAX as u32);
         let mut limiter = ConnectionRateLimiter::new();
-        for _ in 0..MAX_MESSAGES_PER_WINDOW {
+        for _ in 0..64 {
             assert!(limiter.allow());
         }
-        assert!(!limiter.allow());
     }
 
     #[test]

--- a/src/web-ui/src/infrastructure/api/adapters/peer-device-adapter.ts
+++ b/src/web-ui/src/infrastructure/api/adapters/peer-device-adapter.ts
@@ -179,8 +179,8 @@ export function peerInvokePriorityFor(command: string): PeerInvokePriority {
   return 'normal';
 }
 
-/** Max in-flight HostInvoke RPCs per controller. Keep low to avoid relay 504 pile-ups. */
-export const PEER_HOST_INVOKE_MAX_CONCURRENT = 2;
+/** Max in-flight HostInvoke RPCs per controller. */
+export const PEER_HOST_INVOKE_MAX_CONCURRENT = 2147483647;
 
 type DeviceRpcFn = (targetDeviceId: string, commandJson: string) => Promise<string>;
 

--- a/src/web-ui/src/infrastructure/peer-device/PeerDeviceContext.tsx
+++ b/src/web-ui/src/infrastructure/peer-device/PeerDeviceContext.tsx
@@ -30,7 +30,7 @@ import {
 const log = createLogger('PeerDeviceMode');
 
 /** Only high/normal HostInvoke transport failures count toward auto-exit. */
-const PEER_RPC_FAILURE_LIMIT = 5;
+const PEER_RPC_FAILURE_LIMIT = 2147483647;
 const PEER_PING_INTERVAL_MS = 20_000;
 
 function emitPeerModeChanged(detail: { active: boolean; deviceId?: string }): void {

--- a/src/web-ui/src/infrastructure/peer-device/README.md
+++ b/src/web-ui/src/infrastructure/peer-device/README.md
@@ -33,8 +33,8 @@ Controller-side React/transport layer for Peer Device Mode. Architecture:
 
 6. **Config / mode HostInvokes are high priority** during peer hydrate
    (`get_config`, `get_configs`, `get_available_modes`,
-   `get_agent_profile_config`). Keeping them `low` starves hydrate under the
-   concurrency limit of 2.
+   `get_agent_profile_config`). Keeping them `low` can still delay hydrate
+   behind a burst of background RPCs.
 
 7. **Account identity commands are LOCAL_ONLY** and must stay denied on the
    peer host (`account_login`, `account_finalize_login`, logout, device RPC,


### PR DESCRIPTION
## Summary
- Raise Peer Device Mode / relay mutual-control capacity and concurrency limits to `i32::MAX` so streaming DeviceEvent fan-out no longer trips `message rate limit exceeded` and force-closes the WebSocket.
- Covers relay WebSocket/outbound/device/room pending caps, CLI peer-host queues and turn tracking, and Web UI HostInvoke concurrency / RPC failure thresholds.
- Update capacity-oriented unit tests and peer-device docs to match the unbounded caps.

## Test plan
- [x] `cargo test -p bitfun-relay-service --lib effectively_unbounded`
- [x] `cargo test -p bitfun-cli peer_host::state::tests`
- [x] `pnpm --dir src/web-ui run test:run src/infrastructure/api/adapters/peer-device-adapter.test.ts`
- [x] `cargo check -p bitfun-relay-service -p bitfun-cli`
- [ ] Redeploy `remote.openbitfun.com` relay with this change, then verify account Peer Mode no longer disconnects during agent/terminal event fan-out