### PR TITLE
fix(peer-device): improve weak-link recovery and account labels

### DIFF
--- a/docs/architecture/peer-device-mode.md
+++ b/docs/architecture/peer-device-mode.md
@@ -49,13 +49,19 @@ FS) and must not be mixed with Peer Device Mode.
 
 - Controller: `PeerDeviceTransportAdapter` wraps product `invoke` as
   `RemoteCommand::HostInvoke` over `account_device_rpc`.
-- HostInvoke on the controller is **priority-queued** (effectively unbounded
-  concurrency, `i32::MAX` in flight). Session restore / session-list / dialog /
-  workspace-startup commands outrank background `git_*` / `ssh_*` / `lsp_*` /
-  `search_*` / FS / canvas / editor RPCs so hydrate is not starved into relay
-  HTTP 504s. Terminal commands are always interactive priority, and one slot is
-  kept free from low-priority background work so input cannot be trapped behind
-  slow polling requests.
+- HostInvoke on the controller is **priority-queued** with four requests in
+  flight. Session restore / session-list / dialog / workspace-startup commands
+  outrank background `git_*` / `ssh_*` / `lsp_*` / `search_*` / FS / canvas /
+  editor RPCs so hydrate is not starved into relay HTTP 504s. Terminal commands
+  are always interactive priority, and one slot is kept free from normal and
+  low-priority work so input cannot be trapped behind slow polling requests.
+- Idempotent read HostInvokes use a 10s per-attempt deadline and at most two
+  exponential-backoff retries. Mutating commands use a 30s deadline without
+  automatic replay because a timed-out mutation has an unknown outcome. The
+  desktop `account_device_rpc` command enforces the requested deadline around
+  the native HTTP future; the controller's Promise deadline is not merely a UI
+  timer. Failed session-list loads leave the spinner and expose an explicit
+  retry action.
 - While Peer Mode is active, background noise is reduced further:
   - controller-local SSH heartbeats and remote-workspace auto-reconnect pause
   - Git / FilesPanel window-focus refresh pauses
@@ -82,7 +88,10 @@ FS) and must not be mixed with Peer Device Mode.
   controller that attached after turn/round lifecycle events or crossed a
   transient relay gap. The host overlays its authoritative in-memory session
   state onto the persisted view so an executing turn is not misclassified as
-  interrupted history.
+  interrupted history. Continuous host output is checkpointed at least once
+  per 2s coalescing window. A controller accepts an active snapshot before the
+  stale-stream deadline only when its rounds, streams, and tools provably move
+  forward; an older persisted snapshot cannot overwrite newer DeviceEvents.
 - CLI Peer Host forwards only turns submitted through Peer Host and linked
   child turns. A background-result follow-up inherits ownership only when its
   Core-internal metadata identifies the exact tracked parent and source child
@@ -105,9 +114,10 @@ FS) and must not be mixed with Peer Device Mode.
   enqueue attempt. An explicit disconnect still restores the local controller
   UI, but reports a warning when host cancellation was not confirmed. This
   boundary does not change the Relay envelope or add ACK or replay.
-- Relay `POST /api/devices/:id/rpc` waits up to **120s** for the peer response;
-  reverse proxies in front of the relay must use a matching (or higher) read
-  timeout or they will return 504 first.
+- Relay `POST /api/devices/:id/rpc` still permits up to **120s** for generic
+  callers. Peer controllers normally cancel earlier through their per-command
+  10s/30s deadlines; reverse proxies must still accommodate any other caller
+  that relies on the Relay maximum.
 
 ## Workspace directory picking
 

--- a/src/apps/desktop/src/api/remote_connect_api.rs
+++ b/src/apps/desktop/src/api/remote_connect_api.rs
@@ -3405,18 +3405,35 @@ pub async fn account_delete_device(targetDeviceId: String) -> Result<(), String>
 /// which routes it to the target device's WS. The target executes it
 /// and the response is returned (decrypted).
 /// Returns the decrypted response JSON.
