### PR TITLE
style(web): brighten light theme mouse glow

### DIFF
--- a/src/web-ui/src/infrastructure/mouse-glow/MouseGlowEffect.scss
+++ b/src/web-ui/src/infrastructure/mouse-glow/MouseGlowEffect.scss
@@ -66,19 +66,25 @@
   --mouse-glow-border-width: 1.5px;
   --mouse-glow-core: color-mix(
     in srgb,
-    var(--color-static-black) 38%,
+    var(--color-success) 82%,
     var(--color-static-white)
   );
   --mouse-glow-falloff: color-mix(
     in srgb,
-    var(--color-static-black) 16%,
+    var(--color-success) 34%,
     transparent
   );
   --mouse-glow-shadow: color-mix(
     in srgb,
-    var(--color-static-black) 20%,
+    var(--color-success) 28%,
     transparent
   );
+
+  filter:
+    hue-rotate(-18deg)
+    saturate(2.5)
+    brightness(1.12)
+    drop-shadow(0 0 8px var(--mouse-glow-shadow));
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/web-ui/src/infrastructure/mouse-glow/MouseGlowEffect.scss
+++ b/src/web-ui/src/infrastructure/mouse-glow/MouseGlowEffect.scss
@@ -66,24 +66,24 @@
   --mouse-glow-border-width: 1.5px;
   --mouse-glow-core: color-mix(
     in srgb,
-    var(--color-accent-500) 82%,
+    var(--color-accent-500) 88%,
     var(--color-static-white)
   );
   --mouse-glow-falloff: color-mix(
     in srgb,
-    var(--color-accent-500) 34%,
+    var(--color-accent-500) 40%,
     transparent
   );
   --mouse-glow-shadow: color-mix(
     in srgb,
-    var(--color-accent-500) 28%,
+    var(--color-accent-500) 34%,
     transparent
   );
 
   filter:
-    hue-rotate(-8deg)
-    saturate(2.25)
-    brightness(1.12)
+    hue-rotate(4deg)
+    saturate(2.65)
+    brightness(1.2)
     drop-shadow(0 0 8px var(--mouse-glow-shadow));
 }
 

--- a/src/web-ui/src/infrastructure/mouse-glow/MouseGlowEffect.scss
+++ b/src/web-ui/src/infrastructure/mouse-glow/MouseGlowEffect.scss
@@ -66,23 +66,23 @@
   --mouse-glow-border-width: 1.5px;
   --mouse-glow-core: color-mix(
     in srgb,
-    var(--color-success) 82%,
+    var(--color-accent-500) 82%,
     var(--color-static-white)
   );
   --mouse-glow-falloff: color-mix(
     in srgb,
-    var(--color-success) 34%,
+    var(--color-accent-500) 34%,
     transparent
   );
   --mouse-glow-shadow: color-mix(
     in srgb,
-    var(--color-success) 28%,
+    var(--color-accent-500) 28%,
     transparent
   );
 
   filter:
-    hue-rotate(-18deg)
-    saturate(2.5)
+    hue-rotate(-8deg)
+    saturate(2.25)
     brightness(1.12)
     drop-shadow(0 0 8px var(--mouse-glow-shadow));
 }


### PR DESCRIPTION
## Summary
- replace the gray light-theme mouse glow with a bright yellow-green treatment
- derive the glow from existing theme tokens, then increase saturation and brightness locally
- keep the dark-theme glow unchanged

## Verification
- `pnpm run type-check:web`
- `pnpm --dir src/web-ui run test:run src/infrastructure/mouse-glow/core/MouseGlowService.test.ts`
- `pnpm run theme:color-audit:all`
- browser visual check in the light theme