### PR TITLE
fix(flow-chat): navigate to exact search matches

### DIFF
--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx
@@ -24,6 +24,8 @@ const switchChatSessionMock = vi.hoisted(() => vi.fn());
 const virtualListMock = vi.hoisted(() => ({
   scrollToTurn: vi.fn(),
   scrollToIndex: vi.fn(),
+  scrollToSearchMatch: vi.fn(),
+  clearSearchMatch: vi.fn(),
   scrollToPhysicalBottomAndClearPin: vi.fn(),
   scrollToTurnEndAndClearPin: vi.fn(() => true),
   scrollToLatestEndPosition: vi.fn(),
@@ -269,6 +271,8 @@ describe('ModernFlowChatContainer historical empty state', () => {
     switchChatSessionMock.mockReset();
     virtualListMock.scrollToTurn.mockReset();
     virtualListMock.scrollToIndex.mockReset();
+    virtualListMock.scrollToSearchMatch.mockReset();
+    virtualListMock.clearSearchMatch.mockReset();
     virtualListMock.scrollToPhysicalBottomAndClearPin.mockReset();
     virtualListMock.scrollToTurnEndAndClearPin.mockReset();
     virtualListMock.scrollToTurnEndAndClearPin.mockReturnValue(true);
@@ -831,6 +835,51 @@ describe('ModernFlowChatContainer historical empty state', () => {
 
     projectionSpy.mockRestore();
     pendingSpy.mockRestore();
+  });
+
+  it('repositions an unchanged virtual match when the search query changes', async () => {
+    stateMocks.activeSession = createSession({
+      isHistorical: false,
+      historyState: 'ready',
+      dialogTurns: [createTurn('turn-1', 'Searchable prompt')],
+    } as Partial<Session>);
+    stateMocks.virtualItems = [
+      { type: 'user-message', turnId: 'turn-1', data: { id: 'user-turn-1', content: 'Searchable prompt' } },
+    ];
+    searchStateMock.searchQuery = 'search';
+    searchStateMock.matches = [{
+      virtualItemIndex: 0,
+      turnId: 'turn-1',
+      type: 'user-message',
+    }];
+    searchStateMock.currentMatchIndex = 0;
+    searchStateMock.currentMatchVirtualIndex = 0;
+
+    await act(async () => {
+      root.render(<ModernFlowChatContainer />);
+    });
+    flushAnimationFrame();
+
+    expect(virtualListMock.scrollToSearchMatch).toHaveBeenLastCalledWith({
+      virtualItemIndex: 0,
+      query: 'search',
+      flowItemId: undefined,
+      expandableIds: undefined,
+    });
+
+    searchStateMock.searchQuery = 'searchable';
+    await act(async () => {
+      root.render(<ModernFlowChatContainer />);
+    });
+    flushAnimationFrame();
+
+    expect(virtualListMock.scrollToSearchMatch).toHaveBeenCalledTimes(2);
+    expect(virtualListMock.scrollToSearchMatch).toHaveBeenLastCalledWith({
+      virtualItemIndex: 0,
+      query: 'searchable',
+      flowItemId: undefined,
+      expandableIds: undefined,
+    });
   });
 
   it('keeps the new-session welcome for genuinely new empty sessions', () => {

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
@@ -325,6 +325,11 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     goToPrev: handleSearchPrev,
     clearSearch,
   } = useFlowChatSearch(virtualItems);
+  const searchCurrentMatch = searchMatches[searchCurrentMatchIndex];
+  const searchCurrentMatchFlowItemId = searchCurrentMatch?.flowItemId;
+  const searchCurrentMatchTurnId = searchCurrentMatch?.turnId;
+  const searchCurrentMatchVirtualItemIndex = searchCurrentMatch?.virtualItemIndex ?? -1;
+  const searchCurrentMatchExpandableKey = searchCurrentMatch?.expandableIds?.join('\u0000') ?? '';
 
   useFlowChatSync();
   useFlowChatCopyDialog();
@@ -1021,14 +1026,31 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
   ]);
 
   useEffect(() => {
-    if (searchCurrentMatchVirtualIndex < 0) return;
+    if (searchCurrentMatchVirtualItemIndex < 0 || !searchQuery.trim()) {
+      virtualListRef.current?.clearSearchMatch();
+      return;
+    }
+
     const frameId = requestAnimationFrame(() => {
-      virtualListRef.current?.scrollToIndex(searchCurrentMatchVirtualIndex);
+      virtualListRef.current?.scrollToSearchMatch({
+        virtualItemIndex: searchCurrentMatchVirtualItemIndex,
+        query: searchQuery,
+        flowItemId: searchCurrentMatchFlowItemId,
+        expandableIds: searchCurrentMatchExpandableKey
+          ? searchCurrentMatchExpandableKey.split('\u0000')
+          : undefined,
+      });
     });
     return () => {
       cancelAnimationFrame(frameId);
     };
-  }, [searchCurrentMatchVirtualIndex]);
+  }, [
+    searchCurrentMatchFlowItemId,
+    searchCurrentMatchTurnId,
+    searchCurrentMatchExpandableKey,
+    searchCurrentMatchVirtualItemIndex,
+    searchQuery,
+  ]);
 
   const handleJumpToTurn = useCallback((turnId: string) => {
     if (!turnId) return false;

--- a/src/web-ui/src/flow_chat/components/modern/VirtualItemRenderer.scss
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualItemRenderer.scss
@@ -36,3 +36,8 @@
     background: color-mix(in srgb, var(--color-accent-500) 8%, transparent);
   }
 }
+
+::highlight(bitfun-flowchat-search-current) {
+  color: inherit;
+  background: color-mix(in srgb, var(--color-accent-500) 42%, transparent);
+}

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
@@ -103,7 +103,7 @@ vi.mock('react-virtuoso', () => ({
               data-virtual-index={index}
               data-item-type={item.type}
             >
-              {item.turnId}
+              {item.type === 'user-message' ? item.data.content : item.turnId}
             </div>
           ))}
         {props.components?.Footer ? <props.components.Footer /> : null}
@@ -524,6 +524,117 @@ describe('VirtualMessageList session boundary', () => {
     expect(scroller.scrollTop).toBe(4_443);
     expect(target.getBoundingClientRect().top).toBe(57);
     expect(virtuosoMocks.scrollToIndex).toHaveBeenCalledTimes(1);
+  });
+
+  it('centers the exact text range when navigating to a search match', () => {
+    const listRef = React.createRef<VirtualMessageListRef>();
+    stateMocks.activeSession = createSessionWithTurns('session-a', ['turn-a', 'turn-b']);
+    stateMocks.virtualItems = [
+      createItem('turn-a'),
+      {
+        ...createItem('turn-b'),
+        data: {
+          ...createItem('turn-b').data,
+          content: 'prefix needle suffix',
+        },
+      },
+    ];
+
+    act(() => {
+      root.render(<VirtualMessageList ref={listRef} />);
+    });
+
+    const scroller = container.querySelector<HTMLElement>('[data-virtuoso-scroller="true"]');
+    expect(scroller).not.toBeNull();
+    if (!scroller) {
+      return;
+    }
+
+    setScrollerGeometry(scroller, {
+      scrollHeight: 2_000,
+      clientHeight: 500,
+      scrollTop: 0,
+    });
+    vi.spyOn(scroller, 'getBoundingClientRect').mockReturnValue(createRect({
+      top: 0,
+      bottom: 500,
+      height: 500,
+    }));
+    Object.defineProperty(Range.prototype, 'getBoundingClientRect', {
+      configurable: true,
+      value: vi.fn(() => createRect({
+        top: 800,
+        bottom: 820,
+        height: 20,
+      })),
+    });
+    virtuosoMocks.scrollToIndex.mockClear();
+
+    act(() => {
+      listRef.current?.scrollToSearchMatch({
+        virtualItemIndex: 1,
+        query: 'needle',
+      });
+    });
+    flushAnimationFrame();
+
+    expect(virtuosoMocks.scrollToIndex).toHaveBeenCalledWith(expect.objectContaining({
+      align: 'center',
+      behavior: 'auto',
+    }));
+    expect(scroller.scrollTop).toBe(560);
+    delete (Range.prototype as Range & {
+      getBoundingClientRect?: () => DOMRect;
+    }).getBoundingClientRect;
+  });
+
+  it('renders only a bounded static-history window around an omitted search result', () => {
+    const listRef = React.createRef<VirtualMessageListRef>();
+    const turnIds = Array.from({ length: 8 }, (_, index) => `turn-${index}`);
+    const targetTurnId = 'turn-1';
+    const latestTurnId = 'turn-7';
+
+    stateMocks.activeSession = createSessionWithTurns('session-a', turnIds, {
+      isHistorical: false,
+      historyState: 'ready',
+      contextRestoreState: 'pending',
+      isPartial: true,
+    });
+    stateMocks.virtualItems = turnIds.flatMap(turnId => [
+      createItem(turnId),
+      createModelItem(turnId),
+    ]);
+
+    act(() => {
+      root.render(<VirtualMessageList ref={listRef} />);
+    });
+
+    expect(container.querySelector(
+      `[data-turn-id="${targetTurnId}"][data-item-type="user-message"]`,
+    )).toBeNull();
+    expect(container.querySelector(
+      `[data-turn-id="${latestTurnId}"][data-item-type="user-message"]`,
+    )).not.toBeNull();
+
+    act(() => {
+      listRef.current?.scrollToSearchMatch({
+        virtualItemIndex: 2,
+        query: targetTurnId,
+      });
+    });
+    flushAnimationFrame();
+
+    expect(container.querySelector(
+      `[data-turn-id="${targetTurnId}"][data-item-type="user-message"]`,
+    )).not.toBeNull();
+    expect(container.querySelector(
+      `[data-turn-id="${latestTurnId}"][data-item-type="user-message"]`,
+    )).toBeNull();
+    expect(container.querySelector(
+      '[data-history-initial-render-tail-spacer="true"]',
+    )).not.toBeNull();
+    expect(container.querySelectorAll('.virtual-item-wrapper').length)
+      .toBeLessThan(stateMocks.virtualItems.length);
   });
 
   it('keeps a static initial history turn pin from being pulled back to bottom by the initial guard', () => {

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
@@ -53,6 +53,12 @@ import {
   activeSessionHistoryProjectionHandoff,
   type HistoryProjectionHandoffSnapshot,
 } from './historyProjectionHandoff';
+import {
+  findElementWithDataValue,
+  findFlowChatSearchTextRange,
+  getFlowChatSearchTextRoot,
+  setFlowChatSearchHighlight,
+} from './flowChatSearchDom';
 import './VirtualMessageList.scss';
 
 const COMPENSATION_EPSILON_PX = 0.5;
@@ -73,6 +79,7 @@ const PARTIAL_HISTORY_FULL_PROJECTION_TOP_THRESHOLD_PX = 1200;
 const HISTORY_PROJECTION_HANDOFF_MAX_DURATION_MS = 5000;
 const SESSION_OPEN_HANDOFF_ITEM_BUDGET = 24;
 const PREVIOUS_HISTORY_BOUNDARY_STATUS_DURATION_MS = 2500;
+const SEARCH_NAVIGATION_MAX_ATTEMPTS = 24;
 
 type LatestEndAnchorResolveReason =
   | 'raf'
@@ -98,6 +105,14 @@ export type FlowChatTurnPinRequestStatus = 'rejected' | 'pending' | 'settled';
 export interface VirtualMessageListRef {
   scrollToTurn: (turnIndex: number) => void;
   scrollToIndex: (index: number) => void;
+  // Materializes a virtual item, reveals collapsed search content, and centers the exact text range.
+  scrollToSearchMatch: (target: {
+    virtualItemIndex: number;
+    query: string;
+    flowItemId?: string;
+    expandableIds?: readonly string[];
+  }) => void;
+  clearSearchMatch: () => void;
   // Clears pin reservation first, then scrolls to the physical bottom.
   scrollToPhysicalBottomAndClearPin: () => void;
   // Clears pin reservation first, then keeps the target turn visible near the natural tail.
@@ -435,6 +450,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
   const pinReservationReconcileFrameRef = useRef<number | null>(null);
   const turnPinStabilizationFrameRef = useRef<number | null>(null);
   const latestEndAnchorStabilizationFrameRef = useRef<number | null>(null);
+  const searchNavigationRequestIdRef = useRef(0);
   const staticInitialHistoryBottomGuardFrameRef = useRef<number | null>(null);
   const staticInitialHistoryBottomGuardUntilMsRef = useRef(0);
   const latestEndAnchorRequestRef = useRef<LatestEndAnchorRequestState | null>(null);
@@ -3581,6 +3597,204 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     }
   }, [clearPinReservationForUserNavigation, exitFollowOutput, toVirtuosoIndex, virtualItems.length]);
 
+  const clearSearchMatch = useCallback(() => {
+    searchNavigationRequestIdRef.current += 1;
+    setFlowChatSearchHighlight(null);
+  }, []);
+
+  const scrollToSearchMatch = useCallback((target: {
+    virtualItemIndex: number;
+    query: string;
+    flowItemId?: string;
+    expandableIds?: readonly string[];
+  }) => {
+    const query = target.query.trim();
+    if (
+      !query ||
+      target.virtualItemIndex < 0 ||
+      target.virtualItemIndex >= virtualItems.length
+    ) {
+      clearSearchMatch();
+      return;
+    }
+
+    const requestId = searchNavigationRequestIdRef.current + 1;
+    searchNavigationRequestIdRef.current = requestId;
+    setFlowChatSearchHighlight(null);
+    exitFollowOutput('scroll-to-index');
+    clearPinReservationForUserNavigation();
+
+    const virtuoso = virtuosoRef.current;
+    if (virtuoso) {
+      if (target.virtualItemIndex === 0) {
+        virtuoso.scrollTo({ top: 0, behavior: 'auto' });
+      } else {
+        virtuoso.scrollToIndex({
+          index: toVirtuosoIndex(target.virtualItemIndex),
+          align: 'center',
+          behavior: 'auto',
+        });
+      }
+    }
+
+    let attempts = 0;
+    let revealedCollapsedContent = false;
+    const resolveExactTextPosition = () => {
+      if (searchNavigationRequestIdRef.current !== requestId) {
+        return;
+      }
+
+      attempts += 1;
+      const scroller = scrollerElementRef.current;
+      const wrapper = getRenderedVirtualItemElement(target.virtualItemIndex);
+      if (!scroller || !wrapper) {
+        const targetTurnId = virtualItems[target.virtualItemIndex]?.turnId;
+        if (
+          scroller &&
+          !wrapper &&
+          !virtuosoRef.current &&
+          useStaticInitialHistoryListRef.current &&
+          targetTurnId
+        ) {
+          setStaticAnchorWindowTurnId(currentTurnId => (
+            currentTurnId === targetTurnId ? currentTurnId : targetTurnId
+          ));
+        }
+        if (attempts < SEARCH_NAVIGATION_MAX_ATTEMPTS) {
+          requestAnimationFrame(resolveExactTextPosition);
+        }
+        return;
+      }
+
+      for (const expandableId of target.expandableIds ?? []) {
+        const expandable = findElementWithDataValue(
+          wrapper,
+          'data-tool-card-id',
+          expandableId,
+        );
+        if (!expandable) {
+          if (attempts < SEARCH_NAVIGATION_MAX_ATTEMPTS) {
+            requestAnimationFrame(resolveExactTextPosition);
+          }
+          return;
+        }
+
+        if (expandable.dataset.expanded === 'false') {
+          const toggle = expandable.querySelector<HTMLElement>(
+            '[data-testid="chat-explore-group-toggle"], [data-testid="chat-thinking-toggle"]',
+          );
+          if (toggle) {
+            revealedCollapsedContent = true;
+            toggle.click();
+          }
+          if (attempts < SEARCH_NAVIGATION_MAX_ATTEMPTS) {
+            requestAnimationFrame(resolveExactTextPosition);
+          }
+          return;
+        }
+      }
+
+      if (target.flowItemId) {
+        const flowItem = findElementWithDataValue(
+          wrapper,
+          'data-flow-item-id',
+          target.flowItemId,
+        );
+        const thinkingItem = findElementWithDataValue(
+          wrapper,
+          'data-tool-card-id',
+          target.flowItemId,
+        );
+        if (!flowItem && !thinkingItem) {
+          if (attempts < SEARCH_NAVIGATION_MAX_ATTEMPTS) {
+            requestAnimationFrame(resolveExactTextPosition);
+          }
+          return;
+        }
+      }
+
+      const textRoot = getFlowChatSearchTextRoot(wrapper, target.flowItemId);
+      const userMessage = textRoot.closest<HTMLElement>('.user-message-item');
+      if (
+        userMessage &&
+        !userMessage.classList.contains('user-message-item--expanded') &&
+        textRoot.scrollHeight > textRoot.clientHeight + 1
+      ) {
+        revealedCollapsedContent = true;
+        textRoot.click();
+        if (attempts < SEARCH_NAVIGATION_MAX_ATTEMPTS) {
+          requestAnimationFrame(resolveExactTextPosition);
+        }
+        return;
+      }
+
+      const range = findFlowChatSearchTextRange(textRoot, query);
+      if (!range) {
+        if (attempts < SEARCH_NAVIGATION_MAX_ATTEMPTS) {
+          requestAnimationFrame(resolveExactTextPosition);
+        }
+        return;
+      }
+
+      setFlowChatSearchHighlight(range);
+
+      let ancestor = range.startContainer.parentElement;
+      while (ancestor && ancestor !== scroller && wrapper.contains(ancestor)) {
+        const styles = ancestor.ownerDocument.defaultView?.getComputedStyle(ancestor);
+        const canScrollVertically = (
+          ancestor.scrollHeight > ancestor.clientHeight + 1 &&
+          (styles?.overflowY === 'auto' || styles?.overflowY === 'scroll')
+        );
+        if (canScrollVertically) {
+          const rangeRect = range.getBoundingClientRect();
+          const ancestorRect = ancestor.getBoundingClientRect();
+          const nextScrollTop = ancestor.scrollTop +
+            rangeRect.top -
+            ancestorRect.top -
+            Math.max(0, (ancestor.clientHeight - rangeRect.height) / 2);
+          ancestor.scrollTop = Math.max(
+            0,
+            Math.min(nextScrollTop, ancestor.scrollHeight - ancestor.clientHeight),
+          );
+        }
+        ancestor = ancestor.parentElement;
+      }
+
+      const rangeRect = range.getBoundingClientRect();
+      const scrollerRect = scroller.getBoundingClientRect();
+      const nextScrollTop = scroller.scrollTop +
+        rangeRect.top -
+        scrollerRect.top -
+        Math.max(0, (scroller.clientHeight - rangeRect.height) / 2);
+      scroller.scrollTop = Math.max(
+        0,
+        Math.min(nextScrollTop, scroller.scrollHeight - scroller.clientHeight),
+      );
+      previousScrollTopRef.current = scroller.scrollTop;
+      recordScrollerGeometry(scroller);
+      scheduleVisibleTurnMeasure(2);
+      if (revealedCollapsedContent && attempts < SEARCH_NAVIGATION_MAX_ATTEMPTS) {
+        requestAnimationFrame(resolveExactTextPosition);
+      }
+    };
+
+    requestAnimationFrame(resolveExactTextPosition);
+  }, [
+    clearPinReservationForUserNavigation,
+    clearSearchMatch,
+    exitFollowOutput,
+    getRenderedVirtualItemElement,
+    recordScrollerGeometry,
+    scheduleVisibleTurnMeasure,
+    toVirtuosoIndex,
+    virtualItems,
+  ]);
+
+  useEffect(() => () => {
+    searchNavigationRequestIdRef.current += 1;
+    setFlowChatSearchHighlight(null);
+  }, []);
+
   const pinTurnToTopWithStatus = useCallback((turnId: string, options?: { behavior?: ScrollBehavior; pinMode?: FlowChatPinTurnToTopMode }): FlowChatTurnPinRequestStatus => {
     const shouldExitFollowOutput = !(
       options?.pinMode === 'sticky-latest' &&
@@ -3818,6 +4032,8 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
   useImperativeHandle(ref, () => ({
     scrollToTurn,
     scrollToIndex,
+    scrollToSearchMatch,
+    clearSearchMatch,
     scrollToPhysicalBottomAndClearPin,
     scrollToTurnEndAndClearPin,
     isTurnRenderedInViewport,
@@ -3830,8 +4046,10 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     isTurnTextRenderedInViewport,
     pinTurnToTop,
     pinTurnToTopWithStatus,
+    clearSearchMatch,
     scrollToTurn,
     scrollToIndex,
+    scrollToSearchMatch,
     scrollToPhysicalBottomAndClearPin,
     scrollToTurnEndAndClearPin,
     scrollToLatestEndPosition,

--- a/src/web-ui/src/flow_chat/components/modern/flowChatSearchDom.test.ts
+++ b/src/web-ui/src/flow_chat/components/modern/flowChatSearchDom.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from 'vitest';
+import {
+  findElementWithDataValue,
+  findFlowChatSearchTextRange,
+  getFlowChatSearchTextRoot,
+} from './flowChatSearchDom';
+
+describe('FlowChat search DOM navigation', () => {
+  it('finds a query split across Markdown text nodes', () => {
+    const root = document.createElement('div');
+    root.innerHTML = '<p>Before <span>key</span><strong>word</strong> after</p>';
+
+    const range = findFlowChatSearchTextRange(root, 'KEYWORD');
+
+    expect(range?.toString()).toBe('keyword');
+  });
+
+  it('maps a folded match back to original offsets when lowercasing expands a character', () => {
+    const root = document.createElement('div');
+    root.textContent = 'İstanbul';
+
+    const range = findFlowChatSearchTextRange(root, 'stanbul');
+
+    expect(range?.toString()).toBe('stanbul');
+  });
+
+  it('targets an exact flow item id without interpolating it into a selector', () => {
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML = `
+      <div data-flow-item-id="first">wrong</div>
+      <div data-flow-item-id="item&quot;with-special">right needle</div>
+    `;
+
+    const target = findElementWithDataValue(
+      wrapper,
+      'data-flow-item-id',
+      'item"with-special',
+    );
+
+    expect(target?.textContent).toBe('right needle');
+    expect(getFlowChatSearchTextRoot(wrapper, 'item"with-special')).toBe(target);
+  });
+
+  it('ignores text hidden by a collapsed accessible container', () => {
+    const root = document.createElement('div');
+    root.innerHTML = '<div aria-hidden="true">hidden needle</div><div>visible needle</div>';
+
+    const range = findFlowChatSearchTextRange(root, 'needle');
+
+    expect(range?.startContainer.parentElement?.textContent).toBe('visible needle');
+  });
+});

--- a/src/web-ui/src/flow_chat/components/modern/flowChatSearchDom.ts
+++ b/src/web-ui/src/flow_chat/components/modern/flowChatSearchDom.ts
@@ -1,0 +1,160 @@
+const SEARCH_HIGHLIGHT_NAME = 'bitfun-flowchat-search-current';
+
+type HighlightRegistryLike = {
+  set: (name: string, highlight: unknown) => void;
+  delete: (name: string) => void;
+};
+
+type HighlightConstructorLike = new (...ranges: Range[]) => unknown;
+
+interface FoldedTextOffset {
+  start: number;
+  end: number;
+}
+
+function isSearchableTextNode(node: Node): node is Text {
+  if (node.nodeType !== Node.TEXT_NODE || !node.textContent) {
+    return false;
+  }
+
+  const parent = node.parentElement;
+  if (!parent) {
+    return false;
+  }
+
+  return !parent.closest('script, style, [aria-hidden="true"]');
+}
+
+function foldTextWithOriginalOffsets(text: string): {
+  text: string;
+  offsets: FoldedTextOffset[];
+} {
+  const foldedText = text.toLowerCase();
+  const offsets: FoldedTextOffset[] = [];
+  let originalOffset = 0;
+  let foldedOffset = 0;
+
+  for (const character of text) {
+    const start = originalOffset;
+    originalOffset += character.length;
+    const foldedLength = character.toLowerCase().length;
+
+    for (let index = 0; index < foldedLength; index += 1) {
+      offsets[foldedOffset + index] = {
+        start,
+        end: originalOffset,
+      };
+    }
+    foldedOffset += foldedLength;
+  }
+
+  return {
+    text: foldedText,
+    offsets,
+  };
+}
+
+/**
+ * Finds a case-insensitive query even when Markdown splits it across adjacent
+ * text nodes (for example, around inline emphasis or code spans).
+ */
+export function findFlowChatSearchTextRange(root: HTMLElement, query: string): Range | null {
+  const trimmedQuery = query.trim();
+  if (!trimmedQuery) {
+    return null;
+  }
+
+  const ownerDocument = root.ownerDocument;
+  const walker = ownerDocument.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  const textNodes: Array<{ node: Text; start: number; end: number }> = [];
+  let combinedText = '';
+  let currentNode = walker.nextNode();
+
+  while (currentNode) {
+    if (isSearchableTextNode(currentNode)) {
+      const start = combinedText.length;
+      combinedText += currentNode.textContent;
+      textNodes.push({
+        node: currentNode,
+        start,
+        end: combinedText.length,
+      });
+    }
+    currentNode = walker.nextNode();
+  }
+
+  const folded = foldTextWithOriginalOffsets(combinedText);
+  const foldedQuery = trimmedQuery.toLowerCase();
+  const foldedMatchStart = folded.text.indexOf(foldedQuery);
+  if (foldedMatchStart < 0) {
+    return null;
+  }
+
+  const foldedMatchEnd = foldedMatchStart + foldedQuery.length;
+  const matchStart = folded.offsets[foldedMatchStart]?.start;
+  const matchEnd = folded.offsets[foldedMatchEnd - 1]?.end;
+  if (matchStart === undefined || matchEnd === undefined) {
+    return null;
+  }
+
+  const startEntry = textNodes.find(entry => matchStart >= entry.start && matchStart < entry.end);
+  const endEntry = textNodes.find(entry => matchEnd > entry.start && matchEnd <= entry.end);
+  if (!startEntry || !endEntry) {
+    return null;
+  }
+
+  const range = ownerDocument.createRange();
+  range.setStart(startEntry.node, matchStart - startEntry.start);
+  range.setEnd(endEntry.node, matchEnd - endEntry.start);
+  return range;
+}
+
+export function setFlowChatSearchHighlight(range: Range | null): void {
+  const cssWithHighlights = globalThis.CSS as (typeof CSS & {
+    highlights?: HighlightRegistryLike;
+  }) | undefined;
+  const HighlightConstructor = (globalThis as typeof globalThis & {
+    Highlight?: HighlightConstructorLike;
+  }).Highlight;
+
+  if (!cssWithHighlights?.highlights) {
+    return;
+  }
+
+  cssWithHighlights.highlights.delete(SEARCH_HIGHLIGHT_NAME);
+  if (range && HighlightConstructor) {
+    cssWithHighlights.highlights.set(
+      SEARCH_HIGHLIGHT_NAME,
+      new HighlightConstructor(range),
+    );
+  }
+}
+
+export function findElementWithDataValue(
+  root: HTMLElement,
+  attributeName: 'data-flow-item-id' | 'data-tool-card-id',
+  value: string,
+): HTMLElement | null {
+  return Array.from(root.querySelectorAll<HTMLElement>(`[${attributeName}]`))
+    .find(element => element.getAttribute(attributeName) === value) ?? null;
+}
+
+export function getFlowChatSearchTextRoot(
+  wrapper: HTMLElement,
+  flowItemId?: string,
+): HTMLElement {
+  if (flowItemId) {
+    const flowItem = findElementWithDataValue(wrapper, 'data-flow-item-id', flowItemId);
+    if (flowItem) {
+      return flowItem;
+    }
+
+    const thinkingItem = findElementWithDataValue(wrapper, 'data-tool-card-id', flowItemId);
+    const thinkingText = thinkingItem?.querySelector<HTMLElement>('.thinking-markdown');
+    if (thinkingText) {
+      return thinkingText;
+    }
+  }
+
+  return wrapper.querySelector<HTMLElement>('.user-message-item__content') ?? wrapper;
+}

--- a/src/web-ui/src/flow_chat/components/modern/useFlowChatSearch.test.ts
+++ b/src/web-ui/src/flow_chat/components/modern/useFlowChatSearch.test.ts
@@ -1,0 +1,165 @@
+// @vitest-environment jsdom
+
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { VirtualItem } from '../../store/modernFlowChatStore';
+import {
+  buildFlowChatSearchMatches,
+  useFlowChatSearch,
+  type UseFlowChatSearchReturn,
+} from './useFlowChatSearch';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+function searchableItems(count: number): VirtualItem[] {
+  return Array.from({ length: count }, (_, index) => ({
+    type: 'user-message',
+    turnId: `turn-${index}`,
+    data: {
+      id: `message-${index}`,
+      content: `needle ${index}`,
+    },
+  })) as VirtualItem[];
+}
+
+function SearchHarness({
+  items,
+  onController,
+}: {
+  items: VirtualItem[];
+  onController: (controller: UseFlowChatSearchReturn) => void;
+}) {
+  onController(useFlowChatSearch(items));
+  return null;
+}
+
+describe('buildFlowChatSearchMatches', () => {
+  it('keeps the concrete model text source used for exact navigation', () => {
+    const virtualItems = [{
+      type: 'model-round',
+      turnId: 'turn-1',
+      isLastRound: true,
+      isTurnComplete: true,
+      data: {
+        id: 'round-1',
+        items: [
+          { id: 'text-1', type: 'text', content: 'unrelated' },
+          { id: 'text-2', type: 'text', content: 'The precise keyword is here.' },
+        ],
+      },
+    }] as VirtualItem[];
+
+    expect(buildFlowChatSearchMatches(virtualItems, 'KEYWORD')).toEqual([{
+      virtualItemIndex: 0,
+      turnId: 'turn-1',
+      type: 'model-round',
+      flowItemId: 'text-2',
+      expandableIds: undefined,
+    }]);
+  });
+
+  it('records collapsed containers from outermost to innermost', () => {
+    const virtualItems = [{
+      type: 'explore-group',
+      turnId: 'turn-1',
+      data: {
+        groupId: 'group-1',
+        allItems: [{
+          id: 'thinking-1',
+          type: 'thinking',
+          content: 'hidden needle',
+        }],
+      },
+    }] as VirtualItem[];
+
+    expect(buildFlowChatSearchMatches(virtualItems, 'needle')[0]).toMatchObject({
+      flowItemId: 'thinking-1',
+      expandableIds: ['group-1', 'thinking-1'],
+    });
+  });
+
+  it('deduplicates by turn while searching steering messages', () => {
+    const virtualItems = [
+      {
+        type: 'user-steering-message',
+        turnId: 'turn-1',
+        steeringId: 'steering-1',
+        steeringStatus: 'completed',
+        data: { id: 'user-1', content: 'needle in steering' },
+      },
+      {
+        type: 'model-round',
+        turnId: 'turn-1',
+        isLastRound: true,
+        isTurnComplete: true,
+        data: {
+          id: 'round-1',
+          items: [{ id: 'text-1', type: 'text', content: 'needle again' }],
+        },
+      },
+    ] as VirtualItem[];
+
+    expect(buildFlowChatSearchMatches(virtualItems, 'needle')).toHaveLength(1);
+    expect(buildFlowChatSearchMatches(virtualItems, 'needle')[0]).toMatchObject({
+      virtualItemIndex: 0,
+      type: 'user-steering-message',
+    });
+  });
+});
+
+describe('useFlowChatSearch navigation', () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+  let controller: UseFlowChatSearchReturn | null;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    controller = null;
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function render(items: VirtualItem[]): void {
+    act(() => {
+      root.render(React.createElement(SearchHarness, {
+        items,
+        onController: nextController => {
+          controller = nextController;
+        },
+      }));
+    });
+  }
+
+  function selectLastOfFive(): void {
+    render(searchableItems(5));
+    act(() => controller?.onSearchChange('needle'));
+    act(() => controller?.goToPrev());
+    expect(controller?.currentMatchIndex).toBe(4);
+  }
+
+  it('moves next from the resolved index after matches shrink', () => {
+    selectLastOfFive();
+    render(searchableItems(3));
+
+    expect(controller?.currentMatchIndex).toBe(2);
+    act(() => controller?.goToNext());
+
+    expect(controller?.currentMatchIndex).toBe(0);
+  });
+
+  it('moves previous from the resolved index after matches shrink', () => {
+    selectLastOfFive();
+    render(searchableItems(3));
+
+    expect(controller?.currentMatchIndex).toBe(2);
+    act(() => controller?.goToPrev());
+
+    expect(controller?.currentMatchIndex).toBe(1);
+  });
+});

--- a/src/web-ui/src/flow_chat/components/modern/useFlowChatSearch.ts
+++ b/src/web-ui/src/flow_chat/components/modern/useFlowChatSearch.ts
@@ -1,22 +1,28 @@
 /**
  * FlowChat message search hook.
- * Searches user + model text, deduplicated by dialog turn: one match per turn,
- * navigation moves between turns that contain the query.
+ * Searches user + model text, deduplicated by dialog turn: one match per turn.
+ * Each match also keeps the concrete rendered source so navigation can land on
+ * the matching text instead of only centering a potentially very tall turn.
  */
 
 import { useState, useMemo, useCallback } from 'react';
 import type { VirtualItem } from '../../store/modernFlowChatStore';
 
 interface SearchableFlowItem {
+  id?: string;
   type: string;
   content?: string;
 }
 
 export interface SearchMatch {
-  /** Smallest virtual index in this turn where text matched (scroll / current anchor). */
+  /** Smallest virtual index in this turn where text matched. */
   virtualItemIndex: number;
   turnId: string;
   type: VirtualItem['type'];
+  /** Rendered FlowItem containing the first match in this turn, when applicable. */
+  flowItemId?: string;
+  /** Collapsible containers that must be opened, from outermost to innermost. */
+  expandableIds?: readonly string[];
 }
 
 export interface UseFlowChatSearchReturn {
@@ -31,68 +37,106 @@ export interface UseFlowChatSearchReturn {
   clearSearch: () => void;
 }
 
-function extractSearchableText(items: readonly SearchableFlowItem[]): string {
-  return items
-    .filter(item => item.type === 'text' || item.type === 'thinking')
-    .map(item => item.content ?? '')
-    .join(' ');
+interface SearchableSource {
+  content: string;
+  flowItemId?: string;
+  expandableIds?: readonly string[];
 }
 
-function getVirtualItemSearchText(item: VirtualItem): string {
-  if (item.type === 'user-message') {
-    return item.data?.content ?? '';
+function flowItemSearchSources(
+  items: readonly SearchableFlowItem[],
+  outerExpandableId?: string,
+): SearchableSource[] {
+  return items.flatMap(item => {
+    if (item.type !== 'text' && item.type !== 'thinking') {
+      return [];
+    }
+
+    const expandableIds = [
+      ...(outerExpandableId ? [outerExpandableId] : []),
+      ...(item.type === 'thinking' && item.id ? [item.id] : []),
+    ];
+
+    return [{
+      content: item.content ?? '',
+      flowItemId: item.id,
+      expandableIds: expandableIds.length > 0 ? expandableIds : undefined,
+    }];
+  });
+}
+
+function getVirtualItemSearchSources(item: VirtualItem): SearchableSource[] {
+  if (item.type === 'user-message' || item.type === 'user-steering-message') {
+    return [{ content: item.data?.content ?? '' }];
   }
   if (item.type === 'model-round') {
-    return extractSearchableText(item.data.items);
+    return flowItemSearchSources(item.data.items);
   }
   if (item.type === 'explore-group') {
-    return extractSearchableText(item.data.allItems);
+    return flowItemSearchSources(item.data.allItems, item.data.groupId);
   }
   if (item.type === 'turn-completion-notice') {
-    return item.data.reasonCode;
+    return [{ content: item.data.reasonCode }];
   }
   if (item.type === 'turn-failure-notice') {
-    return [
-      item.data.error,
-      item.data.errorDetail?.provider,
-      item.data.errorDetail?.providerCode,
-      item.data.errorDetail?.providerMessage,
-      item.data.errorDetail?.requestId,
-    ].filter(Boolean).join(' ');
+    return [{
+      content: [
+        item.data.error,
+        item.data.errorDetail?.provider,
+        item.data.errorDetail?.providerCode,
+        item.data.errorDetail?.providerMessage,
+        item.data.errorDetail?.requestId,
+      ].filter(Boolean).join(' '),
+    }];
   }
-  return '';
+  return [];
+}
+
+export function buildFlowChatSearchMatches(
+  virtualItems: readonly VirtualItem[],
+  searchQuery: string,
+): SearchMatch[] {
+  const trimmed = searchQuery.trim();
+  if (!trimmed) return [];
+  const query = trimmed.toLowerCase();
+  const firstMatchByTurn = new Map<string, SearchMatch>();
+
+  virtualItems.forEach((item, virtualItemIndex) => {
+    if (firstMatchByTurn.has(item.turnId)) {
+      return;
+    }
+
+    const source = getVirtualItemSearchSources(item).find(candidate => (
+      candidate.content.toLowerCase().includes(query)
+    ));
+    if (!source) {
+      return;
+    }
+
+    firstMatchByTurn.set(item.turnId, {
+      virtualItemIndex,
+      turnId: item.turnId,
+      type: item.type,
+      flowItemId: source.flowItemId,
+      expandableIds: source.expandableIds,
+    });
+  });
+
+  return [...firstMatchByTurn.values()]
+    .sort((left, right) => left.virtualItemIndex - right.virtualItemIndex);
 }
 
 export function useFlowChatSearch(virtualItems: VirtualItem[]): UseFlowChatSearchReturn {
   const [searchQuery, setSearchQuery] = useState('');
   const [currentMatchIndex, setCurrentMatchIndex] = useState(0);
 
-  const matches = useMemo<SearchMatch[]>(() => {
-    const trimmed = searchQuery.trim();
-    if (!trimmed) return [];
-    const q = trimmed.toLowerCase();
+  const matches = useMemo<SearchMatch[]>(() => (
+    buildFlowChatSearchMatches(virtualItems, searchQuery)
+  ), [virtualItems, searchQuery]);
 
-    const minIndexByTurn = new Map<string, number>();
-
-    virtualItems.forEach((item, index) => {
-      const text = getVirtualItemSearchText(item);
-      if (!text.toLowerCase().includes(q)) return;
-
-      const turnId = item.turnId;
-      const prev = minIndexByTurn.get(turnId);
-      if (prev === undefined || index < prev) {
-        minIndexByTurn.set(turnId, index);
-      }
-    });
-
-    return [...minIndexByTurn.entries()]
-      .sort((a, b) => a[1] - b[1])
-      .map(([turnId, virtualItemIndex]) => ({
-        virtualItemIndex,
-        turnId,
-        type: virtualItems[virtualItemIndex].type,
-      }));
-  }, [virtualItems, searchQuery]);
+  const resolvedCurrentMatchIndex = matches.length > 0
+    ? Math.min(currentMatchIndex, matches.length - 1)
+    : 0;
 
   const matchIndices = useMemo<ReadonlySet<number>>(() => {
     if (matches.length === 0) return new Set();
@@ -106,7 +150,7 @@ export function useFlowChatSearch(virtualItems: VirtualItem[]): UseFlowChatSearc
     return indices;
   }, [virtualItems, matches]);
 
-  const currentMatchVirtualIndex = matches[currentMatchIndex]?.virtualItemIndex ?? -1;
+  const currentMatchVirtualIndex = matches[resolvedCurrentMatchIndex]?.virtualItemIndex ?? -1;
 
   const onSearchChange = useCallback((query: string) => {
     setSearchQuery(query);
@@ -115,12 +159,18 @@ export function useFlowChatSearch(virtualItems: VirtualItem[]): UseFlowChatSearc
 
   const goToNext = useCallback(() => {
     if (matches.length === 0) return;
-    setCurrentMatchIndex(prev => (prev + 1) % matches.length);
+    setCurrentMatchIndex(prev => {
+      const current = Math.min(prev, matches.length - 1);
+      return (current + 1) % matches.length;
+    });
   }, [matches.length]);
 
   const goToPrev = useCallback(() => {
     if (matches.length === 0) return;
-    setCurrentMatchIndex(prev => (prev - 1 + matches.length) % matches.length);
+    setCurrentMatchIndex(prev => {
+      const current = Math.min(prev, matches.length - 1);
+      return (current - 1 + matches.length) % matches.length;
+    });
   }, [matches.length]);
 
   const clearSearch = useCallback(() => {
@@ -133,7 +183,7 @@ export function useFlowChatSearch(virtualItems: VirtualItem[]): UseFlowChatSearc
     onSearchChange,
     matches,
     matchIndices,
-    currentMatchIndex,
+    currentMatchIndex: resolvedCurrentMatchIndex,
     currentMatchVirtualIndex,
     goToNext,
     goToPrev,


### PR DESCRIPTION
## Summary

- Keep the concrete matching Flow item and collapsed-container path for each deduplicated dialog-turn search result.
- Materialize virtualized results, reveal collapsed thinking/explore/user content, center the exact text range, and highlight the active match.
- Cancel stale navigation attempts and clear highlights when search is cleared or the list unmounts.
- Normalize next/previous navigation against the current match count when streaming or history updates shrink the result set.

## Type and Areas

Type: bug fix / UI/UX

Areas: web UI, Flow Chat

## Motivation / Impact

Search navigation previously centered only the containing virtual turn, which could leave the matching text off-screen inside a long or collapsed message. Result-count changes could also leave a stale internal index and make next/previous navigation appear to do nothing. Navigation now lands on the exact visible match and remains consistent as the conversation changes.

## Verification

- `pnpm --dir src/web-ui run test:run src/flow_chat/components/modern/useFlowChatSearch.test.ts src/flow_chat/components/modern/flowChatSearchDom.test.ts src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx` — 4 files, 55 tests passed
- `pnpm run type-check:web` — passed
- `git diff --check upstream/main...HEAD` — passed

## Reviewer Notes

The exact-position resolver is bounded to 24 animation-frame attempts so it can wait for virtualization and expansion without leaving an unbounded retry loop. A newer navigation request cancels an older one.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.