### PR TITLE
feat(web-ui): improve Canvas streaming and subagent badge alignment

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.scss
+++ b/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.scss
@@ -313,10 +313,6 @@
     transition: opacity $motion-fast $easing-standard, transform $motion-fast $easing-standard;
 
     &.is-bot {
-      // Lucide Bot head mass sits below the viewBox center (thin antenna above).
-      // Nudge up so the glyph reads centered inside the circular badge.
-      --bitfun-subagent-bot-optical-y: -1px;
-      transform: translateY(var(--bitfun-subagent-bot-optical-y));
       animation: bitfun-nav-background-subagent-bot-cycle 3.6s ease-in-out infinite;
     }
 
@@ -727,13 +723,13 @@
   62%,
   100% {
     opacity: 1;
-    transform: translateY(var(--bitfun-subagent-bot-optical-y)) scale(1);
+    transform: scale(1);
   }
 
   70%,
   88% {
     opacity: 0;
-    transform: translateY(var(--bitfun-subagent-bot-optical-y)) scale(0.82);
+    transform: scale(0.82);
   }
 }
 
@@ -777,7 +773,7 @@
 
     &.is-bot {
       opacity: 1;
-      transform: translateY(var(--bitfun-subagent-bot-optical-y));
+      transform: none;
     }
 
     &.is-loader {

--- a/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSectionLayout.test.ts
+++ b/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSectionLayout.test.ts
@@ -100,9 +100,7 @@ describe('SessionsSection layout styles', () => {
     expect(backgroundSubagentIconBlock).toContain('place-self: center;');
     expect(backgroundSubagentIconBlock).toContain('display: block;');
     expect(backgroundSubagentIconBlock).toContain('transform-origin: center center;');
-    expect(backgroundSubagentIconBlock).toContain('--bitfun-subagent-bot-optical-y: -1px;');
-    expect(stylesheet).toContain(
-      'transform: translateY(var(--bitfun-subagent-bot-optical-y)) scale(1);',
-    );
+    expect(stylesheet).not.toContain('--bitfun-subagent-bot-optical-y');
+    expect(stylesheet).not.toContain('translateY(var(--bitfun-subagent-bot-optical-y))');
   });
 });

--- a/src/web-ui/src/flow_chat/tool-cards/CanvasToolCard.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/CanvasToolCard.scss
@@ -43,6 +43,11 @@
   padding: var(--flowchat-card-expanded-pad-y) var(--flowchat-card-expanded-pad-x);
 }
 
+.canvas-tool-card__source-preview {
+  width: 100%;
+  min-width: 0;
+}
+
 .canvas-tool-card__meta {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/web-ui/src/flow_chat/tool-cards/CanvasToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/CanvasToolCard.tsx
@@ -4,6 +4,10 @@ import type { ToolCardProps } from '../types/flow-chat';
 import { BaseToolCard, ToolCardHeader } from './BaseToolCard';
 import { getToolCardConfig } from './toolCardMetadata';
 import { flowChatStore } from '../store/FlowChatStore';
+import { CodePreview } from '../components/CodePreview';
+import { useTypewriter } from '../hooks/useTypewriter';
+import { useReportTypewriterReveal } from '../hooks/typewriterRevealGateContext';
+import { i18nService } from '@/infrastructure/i18n';
 import { createTab } from '@/shared/utils/tabUtils';
 import { createLogger } from '@/shared/utils/logger';
 import './CanvasToolCard.scss';
@@ -65,11 +69,15 @@ function canvasTitle(result: CanvasToolResult | null, fallback: unknown): string
   return 'BitFun Canvas';
 }
 
