### PR TITLE
fix(desktop): raise trait recursion limit for HTTP/2

### DIFF
--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -1,5 +1,9 @@
+#![recursion_limit = "256"]
 #![allow(non_snake_case)]
 //! BitFun Desktop - Tauri-based desktop application with TransportAdapter architecture
+//!
+//! The reqwest HTTP/2 and MCP transport type graph exceeds rustc's default
+//! trait-evaluation recursion budget when desktop tasks require `Send`.
 
 pub mod api;
 pub mod computer_use;


### PR DESCRIPTION
## Summary
- raise the desktop library crate recursion limit to accommodate the reqwest HTTP/2 and MCP transport type graph
- preserve the recently enabled HTTP/2 streaming support
- document why the non-default compiler budget is required

## Root cause
Enabling reqwest HTTP/2 deepened the `Send`/`Sync` trait graph reachable from desktop spawned tasks. rustc exhausted the default recursion limit while evaluating the MCP-backed scheduler future and reported E0275.

## Verification
- `cargo check -p bitfun-desktop`
- `cargo test -p bitfun-desktop` (205 passed, 2 ignored)