### PR TITLE
fix(remote-connect): harden relay recovery on weak networks

### DIFF
--- a/src/apps/desktop/src/api/remote_connect_api.rs
+++ b/src/apps/desktop/src/api/remote_connect_api.rs
@@ -1276,10 +1276,10 @@ pub fn init_on_startup() {
                 // Re-establish device routing WebSocket in the background.
                 // Uses the same Tauri command logic — fire and forget.
                 tokio::spawn(async {
-                    if let Err(e) = account_connect_devices().await {
-                        log::warn!("Startup device connect failed: {e}");
+                    match account_connect_devices_with_retry().await {
+                        Ok(_) => log::info!("Device routing restored on startup"),
+                        Err(e) => log::warn!("Startup device connect failed: {e}"),
                     }
-                    log::info!("Device routing restored on startup");
                 });
             }
             Ok(None) => {
@@ -2370,6 +2370,35 @@ fn set_self_hosted_form_url(url: Option<&str>) {
 pub struct OnlineDeviceInfo {
     pub device_id: String,
     pub device_name: String,
+}
+
+const STARTUP_DEVICE_CONNECT_MAX_ATTEMPTS: usize = 5;
+
+async fn account_connect_devices_with_retry() -> Result<Vec<OnlineDeviceInfo>, String> {
+    let expected_generation = account_context_generation();
+    for attempt in 1..=STARTUP_DEVICE_CONNECT_MAX_ATTEMPTS {
+        if !account_context_is_current(expected_generation) {
+            return Err("account context changed".to_string());
+        }
+        match account_connect_devices().await {
+            Ok(devices) => return Ok(devices),
+            Err(error) => {
+                if error_indicates_expired_token(&error)
+                    || error.contains("account context changed")
+                    || attempt == STARTUP_DEVICE_CONNECT_MAX_ATTEMPTS
+                {
+                    return Err(error);
+                }
+                let delay_ms = 500_u64.saturating_mul(2_u64.pow((attempt - 1) as u32));
+                log::warn!(
+                    "Startup device connection attempt {attempt}/{STARTUP_DEVICE_CONNECT_MAX_ATTEMPTS} \
+                     failed; retrying in {delay_ms}ms: {error}"
+                );
+                tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+            }
+        }
+    }
+    Err("device connection failed".to_string())
 }
 
 /// Connect to the account relay for device-to-device routing. Must be called

--- a/src/crates/assembly/core/src/service/remote_connect/mod.rs
+++ b/src/crates/assembly/core/src/service/remote_connect/mod.rs
@@ -48,8 +48,8 @@ pub mod sync_state {
 }
 
 pub use account::{
-    validate_relay_base_url, AccountClient, AccountSession, DelegateToken, DelegatedIdentity,
-    FetchedSession, KdfParams, ListedSessionEntry, SettingsBlob,
+    build_relay_websocket_url, validate_relay_base_url, AccountClient, AccountSession,
+    DelegateToken, DelegatedIdentity, FetchedSession, KdfParams, ListedSessionEntry, SettingsBlob,
 };
 pub use device::DeviceIdentity;
 pub use encryption::{decrypt_from_base64, encrypt_to_base64, KeyPair};
@@ -734,14 +734,7 @@ impl RemoteConnectService {
             ConnectionMethod::Lan { .. } | ConnectionMethod::Ngrok => {
                 format!("ws://127.0.0.1:{}/ws", self.config.lan_port)
             }
-            _ => {
-                format!(
-                    "{}/ws",
-                    relay_url
-                        .replace("https://", "wss://")
-                        .replace("http://", "ws://")
-                )
-            }
+            _ => build_relay_websocket_url(&relay_url)?,
         };
 
         let (client, mut event_rx) = RelayClient::new();
@@ -1704,12 +1697,7 @@ impl RemoteConnectService {
         // Disconnect previous device connection if any.
         self.stop_device_connection_inner().await;
 
-        let ws_url = format!(
-            "{}/ws",
-            relay_url
-                .replace("https://", "wss://")
-                .replace("http://", "ws://")
-        );
+        let ws_url = build_relay_websocket_url(relay_url)?;
 
         let (client, mut event_rx) = RelayClient::new();
         client.connect(&ws_url).await?;

--- a/src/crates/services/relay-service/src/db.rs
+++ b/src/crates/services/relay-service/src/db.rs
@@ -48,6 +48,7 @@ CREATE TABLE IF NOT EXISTS auth_tokens (
   user_id     TEXT NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
   device_id   TEXT NOT NULL,
   token_kind  TEXT NOT NULL DEFAULT 'device',
+  request_id  TEXT,
   created_at  INTEGER NOT NULL,
   expires_at  INTEGER NOT NULL,
   FOREIGN KEY (user_id, device_id) REFERENCES devices(user_id, device_id) ON DELETE CASCADE
@@ -90,6 +91,7 @@ CREATE TABLE IF NOT EXISTS page_versions (
   user_id     TEXT NOT NULL,
   slug        TEXT NOT NULL,
   version_id  TEXT NOT NULL,
+  source_upload_id TEXT,
   title       TEXT NOT NULL DEFAULT '',
   file_count  INTEGER NOT NULL DEFAULT 0,
   total_bytes INTEGER NOT NULL DEFAULT 0,
@@ -127,8 +129,16 @@ const MIGRATE_PAGES_GENERATION: &str = r#"
 ALTER TABLE pages ADD COLUMN generation TEXT NOT NULL DEFAULT '';
 "#;
 
+const MIGRATE_PAGE_VERSION_SOURCE_UPLOAD_ID: &str = r#"
+ALTER TABLE page_versions ADD COLUMN source_upload_id TEXT;
+"#;
+
 const MIGRATE_AUTH_TOKEN_KIND: &str = r#"
 ALTER TABLE auth_tokens ADD COLUMN token_kind TEXT NOT NULL DEFAULT 'device';
+"#;
+
+const MIGRATE_AUTH_TOKEN_REQUEST_ID: &str = r#"
+ALTER TABLE auth_tokens ADD COLUMN request_id TEXT;
 "#;
 
 /// Open (or create) the SQLite database and ensure the schema exists.
@@ -175,13 +185,44 @@ async fn connect_with_presence_reset(db_path: &str, reset_presence: bool) -> Res
     .execute(&pool)
     .await
     .map_err(|e| anyhow!("initialize page generations: {e}"))?;
+    if let Err(error) = sqlx::query(MIGRATE_PAGE_VERSION_SOURCE_UPLOAD_ID)
+        .execute(&pool)
+        .await
+    {
+        if !error.to_string().contains("duplicate column name") {
+            return Err(anyhow!("migrate page version upload ids: {error}"));
+        }
+    }
+    sqlx::query(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_page_versions_source_upload \
+         ON page_versions(user_id, slug, source_upload_id) \
+         WHERE source_upload_id IS NOT NULL",
+    )
+    .execute(&pool)
+    .await
+    .map_err(|e| anyhow!("index page version upload ids: {e}"))?;
     // Existing tokens predate delegation scopes and are full device tokens.
     if let Err(error) = sqlx::query(MIGRATE_AUTH_TOKEN_KIND).execute(&pool).await {
         if !error.to_string().contains("duplicate column name") {
             return Err(anyhow!("migrate auth token capabilities: {error}"));
         }
     }
+    if let Err(error) = sqlx::query(MIGRATE_AUTH_TOKEN_REQUEST_ID)
+        .execute(&pool)
+        .await
+    {
+        if !error.to_string().contains("duplicate column name") {
+            return Err(anyhow!("migrate auth token request ids: {error}"));
+        }
+    }
     migrate_account_scoped_devices(&pool).await?;
+    sqlx::query(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_auth_tokens_request_id \
+         ON auth_tokens(request_id) WHERE request_id IS NOT NULL",
+    )
+    .execute(&pool)
+    .await
+    .map_err(|e| anyhow!("index auth token request ids: {e}"))?;
     let now = Utc::now().timestamp();
     sqlx::query("DELETE FROM auth_tokens WHERE expires_at <= ?")
         .bind(now)
@@ -256,6 +297,7 @@ async fn migrate_account_scoped_devices(pool: &DbPool) -> Result<()> {
            user_id TEXT NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,\
            device_id TEXT NOT NULL,\
            token_kind TEXT NOT NULL DEFAULT 'device',\
+           request_id TEXT,\
            created_at INTEGER NOT NULL, expires_at INTEGER NOT NULL,\
            FOREIGN KEY (user_id, device_id)\
              REFERENCES devices(user_id, device_id) ON DELETE CASCADE\
@@ -278,8 +320,8 @@ async fn migrate_account_scoped_devices(pool: &DbPool) -> Result<()> {
     // upsert behavior and must not survive the ownership migration.
     sqlx::query(
         "INSERT INTO auth_tokens \
-         (token, user_id, device_id, token_kind, created_at, expires_at) \
-         SELECT a.token, a.user_id, a.device_id, a.token_kind, a.created_at, a.expires_at \
+         (token, user_id, device_id, token_kind, request_id, created_at, expires_at) \
+         SELECT a.token, a.user_id, a.device_id, a.token_kind, a.request_id, a.created_at, a.expires_at \
          FROM auth_tokens_legacy a \
          INNER JOIN devices_legacy d \
            ON d.user_id = a.user_id AND d.device_id = a.device_id",
@@ -686,13 +728,23 @@ pub struct AuthToken {
     pub user_id: String,
     pub device_id: String,
     pub token_kind: String,
+    pub request_id: Option<String>,
     pub created_at: i64,
     pub expires_at: i64,
 }
 
 impl AuthToken {
     pub async fn create(pool: &DbPool, user_id: &str, device_id: &str) -> Result<AuthToken> {
-        Self::create_with_kind(pool, user_id, device_id, "device").await
+        Self::create_with_kind(pool, user_id, device_id, "device", None).await
+    }
+
+    pub async fn create_idempotent(
+        pool: &DbPool,
+        user_id: &str,
+        device_id: &str,
+        request_id: &str,
+    ) -> Result<AuthToken> {
+        Self::create_with_kind(pool, user_id, device_id, "device", Some(request_id)).await
     }
 
     pub async fn create_delegated(
@@ -702,7 +754,7 @@ impl AuthToken {
     ) -> Result<AuthToken> {
         let now = Utc::now().timestamp();
         if let Some(existing) = sqlx::query_as::<_, AuthToken>(
-            "SELECT token, user_id, device_id, token_kind, created_at, expires_at \
+            "SELECT token, user_id, device_id, token_kind, request_id, created_at, expires_at \
              FROM auth_tokens \
              WHERE user_id = ? AND device_id = ? \
                AND token_kind = 'delegated_control' AND expires_at > ? \
@@ -717,7 +769,7 @@ impl AuthToken {
         {
             return Ok(existing);
         }
-        Self::create_with_kind(pool, user_id, device_id, "delegated_control").await
+        Self::create_with_kind(pool, user_id, device_id, "delegated_control", None).await
     }
 
     async fn create_with_kind(
@@ -725,6 +777,7 @@ impl AuthToken {
         user_id: &str,
         device_id: &str,
         token_kind: &str,
+        request_id: Option<&str>,
     ) -> Result<AuthToken> {
         let token = generate_token();
         let now = Utc::now().timestamp();
@@ -734,25 +787,50 @@ impl AuthToken {
             DEVICE_TOKEN_TTL_SECS
         };
         let expires_at = now + ttl;
-        sqlx::query(
-            "INSERT INTO auth_tokens \
-             (token, user_id, device_id, token_kind, created_at, expires_at) \
-             VALUES (?, ?, ?, ?, ?, ?)",
+        let result = sqlx::query(
+            "INSERT OR IGNORE INTO auth_tokens \
+             (token, user_id, device_id, token_kind, request_id, created_at, expires_at) \
+             VALUES (?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(&token)
         .bind(user_id)
         .bind(device_id)
         .bind(token_kind)
+        .bind(request_id)
         .bind(now)
         .bind(expires_at)
         .execute(pool)
         .await
         .map_err(|e| anyhow!("create token: {e}"))?;
+        if result.rows_affected() == 0 {
+            let request_id =
+                request_id.ok_or_else(|| anyhow!("unexpected auth token collision"))?;
+            let existing = sqlx::query_as::<_, AuthToken>(
+                "SELECT token, user_id, device_id, token_kind, request_id, created_at, expires_at \
+                 FROM auth_tokens WHERE request_id = ?",
+            )
+            .bind(request_id)
+            .fetch_optional(pool)
+            .await
+            .map_err(|e| anyhow!("find idempotent token: {e}"))?
+            .ok_or_else(|| anyhow!("idempotent auth token disappeared"))?;
+            if existing.user_id != user_id
+                || existing.device_id != device_id
+                || existing.token_kind != token_kind
+                || existing.expires_at <= now
+            {
+                return Err(anyhow!(
+                    "auth token request id conflicts with another request"
+                ));
+            }
+            return Ok(existing);
+        }
         Ok(AuthToken {
             token,
             user_id: user_id.to_string(),
             device_id: device_id.to_string(),
             token_kind: token_kind.to_string(),
+            request_id: request_id.map(str::to_string),
             created_at: now,
             expires_at,
         })
@@ -773,7 +851,7 @@ impl AuthToken {
             return Ok(None);
         }
         let row = sqlx::query_as::<_, AuthToken>(
-            "SELECT token, user_id, device_id, token_kind, created_at, expires_at \
+            "SELECT token, user_id, device_id, token_kind, request_id, created_at, expires_at \
              FROM auth_tokens WHERE token = ?",
         )
         .bind(token)
@@ -807,7 +885,7 @@ impl AuthToken {
         let mut valid = Vec::new();
         for chunk in tokens.chunks(TOKEN_QUERY_CHUNK_SIZE) {
             let mut query = QueryBuilder::<Sqlite>::new(
-                "SELECT token, user_id, device_id, token_kind, created_at, expires_at \
+                "SELECT token, user_id, device_id, token_kind, request_id, created_at, expires_at \
                  FROM auth_tokens WHERE token_kind = 'device' AND expires_at > ",
             );
             query.push_bind(now);
@@ -1262,6 +1340,7 @@ impl PageRow {
         total_bytes: i64,
         has_worker: bool,
         note: &str,
+        source_upload_id: Option<&str>,
         max_pages_per_user: i64,
         max_versions_per_page: i64,
         expected_generation: Option<&str>,
@@ -1347,12 +1426,13 @@ impl PageRow {
 
         sqlx::query(
             "INSERT INTO page_versions \
-             (user_id, slug, version_id, title, file_count, total_bytes, has_worker, note, created_at) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+             (user_id, slug, version_id, source_upload_id, title, file_count, total_bytes, has_worker, note, created_at) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(user_id)
         .bind(slug)
         .bind(version_id)
+        .bind(source_upload_id)
         .bind(title)
         .bind(file_count)
         .bind(total_bytes)
@@ -1802,6 +1882,26 @@ impl PageVersionRow {
         .fetch_optional(pool)
         .await
         .map_err(|e| anyhow!("get page version: {e}"))?;
+        Ok(row)
+    }
+
+    pub async fn get_by_source_upload_id(
+        pool: &DbPool,
+        user_id: &str,
+        slug: &str,
+        source_upload_id: &str,
+    ) -> Result<Option<PageVersionRow>> {
+        let row = sqlx::query_as::<_, PageVersionRow>(
+            "SELECT user_id, slug, version_id, title, file_count, total_bytes, has_worker, note, created_at \
+             FROM page_versions \
+             WHERE user_id = ? AND slug = ? AND source_upload_id = ?",
+        )
+        .bind(user_id)
+        .bind(slug)
+        .bind(source_upload_id)
+        .fetch_optional(pool)
+        .await
+        .map_err(|e| anyhow!("get page version by upload id: {e}"))?;
         Ok(row)
     }
 
@@ -2646,6 +2746,7 @@ mod tests {
             20,
             false,
             "new",
+            None,
             50,
             1,
             Some(&original.generation),
@@ -2678,6 +2779,7 @@ mod tests {
                 20,
                 false,
                 "new",
+                None,
                 50,
                 2,
                 Some(&original.generation),

--- a/src/crates/services/relay-service/src/routes/auth.rs
+++ b/src/crates/services/relay-service/src/routes/auth.rs
@@ -56,6 +56,10 @@ fn valid_password_hash(value: &str) -> bool {
         })
 }
 
+fn valid_login_request_id(value: &str) -> bool {
+    uuid::Uuid::parse_str(value).is_ok()
+}
+
 fn decoy_login_challenge(username: &str) -> LoginChallengeResponse {
     use sha2::{Digest, Sha256};
 
@@ -86,6 +90,7 @@ fn decoy_login_challenge(username: &str) -> LoginChallengeResponse {
             BASE64.encode(ciphertext),
             BASE64.encode(&nonce_material[..12])
         ),
+        login_idempotency_supported: true,
     }
 }
 
@@ -180,6 +185,7 @@ pub struct LoginChallengeResponse {
     pub kdf_salt: String,
     pub argon2_params: String,
     pub wrapped_master_key: String,
+    pub login_idempotency_supported: bool,
 }
 
 #[derive(Deserialize)]
@@ -188,6 +194,8 @@ pub struct LoginRequest {
     pub password_hash: String,
     pub device_id: String,
     pub device_name: String,
+    #[serde(default)]
+    pub request_id: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -349,6 +357,7 @@ pub async fn login_challenge(
         kdf_salt: user.kdf_salt,
         argon2_params: user.argon2_params,
         wrapped_master_key: user.wrapped_master_key,
+        login_idempotency_supported: true,
     }))
 }
 
@@ -361,6 +370,10 @@ pub async fn login(
 ) -> Result<Json<AuthResponse>, (StatusCode, Json<ErrorResponse>)> {
     if !valid_device_id(&body.device_id)
         || !valid_bounded_text(&body.device_name, MAX_DEVICE_NAME_BYTES)
+        || body
+            .request_id
+            .as_deref()
+            .is_some_and(|request_id| !valid_login_request_id(request_id))
     {
         return Err(err("invalid login parameters", StatusCode::BAD_REQUEST));
     }
@@ -384,12 +397,16 @@ pub async fn login(
             err("internal error", StatusCode::INTERNAL_SERVER_ERROR)
         })?;
 
-    let token = AuthToken::create(db, &user.user_id, &body.device_id)
-        .await
-        .map_err(|e| {
-            tracing::error!("login: failed to create token: {e}");
-            err("internal error", StatusCode::INTERNAL_SERVER_ERROR)
-        })?;
+    let token = match body.request_id.as_deref() {
+        Some(request_id) => {
+            AuthToken::create_idempotent(db, &user.user_id, &body.device_id, request_id).await
+        }
+        None => AuthToken::create(db, &user.user_id, &body.device_id).await,
+    }
+    .map_err(|e| {
+        tracing::error!("login: failed to create token: {e}");
+        err("internal error", StatusCode::INTERNAL_SERVER_ERROR)
+    })?;
 
     tracing::info!("Account login: user_id={}", user.user_id);
     Ok(Json(AuthResponse {
@@ -665,6 +682,7 @@ mod tests {
         assert_eq!(first.status(), StatusCode::OK);
         let first_body = to_bytes(first.into_body(), 16 * 1024).await.unwrap();
         let first_json: LoginChallengeResponse = serde_json::from_slice(&first_body).unwrap();
+        assert!(first_json.login_idempotency_supported);
         assert_eq!(BASE64.decode(&first_json.salt).unwrap().len(), 16);
         assert_eq!(BASE64.decode(&first_json.kdf_salt).unwrap().len(), 16);
         let (ciphertext, nonce) = first_json.wrapped_master_key.split_once('.').unwrap();
@@ -674,5 +692,53 @@ mod tests {
         let second = app.oneshot(request()).await.unwrap();
         let second_body = to_bytes(second.into_body(), 16 * 1024).await.unwrap();
         assert_eq!(first_body, second_body);
+    }
+
+    #[tokio::test]
+    async fn login_request_id_reuses_the_issued_token() {
+        let (app, db, _token) = setup_app().await;
+        let request_id = uuid::Uuid::new_v4().to_string();
+        let request = || {
+            Request::builder()
+                .method("POST")
+                .uri("/api/auth/login")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "username": "alice",
+                        "password_hash": "hash",
+                        "device_id": "retry-device",
+                        "device_name": "Retry Device",
+                        "request_id": request_id,
+                    })
+                    .to_string(),
+                ))
+                .unwrap()
+        };
+
+        let first = app.clone().oneshot(request()).await.unwrap();
+        assert_eq!(first.status(), StatusCode::OK);
+        let first_body = to_bytes(first.into_body(), 16 * 1024).await.unwrap();
+        let second = app.oneshot(request()).await.unwrap();
+        assert_eq!(second.status(), StatusCode::OK);
+        let second_body = to_bytes(second.into_body(), 16 * 1024).await.unwrap();
+        let first_token = serde_json::from_slice::<serde_json::Value>(&first_body).unwrap()
+            ["token"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let second_token = serde_json::from_slice::<serde_json::Value>(&second_body).unwrap()
+            ["token"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        assert_eq!(first_token, second_token);
+        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM auth_tokens WHERE request_id = ?")
+            .bind(&request_id)
+            .fetch_one(&*db)
+            .await
+            .unwrap();
+        assert_eq!(count.0, 1);
     }
 }

--- a/src/crates/services/relay-service/src/routes/auth.rs
+++ b/src/crates/services/relay-service/src/routes/auth.rs
@@ -18,6 +18,7 @@ use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use chrono::Utc;
 use dashmap::DashMap;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::net::SocketAddr;
 use std::sync::OnceLock;
 use subtle::ConstantTimeEq;
@@ -61,8 +62,6 @@ fn valid_login_request_id(value: &str) -> bool {
 }
 
 fn decoy_login_challenge(username: &str) -> LoginChallengeResponse {
-    use sha2::{Digest, Sha256};
-
     static SECRET: OnceLock<[u8; 32]> = OnceLock::new();
     let secret = SECRET.get_or_init(rand::random);
     let material = |label: &[u8]| {
@@ -100,7 +99,12 @@ fn decoy_login_challenge(username: &str) -> LoginChallengeResponse {
 /// which is acceptable for brute-force throttling (the account lockout in the
 /// DB is the durable backstop).
 pub struct LoginRateLimiter {
-    attempts: DashMap<String, Vec<i64>>,
+    attempts: DashMap<String, Vec<RateLimitAttempt>>,
+}
+
+struct RateLimitAttempt {
+    timestamp: i64,
+    replay_key: Option<String>,
 }
 
 impl LoginRateLimiter {
@@ -110,27 +114,46 @@ impl LoginRateLimiter {
         }
     }
 
-    /// Record an attempt for `ip` and return `true` if the IP is still under
-    /// the per-minute limit (i.e. the attempt is allowed).
-    fn check_and_record(&self, ip: &str, max_per_min: usize) -> bool {
+    /// Record an attempt for one rate-limit scope and return `true` if the IP
+    /// is still under the per-minute limit. An exact replay key is counted once
+    /// so an ambiguous idempotent response cannot consume the full login budget.
+    fn check_and_record(
+        &self,
+        scope: &str,
+        ip: &str,
+        max_per_min: usize,
+        replay_key: Option<&str>,
+    ) -> bool {
         let now = Utc::now().timestamp();
         let cutoff = now - 60;
-        if self.attempts.len() >= MAX_RATE_LIMIT_BUCKETS && !self.attempts.contains_key(ip) {
+        let bucket_key = format!("{scope}:{ip}");
+        if self.attempts.len() >= MAX_RATE_LIMIT_BUCKETS && !self.attempts.contains_key(&bucket_key)
+        {
             self.attempts.retain(|_, timestamps| {
-                timestamps.retain(|timestamp| *timestamp > cutoff);
+                timestamps.retain(|attempt| attempt.timestamp > cutoff);
                 !timestamps.is_empty()
             });
             if self.attempts.len() >= MAX_RATE_LIMIT_BUCKETS {
                 return false;
             }
         }
-        let mut entry = self.attempts.entry(ip.to_string()).or_default();
+        let mut entry = self.attempts.entry(bucket_key).or_default();
         let timestamps = entry.value_mut();
-        timestamps.retain(|t| *t > cutoff);
+        timestamps.retain(|attempt| attempt.timestamp > cutoff);
+        if replay_key.is_some_and(|key| {
+            timestamps
+                .iter()
+                .any(|attempt| attempt.replay_key.as_deref() == Some(key))
+        }) {
+            return true;
+        }
         if timestamps.len() >= max_per_min {
             return false;
         }
-        timestamps.push(now);
+        timestamps.push(RateLimitAttempt {
+            timestamp: now,
+            replay_key: replay_key.map(str::to_string),
+        });
         true
     }
 }
@@ -221,6 +244,7 @@ pub(crate) async fn verify_password_hash_credentials(
     headers: &HeaderMap,
     username: &str,
     password_hash: &str,
+    rate_limit_replay_key: Option<&str>,
 ) -> Result<UserRow, (StatusCode, Json<ErrorResponse>)> {
     let Some(db) = state.db.as_ref() else {
         return Err(err(
@@ -230,10 +254,12 @@ pub(crate) async fn verify_password_hash_credentials(
     };
 
     let ip = client_ip(headers, peer_addr);
-    if !state
-        .login_rate_limiter
-        .check_and_record(&ip, MAX_LOGIN_ATTEMPTS_PER_MIN)
-    {
+    if !state.login_rate_limiter.check_and_record(
+        "credentials",
+        &ip,
+        MAX_LOGIN_ATTEMPTS_PER_MIN,
+        rate_limit_replay_key,
+    ) {
         return Err(err(
             "too many login attempts from this IP",
             StatusCode::TOO_MANY_REQUESTS,
@@ -326,7 +352,7 @@ pub async fn login_challenge(
     );
     if !state
         .login_rate_limiter
-        .check_and_record(&ip, MAX_CHALLENGE_PER_MIN)
+        .check_and_record("challenge", &ip, MAX_CHALLENGE_PER_MIN, None)
     {
         return Err(err(
             "too many requests, try later",
@@ -381,12 +407,27 @@ pub async fn login(
         .db
         .as_ref()
         .ok_or_else(|| err("account features disabled", StatusCode::NOT_IMPLEMENTED))?;
+    let rate_limit_replay_key = body.request_id.as_ref().map(|request_id| {
+        let mut hasher = Sha256::new();
+        for value in [
+            request_id.as_str(),
+            body.username.as_str(),
+            body.password_hash.as_str(),
+            body.device_id.as_str(),
+            body.device_name.as_str(),
+        ] {
+            hasher.update((value.len() as u64).to_be_bytes());
+            hasher.update(value.as_bytes());
+        }
+        BASE64.encode(hasher.finalize())
+    });
     let user = verify_password_hash_credentials(
         &state,
         connect_info.map(|Extension(ConnectInfo(addr))| addr),
         &headers,
         &body.username,
         &body.password_hash,
+        rate_limit_replay_key.as_deref(),
     )
     .await?;
 
@@ -740,5 +781,19 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(count.0, 1);
+    }
+
+    #[test]
+    fn exact_idempotent_login_replays_consume_one_rate_limit_slot() {
+        let limiter = LoginRateLimiter::new();
+        for _ in 0..20 {
+            assert!(limiter.check_and_record("credentials", "127.0.0.1", 2, Some("same")));
+        }
+        assert!(limiter.check_and_record("credentials", "127.0.0.1", 2, Some("second")));
+        assert!(!limiter.check_and_record("credentials", "127.0.0.1", 2, Some("third")));
+
+        // Challenge traffic has its own budget and cannot exhaust credential
+        // verification for the same client IP.
+        assert!(limiter.check_and_record("challenge", "127.0.0.1", 1, None));
     }
 }

--- a/src/crates/services/relay-service/src/routes/pages.rs
+++ b/src/crates/services/relay-service/src/routes/pages.rs
@@ -1038,6 +1038,7 @@ async fn page_browser_login(
             &headers,
             &body.username,
             &body.password_hash,
+            None,
         )
         .await
         {
@@ -1127,6 +1128,7 @@ async fn page_browser_login(
         &headers,
         &body.username,
         &body.password_hash,
+        None,
     )
     .await
     {

--- a/src/crates/services/relay-service/src/routes/pages.rs
+++ b/src/crates/services/relay-service/src/routes/pages.rs
@@ -621,6 +621,7 @@ pub struct CheckPageFilesResponse {
     pub needed: Vec<String>,
     pub existing_count: usize,
     pub total_count: usize,
+    pub freeze_idempotency_supported: bool,
 }
 
 #[derive(Deserialize)]
@@ -1839,6 +1840,41 @@ async fn freeze_version(
 
     let page_key = page_upload_session_key(&auth.user_id, &slug);
     let _page_guard = state.page_upload_manager.lock_for(&page_key).lock().await;
+    // A completed freeze consumes its in-memory upload session. Persisting the
+    // source upload id with the immutable version lets the exact same request
+    // recover its original response after a lost HTTP response or relay restart.
+    if let Some(upload_id) = body.upload_id.as_deref() {
+        if let Some(version) =
+            PageVersionRow::get_by_source_upload_id(db, &auth.user_id, &slug, upload_id)
+                .await
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        {
+            let page = PageRow::get(db, &auth.user_id, &slug)
+                .await
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+                .ok_or(StatusCode::CONFLICT)?;
+            let username = UserRow::find_by_username_for_user_id(db, &auth.user_id)
+                .await
+                .ok()
+                .flatten()
+                .unwrap_or_default();
+            return Ok(Json(VersionInfo {
+                generation: page.generation,
+                version_id: version.version_id.clone(),
+                title: version.title,
+                file_count: version.file_count,
+                total_bytes: version.total_bytes,
+                has_worker: version.has_worker != 0,
+                note: version.note,
+                created_at: version.created_at,
+                deployed: page.deployed_version_id.as_deref() == Some(version.version_id.as_str()),
+                preview_url_path: external_page_url(
+                    &state,
+                    &format!("/p/{username}/{slug}/@v/{}", version.version_id),
+                ),
+            }));
+        }
+    }
     let session = state
         .page_upload_manager
         .sessions
@@ -1939,6 +1975,7 @@ async fn freeze_version(
         total_bytes,
         has_worker,
         &body.note,
+        body.upload_id.as_deref(),
         MAX_PAGES_PER_USER,
         MAX_VERSIONS_PER_PAGE,
         session.expected_generation.as_deref(),
@@ -2907,6 +2944,7 @@ fn process_check_page_files(
         needed,
         existing_count,
         total_count,
+        freeze_idempotency_supported: true,
     })
 }
 
@@ -3214,6 +3252,66 @@ mod tests {
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let version: serde_json::Value = serde_json::from_slice(&body).unwrap();
         version["version_id"].as_str().unwrap().to_string()
+    }
+
+    #[tokio::test]
+    async fn completed_freeze_replays_the_original_version() {
+        let (app, alice, _) = setup_app().await;
+        let files = [("index.html", b"<h1>retry</h1>".as_slice())];
+        let (upload_id, upload_files) =
+            begin_test_upload(&app, &alice, "freeze-retry", &files).await;
+        let first_version = finish_test_upload(
+            &app,
+            &alice,
+            "freeze-retry",
+            "private",
+            &upload_id,
+            upload_files,
+        )
+        .await;
+        let replay = serde_json::json!({
+            "upload_id": upload_id,
+            "expected_generation": null,
+            "create": true,
+            "title": "freeze-retry",
+        });
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/pages/freeze-retry/versions")
+                    .header("Authorization", format!("Bearer {alice}"))
+                    .header("content-type", "application/json")
+                    .body(axum::body::Body::from(replay.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let replayed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            replayed["version_id"].as_str(),
+            Some(first_version.as_str())
+        );
+
+        let versions = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!(
+                        "/api/pages/freeze-retry/versions?expected_generation={}",
+                        replayed["generation"].as_str().unwrap()
+                    ))
+                    .header("Authorization", format!("Bearer {alice}"))
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = to_bytes(versions.into_body(), usize::MAX).await.unwrap();
+        let versions: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
+        assert_eq!(versions.len(), 1);
     }
 
     async fn save_version_with_legacy_generation_intent(

--- a/src/crates/services/services-integrations/src/remote_connect.rs
+++ b/src/crates/services/services-integrations/src/remote_connect.rs
@@ -19,6 +19,7 @@ mod page_upload;
 pub mod pairing;
 pub mod qr_generator;
 pub mod relay_client;
+mod relay_http;
 pub mod session_store;
 pub mod sync_state;
 

--- a/src/crates/services/services-integrations/src/remote_connect/account.rs
+++ b/src/crates/services/services-integrations/src/remote_connect/account.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::remote_connect::device::DeviceIdentity;
 use crate::remote_connect::encryption::{decrypt, encrypt};
+use crate::remote_connect::relay_http::{relay_http_client, send_with_retry, RelayHttpRetry};
 
 /// Salt length for provisioning (client-side account-blob export). Only used
 /// by tests until that tooling lands.
@@ -234,12 +235,7 @@ impl Default for AccountClient {
 impl AccountClient {
     pub fn new() -> Self {
         Self {
-            // Sync uploads full encrypted session bundles; 30s is too short for
-            // large conversations over slower links.
-            http: reqwest::Client::builder()
-                .timeout(std::time::Duration::from_secs(120))
-                .build()
-                .unwrap_or_else(|_| reqwest::Client::new()),
+            http: relay_http_client(),
         }
     }
 
@@ -295,12 +291,14 @@ impl AccountClient {
             return Err(anyhow!("invalid account credential fields"));
         }
         let challenge_req = serde_json::json!({ "username": username });
-        let resp = self
-            .http
-            .post(Self::endpoint(relay_url, "/api/auth/login/challenge")?)
-            .json(&challenge_req)
-            .send()
-            .await?;
+        let resp = send_with_retry(
+            "login challenge",
+            self.http
+                .post(Self::endpoint(relay_url, "/api/auth/login/challenge")?)
+                .json(&challenge_req),
+            RelayHttpRetry::SafeRead,
+        )
+        .await?;
         if !resp.status().is_success() {
             return Err(Self::into_error(resp).await);
         }
@@ -479,13 +477,15 @@ impl AccountClient {
             "nonce": nonce,
             "version": version,
         });
-        let resp = self
-            .http
-            .post(Self::endpoint(relay_url, "/api/sync/sessions")?)
-            .header("Authorization", Self::auth_header(session))
-            .json(&body)
-            .send()
-            .await?;
+        let resp = send_with_retry(
+            "upload session",
+            self.http
+                .post(Self::endpoint(relay_url, "/api/sync/sessions")?)
+                .header("Authorization", Self::auth_header(session))
+                .json(&body),
+            RelayHttpRetry::IdempotentWrite,
+        )
+        .await?;
         if !resp.status().is_success() {
             return Err(Self::into_error(resp).await);
         }
@@ -531,12 +531,14 @@ impl AccountClient {
         let mut url = Self::endpoint(relay_url, "/api/sync/sessions")?;
         url.query_pairs_mut()
             .append_pair("since", &since.max(0).to_string());
-        let resp = self
-            .http
-            .get(url)
-            .header("Authorization", Self::auth_header(session))
-            .send()
-            .await?;
+        let resp = send_with_retry(
+            "list sessions",
+            self.http
+                .get(url)
+                .header("Authorization", Self::auth_header(session)),
+            RelayHttpRetry::SafeRead,
+        )
+        .await?;
         if !resp.status().is_success() {
             return Err(Self::into_error(resp).await);
         }
@@ -590,15 +592,17 @@ impl AccountClient {
         session: &AccountSession,
         session_id: &str,
     ) -> Result<Option<FetchedSession>> {
-        let resp = self
-            .http
-            .get(Self::endpoint(
-                relay_url,
-                &format!("/api/sync/sessions/{}", urlencoding::encode(session_id)),
-            )?)
-            .header("Authorization", Self::auth_header(session))
-            .send()
-            .await?;
+        let resp = send_with_retry(
+            "fetch session",
+            self.http
+                .get(Self::endpoint(
+                    relay_url,
+                    &format!("/api/sync/sessions/{}", urlencoding::encode(session_id)),
+                )?)
+                .header("Authorization", Self::auth_header(session)),
+            RelayHttpRetry::SafeRead,
+        )
+        .await?;
         if resp.status() == reqwest::StatusCode::NOT_FOUND {
             return Ok(None);
         }
@@ -652,13 +656,15 @@ impl AccountClient {
             "nonce": nonce,
             "version": version,
         });
-        let resp = self
-            .http
-            .post(Self::endpoint(relay_url, "/api/sync/settings")?)
-            .header("Authorization", Self::auth_header(session))
-            .json(&body)
-            .send()
-            .await?;
+        let resp = send_with_retry(
+            "upload settings",
+            self.http
+                .post(Self::endpoint(relay_url, "/api/sync/settings")?)
+                .header("Authorization", Self::auth_header(session))
+                .json(&body),
+            RelayHttpRetry::IdempotentWrite,
+        )
+        .await?;
         if !resp.status().is_success() {
             return Err(Self::into_error(resp).await);
         }
@@ -685,12 +691,14 @@ impl AccountClient {
         relay_url: &str,
         session: &AccountSession,
     ) -> Result<Option<SettingsBlob>> {
-        let resp = self
-            .http
-            .get(Self::endpoint(relay_url, "/api/sync/settings")?)
-            .header("Authorization", Self::auth_header(session))
-            .send()
-            .await?;
+        let resp = send_with_retry(
+            "fetch settings",
+            self.http
+                .get(Self::endpoint(relay_url, "/api/sync/settings")?)
+                .header("Authorization", Self::auth_header(session)),
+            RelayHttpRetry::SafeRead,
+        )
+        .await?;
         if resp.status() == reqwest::StatusCode::NOT_FOUND {
             return Ok(None);
         }
@@ -758,12 +766,14 @@ impl AccountClient {
         relay_url: &str,
         session: &AccountSession,
     ) -> Result<Vec<DeviceInfo>> {
-        let resp = self
-            .http
-            .get(Self::endpoint(relay_url, "/api/devices")?)
-            .header("Authorization", Self::auth_header(session))
-            .send()
-            .await?;
+        let resp = send_with_retry(
+            "list devices",
+            self.http
+                .get(Self::endpoint(relay_url, "/api/devices")?)
+                .header("Authorization", Self::auth_header(session)),
+            RelayHttpRetry::SafeRead,
+        )
+        .await?;
         if !resp.status().is_success() {
             return Err(Self::into_error(resp).await);
         }

--- a/src/crates/services/services-integrations/src/remote_connect/account.rs
+++ b/src/crates/services/services-integrations/src/remote_connect/account.rs
@@ -230,6 +230,23 @@ pub fn validate_relay_base_url(relay_url: &str) -> Result<reqwest::Url> {
     Ok(url)
 }
 
+/// Build the Relay WebSocket endpoint from the same validated base URL used by
+/// account HTTP requests. This preserves reverse-proxy prefixes while avoiding
+/// `//ws` when a user- or config-supplied base URL has a trailing slash.
+pub fn build_relay_websocket_url(relay_url: &str) -> Result<String> {
+    let mut url = validate_relay_base_url(relay_url)?;
+    let websocket_scheme = match url.scheme() {
+        "https" => "wss",
+        "http" => "ws",
+        _ => unreachable!("validate_relay_base_url accepts only http(s) schemes"),
+    };
+    url.set_scheme(websocket_scheme)
+        .map_err(|_| anyhow!("failed to convert relay URL to WebSocket scheme"))?;
+    let base_path = url.path().trim_end_matches('/').to_string();
+    url.set_path(&format!("{base_path}/ws"));
+    Ok(url.to_string())
+}
+
 impl Default for AccountClient {
     fn default() -> Self {
         Self::new()
@@ -1052,5 +1069,21 @@ mod tests {
         ] {
             assert!(AccountClient::endpoint(invalid, "/api/devices").is_err());
         }
+    }
+
+    #[test]
+    fn relay_websocket_endpoint_normalizes_root_and_prefixed_urls() {
+        assert_eq!(
+            build_relay_websocket_url("https://relay.example.com/").unwrap(),
+            "wss://relay.example.com/ws"
+        );
+        assert_eq!(
+            build_relay_websocket_url("https://relay.example.com/prefix/").unwrap(),
+            "wss://relay.example.com/prefix/ws"
+        );
+        assert_eq!(
+            build_relay_websocket_url("http://127.0.0.1:3000/relay").unwrap(),
+            "ws://127.0.0.1:3000/relay/ws"
+        );
     }
 }

--- a/src/crates/services/services-integrations/src/remote_connect/account.rs
+++ b/src/crates/services/services-integrations/src/remote_connect/account.rs
@@ -14,7 +14,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::remote_connect::device::DeviceIdentity;
 use crate::remote_connect::encryption::{decrypt, encrypt};
-use crate::remote_connect::relay_http::{relay_http_client, send_with_retry, RelayHttpRetry};
+use crate::remote_connect::relay_http::{
+    relay_http_client, send_with_retry, BufferedRelayResponse, RelayHttpRetry,
+};
 
 /// Salt length for provisioning (client-side account-blob export). Only used
 /// by tests until that tooling lands.
@@ -181,6 +183,8 @@ struct ChallengeResponse {
     kdf_salt: String,
     argon2_params: String,
     wrapped_master_key: String,
+    #[serde(default)]
+    login_idempotency_supported: bool,
 }
 
 #[derive(Deserialize)]
@@ -249,6 +253,16 @@ impl AccountClient {
     /// Map a non-2xx relay response into a human-readable error.
     async fn into_error(resp: reqwest::Response) -> anyhow::Error {
         let status = resp.status();
+        let body = resp.bytes().await.unwrap_or_default();
+        Self::error_from_response_parts(status, &body)
+    }
+
+    fn into_buffered_error(resp: BufferedRelayResponse) -> anyhow::Error {
+        let (status, body) = resp.into_parts();
+        Self::error_from_response_parts(status, &body)
+    }
+
+    fn error_from_response_parts(status: reqwest::StatusCode, body: &[u8]) -> anyhow::Error {
         if status == reqwest::StatusCode::PAYLOAD_TOO_LARGE {
             return anyhow!(
                 "relay returned HTTP 413 Payload Too Large \
@@ -262,7 +276,7 @@ impl AccountClient {
                 "relay returned HTTP 507 Insufficient Storage (the configured account or asset quota is full)"
             );
         }
-        match resp.json::<ErrorBody>().await {
+        match serde_json::from_slice::<ErrorBody>(body) {
             Ok(body) => {
                 let msg = body.error;
                 if let Some(retry) = body.retry_after_secs {
@@ -300,7 +314,7 @@ impl AccountClient {
         )
         .await?;
         if !resp.status().is_success() {
-            return Err(Self::into_error(resp).await);
+            return Err(Self::into_buffered_error(resp));
         }
         let challenge: ChallengeResponse = resp.json().await?;
 
@@ -369,15 +383,22 @@ impl AccountClient {
             "password_hash": password_hash,
             "device_id": device.device_id,
             "device_name": device.device_name,
+            "request_id": uuid::Uuid::new_v4().to_string(),
         });
-        let resp = self
+        let request = self
             .http
             .post(Self::endpoint(relay_url, "/api/auth/login")?)
-            .json(&login_req)
-            .send()
-            .await?;
+            .json(&login_req);
+        // New relays persist request_id with the issued token, making an
+        // ambiguous response safe to replay. Older relays omit the challenge
+        // capability flag, so retain one-shot login behavior with them.
+        let resp = if challenge.login_idempotency_supported {
+            send_with_retry("account login", request, RelayHttpRetry::IdempotentWrite).await?
+        } else {
+            send_with_retry("account login", request, RelayHttpRetry::SingleAttempt).await?
+        };
         if !resp.status().is_success() {
-            return Err(Self::into_error(resp).await);
+            return Err(Self::into_buffered_error(resp));
         }
         let auth: AuthResponse = resp.json().await?;
         Ok(AccountSession {
@@ -487,7 +508,7 @@ impl AccountClient {
         )
         .await?;
         if !resp.status().is_success() {
-            return Err(Self::into_error(resp).await);
+            return Err(Self::into_buffered_error(resp));
         }
         Ok(version)
     }
@@ -540,7 +561,7 @@ impl AccountClient {
         )
         .await?;
         if !resp.status().is_success() {
-            return Err(Self::into_error(resp).await);
+            return Err(Self::into_buffered_error(resp));
         }
         let bytes = resp.bytes().await?;
         let payload: SessionsListResponse = serde_json::from_slice(&bytes)
@@ -607,7 +628,7 @@ impl AccountClient {
             return Ok(None);
         }
         if !resp.status().is_success() {
-            return Err(Self::into_error(resp).await);
+            return Err(Self::into_buffered_error(resp));
         }
         let entry: SessionEntry = resp.json().await?;
         let plaintext = Self::open(session, &entry.encrypted_data, &entry.nonce)?;
@@ -625,17 +646,19 @@ impl AccountClient {
         session: &AccountSession,
         session_id: &str,
     ) -> Result<()> {
-        let resp = self
-            .http
-            .delete(Self::endpoint(
-                relay_url,
-                &format!("/api/sync/sessions/{}", urlencoding::encode(session_id)),
-            )?)
-            .header("Authorization", Self::auth_header(session))
-            .send()
-            .await?;
+        let resp = send_with_retry(
+            "delete session",
+            self.http
+                .delete(Self::endpoint(
+                    relay_url,
+                    &format!("/api/sync/sessions/{}", urlencoding::encode(session_id)),
+                )?)
+                .header("Authorization", Self::auth_header(session)),
+            RelayHttpRetry::IdempotentWrite,
+        )
+        .await?;
         if !resp.status().is_success() {
-            return Err(Self::into_error(resp).await);
+            return Err(Self::into_buffered_error(resp));
         }
         Ok(())
     }
@@ -666,7 +689,7 @@ impl AccountClient {
         )
         .await?;
         if !resp.status().is_success() {
-            return Err(Self::into_error(resp).await);
+            return Err(Self::into_buffered_error(resp));
         }
         Ok(version)
     }
@@ -703,7 +726,7 @@ impl AccountClient {
             return Ok(None);
         }
         if !resp.status().is_success() {
-            return Err(Self::into_error(resp).await);
+            return Err(Self::into_buffered_error(resp));
         }
         let opt: Option<SettingsEntry> = resp.json().await?;
         match opt {
@@ -728,14 +751,16 @@ impl AccountClient {
         relay_url: &str,
         session: &AccountSession,
     ) -> Result<DelegateToken> {
-        let resp = self
-            .http
-            .post(Self::endpoint(relay_url, "/api/auth/delegate")?)
-            .header("Authorization", Self::auth_header(session))
-            .send()
-            .await?;
+        let resp = send_with_retry(
+            "delegate account token",
+            self.http
+                .post(Self::endpoint(relay_url, "/api/auth/delegate")?)
+                .header("Authorization", Self::auth_header(session)),
+            RelayHttpRetry::IdempotentWrite,
+        )
+        .await?;
         if !resp.status().is_success() {
-            return Err(Self::into_error(resp).await);
+            return Err(Self::into_buffered_error(resp));
         }
         let auth: AuthResponse = resp.json().await?;
         Ok(DelegateToken {
@@ -746,12 +771,14 @@ impl AccountClient {
 
     /// Revoke the account token on the relay (server-side logout).
     pub async fn revoke_token(&self, relay_url: &str, session: &AccountSession) -> Result<()> {
-        let resp = self
-            .http
-            .post(Self::endpoint(relay_url, "/api/auth/logout")?)
-            .header("Authorization", Self::auth_header(session))
-            .send()
-            .await?;
+        let resp = send_with_retry(
+            "revoke account token",
+            self.http
+                .post(Self::endpoint(relay_url, "/api/auth/logout")?)
+                .header("Authorization", Self::auth_header(session)),
+            RelayHttpRetry::IdempotentWrite,
+        )
+        .await?;
         if !resp.status().is_success() {
             // Non-fatal — best-effort revocation
             log::warn!("revoke_token: relay returned {}", resp.status());
@@ -775,7 +802,7 @@ impl AccountClient {
         )
         .await?;
         if !resp.status().is_success() {
-            return Err(Self::into_error(resp).await);
+            return Err(Self::into_buffered_error(resp));
         }
         let entries: Vec<DeviceListEntry> = resp.json().await?;
         Ok(entries

--- a/src/crates/services/services-integrations/src/remote_connect/page_upload.rs
+++ b/src/crates/services/services-integrations/src/remote_connect/page_upload.rs
@@ -371,20 +371,23 @@ async fn save_page_version_from_collected_files(
         .map(str::to_string);
 
     let check_url = format!("{relay_base}/api/pages/check-files");
-    let check_resp = client
-        .post(&check_url)
-        .header("Authorization", &auth)
-        .json(&serde_json::json!({
-            "slug": slug,
-            "upload_id": upload_id,
-            "expected_generation": expected_generation,
-            "create": create,
-            "files": manifest,
-        }))
-        .timeout(std::time::Duration::from_secs(30))
-        .send()
-        .await
-        .map_err(|e| anyhow!("check-files request failed: {e}"))?;
+    let check_resp = send_with_retry(
+        "check page files",
+        client
+            .post(&check_url)
+            .header("Authorization", &auth)
+            .json(&serde_json::json!({
+                "slug": slug,
+                "upload_id": upload_id,
+                "expected_generation": expected_generation,
+                "create": create,
+                "files": manifest,
+            }))
+            .timeout(std::time::Duration::from_secs(30)),
+        RelayHttpRetry::IdempotentWrite,
+    )
+    .await
+    .map_err(|e| anyhow!("check-files request failed: {e}"))?;
     if !check_resp.status().is_success() {
         let status = check_resp.status();
         let body = check_resp.text().await.unwrap_or_default();
@@ -394,6 +397,9 @@ async fn save_page_version_from_collected_files(
         .json()
         .await
         .map_err(|e| anyhow!("parse check-files response: {e}"))?;
+    let freeze_idempotency_supported = check_body["freeze_idempotency_supported"]
+        .as_bool()
+        .unwrap_or(false);
     let upload_mode = validate_upload_session_echo(&check_body, &upload_id)?;
     if upload_mode == UploadSessionMode::LegacyRelay {
         warn!(
@@ -450,7 +456,7 @@ async fn save_page_version_from_collected_files(
     }
 
     let freeze_url = format!("{relay_base}/api/pages/{slug}/versions");
-    let freeze_resp = client
+    let freeze_request = client
         .post(&freeze_url)
         .header("Authorization", &auth)
         .json(&serde_json::json!({
@@ -460,8 +466,13 @@ async fn save_page_version_from_collected_files(
             "title": title,
             "note": note.unwrap_or(""),
         }))
-        .timeout(std::time::Duration::from_secs(30))
-        .send()
+        .timeout(std::time::Duration::from_secs(30));
+    let freeze_policy = if freeze_idempotency_supported {
+        RelayHttpRetry::IdempotentWrite
+    } else {
+        RelayHttpRetry::SingleAttempt
+    };
+    let freeze_resp = send_with_retry("freeze page version", freeze_request, freeze_policy)
         .await
         .map_err(|e| anyhow!("freeze version failed: {e}"))?;
     if !freeze_resp.status().is_success() {
@@ -572,17 +583,20 @@ pub async fn create_page_open_link_on_relay(
     validate_slug(slug)?;
     let client = relay_http_client();
     let url = format!("{}/api/pages/{}", relay_url.trim_end_matches('/'), slug);
-    let resp = client
-        .post(&url)
-        .header("Authorization", format!("Bearer {token}"))
-        .json(&serde_json::json!({
-            "version_id": version_id,
-            "expected_generation": expected_generation,
-        }))
-        .timeout(std::time::Duration::from_secs(15))
-        .send()
-        .await
-        .map_err(|e| anyhow!("create page open link failed: {e}"))?;
+    let resp = send_with_retry(
+        "create page open link",
+        client
+            .post(&url)
+            .header("Authorization", format!("Bearer {token}"))
+            .json(&serde_json::json!({
+                "version_id": version_id,
+                "expected_generation": expected_generation,
+            }))
+            .timeout(std::time::Duration::from_secs(15)),
+        RelayHttpRetry::SafeRead,
+    )
+    .await
+    .map_err(|e| anyhow!("create page open link failed: {e}"))?;
     if !resp.status().is_success() {
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
@@ -620,17 +634,20 @@ pub async fn deploy_page_version_on_relay(
         relay_url.trim_end_matches('/'),
         slug
     );
-    let resp = client
-        .post(&url)
-        .header("Authorization", format!("Bearer {token}"))
-        .json(&serde_json::json!({
-            "version_id": version_id,
-            "expected_generation": expected_generation,
-        }))
-        .timeout(std::time::Duration::from_secs(15))
-        .send()
-        .await
-        .map_err(|e| anyhow!("deploy failed: {e}"))?;
+    let resp = send_with_retry(
+        "deploy page version",
+        client
+            .post(&url)
+            .header("Authorization", format!("Bearer {token}"))
+            .json(&serde_json::json!({
+                "version_id": version_id,
+                "expected_generation": expected_generation,
+            }))
+            .timeout(std::time::Duration::from_secs(15)),
+        RelayHttpRetry::IdempotentWrite,
+    )
+    .await
+    .map_err(|e| anyhow!("deploy failed: {e}"))?;
     if !resp.status().is_success() {
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
@@ -698,14 +715,17 @@ pub async fn update_page_on_relay(
     if let Some(t) = title {
         body.insert("title".into(), serde_json::json!(t));
     }
-    let resp = client
-        .patch(&url)
-        .header("Authorization", format!("Bearer {token}"))
-        .json(&body)
-        .timeout(std::time::Duration::from_secs(15))
-        .send()
-        .await
-        .map_err(|e| anyhow!("update page failed: {e}"))?;
+    let resp = send_with_retry(
+        "update page",
+        client
+            .patch(&url)
+            .header("Authorization", format!("Bearer {token}"))
+            .json(&body)
+            .timeout(std::time::Duration::from_secs(15)),
+        RelayHttpRetry::IdempotentWrite,
+    )
+    .await
+    .map_err(|e| anyhow!("update page failed: {e}"))?;
     if !resp.status().is_success() {
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
@@ -731,13 +751,16 @@ pub async fn unpublish_page_from_relay(
         slug,
         expected_generation
     );
-    let resp = client
-        .post(&url)
-        .header("Authorization", format!("Bearer {token}"))
-        .timeout(std::time::Duration::from_secs(15))
-        .send()
-        .await
-        .map_err(|e| anyhow!("unpublish page failed: {e}"))?;
+    let resp = send_with_retry(
+        "unpublish page",
+        client
+            .post(&url)
+            .header("Authorization", format!("Bearer {token}"))
+            .timeout(std::time::Duration::from_secs(15)),
+        RelayHttpRetry::IdempotentWrite,
+    )
+    .await
+    .map_err(|e| anyhow!("unpublish page failed: {e}"))?;
     if !resp.status().is_success() {
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
@@ -1046,23 +1069,26 @@ async fn post_upload_batch(
     batch_index: usize,
     finalize: bool,
 ) -> Result<()> {
-    let resp = client
-        .post(url)
-        .header("Authorization", auth)
-        .json(&serde_json::json!({
-            "slug": slug,
-            "upload_id": upload_id,
-            "expected_generation": expected_generation,
-            "create": create,
-            "title": title,
-            "visibility": visibility,
-            "files": files,
-            "finalize": finalize,
-        }))
-        .timeout(std::time::Duration::from_secs(60))
-        .send()
-        .await
-        .map_err(|e| anyhow!("upload-files batch {batch_index}: {e}"))?;
+    let resp = send_with_retry(
+        "upload page files",
+        client
+            .post(url)
+            .header("Authorization", auth)
+            .json(&serde_json::json!({
+                "slug": slug,
+                "upload_id": upload_id,
+                "expected_generation": expected_generation,
+                "create": create,
+                "title": title,
+                "visibility": visibility,
+                "files": files,
+                "finalize": finalize,
+            }))
+            .timeout(std::time::Duration::from_secs(60)),
+        RelayHttpRetry::IdempotentWrite,
+    )
+    .await
+    .map_err(|e| anyhow!("upload-files batch {batch_index}: {e}"))?;
     if !resp.status().is_success() {
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();

--- a/src/crates/services/services-integrations/src/remote_connect/page_upload.rs
+++ b/src/crates/services/services-integrations/src/remote_connect/page_upload.rs
@@ -6,6 +6,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
+use crate::remote_connect::relay_http::{relay_http_client, send_with_retry, RelayHttpRetry};
+
 const MAX_UPLOAD_BATCH_BASE64_BYTES: usize = 256 * 1024;
 const MAX_PAGE_BYTES: u64 = 100 * 1024 * 1024;
 const MAX_FILE_BYTES: u64 = 10 * 1024 * 1024;
@@ -344,7 +346,7 @@ async fn save_page_version_from_collected_files(
         total_bytes
     );
 
-    let client = reqwest::Client::new();
+    let client = relay_http_client();
     let relay_base = relay_url.trim_end_matches('/');
     let auth = format!("Bearer {token}");
 
@@ -499,15 +501,18 @@ pub async fn publish_page_to_relay(
 }
 
 pub async fn list_pages_from_relay(relay_url: &str, token: &str) -> Result<Vec<PageInfo>> {
-    let client = reqwest::Client::new();
+    let client = relay_http_client();
     let url = format!("{}/api/pages", relay_url.trim_end_matches('/'));
-    let resp = client
-        .get(&url)
-        .header("Authorization", format!("Bearer {token}"))
-        .timeout(std::time::Duration::from_secs(15))
-        .send()
-        .await
-        .map_err(|e| anyhow!("list pages failed: {e}"))?;
+    let resp = send_with_retry(
+        "list pages",
+        client
+            .get(&url)
+            .header("Authorization", format!("Bearer {token}"))
+            .timeout(std::time::Duration::from_secs(15)),
+        RelayHttpRetry::SafeRead,
+    )
+    .await
+    .map_err(|e| anyhow!("list pages failed: {e}"))?;
     if !resp.status().is_success() {
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
@@ -526,20 +531,23 @@ pub async fn list_page_versions_from_relay(
     expected_generation: &str,
 ) -> Result<Vec<PageVersionInfo>> {
     validate_slug(slug)?;
-    let client = reqwest::Client::new();
+    let client = relay_http_client();
     let url = format!(
         "{}/api/pages/{}/versions?expected_generation={}",
         relay_url.trim_end_matches('/'),
         slug,
         expected_generation
     );
-    let resp = client
-        .get(&url)
-        .header("Authorization", format!("Bearer {token}"))
-        .timeout(std::time::Duration::from_secs(15))
-        .send()
-        .await
-        .map_err(|e| anyhow!("list versions failed: {e}"))?;
+    let resp = send_with_retry(
+        "list page versions",
+        client
+            .get(&url)
+            .header("Authorization", format!("Bearer {token}"))
+            .timeout(std::time::Duration::from_secs(15)),
+        RelayHttpRetry::SafeRead,
+    )
+    .await
+    .map_err(|e| anyhow!("list versions failed: {e}"))?;
     if !resp.status().is_success() {
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
@@ -562,7 +570,7 @@ pub async fn create_page_open_link_on_relay(
     expected_generation: &str,
 ) -> Result<PageOpenLink> {
     validate_slug(slug)?;
-    let client = reqwest::Client::new();
+    let client = relay_http_client();
     let url = format!("{}/api/pages/{}", relay_url.trim_end_matches('/'), slug);
     let resp = client
         .post(&url)
@@ -606,7 +614,7 @@ pub async fn deploy_page_version_on_relay(
     expected_generation: &str,
 ) -> Result<PageInfo> {
     validate_slug(slug)?;
-    let client = reqwest::Client::new();
+    let client = relay_http_client();
     let url = format!(
         "{}/api/pages/{}/deploy",
         relay_url.trim_end_matches('/'),
@@ -642,7 +650,7 @@ pub async fn delete_page_version_on_relay(
     expected_generation: &str,
 ) -> Result<()> {
     validate_slug(slug)?;
-    let client = reqwest::Client::new();
+    let client = relay_http_client();
     let url = format!(
         "{}/api/pages/{}/versions/{}?expected_generation={}",
         relay_url.trim_end_matches('/'),
@@ -677,7 +685,7 @@ pub async fn update_page_on_relay(
     if let Some(v) = visibility {
         validate_visibility(v)?;
     }
-    let client = reqwest::Client::new();
+    let client = relay_http_client();
     let url = format!("{}/api/pages/{}", relay_url.trim_end_matches('/'), slug);
     let mut body = serde_json::Map::new();
     body.insert(
@@ -716,7 +724,7 @@ pub async fn unpublish_page_from_relay(
     expected_generation: &str,
 ) -> Result<()> {
     validate_slug(slug)?;
-    let client = reqwest::Client::new();
+    let client = relay_http_client();
     let url = format!(
         "{}/api/pages/{}/unpublish?expected_generation={}",
         relay_url.trim_end_matches('/'),
@@ -745,7 +753,7 @@ pub async fn delete_page_from_relay(
     expected_generation: &str,
 ) -> Result<()> {
     validate_slug(slug)?;
-    let client = reqwest::Client::new();
+    let client = relay_http_client();
     let url = format!(
         "{}/api/pages/{}?expected_generation={}",
         relay_url.trim_end_matches('/'),

--- a/src/crates/services/services-integrations/src/remote_connect/relay_client.rs
+++ b/src/crates/services/services-integrations/src/remote_connect/relay_client.rs
@@ -36,6 +36,10 @@ type WsStream =
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
 
 const RELAY_DIAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+/// Heartbeats are sent every 30 seconds. Two missed acknowledgements plus
+/// scheduling/network slack indicates a half-open socket that should be
+/// replaced even when the OS has not surfaced a read error yet.
+const RELAY_INBOUND_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(75);
 
 /// Messages in the relay protocol (both directions).
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -254,7 +258,19 @@ impl RelayClient {
         let mut ws_read = ws_read;
         tokio::spawn(async move {
             'outer: loop {
-                while let Some(res) = ws_read.next().await {
+                loop {
+                    let res = match await_relay_inbound(ws_read.next()).await {
+                        Ok(Some(res)) => res,
+                        Ok(None) => break,
+                        Err(_) => {
+                            warn!(
+                                "Relay connection received no traffic for {} seconds; \
+                                 treating socket as stale",
+                                RELAY_INBOUND_IDLE_TIMEOUT.as_secs()
+                            );
+                            break;
+                        }
+                    };
                     match res {
                         Ok(Message::Text(text)) => {
                             match serde_json::from_str::<RelayMessage>(&text) {
@@ -624,6 +640,15 @@ where
         })?
 }
 
+async fn await_relay_inbound<T, F>(inbound_future: F) -> std::result::Result<T, ()>
+where
+    F: std::future::Future<Output = T>,
+{
+    tokio::time::timeout(RELAY_INBOUND_IDLE_TIMEOUT, inbound_future)
+        .await
+        .map_err(|_| ())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -655,6 +680,12 @@ mod tests {
             result.expect_err("dial error must be returned").to_string(),
             "dial failed before timeout"
         );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn inbound_idle_timeout_detects_a_half_open_socket() {
+        let result = await_relay_inbound(std::future::pending::<()>()).await;
+        assert!(result.is_err(), "an idle relay stream must time out");
     }
 }
 

--- a/src/crates/services/services-integrations/src/remote_connect/relay_http.rs
+++ b/src/crates/services/services-integrations/src/remote_connect/relay_http.rs
@@ -13,6 +13,8 @@ use std::{
 
 const RELAY_HTTP_TIMEOUT: Duration = Duration::from_secs(120);
 const RELAY_HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const RELAY_HTTP_READ_TIMEOUT: Duration = Duration::from_secs(30);
+const RELAY_HTTP_RETRY_BUDGET: Duration = Duration::from_secs(120);
 const MAX_RETRY_AFTER: Duration = Duration::from_secs(5);
 
 static RELAY_HTTP_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
@@ -76,6 +78,7 @@ pub(crate) fn relay_http_client() -> reqwest::Client {
             reqwest::Client::builder()
                 .timeout(RELAY_HTTP_TIMEOUT)
                 .connect_timeout(RELAY_HTTP_CONNECT_TIMEOUT)
+                .read_timeout(RELAY_HTTP_READ_TIMEOUT)
                 .pool_idle_timeout(Duration::from_secs(90))
                 .build()
                 .unwrap_or_else(|error| {
@@ -89,6 +92,24 @@ pub(crate) fn relay_http_client() -> reqwest::Client {
 }
 
 pub(crate) async fn send_with_retry(
+    operation: &'static str,
+    request: RequestBuilder,
+    policy: RelayHttpRetry,
+) -> Result<BufferedRelayResponse> {
+    tokio::time::timeout(
+        RELAY_HTTP_RETRY_BUDGET,
+        send_with_retry_within_budget(operation, request, policy),
+    )
+    .await
+    .map_err(|_| {
+        anyhow!(
+            "relay HTTP {operation} exceeded the {}s total retry budget",
+            RELAY_HTTP_RETRY_BUDGET.as_secs()
+        )
+    })?
+}
+
+async fn send_with_retry_within_budget(
     operation: &'static str,
     request: RequestBuilder,
     policy: RelayHttpRetry,
@@ -123,6 +144,15 @@ pub(crate) async fn send_with_retry(
                     Err(error)
                         if is_retryable_transport_error(&error) && attempt < max_attempts =>
                     {
+                        // Once a definitive non-retryable HTTP status arrives,
+                        // replaying a write just to recover its error body can
+                        // repeat authentication/validation side effects.
+                        if !status.is_success() && !is_transient_status(status) {
+                            return Ok(BufferedRelayResponse {
+                                status,
+                                body: Vec::new(),
+                            });
+                        }
                         let delay = retry_delay(attempt, None);
                         warn!(
                             "Relay HTTP response body will retry: operation={operation} \
@@ -167,7 +197,6 @@ fn is_transient_status(status: StatusCode) -> bool {
         status,
         StatusCode::REQUEST_TIMEOUT
             | StatusCode::TOO_EARLY
-            | StatusCode::TOO_MANY_REQUESTS
             | StatusCode::INTERNAL_SERVER_ERROR
             | StatusCode::BAD_GATEWAY
             | StatusCode::SERVICE_UNAVAILABLE
@@ -243,7 +272,6 @@ mod tests {
         for status in [
             StatusCode::REQUEST_TIMEOUT,
             StatusCode::TOO_EARLY,
-            StatusCode::TOO_MANY_REQUESTS,
             StatusCode::INTERNAL_SERVER_ERROR,
             StatusCode::BAD_GATEWAY,
             StatusCode::SERVICE_UNAVAILABLE,
@@ -256,6 +284,7 @@ mod tests {
             StatusCode::UNAUTHORIZED,
             StatusCode::NOT_FOUND,
             StatusCode::CONFLICT,
+            StatusCode::TOO_MANY_REQUESTS,
             StatusCode::PAYLOAD_TOO_LARGE,
         ] {
             assert!(!is_transient_status(status), "{status} must not be retried");
@@ -336,6 +365,40 @@ mod tests {
 
         assert_eq!(response.text().await.unwrap(), "ok");
         assert_eq!(attempts.load(Ordering::SeqCst), 2);
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn non_retryable_status_does_not_replay_for_a_truncated_error_body() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let server_attempts = attempts.clone();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = vec![0u8; 2048];
+            let _ = stream.read(&mut request).await.unwrap();
+            server_attempts.fetch_add(1, Ordering::SeqCst);
+            stream
+                .write_all(
+                    b"HTTP/1.1 401 Unauthorized\r\nContent-Length: 10\r\nConnection: close\r\n\r\nshort",
+                )
+                .await
+                .unwrap();
+        });
+        let client = reqwest::Client::builder().no_proxy().build().unwrap();
+
+        let response = send_with_retry(
+            "test-truncated-error-body",
+            client.post(format!("http://{address}/login")),
+            RelayHttpRetry::IdempotentWrite,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert!(response.bytes().await.unwrap().is_empty());
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
         server.await.unwrap();
     }
 }

--- a/src/crates/services/services-integrations/src/remote_connect/relay_http.rs
+++ b/src/crates/services/services-integrations/src/remote_connect/relay_http.rs
@@ -2,8 +2,9 @@ use anyhow::{anyhow, Result};
 use log::warn;
 use reqwest::{
     header::{HeaderMap, RETRY_AFTER},
-    RequestBuilder, Response, StatusCode,
+    RequestBuilder, StatusCode,
 };
+use serde::de::DeserializeOwned;
 use std::{
     error::Error as StdError,
     sync::OnceLock,
@@ -20,18 +21,49 @@ static RELAY_HTTP_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
 /// same request can be replayed without duplicating a user-visible action.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RelayHttpRetry {
+    /// Compatibility path for an operation that an older relay cannot dedupe.
+    SingleAttempt,
     /// GET-like reads and challenge probes that do not mutate relay state.
     SafeRead,
-    /// Upserts whose body carries a stable key/version across every attempt.
+    /// Writes with a stable final state or a relay-persisted idempotency key.
     IdempotentWrite,
 }
 
 impl RelayHttpRetry {
     const fn max_attempts(self) -> usize {
         match self {
-            Self::SafeRead => 3,
-            Self::IdempotentWrite => 2,
+            Self::SingleAttempt => 1,
+            Self::SafeRead => 5,
+            Self::IdempotentWrite => 5,
         }
+    }
+}
+
+pub(crate) struct BufferedRelayResponse {
+    status: StatusCode,
+    body: Vec<u8>,
+}
+
+impl BufferedRelayResponse {
+    pub(crate) fn status(&self) -> StatusCode {
+        self.status
+    }
+
+    pub(crate) async fn json<T: DeserializeOwned>(self) -> Result<T> {
+        serde_json::from_slice(&self.body)
+            .map_err(|error| anyhow!("decode relay JSON response: {error}"))
+    }
+
+    pub(crate) async fn bytes(self) -> Result<Vec<u8>> {
+        Ok(self.body)
+    }
+
+    pub(crate) async fn text(self) -> Result<String> {
+        Ok(String::from_utf8_lossy(&self.body).into_owned())
+    }
+
+    pub(crate) fn into_parts(self) -> (StatusCode, Vec<u8>) {
+        (self.status, self.body)
     }
 }
 
@@ -60,7 +92,7 @@ pub(crate) async fn send_with_retry(
     operation: &'static str,
     request: RequestBuilder,
     policy: RelayHttpRetry,
-) -> Result<Response> {
+) -> Result<BufferedRelayResponse> {
     let max_attempts = policy.max_attempts();
     for attempt in 1..=max_attempts {
         let request = request.try_clone().ok_or_else(|| {
@@ -79,7 +111,35 @@ pub(crate) async fn send_with_retry(
                 drop(response);
                 tokio::time::sleep(delay).await;
             }
-            Ok(response) => return Ok(response),
+            Ok(response) => {
+                let status = response.status();
+                match response.bytes().await {
+                    Ok(body) => {
+                        return Ok(BufferedRelayResponse {
+                            status,
+                            body: body.to_vec(),
+                        });
+                    }
+                    Err(error)
+                        if is_retryable_transport_error(&error) && attempt < max_attempts =>
+                    {
+                        let delay = retry_delay(attempt, None);
+                        warn!(
+                            "Relay HTTP response body will retry: operation={operation} \
+                             attempt={attempt}/{max_attempts} delay_ms={} error={}",
+                            delay.as_millis(),
+                            reqwest_error_summary(&error)
+                        );
+                        tokio::time::sleep(delay).await;
+                    }
+                    Err(error) => {
+                        return Err(anyhow!(
+                            "relay HTTP {operation} response body failed after {attempt} attempt(s): {}",
+                            reqwest_error_summary(&error)
+                        ));
+                    }
+                }
+            }
             Err(error) if is_retryable_transport_error(&error) && attempt < max_attempts => {
                 let delay = retry_delay(attempt, None);
                 warn!(
@@ -116,7 +176,7 @@ fn is_transient_status(status: StatusCode) -> bool {
 }
 
 fn is_retryable_transport_error(error: &reqwest::Error) -> bool {
-    error.is_connect() || error.is_timeout() || error.is_body()
+    error.is_connect() || error.is_timeout() || error.is_body() || error.is_decode()
 }
 
 fn retry_delay(attempt: usize, headers: Option<&HeaderMap>) -> Duration {
@@ -142,11 +202,12 @@ fn retry_delay(attempt: usize, headers: Option<&HeaderMap>) -> Duration {
 
 fn reqwest_error_summary(error: &reqwest::Error) -> String {
     let mut details = vec![format!(
-        "{} [connect={}, timeout={}, body={}]",
+        "{} [connect={}, timeout={}, body={}, decode={}]",
         error,
         error.is_connect(),
         error.is_timeout(),
-        error.is_body()
+        error.is_body(),
+        error.is_decode()
     )];
     let mut source = error.source();
     for _ in 0..4 {
@@ -176,6 +237,9 @@ mod tests {
 
     #[test]
     fn retries_only_transient_http_statuses() {
+        assert_eq!(RelayHttpRetry::SingleAttempt.max_attempts(), 1);
+        assert_eq!(RelayHttpRetry::SafeRead.max_attempts(), 5);
+        assert_eq!(RelayHttpRetry::IdempotentWrite.max_attempts(), 5);
         for status in [
             StatusCode::REQUEST_TIMEOUT,
             StatusCode::TOO_EARLY,
@@ -236,6 +300,41 @@ mod tests {
         .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn safe_read_retries_a_truncated_response_body() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let server_attempts = attempts.clone();
+        let server = tokio::spawn(async move {
+            for _ in 0..2 {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let mut request = vec![0u8; 2048];
+                let _ = stream.read(&mut request).await.unwrap();
+                let attempt = server_attempts.fetch_add(1, Ordering::SeqCst);
+                let response = if attempt == 0 {
+                    "HTTP/1.1 200 OK\r\nContent-Length: 10\r\nConnection: close\r\n\r\nshort"
+                } else {
+                    "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok"
+                };
+                stream.write_all(response.as_bytes()).await.unwrap();
+            }
+        });
+        let client = reqwest::Client::builder().no_proxy().build().unwrap();
+
+        let response = send_with_retry(
+            "test-truncated-body",
+            client.get(format!("http://{address}/health")),
+            RelayHttpRetry::SafeRead,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(response.text().await.unwrap(), "ok");
         assert_eq!(attempts.load(Ordering::SeqCst), 2);
         server.await.unwrap();
     }

--- a/src/crates/services/services-integrations/src/remote_connect/relay_http.rs
+++ b/src/crates/services/services-integrations/src/remote_connect/relay_http.rs
@@ -1,0 +1,242 @@
+use anyhow::{anyhow, Result};
+use log::warn;
+use reqwest::{
+    header::{HeaderMap, RETRY_AFTER},
+    RequestBuilder, Response, StatusCode,
+};
+use std::{
+    error::Error as StdError,
+    sync::OnceLock,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+const RELAY_HTTP_TIMEOUT: Duration = Duration::from_secs(120);
+const RELAY_HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const MAX_RETRY_AFTER: Duration = Duration::from_secs(5);
+
+static RELAY_HTTP_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+
+/// Retry classes are intentionally narrow. Callers must opt in only when the
+/// same request can be replayed without duplicating a user-visible action.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RelayHttpRetry {
+    /// GET-like reads and challenge probes that do not mutate relay state.
+    SafeRead,
+    /// Upserts whose body carries a stable key/version across every attempt.
+    IdempotentWrite,
+}
+
+impl RelayHttpRetry {
+    const fn max_attempts(self) -> usize {
+        match self {
+            Self::SafeRead => 3,
+            Self::IdempotentWrite => 2,
+        }
+    }
+}
+
+/// Reuse one reqwest pool across account, sync, and Page management calls.
+/// Rebuilding a client for every poll forces a fresh proxy CONNECT + TLS
+/// handshake and makes short proxy/node disturbances much more visible.
+pub(crate) fn relay_http_client() -> reqwest::Client {
+    RELAY_HTTP_CLIENT
+        .get_or_init(|| {
+            reqwest::Client::builder()
+                .timeout(RELAY_HTTP_TIMEOUT)
+                .connect_timeout(RELAY_HTTP_CONNECT_TIMEOUT)
+                .pool_idle_timeout(Duration::from_secs(90))
+                .build()
+                .unwrap_or_else(|error| {
+                    warn!(
+                        "Failed to build shared relay HTTP client; using reqwest defaults: {error}"
+                    );
+                    reqwest::Client::new()
+                })
+        })
+        .clone()
+}
+
+pub(crate) async fn send_with_retry(
+    operation: &'static str,
+    request: RequestBuilder,
+    policy: RelayHttpRetry,
+) -> Result<Response> {
+    let max_attempts = policy.max_attempts();
+    for attempt in 1..=max_attempts {
+        let request = request.try_clone().ok_or_else(|| {
+            anyhow!("relay HTTP {operation} request body cannot be replayed safely")
+        })?;
+
+        match request.send().await {
+            Ok(response) if is_transient_status(response.status()) && attempt < max_attempts => {
+                let status = response.status();
+                let delay = retry_delay(attempt, Some(response.headers()));
+                warn!(
+                    "Relay HTTP request will retry: operation={operation} \
+                     attempt={attempt}/{max_attempts} status={status} delay_ms={}",
+                    delay.as_millis()
+                );
+                drop(response);
+                tokio::time::sleep(delay).await;
+            }
+            Ok(response) => return Ok(response),
+            Err(error) if is_retryable_transport_error(&error) && attempt < max_attempts => {
+                let delay = retry_delay(attempt, None);
+                warn!(
+                    "Relay HTTP request will retry: operation={operation} \
+                     attempt={attempt}/{max_attempts} delay_ms={} error={}",
+                    delay.as_millis(),
+                    reqwest_error_summary(&error)
+                );
+                tokio::time::sleep(delay).await;
+            }
+            Err(error) => {
+                return Err(anyhow!(
+                    "relay HTTP {operation} failed after {attempt} attempt(s): {}",
+                    reqwest_error_summary(&error)
+                ));
+            }
+        }
+    }
+
+    unreachable!("relay HTTP retry loop always returns")
+}
+
+fn is_transient_status(status: StatusCode) -> bool {
+    matches!(
+        status,
+        StatusCode::REQUEST_TIMEOUT
+            | StatusCode::TOO_EARLY
+            | StatusCode::TOO_MANY_REQUESTS
+            | StatusCode::INTERNAL_SERVER_ERROR
+            | StatusCode::BAD_GATEWAY
+            | StatusCode::SERVICE_UNAVAILABLE
+            | StatusCode::GATEWAY_TIMEOUT
+    )
+}
+
+fn is_retryable_transport_error(error: &reqwest::Error) -> bool {
+    error.is_connect() || error.is_timeout() || error.is_body()
+}
+
+fn retry_delay(attempt: usize, headers: Option<&HeaderMap>) -> Duration {
+    if let Some(delay) = headers
+        .and_then(|headers| headers.get(RETRY_AFTER))
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u64>().ok())
+        .map(Duration::from_secs)
+    {
+        return delay.min(MAX_RETRY_AFTER);
+    }
+
+    let exponent = attempt.saturating_sub(1).min(4) as u32;
+    let base_ms = 300u64.saturating_mul(2u64.pow(exponent));
+    // Small local jitter prevents many clients from retrying a recovered relay
+    // or proxy at exactly the same instant without adding another dependency.
+    let jitter_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| u64::from(duration.subsec_nanos()) % 151)
+        .unwrap_or_default();
+    Duration::from_millis(base_ms + jitter_ms)
+}
+
+fn reqwest_error_summary(error: &reqwest::Error) -> String {
+    let mut details = vec![format!(
+        "{} [connect={}, timeout={}, body={}]",
+        error,
+        error.is_connect(),
+        error.is_timeout(),
+        error.is_body()
+    )];
+    let mut source = error.source();
+    for _ in 0..4 {
+        let Some(cause) = source else {
+            break;
+        };
+        let cause_text = cause.to_string();
+        if !details.iter().any(|detail| detail == &cause_text) {
+            details.push(cause_text);
+        }
+        source = cause.source();
+    }
+    details.join("; caused by: ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::TcpListener,
+    };
+
+    #[test]
+    fn retries_only_transient_http_statuses() {
+        for status in [
+            StatusCode::REQUEST_TIMEOUT,
+            StatusCode::TOO_EARLY,
+            StatusCode::TOO_MANY_REQUESTS,
+            StatusCode::INTERNAL_SERVER_ERROR,
+            StatusCode::BAD_GATEWAY,
+            StatusCode::SERVICE_UNAVAILABLE,
+            StatusCode::GATEWAY_TIMEOUT,
+        ] {
+            assert!(is_transient_status(status), "{status} should be transient");
+        }
+        for status in [
+            StatusCode::BAD_REQUEST,
+            StatusCode::UNAUTHORIZED,
+            StatusCode::NOT_FOUND,
+            StatusCode::CONFLICT,
+            StatusCode::PAYLOAD_TOO_LARGE,
+        ] {
+            assert!(!is_transient_status(status), "{status} must not be retried");
+        }
+    }
+
+    #[test]
+    fn retry_after_is_bounded() {
+        let mut headers = HeaderMap::new();
+        headers.insert(RETRY_AFTER, "60".parse().unwrap());
+        assert_eq!(retry_delay(1, Some(&headers)), MAX_RETRY_AFTER);
+    }
+
+    #[tokio::test]
+    async fn safe_read_retries_a_transient_response() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let server_attempts = attempts.clone();
+        let server = tokio::spawn(async move {
+            for _ in 0..2 {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let mut request = vec![0u8; 2048];
+                let _ = stream.read(&mut request).await.unwrap();
+                let attempt = server_attempts.fetch_add(1, Ordering::SeqCst);
+                let response = if attempt == 0 {
+                    "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                } else {
+                    "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok"
+                };
+                stream.write_all(response.as_bytes()).await.unwrap();
+            }
+        });
+        let client = reqwest::Client::builder().no_proxy().build().unwrap();
+
+        let response = send_with_retry(
+            "test-safe-read",
+            client.get(format!("http://{address}/health")),
+            RelayHttpRetry::SafeRead,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+        server.await.unwrap();
+    }
+}

--- a/src/mobile-web/src/pages/DevicesPage.tsx
+++ b/src/mobile-web/src/pages/DevicesPage.tsx
@@ -201,7 +201,7 @@ const DevicesPage: React.FC<Props> = ({ client, onBack }) => {
         cmd: 'host_invoke',
         command: 'peer_mode_ping',
         args: {},
-      });
+      }, { retryable: true });
       if (!isCurrent()) return;
       if (ping.resp === 'host_invoke_result' && ping.ok === false) {
         throw new Error(ping.error || t('devices.switchFailed'));

--- a/src/mobile-web/src/services/RelayHttpClient.ts
+++ b/src/mobile-web/src/services/RelayHttpClient.ts
@@ -63,6 +63,14 @@ export function isDelegatedIdentityChangedError(
   return value instanceof DelegatedIdentityChangedError;
 }
 
+const RELAY_HTTP_MAX_ATTEMPTS = 5;
+const RELAY_HTTP_RETRY_BASE_DELAY_MS = 300;
+const TRANSIENT_RELAY_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
+
+type RelayRequestOptions = {
+  retryable?: boolean;
+};
+
 function equalBytesConstantTime(left: Uint8Array, right: Uint8Array): boolean {
   if (left.length !== right.length) return false;
   let difference = 0;
@@ -132,6 +140,42 @@ export class RelayHttpClient {
     }
   }
 
+  private async fetchWithRetry(
+    input: RequestInfo | URL,
+    init: RequestInit,
+    timeoutMs: number,
+  ): Promise<Response> {
+    let lastError: unknown = null;
+    for (let attempt = 1; attempt <= RELAY_HTTP_MAX_ATTEMPTS; attempt += 1) {
+      try {
+        const response = await this.fetchWithTimeout(input, init, timeoutMs);
+        if (
+          TRANSIENT_RELAY_STATUSES.has(response.status)
+          && attempt < RELAY_HTTP_MAX_ATTEMPTS
+        ) {
+          lastError = new Error(`Relay returned HTTP ${response.status}`);
+          void response.body?.cancel();
+        } else {
+          // `fetch()` may resolve after headers and fail only while the caller
+          // consumes JSON. Buffer inside the retry boundary so truncated bodies
+          // from a weak link are replayed just like connect/time-out failures.
+          const body = await response.arrayBuffer();
+          return new Response(body, {
+            status: response.status,
+            statusText: response.statusText,
+            headers: response.headers,
+          });
+        }
+      } catch (error) {
+        lastError = error;
+        if (attempt === RELAY_HTTP_MAX_ATTEMPTS) throw error;
+      }
+      const delayMs = RELAY_HTTP_RETRY_BASE_DELAY_MS * (2 ** (attempt - 1));
+      await new Promise(resolve => window.setTimeout(resolve, delayMs));
+    }
+    throw lastError;
+  }
+
   /**
    * Pair with the desktop via two HTTP round-trips:
    * 1. POST /pair with our public key → receive encrypted challenge
@@ -163,7 +207,7 @@ export class RelayHttpClient {
       : undefined;
 
     // Step 1: POST /pair → encrypted challenge
-    const pairResp = await this.fetchWithTimeout(
+    const pairResp = await this.fetchWithRetry(
       `${this.relayUrl}/api/rooms/${encodeURIComponent(this.roomId)}/pair`,
       {
         method: 'POST',
@@ -258,7 +302,7 @@ export class RelayHttpClient {
         user_id?: string;
         device_id?: string;
         message?: string;
-      }>({ cmd: 'get_delegated_identity' });
+      }>({ cmd: 'get_delegated_identity' }, { retryable: true });
       if (this.delegatedIdentityRequestEpoch !== requestGeneration) return false;
       if (resp?.resp === 'delegate_identity' && resp.token && resp.master_key) {
         const homeDeviceId = resp.device_id ?? null;
@@ -395,7 +439,10 @@ export class RelayHttpClient {
   /**
    * Send an encrypted command to the desktop and return the decrypted response.
    */
-  async sendCommand<T = any>(cmd: object): Promise<T> {
+  async sendCommand<T = any>(
+    cmd: object,
+    options: RelayRequestOptions = {},
+  ): Promise<T> {
     if (!this.sharedKey) throw new Error('Not paired');
 
     const plaintext = JSON.stringify(cmd);
@@ -406,14 +453,15 @@ export class RelayHttpClient {
 
     const body = JSON.stringify({ encrypted_data: encData, nonce: encNonce });
 
-    const resp = await this.fetchWithTimeout(
+    const resp = await (options.retryable ? this.fetchWithRetry : this.fetchWithTimeout).call(
+      this,
       `${this.relayUrl}/api/rooms/${encodeURIComponent(this.roomId)}/command`,
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body,
       },
-      65_000,
+      options.retryable ? 20_000 : 65_000,
     );
 
     if (!resp.ok) {
@@ -548,7 +596,7 @@ export class RelayHttpClient {
    */
   async listDevices(): Promise<Array<{ device_id: string; device_name: string; online: boolean }>> {
     return this.withDelegatedAuthRetry(async (identity) => {
-      const resp = await this.fetchWithTimeout(`${this.relayUrl}/api/devices`, {
+      const resp = await this.fetchWithRetry(`${this.relayUrl}/api/devices`, {
         headers: { 'Authorization': `Bearer ${identity.token}` },
       }, 20_000);
       if (!resp.ok) {
@@ -568,7 +616,11 @@ export class RelayHttpClient {
    * desktop uses, shared via the room channel at pairing time).
    * On HTTP 401, refreshes identity from the paired desktop and retries once.
    */
-  async sendDeviceRpc<T = any>(targetDeviceId: string, command: object): Promise<T> {
+  async sendDeviceRpc<T = any>(
+    targetDeviceId: string,
+    command: object,
+    options: RelayRequestOptions = {},
+  ): Promise<T> {
     return this.withDelegatedAuthRetry(async (identity) => {
       const plaintext = JSON.stringify(command);
       const { data: encData, nonce: encNonce } = await encrypt(
@@ -576,7 +628,8 @@ export class RelayHttpClient {
         plaintext,
       );
 
-      const resp = await this.fetchWithTimeout(
+      const resp = await (options.retryable ? this.fetchWithRetry : this.fetchWithTimeout).call(
+        this,
         `${this.relayUrl}/api/devices/${encodeURIComponent(targetDeviceId)}/rpc`,
         {
           method: 'POST',
@@ -586,7 +639,7 @@ export class RelayHttpClient {
           },
           body: JSON.stringify({ encrypted_data: encData, nonce: encNonce }),
         },
-        130_000,
+        options.retryable ? 20_000 : 130_000,
       );
 
       if (!resp.ok) {

--- a/src/mobile-web/src/services/RelayHttpClient.ts
+++ b/src/mobile-web/src/services/RelayHttpClient.ts
@@ -65,7 +65,8 @@ export function isDelegatedIdentityChangedError(
 
 const RELAY_HTTP_MAX_ATTEMPTS = 5;
 const RELAY_HTTP_RETRY_BASE_DELAY_MS = 300;
-const TRANSIENT_RELAY_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
+const RELAY_HTTP_RETRY_BUDGET_MS = 120_000;
+const TRANSIENT_RELAY_STATUSES = new Set([408, 425, 500, 502, 503, 504]);
 
 type RelayRequestOptions = {
   retryable?: boolean;
@@ -129,7 +130,16 @@ export class RelayHttpClient {
     const controller = new AbortController();
     const timer = window.setTimeout(() => controller.abort(), timeoutMs);
     try {
-      return await fetch(input, { ...init, signal: controller.signal });
+      const response = await fetch(input, { ...init, signal: controller.signal });
+      // Keep the deadline active until the full body has been received.
+      // `fetch()` resolves after response headers, so returning that Response
+      // directly would let a stalled body wait forever outside the timeout.
+      const body = await response.arrayBuffer();
+      return new Response(body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+      });
     } catch (error: unknown) {
       if ((error as { name?: string })?.name === 'AbortError') {
         throw new Error('Request timed out');
@@ -146,9 +156,18 @@ export class RelayHttpClient {
     timeoutMs: number,
   ): Promise<Response> {
     let lastError: unknown = null;
+    const deadlineMs = Date.now() + RELAY_HTTP_RETRY_BUDGET_MS;
     for (let attempt = 1; attempt <= RELAY_HTTP_MAX_ATTEMPTS; attempt += 1) {
       try {
-        const response = await this.fetchWithTimeout(input, init, timeoutMs);
+        const remainingMs = deadlineMs - Date.now();
+        if (remainingMs <= 0) {
+          throw lastError ?? new Error('Relay request retry budget exceeded');
+        }
+        const response = await this.fetchWithTimeout(
+          input,
+          init,
+          Math.min(timeoutMs, remainingMs),
+        );
         if (
           TRANSIENT_RELAY_STATUSES.has(response.status)
           && attempt < RELAY_HTTP_MAX_ATTEMPTS
@@ -156,21 +175,16 @@ export class RelayHttpClient {
           lastError = new Error(`Relay returned HTTP ${response.status}`);
           void response.body?.cancel();
         } else {
-          // `fetch()` may resolve after headers and fail only while the caller
-          // consumes JSON. Buffer inside the retry boundary so truncated bodies
-          // from a weak link are replayed just like connect/time-out failures.
-          const body = await response.arrayBuffer();
-          return new Response(body, {
-            status: response.status,
-            statusText: response.statusText,
-            headers: response.headers,
-          });
+          return response;
         }
       } catch (error) {
         lastError = error;
         if (attempt === RELAY_HTTP_MAX_ATTEMPTS) throw error;
       }
       const delayMs = RELAY_HTTP_RETRY_BASE_DELAY_MS * (2 ** (attempt - 1));
+      if (Date.now() + delayMs >= deadlineMs) {
+        throw lastError ?? new Error('Relay request retry budget exceeded');
+      }
       await new Promise(resolve => window.setTimeout(resolve, delayMs));
     }
     throw lastError;

--- a/src/mobile-web/src/services/RemoteSessionManager.ts
+++ b/src/mobile-web/src/services/RemoteSessionManager.ts
@@ -26,6 +26,19 @@ export function isRemoteControlTargetChangedError(
   return value instanceof RemoteControlTargetChangedError;
 }
 
+const RETRYABLE_REMOTE_READ_COMMANDS = new Set([
+  'get_workspace_info',
+  'list_recent_workspaces',
+  'list_assistants',
+  'list_sessions',
+  'get_session_messages',
+  'get_model_catalog',
+  'poll_session',
+  'ping',
+  'get_file_info',
+  'read_file_chunk',
+]);
+
 export interface WorkspaceInfo {
   has_workspace: boolean;
   path?: string;
@@ -198,6 +211,9 @@ export class RemoteSessionManager {
     this.ensureControlTargetCurrent(target);
     const requestId = `req_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
     const cmdWithId = { ...cmd, _request_id: requestId };
+    const commandName = (cmd as { cmd?: unknown }).cmd;
+    const retryable = typeof commandName === 'string'
+      && RETRYABLE_REMOTE_READ_COMMANDS.has(commandName);
     // The QR-paired desktop keeps the proven room channel. Only a switched
     // control target (another same-account device) is reached through the
     // relay device RPC API using the delegated identity.
@@ -208,9 +224,13 @@ export class RemoteSessionManager {
     try {
       let resp: T;
       if (isRemoteTarget && targetDeviceId) {
-        resp = await this.client.sendDeviceRpc<T>(targetDeviceId, cmdWithId);
+        resp = await this.client.sendDeviceRpc<T>(
+          targetDeviceId,
+          cmdWithId,
+          { retryable },
+        );
       } else {
-        resp = await this.client.sendCommand<T>(cmdWithId);
+        resp = await this.client.sendCommand<T>(cmdWithId, { retryable });
       }
       this.ensureControlTargetCurrent(target);
       const respAny = resp as any;

--- a/src/web-ui/src/app/components/RemoteConnectDialog/AccountPanel.tsx
+++ b/src/web-ui/src/app/components/RemoteConnectDialog/AccountPanel.tsx
@@ -30,7 +30,11 @@ import {
 } from 'lucide-react';
 import { useSceneStore } from '@/app/stores/sceneStore';
 import { remoteConnectAPI } from '@/infrastructure/api/service-api/RemoteConnectAPI';
-import type { AccountHint, AccountDeviceInfo } from '@/infrastructure/api/service-api/RemoteConnectAPI';
+import type {
+  AccountHint,
+  AccountDeviceInfo,
+  OnlineDeviceInfo,
+} from '@/infrastructure/api/service-api/RemoteConnectAPI';
 import { RelayDeployWizard } from '@/features/relay-deploy';
 import type { RelayDeployResult } from '@/features/relay-deploy';
 import { configAPI } from '@/infrastructure/api/service-api/ConfigAPI';
@@ -39,7 +43,10 @@ import { api } from '@/infrastructure/api/service-api/ApiClient';
 import { usePeerDeviceMode } from '@/infrastructure/peer-device/peerDeviceContextState';
 import { useAccountSyncStore, ensureAccountSyncProgressListener } from '@/infrastructure/account/accountSyncStore';
 import type { AccountSyncPhase } from '@/infrastructure/account/accountSyncStore';
-import { isAccountAuthFailure } from '@/infrastructure/account/accountErrorUtils';
+import {
+  isAccountAuthFailure,
+  isRelayUnreachable,
+} from '@/infrastructure/account/accountErrorUtils';
 import { useNotification } from '@/shared/notification-system';
 import { copyTextToClipboard } from '@/shared/utils/textSelection';
 import { createLogger } from '@/shared/utils/logger';
@@ -48,6 +55,36 @@ import './AccountPanel.scss';
 const log = createLogger('AccountPanel');
 
 const DEVICE_POLL_FALLBACK_MS = 30_000;
+const DEVICE_CONNECT_MAX_ATTEMPTS = 3;
+const DEVICE_LIST_FAILURE_THRESHOLD = 2;
+
+async function connectDevicesWithRetry(
+  isCurrent: () => boolean,
+): Promise<OnlineDeviceInfo[]> {
+  let lastError: unknown = null;
+  for (let attempt = 1; attempt <= DEVICE_CONNECT_MAX_ATTEMPTS; attempt += 1) {
+    if (!isCurrent()) {
+      throw new Error('account context changed');
+    }
+    try {
+      return await remoteConnectAPI.accountConnectDevices();
+    } catch (error) {
+      lastError = error;
+      if (isAccountAuthFailure(error)
+        || !isRelayUnreachable(error)
+        || attempt === DEVICE_CONNECT_MAX_ATTEMPTS) {
+        throw error;
+      }
+      const delayMs = 500 * (2 ** (attempt - 1));
+      log.warn(
+        `Device connection attempt ${attempt}/${DEVICE_CONNECT_MAX_ATTEMPTS} failed; retrying`,
+        error,
+      );
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+    }
+  }
+  throw lastError;
+}
 
 function parseRelayServer(value: string): URL | null {
   try {
@@ -172,7 +209,7 @@ export const AccountPanel: React.FC<AccountPanelProps> = ({
 
   const [devices, setDevices] = useState<AccountDeviceInfo[]>([]);
   const [localDeviceId, setLocalDeviceId] = useState<string | null>(null);
-  /** Only true after a successful list_devices response; gates the empty-state copy. */
+  /** True after either device presence or a list_devices response is available. */
   const [devicesReady, setDevicesReady] = useState(false);
   const [relayError, setRelayError] = useState<string | null>(null);
   /** Relay URL of the current account session, shown in the devices view. */
@@ -185,6 +222,11 @@ export const AccountPanel: React.FC<AccountPanelProps> = ({
   const mountedRef = useRef(false);
   const accountEpochRef = useRef(0);
   const refreshRequestRef = useRef(0);
+  /** Allow at most one list_devices request per account epoch. */
+  const refreshInFlightRef = useRef<{ epoch: number; requestId: number } | null>(null);
+  /** A working device-routing WS is independent evidence that Relay is reachable. */
+  const deviceRoutingReadyRef = useRef(false);
+  const deviceListFailureCountRef = useRef(0);
   /** Prevent overlapping background syncs from rapid clicks. */
   const syncInFlightRef = useRef(false);
   /** Opaque backend owner ID for the memory-only overwrite decision. */
@@ -196,6 +238,9 @@ export const AccountPanel: React.FC<AccountPanelProps> = ({
   const invalidateAccountRequests = useCallback(() => {
     accountEpochRef.current += 1;
     refreshRequestRef.current += 1;
+    refreshInFlightRef.current = null;
+    deviceRoutingReadyRef.current = false;
+    deviceListFailureCountRef.current = 0;
     setActiveAccountEpoch(null);
     return accountEpochRef.current;
   }, []);
@@ -220,6 +265,9 @@ export const AccountPanel: React.FC<AccountPanelProps> = ({
     setRelayError(null);
     setAccountRelayUrl('');
     setCopiedServerUrl(false);
+    refreshInFlightRef.current = null;
+    deviceRoutingReadyRef.current = false;
+    deviceListFailureCountRef.current = 0;
     if (refreshTimer.current) { clearInterval(refreshTimer.current); refreshTimer.current = null; }
   }, []);
 
@@ -256,7 +304,12 @@ export const AccountPanel: React.FC<AccountPanelProps> = ({
 
   const refreshDevices = useCallback(async () => {
     const epoch = accountEpochRef.current;
+    if (refreshInFlightRef.current?.epoch === epoch) {
+      log.debug('Device list refresh already in flight; coalescing duplicate request');
+      return;
+    }
     const requestId = ++refreshRequestRef.current;
+    refreshInFlightRef.current = { epoch, requestId };
     const isCurrent = () => (
       isAccountEpochCurrent(epoch) && refreshRequestRef.current === requestId
     );
@@ -273,37 +326,29 @@ export const AccountPanel: React.FC<AccountPanelProps> = ({
       setDevices(list);
       setDevicesReady(true);
       setRelayError(null);
+      deviceListFailureCountRef.current = 0;
     } catch (e) {
       if (!isCurrent()) return;
       log.warn('refreshDevices failed', e);
       if (isAccountAuthFailure(e)) {
         await handleSessionExpired(e, epoch);
       } else {
-        markRelayUnreachable();
+        deviceListFailureCountRef.current += 1;
+        // list_devices is an HTTP snapshot while account device routing uses
+        // WebSocket. Keep the last/presence-derived list when WS is healthy;
+        // one failed snapshot must not be reported as a total Relay outage.
+        if (!deviceRoutingReadyRef.current
+          && deviceListFailureCountRef.current >= DEVICE_LIST_FAILURE_THRESHOLD) {
+          markRelayUnreachable();
+        }
+      }
+    } finally {
+      if (refreshInFlightRef.current?.epoch === epoch
+        && refreshInFlightRef.current.requestId === requestId) {
+        refreshInFlightRef.current = null;
       }
     }
   }, [localDeviceId, handleSessionExpired, isAccountEpochCurrent, markRelayUnreachable]);
-
-  const handleRetryConnect = useCallback(async () => {
-    const epoch = accountEpochRef.current;
-    setLoading(true);
-    setRelayError(null);
-    try {
-      await remoteConnectAPI.accountConnectDevices();
-      if (!isAccountEpochCurrent(epoch)) return;
-      await refreshDevices();
-    } catch (err) {
-      log.warn('retry connect failed', err);
-      if (!isAccountEpochCurrent(epoch)) return;
-      if (isAccountAuthFailure(err)) {
-        await handleSessionExpired(err, epoch);
-        return;
-      }
-      markRelayUnreachable();
-    } finally {
-      if (isAccountEpochCurrent(epoch)) setLoading(false);
-    }
-  }, [handleSessionExpired, isAccountEpochCurrent, markRelayUnreachable, refreshDevices]);
 
   const applyPresenceOnline = useCallback((onlineDevices: Array<{ device_id: string; device_name: string }>) => {
     const onlineIds = new Set(onlineDevices.map(d => d.device_id));
@@ -331,6 +376,39 @@ export const AccountPanel: React.FC<AccountPanelProps> = ({
     });
   }, []);
 
+  const handleRetryConnect = useCallback(async () => {
+    const epoch = accountEpochRef.current;
+    setLoading(true);
+    setRelayError(null);
+    try {
+      const onlineDevices = await connectDevicesWithRetry(
+        () => isAccountEpochCurrent(epoch),
+      );
+      if (!isAccountEpochCurrent(epoch)) return;
+      deviceRoutingReadyRef.current = true;
+      deviceListFailureCountRef.current = 0;
+      applyPresenceOnline(onlineDevices);
+      setDevicesReady(true);
+      await refreshDevices();
+    } catch (err) {
+      log.warn('retry connect failed', err);
+      if (!isAccountEpochCurrent(epoch)) return;
+      if (isAccountAuthFailure(err)) {
+        await handleSessionExpired(err, epoch);
+        return;
+      }
+      markRelayUnreachable();
+    } finally {
+      if (isAccountEpochCurrent(epoch)) setLoading(false);
+    }
+  }, [
+    applyPresenceOnline,
+    handleSessionExpired,
+    isAccountEpochCurrent,
+    markRelayUnreachable,
+    refreshDevices,
+  ]);
+
   /** Latest refreshDevices for the polling interval (avoids stale closures). */
   const refreshDevicesRef = useRef(refreshDevices);
   refreshDevicesRef.current = refreshDevices;
@@ -349,8 +427,15 @@ export const AccountPanel: React.FC<AccountPanelProps> = ({
   const initializeDevices = useCallback(async () => {
     const epoch = accountEpochRef.current;
     try {
-      await remoteConnectAPI.accountConnectDevices();
+      const onlineDevices = await connectDevicesWithRetry(
+        () => isAccountEpochCurrent(epoch),
+      );
       if (!isAccountEpochCurrent(epoch)) return;
+      deviceRoutingReadyRef.current = true;
+      deviceListFailureCountRef.current = 0;
+      applyPresenceOnline(onlineDevices);
+      setDevicesReady(true);
+      setRelayError(null);
       // Re-read after AuthOk may have adopted the account-bound device_id.
       try {
         const info = await remoteConnectAPI.getDeviceInfo();
@@ -367,11 +452,19 @@ export const AccountPanel: React.FC<AccountPanelProps> = ({
         return;
       }
       markRelayUnreachable();
+      return;
     }
     if (!isAccountEpochCurrent(epoch)) return;
     void refreshDevices();
     startDevicePolling();
-  }, [handleSessionExpired, isAccountEpochCurrent, markRelayUnreachable, refreshDevices, startDevicePolling]);
+  }, [
+    applyPresenceOnline,
+    handleSessionExpired,
+    isAccountEpochCurrent,
+    markRelayUnreachable,
+    refreshDevices,
+    startDevicePolling,
+  ]);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -451,6 +544,16 @@ export const AccountPanel: React.FC<AccountPanelProps> = ({
       'account://device-presence',
       (payload) => {
         if (isAccountEpochCurrent(subscribedEpoch) && payload?.devices) {
+          deviceRoutingReadyRef.current = payload.devices.length > 0;
+          if (deviceRoutingReadyRef.current) {
+            deviceListFailureCountRef.current = 0;
+            setDevicesReady(true);
+            setRelayError(null);
+          } else {
+            // Start a fresh debounce window after routing loss; HTTP failures
+            // observed while WS was healthy must not count against it.
+            deviceListFailureCountRef.current = 0;
+          }
           applyPresenceOnline(payload.devices);
         }
       },
@@ -492,12 +595,6 @@ export const AccountPanel: React.FC<AccountPanelProps> = ({
       useAccountSyncStore.getState().operationId === operationId
     );
     info(t('accountLogin.syncStarted'));
-
-    // Connect device presence immediately so the device list can populate
-    // while the heavier settings/session sync continues.
-    void remoteConnectAPI.accountConnectDevices().catch((err) => {
-      log.warn('accountConnectDevices failed at sync start', err);
-    });
 
     void (async () => {
       try {

--- a/src/web-ui/src/app/components/RemoteConnectDialog/AccountPanel.tsx
+++ b/src/web-ui/src/app/components/RemoteConnectDialog/AccountPanel.tsx
@@ -643,40 +643,15 @@ export const AccountPanel: React.FC<AccountPanelProps> = ({
           if (!isCurrentOperation()) return;
         }
         const wp = workspacePath || '/';
-        const maxAttempts = 5;
-        let result: Awaited<ReturnType<typeof remoteConnectAPI.accountAutoSync>> | null = null;
-        let lastError: unknown = null;
-        for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-          if (!isCurrentOperation()) return;
-          try {
-            result = await remoteConnectAPI.accountAutoSync(
-              isFirstLogin,
-              wp,
-              configJson,
-              operationId,
-            );
-            if (!isCurrentOperation()) return;
-            lastError = null;
-            break;
-          } catch (e) {
-            if (!isCurrentOperation()) return;
-            lastError = e;
-            log.warn(`Auto-sync attempt ${attempt}/${maxAttempts} failed`, e);
-            if (isNonRetryableSyncError(e)) {
-              break;
-            }
-            if (attempt < maxAttempts) {
-              info(t('accountLogin.syncRetrying', { attempt, max: maxAttempts }));
-              await new Promise((resolve) => setTimeout(resolve, 2000 * attempt));
-              if (!isCurrentOperation()) return;
-            }
-          }
-        }
-        if (!result) {
-          throw lastError instanceof Error
-            ? lastError
-            : new Error(String(lastError ?? 'auto-sync failed'));
-        }
+        // AccountClient owns transient Relay retries with one shared deadline.
+        // Replaying this entire workflow would also repeat deterministic local
+        // config/filesystem work and multiply the transport retry budget.
+        const result = await remoteConnectAPI.accountAutoSync(
+          isFirstLogin,
+          wp,
+          configJson,
+          operationId,
+        );
         if (!isCurrentOperation()) return;
         log.info(
           `Auto-sync done: settings=${result.settings_synced} exported=${result.sessions_exported}`,

--- a/src/web-ui/src/app/components/RemoteConnectDialog/AccountPanel.tsx
+++ b/src/web-ui/src/app/components/RemoteConnectDialog/AccountPanel.tsx
@@ -55,8 +55,9 @@ import './AccountPanel.scss';
 const log = createLogger('AccountPanel');
 
 const DEVICE_POLL_FALLBACK_MS = 30_000;
-const DEVICE_CONNECT_MAX_ATTEMPTS = 3;
-const DEVICE_LIST_FAILURE_THRESHOLD = 2;
+const DEVICE_CONNECT_MAX_ATTEMPTS = 5;
+const DEVICE_LIST_FAILURE_THRESHOLD = 3;
+const ACCOUNT_TRANSITION_MAX_ATTEMPTS = 4;
 
 async function connectDevicesWithRetry(
   isCurrent: () => boolean,
@@ -104,12 +105,40 @@ function parseRelayServer(value: string): URL | null {
 }
 
 async function cancelPendingLoginWithRetry(pendingLoginId: string): Promise<boolean> {
-  try {
-    return await remoteConnectAPI.accountCancelPendingLogin(pendingLoginId);
-  } catch (firstError) {
-    log.warn('pending login cancel response was ambiguous; retrying', firstError);
-    return await remoteConnectAPI.accountCancelPendingLogin(pendingLoginId);
+  let lastError: unknown = null;
+  for (let attempt = 1; attempt <= ACCOUNT_TRANSITION_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      return await remoteConnectAPI.accountCancelPendingLogin(pendingLoginId);
+    } catch (error) {
+      lastError = error;
+      if (attempt === ACCOUNT_TRANSITION_MAX_ATTEMPTS) break;
+      log.warn(
+        `Pending login cancel attempt ${attempt}/${ACCOUNT_TRANSITION_MAX_ATTEMPTS} was ambiguous; retrying`,
+        error,
+      );
+      await new Promise(resolve => setTimeout(resolve, 250 * (2 ** (attempt - 1))));
+    }
   }
+  throw lastError;
+}
+
+async function finalizePendingLoginWithRetry(pendingLoginId: string): Promise<void> {
+  let lastError: unknown = null;
+  for (let attempt = 1; attempt <= ACCOUNT_TRANSITION_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      await remoteConnectAPI.accountFinalizeLogin(pendingLoginId);
+      return;
+    } catch (error) {
+      lastError = error;
+      if (attempt === ACCOUNT_TRANSITION_MAX_ATTEMPTS) break;
+      log.warn(
+        `Pending login finalize attempt ${attempt}/${ACCOUNT_TRANSITION_MAX_ATTEMPTS} was ambiguous; retrying`,
+        error,
+      );
+      await new Promise(resolve => setTimeout(resolve, 250 * (2 ** (attempt - 1))));
+    }
+  }
+  throw lastError;
 }
 
 /** Quota / payload-limit failures will not succeed on blind retry. */
@@ -614,7 +643,7 @@ export const AccountPanel: React.FC<AccountPanelProps> = ({
           if (!isCurrentOperation()) return;
         }
         const wp = workspacePath || '/';
-        const maxAttempts = 3;
+        const maxAttempts = 5;
         let result: Awaited<ReturnType<typeof remoteConnectAPI.accountAutoSync>> | null = null;
         let lastError: unknown = null;
         for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
@@ -797,16 +826,9 @@ export const AccountPanel: React.FC<AccountPanelProps> = ({
     setLoading(true);
     setError(null);
     try {
-      try {
-        await remoteConnectAPI.accountFinalizeLogin(pendingLoginId);
-      } catch (firstError) {
-        if (!isAccountEpochCurrent(epoch)) return;
-        // The backend commit may have succeeded even when its transport
-        // response was lost. Retrying the same opaque owner is idempotent and
-        // cannot authorize a replacement account generation.
-        log.warn('pending login finalize response was ambiguous; retrying', firstError);
-        await remoteConnectAPI.accountFinalizeLogin(pendingLoginId);
-      }
+      // The backend records the exact pending owner after commit, so retrying
+      // the same opaque owner remains fenced from a replacement account.
+      await finalizePendingLoginWithRetry(pendingLoginId);
       if (!isAccountEpochCurrent(epoch)) return;
       if (pendingLoginIdRef.current === pendingLoginId) {
         pendingLoginIdRef.current = null;

--- a/src/web-ui/src/app/components/RemoteConnectDialog/AccountPanel.tsx
+++ b/src/web-ui/src/app/components/RemoteConnectDialog/AccountPanel.tsx
@@ -56,6 +56,7 @@ const log = createLogger('AccountPanel');
 
 const DEVICE_POLL_FALLBACK_MS = 30_000;
 const DEVICE_CONNECT_MAX_ATTEMPTS = 5;
+const DEVICE_CONNECT_RECOVERY_INTERVAL_MS = 30_000;
 const DEVICE_LIST_FAILURE_THRESHOLD = 3;
 const ACCOUNT_TRANSITION_MAX_ATTEMPTS = 4;
 
@@ -256,6 +257,8 @@ export const AccountPanel: React.FC<AccountPanelProps> = ({
   /** A working device-routing WS is independent evidence that Relay is reachable. */
   const deviceRoutingReadyRef = useRef(false);
   const deviceListFailureCountRef = useRef(0);
+  /** Coalesce manual and background recovery so they never replace each other's WS. */
+  const deviceReconnectInFlightRef = useRef(false);
   /** Prevent overlapping background syncs from rapid clicks. */
   const syncInFlightRef = useRef(false);
   /** Opaque backend owner ID for the memory-only overwrite decision. */
@@ -405,39 +408,6 @@ export const AccountPanel: React.FC<AccountPanelProps> = ({
     });
   }, []);
 
-  const handleRetryConnect = useCallback(async () => {
-    const epoch = accountEpochRef.current;
-    setLoading(true);
-    setRelayError(null);
-    try {
-      const onlineDevices = await connectDevicesWithRetry(
-        () => isAccountEpochCurrent(epoch),
-      );
-      if (!isAccountEpochCurrent(epoch)) return;
-      deviceRoutingReadyRef.current = true;
-      deviceListFailureCountRef.current = 0;
-      applyPresenceOnline(onlineDevices);
-      setDevicesReady(true);
-      await refreshDevices();
-    } catch (err) {
-      log.warn('retry connect failed', err);
-      if (!isAccountEpochCurrent(epoch)) return;
-      if (isAccountAuthFailure(err)) {
-        await handleSessionExpired(err, epoch);
-        return;
-      }
-      markRelayUnreachable();
-    } finally {
-      if (isAccountEpochCurrent(epoch)) setLoading(false);
-    }
-  }, [
-    applyPresenceOnline,
-    handleSessionExpired,
-    isAccountEpochCurrent,
-    markRelayUnreachable,
-    refreshDevices,
-  ]);
-
   /** Latest refreshDevices for the polling interval (avoids stale closures). */
   const refreshDevicesRef = useRef(refreshDevices);
   refreshDevicesRef.current = refreshDevices;
@@ -451,6 +421,77 @@ export const AccountPanel: React.FC<AccountPanelProps> = ({
       DEVICE_POLL_FALLBACK_MS,
     );
   }, []);
+
+  const attemptDeviceReconnect = useCallback(async (showLoading: boolean) => {
+    if (deviceReconnectInFlightRef.current) {
+      log.debug('Device routing recovery already in flight; coalescing duplicate request');
+      return;
+    }
+    const epoch = accountEpochRef.current;
+    deviceReconnectInFlightRef.current = true;
+    if (showLoading) {
+      setLoading(true);
+      setRelayError(null);
+    }
+    try {
+      const onlineDevices = await connectDevicesWithRetry(
+        () => isAccountEpochCurrent(epoch),
+      );
+      if (!isAccountEpochCurrent(epoch)) return;
+      deviceRoutingReadyRef.current = true;
+      deviceListFailureCountRef.current = 0;
+      applyPresenceOnline(onlineDevices);
+      setDevicesReady(true);
+      setRelayError(null);
+      try {
+        const info = await remoteConnectAPI.getDeviceInfo();
+        if (!isAccountEpochCurrent(epoch)) return;
+        setLocalDeviceId(info.device_id);
+      } catch (error) {
+        log.warn('getDeviceInfo after reconnect failed', error);
+      }
+      if (!isAccountEpochCurrent(epoch)) return;
+      await refreshDevices();
+      startDevicePolling();
+    } catch (err) {
+      log.warn(
+        showLoading ? 'manual device reconnect failed' : 'background device reconnect failed',
+        err,
+      );
+      if (!isAccountEpochCurrent(epoch)) return;
+      if (isAccountAuthFailure(err)) {
+        await handleSessionExpired(err, epoch);
+        return;
+      }
+      markRelayUnreachable();
+    } finally {
+      deviceReconnectInFlightRef.current = false;
+      if (showLoading && isAccountEpochCurrent(epoch)) setLoading(false);
+    }
+  }, [
+    applyPresenceOnline,
+    handleSessionExpired,
+    isAccountEpochCurrent,
+    markRelayUnreachable,
+    refreshDevices,
+    startDevicePolling,
+  ]);
+
+  const handleRetryConnect = useCallback(() => {
+    void attemptDeviceReconnect(true);
+  }, [attemptDeviceReconnect]);
+
+  // Initial dial failures have no RelayClient instance to run its built-in
+  // reconnect loop. Keep recovering in the background while this account view
+  // is active; once a socket succeeds, RelayClient owns subsequent reconnects.
+  useEffect(() => {
+    if (activeAccountEpoch === null || !relayError) return undefined;
+    const timer = setInterval(
+      () => { void attemptDeviceReconnect(false); },
+      DEVICE_CONNECT_RECOVERY_INTERVAL_MS,
+    );
+    return () => clearInterval(timer);
+  }, [activeAccountEpoch, attemptDeviceReconnect, relayError]);
 
   /** Connect presence + load the device list for an active account session. */
   const initializeDevices = useCallback(async () => {

--- a/src/web-ui/src/app/components/RemoteConnectDialog/RemoteConnectDialog.contract.test.ts
+++ b/src/web-ui/src/app/components/RemoteConnectDialog/RemoteConnectDialog.contract.test.ts
@@ -85,6 +85,18 @@ describe('Remote Connect safety contracts', () => {
     expect(backgroundSync).not.toContain('accountConnectDevices');
   });
 
+  it('keeps recovering an initial device-routing failure without overlapping attempts', () => {
+    const recoveryFlow = accountPanelSource.slice(
+      accountPanelSource.indexOf('const attemptDeviceReconnect'),
+      accountPanelSource.indexOf('/** Connect presence + load the device list'),
+    );
+
+    expect(recoveryFlow).toContain('deviceReconnectInFlightRef.current');
+    expect(recoveryFlow).toContain('DEVICE_CONNECT_RECOVERY_INTERVAL_MS');
+    expect(recoveryFlow).toContain('attemptDeviceReconnect(false)');
+    expect(recoveryFlow).toContain('startDevicePolling()');
+  });
+
   it('delegates transient retries without replaying the complete account sync workflow', () => {
     const backgroundSync = accountPanelSource.slice(
       accountPanelSource.indexOf('const startBackgroundSync'),

--- a/src/web-ui/src/app/components/RemoteConnectDialog/RemoteConnectDialog.contract.test.ts
+++ b/src/web-ui/src/app/components/RemoteConnectDialog/RemoteConnectDialog.contract.test.ts
@@ -178,12 +178,13 @@ describe('Remote Connect safety contracts', () => {
   });
 
   it('retries an ambiguous finalize response with the same opaque owner', () => {
-    const finalizeFlow = accountPanelSource.slice(
-      accountPanelSource.indexOf('const finalizeAndSync'),
-      accountPanelSource.indexOf('const handleConfirmOverwrite'),
+    const retryHelper = accountPanelSource.slice(
+      accountPanelSource.indexOf('async function finalizePendingLoginWithRetry'),
+      accountPanelSource.indexOf('/** Quota / payload-limit failures'),
     );
-    expect(finalizeFlow.match(/accountFinalizeLogin\(pendingLoginId\)/g)).toHaveLength(2);
-    expect(finalizeFlow).toContain('pending login finalize response was ambiguous; retrying');
+    expect(retryHelper).toContain('ACCOUNT_TRANSITION_MAX_ATTEMPTS');
+    expect(retryHelper).toContain('accountFinalizeLogin(pendingLoginId)');
+    expect(retryHelper).toContain('was ambiguous; retrying');
   });
 
   it('invalidates the prior background sync before starting a replacement login', () => {

--- a/src/web-ui/src/app/components/RemoteConnectDialog/RemoteConnectDialog.contract.test.ts
+++ b/src/web-ui/src/app/components/RemoteConnectDialog/RemoteConnectDialog.contract.test.ts
@@ -85,6 +85,17 @@ describe('Remote Connect safety contracts', () => {
     expect(backgroundSync).not.toContain('accountConnectDevices');
   });
 
+  it('delegates transient retries without replaying the complete account sync workflow', () => {
+    const backgroundSync = accountPanelSource.slice(
+      accountPanelSource.indexOf('const startBackgroundSync'),
+      accountPanelSource.indexOf('const handleRetrySync'),
+    );
+
+    expect(backgroundSync).toContain('AccountClient owns transient Relay retries');
+    expect(backgroundSync).not.toContain('for (let attempt');
+    expect(backgroundSync.match(/accountAutoSync/g)).toHaveLength(1);
+  });
+
   it('binds overwrite finalize and cleanup to an opaque pending login id', () => {
     expect(accountPanelSource).toContain('pendingLoginIdRef.current = result.pending_login_id');
     expect(accountPanelSource).toContain('accountFinalizeLogin(pendingLoginId)');

--- a/src/web-ui/src/app/components/RemoteConnectDialog/RemoteConnectDialog.contract.test.ts
+++ b/src/web-ui/src/app/components/RemoteConnectDialog/RemoteConnectDialog.contract.test.ts
@@ -55,6 +55,36 @@ describe('Remote Connect safety contracts', () => {
     expect(invalidation).toContain('setActiveAccountEpoch(null)');
   });
 
+  it('debounces transient device-list failures while device routing remains healthy', () => {
+    const refreshFlow = accountPanelSource.slice(
+      accountPanelSource.indexOf('const refreshDevices'),
+      accountPanelSource.indexOf('const applyPresenceOnline'),
+    );
+
+    expect(refreshFlow).toContain('refreshInFlightRef.current?.epoch === epoch');
+    expect(refreshFlow).toContain('deviceListFailureCountRef.current += 1');
+    expect(refreshFlow).toContain('!deviceRoutingReadyRef.current');
+    expect(refreshFlow).toContain('DEVICE_LIST_FAILURE_THRESHOLD');
+    expect(refreshFlow.indexOf('!deviceRoutingReadyRef.current')).toBeLessThan(
+      refreshFlow.indexOf('markRelayUnreachable()'),
+    );
+  });
+
+  it('retries initial device routing without starting a duplicate sync-time connection', () => {
+    const retryHelper = accountPanelSource.slice(
+      accountPanelSource.indexOf('async function connectDevicesWithRetry'),
+      accountPanelSource.indexOf('function parseRelayServer'),
+    );
+    const backgroundSync = accountPanelSource.slice(
+      accountPanelSource.indexOf('const startBackgroundSync'),
+      accountPanelSource.indexOf('const handleRetrySync'),
+    );
+
+    expect(retryHelper).toContain('DEVICE_CONNECT_MAX_ATTEMPTS');
+    expect(retryHelper).toContain('isRelayUnreachable(error)');
+    expect(backgroundSync).not.toContain('accountConnectDevices');
+  });
+
   it('binds overwrite finalize and cleanup to an opaque pending login id', () => {
     expect(accountPanelSource).toContain('pendingLoginIdRef.current = result.pending_login_id');
     expect(accountPanelSource).toContain('accountFinalizeLogin(pendingLoginId)');

--- a/src/web-ui/src/app/components/RemoteConnectDialog/RemoteSessionManager.routing.test.ts
+++ b/src/web-ui/src/app/components/RemoteConnectDialog/RemoteSessionManager.routing.test.ts
@@ -93,6 +93,7 @@ describe('mobile RemoteSessionManager target routing', () => {
     expect(remoteRequest).toHaveBeenCalledWith(
       'remote-device',
       expect.objectContaining({ cmd: 'get_workspace_info' }),
+      { retryable: true },
     );
     expect(homeRequest).not.toHaveBeenCalled();
   });
@@ -172,6 +173,7 @@ describe('mobile RemoteSessionManager target routing', () => {
         cmd: 'read_file_chunk',
         offset: 0,
       }),
+      { retryable: true },
     );
   });
 });

--- a/src/web-ui/src/infrastructure/account/accountErrorUtils.test.ts
+++ b/src/web-ui/src/infrastructure/account/accountErrorUtils.test.ts
@@ -22,6 +22,15 @@ describe('isRelayUnreachable', () => {
     expect(isRelayUnreachable(new Error('failed to connect to relay'))).toBe(true);
   });
 
+  it('detects transient WebSocket upgrade and handshake failures', () => {
+    expect(isRelayUnreachable(new Error('dial wss://relay/ws: HTTP error: 502 Bad Gateway')))
+      .toBe(true);
+    expect(isRelayUnreachable(new Error('HTTP 503 Service Unavailable'))).toBe(true);
+    expect(isRelayUnreachable(new Error('WebSocket protocol error: Handshake not finished')))
+      .toBe(true);
+    expect(isRelayUnreachable(new Error('TLS stream ended with unexpected EOF'))).toBe(true);
+  });
+
   it('does not treat auth failures as unreachable', () => {
     expect(isRelayUnreachable(new Error('HTTP 401 Unauthorized'))).toBe(false);
     expect(isRelayUnreachable(new Error('invalid or expired token'))).toBe(false);
@@ -30,5 +39,8 @@ describe('isRelayUnreachable', () => {
   it('does not treat unrelated application errors as unreachable', () => {
     expect(isRelayUnreachable(new Error('not logged in'))).toBe(false);
     expect(isRelayUnreachable(new Error('remote connect service not initialized'))).toBe(false);
+    expect(isRelayUnreachable(new Error('dial wss://relay/ws: HTTP error: 404 Not Found')))
+      .toBe(false);
+    expect(isRelayUnreachable(new Error('invalid certificate: UnknownIssuer'))).toBe(false);
   });
 });

--- a/src/web-ui/src/infrastructure/account/accountErrorUtils.ts
+++ b/src/web-ui/src/infrastructure/account/accountErrorUtils.ts
@@ -23,8 +23,13 @@ export function isRelayUnreachable(error: unknown): boolean {
     return false;
   }
   const msg = errorMessage(error);
+  // WebSocket upgrades surface proxy/node instability as an HTTP handshake
+  // status rather than a generic network error. Retry only transient statuses;
+  // persistent 4xx responses (for example a missing /ws route) stay terminal.
+  const hasTransientHttpStatus = /\b(?:408|425|429|500|502|503|504)\b/.test(msg);
   return (
-    msg.includes('connection refused')
+    hasTransientHttpStatus
+    || msg.includes('connection refused')
     || msg.includes('connect error')
     || msg.includes('connection reset')
     || msg.includes('timed out')
@@ -40,5 +45,15 @@ export function isRelayUnreachable(error: unknown): boolean {
     || msg.includes('failed to connect')
     || msg.includes('empty reply')
     || msg.includes('connection closed')
+    || msg.includes('bad gateway')
+    || msg.includes('service unavailable')
+    || msg.includes('gateway timeout')
+    || msg.includes('temporarily unavailable')
+    || msg.includes('unexpected eof')
+    || msg.includes('unexpected end of file')
+    || msg.includes('handshake not finished')
+    || msg.includes('handshake incomplete')
+    || msg.includes('broken pipe')
+    || msg.includes('socket hang up')
   );
 }

--- a/src/web-ui/src/infrastructure/api/adapters/peer-device-adapter.test.ts
+++ b/src/web-ui/src/infrastructure/api/adapters/peer-device-adapter.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   PEER_MUTATION_REQUEST_TIMEOUT_MS,
+  PEER_READ_MAX_RETRIES,
   PEER_READ_REQUEST_TIMEOUT_MS,
+  PEER_RETRY_BASE_DELAY_MS,
   PeerDeviceTransportAdapter,
   isPeerLocalOnlyCommand,
   isPeerRetryableIdempotentMutation,
@@ -317,10 +319,11 @@ describe('PeerDeviceTransportAdapter queue', () => {
       );
 
       await vi.advanceTimersByTimeAsync(
-        (PEER_READ_REQUEST_TIMEOUT_MS * 3) + 1500,
+        (PEER_READ_REQUEST_TIMEOUT_MS * (PEER_READ_MAX_RETRIES + 1))
+          + (PEER_RETRY_BASE_DELAY_MS * ((2 ** PEER_READ_MAX_RETRIES) - 1)),
       );
       await rejection;
-      expect(deviceRpc).toHaveBeenCalledTimes(3);
+      expect(deviceRpc).toHaveBeenCalledTimes(PEER_READ_MAX_RETRIES + 1);
     } finally {
       vi.useRealTimers();
     }

--- a/src/web-ui/src/infrastructure/api/adapters/peer-device-adapter.ts
+++ b/src/web-ui/src/infrastructure/api/adapters/peer-device-adapter.ts
@@ -248,8 +248,8 @@ export function peerInvokePriorityFor(command: string): PeerInvokePriority {
 export const PEER_HOST_INVOKE_MAX_CONCURRENT = 4;
 export const PEER_READ_REQUEST_TIMEOUT_MS = 10_000;
 export const PEER_MUTATION_REQUEST_TIMEOUT_MS = 30_000;
-export const PEER_READ_MAX_RETRIES = 2;
-export const PEER_IDEMPOTENT_MUTATION_MAX_RETRIES = 2;
+export const PEER_READ_MAX_RETRIES = 4;
+export const PEER_IDEMPOTENT_MUTATION_MAX_RETRIES = 4;
 export const PEER_RETRY_BASE_DELAY_MS = 500;
 
 interface PeerRpcPolicy {

--- a/src/web-ui/src/infrastructure/peer-device/README.md
+++ b/src/web-ui/src/infrastructure/peer-device/README.md
@@ -75,7 +75,7 @@ Controller-side React/transport layer for Peer Device Mode. Architecture:
 
 13. **Weak links use bounded, idempotency-aware recovery.** Default Peer
     HostInvoke concurrency is four with one slot reserved from normal/low
-    traffic. Read-only commands have a real 10s deadline and two
+    traffic. Read-only commands have a real 10s deadline and four
     exponential-backoff retries. Mutations have a 30s deadline and are never
     replayed automatically without an idempotency contract. Dialog submission
     is the explicit exception: `start_dialog_turn` and


### PR DESCRIPTION
## Summary

- reuse a shared Relay HTTP connection pool and retry safe reads, buffered response bodies, and idempotent writes with exponential backoff (5 attempts)
- make account login token issuance replay-safe with a persisted `request_id`; older relays remain single-shot through an advertised capability flag
- make Page freeze replay-safe by persisting `source_upload_id`, then retry Page manifest checks, uploads, freeze, deploy, metadata updates, and unpublish
- increase device initial-connect, account transition, auto-sync, Peer read, and idempotent dialog-submit retry budgets
- add startup device-routing retries; established Relay WebSockets still reconnect indefinitely with half-open detection
- add mobile-web retries for pairing setup, delegated identity, device lists, peer probes, and read-only session/workspace/file requests, including truncated response bodies
- keep ordinary mutations, destructive deletes, and opaque device RPC commands single-shot unless they have a verified idempotency contract

## Why

Diagnostics showed successful account login and Relay WebSocket heartbeats while individual HTTP calls through a local proxy intermittently failed. A single `/api/devices` failure could then be presented as a total Relay outage, and a response body cut off after HTTP headers was not previously inside the retry boundary. This change makes the account lifecycle recover according to the actual idempotency of each operation without duplicating user actions.

## Retry behavior

- one safe HTTP operation: up to 5 attempts with bounded exponential backoff
- device initial connect: up to 5 attempts; periodic device refresh continues afterward
- account finalize/cancel IPC ambiguity: up to 4 attempts using the same opaque owner
- account auto-sync: up to 5 operation attempts; non-retryable quota/payload errors still stop immediately
- Peer read and capability-gated dialog submission: 4 retries after the first attempt
- established Relay WebSocket: reconnects continuously with backoff; it is not limited to 5 attempts

## Relay deployment

Relay server redeployment is required for the new login and Page freeze idempotency contracts. SQLite migrations for `auth_tokens.request_id` and `page_versions.source_upload_id` run automatically on startup. New clients remain compatible with older relays and do not retry the two ambiguous mutations unless the relay advertises support.

## Verification

- `cargo check --workspace`
- `cargo test -p bitfun-relay-service --lib` (94 passed)
- `cargo test -p bitfun-services-integrations --features remote-connect remote_connect:: --lib` (84 passed)
- `pnpm run type-check:web`
- `pnpm --dir src/web-ui run test:run src/infrastructure/api/adapters/peer-device-adapter.test.ts src/app/components/RemoteConnectDialog/RemoteConnectDialog.contract.test.ts` (32 passed)
- `pnpm --dir src/mobile-web run type-check`
- `pnpm run build:mobile-web`
- `pnpm run check:repo-hygiene`
- `git diff --check`

Manual pairing/reconnect verification was not performed because no paired physical mobile browser was available in this environment; automated mobile type-check/build and Relay pairing/reconnect tests passed.

AI-assisted: yes. Testing level: full Relay unit tests, focused Remote Connect/Web tests, mobile production build, and workspace compile check.