### PR TITLE
fix(mobile-web): match language button size

### DIFF
--- a/src/mobile-web/src/styles/components/sessions.scss
+++ b/src/mobile-web/src/styles/components/sessions.scss
@@ -106,7 +106,7 @@
   gap: var(--size-gap-2);
 }
 
-.session-list__language-btn {
+.mobile-lang-btn.session-list__language-btn {
   width: 32px;
   min-width: 32px;
   height: 32px;


### PR DESCRIPTION
## Summary
- increase the session header language-button override specificity
- keep the compact language control at 32x32px alongside the other header actions
- prevent the later-loaded 44px global mobile language style from winning the cascade

## Verification
- pnpm --dir src/mobile-web run build
- inspected the compiled CSS to confirm the 32x32px rule has higher specificity
- git diff --check