### PR TITLE
fix(peer-device): retry idempotent prompt submissions

### DIFF
--- a/docs/architecture/peer-device-mode.md
+++ b/docs/architecture/peer-device-mode.md
@@ -56,12 +56,19 @@ FS) and must not be mixed with Peer Device Mode.
   are always interactive priority, and one slot is kept free from normal and
   low-priority work so input cannot be trapped behind slow polling requests.
 - Idempotent read HostInvokes use a 10s per-attempt deadline and at most two
-  exponential-backoff retries. Mutating commands use a 30s deadline without
-  automatic replay because a timed-out mutation has an unknown outcome. The
-  desktop `account_device_rpc` command enforces the requested deadline around
-  the native HTTP future; the controller's Promise deadline is not merely a UI
-  timer. Failed session-list loads leave the spinner and expose an explicit
-  retry action.
+  exponential-backoff retries. Mutating commands use a 30s deadline and are
+  not replayed unless both ends share an explicit idempotency contract.
+  `start_dialog_turn` and `start_acp_dialog_turn` use their stable
+  `(sessionId, turnId)` identity for bounded retry: the controller reuses the
+  exact payload, while the host coalesces concurrent attempts and caches the
+  completed result for the retry window. The controller enables this exception
+  only when the initial `peer_mode_ping` advertises
+  `idempotent_dialog_submit`, so mixed-version peers remain single-shot.
+  Other mutations remain single-shot because a timed-out outcome is unknown.
+  The desktop `account_device_rpc` command enforces the requested deadline
+  around the native HTTP future; the controller's Promise deadline is not
+  merely a UI timer. Failed session-list loads leave the spinner and expose an
+  explicit retry action.
 - While Peer Mode is active, background noise is reduced further:
   - controller-local SSH heartbeats and remote-workspace auto-reconnect pause
   - Git / FilesPanel window-focus refresh pauses

--- a/src/apps/desktop/src/api/peer_host_invoke.rs
+++ b/src/apps/desktop/src/api/peer_host_invoke.rs
@@ -318,6 +318,9 @@ pub async fn peer_mode_ping() -> Result<Value, String> {
         "peer": true,
         "device_id": current_device_id_for_peer()
             .unwrap_or_else(|_| "unknown".to_string()),
+        "capabilities": {
+            "idempotent_dialog_submit": true,
+        },
     }))
 }
 
@@ -413,6 +416,17 @@ mod tests {
             controllers: controllers.iter().map(|value| value.to_string()).collect(),
             permission_request_ids: requests.iter().map(|value| value.to_string()).collect(),
         }
+    }
+
+    #[tokio::test]
+    async fn peer_ping_advertises_idempotent_dialog_submission() {
+        let value = peer_mode_ping().await.expect("peer ping");
+        assert_eq!(
+            value
+                .pointer("/capabilities/idempotent_dialog_submit")
+                .and_then(Value::as_bool),
+            Some(true)
+        );
     }
 
     #[test]

--- a/src/web-ui/src/infrastructure/api/adapters/peer-device-adapter.test.ts
+++ b/src/web-ui/src/infrastructure/api/adapters/peer-device-adapter.test.ts
@@ -4,6 +4,7 @@ import {
   PEER_READ_REQUEST_TIMEOUT_MS,
   PeerDeviceTransportAdapter,
   isPeerLocalOnlyCommand,
+  isPeerRetryableIdempotentMutation,
   isPeerRetryableReadCommand,
   peerInvokePriorityFor,
 } from './peer-device-adapter';
