### PR TITLE
fix(ai): enable HTTP/2 for streaming requests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ encoding_rs = "0.8.35"
 url = "2"
 
 # HTTP client
-reqwest = { version = "0.13.4", default-features = false, features = ["native-tls", "rustls", "json", "stream", "multipart", "query", "form"] }
+reqwest = { version = "0.13.4", default-features = false, features = ["native-tls", "rustls", "http2", "json", "stream", "multipart", "query", "form"] }
 
 # Debug Log HTTP Server
 axum = { version = "0.8", features = ["json", "ws"] }

--- a/src/crates/adapters/ai-adapters/src/client/sse.rs
+++ b/src/crates/adapters/ai-adapters/src/client/sse.rs
@@ -240,6 +240,7 @@ where
             StreamSendOutcome::Response(resp) => {
                 let connect_time = elapsed_ms_u64(request_start_time);
                 let status = resp.status();
+                let http_version = resp.version();
                 let headers = resp.headers().clone();
 
                 if status.is_client_error() && !is_retryable_http_status(status) {
@@ -262,10 +263,11 @@ where
 
                 if status.is_success() {
                     debug!(
-                        "{} request connected: {}ms, status: {}, attempt: {}/{}",
+                        "{} request connected: {}ms, status: {}, protocol: {:?}, attempt: {}/{}",
                         label,
                         connect_time,
                         status,
+                        http_version,
                         attempt + 1,
                         max_tries
                     );


### PR DESCRIPTION
## Summary

- Enable the `reqwest` HTTP/2 feature for automatic protocol negotiation.
- Log the negotiated HTTP version when an AI streaming response connects.

## Type and Areas

Type: bug fix

Areas: AI adapters, Rust networking

## Motivation / Impact

Some API gateways buffer HTTP/1.1 SSE responses in large batches while forwarding the same response incrementally over HTTP/2. This can make supported models appear non-streaming in BitFun.

The change enables ALPN-based HTTP/2 negotiation without forcing HTTP/2. Providers that do not support HTTP/2 continue to use HTTP/1.1. Recording the negotiated protocol makes future streaming diagnostics explicit.

## Verification

- `cargo test -p bitfun-ai-adapters --test stream_processor_anthropic --test stream_test_harness` — 7 passed.
- `cargo check --workspace` — passed.
- `cargo tree -e features -p bitfun-ai-adapters` — confirms `reqwest feature "http2"` and `h2 v0.4.13`.
- `git diff --check` — passed.

## Reviewer Notes

This does not use `http2_prior_knowledge()` or otherwise force HTTP/2. Protocol selection remains negotiated per endpoint, with HTTP/1.1 compatibility retained.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.
