### PR TITLE
fix(peer-device): reconcile live session snapshots

### DIFF
--- a/docs/architecture/peer-device-mode.md
+++ b/docs/architecture/peer-device-mode.md
@@ -75,6 +75,14 @@ FS) and must not be mixed with Peer Device Mode.
   controllers; controller re-emits the same event names locally. This includes
   SSH-backed remote PTY Ready / Data / Exit events created on B, not only B's
   local terminal service events.
+- Because DeviceEvent delivery has no ACK/replay contract, the controller also
+  reconciles its active chat session from the Peer Host every 3s, immediately
+  after session/visibility changes, and after detecting a dropped data event.
+  Realtime events remain the primary path; snapshot reconciliation repairs a
+  controller that attached after turn/round lifecycle events or crossed a
+  transient relay gap. The host overlays its authoritative in-memory session
+  state onto the persisted view so an executing turn is not misclassified as
+  interrupted history.
 - CLI Peer Host forwards only turns submitted through Peer Host and linked
   child turns. A background-result follow-up inherits ownership only when its
   Core-internal metadata identifies the exact tracked parent and source child
@@ -96,8 +104,7 @@ FS) and must not be mixed with Peer Device Mode.
   delivery lease serializes detach or offline removal with the local Relay
   enqueue attempt. An explicit disconnect still restores the local controller
   UI, but reports a warning when host cancellation was not confirmed. This
-  boundary does not change the Relay envelope or add ACK, replay, or reconnect
-  recovery.
+  boundary does not change the Relay envelope or add ACK or replay.
 - Relay `POST /api/devices/:id/rpc` waits up to **120s** for the peer response;
   reverse proxies in front of the relay must use a matching (or higher) read
   timeout or they will return 504 first.

--- a/src/apps/cli/src/peer_host/commands/session.rs
+++ b/src/apps/cli/src/peer_host/commands/session.rs
@@ -69,6 +69,15 @@ fn session_to_json(session: Session, turn_count: usize) -> Value {
     })
 }
 