@@ -68,6 +69,21 @@ describe('peerInvokePriorityFor', () => {
     expect(isPeerRetryableReadCommand('start_dialog_turn')).toBe(false);
     expect(isPeerRetryableReadCommand('delete_session')).toBe(false);
     expect(isPeerRetryableReadCommand('respond_permission')).toBe(false);
+  });
+
+  it('retries only mutations with an explicit host idempotency identity', () => {
+    expect(isPeerRetryableIdempotentMutation('start_dialog_turn', {
+      request: { sessionId: 'session-1', turnId: 'turn-1' },
+    })).toBe(true);
+    expect(isPeerRetryableIdempotentMutation('start_acp_dialog_turn', {
+      request: { sessionId: 'session-1', turnId: 'turn-1' },
+    })).toBe(true);
+    expect(isPeerRetryableIdempotentMutation('start_dialog_turn', {
+      request: { sessionId: 'session-1' },
+    })).toBe(false);
+    expect(isPeerRetryableIdempotentMutation('delete_session', {
+      request: { sessionId: 'session-1', turnId: 'turn-1' },
+    })).toBe(false);
   });
 
   it('ranks git/ssh/editor/fs/search noise low', () => {
@@ -225,12 +241,14 @@ describe('PeerDeviceTransportAdapter queue', () => {
     }
   });
 
-  it('does not replay mutations after a transport failure', async () => {
+  it('does not replay mutations when the host has not advertised deduplication', async () => {
     const deviceRpc = vi.fn().mockRejectedValue(new Error('outcome unknown'));
     const adapter = new PeerDeviceTransportAdapter('peer-1', deviceRpc);
 
     await expect(
-      adapter.request('start_dialog_turn', { request: { sessionId: 's1' } }),
+      adapter.request('start_dialog_turn', {
+        request: { sessionId: 's1', turnId: 'turn-1' },
+      }),
     ).rejects.toThrow('outcome unknown');
     expect(deviceRpc).toHaveBeenCalledTimes(1);
     expect(deviceRpc).toHaveBeenCalledWith(
@@ -238,6 +256,47 @@ describe('PeerDeviceTransportAdapter queue', () => {
       expect.any(String),
       PEER_MUTATION_REQUEST_TIMEOUT_MS,
     );
+  });
+
+  it('recovers an idempotent dialog submission after a transient Relay failure', async () => {
+    vi.useFakeTimers();
+    try {
+      const deviceRpc = vi.fn()
+        .mockRejectedValueOnce(new Error('error sending request for url'))
+        .mockResolvedValueOnce(JSON.stringify({
+          resp: 'host_invoke_result',
+          ok: true,
+          value: { success: true, message: 'Dialog turn started' },
+        }));
+      const adapter = new PeerDeviceTransportAdapter('peer-1', deviceRpc, {
+        supportsIdempotentDialogSubmit: true,
+      });
+      const params = {
+        request: {
+          sessionId: 'session-1',
+          turnId: 'turn-1',
+          userInput: 'hello',
+        },
+      };
+
+      const request = adapter.request('start_dialog_turn', params);
+      await vi.advanceTimersByTimeAsync(500);
+
+      await expect(request).resolves.toEqual({
+        success: true,
+        message: 'Dialog turn started',
+      });
+      expect(deviceRpc).toHaveBeenCalledTimes(2);
+      expect(deviceRpc).toHaveBeenNthCalledWith(
+        1,
+        'peer-1',
+        expect.any(String),
+        PEER_MUTATION_REQUEST_TIMEOUT_MS,
+      );
+      expect(deviceRpc.mock.calls[1][1]).toBe(deviceRpc.mock.calls[0][1]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('bounds a hung read and rejects after its retry budget', async () => {

--- a/src/web-ui/src/infrastructure/api/adapters/peer-device-adapter.ts
+++ b/src/web-ui/src/infrastructure/api/adapters/peer-device-adapter.ts
@@ -161,6 +161,11 @@ const RETRYABLE_READ_COMMANDS = new Set([
   'get_system_info',
 ]);
 
+const RETRYABLE_IDEMPOTENT_MUTATION_COMMANDS = new Set([
+  'start_dialog_turn',
+  'start_acp_dialog_turn',
+]);
+
 export function isPeerLocalOnlyCommand(command: string): boolean {
   return LOCAL_ONLY_COMMANDS.has(command);
 }
@@ -170,6 +175,31 @@ export function isPeerRetryableReadCommand(command: string): boolean {
     command.startsWith('read_') ||
     command.startsWith('list_') ||
     command.startsWith('get_');
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null
+    ? value as Record<string, unknown>
+    : null;
+}
+
+/**
+ * Mutations are retryable only when the peer can deduplicate the same logical
+ * submission. Dialog turns carry a controller-generated turnId, which the
+ * Peer Host bridge uses as an idempotency key.
+ */
+export function isPeerRetryableIdempotentMutation(
+  command: string,
+  params: unknown,
+): boolean {
+  if (!RETRYABLE_IDEMPOTENT_MUTATION_COMMANDS.has(command)) {
+    return false;
+  }
+  const request = asRecord(asRecord(params)?.request);
+  return typeof request?.sessionId === 'string' &&
+    request.sessionId.trim().length > 0 &&
+    typeof request.turnId === 'string' &&
+    request.turnId.trim().length > 0;
 }
 
 export type PeerInvokePriority = 'high' | 'normal' | 'low';
@@ -219,7 +249,32 @@ export const PEER_HOST_INVOKE_MAX_CONCURRENT = 4;
 export const PEER_READ_REQUEST_TIMEOUT_MS = 10_000;
 export const PEER_MUTATION_REQUEST_TIMEOUT_MS = 30_000;
 export const PEER_READ_MAX_RETRIES = 2;
+export const PEER_IDEMPOTENT_MUTATION_MAX_RETRIES = 2;
 export const PEER_RETRY_BASE_DELAY_MS = 500;
+
+interface PeerRpcPolicy {
+  timeoutMs: number;
+  maxRetries: number;
+  retryKind: 'read' | 'idempotent-mutation' | 'none';
+}
+
+const READ_RPC_POLICY: PeerRpcPolicy = {
+  timeoutMs: PEER_READ_REQUEST_TIMEOUT_MS,
+  maxRetries: PEER_READ_MAX_RETRIES,
+  retryKind: 'read',
+};
+
+const MUTATION_RPC_POLICY: PeerRpcPolicy = {
+  timeoutMs: PEER_MUTATION_REQUEST_TIMEOUT_MS,
+  maxRetries: 0,
+  retryKind: 'none',
+};
+
+const IDEMPOTENT_MUTATION_RPC_POLICY: PeerRpcPolicy = {
+  timeoutMs: PEER_MUTATION_REQUEST_TIMEOUT_MS,
+  maxRetries: PEER_IDEMPOTENT_MUTATION_MAX_RETRIES,
+  retryKind: 'idempotent-mutation',
+};
 
 type DeviceRpcFn = (
   targetDeviceId: string,
@@ -231,6 +286,11 @@ export interface PeerDeviceTransportHooks {
   /** Fired only for transport/RPC layer failures, not product command errors. */
   onHostInvokeTransportFailure?: (error: unknown, meta?: { action: string; priority: PeerInvokePriority }) => void;
   onHostInvokeSuccess?: () => void;
+  /**
+   * Enables replay of stable dialog submissions only when the target host
+   * advertises matching execution-side deduplication.
+   */
+  supportsIdempotentDialogSubmit?: boolean;
 }
 
 interface HostInvokeResultEnvelope {
@@ -447,7 +507,7 @@ export class PeerDeviceTransportAdapter implements ITransportAdapter {
       const raw = await this.invokeDeviceRpc(
         action,
         JSON.stringify(command),
-        retryable,
+        retryable ? READ_RPC_POLICY : MUTATION_RPC_POLICY,
       );
       const envelope = JSON.parse(raw) as T;
       if (envelope.resp === 'error') {
@@ -484,12 +544,18 @@ export class PeerDeviceTransportAdapter implements ITransportAdapter {
       command: action,
       args: params === undefined ? {} : params,
     });
+    const rpcPolicy = isPeerRetryableReadCommand(action)
+      ? READ_RPC_POLICY
+      : this.hooks.supportsIdempotentDialogSubmit === true &&
+          isPeerRetryableIdempotentMutation(action, params)
+        ? IDEMPOTENT_MUTATION_RPC_POLICY
+        : MUTATION_RPC_POLICY;
 
     try {
       const raw = await this.invokeDeviceRpc(
         action,
         commandJson,
-        isPeerRetryableReadCommand(action),
+        rpcPolicy,
       );
       const envelope = JSON.parse(raw) as HostInvokeResultEnvelope;
       if (timing) {
@@ -527,29 +593,25 @@ export class PeerDeviceTransportAdapter implements ITransportAdapter {
   private async invokeDeviceRpc(
     action: string,
     commandJson: string,
-    retryable: boolean,
+    policy: PeerRpcPolicy,
   ): Promise<string> {
-    const timeoutMs = retryable
-      ? PEER_READ_REQUEST_TIMEOUT_MS
-      : PEER_MUTATION_REQUEST_TIMEOUT_MS;
-    const maxRetries = retryable ? PEER_READ_MAX_RETRIES : 0;
-
     for (let attempt = 0; ; attempt += 1) {
       try {
         return await this.withTimeout(
-          this.deviceRpc(this.targetDeviceId, commandJson, timeoutMs),
+          this.deviceRpc(this.targetDeviceId, commandJson, policy.timeoutMs),
           action,
-          timeoutMs,
+          policy.timeoutMs,
         );
       } catch (error) {
-        if (attempt >= maxRetries) {
+        if (attempt >= policy.maxRetries) {
           throw error;
         }
         const delayMs = PEER_RETRY_BASE_DELAY_MS * (2 ** attempt);
-        log.warn('Retrying read-only Peer request', {
+        log.warn('Retrying recoverable Peer request', {
           action,
+          retryKind: policy.retryKind,
           attempt: attempt + 1,
-          maxRetries,
+          maxRetries: policy.maxRetries,
           delayMs,
           error,
         });

--- a/src/web-ui/src/infrastructure/peer-device/PeerDeviceContext.tsx
+++ b/src/web-ui/src/infrastructure/peer-device/PeerDeviceContext.tsx
@@ -138,10 +138,11 @@ async function detachPeerControl(deviceId: string, controllerDeviceId: string): 
   );
 }
 
-function parseHostInvokeResult(raw: string): void {
+function parseHostInvokeResult<T = unknown>(raw: string): T | undefined {
   const envelope = JSON.parse(raw) as {
     resp?: string;
     ok?: boolean;
+    value?: unknown;
     error?: string;
     message?: string;
   };
@@ -151,6 +152,7 @@ function parseHostInvokeResult(raw: string): void {
   if (envelope.resp === 'host_invoke_result' && !envelope.ok) {
     throw new Error(envelope.error || 'Peer HostInvoke failed');
   }
+  return envelope.value as T | undefined;
 }
 
 export const PeerDeviceProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
@@ -248,7 +250,11 @@ export const PeerDeviceProvider: React.FC<{ children: React.ReactNode }> = ({ ch
       await exitPeerMode('switch');
     }
 
-    parseHostInvokeResult(
+    const peerCapabilities = parseHostInvokeResult<{
+      capabilities?: {
+        idempotent_dialog_submit?: boolean;
+      };
+    }>(
       await remoteConnectAPI.accountDeviceRpc(
         deviceId,
         JSON.stringify({ cmd: 'host_invoke', command: 'peer_mode_ping', args: {} }),
@@ -273,6 +279,8 @@ export const PeerDeviceProvider: React.FC<{ children: React.ReactNode }> = ({ ch
         {
           onHostInvokeSuccess: notePeerRpcSuccess,
           onHostInvokeTransportFailure: notePeerTransportFailure,
+          supportsIdempotentDialogSubmit:
+            peerCapabilities?.capabilities?.idempotent_dialog_submit === true,
         },
       );
 

--- a/src/web-ui/src/infrastructure/peer-device/PeerHostInvokeBridge.test.tsx
+++ b/src/web-ui/src/infrastructure/peer-device/PeerHostInvokeBridge.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PeerHostInvokeBridge } from './PeerHostInvokeBridge';
+
+interface BridgeEvent {
+  payload: {
+    id: string;
+    command: string;
+    args: unknown;
+  };
+}
+
+const mocks = vi.hoisted(() => ({
+  invoke: vi.fn(),
+  unlisten: vi.fn(),
+  listener: null as null | ((event: BridgeEvent) => Promise<void>),
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(async (
+    _event: string,
+    listener: (event: BridgeEvent) => Promise<void>,
+  ) => {
+    mocks.listener = listener;
+    return mocks.unlisten;
+  }),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => mocks.invoke(...args),
+}));
+
+vi.mock('@/infrastructure/runtime', () => ({
+  isTauriRuntime: () => true,
+}));
+
+vi.mock('@/shared/utils/logger', () => ({
+  createLogger: () => ({
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe('PeerHostInvokeBridge', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(async () => {
+    mocks.invoke.mockReset();
+    mocks.unlisten.mockReset();
+    mocks.listener = null;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<PeerHostInvokeBridge />);
+    });
+    await vi.waitFor(() => expect(mocks.listener).not.toBeNull());
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('executes duplicate dialog submissions once and completes every RPC', async () => {
+    const startResult = deferred<{ success: boolean }>();
+    mocks.invoke.mockImplementation((command: string) => {
+      if (command === 'start_dialog_turn') {
+        return startResult.promise;
+      }
+      if (command === 'peer_host_invoke_complete') {
+        return Promise.resolve();
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+    const args = {
+      request: {
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        userInput: 'hello',
+      },
+    };
+
+    const first = mocks.listener?.({
+      payload: {
+        id: 'rpc-1',
+        command: 'start_dialog_turn',
+        args,
+      },
+    });
+    const retry = mocks.listener?.({
+      payload: {
+        id: 'rpc-2',
+        command: 'start_dialog_turn',
+        args,
+      },
+    });
+    await Promise.resolve();
+
+    expect(mocks.invoke.mock.calls.filter(
+      ([command]) => command === 'start_dialog_turn',
+    )).toHaveLength(1);
+
+    startResult.resolve({ success: true });
+    await Promise.all([first, retry]);
+
+    const completions = mocks.invoke.mock.calls.filter(
+      ([command]) => command === 'peer_host_invoke_complete',
+    );
+    expect(completions).toHaveLength(2);
+    expect(completions.map(([, payload]) => payload)).toEqual([
+      expect.objectContaining({ id: 'rpc-1', ok: true }),
+      expect.objectContaining({ id: 'rpc-2', ok: true }),
+    ]);
+  });
+});

--- a/src/web-ui/src/infrastructure/peer-device/PeerHostInvokeBridge.tsx
+++ b/src/web-ui/src/infrastructure/peer-device/PeerHostInvokeBridge.tsx
@@ -8,6 +8,10 @@ import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { invoke } from '@tauri-apps/api/core';
 import { createLogger } from '@/shared/utils/logger';
 import { isTauriRuntime } from '@/infrastructure/runtime';
+import {
+  PeerHostInvokeIdempotencyCache,
+  type PeerHostInvokeExecutionResult,
+} from './peerHostInvokeIdempotency';
 
 const log = createLogger('PeerHostInvokeBridge');
 
@@ -31,6 +35,33 @@ interface HostInvokeBridgeRequest {
   args: unknown;
 }
 
+async function executeHostInvoke(
+  command: string,
+  args: unknown,
+): Promise<PeerHostInvokeExecutionResult> {
+  try {
+    const value = args === undefined || args === null
+      ? await invoke(command)
+      : await invoke(command, args as Record<string, unknown>);
+    return {
+      ok: true,
+      value: value ?? null,
+      error: null,
+    };
+  } catch (error) {
+    const message = serializeInvokeError(error);
+    log.warn('Peer host invoke failed', {
+      command: safeCommandForLog(command),
+      error_category: 'host_invoke',
+    });
+    return {
+      ok: false,
+      value: null,
+      error: message,
+    };
+  }
+}
+
 export function PeerHostInvokeBridge(): null {
   useEffect(() => {
     if (!isTauriRuntime()) {
@@ -39,42 +70,31 @@ export function PeerHostInvokeBridge(): null {
 
     let disposed = false;
     let unlisten: UnlistenFn | null = null;
+    const idempotencyCache = new PeerHostInvokeIdempotencyCache();
 
     void (async () => {
       try {
         unlisten = await listen<HostInvokeBridgeRequest>('peer-host-invoke://request', async (event) => {
           if (disposed) return;
           const { id, command, args } = event.payload;
+          const result = await idempotencyCache.execute(
+            command,
+            args,
+            () => executeHostInvoke(command, args),
+          );
           try {
-            const value = args === undefined || args === null
-              ? await invoke(command)
-              : await invoke(command, args as Record<string, unknown>);
             await invoke('peer_host_invoke_complete', {
               id,
-              ok: true,
-              value: value ?? null,
-              error: null,
+              ok: result.ok,
+              value: result.value,
+              error: result.error,
             });
-          } catch (error) {
-            const message = serializeInvokeError(error);
+          } catch {
             const loggedCommand = safeCommandForLog(command);
-            log.warn('Peer host invoke failed', {
+            log.error('Failed to report peer host invoke result', {
               command: loggedCommand,
-              error_category: 'host_invoke',
+              error_category: 'completion',
             });
-            try {
-              await invoke('peer_host_invoke_complete', {
-                id,
-                ok: false,
-                value: null,
-                error: message,
-              });
-            } catch {
-              log.error('Failed to report peer host invoke error', {
-                command: loggedCommand,
-                error_category: 'completion',
-              });
-            }
           }
         });
       } catch {

--- a/src/web-ui/src/infrastructure/peer-device/README.md
+++ b/src/web-ui/src/infrastructure/peer-device/README.md
@@ -77,8 +77,13 @@ Controller-side React/transport layer for Peer Device Mode. Architecture:
     HostInvoke concurrency is four with one slot reserved from normal/low
     traffic. Read-only commands have a real 10s deadline and two
     exponential-backoff retries. Mutations have a 30s deadline and are never
-    replayed automatically without an idempotency contract. A failed session
-    list must leave its loading state and offer an explicit retry.
+    replayed automatically without an idempotency contract. Dialog submission
+    is the explicit exception: `start_dialog_turn` and
+    `start_acp_dialog_turn` reuse `(sessionId, turnId)`, and the host
+    coalesces/caches duplicate execution attempts. The controller must observe
+    the matching `idempotent_dialog_submit` capability in `peer_mode_ping`
+    before replaying either command; an older host stays single-shot. A failed
+    session list must leave its loading state and offer an explicit retry.
 
 ## Related account-login guards
 

--- a/src/web-ui/src/infrastructure/peer-device/peerHostInvokeIdempotency.test.ts
+++ b/src/web-ui/src/infrastructure/peer-device/peerHostInvokeIdempotency.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  PeerHostInvokeIdempotencyCache,
+  peerHostInvokeIdempotencyKey,
+  type PeerHostInvokeExecutionResult,
+} from './peerHostInvokeIdempotency';
+
+function startTurnArgs(sessionId = 'session-1', turnId = 'turn-1') {
+  return {
+    request: {
+      sessionId,
+      turnId,
+      userInput: 'hello',
+    },
+  };
+}
+
+function successResult(): PeerHostInvokeExecutionResult {
+  return {
+    ok: true,
+    value: { success: true },
+    error: null,
+  };
+}
+
+describe('PeerHostInvokeIdempotencyCache', () => {
+  it('keys only dialog submissions with stable session and turn ids', () => {
+    expect(peerHostInvokeIdempotencyKey(
+      'start_dialog_turn',
+      startTurnArgs(),
+    )).toBe('start_dialog_turn:session-1:turn-1');
+    expect(peerHostInvokeIdempotencyKey(
+      'start_acp_dialog_turn',
+      startTurnArgs(),
+    )).toBe('start_acp_dialog_turn:session-1:turn-1');
+    expect(peerHostInvokeIdempotencyKey(
+      'start_dialog_turn',
+      { request: { sessionId: 'session-1' } },
+    )).toBeNull();
+    expect(peerHostInvokeIdempotencyKey(
+      'delete_session',
+      startTurnArgs(),
+    )).toBeNull();
+  });
+
+  it('coalesces concurrent retries and reuses the completed result', async () => {
+    let resolveExecution!: (result: PeerHostInvokeExecutionResult) => void;
+    const execution = new Promise<PeerHostInvokeExecutionResult>((resolve) => {
+      resolveExecution = resolve;
+    });
+    const operation = vi.fn(() => execution);
+    const duplicateOperation = vi.fn(async () => ({
+      ok: false,
+      value: null,
+      error: 'must not execute',
+    }));
+    const cache = new PeerHostInvokeIdempotencyCache();
+
+    const first = cache.execute('start_dialog_turn', startTurnArgs(), operation);
+    const concurrent = cache.execute(
+      'start_dialog_turn',
+      startTurnArgs(),
+      duplicateOperation,
+    );
+    expect(first).toBe(concurrent);
+    await Promise.resolve();
+    expect(operation).toHaveBeenCalledTimes(1);
+    expect(duplicateOperation).not.toHaveBeenCalled();
+
+    const result = successResult();
+    resolveExecution(result);
+    await expect(first).resolves.toEqual(result);
+    await expect(cache.execute(
+      'start_dialog_turn',
+      startTurnArgs(),
+      duplicateOperation,
+    )).resolves.toEqual(result);
+    expect(duplicateOperation).not.toHaveBeenCalled();
+  });
+
+  it('executes a new submission after the cache window expires', async () => {
+    let now = 100;
+    const cache = new PeerHostInvokeIdempotencyCache(1_000, 128, () => now);
+    const firstOperation = vi.fn(async () => successResult());
+    const secondResult: PeerHostInvokeExecutionResult = {
+      ok: false,
+      value: null,
+      error: 'new execution',
+    };
+    const secondOperation = vi.fn(async () => secondResult);
+
+    await cache.execute('start_dialog_turn', startTurnArgs(), firstOperation);
+    now += 1_001;
+
+    await expect(cache.execute(
+      'start_dialog_turn',
+      startTurnArgs(),
+      secondOperation,
+    )).resolves.toEqual(secondResult);
+    expect(firstOperation).toHaveBeenCalledTimes(1);
+    expect(secondOperation).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/web-ui/src/infrastructure/peer-device/peerHostInvokeIdempotency.ts
+++ b/src/web-ui/src/infrastructure/peer-device/peerHostInvokeIdempotency.ts
@@ -1,0 +1,104 @@
+export interface PeerHostInvokeExecutionResult {
+  ok: boolean;
+  value: unknown;
+  error: string | null;
+}
+
+interface CachedExecution {
+  expiresAt: number;
+  promise: Promise<PeerHostInvokeExecutionResult>;
+}
+
+const IDEMPOTENT_HOST_INVOKE_COMMANDS = new Set([
+  'start_dialog_turn',
+  'start_acp_dialog_turn',
+]);
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null
+    ? value as Record<string, unknown>
+    : null;
+}
+
+/**
+ * Returns a stable key only for mutations whose execution side has an
+ * explicit idempotency identity.
+ */
+export function peerHostInvokeIdempotencyKey(
+  command: string,
+  args: unknown,
+): string | null {
+  if (!IDEMPOTENT_HOST_INVOKE_COMMANDS.has(command)) {
+    return null;
+  }
+  const request = asRecord(asRecord(args)?.request);
+  const sessionId = typeof request?.sessionId === 'string'
+    ? request.sessionId.trim()
+    : '';
+  const turnId = typeof request?.turnId === 'string'
+    ? request.turnId.trim()
+    : '';
+  if (!sessionId || !turnId) {
+    return null;
+  }
+  return `${command}:${sessionId}:${turnId}`;
+}
+
+/**
+ * Coalesces concurrent retries and briefly caches the completed result. The
+ * controller can therefore replay the same turn submission after an
+ * ambiguous Relay failure without executing the prompt twice on the host.
+ */
+export class PeerHostInvokeIdempotencyCache {
+  private readonly entries = new Map<string, CachedExecution>();
+
+  constructor(
+    private readonly ttlMs = 2 * 60_000,
+    private readonly maxEntries = 128,
+    private readonly now: () => number = Date.now,
+  ) {}
+
+  execute(
+    command: string,
+    args: unknown,
+    operation: () => Promise<PeerHostInvokeExecutionResult>,
+  ): Promise<PeerHostInvokeExecutionResult> {
+    const key = peerHostInvokeIdempotencyKey(command, args);
+    if (!key) {
+      return operation();
+    }
+
+    this.prune();
+    const cached = this.entries.get(key);
+    if (cached) {
+      return cached.promise;
+    }
+
+    const promise = Promise.resolve().then(operation);
+    this.entries.set(key, {
+      expiresAt: this.now() + this.ttlMs,
+      promise,
+    });
+    this.enforceCapacity();
+    return promise;
+  }
+
+  private prune(): void {
+    const now = this.now();
+    for (const [key, entry] of this.entries) {
+      if (entry.expiresAt <= now) {
+        this.entries.delete(key);
+      }
+    }
+  }
+
+  private enforceCapacity(): void {
+    while (this.entries.size > this.maxEntries) {
+      const oldestKey = this.entries.keys().next().value;
+      if (oldestKey === undefined) {
+        return;
+      }
+      this.entries.delete(oldestKey);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- advertise `idempotent_dialog_submit` from updated desktop Peer Hosts and enable prompt replay only after the controller observes that capability
- retry `start_dialog_turn` and `start_acp_dialog_turn` with the exact same `(sessionId, turnId)` payload after transient Relay transport failures
- coalesce concurrent retries and cache the host execution result for the retry window, so a lost response cannot execute the prompt twice
- keep mixed-version hosts and every other mutation single-shot

## Root cause

Prompt submission already had a stable controller-generated `turnId`, but the weak-link policy treated every mutation as non-retryable. A one-off reqwest/Relay send failure therefore surfaced directly as `Thinking process error`, even when a manual retry succeeded.

## Deployment

No Relay Server change is required. Both controlling and controlled desktop clients must be updated so capability negotiation, controller retry, and host deduplication are all active.

## Verification

- `pnpm run type-check:web`
- focused Peer transport/idempotency/HostInvoke bridge tests (19 tests)
- `pnpm --dir src/web-ui run test:run` (304 files, 1928 tests)
- `pnpm run lint:web` (0 errors; 1 pre-existing warning)
- `cargo check -p bitfun-desktop`
- `cargo test -p bitfun-desktop peer_ping_advertises_idempotent_dialog_submission --lib`

Manual two-device Relay verification was not run locally.