### PR TITLE
fix(settings): restore consistent section spacing

### DIFF
--- a/src/web-ui/src/infrastructure/config/components/AcpAgentsConfig.scss
+++ b/src/web-ui/src/infrastructure/config/components/AcpAgentsConfig.scss
@@ -1,12 +1,6 @@
 @use '../../../component-library/styles/tokens' as *;
 
 .bitfun-acp-agents {
-  &__manager {
-    display: flex;
-    flex-direction: column;
-    gap: $size-gap-4;
-  }
-
   &__toolbar {
     display: grid;
     grid-template-columns: minmax(0, 1fr) auto;

--- a/src/web-ui/src/infrastructure/config/components/AcpAgentsConfig.test.tsx
+++ b/src/web-ui/src/infrastructure/config/components/AcpAgentsConfig.test.tsx
@@ -78,6 +78,7 @@ vi.mock('./common', () => ({
     </header>
   ),
   ConfigPageLayout: ({ children }: { children: React.ReactNode }) => <main>{children}</main>,
+  ConfigPageSectionStack: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   ConfigPageSection: ({
     children,
     title,

--- a/src/web-ui/src/infrastructure/config/components/AcpAgentsConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/AcpAgentsConfig.tsx
@@ -20,6 +20,7 @@ import {
   ConfigPageHeader,
   ConfigPageLayout,
   ConfigPageSection,
+  ConfigPageSectionStack,
 } from './common';
 import {
   ACPClientAPI,
@@ -908,7 +909,7 @@ const AcpAgentsConfig: React.FC = () => {
       />
 
       <ConfigPageContent>
-        <div className="bitfun-acp-agents__manager">
+        <ConfigPageSectionStack className="bitfun-acp-agents__manager">
           <div className="bitfun-acp-agents__toolbar">
             <Input
               className="bitfun-acp-agents__search"
@@ -1481,7 +1482,7 @@ const AcpAgentsConfig: React.FC = () => {
               </div>
             )}
           </ConfigPageSection>
-        </div>
+        </ConfigPageSectionStack>
       </ConfigPageContent>
     </ConfigPageLayout>
   );

--- a/src/web-ui/src/infrastructure/config/components/AppearanceConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/AppearanceConfig.tsx
@@ -16,6 +16,7 @@ import {
   ConfigPageHeader,
   ConfigPageLayout,
   ConfigPageSection,
+  ConfigPageSectionStack,
   ConfigPageRow,
 } from './common';
 import './AppearanceConfig.scss';
@@ -395,10 +396,10 @@ const AppearanceConfig: React.FC = () => {
     <ConfigPageLayout className="bitfun-appearance-config">
       <ConfigPageHeader title={t('title')} subtitle={t('subtitle')} />
       <ConfigPageContent className="bitfun-appearance-config__content">
-        <div data-testid="appearance-config">
+        <ConfigPageSectionStack data-testid="appearance-config">
           <AppearanceThemeSection />
           <FontPreferencePanel />
-        </div>
+        </ConfigPageSectionStack>
       </ConfigPageContent>
     </ConfigPageLayout>
   );

--- a/src/web-ui/src/infrastructure/config/components/common/ConfigPageLayout.scss
+++ b/src/web-ui/src/infrastructure/config/components/common/ConfigPageLayout.scss
@@ -46,6 +46,13 @@
   gap: var(--config-page-section-gap);
 }
 
+.bitfun-config-page-section-stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--config-page-section-gap);
+  min-width: 0;
+}
+
 .bitfun-config-page-section {
   display: flex;
   flex-direction: column;
@@ -174,12 +181,12 @@
 }
 
 @container config-panel (max-width: 900px) {
-  .bitfun-config-page-layout {
-    --config-page-content-bottom-padding: 40px;
-    --config-page-section-gap: var(--size-gap-8);
+  .bitfun-config-page-layout__scroll-end-spacer {
+    height: 40px;
   }
 
   .bitfun-config-page-content {
+    --config-page-section-gap: var(--size-gap-8);
     padding-inline: var(--size-gap-4);
   }
 
@@ -214,4 +221,3 @@
     justify-self: stretch;
   }
 }
-

--- a/src/web-ui/src/infrastructure/config/components/common/ConfigPageLayout.test.tsx
+++ b/src/web-ui/src/infrastructure/config/components/common/ConfigPageLayout.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import {
+  ConfigPageContent,
+  ConfigPageSection,
+  ConfigPageSectionStack,
+} from './ConfigPageLayout';
+
+describe('ConfigPageLayout', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('preserves the standard section stack inside a shared wrapper', () => {
+    act(() => {
+      root.render(
+        <ConfigPageContent>
+          <ConfigPageSectionStack data-testid="section-stack">
+            <ConfigPageSection title="First">
+              <div>First body</div>
+            </ConfigPageSection>
+            <ConfigPageSection title="Second">
+              <div>Second body</div>
+            </ConfigPageSection>
+          </ConfigPageSectionStack>
+        </ConfigPageContent>,
+      );
+    });
+
+    const contentInner = container.querySelector('.bitfun-config-page-content__inner');
+    const stack = container.querySelector('[data-testid="section-stack"]');
+
+    expect(contentInner?.children).toHaveLength(1);
+    expect(contentInner?.firstElementChild).toBe(stack);
+    expect(stack?.classList.contains('bitfun-config-page-section-stack')).toBe(true);
+    expect(stack?.querySelectorAll(':scope > .bitfun-config-page-section')).toHaveLength(2);
+  });
+});

--- a/src/web-ui/src/infrastructure/config/components/common/ConfigPageLayout.tsx
+++ b/src/web-ui/src/infrastructure/config/components/common/ConfigPageLayout.tsx
@@ -47,6 +47,29 @@ export const ConfigPageContent: React.FC<ConfigPageContentProps> = ({
   );
 };
 
+export interface ConfigPageSectionStackProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode;
+}
+
+/**
+ * Keeps the standard page-level spacing when sections need a shared wrapper
+ * for state, test hooks, or adjacent page controls.
+ */
+export const ConfigPageSectionStack: React.FC<ConfigPageSectionStackProps> = ({
+  children,
+  className = '',
+  ...props
+}) => {
+  return (
+    <div
+      {...props}
+      className={`bitfun-config-page-section-stack ${className}`.trim()}
+    >
+      {children}
+    </div>
+  );
+};
+
 export interface ConfigPageSectionProps {
   title: string;
   /** Renders inline after the title (e.g. status badge). */
@@ -151,6 +174,5 @@ export const ConfigPageRow: React.FC<ConfigPageRowProps> = ({
 };
 
 export default ConfigPageLayout;
-
 
 

--- a/src/web-ui/src/infrastructure/config/components/common/index.ts
+++ b/src/web-ui/src/infrastructure/config/components/common/index.ts
@@ -10,15 +10,16 @@ export type { ConfigCollectionItemProps } from './ConfigCollectionItem';
 export {
   ConfigPageLayout,
   ConfigPageContent,
+  ConfigPageSectionStack,
   ConfigPageSection,
   ConfigPageRow,
 } from './ConfigPageLayout';
 export type {
   ConfigPageLayoutProps,
   ConfigPageContentProps,
+  ConfigPageSectionStackProps,
   ConfigPageSectionProps,
   ConfigPageRowProps,
 } from './ConfigPageLayout';
-
 
 


### PR DESCRIPTION
## Summary

- add a shared `ConfigPageSectionStack` for wrapped top-level settings sections
- restore standard spacing between Appearance sections and align ACP Agent settings with the same layout contract
- fix the narrow-container override so responsive section spacing and the scroll-end spacer take effect
- add a focused layout regression test

## Verification

- `pnpm run type-check:web`
- `pnpm --dir src/web-ui run test:run src/infrastructure/config/components/common/ConfigPageLayout.test.tsx src/infrastructure/config/components/AcpAgentsConfig.test.tsx` (7 tests passed)
- focused ESLint: no errors
- `git diff --check`
- local visual QA: 40px section gap at the default viewport and 32px at an 800px viewport