+fn overlay_live_session_state(restored: &mut Session, live: Option<Session>) {
+    let Some(live) = live else {
+        return;
+    };
+    if live.session_id == restored.session_id {
+        restored.state = live.state;
+    }
+}
+
 fn restored_session_to_json(restored: AgentSessionRestoreResult) -> Value {
     let session = restored.session;
     json!({
@@ -165,7 +174,7 @@ pub(crate) async fn restore_session_view(
         .filter(|n| *n > 0)
         .map(|n| n.min(16));
 
-    let (session, turns, total_turn_count, timings) = state
+    let (mut session, turns, total_turn_count, timings) = state
         .compatibility
         .restore_session_view_for_workspace(
             storage_request,
@@ -175,6 +184,11 @@ pub(crate) async fn restore_session_view(
         )
         .await
         .map_err(|e| format!("Failed to restore session view: {e}"))?;
+    let live_session = state
+        .compatibility
+        .loaded_session_snapshot(&session_id)
+        .map_err(|e| format!("Failed to read live session state: {e}"))?;
+    overlay_live_session_state(&mut session, live_session);
 
     let loaded_turn_count = turns.len();
     let is_partial = loaded_turn_count < total_turn_count;
@@ -533,8 +547,13 @@ pub(crate) async fn save_session_turn(
 
 #[cfg(test)]
 mod tests {
-    use super::{restored_session_to_json, session_stats_validation_error};
+    use super::{
+        overlay_live_session_state, restored_session_to_json, session_stats_validation_error,
+    };
     use bitfun_agent_runtime::sdk::{AgentSessionRestoreResult, AgentSessionSummary, SessionState};
+    use bitfun_core::agentic::core::{
+        ProcessingPhase, Session as CoreSession, SessionConfig, SessionState as CoreSessionState,
+    };
 
     #[test]
     fn basic_restore_keeps_peer_host_session_shape() {
@@ -571,5 +590,30 @@ mod tests {
             session_stats_validation_error("session_id cannot contain path separators"),
             "Failed to get session stats: Validation error: session_id cannot contain path separators"
         );
+    }
+
+    #[test]
+    fn view_restore_uses_the_cli_hosts_live_processing_state() {
+        let mut restored = CoreSession::new_with_id(
+            "session_1".to_string(),
+            "Main".to_string(),
+            "agentic".to_string(),
+            SessionConfig::default(),
+        );
+        let mut live = restored.clone();
+        live.state = CoreSessionState::Processing {
+            current_turn_id: "turn_1".to_string(),
+            phase: ProcessingPhase::Streaming,
+        };
+
+        overlay_live_session_state(&mut restored, Some(live));
+
+        assert!(matches!(
+            restored.state,
+            CoreSessionState::Processing {
+                ref current_turn_id,
+                ..
+            } if current_turn_id == "turn_1"
+        ));
     }
 }

--- a/src/apps/desktop/src/runtime/session_application.rs
+++ b/src/apps/desktop/src/runtime/session_application.rs
@@ -76,6 +76,21 @@ pub(crate) struct DesktopSessionWithTurnsRestore {
     pub turns: Vec<DialogTurnData>,
 }
 
+fn overlay_live_session_state(restored: &mut Session, live: Option<Session>) {
+    let Some(live) = live else {
+        return;
+    };
+    if live.session_id != restored.session_id {
+        return;
+    }
+
+    // Disk state deliberately stores Processing as Idle so a process restart
+    // never revives work. A view served by the process that still owns the
+    // runtime must expose its live state, otherwise a Peer controller treats
+    // an executing turn as interrupted history and drops subsequent chunks.
+    restored.state = live.state;
+}
+
 #[derive(Clone)]
 struct ResolvedDesktopSessionScope {
     workspace_path: String,
@@ -510,7 +525,7 @@ impl DesktopSessionApplication {
         let resolve_storage_path_duration_ms =
             path_started_at.elapsed().as_millis().min(u64::MAX as u128) as u64;
         on_storage_path_resolved(resolve_storage_path_duration_ms);
-        let (session, turns, total_turn_count, mut timings) = self
+        let (mut session, turns, total_turn_count, mut timings) = self
             .compatibility
             .restore_session_view_from_storage_path(
                 &storage_path,
@@ -520,6 +535,11 @@ impl DesktopSessionApplication {
             )
             .await
             .map_err(|error| DesktopSessionApplicationError::Core(error.to_string()))?;
+        let live_session = self
+            .compatibility
+            .loaded_session_snapshot(session_id)
+            .map_err(|error| DesktopSessionApplicationError::Core(error.to_string()))?;
+        overlay_live_session_state(&mut session, live_session);
         timings.resolve_storage_path_duration_ms = resolve_storage_path_duration_ms;
         Ok(DesktopSessionViewRestore {
             session,
@@ -763,6 +783,48 @@ mod tests {
             choose_remote_ssh_host(None, None, Some(" saved-host ")),
             Some("saved-host".to_string())
         );
+    }
+
+    #[test]
+    fn live_processing_state_overlays_sanitized_view_state() {
+        let mut restored = Session::new_with_id(
+            "session-1".to_string(),
+            "Restored".to_string(),
+            "agentic".to_string(),
+            Default::default(),
+        );
+        let mut live = restored.clone();
+        live.state = bitfun_core::agentic::core::SessionState::Processing {
+            current_turn_id: "turn-1".to_string(),
+            phase: bitfun_core::agentic::core::ProcessingPhase::Streaming,
+        };
+
+        overlay_live_session_state(&mut restored, Some(live));
+
+        assert!(matches!(
+            restored.state,
+            bitfun_core::agentic::core::SessionState::Processing {
+                ref current_turn_id,
+                ..
+            } if current_turn_id == "turn-1"
+        ));
+    }
+
+    #[test]
+    fn missing_live_session_keeps_persisted_view_state() {
+        let mut restored = Session::new_with_id(
+            "session-1".to_string(),
+            "Restored".to_string(),
+            "agentic".to_string(),
+            Default::default(),
+        );
+
+        overlay_live_session_state(&mut restored, None);
+
+        assert!(matches!(
+            restored.state,
+            bitfun_core::agentic::core::SessionState::Idle
+        ));
     }
 
     #[tokio::test]

--- a/src/crates/assembly/core/src/product_runtime.rs
+++ b/src/crates/assembly/core/src/product_runtime.rs
@@ -541,6 +541,21 @@ impl CoreAgentRuntimeCompatibility {
             .is_some())
     }
 
+    /// Return the authoritative in-memory session snapshot when this process
+    /// currently owns the session runtime.
+    ///
+    /// Persisted session state intentionally sanitizes `Processing` to `Idle`
+    /// so a later process restart cannot resurrect work. Live read-only views
+    /// (for example Peer Device controllers) still need the current process
+    /// state to distinguish an executing session from interrupted history.
+    pub fn loaded_session_snapshot(&self, session_id: &str) -> BitFunResult<Option<Session>> {
+        validate_persisted_session_id(session_id)?;
+        Ok(self
+            .coordinator
+            .get_session_manager()
+            .get_session(session_id))
+    }
+
     pub async fn update_loaded_session_title(
         &self,
         session_id: &str,
@@ -1056,6 +1071,7 @@ mod tests {
         let _ = build;
         let _ = CoreAgentRuntimeCompatibility::list_persisted_sessions;
         let _ = CoreAgentRuntimeCompatibility::load_persisted_session_turns;
+        let _ = CoreAgentRuntimeCompatibility::loaded_session_snapshot;
         let _ = CoreAgentRuntimeCompatibility::unload_persisted_session;
     }
 

--- a/src/web-ui/src/flow_chat/services/FlowChatManager.ts
+++ b/src/web-ui/src/flow_chat/services/FlowChatManager.ts
@@ -49,6 +49,7 @@ import {
   updateImageAnalysisItem as updateImageAnalysisItemModule,
   updateSessionMetadata,
 } from './flow-chat-manager';
+import { installPeerSessionRefresh } from './flow-chat-manager/PeerSessionRefreshModule';
 
 const log = createLogger('FlowChatManager');
 
@@ -61,6 +62,7 @@ export class FlowChatManager {
   private eventListenerCleanup: (() => void) | null = null;
   private initializationRequests = new Map<string, Promise<boolean>>();
   private latestInitializationRequestKey: string | null = null;
+  private peerSessionRefreshCleanup: (() => void) | null = null;
   private disposed = false;
 
   private constructor() {
@@ -88,6 +90,7 @@ export class FlowChatManager {
     
     this.agentService = AgentService.getInstance();
     installPendingQueueDrainListener(this.context);
+    this.peerSessionRefreshCleanup = installPeerSessionRefresh(this.context);
   }
 
   /** Public hook used by the queue panel "send now" fallback to drain head item. */
@@ -414,6 +417,8 @@ export class FlowChatManager {
     this.initializationRequests.clear();
     this.latestInitializationRequestKey = null;
     this.cleanupEventListeners();
+    this.peerSessionRefreshCleanup?.();
+    this.peerSessionRefreshCleanup = null;
     this.context.eventBatcher.destroy();
   }
 

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
@@ -80,6 +80,7 @@ import {
   clearRuntimeStatus,
   scheduleModelResponseStatus,
 } from './RuntimeStatusModule';
+import { requestPeerSessionRefresh } from './PeerSessionRefreshModule';
 
 const log = createLogger('EventHandlerModule');
 const TURN_COMPLETION_QUIET_WINDOW_MS = 500;
@@ -167,6 +168,7 @@ function logDroppedDataEvent(
   turnId: string | null,
   details: Record<string, unknown>
 ): void {
+  requestPeerSessionRefresh(sessionId);
   log.debug('Dropped agentic data event', {
     eventName,
     sessionId,
@@ -1623,6 +1625,7 @@ function handleTextChunk(context: FlowChatContext, event: any): void {
 
   const dialogTurn = session.dialogTurns.find((turn: DialogTurn) => turn.id === turnId);
   if (!dialogTurn) {
+    requestPeerSessionRefresh(sessionId);
     log.debug('Dialog turn not found', { turnId });
     return;
   }
@@ -1795,6 +1798,7 @@ function handleModelRoundStart(context: FlowChatContext, event: ModelRoundStarte
 
   const dialogTurn = session.dialogTurns.find((turn: DialogTurn) => turn.id === turnId);
   if (!dialogTurn) {
+    requestPeerSessionRefresh(sessionId);
     log.debug('Dialog turn not found (model round start)', { turnId });
     return;
   }

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const peerModeMock = vi.hoisted(() => ({ active: true }));
+const stateMachineMock = vi.hoisted(() => ({
+  get: vi.fn(() => ({
+    getCurrentState: () => 'idle',
+    getContext: () => ({ lastUpdateTime: 0 }),
+  })),
+  reset: vi.fn(),
+  transition: vi.fn(async () => true),
+}));
+
+vi.mock('@/infrastructure/peer-device/peerModeFlag', () => ({
+  isPeerDeviceModeActive: () => peerModeMock.active,
+}));
+
+vi.mock('../../state-machine', () => ({
+  stateMachineManager: stateMachineMock,
+}));
+
+import {
+  installPeerSessionRefresh,
+  PEER_SESSION_REFRESH_INTERVAL_MS,
+  requestPeerSessionRefresh,
+} from './PeerSessionRefreshModule';
+
+describe('PeerSessionRefreshModule', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    peerModeMock.active = true;
+    vi.stubGlobal('document', {
+      visibilityState: 'visible',
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+    vi.stubGlobal('window', {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('refreshes immediately, periodically, and on an event-gap request', async () => {
+    const refreshPeerSessionSnapshot = vi.fn(async () => ({
+      applied: false,
+      backendState: 'Processing',
+      latestTurnId: 'turn-1',
+      latestTurnStatus: 'processing',
+    }));
+    const state = {
+      activeSessionId: 'session-1',
+      sessions: new Map([
+        ['session-1', {
+          sessionId: 'session-1',
+          workspacePath: '/peer/project',
+          historyState: 'ready',
+          isHistorical: false,
+          isTransient: false,
+        }],
+      ]),
+    };
+    const context = {
+      flowChatStore: {
+        getState: () => state,
+        subscribeSelector: vi.fn(() => () => {}),
+        refreshPeerSessionSnapshot,
+      },
+      eventBatcher: {
+        flushNow: vi.fn(),
+      },
+      contentBuffers: new Map(),
+      activeTextItems: new Map(),
+    } as any;
+
+    const cleanup = installPeerSessionRefresh(context);
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(refreshPeerSessionSnapshot).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(PEER_SESSION_REFRESH_INTERVAL_MS);
+    expect(refreshPeerSessionSnapshot).toHaveBeenCalledTimes(2);
+
+    requestPeerSessionRefresh('session-1');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(refreshPeerSessionSnapshot).toHaveBeenCalledTimes(3);
+
+    cleanup();
+  });
+
+  it('does not poll when Peer Device Mode is inactive', async () => {
+    peerModeMock.active = false;
+    const refreshPeerSessionSnapshot = vi.fn();
+    const context = {
+      flowChatStore: {
+        getState: () => ({
+          activeSessionId: 'session-1',
+          sessions: new Map(),
+        }),
+        subscribeSelector: vi.fn(() => () => {}),
+        refreshPeerSessionSnapshot,
+      },
+      eventBatcher: {
+        flushNow: vi.fn(),
+      },
+      contentBuffers: new Map(),
+      activeTextItems: new Map(),
+    } as any;
+
+    const cleanup = installPeerSessionRefresh(context);
+    await vi.advanceTimersByTimeAsync(PEER_SESSION_REFRESH_INTERVAL_MS * 2);
+
+    expect(refreshPeerSessionSnapshot).not.toHaveBeenCalled();
+    cleanup();
+  });
+});

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.ts
@@ -1,0 +1,265 @@
+/**
+ * Peer Device active-session snapshot reconciliation.
+ *
+ * DeviceEvent fan-out is the real-time path, but the relay protocol has no
+ * ACK/replay recovery. A controller that attaches mid-turn can therefore miss
+ * lifecycle events required by the local FlowChat state machine. This module
+ * periodically reconciles a small host snapshot and also supports immediate
+ * refresh requests when an event gap is detected.
+ */
+
+import { isPeerDeviceModeActive } from '@/infrastructure/peer-device/peerModeFlag';
+import { createLogger } from '@/shared/utils/logger';
+import {
+  isBackendSessionActivelyProcessing,
+} from '../../store/FlowChatStore';
+import { stateMachineManager } from '../../state-machine';
+import {
+  SessionExecutionEvent,
+  SessionExecutionState,
+} from '../../state-machine/types';
+import type { AnyFlowItem, DialogTurn } from '../../types/flow-chat';
+import type { FlowChatContext } from './types';
+
+const log = createLogger('PeerSessionRefresh');
+
+export const PEER_SESSION_REFRESH_INTERVAL_MS = 3000;
+export const PEER_SESSION_STREAM_STALE_MS = 6000;
+
+type RefreshRequester = (sessionId?: string) => void;
+let installedRefreshRequester: RefreshRequester | null = null;
+
+export function requestPeerSessionRefresh(sessionId?: string): void {
+  if (!isPeerDeviceModeActive()) {
+    return;
+  }
+  installedRefreshRequester?.(sessionId);
+}
+
+function streamKey(
+  roundId: string,
+  item: Pick<AnyFlowItem, 'attemptId' | 'attemptIndex'>,
+): string {
+  if (item.attemptId) {
+    return item.attemptId;
+  }
+  if (typeof item.attemptIndex === 'number' && Number.isFinite(item.attemptIndex)) {
+    return `${roundId}:attempt:${item.attemptIndex}`;
+  }
+  return roundId;
+}
+
+function seedActiveTurnBuffers(
+  context: FlowChatContext,
+  sessionId: string,
+  turn: DialogTurn,
+): void {
+  const contentBuffers = new Map<string, string>();
+  const activeTextItems = new Map<string, string>();
+
+  for (const round of turn.modelRounds) {
+    for (const item of round.items) {
+      if (item.type !== 'text' && item.type !== 'thinking') {
+        continue;
+      }
+      const baseKey = streamKey(round.id, item);
+      const key = item.type === 'thinking' ? `thinking_${baseKey}` : baseKey;
+      contentBuffers.set(key, item.content || '');
+      activeTextItems.set(key, item.id);
+    }
+  }
+
+  context.contentBuffers.set(sessionId, contentBuffers);
+  context.activeTextItems.set(sessionId, activeTextItems);
+}
+
+function isTerminalTurn(turn: DialogTurn | undefined): boolean {
+  return turn?.status === 'completed' ||
+    turn?.status === 'cancelled' ||
+    turn?.status === 'error';
+}
+
+async function alignStateMachineWithSnapshot(
+  context: FlowChatContext,
+  sessionId: string,
+  backendState: string,
+  latestTurnId?: string,
+): Promise<void> {
+  const session = context.flowChatStore.getState().sessions.get(sessionId);
+  const latestTurn = latestTurnId
+    ? session?.dialogTurns.find(turn => turn.id === latestTurnId)
+    : session?.dialogTurns[session.dialogTurns.length - 1];
+
+  if (
+    isBackendSessionActivelyProcessing(backendState) &&
+    latestTurn &&
+    !isTerminalTurn(latestTurn)
+  ) {
+    stateMachineManager.reset(sessionId);
+    seedActiveTurnBuffers(context, sessionId, latestTurn);
+    await stateMachineManager.transition(sessionId, SessionExecutionEvent.START, {
+      taskId: sessionId,
+      dialogTurnId: latestTurn.id,
+    });
+    const latestRound = latestTurn.modelRounds[latestTurn.modelRounds.length - 1];
+    if (latestRound) {
+      await stateMachineManager.transition(sessionId, SessionExecutionEvent.MODEL_ROUND_START, {
+        modelRoundId: latestRound.id,
+      });
+    }
+    return;
+  }
+
+  context.contentBuffers.delete(sessionId);
+  context.activeTextItems.delete(sessionId);
+  stateMachineManager.reset(sessionId);
+}
+
+export function installPeerSessionRefresh(context: FlowChatContext): () => void {
+  let disposed = false;
+  let inFlight = false;
+  let queued = false;
+  let immediateTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const runRefresh = async (requestedSessionId?: string): Promise<void> => {
+    if (disposed || inFlight || !isPeerDeviceModeActive()) {
+      if (inFlight) {
+        queued = true;
+      }
+      return;
+    }
+    if (typeof document !== 'undefined' && document.visibilityState === 'hidden') {
+      return;
+    }
+
+    const state = context.flowChatStore.getState();
+    const sessionId = requestedSessionId || state.activeSessionId;
+    if (!sessionId || state.activeSessionId !== sessionId) {
+      return;
+    }
+    const session = state.sessions.get(sessionId);
+    const workspacePath = session?.workspacePath?.trim();
+    if (
+      !session ||
+      !workspacePath ||
+      session.isTransient ||
+      session.isHistorical ||
+      session.historyState !== 'ready'
+    ) {
+      return;
+    }
+
+    const machine = stateMachineManager.get(sessionId);
+    const machineState = machine?.getCurrentState() ?? SessionExecutionState.IDLE;
+    if (machineState === SessionExecutionState.FINISHING) {
+      return;
+    }
+    const lastUpdateTime = machine?.getContext().lastUpdateTime ?? 0;
+    const replaceRunningSnapshot =
+      machineState === SessionExecutionState.IDLE ||
+      machineState === SessionExecutionState.ERROR ||
+      Date.now() - lastUpdateTime >= PEER_SESSION_STREAM_STALE_MS;
+    context.eventBatcher.flushNow();
+    const machineVersion = machine?.getContext().version ?? 0;
+
+    inFlight = true;
+    try {
+      const result = await context.flowChatStore.refreshPeerSessionSnapshot(
+        sessionId,
+        workspacePath,
+        {
+          replaceRunningSnapshot,
+          requireActiveSession: true,
+          shouldApply: () => {
+            if (!isPeerDeviceModeActive()) {
+              return false;
+            }
+            const currentMachine = stateMachineManager.get(sessionId);
+            return (currentMachine?.getContext().version ?? 0) === machineVersion;
+          },
+        },
+      );
+      if (!result.applied) {
+        return;
+      }
+      await alignStateMachineWithSnapshot(
+        context,
+        sessionId,
+        result.backendState,
+        result.latestTurnId,
+      );
+      log.debug('Peer session snapshot reconciled', {
+        sessionId,
+        backendState: result.backendState,
+        latestTurnId: result.latestTurnId,
+      });
+    } catch (error) {
+      // Realtime DeviceEvents remain usable when a background refresh fails.
+      // The next interval or gap-triggered request retries without forcing an
+      // auto-exit from Peer Mode.
+      log.warn('Peer session snapshot refresh failed', { sessionId, error });
+    } finally {
+      inFlight = false;
+      if (queued && !disposed) {
+        queued = false;
+        scheduleRefresh();
+      }
+    }
+  };
+
+  const scheduleRefresh: RefreshRequester = (sessionId) => {
+    if (disposed) {
+      return;
+    }
+    if (immediateTimer !== null) {
+      clearTimeout(immediateTimer);
+    }
+    immediateTimer = setTimeout(() => {
+      immediateTimer = null;
+      void runRefresh(sessionId);
+    }, 0);
+  };
+
+  installedRefreshRequester = scheduleRefresh;
+
+  const unsubscribeActiveSession = context.flowChatStore.subscribeSelector(
+    state => state.activeSessionId,
+    sessionId => scheduleRefresh(sessionId ?? undefined),
+  );
+  const interval = setInterval(() => {
+    void runRefresh();
+  }, PEER_SESSION_REFRESH_INTERVAL_MS);
+
+  const handlePeerModeChanged = (): void => scheduleRefresh();
+  const handleVisibilityChanged = (): void => {
+    if (typeof document === 'undefined' || document.visibilityState === 'visible') {
+      scheduleRefresh();
+    }
+  };
+  if (typeof window !== 'undefined') {
+    window.addEventListener('peer-mode:changed', handlePeerModeChanged);
+  }
+  if (typeof document !== 'undefined') {
+    document.addEventListener('visibilitychange', handleVisibilityChanged);
+  }
+
+  scheduleRefresh();
+
+  return () => {
+    disposed = true;
+    if (installedRefreshRequester === scheduleRefresh) {
+      installedRefreshRequester = null;
+    }
+    if (immediateTimer !== null) {
+      clearTimeout(immediateTimer);
+    }
+    clearInterval(interval);
+    unsubscribeActiveSession();
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('peer-mode:changed', handlePeerModeChanged);
+    }
+    if (typeof document !== 'undefined') {
+      document.removeEventListener('visibilitychange', handleVisibilityChanged);
+    }
+  };
+}

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/TextChunkModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/TextChunkModule.test.ts
@@ -113,6 +113,60 @@ function insertTool(session: Session): void {
 }
 
 describe('processNormalTextChunkInternal', () => {
+  it('continues a streaming text item restored by a mid-turn Peer snapshot', () => {
+    const session = makeSession();
+    session.dialogTurns[0].modelRounds[0].items.push({
+      id: 'restored-text',
+      type: 'text',
+      content: 'Restored partial',
+      isStreaming: true,
+      isMarkdown: true,
+      timestamp: 1001,
+      status: 'streaming',
+    });
+    const context = makeContext(session);
+
+    processNormalTextChunkInternal(
+      context,
+      'session-1',
+      'turn-1',
+      'round-1',
+      ' plus live chunk',
+    );
+
+    const textItems = session.dialogTurns[0].modelRounds[0].items
+      .filter(item => item.type === 'text');
+    expect(textItems).toHaveLength(1);
+    expect((textItems[0] as any).content).toBe('Restored partial plus live chunk');
+  });
+
+  it('continues a streaming thinking item restored by a mid-turn Peer snapshot', () => {
+    const session = makeSession();
+    session.dialogTurns[0].modelRounds[0].items.push({
+      id: 'restored-thinking',
+      type: 'thinking',
+      content: 'Restored reasoning',
+      isStreaming: true,
+      isCollapsed: false,
+      timestamp: 1001,
+      status: 'streaming',
+    });
+    const context = makeContext(session);
+
+    processThinkingChunkInternal(
+      context,
+      'session-1',
+      'turn-1',
+      'round-1',
+      ' plus live reasoning',
+    );
+
+    const thinkingItems = session.dialogTurns[0].modelRounds[0].items
+      .filter(item => item.type === 'thinking');
+    expect(thinkingItems).toHaveLength(1);
+    expect((thinkingItems[0] as any).content).toBe('Restored reasoning plus live reasoning');
+  });
+
   it('keeps using the existing active text item after tools in the same round', () => {
     const session = makeSession();
     const context = makeContext(session);

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/TextChunkModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/TextChunkModule.ts
@@ -109,13 +109,14 @@ export function processNormalTextChunkInternal(
 
   let textItemId = sessionActiveTextItems.get(streamKey);
   let recoveredExistingContent = '';
-  if (!textItemId && isRoundClosed(round)) {
+  if (!textItemId) {
     const reusableTextItem = [...(round?.items ?? [])]
       .reverse()
       .find((item): item is FlowTextItem =>
         item.type === 'text' &&
         item.attemptId === attemptId &&
-        item.attemptIndex === attemptIndex
+        item.attemptIndex === attemptIndex &&
+        (item.isStreaming || isRoundClosed(round))
       );
 
     if (reusableTextItem) {
@@ -195,13 +196,14 @@ export function processThinkingChunkInternal(
 
   let thinkingItemId = sessionActiveTextItems.get(thinkingKey);
   let recoveredExistingContent = '';
-  if (!thinkingItemId && isRoundClosed(round)) {
+  if (!thinkingItemId) {
     const reusableThinkingItem = [...(round?.items ?? [])]
       .reverse()
       .find((item): item is import('../../types/flow-chat').FlowThinkingItem =>
         item.type === 'thinking' &&
         item.attemptId === attemptId &&
-        item.attemptIndex === attemptIndex
+        item.attemptIndex === attemptIndex &&
+        (item.isStreaming || isRoundClosed(round))
       );
 
     if (reusableThinkingItem) {

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
@@ -40,6 +40,7 @@ const stateMachineManagerMock = vi.hoisted(() => ({
   delete: vi.fn(),
   getOrCreate: vi.fn(),
   reset: vi.fn(),
+  transition: vi.fn(async () => true),
 }));
 
 vi.mock('@/infrastructure/api', () => ({
@@ -87,6 +88,9 @@ vi.mock('@/infrastructure/config/services/ConfigManager', () => ({
 
 vi.mock('../state-machine', () => ({
   stateMachineManager: stateMachineManagerMock,
+  SessionExecutionEvent: {
+    START: 'start',
+  },
 }));
 
 const resetStore = () => {
@@ -843,6 +847,231 @@ describe('FlowChatStore historical session hydration state', () => {
     expect(apiMocks.accountFetchSessionTurns).not.toHaveBeenCalled();
     expect(apiMocks.restoreSessionView).toHaveBeenCalled();
     expect(flowChatStore.getState().sessions.get('history-1')?.historyState).not.toBe('failed');
+  });
+
+  it('keeps an in-memory Peer Host turn live when opening mid-execution', async () => {
+    peerModeFlagMock.active = true;
+    apiMocks.restoreSessionView.mockResolvedValueOnce({
+      session: {
+        sessionId: 'history-1',
+        sessionName: 'History 1',
+        agentType: 'agentic',
+        state: 'Processing { current_turn_id: "turn-live", phase: Streaming }',
+        turnCount: 1,
+        createdAt: 1,
+      },
+      turns: [{
+        turnId: 'turn-live',
+        turnIndex: 0,
+        sessionId: 'history-1',
+        timestamp: 1,
+        userMessage: { id: 'user-live', content: 'keep going', timestamp: 1 },
+        modelRounds: [{
+          id: 'round-live',
+          turnId: 'turn-live',
+          roundIndex: 0,
+          timestamp: 1,
+          textItems: [{
+            id: 'text-live',
+            content: 'partial',
+            isStreaming: true,
+            timestamp: 2,
+            status: 'streaming',
+          }],
+          toolItems: [],
+          thinkingItems: [],
+          startTime: 1,
+          status: 'streaming',
+        }],
+        startTime: 1,
+        status: 'inprogress',
+      }],
+      contextRestoreState: 'pending',
+    });
+    flowChatStore.setState(() => ({
+      sessions: new Map([
+        ['history-1', createSession({
+          sessionId: 'history-1',
+          isHistorical: true,
+          historyState: 'metadata-only',
+        })],
+      ]),
+      activeSessionId: 'history-1',
+    }));
+
+    await flowChatStore.loadSessionHistory('history-1', '/Users/host/project');
+
+    const turn = flowChatStore.getState().sessions.get('history-1')?.dialogTurns[0];
+    expect(turn).toMatchObject({
+      id: 'turn-live',
+      status: 'processing',
+      modelRounds: [{
+        id: 'round-live',
+        status: 'streaming',
+        isStreaming: true,
+        items: [{
+          id: 'text-live',
+          status: 'streaming',
+          isStreaming: true,
+          content: 'partial',
+        }],
+      }],
+    });
+    expect(stateMachineManagerMock.reset).toHaveBeenCalledWith('history-1');
+    expect(stateMachineManagerMock.transition).toHaveBeenCalledWith(
+      'history-1',
+      'start',
+      {
+        taskId: 'history-1',
+        dialogTurnId: 'turn-live',
+      },
+    );
+  });
+
+  it('reconciles a newly persisted active Peer turn without replacing older history', async () => {
+    peerModeFlagMock.active = true;
+    apiMocks.restoreSessionView.mockResolvedValueOnce({
+      session: {
+        sessionId: 'history-1',
+        sessionName: 'History 1',
+        agentType: 'agentic',
+        state: 'Processing { current_turn_id: "turn-live", phase: Streaming }',
+        turnCount: 2,
+        createdAt: 1,
+      },
+      turns: [{
+        turnId: 'turn-live',
+        turnIndex: 1,
+        sessionId: 'history-1',
+        timestamp: 2,
+        userMessage: { id: 'user-live', content: 'new prompt', timestamp: 2 },
+        modelRounds: [],
+        startTime: 2,
+        status: 'inprogress',
+      }],
+      contextRestoreState: 'pending',
+      isPartial: true,
+      loadedTurnCount: 1,
+      totalTurnCount: 2,
+    });
+    const oldTurn = {
+      id: 'turn-old',
+      sessionId: 'history-1',
+      userMessage: { id: 'user-old', content: 'old prompt', timestamp: 1 },
+      modelRounds: [],
+      status: 'completed' as const,
+      startTime: 1,
+      backendTurnIndex: 0,
+    };
+    flowChatStore.setState(() => ({
+      sessions: new Map([
+        ['history-1', createSession({
+          sessionId: 'history-1',
+          historyState: 'ready',
+          dialogTurns: [oldTurn],
+        })],
+      ]),
+      activeSessionId: 'history-1',
+    }));
+
+    const result = await flowChatStore.refreshPeerSessionSnapshot(
+      'history-1',
+      '/Users/host/project',
+      { replaceRunningSnapshot: false },
+    );
+
+    expect(result).toMatchObject({
+      applied: true,
+      latestTurnId: 'turn-live',
+      latestTurnStatus: 'processing',
+    });
+    expect(
+      flowChatStore.getState().sessions.get('history-1')?.dialogTurns.map(turn => turn.id),
+    ).toEqual(['turn-old', 'turn-live']);
+  });
+
+  it('replaces a stale running projection after the Peer Host has completed', async () => {
+    peerModeFlagMock.active = true;
+    apiMocks.restoreSessionView.mockResolvedValueOnce({
+      session: {
+        sessionId: 'history-1',
+        sessionName: 'History 1',
+        agentType: 'agentic',
+        state: 'Idle',
+        turnCount: 1,
+        createdAt: 1,
+      },
+      turns: [{
+        turnId: 'turn-live',
+        turnIndex: 0,
+        sessionId: 'history-1',
+        timestamp: 1,
+        userMessage: { id: 'user-live', content: 'finish this', timestamp: 1 },
+        modelRounds: [{
+          id: 'round-live',
+          turnId: 'turn-live',
+          roundIndex: 0,
+          timestamp: 1,
+          textItems: [{
+            id: 'text-live',
+            content: 'complete answer',
+            isStreaming: false,
+            timestamp: 2,
+            status: 'completed',
+          }],
+          toolItems: [],
+          thinkingItems: [],
+          startTime: 1,
+          endTime: 3,
+          status: 'completed',
+        }],
+        startTime: 1,
+        endTime: 3,
+        status: 'completed',
+      }],
+      contextRestoreState: 'pending',
+      isPartial: false,
+      loadedTurnCount: 1,
+      totalTurnCount: 1,
+    });
+    const staleTurn = {
+      id: 'turn-live',
+      sessionId: 'history-1',
+      userMessage: { id: 'user-live', content: 'finish this', timestamp: 1 },
+      modelRounds: [],
+      status: 'processing' as const,
+      startTime: 1,
+      backendTurnIndex: 0,
+    };
+    flowChatStore.setState(() => ({
+      sessions: new Map([
+        ['history-1', createSession({
+          sessionId: 'history-1',
+          historyState: 'ready',
+          dialogTurns: [staleTurn],
+        })],
+      ]),
+      activeSessionId: 'history-1',
+    }));
+
+    const result = await flowChatStore.refreshPeerSessionSnapshot(
+      'history-1',
+      '/Users/host/project',
+      { replaceRunningSnapshot: false },
+    );
+
+    expect(result.applied).toBe(true);
+    expect(flowChatStore.getState().sessions.get('history-1')?.dialogTurns[0])
+      .toMatchObject({
+        status: 'completed',
+        modelRounds: [{
+          status: 'completed',
+          items: [{
+            type: 'text',
+            content: 'complete answer',
+          }],
+        }],
+      });
   });
 
   it('loads model config once while processing multiple persisted sessions', async () => {

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.ts
@@ -81,12 +81,125 @@ const HISTORICAL_SESSION_INITIAL_REMOTE_TAIL_TURN_COUNT = 3;
 const HISTORICAL_SESSION_INITIAL_LOCAL_TAIL_TURN_COUNT = 3;
 const HISTORICAL_SESSION_FULL_HISTORY_IDLE_TIMEOUT_MS = 1500;
 const HISTORICAL_SESSION_PREVIOUS_WINDOW_TURN_COUNT = 12;
+const PEER_SESSION_REFRESH_TAIL_TURN_COUNT = 3;
 
 type RemoveSessionOptions = {
   nextActiveSessionId?: string | null;
 };
 const HISTORICAL_SESSION_FULL_HISTORY_FIRST_PAINT_TIMEOUT_MS = 2500;
 const MAX_DEFERRED_FULL_HISTORY_PROJECTIONS = 3;
+
+export interface PeerSessionSnapshotRefreshResult {
+  applied: boolean;
+  backendState: string;
+  latestTurnId?: string;
+  latestTurnStatus?: DialogTurn['status'];
+}
+
+export function isBackendSessionActivelyProcessing(state: unknown): boolean {
+  if (typeof state !== 'string') {
+    return false;
+  }
+
+  const normalized = state.trim().toLowerCase();
+  return normalized === 'processing' ||
+    normalized.startsWith('processing ') ||
+    normalized.startsWith('processing {') ||
+    normalized === 'waitingfortoolresponse' ||
+    normalized === 'paused';
+}
+
+function normalizeLiveTurnStatus(status: unknown): DialogTurn['status'] {
+  const normalized = typeof status === 'string' ? status.trim().toLowerCase() : '';
+  switch (normalized) {
+    case 'pending':
+      return 'pending';
+    case 'image_analyzing':
+      return 'image_analyzing';
+    case 'finishing':
+      return 'finishing';
+    case 'cancelling':
+      return 'cancelling';
+    case 'completed':
+      return 'completed';
+    case 'cancelled':
+      return 'cancelled';
+    case 'error':
+      return 'error';
+    case 'inprogress':
+    case 'processing':
+    default:
+      return 'processing';
+  }
+}
+
+function normalizeLiveRoundStatus(
+  status: unknown,
+  parentTurnStatus: DialogTurn['status'],
+): ModelRound['status'] {
+  const normalized = typeof status === 'string' ? status.trim().toLowerCase() : '';
+  switch (normalized) {
+    case 'pending':
+      return 'pending';
+    case 'streaming':
+    case 'inprogress':
+    case 'running':
+      return 'streaming';
+    case 'pending_confirmation':
+      return 'pending_confirmation';
+    case 'completed':
+      return 'completed';
+    case 'cancelled':
+      return 'cancelled';
+    case 'rejected':
+      return 'rejected';
+    case 'error':
+      return 'error';
+    default:
+      return parentTurnStatus === 'processing' || parentTurnStatus === 'pending'
+        ? 'streaming'
+        : normalizeRecoveredRoundStatus(status, parentTurnStatus);
+  }
+}
+
+function normalizeLiveItemStatus(
+  status: unknown,
+  fallback: AnyFlowItem['status'],
+): AnyFlowItem['status'] {
+  const normalized = typeof status === 'string' ? status.trim().toLowerCase() : '';
+  switch (normalized) {
+    case 'pending':
+    case 'queued':
+    case 'waiting':
+    case 'preparing':
+    case 'running':
+    case 'streaming':
+    case 'receiving':
+    case 'completed':
+    case 'cancelled':
+    case 'rejected':
+    case 'error':
+    case 'analyzing':
+    case 'pending_confirmation':
+    case 'confirmed':
+      return normalized;
+    case 'starting':
+      return 'preparing';
+    default:
+      return fallback;
+  }
+}
+
+function compareDialogTurnOrder(left: DialogTurn, right: DialogTurn): number {
+  if (
+    typeof left.backendTurnIndex === 'number' &&
+    typeof right.backendTurnIndex === 'number' &&
+    left.backendTurnIndex !== right.backendTurnIndex
+  ) {
+    return left.backendTurnIndex - right.backendTurnIndex;
+  }
+  return left.startTime - right.startTime;
+}
 
 function itemMatchesIdentity(item: AnyFlowItem, itemId: string): boolean {
   if (item.id === itemId) {
@@ -1200,7 +1313,10 @@ export class FlowChatStore {
     }
 
     const convertStartedAt = nowMs();
-    const dialogTurns = this.convertToDialogTurns(restored.turns);
+    const activeTurnId = isBackendSessionActivelyProcessing(restored.session.state)
+      ? restored.turns[restored.turns.length - 1]?.turnId
+      : undefined;
+    const dialogTurns = this.convertToDialogTurns(restored.turns, { activeTurnId });
     const restoredLastUserDialogMode =
       restored.session.lastUserDialogAgentType || this.deriveLastUserDialogMode(dialogTurns);
     const contextRestoreState: SessionContextRestoreState =
@@ -3936,6 +4052,131 @@ export class FlowChatStore {
   }
 
   /**
+   * Reconcile the active Peer Device session with a small authoritative
+   * snapshot from the host.
+   *
+   * Peer agentic events remain the primary low-latency path. This snapshot is
+   * the recovery path for a controller that attached after lifecycle events,
+   * or for a DeviceEvent gap (the relay stream has no ACK/replay contract).
+   */
+  public async refreshPeerSessionSnapshot(
+    sessionId: string,
+    workspacePath: string,
+    options?: {
+      replaceRunningSnapshot?: boolean;
+      requireActiveSession?: boolean;
+      shouldApply?: () => boolean;
+    },
+  ): Promise<PeerSessionSnapshotRefreshResult> {
+    const initialSession = this.state.sessions.get(sessionId);
+    if (!initialSession) {
+      return {
+        applied: false,
+        backendState: 'Unknown',
+      };
+    }
+
+    const restored = await agentAPI.restoreSessionView(
+      sessionId,
+      workspacePath,
+      initialSession.remoteConnectionId,
+      initialSession.remoteSshHost,
+      `peer-refresh-${sessionId.slice(0, 8)}`,
+      undefined,
+      PEER_SESSION_REFRESH_TAIL_TURN_COUNT,
+    );
+    const backendActive = isBackendSessionActivelyProcessing(restored.session.state);
+    const activeTurnId = backendActive
+      ? restored.turns[restored.turns.length - 1]?.turnId
+      : undefined;
+    const snapshotTurns = this.convertToDialogTurns(restored.turns, { activeTurnId });
+    const replaceExistingTurns =
+      !backendActive || options?.replaceRunningSnapshot === true;
+    let applied = false;
+
+    this.setState(prev => {
+      if (
+        options?.shouldApply?.() === false ||
+        (
+          options?.requireActiveSession !== false &&
+          prev.activeSessionId !== sessionId
+        )
+      ) {
+        return prev;
+      }
+
+      const session = prev.sessions.get(sessionId);
+      // A live event or another refresh won the race while HostInvoke was in
+      // flight. Do not overwrite that newer local projection.
+      if (!session || session !== initialSession) {
+        return prev;
+      }
+
+      const mergedTurns = [...session.dialogTurns];
+      let turnsChanged = false;
+      for (const snapshotTurn of snapshotTurns) {
+        const existingIndex = mergedTurns.findIndex(turn => turn.id === snapshotTurn.id);
+        if (existingIndex === -1) {
+          mergedTurns.push(snapshotTurn);
+          turnsChanged = true;
+        } else if (replaceExistingTurns) {
+          mergedTurns[existingIndex] = snapshotTurn;
+          turnsChanged = true;
+        }
+      }
+
+      if (!turnsChanged) {
+        return prev;
+      }
+
+      mergedTurns.sort(compareDialogTurnOrder);
+      const newSessions = new Map(prev.sessions);
+      newSessions.set(sessionId, {
+        ...session,
+        dialogTurns: mergedTurns,
+        isHistorical: false,
+        historyState: 'ready',
+        contextRestoreState:
+          session.contextRestoreState === 'ready'
+            ? 'ready'
+            : restored.contextRestoreState,
+        isPartial: session.isPartial === true,
+        loadedTurnCount: Math.max(session.loadedTurnCount ?? 0, mergedTurns.length),
+        totalTurnCount: Math.max(
+          session.totalTurnCount ?? 0,
+          restored.totalTurnCount ?? restored.session.turnCount,
+          mergedTurns.length,
+        ),
+        config: {
+          ...session.config,
+          ...(restored.session.modelName
+            ? { modelName: restored.session.modelName }
+            : {}),
+        },
+        mode: restored.session.agentType || session.mode,
+        lastUserDialogMode:
+          restored.session.lastUserDialogAgentType || session.lastUserDialogMode,
+        lastSubmittedMode:
+          restored.session.lastSubmittedAgentType ?? session.lastSubmittedMode,
+      });
+      applied = true;
+
+      return {
+        ...prev,
+        sessions: newSessions,
+      };
+    });
+
+    const latestTurn = snapshotTurns[snapshotTurns.length - 1];
+    return {
+      applied,
+      backendState: restored.session.state,
+      latestTurnId: latestTurn?.id,
+      latestTurnStatus: latestTurn?.status,
+    };
+  }
+
+  /**
    * Lazy load session history (convert historical data to FlowChat format)
    */
   public async loadSessionHistory(
@@ -4193,7 +4434,7 @@ export class FlowChatStore {
           durationMs: elapsedMs(turnsLoadStartedAt),
         });
       }
-      const { stateMachineManager } = await stateMachineManagerPromise;
+      const { stateMachineManager, SessionExecutionEvent } = await stateMachineManagerPromise;
       stateMachineManager.getOrCreate(sessionId);
       startupTrace.markPhase('historical_session_turns_loaded', {
         remote,
@@ -4254,7 +4495,10 @@ export class FlowChatStore {
       }
       
       const convertStartedAt = nowMs();
-      const dialogTurns = this.convertToDialogTurns(turns);
+      const activeTurnId = isBackendSessionActivelyProcessing(restoredSessionInfo?.state)
+        ? turns[turns.length - 1]?.turnId
+        : undefined;
+      const dialogTurns = this.convertToDialogTurns(turns, { activeTurnId });
       const restoredLastUserDialogMode =
         restoredSessionInfo?.lastUserDialogAgentType || this.deriveLastUserDialogMode(dialogTurns);
       startupTrace.markPhase('historical_session_convert_end', {
@@ -4327,9 +4571,17 @@ export class FlowChatStore {
         frameCount: 2,
       });
       
-      // Reset state machine to IDLE after loading history
-      // This handles the case where restoreSession triggered events that left the state machine in PROCESSING
+      // Historical views normally settle to IDLE. When the same process still
+      // owns a live turn (notably a Peer Host), keep the controller state
+      // machine aligned so subsequent streamed chunks are accepted even though
+      // their DialogTurnStarted event happened before the controller attached.
       stateMachineManager.reset(sessionId);
+      if (activeTurnId) {
+        await stateMachineManager.transition(sessionId, SessionExecutionEvent.START, {
+          taskId: sessionId,
+          dialogTurnId: activeTurnId,
+        });
+      }
       startupTrace.markPhase('historical_session_hydrate_end', {
         remote,
         sessionId,
@@ -4415,8 +4667,12 @@ export class FlowChatStore {
   /**
    * Convert DialogTurnData to FlowChat DialogTurn format
    */
-  private convertToDialogTurns(turns: any[]): DialogTurn[] {
+  private convertToDialogTurns(
+    turns: any[],
+    options?: { activeTurnId?: string },
+  ): DialogTurn[] {
     return turns.map(turn => {
+      const isLiveTurn = options?.activeTurnId === turn.turnId;
       const metadata = turn.userMessage.metadata;
       const metaImages = metadata?.images;
       const hasImages = Array.isArray(metaImages) && metaImages.length > 0;
@@ -4441,7 +4697,9 @@ export class FlowChatStore {
         rawDisplay,
         metadata as Record<string, unknown> | undefined
       );
-      const normalizedTurnStatus = normalizeRecoveredTurnStatus(turn.status, { error: undefined });
+      const normalizedTurnStatus = isLiveTurn
+        ? normalizeLiveTurnStatus(turn.status)
+        : normalizeRecoveredTurnStatus(turn.status, { error: undefined });
       const rawTokenUsage = turn.tokenUsage ?? turn.token_usage;
 
       return {
@@ -4459,16 +4717,23 @@ export class FlowChatStore {
         images,
       },
       modelRounds: turn.modelRounds.map((round: any) => {
-        const normalizedRoundStatus = normalizeRecoveredRoundStatus(round.status, normalizedTurnStatus);
+        const normalizedRoundStatus = isLiveTurn
+          ? normalizeLiveRoundStatus(round.status, normalizedTurnStatus)
+          : normalizeRecoveredRoundStatus(round.status, normalizedTurnStatus);
         const flatItems = [
           ...round.textItems.map((text: any) => ({
             id: text.id,
             type: 'text' as const,
             content: text.content,
-            isStreaming: false,
+            isStreaming: isLiveTurn ? text.isStreaming === true : false,
             isMarkdown: text.isMarkdown !== undefined ? text.isMarkdown : true,
             timestamp: text.timestamp,
-            status: normalizeRecoveredTextStatus(text.status, normalizedTurnStatus),
+            status: isLiveTurn
+              ? normalizeLiveItemStatus(
+                  text.status,
+                  text.isStreaming === true ? 'streaming' : 'completed',
+                )
+              : normalizeRecoveredTextStatus(text.status, normalizedTurnStatus),
             orderIndex: text.orderIndex,
             subagentSessionId: text.subagentSessionId,
             attemptId: text.attemptId,
@@ -4496,11 +4761,16 @@ export class FlowChatStore {
               confirmationWaitMs: tool.confirmationWaitMs,
               executionMs: tool.executionMs,
               timestamp: tool.startTime,
-              status: normalizeRecoveredToolStatus(
-                tool.status,
-                normalizedTurnStatus,
-                tool.toolResult,
-              ),
+              status: isLiveTurn
+                ? normalizeLiveItemStatus(
+                    tool.status,
+                    tool.toolResult ? (tool.toolResult.success ? 'completed' : 'error') : 'running',
+                  )
+                : normalizeRecoveredToolStatus(
+                    tool.status,
+                    normalizedTurnStatus,
+                    tool.toolResult,
+                  ),
               orderIndex: tool.orderIndex,
               subagentSessionId: tool.subagentSessionId,
               subagentDialogTurnId: tool.subagentDialogTurnId,
@@ -4513,10 +4783,17 @@ export class FlowChatStore {
             id: thinking.id,
             type: 'thinking' as const,
             content: thinking.content,
-            isStreaming: false,
-            isCollapsed: thinking.isCollapsed ?? true,
+            isStreaming: isLiveTurn ? thinking.isStreaming === true : false,
+            isCollapsed: isLiveTurn
+              ? (thinking.isCollapsed ?? thinking.isStreaming !== true)
+              : (thinking.isCollapsed ?? true),
             timestamp: thinking.timestamp,
-            status: normalizeRecoveredThinkingStatus(thinking.status, normalizedTurnStatus),
+            status: isLiveTurn
+              ? normalizeLiveItemStatus(
+                  thinking.status,
+                  thinking.isStreaming === true ? 'streaming' : 'completed',
+                )
+              : normalizeRecoveredThinkingStatus(thinking.status, normalizedTurnStatus),
             orderIndex: thinking.orderIndex,
             subagentSessionId: thinking.subagentSessionId,
             attemptId: thinking.attemptId,
@@ -4535,8 +4812,15 @@ export class FlowChatStore {
           roundGroupId: round.roundGroupId,
           renderHints: round.renderHints,
           items: flatItems,
-          isStreaming: false,
-          isComplete: normalizedRoundStatus !== 'pending' && normalizedRoundStatus !== 'streaming',
+          isStreaming:
+            isLiveTurn &&
+            (normalizedRoundStatus === 'pending' ||
+              normalizedRoundStatus === 'streaming' ||
+              normalizedRoundStatus === 'pending_confirmation'),
+          isComplete:
+            normalizedRoundStatus !== 'pending' &&
+            normalizedRoundStatus !== 'streaming' &&
+            normalizedRoundStatus !== 'pending_confirmation',
           status: normalizedRoundStatus,
           startTime: round.startTime ?? round.timestamp,
           endTime: round.endTime,

--- a/src/web-ui/src/infrastructure/peer-device/README.md
+++ b/src/web-ui/src/infrastructure/peer-device/README.md
@@ -62,6 +62,14 @@ Controller-side React/transport layer for Peer Device Mode. Architecture:
     Remote `SIGINT` / `SIGTSTP` map to PTY control bytes instead of silently
     succeeding without affecting the process.
 
+12. **Active chat has snapshot self-healing.** DeviceEvent has no ACK/replay, so
+    FlowChat reconciles the active Peer session from `restore_session_view`
+    every 3s and immediately after a detected event gap. The Peer Host must
+    overlay its live in-memory session state on the persisted view; otherwise
+    an in-progress turn is normalized as interrupted history and later chunks
+    are dropped by the controller state machine. Reconciliation must not
+    overwrite a local projection that changed while HostInvoke was in flight.
+
 ## Related account-login guards
 
 Incomplete login (cloud vs local settings choice) must not persist a session


### PR DESCRIPTION
## Summary

- expose the host process's live session state when restoring Peer Device session views on desktop and CLI hosts
- keep DeviceEvents as the low-latency path while reconciling the active controller session every 3 seconds and after detected event gaps, session changes, or visibility recovery
- preserve restored streaming items, converge completed turns, and prevent stale snapshots from overwriting newer realtime events
- document the snapshot self-healing contract and add regression coverage

## Testing

- `pnpm --dir src/web-ui run test:run src/flow_chat/store/FlowChatStore.test.ts src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.test.ts src/flow_chat/services/flow-chat-manager/TextChunkModule.test.ts`
- `pnpm run type-check:web`
- `cargo test -p bitfun-desktop live_processing_state_overlays_sanitized_view_state --lib`
- `cargo test -p bitfun-cli view_restore_uses_the_cli_hosts_live_processing_state`
- `cargo test -p bitfun-core remaining_compatibility_operations_have_one_core_owned_facade --lib`
- `cargo check --workspace`
- `cargo check -p bitfun-cli`