+const TERMINAL_STATUSES = new Set(['completed', 'error', 'cancelled', 'rejected']);
+
 export const CanvasToolCard: React.FC<ToolCardProps> = ({ toolItem, sessionId }) => {
-  const { status, toolCall, toolResult } = toolItem;
+  const { status, toolCall, toolResult, partialParams, isParamsStreaming } = toolItem;
   const toolDisplayName = getToolCardConfig(toolItem.toolName).displayName;
   const resultData = useMemo(() => parseCanvasResult(toolResult?.result), [toolResult?.result]);
-  const title = useMemo(() => canvasTitle(resultData, toolCall?.input), [resultData, toolCall?.input]);
+  // Params stream in progressively; fall back to the finalized input afterwards.
+  const liveParams = partialParams ?? toolCall?.input;
+  const title = useMemo(() => canvasTitle(resultData, liveParams), [resultData, liveParams]);
   const diagnostics = useMemo(
     () => resultData?.canvas?.diagnostics || [],
     [resultData?.canvas?.diagnostics],
@@ -82,6 +90,24 @@ export const CanvasToolCard: React.FC<ToolCardProps> = ({ toolItem, sessionId })
     status === 'preparing' || status === 'streaming' || status === 'running' || status === 'pending';
   const isFailed = status === 'error' || toolResult?.success === false;
   const isOpenable = status === 'completed' && Boolean(artifactReference);
+
+  // CreateCanvas/UpdateCanvas stream their `source` argument; render it live like Write does.
+  const liveSource = typeof liveParams?.source === 'string' ? liveParams.source : '';
+  const isSourceAnimating =
+    Boolean(isParamsStreaming) && !TERMINAL_STATUSES.has(status) && liveSource.length > 0;
+  const sourceTypewriter = useTypewriter(liveSource, isSourceAnimating);
+  useReportTypewriterReveal(
+    `${toolCall?.id ?? toolItem.id}:canvas-source`,
+    sourceTypewriter.isRevealing,
+  );
+  const isSourceVisuallyStreaming = isSourceAnimating || sourceTypewriter.isRevealing;
+  const showSourcePreview =
+    liveSource.length > 0 && !isFailed && (status !== 'completed' || sourceTypewriter.isRevealing);
+  const sourceDisplayContent = isSourceVisuallyStreaming ? sourceTypewriter.displayText : liveSource;
+  const metaText = artifactReference
+    || (liveSource.length > 0
+      ? `Source · ${i18nService.formatNumber(liveSource.length)} chars`
+      : 'Waiting for artifact reference');
 
   const handleOpenPanel = useCallback(() => {
     if (!isOpenable) return;
@@ -169,7 +195,9 @@ export const CanvasToolCard: React.FC<ToolCardProps> = ({ toolItem, sessionId })
             </span>
           )}
           <span className="canvas-tool-card__status">
-            {isLoading ? 'Rendering' : resultData?.compiled ? 'Preview ready' : canvasStatus || 'Saved'}
+            {isLoading
+              ? (isSourceVisuallyStreaming ? 'Writing source' : 'Rendering')
+              : resultData?.compiled ? 'Preview ready' : canvasStatus || 'Saved'}
           </span>
           {isOpenable && <PanelRightOpen size={14} className="canvas-tool-card__open-icon" />}
         </div>
@@ -180,8 +208,20 @@ export const CanvasToolCard: React.FC<ToolCardProps> = ({ toolItem, sessionId })
 
   const body = (
     <div className="canvas-tool-card__body">
+      {showSourcePreview && (
+        <div className="canvas-tool-card__source-preview">
+          <CodePreview
+            content={sourceDisplayContent}
+            language="tsx"
+            isStreaming={isSourceVisuallyStreaming}
+            showLineNumbers={false}
+            maxHeight={260}
+            autoScrollToBottom={false}
+          />
+        </div>
+      )}
       <div className="canvas-tool-card__meta">
-        <span>{artifactReference || 'Waiting for artifact reference'}</span>
+        <span>{metaText}</span>
       </div>
       {diagnostics.length > 0 && (
         <ul className="canvas-tool-card__diagnostic-list">


### PR DESCRIPTION
## Summary

- preview streamed CreateCanvas and UpdateCanvas source in the tool card with the shared typewriter experience
- keep Canvas metadata useful while the artifact reference is pending
- remove the extra optical offset that placed the background subagent Bot icon above the badge center
- add a layout regression assertion for the centered subagent icon

## Verification

- pnpm run type-check:web
- pnpm --dir src/web-ui run test:run src/app/components/NavPanel/sections/sessions/SessionsSectionLayout.test.ts src/flow_chat/tool-cards/CanvasToolCard.test.tsx
- git diff --check