+const ACCOUNT_DEVICE_RPC_DEFAULT_TIMEOUT_MS: u64 = 120_000;
+const ACCOUNT_DEVICE_RPC_MIN_TIMEOUT_MS: u64 = 1_000;
+
+fn account_device_rpc_timeout_ms(requested: Option<u64>) -> u64 {
+    requested
+        .unwrap_or(ACCOUNT_DEVICE_RPC_DEFAULT_TIMEOUT_MS)
+        .clamp(
+            ACCOUNT_DEVICE_RPC_MIN_TIMEOUT_MS,
+            ACCOUNT_DEVICE_RPC_DEFAULT_TIMEOUT_MS,
+        )
+}
+
 #[tauri::command]
 pub async fn account_device_rpc(
     target_device_id: String,
     command_json: String,
+    timeout_ms: Option<u64>,
 ) -> Result<String, String> {
     let account_generation = account_context_generation();
     let (session, relay_url) = read_account_context_for_generation(account_generation).await?;
     let client = AccountClient::new();
-    let response = client
-        .device_rpc(&relay_url, &session, &target_device_id, &command_json)
-        .await
-        .map_err(|e| format!("{e}"))?;
+    let timeout_ms = account_device_rpc_timeout_ms(timeout_ms);
+    let response = tokio::time::timeout(
+        std::time::Duration::from_millis(timeout_ms),
+        client.device_rpc(&relay_url, &session, &target_device_id, &command_json),
+    )
+    .await
+    .map_err(|_| format!("device RPC timed out after {timeout_ms}ms"))?
+    .map_err(|e| format!("{e}"))?;
     if !account_context_matches(account_generation, &session.token).await {
         return Err("account context changed".to_string());
     }
@@ -3706,58 +3723,56 @@ async fn account_auto_sync_inner(
     );
 
     let completed = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
-    let upload_outcomes: Vec<Result<(String, String, i64), String>> =
-        stream::iter(pending_uploads)
-            .map(|(session_id, bundle_json, hash)| {
-                let client = AccountClient::new();
-                let relay_url = relay_url.clone();
-                let acct_session = acct_session.clone();
-                let completed = completed.clone();
-                async move {
-                    if ensure_account_auto_sync_current(sync_operation_id).is_err() {
-                        return Err("account sync cancelled".to_string());
+    let upload_outcomes: Vec<Result<(String, String, i64), String>> = stream::iter(pending_uploads)
+        .map(|(session_id, bundle_json, hash)| {
+            let client = AccountClient::new();
+            let relay_url = relay_url.clone();
+            let acct_session = acct_session.clone();
+            let completed = completed.clone();
+            async move {
+                if ensure_account_auto_sync_current(sync_operation_id).is_err() {
+                    return Err("account sync cancelled".to_string());
+                }
+                let result = match await_account_auto_sync(
+                    sync_operation_id,
+                    client.upload_session(&relay_url, &acct_session, &session_id, &bundle_json),
+                )
+                .await
+                {
+                    Ok(result) => result,
+                    Err(e) => return Err(e),
+                };
+                match result {
+                    Ok(version) => {
+                        let done = completed.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+                        let percent = if upload_total == 0 {
+                            95u8
+                        } else {
+                            20 + ((75 * done) / upload_total) as u8
+                        };
+                        if ensure_account_auto_sync_current(sync_operation_id).is_err() {
+                            return Err("account sync cancelled".to_string());
+                        }
+                        emit_sync_progress(
+                            sync_operation_id,
+                            "exporting_sessions",
+                            percent.min(95),
+                            Some(done),
+                            Some(upload_total),
+                            Some(session_id.as_str()),
+                        );
+                        Ok((session_id, hash, version))
                     }
-                    let result = match await_account_auto_sync(
-                        sync_operation_id,
-                        client.upload_session(&relay_url, &acct_session, &session_id, &bundle_json),
-                    )
-                    .await
-                    {
-                        Ok(result) => result,
-                        Err(e) => return Err(e),
-                    };
-                    match result {
-                        Ok(version) => {
-                            let done =
-                                completed.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
-                            let percent = if upload_total == 0 {
-                                95u8
-                            } else {
-                                20 + ((75 * done) / upload_total) as u8
-                            };
-                            if ensure_account_auto_sync_current(sync_operation_id).is_err() {
-                                return Err("account sync cancelled".to_string());
-                            }
-                            emit_sync_progress(
-                                sync_operation_id,
-                                "exporting_sessions",
-                                percent.min(95),
-                                Some(done),
-                                Some(upload_total),
-                                Some(session_id.as_str()),
-                            );
-                            Ok((session_id, hash, version))
-                        }
-                        Err(e) => {
-                            log::warn!("Auto-sync upload {session_id} failed: {e}");
-                            Err(format!("{session_id}: {e}"))
-                        }
+                    Err(e) => {
+                        log::warn!("Auto-sync upload {session_id} failed: {e}");
+                        Err(format!("{session_id}: {e}"))
                     }
                 }
-            })
-            .buffer_unordered(UPLOAD_CONCURRENCY)
-            .collect()
-            .await;
+            }
+        })
+        .buffer_unordered(UPLOAD_CONCURRENCY)
+        .collect()
+        .await;
 
     ensure_account_auto_sync_current(sync_operation_id)?;
 
@@ -4343,6 +4358,23 @@ mod sync_state_tests {
         assert_eq!(
             cloud_settings_exist_from_probe::<u8, &str>(Err("relay unavailable")),
             Err("relay unavailable")
+        );
+    }
+
+    #[test]
+    fn device_rpc_timeout_is_bounded_for_peer_requests() {
+        assert_eq!(
+            account_device_rpc_timeout_ms(None),
+            ACCOUNT_DEVICE_RPC_DEFAULT_TIMEOUT_MS
+        );
+        assert_eq!(account_device_rpc_timeout_ms(Some(10_000)), 10_000);
+        assert_eq!(
+            account_device_rpc_timeout_ms(Some(100)),
+            ACCOUNT_DEVICE_RPC_MIN_TIMEOUT_MS
+        );
+        assert_eq!(
+            account_device_rpc_timeout_ms(Some(u64::MAX)),
+            ACCOUNT_DEVICE_RPC_DEFAULT_TIMEOUT_MS
         );
     }
 

--- a/src/mobile-web/src/components/LanguageToggleButton.tsx
+++ b/src/mobile-web/src/components/LanguageToggleButton.tsx
@@ -8,11 +8,12 @@ interface LanguageToggleButtonProps {
 
 const LanguageToggleButton: React.FC<LanguageToggleButtonProps> = ({ className }) => {
   const { language, toggleLanguage, t } = useI18n();
+  const buttonClassName = ['mobile-lang-btn', className].filter(Boolean).join(' ');
 
   return (
     <button
       type="button"
-      className={className || 'mobile-lang-btn'}
+      className={buttonClassName}
       onClick={toggleLanguage}
       aria-label={t('common.switchLanguage')}
       title={t('common.switchLanguage')}
@@ -23,4 +24,3 @@ const LanguageToggleButton: React.FC<LanguageToggleButtonProps> = ({ className }
 };
 
 export default LanguageToggleButton;
-

--- a/src/mobile-web/src/pages/PairingPage.tsx
+++ b/src/mobile-web/src/pages/PairingPage.tsx
@@ -131,6 +131,7 @@ const PairingPage: React.FC<PairingPageProps> = ({ onPaired }) => {
     setError,
     error,
     setAuthenticatedUserId,
+    setAuthenticatedUserLabel,
   } = useMobileStore();
   const [userId, setUserId] = useState('');
   const [password, setPassword] = useState('');
@@ -237,7 +238,14 @@ const PairingPage: React.FC<PairingPageProps> = ({ onPaired }) => {
       setFailureCount(0);
       setLockUntil(null);
       setPassword('');
-      setAuthenticatedUserId(initialSync.authenticated_user_id ?? userIdValue);
+      // `authenticated_user_id` is the canonical account UUID used for
+      // ownership checks. The submitted value is the verified username in
+      // account mode and is the appropriate user-facing label.
+      setAuthenticatedUserId(
+        initialSync.authenticated_user_id
+        ?? (requiresAccountAuth ? null : userIdValue),
+      );
+      setAuthenticatedUserLabel(userIdValue);
 
       const sessionMgr = new RemoteSessionManager(client);
       const store = useMobileStore.getState();
@@ -359,6 +367,7 @@ const PairingPage: React.FC<PairingPageProps> = ({ onPaired }) => {
     pairingTarget.room,
     requiresAccountAuth,
     setAuthenticatedUserId,
+    setAuthenticatedUserLabel,
     setConnectionStatus,
     setError,
     t,

--- a/src/mobile-web/src/pages/SessionListPage.tsx
+++ b/src/mobile-web/src/pages/SessionListPage.tsx
@@ -186,7 +186,7 @@ const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectS
     currentAssistant,
     setCurrentAssistant,
     setPairedDisplayMode,
-    authenticatedUserId,
+    authenticatedUserLabel,
     connectionHealth,
     controlTarget,
   } = useMobileStore();
@@ -945,10 +945,10 @@ const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectS
           <img src={logoIcon} alt="BitFun" className="session-list__logo" />
           <div className="session-list__header-copy">
             <h1>{t('shared.product.remote')}</h1>
-            {authenticatedUserId && (
-              <span className="session-list__header-user-id">
+            {authenticatedUserLabel && (
+              <span className="session-list__header-account-name">
                 <span className={`session-list__health-dot session-list__health-dot--${connectionHealth}`} title={(() => { switch (connectionHealth) { case 'connected': return t('sessions.connectionConnected'); case 'checking': return t('sessions.connectionChecking'); case 'unreachable': return t('sessions.connectionUnreachable'); default: return t('sessions.connectionUnpaired'); } })()} />
-                {authenticatedUserId}
+                {authenticatedUserLabel}
                 {controlTarget && !controlTarget.isHome && controlTarget.deviceName && (
                   <span className="session-list__header-target" title={t('devices.controllingDevice', { name: controlTarget.deviceName })}>
                     {controlTarget.deviceName}
@@ -971,7 +971,7 @@ const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectS
               </svg>
             </button>
           )}
-          <LanguageToggleButton />
+          <LanguageToggleButton className="session-list__language-btn" />
           <button className="session-list__theme-btn" onClick={toggleTheme} aria-label={t('common.toggleTheme')}>
             <ThemeToggleIcon isDark={isDark} />
           </button>

--- a/src/mobile-web/src/services/delegatedAccountOwner.ts
+++ b/src/mobile-web/src/services/delegatedAccountOwner.ts
@@ -20,6 +20,10 @@ export function reconcileDelegatedAccountOwner(
 
   if (ownerWasReplaced) {
     store.resetForDeviceSwitch();
+    // A canonical account id is not user-facing, and the previous username no
+    // longer describes the active owner. Wait for a new authenticated pairing
+    // before showing an account label again.
+    store.setAuthenticatedUserLabel(null);
   }
 
   if (change.kind === 'unavailable') {

--- a/src/mobile-web/src/services/store.ts
+++ b/src/mobile-web/src/services/store.ts
@@ -26,8 +26,12 @@ interface MobileStore {
   pairedDisplayMode: 'pro' | 'assistant' | null;
   setPairedDisplayMode: (m: 'pro' | 'assistant' | null) => void;
 
+  /** Canonical account identity used for ownership checks. Never render this value. */
   authenticatedUserId: string | null;
   setAuthenticatedUserId: (userId: string | null) => void;
+  /** Username in account mode, or the user-entered pairing id in legacy mode. */
+  authenticatedUserLabel: string | null;
+  setAuthenticatedUserLabel: (label: string | null) => void;
 
   /**
    * Current same-account control target (delegated identity flow).
@@ -82,6 +86,8 @@ export const useMobileStore = create<MobileStore>((set, get) => ({
 
   authenticatedUserId: null,
   setAuthenticatedUserId: (authenticatedUserId) => set({ authenticatedUserId }),
+  authenticatedUserLabel: null,
+  setAuthenticatedUserLabel: (authenticatedUserLabel) => set({ authenticatedUserLabel }),
 
   controlTarget: null,
   setControlTarget: (controlTarget) => set({ controlTarget }),
@@ -162,6 +168,7 @@ export const useMobileStore = create<MobileStore>((set, get) => ({
       currentAssistant: null,
       pairedDisplayMode: null,
       authenticatedUserId: null,
+      authenticatedUserLabel: null,
       controlTarget: null,
       sessions: [],
       activeSessionId: null,

--- a/src/mobile-web/src/styles/components/sessions.scss
+++ b/src/mobile-web/src/styles/components/sessions.scss
@@ -52,7 +52,7 @@
   }
 }
 
-.session-list__header-user-id {
+.session-list__header-account-name {
   font-size: 11px;
   font-weight: var(--font-weight-medium);
   color: var(--color-text-muted);
@@ -104,6 +104,13 @@
   display: flex;
   align-items: center;
   gap: var(--size-gap-2);
+}
+
+.session-list__language-btn {
+  width: 32px;
+  min-width: 32px;
+  height: 32px;
+  padding: 0;
 }
 
 .session-list__theme-btn {

--- a/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.tsx
+++ b/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.tsx
@@ -187,12 +187,14 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
     nextCursor?: string;
     hasMore: boolean;
     isLoading: boolean;
+    loadError: boolean;
   }>({
     totalTopLevelCount: null,
     syncedTopLevelCount: null,
     nextCursor: undefined,
     hasMore: false,
     isLoading: false,
+    loadError: false,
   });
   const [openMenuSessionId, setOpenMenuSessionId] = useState<string | null>(null);
   const [sessionMenuPosition, setSessionMenuPosition] = useState<{ top: number; left: number } | null>(null);
@@ -291,6 +293,7 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
       nextCursor: undefined,
       hasMore: false,
       isLoading: false,
+      loadError: false,
     });
   }, [workspaceId, workspacePath, remoteConnectionId, remoteSshHost]);
 
@@ -302,7 +305,11 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
 
       const requestId = metadataLoadRequestIdRef.current + 1;
       metadataLoadRequestIdRef.current = requestId;
-      setMetadataPageState(prev => ({ ...prev, isLoading: true }));
+      setMetadataPageState(prev => ({
+        ...prev,
+        isLoading: true,
+        loadError: false,
+      }));
 
       try {
         const page = await flowChatStore.loadSessionMetadataPage(
@@ -326,12 +333,17 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
             nextCursor: page.nextCursor,
             hasMore: page.hasMore,
             isLoading: false,
+            loadError: false,
           });
         }
         return page;
       } catch (error) {
         if (metadataLoadRequestIdRef.current === requestId) {
-          setMetadataPageState(prev => ({ ...prev, isLoading: false }));
+          setMetadataPageState(prev => ({
+            ...prev,
+            isLoading: false,
+            loadError: true,
+          }));
         }
         log.warn('Failed to load visible session metadata page', { error, workspacePath, cursor, limit });
         return null;
@@ -445,6 +457,7 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
         nextCursor: undefined,
         hasMore: false,
         isLoading: false,
+        loadError: false,
       });
       if (isVisible && workspacePath) {
         void loadMetadataPage(SESSIONS_LEVEL_0, undefined, 'sessions_nav_post_archive');
@@ -930,6 +943,21 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
             <Loader2 size={12} />
             <span>{t('nav.sessions.loading')}</span>
           </div>
+        </div>
+      );
+    }
+    if (metadataPageState.loadError) {
+      return (
+        <div className="bitfun-nav-panel__inline-list">
+          <button
+            type="button"
+            className="bitfun-nav-panel__inline-action"
+            onClick={() => {
+              void loadInitialMetadataPage('sessions_nav_manual_retry');
+            }}
+          >
+            <span>{t('nav.sessions.loadFailedRetry')}</span>
+          </button>
         </div>
       );
     }

--- a/src/web-ui/src/app/components/RemoteConnectDialog/AccountPanel.tsx
+++ b/src/web-ui/src/app/components/RemoteConnectDialog/AccountPanel.tsx
@@ -644,7 +644,7 @@ export const AccountPanel: React.FC<AccountPanelProps> = ({
         setLoading(false);
         return;
       }
-      success(t('accountLogin.loginSuccess', { user_id: result.user_id }));
+      success(t('accountLogin.loginSuccess', { user_id: user }));
       completeLogin(server, true, epoch);
     } catch (e: unknown) {
       if (!isAccountEpochCurrent(epoch)) return;

--- a/src/web-ui/src/app/components/RemoteConnectDialog/RemoteConnectDialog.contract.test.ts
+++ b/src/web-ui/src/app/components/RemoteConnectDialog/RemoteConnectDialog.contract.test.ts
@@ -80,6 +80,25 @@ describe('Remote Connect safety contracts', () => {
     expect(loginResult).not.toContain('token:');
   });
 
+  it('uses verified usernames instead of opaque account ids in user-facing login states', () => {
+    const connectedView = dialogSource.slice(
+      dialogSource.indexOf('const renderConnectedView'),
+      dialogSource.indexOf('const handleCopyPairingUrl'),
+    );
+    const performLogin = accountPanelSource.slice(
+      accountPanelSource.indexOf('const performLogin'),
+      accountPanelSource.indexOf('const handleLogin'),
+    );
+
+    expect(dialogSource).toContain('remoteConnectAPI.accountGetCredentialHint()');
+    expect(dialogSource).toContain('setAccountUsername(hint?.username.trim() || null)');
+    expect(connectedView).toContain("t('accountLogin.username')");
+    expect(connectedView).not.toContain('connectedUserId');
+    expect(dialogSource).toContain('handleDisconnectRelay,\n            accountUsername,');
+    expect(performLogin).toContain("loginSuccess', { user_id: user }");
+    expect(performLogin).not.toContain("loginSuccess', { user_id: result.user_id }");
+  });
+
   it('keeps transport failures distinct from a stale pending-owner response', () => {
     const cancelMethod = remoteConnectApiSource.slice(
       remoteConnectApiSource.indexOf('async accountCancelPendingLogin'),

--- a/src/web-ui/src/app/components/RemoteConnectDialog/RemoteConnectDialog.scss
+++ b/src/web-ui/src/app/components/RemoteConnectDialog/RemoteConnectDialog.scss
@@ -223,7 +223,7 @@
   gap: 8px;
 }
 
-.bitfun-remote-connect__peer-user-id {
+.bitfun-remote-connect__peer-username {
   font-size: 12px;
   color: var(--color-text-secondary);
 }

--- a/src/web-ui/src/app/components/RemoteConnectDialog/RemoteConnectDialog.tsx
+++ b/src/web-ui/src/app/components/RemoteConnectDialog/RemoteConnectDialog.tsx
@@ -171,6 +171,7 @@ export const RemoteConnectDialog: React.FC<RemoteConnectDialogProps> = ({
   const [hasAgreedDisclaimer, setHasAgreedDisclaimer] = useState<boolean>(() => getRemoteConnectDisclaimerAgreed());
   const [botVerboseMode, setBotVerboseMode] = useState<boolean>(false);
   const [showRelayDeploy, setShowRelayDeploy] = useState(false);
+  const [accountUsername, setAccountUsername] = useState<string | null>(null);
 
   const [qrCopied, setQrCopied] = useState(false);
   const [customUrl, setCustomUrl] = useState('');
@@ -453,6 +454,25 @@ export const RemoteConnectDialog: React.FC<RemoteConnectDialogProps> = ({
       unlisten();
     };
   }, []);
+
+  // The account status and pairing status intentionally expose opaque UUIDs
+  // for identity checks. Resolve the persisted, non-secret login hint for the
+  // user-facing connected state instead.
+  useEffect(() => {
+    if (!isOpen || !accountLoggedIn) {
+      setAccountUsername(null);
+      return;
+    }
+    let cancelled = false;
+    void remoteConnectAPI.accountGetCredentialHint().then((hint) => {
+      if (!cancelled) {
+        setAccountUsername(hint?.username.trim() || null);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [accountLoggedIn, isOpen]);
 
   useEffect(() => {
     formSnapshotRef.current = {
@@ -833,14 +853,14 @@ export const RemoteConnectDialog: React.FC<RemoteConnectDialogProps> = ({
 
   const renderConnectedView = (
     onDisconnect: () => void,
-    userId?: string | null,
+    username?: string | null,
   ) => (
     <div className="bitfun-remote-connect__connected">
       <div className="bitfun-remote-connect__status">
         <Badge variant="success">{t('remoteConnect.stateConnected')}</Badge>
-        {userId && (
-          <span className="bitfun-remote-connect__peer-user-id">
-            {t('remoteConnect.connectedUserId')}: {userId}
+        {username && (
+          <span className="bitfun-remote-connect__peer-username">
+            {t('accountLogin.username')}: {username}
           </span>
         )}
       </div>
@@ -930,7 +950,7 @@ export const RemoteConnectDialog: React.FC<RemoteConnectDialogProps> = ({
           )}
           {renderConnectedView(
             handleDisconnectRelay,
-            status?.peer_user_id,
+            accountUsername,
           )}
         </>
       );

--- a/src/web-ui/src/app/scenes/pages/PagesScene.scss
+++ b/src/web-ui/src/app/scenes/pages/PagesScene.scss
@@ -118,7 +118,6 @@ $pages-gutter: clamp(24px, 4vw, 56px);
     min-width: 0;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
     border: 1px solid var(--border-subtle);
     border-radius: var(--size-radius-lg);
     background: var(--color-bg-secondary);
@@ -133,6 +132,24 @@ $pages-gutter: clamp(24px, 4vw, 56px);
       box-shadow: 0 12px 28px var(--color-overlay-black-08);
       transform: translateY(-1px);
     }
+  }
+
+  // Keep the bottom section's background inside the card radius without
+  // clipping absolutely positioned dropdowns (e.g. the visibility Select).
+  // The management section stays in the DOM with [hidden] when collapsed,
+  // so the radius follows the last *visible* section via :has().
+  &__actions,
+  &__management,
+  &__versions {
+    border-bottom-right-radius: calc(var(--size-radius-lg) - 1px);
+    border-bottom-left-radius: calc(var(--size-radius-lg) - 1px);
+  }
+
+  &__actions:has(~ .pages-scene__management:not([hidden])),
+  &__actions:has(~ .pages-scene__versions),
+  &__management:has(~ .pages-scene__versions) {
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0;
   }
 
   &__card-head {
@@ -180,12 +197,13 @@ $pages-gutter: clamp(24px, 4vw, 56px);
 
   &__slug {
     max-width: 100%;
-    padding: 1px 7px;
+    padding: 2px 8px;
     overflow: hidden;
     border-radius: $size-radius-sm;
     background: var(--element-bg-soft);
     color: var(--color-text-muted);
-    font-size: var(--font-size-2xs);
+    font-size: var(--font-size-xs);
+    line-height: 1.4;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
@@ -201,7 +219,7 @@ $pages-gutter: clamp(24px, 4vw, 56px);
     border-radius: 999px;
     background: var(--element-bg-soft);
     color: var(--color-text-secondary);
-    font-size: var(--font-size-2xs);
+    font-size: var(--font-size-xs);
     font-weight: 600;
 
     &.is-deployed {
@@ -274,7 +292,7 @@ $pages-gutter: clamp(24px, 4vw, 56px);
     display: flex;
     align-items: baseline;
     flex-wrap: wrap;
-    gap: $size-gap-2;
+    gap: $size-gap-1 $size-gap-3;
 
     h4,
     p {
@@ -283,20 +301,19 @@ $pages-gutter: clamp(24px, 4vw, 56px);
 
     h4 {
       color: var(--color-text-primary);
-      font-size: var(--font-size-xs);
+      font-size: var(--font-size-sm);
       font-weight: 600;
-      line-height: 1.4;
+      line-height: 1.5;
     }
 
     p {
       color: var(--color-text-muted);
-      font-size: var(--font-size-2xs);
-      line-height: 1.4;
+      font-size: var(--font-size-xs);
+      line-height: 1.5;
     }
   }
 
   &__settings {
-    overflow: hidden;
     display: flex;
     flex-direction: column;
     border: 1px solid color-mix(in srgb, var(--border-subtle) 72%, transparent);
@@ -310,7 +327,7 @@ $pages-gutter: clamp(24px, 4vw, 56px);
     grid-template-columns: minmax(92px, 0.18fr) minmax(0, 1fr);
     align-items: center;
     gap: $size-gap-4;
-    padding: 12px $size-gap-4;
+    padding: $size-gap-3 + 2px $size-gap-4;
 
     + .pages-scene__setting-field {
       border-top: 1px solid color-mix(in srgb, var(--border-subtle) 62%, transparent);
@@ -319,7 +336,7 @@ $pages-gutter: clamp(24px, 4vw, 56px);
 
   &__setting-label {
     color: var(--color-text-secondary);
-    font-size: var(--font-size-2xs);
+    font-size: var(--font-size-xs);
     font-weight: 600;
   }
 
@@ -333,6 +350,13 @@ $pages-gutter: clamp(24px, 4vw, 56px);
       width: 100%;
       flex: 1;
     }
+
+    // The Input component only inherits font-family, so the native <input>
+    // falls back to the WebView UA size. Pin it to the container size (13px
+    // for size="small") so it matches the visibility Select below.
+    .bitfun-input {
+      font-size: inherit;
+    }
   }
 
   &__visibility-control {
@@ -345,15 +369,21 @@ $pages-gutter: clamp(24px, 4vw, 56px);
     .select {
       width: 100%;
     }
+
+    .select__value,
+    .select__placeholder,
+    .select__option {
+      font-size: 13px;
+    }
   }
 
   &__visibility-hint {
     display: inline-flex;
     align-items: center;
-    gap: 5px;
+    gap: 6px;
     color: var(--color-text-muted);
-    font-size: var(--font-size-2xs);
-    line-height: 1.4;
+    font-size: var(--font-size-xs);
+    line-height: 1.5;
     text-align: left;
 
     svg {
@@ -367,7 +397,7 @@ $pages-gutter: clamp(24px, 4vw, 56px);
     align-items: center;
     justify-content: space-between;
     gap: $size-gap-4;
-    padding-top: $size-gap-3;
+    padding-top: $size-gap-4;
     border-top: 1px solid color-mix(in srgb, var(--border-subtle) 72%, transparent);
   }
 
@@ -375,17 +405,17 @@ $pages-gutter: clamp(24px, 4vw, 56px);
     min-width: 0;
     display: flex;
     flex-direction: column;
-    gap: 2px;
+    gap: 3px;
 
     strong {
       color: var(--color-text-secondary);
-      font-size: var(--font-size-xs);
+      font-size: var(--font-size-sm);
       font-weight: 600;
     }
 
     span {
       color: var(--color-text-muted);
-      font-size: var(--font-size-2xs);
+      font-size: var(--font-size-xs);
       line-height: 1.5;
     }
   }

--- a/src/web-ui/src/flow_chat/components/modern/UserMessageItem.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/UserMessageItem.test.tsx
@@ -34,6 +34,10 @@ vi.mock('../../store/modernFlowChatStore', () => ({
   useActiveSession: () => activeSessionRef.current,
 }));
 
+vi.mock('../../services/flow-chat-manager/PeerSessionRefreshModule', () => ({
+  installPeerSessionRefresh: vi.fn(() => () => {}),
+}));
+
 const flowChatStoreMock = vi.hoisted(() => ({
   getState: vi.fn(() => ({
     sessions: new Map(),

--- a/src/web-ui/src/flow_chat/services/FlowChatManager.test.ts
+++ b/src/web-ui/src/flow_chat/services/FlowChatManager.test.ts
@@ -15,6 +15,10 @@ vi.mock('./ProcessingStatusManager', () => ({
   processingStatusManager: {},
 }));
 
+vi.mock('./flow-chat-manager/PeerSessionRefreshModule', () => ({
+  installPeerSessionRefresh: vi.fn(() => () => {}),
+}));
+
 vi.mock('../store/FlowChatStore', () => ({
   FlowChatStore: {
     getInstance: () => storeMocks.store,

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
@@ -82,6 +82,7 @@ import {
   scheduleModelResponseStatus,
 } from './RuntimeStatusModule';
 import { requestPeerSessionRefresh } from './PeerSessionRefreshModule';
+import { isPeerDeviceModeActive } from '@/infrastructure/peer-device/peerModeFlag';
 
 const log = createLogger('EventHandlerModule');
 const TURN_COMPLETION_QUIET_WINDOW_MS = 500;
@@ -1698,7 +1699,12 @@ export function processBatchedEvents(
           processNormalTextChunkInternal(context, sessionId, turnId, roundId, text, attemptId, attemptIndex);
         }
         
-        debouncedSaveDialogTurn(context, sessionId, turnId, 2000);
+        // The executing host owns turn persistence. A Peer controller receives
+        // the same chunks for rendering and must not echo a save RPC for every
+        // checkpoint, especially on a weak link.
+        if (!isPeerDeviceModeActive()) {
+          debouncedSaveDialogTurn(context, sessionId, turnId, 2000);
+        }
       } else if (eventType === 'tool:params') {
         const { sessionId, turnId, toolEvent } = payload;
         processToolParamsPartialInternal(sessionId, turnId, toolEvent);

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.ts
@@ -120,6 +120,7 @@ export function installPeerSessionRefresh(context: FlowChatContext): () => void 
   let inFlight = false;
   let queued = false;
   let immediateTimer: ReturnType<typeof setTimeout> | null = null;
+  let scheduleRefresh: RefreshRequester = () => {};
 
   const runRefresh = async (requestedSessionId?: string): Promise<void> => {
     if (disposed || inFlight || !isPeerDeviceModeActive()) {
@@ -207,7 +208,7 @@ export function installPeerSessionRefresh(context: FlowChatContext): () => void 
     }
   };
 
-  const scheduleRefresh: RefreshRequester = (sessionId) => {
+  scheduleRefresh = (sessionId) => {
     if (disposed) {
       return;
     }

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/PersistenceModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/PersistenceModule.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { DialogTurn, FlowTextItem, ModelRound } from '../../types/flow-chat';
 import {
   convertDialogTurnToBackendFormat,
+  debouncedSaveDialogTurn,
   immediateSaveDialogTurn,
   saveDialogTurnToDisk,
 } from './PersistenceModule';
@@ -289,6 +290,26 @@ describe('PersistenceModule', () => {
     await vi.advanceTimersByTimeAsync(1);
     await flushMicrotasks();
     expect(saveSessionTurn).toHaveBeenCalledTimes(1);
+  });
+
+  it('checkpoints continuous streamed output without waiting for a quiet period', async () => {
+    const turn = createDialogTurn('processing');
+    const context = createContext(turn);
+
+    debouncedSaveDialogTurn(context, SESSION_ID, TURN_ID, 2000);
+    await vi.advanceTimersByTimeAsync(1000);
+    debouncedSaveDialogTurn(context, SESSION_ID, TURN_ID, 2000);
+    await vi.advanceTimersByTimeAsync(999);
+    expect(saveSessionTurn).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await flushMicrotasks();
+    expect(saveSessionTurn).toHaveBeenCalledTimes(1);
+
+    debouncedSaveDialogTurn(context, SESSION_ID, TURN_ID, 2000);
+    await vi.advanceTimersByTimeAsync(2000);
+    await flushMicrotasks();
+    expect(saveSessionTurn).toHaveBeenCalledTimes(2);
   });
 
   it('flushes terminal turn saves immediately', async () => {

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/PersistenceModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/PersistenceModule.ts
@@ -105,8 +105,11 @@ export function calculateTurnHash(dialogTurn: DialogTurn): string {
 }
 
 /**
- * Debounced save dialog turn
- * Only executes the last call when called multiple times in a short period
+ * Coalesce frequent dialog-turn updates into periodic latest-state saves.
+ *
+ * This intentionally behaves like a trailing throttle, not a pure debounce:
+ * continuous model output must still reach persistence so Peer Device
+ * snapshot recovery can advance while a turn is running.
  */
 export function debouncedSaveDialogTurn(
   context: FlowChatContext,
@@ -118,14 +121,14 @@ export function debouncedSaveDialogTurn(
   
   const existingTimer = context.saveDebouncers.get(key);
   if (existingTimer) {
-    clearTimeout(existingTimer);
+    return;
   }
   
   const timer = setTimeout(() => {
-    saveDialogTurnToDisk(context, sessionId, turnId).catch(error => {
-      log.warn('Debounced save failed', { sessionId, turnId, error });
-    });
     context.saveDebouncers.delete(key);
+    saveDialogTurnToDisk(context, sessionId, turnId).catch(error => {
+      log.warn('Coalesced checkpoint save failed', { sessionId, turnId, error });
+    });
   }, delay);
   
   context.saveDebouncers.set(key, timer);

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
@@ -1176,6 +1176,194 @@ describe('FlowChatStore historical session hydration state', () => {
     ).toEqual(['turn-old', 'turn-live']);
   });
 
+  it('advances a running Peer turn from a newer persisted checkpoint', async () => {
+    peerModeFlagMock.active = true;
+    apiMocks.restoreSessionView.mockResolvedValueOnce({
+      session: {
+        sessionId: 'history-1',
+        sessionName: 'History 1',
+        agentType: 'agentic',
+        state: 'Processing { current_turn_id: "turn-live", phase: Streaming }',
+        turnCount: 1,
+        createdAt: 1,
+      },
+      turns: [{
+        turnId: 'turn-live',
+        turnIndex: 0,
+        sessionId: 'history-1',
+        timestamp: 1,
+        userMessage: { id: 'user-live', content: 'continue', timestamp: 1 },
+        modelRounds: [{
+          id: 'round-live',
+          turnId: 'turn-live',
+          roundIndex: 0,
+          timestamp: 1,
+          textItems: [{
+            id: 'host-text-id',
+            content: 'partial answer plus checkpoint',
+            isStreaming: true,
+            timestamp: 3,
+            status: 'streaming',
+          }],
+          toolItems: [],
+          thinkingItems: [],
+          startTime: 1,
+          status: 'streaming',
+        }],
+        startTime: 1,
+        status: 'inprogress',
+      }],
+      contextRestoreState: 'pending',
+      isPartial: false,
+      loadedTurnCount: 1,
+      totalTurnCount: 1,
+    });
+    const localTurn = {
+      id: 'turn-live',
+      sessionId: 'history-1',
+      userMessage: { id: 'user-live', content: 'continue', timestamp: 1 },
+      modelRounds: [{
+        id: 'round-live',
+        index: 0,
+        items: [{
+          id: 'controller-text-id',
+          type: 'text' as const,
+          content: 'partial answer',
+          isStreaming: true,
+          isMarkdown: true,
+          timestamp: 2,
+          status: 'streaming' as const,
+        }],
+        isStreaming: true,
+        isComplete: false,
+        status: 'streaming' as const,
+        startTime: 1,
+      }],
+      status: 'processing' as const,
+      startTime: 1,
+      backendTurnIndex: 0,
+    };
+    flowChatStore.setState(() => ({
+      sessions: new Map([
+        ['history-1', createSession({
+          sessionId: 'history-1',
+          historyState: 'ready',
+          dialogTurns: [localTurn],
+        })],
+      ]),
+      activeSessionId: 'history-1',
+    }));
+
+    const result = await flowChatStore.refreshPeerSessionSnapshot(
+      'history-1',
+      '/Users/host/project',
+      { replaceRunningSnapshot: false },
+    );
+
+    expect(result.applied).toBe(true);
+    expect(
+      flowChatStore.getState().sessions.get('history-1')
+        ?.dialogTurns[0].modelRounds[0].items[0],
+    ).toMatchObject({
+      id: 'host-text-id',
+      content: 'partial answer plus checkpoint',
+    });
+  });
+
+  it('does not regress a running Peer turn to an older persisted checkpoint', async () => {
+    peerModeFlagMock.active = true;
+    apiMocks.restoreSessionView.mockResolvedValueOnce({
+      session: {
+        sessionId: 'history-1',
+        sessionName: 'History 1',
+        agentType: 'agentic',
+        state: 'Processing { current_turn_id: "turn-live", phase: Streaming }',
+        turnCount: 1,
+        createdAt: 1,
+      },
+      turns: [{
+        turnId: 'turn-live',
+        turnIndex: 0,
+        sessionId: 'history-1',
+        timestamp: 1,
+        userMessage: { id: 'user-live', content: 'continue', timestamp: 1 },
+        modelRounds: [{
+          id: 'round-live',
+          turnId: 'turn-live',
+          roundIndex: 0,
+          timestamp: 1,
+          textItems: [{
+            id: 'host-text-id',
+            content: 'partial answer',
+            isStreaming: true,
+            timestamp: 2,
+            status: 'streaming',
+          }],
+          toolItems: [],
+          thinkingItems: [],
+          startTime: 1,
+          status: 'streaming',
+        }],
+        startTime: 1,
+        status: 'inprogress',
+      }],
+      contextRestoreState: 'pending',
+      isPartial: false,
+      loadedTurnCount: 1,
+      totalTurnCount: 1,
+    });
+    const localTurn = {
+      id: 'turn-live',
+      sessionId: 'history-1',
+      userMessage: { id: 'user-live', content: 'continue', timestamp: 1 },
+      modelRounds: [{
+        id: 'round-live',
+        index: 0,
+        items: [{
+          id: 'controller-text-id',
+          type: 'text' as const,
+          content: 'partial answer plus live data',
+          isStreaming: true,
+          isMarkdown: true,
+          timestamp: 3,
+          status: 'streaming' as const,
+        }],
+        isStreaming: true,
+        isComplete: false,
+        status: 'streaming' as const,
+        startTime: 1,
+      }],
+      status: 'processing' as const,
+      startTime: 1,
+      backendTurnIndex: 0,
+    };
+    flowChatStore.setState(() => ({
+      sessions: new Map([
+        ['history-1', createSession({
+          sessionId: 'history-1',
+          historyState: 'ready',
+          dialogTurns: [localTurn],
+        })],
+      ]),
+      activeSessionId: 'history-1',
+    }));
+
+    const result = await flowChatStore.refreshPeerSessionSnapshot(
+      'history-1',
+      '/Users/host/project',
+      { replaceRunningSnapshot: false },
+    );
+
+    expect(result.applied).toBe(false);
+    expect(
+      flowChatStore.getState().sessions.get('history-1')
+        ?.dialogTurns[0].modelRounds[0].items[0],
+    ).toMatchObject({
+      id: 'controller-text-id',
+      content: 'partial answer plus live data',
+    });
+  });
+
   it('replaces a stale running projection after the Peer Host has completed', async () => {
     peerModeFlagMock.active = true;
     apiMocks.restoreSessionView.mockResolvedValueOnce({

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.ts
@@ -202,6 +202,150 @@ function compareDialogTurnOrder(left: DialogTurn, right: DialogTurn): number {
   return left.startTime - right.startTime;
 }
 
+function runningStatusRank(status: string | undefined): number {
+  switch (status) {
+    case 'pending':
+    case 'queued':
+    case 'waiting':
+    case 'preparing':
+      return 0;
+    case 'processing':
+    case 'running':
+    case 'streaming':
+    case 'receiving':
+    case 'analyzing':
+      return 1;
+    case 'pending_confirmation':
+    case 'confirmed':
+    case 'finishing':
+    case 'cancelling':
+      return 2;
+    case 'completed':
+    case 'cancelled':
+    case 'rejected':
+    case 'error':
+      return 3;
+    default:
+      return 0;
+  }
+}
+
+function substantiveRoundItems(round: ModelRound): AnyFlowItem[] {
+  return round.items.filter(item => (
+    item.type !== 'text' ||
+    !(item as AnyFlowItem & { runtimeStatus?: unknown }).runtimeStatus
+  ));
+}
+
+type RunningStreamItem = AnyFlowItem & {
+  type: 'text' | 'thinking';
+  content: string;
+};
+
+function streamProgressEntries(round: ModelRound): Map<string, RunningStreamItem> {
+  const entries = new Map<string, RunningStreamItem>();
+  const ordinals: Record<'text' | 'thinking', number> = {
+    text: 0,
+    thinking: 0,
+  };
+
+  for (const item of substantiveRoundItems(round)) {
+    if (item.type !== 'text' && item.type !== 'thinking') {
+      continue;
+    }
+    const ordinal = ordinals[item.type]++;
+    const attempt =
+      item.attemptId ||
+      (typeof item.attemptIndex === 'number' ? `index:${item.attemptIndex}` : 'default');
+    entries.set(`${item.type}:${attempt}:${ordinal}`, item as RunningStreamItem);
+  }
+
+  return entries;
+}
+
+function toolProgressEntries(round: ModelRound): Map<string, FlowToolItem> {
+  const entries = new Map<string, FlowToolItem>();
+  for (const item of substantiveRoundItems(round)) {
+    if (item.type !== 'tool') {
+      continue;
+    }
+    const tool = item as FlowToolItem;
+    entries.set(tool.toolCall?.id || tool.id, tool);
+  }
+  return entries;
+}
+
+/**
+ * Accept an active persisted snapshot only when it is provably ahead of the
+ * controller projection. Peer text-item ids are generated independently on
+ * each device, so progress is compared by round/type/attempt/ordinal and
+ * content prefix instead of item id.
+ */
+function isRunningSnapshotForwardProgress(
+  current: DialogTurn,
+  snapshot: DialogTurn,
+): boolean {
+  if (current.id !== snapshot.id) {
+    return false;
+  }
+
+  let advanced =
+    runningStatusRank(snapshot.status) > runningStatusRank(current.status) ||
+    snapshot.modelRounds.length > current.modelRounds.length;
+
+  for (const currentRound of current.modelRounds) {
+    const snapshotRound = snapshot.modelRounds.find(round => round.id === currentRound.id);
+    if (!snapshotRound) {
+      return false;
+    }
+    if (runningStatusRank(snapshotRound.status) < runningStatusRank(currentRound.status)) {
+      return false;
+    }
+    if (runningStatusRank(snapshotRound.status) > runningStatusRank(currentRound.status)) {
+      advanced = true;
+    }
+
+    const currentStreams = streamProgressEntries(currentRound);
+    const snapshotStreams = streamProgressEntries(snapshotRound);
+    for (const [key, currentItem] of currentStreams) {
+      const snapshotItem = snapshotStreams.get(key);
+      if (!snapshotItem || !snapshotItem.content.startsWith(currentItem.content)) {
+        return false;
+      }
+      if (snapshotItem.content.length > currentItem.content.length) {
+        advanced = true;
+      }
+    }
+    if (snapshotStreams.size > currentStreams.size) {
+      advanced = true;
+    }
+
+    const currentTools = toolProgressEntries(currentRound);
+    const snapshotTools = toolProgressEntries(snapshotRound);
+    for (const [key, currentTool] of currentTools) {
+      const snapshotTool = snapshotTools.get(key);
+      if (
+        !snapshotTool ||
+        runningStatusRank(snapshotTool.status) < runningStatusRank(currentTool.status) ||
+        (currentTool.toolResult && !snapshotTool.toolResult)
+      ) {
+        return false;
+      }
+      if (
+        runningStatusRank(snapshotTool.status) > runningStatusRank(currentTool.status) ||
+        (!currentTool.toolResult && Boolean(snapshotTool.toolResult))
+      ) {
+        advanced = true;
+      }
+    }
+    if (snapshotTools.size > currentTools.size) {
+      advanced = true;
+    }
+  }
+
+  return advanced;
+}
+
 function itemMatchesIdentity(item: AnyFlowItem, itemId: string): boolean {
   if (item.id === itemId) {
     return true;
@@ -4181,7 +4325,10 @@ export class FlowChatStore {
         if (existingIndex === -1) {
           mergedTurns.push(snapshotTurn);
           turnsChanged = true;
-        } else if (replaceExistingTurns) {
+        } else if (
+          replaceExistingTurns ||
+          isRunningSnapshotForwardProgress(mergedTurns[existingIndex], snapshotTurn)
+        ) {
           mergedTurns[existingIndex] = snapshotTurn;
           turnsChanged = true;
         }

--- a/src/web-ui/src/infrastructure/api/adapters/peer-device-adapter.test.ts
+++ b/src/web-ui/src/infrastructure/api/adapters/peer-device-adapter.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  PEER_MUTATION_REQUEST_TIMEOUT_MS,
+  PEER_READ_REQUEST_TIMEOUT_MS,
   PeerDeviceTransportAdapter,
   isPeerLocalOnlyCommand,
+  isPeerRetryableReadCommand,
   peerInvokePriorityFor,
 } from './peer-device-adapter';
 
@@ -56,6 +59,15 @@ describe('peerInvokePriorityFor', () => {
     expect(peerInvokePriorityFor('terminal_write')).toBe('high');
     expect(peerInvokePriorityFor('terminal_resize')).toBe('high');
     expect(peerInvokePriorityFor('terminal_signal')).toBe('high');
+  });
+
+  it('retries only idempotent Peer reads', () => {
+    expect(isPeerRetryableReadCommand('list_persisted_sessions_page')).toBe(true);
+    expect(isPeerRetryableReadCommand('get_opened_workspaces')).toBe(true);
+    expect(isPeerRetryableReadCommand('restore_session_view')).toBe(true);
+    expect(isPeerRetryableReadCommand('start_dialog_turn')).toBe(false);
+    expect(isPeerRetryableReadCommand('delete_session')).toBe(false);
+    expect(isPeerRetryableReadCommand('respond_permission')).toBe(false);
   });
 
   it('ranks git/ssh/editor/fs/search noise low', () => {
@@ -183,6 +195,76 @@ describe('PeerDeviceTransportAdapter queue', () => {
 
     expect(response.resp).toBe('file_info');
     expect(deviceRpc).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries transient failures for read-only HostInvoke requests', async () => {
+    vi.useFakeTimers();
+    try {
+      const deviceRpc = vi.fn()
+        .mockRejectedValueOnce(new Error('relay unavailable'))
+        .mockRejectedValueOnce(new Error('gateway timeout'))
+        .mockResolvedValueOnce(JSON.stringify({
+          resp: 'host_invoke_result',
+          ok: true,
+          value: [{ id: 'workspace-1' }],
+        }));
+      const adapter = new PeerDeviceTransportAdapter('peer-1', deviceRpc);
+
+      const request = adapter.request('get_opened_workspaces', { request: {} });
+      await vi.advanceTimersByTimeAsync(1500);
+
+      await expect(request).resolves.toEqual([{ id: 'workspace-1' }]);
+      expect(deviceRpc).toHaveBeenCalledTimes(3);
+      expect(deviceRpc).toHaveBeenCalledWith(
+        'peer-1',
+        expect.any(String),
+        PEER_READ_REQUEST_TIMEOUT_MS,
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not replay mutations after a transport failure', async () => {
+    const deviceRpc = vi.fn().mockRejectedValue(new Error('outcome unknown'));
+    const adapter = new PeerDeviceTransportAdapter('peer-1', deviceRpc);
+
+    await expect(
+      adapter.request('start_dialog_turn', { request: { sessionId: 's1' } }),
+    ).rejects.toThrow('outcome unknown');
+    expect(deviceRpc).toHaveBeenCalledTimes(1);
+    expect(deviceRpc).toHaveBeenCalledWith(
+      'peer-1',
+      expect.any(String),
+      PEER_MUTATION_REQUEST_TIMEOUT_MS,
+    );
+  });
+
+  it('bounds a hung read and rejects after its retry budget', async () => {
+    vi.useFakeTimers();
+    try {
+      const deviceRpc = vi.fn(
+        () => new Promise<string>(() => {
+          // Simulate a Tauri/relay request that never settles.
+        }),
+      );
+      const adapter = new PeerDeviceTransportAdapter('peer-1', deviceRpc);
+
+      const request = adapter.request('list_persisted_sessions_page', {
+        request: { workspacePath: '/repo' },
+      });
+      const rejection = expect(request).rejects.toThrow(
+        "Peer request 'list_persisted_sessions_page' timed out",
+      );
+
+      await vi.advanceTimersByTimeAsync(
+        (PEER_READ_REQUEST_TIMEOUT_MS * 3) + 1500,
+      );
+      await rejection;
+      expect(deviceRpc).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/src/web-ui/src/infrastructure/api/adapters/peer-device-adapter.ts
+++ b/src/web-ui/src/infrastructure/api/adapters/peer-device-adapter.ts
@@ -133,8 +133,43 @@ const HIGH_PRIORITY_COMMANDS = new Set([
   'get_system_info',
 ]);
 
+const RETRYABLE_READ_COMMANDS = new Set([
+  'initialize_workspace_startup_state',
+  'restore_session_view',
+  'restore_session_with_turns',
+  'load_session_turns',
+  'list_persisted_sessions',
+  'list_persisted_sessions_page',
+  'list_persisted_sessions_count',
+  'get_session_thread_goal',
+  'get_opened_workspaces',
+  'get_recent_workspaces',
+  'get_current_workspace',
+  'get_workspace_info',
+  'get_config',
+  'get_configs',
+  'get_available_modes',
+  'get_agent_profile_config',
+  'list_pending_permission_requests',
+  'list_project_permission_grants',
+  'list_project_permission_audit',
+  'get_project_permission_rules',
+  'get_directory_children',
+  'get_directory_children_paginated',
+  'list_files',
+  'check_path_exists',
+  'get_system_info',
+]);
+
 export function isPeerLocalOnlyCommand(command: string): boolean {
   return LOCAL_ONLY_COMMANDS.has(command);
+}
+
+export function isPeerRetryableReadCommand(command: string): boolean {
+  return RETRYABLE_READ_COMMANDS.has(command) ||
+    command.startsWith('read_') ||
+    command.startsWith('list_') ||
+    command.startsWith('get_');
 }
 
 export type PeerInvokePriority = 'high' | 'normal' | 'low';
@@ -180,9 +215,17 @@ export function peerInvokePriorityFor(command: string): PeerInvokePriority {
 }
 
 /** Max in-flight HostInvoke RPCs per controller. */
-export const PEER_HOST_INVOKE_MAX_CONCURRENT = 2147483647;
+export const PEER_HOST_INVOKE_MAX_CONCURRENT = 4;
+export const PEER_READ_REQUEST_TIMEOUT_MS = 10_000;
+export const PEER_MUTATION_REQUEST_TIMEOUT_MS = 30_000;
+export const PEER_READ_MAX_RETRIES = 2;
+export const PEER_RETRY_BASE_DELAY_MS = 500;
 
-type DeviceRpcFn = (targetDeviceId: string, commandJson: string) => Promise<string>;
+type DeviceRpcFn = (
+  targetDeviceId: string,
+  commandJson: string,
+  timeoutMs?: number,
+) => Promise<string>;
 
 export interface PeerDeviceTransportHooks {
   /** Fired only for transport/RPC layer failures, not product command errors. */
@@ -210,6 +253,13 @@ export class PeerProductCommandError extends Error {
   constructor(message: string) {
     super(message);
     this.name = 'PeerProductCommandError';
+  }
+}
+
+class PeerRpcTimeoutError extends Error {
+  constructor(action: string, timeoutMs: number) {
+    super(`Peer request '${action}' timed out after ${timeoutMs}ms`);
+    this.name = 'PeerRpcTimeoutError';
   }
 }
 
@@ -361,7 +411,13 @@ export class PeerDeviceTransportAdapter implements ITransportAdapter {
     if (this.queues.high.length > 0) {
       return this.queues.high.shift();
     }
-    if (this.queues.normal.length > 0) {
+    const nonHighConcurrencyLimit =
+      this.maxConcurrent > 1 ? this.maxConcurrent - 1 : 1;
+    const activeNonHigh = this.activeByPriority.normal + this.activeByPriority.low;
+    if (
+      this.queues.normal.length > 0 &&
+      activeNonHigh < nonHighConcurrencyLimit
+    ) {
       return this.queues.normal.shift();
     }
     // Keep one transport slot available for future interactive work. Without
@@ -382,7 +438,17 @@ export class PeerDeviceTransportAdapter implements ITransportAdapter {
   ): Promise<T> {
     const action = typeof command.cmd === 'string' ? command.cmd : 'unknown';
     try {
-      const raw = await this.deviceRpc(this.targetDeviceId, JSON.stringify(command));
+      const retryable =
+        action === 'get_file_info' ||
+        action === 'read_file_chunk' ||
+        action.startsWith('get_') ||
+        action.startsWith('read_') ||
+        action.startsWith('list_');
+      const raw = await this.invokeDeviceRpc(
+        action,
+        JSON.stringify(command),
+        retryable,
+      );
       const envelope = JSON.parse(raw) as T;
       if (envelope.resp === 'error') {
         throw new PeerProductCommandError(
@@ -420,7 +486,11 @@ export class PeerDeviceTransportAdapter implements ITransportAdapter {
     });
 
     try {
-      const raw = await this.deviceRpc(this.targetDeviceId, commandJson);
+      const raw = await this.invokeDeviceRpc(
+        action,
+        commandJson,
+        isPeerRetryableReadCommand(action),
+      );
       const envelope = JSON.parse(raw) as HostInvokeResultEnvelope;
       if (timing) {
         timing.invokeDurationMs = elapsedMs(invokeStartedAt);
@@ -451,6 +521,62 @@ export class PeerDeviceTransportAdapter implements ITransportAdapter {
       log.error('Peer HostInvoke transport failed', { action, error });
       this.hooks.onHostInvokeTransportFailure?.(error, { action, priority });
       throw error;
+    }
+  }
+
+  private async invokeDeviceRpc(
+    action: string,
+    commandJson: string,
+    retryable: boolean,
+  ): Promise<string> {
+    const timeoutMs = retryable
+      ? PEER_READ_REQUEST_TIMEOUT_MS
+      : PEER_MUTATION_REQUEST_TIMEOUT_MS;
+    const maxRetries = retryable ? PEER_READ_MAX_RETRIES : 0;
+
+    for (let attempt = 0; ; attempt += 1) {
+      try {
+        return await this.withTimeout(
+          this.deviceRpc(this.targetDeviceId, commandJson, timeoutMs),
+          action,
+          timeoutMs,
+        );
+      } catch (error) {
+        if (attempt >= maxRetries) {
+          throw error;
+        }
+        const delayMs = PEER_RETRY_BASE_DELAY_MS * (2 ** attempt);
+        log.warn('Retrying read-only Peer request', {
+          action,
+          attempt: attempt + 1,
+          maxRetries,
+          delayMs,
+          error,
+        });
+        await new Promise(resolve => setTimeout(resolve, delayMs));
+      }
+    }
+  }
+
+  private async withTimeout<T>(
+    request: Promise<T>,
+    action: string,
+    timeoutMs: number,
+  ): Promise<T> {
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        request,
+        new Promise<T>((_resolve, reject) => {
+          timeout = setTimeout(() => {
+            reject(new PeerRpcTimeoutError(action, timeoutMs));
+          }, timeoutMs);
+        }),
+      ]);
+    } finally {
+      if (timeout !== undefined) {
+        clearTimeout(timeout);
+      }
     }
   }
 }

--- a/src/web-ui/src/infrastructure/api/service-api/RemoteConnectAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/RemoteConnectAPI.ts
@@ -570,11 +570,13 @@ class RemoteConnectAPIService {
   async accountDeviceRpc(
     targetDeviceId: string,
     commandJson: string,
+    timeoutMs?: number,
   ): Promise<string> {
     try {
       return await this.adapter.request<string>('account_device_rpc', {
         targetDeviceId,
         commandJson,
+        timeoutMs: timeoutMs ?? null,
       });
     } catch (e) {
       log.error('accountDeviceRpc failed', e);

--- a/src/web-ui/src/infrastructure/peer-device/PeerDeviceContext.tsx
+++ b/src/web-ui/src/infrastructure/peer-device/PeerDeviceContext.tsx
@@ -32,6 +32,7 @@ const log = createLogger('PeerDeviceMode');
 /** Only high/normal HostInvoke transport failures count toward auto-exit. */
 const PEER_RPC_FAILURE_LIMIT = 2147483647;
 const PEER_PING_INTERVAL_MS = 20_000;
+const PEER_CONTROL_RPC_TIMEOUT_MS = 15_000;
 
 function emitPeerModeChanged(detail: { active: boolean; deviceId?: string }): void {
   setPeerDeviceModeActiveFlag(detail.active);
@@ -132,6 +133,7 @@ async function detachPeerControl(deviceId: string, controllerDeviceId: string): 
         command: 'peer_control_detach',
         args: { controller_device_id: controllerDeviceId },
       }),
+      PEER_CONTROL_RPC_TIMEOUT_MS,
     ),
   );
 }
@@ -250,6 +252,7 @@ export const PeerDeviceProvider: React.FC<{ children: React.ReactNode }> = ({ ch
       await remoteConnectAPI.accountDeviceRpc(
         deviceId,
         JSON.stringify({ cmd: 'host_invoke', command: 'peer_mode_ping', args: {} }),
+        PEER_CONTROL_RPC_TIMEOUT_MS,
       ),
     );
 
@@ -265,7 +268,8 @@ export const PeerDeviceProvider: React.FC<{ children: React.ReactNode }> = ({ ch
 
       const peerTransport = new PeerDeviceTransportAdapter(
         deviceId,
-        (target, commandJson) => remoteConnectAPI.accountDeviceRpc(target, commandJson),
+        (target, commandJson, timeoutMs) =>
+          remoteConnectAPI.accountDeviceRpc(target, commandJson, timeoutMs),
         {
           onHostInvokeSuccess: notePeerRpcSuccess,
           onHostInvokeTransportFailure: notePeerTransportFailure,
@@ -284,6 +288,7 @@ export const PeerDeviceProvider: React.FC<{ children: React.ReactNode }> = ({ ch
             command: 'peer_control_attach',
             args: { controller_device_id: controllerDeviceId },
           }),
+          PEER_CONTROL_RPC_TIMEOUT_MS,
         ),
       );
       attached = true;
@@ -341,6 +346,7 @@ export const PeerDeviceProvider: React.FC<{ children: React.ReactNode }> = ({ ch
             await remoteConnectAPI.accountDeviceRpc(
               deviceId,
               JSON.stringify({ cmd: 'host_invoke', command: 'peer_mode_ping', args: {} }),
+              PEER_CONTROL_RPC_TIMEOUT_MS,
             ),
           );
           notePeerRpcSuccess();

--- a/src/web-ui/src/infrastructure/peer-device/README.md
+++ b/src/web-ui/src/infrastructure/peer-device/README.md
@@ -69,6 +69,16 @@ Controller-side React/transport layer for Peer Device Mode. Architecture:
     an in-progress turn is normalized as interrupted history and later chunks
     are dropped by the controller state machine. Reconciliation must not
     overwrite a local projection that changed while HostInvoke was in flight.
+    Continuous host output must create a persisted checkpoint within each 2s
+    coalescing window, and active snapshots may replace a running projection
+    early only when stream/tool content proves forward progress.
+
+13. **Weak links use bounded, idempotency-aware recovery.** Default Peer
+    HostInvoke concurrency is four with one slot reserved from normal/low
+    traffic. Read-only commands have a real 10s deadline and two
+    exponential-backoff retries. Mutations have a 30s deadline and are never
+    replayed automatically without an idempotency contract. A failed session
+    list must leave its loading state and offer an explicit retry.
 
 ## Related account-login guards
 

--- a/src/web-ui/src/infrastructure/services/business/workspaceManager.test.ts
+++ b/src/web-ui/src/infrastructure/services/business/workspaceManager.test.ts
@@ -287,6 +287,23 @@ describe('WorkspaceManager startup initialization', () => {
     expect(manager.getState().error).toBeNull();
   });
 
+  it('fails a Peer-mode rebootstrap instead of leaving workspace loading unresolved', async () => {
+    globalStateMocks.initializeWorkspaceStartupState.mockRejectedValue(
+      new Error('peer request timed out'),
+    );
+    listenMock.mockResolvedValue(() => undefined);
+    const manager = await getFreshWorkspaceManager();
+
+    await expect(manager.reinitializeForPeerModeSwitch()).rejects.toThrow(
+      'peer request timed out',
+    );
+
+    expect(manager.getState()).toMatchObject({
+      loading: false,
+      error: 'peer request timed out',
+    });
+  });
+
   it('stores the startup legacy remote workspace snapshot for one reconnect pass', async () => {
     const legacyRemoteWorkspace = {
       connectionId: 'conn-1',

--- a/src/web-ui/src/infrastructure/services/business/workspaceManager.ts
+++ b/src/web-ui/src/infrastructure/services/business/workspaceManager.ts
@@ -593,6 +593,11 @@ class WorkspaceManager {
     this.clearForPeerModeSwitch();
     this.emit({ type: 'workspace:loading', loading: true });
     await this.initialize();
+    if (!this.isInitialized) {
+      throw new Error(
+        this.state.error || 'Workspace state could not be loaded from the Peer host',
+      );
+    }
   }
 
   public async openWorkspace(path: string): Promise<WorkspaceInfo> {

--- a/src/web-ui/src/locales/en-US/common.json
+++ b/src/web-ui/src/locales/en-US/common.json
@@ -172,6 +172,7 @@
       "confirmEdit": "Confirm",
       "cancelEdit": "Cancel",
       "loading": "Loading...",
+      "loadFailedRetry": "Couldn't load sessions — retry",
       "showMore": "{{count}} more sessions",
       "showAll": "{{count}} more (show all)",
       "showLess": "Show less",

--- a/src/web-ui/src/locales/zh-CN/common.json
+++ b/src/web-ui/src/locales/zh-CN/common.json
@@ -172,6 +172,7 @@
       "confirmEdit": "确认",
       "cancelEdit": "取消",
       "loading": "加载中...",
+      "loadFailedRetry": "会话加载失败 — 重试",
       "showMore": "还有 {{count}} 个会话",
       "showAll": "还有 {{count}} 个（展开全部）",
       "showLess": "收起",

--- a/src/web-ui/src/locales/zh-TW/common.json
+++ b/src/web-ui/src/locales/zh-TW/common.json
@@ -172,6 +172,7 @@
       "confirmEdit": "確認",
       "cancelEdit": "取消",
       "loading": "載入中...",
+      "loadFailedRetry": "會話載入失敗 — 重試",
       "showMore": "還有 {{count}} 個會話",
       "showAll": "還有 {{count}} 個（展開全部）",
       "showLess": "收起",


### PR DESCRIPTION
## Summary

- checkpoint continuous host output every 2 seconds and let controllers apply only provably forward active-session snapshots, without echoing persistence writes from the controller
- bound Peer HostInvoke concurrency and add native 10-second read deadlines with two retries; mutations use a single 30-second attempt to avoid replaying unknown outcomes
- leave failed workspace/session loading states cleanly and expose an explicit session-list retry action
- keep canonical account UUIDs internal while showing verified usernames in desktop and mobile remote-control surfaces
- preserve the user-facing account label across mobile pairing, clear it on delegated-owner replacement, and align the mobile header controls
- prevent Pages card dropdowns from being clipped while improving visible-section rounding and settings readability
- isolate Peer session refresh from unrelated FlowChat component test doubles so the complete frontend suite remains stable

## Deployment

The Relay protocol and server behavior are unchanged. Updating the desktop/mobile clients is sufficient; no Relay Server redeploy is required.

## Verification

- `pnpm run type-check:web`
- `pnpm --dir src/web-ui run test:run` (302 files, 1922 tests)
- `pnpm run lint:web` (0 errors; 1 pre-existing warning)
- `pnpm run i18n:audit`
- `pnpm run theme:color-audit:all`
- `pnpm --dir src/mobile-web run type-check`
- `pnpm run build:mobile-web`
- `cargo check -p bitfun-desktop`
- `cargo test -p bitfun-desktop device_rpc_timeout_is_bounded_for_peer_requests --lib`

Manual paired-device verification was not run locally because no test Relay account/device was available.