### PR TITLE
feat(web-ui): add desktop pet bubble composer

### DIFF
--- a/src/web-ui/src/app/App.tsx
+++ b/src/web-ui/src/app/App.tsx
@@ -26,6 +26,7 @@ import {
   isStartupOverlayPresent,
 } from './startup/startupOverlay';
 import { ToolbarModeProvider } from '../flow_chat/components/toolbar-mode/ToolbarModeProvider';
+import type { AgentCompanionPetCommand } from './services/agentCompanionPetCommands';
 import AskUserAnnouncer from './components/NavPanel/AskUserAnnouncer';
 
 const log = createLogger('App');
@@ -674,6 +675,35 @@ function App() {
       })
       .catch(error => {
         log.warn('Failed to listen for Agent companion session open events', error);
+      });
+
+    return () => {
+      unlisten?.();
+    };
+  }, []);
+
+  useEffect(() => {
+    let unlisten: (() => void) | null = null;
+    void import('@tauri-apps/api/event')
+      .then(({ listen }) => listen<AgentCompanionPetCommand>(
+        'agent-companion://pet-command',
+        async event => {
+          try {
+            const { handleAgentCompanionPetCommand } = await import('./services/agentCompanionPetCommands');
+            await handleAgentCompanionPetCommand(event.payload);
+          } catch (error) {
+            log.warn('Failed to handle Agent companion pet command', {
+              commandType: event.payload?.type,
+              error,
+            });
+          }
+        },
+      ))
+      .then(removeListener => {
+        unlisten = removeListener;
+      })
+      .catch(error => {
+        log.warn('Failed to listen for Agent companion pet commands', error);
       });
 
     return () => {

--- a/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.scss
+++ b/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.scss
@@ -32,10 +32,33 @@
   background: transparent;
   user-select: none;
 
-  &__dock {
+  /* Holds the dock anchored bottom-right, above the click-away backdrop. */
+  &__stack {
     position: absolute;
     right: 0;
     bottom: 0;
+    z-index: 2;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    justify-content: flex-end;
+    max-width: 100vw;
+    max-height: 100vh;
+    min-height: 0;
+    pointer-events: none;
+  }
+
+  &__backdrop {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    background: transparent;
+  }
+
+  &__dock {
+    position: relative;
+    flex: 0 1 auto;
+    min-height: 0;
     display: flex;
     flex-direction: row;
     align-items: center;
@@ -44,6 +67,143 @@
     width: max-content;
     max-height: 100vh;
     pointer-events: none;
+  }
+
+  /* While a menu is open every click outside it must reach the backdrop. The
+     bubble composer is excluded: it lives inside a bubble and stays usable. */
+  &--menu-open &__pet-hitbox,
+  &--menu-open &__bubbles {
+    pointer-events: none;
+  }
+
+  &--menu-open &__bubble-compose {
+    pointer-events: none;
+  }
+
+  &__overlay {
+    box-sizing: border-box;
+    width: max-content;
+    max-width: min(240px, 100vw);
+    padding: 5px;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    border: 1px solid var(--color-overlay-slate-12);
+    border-radius: 10px;
+    /* Intentionally no backdrop-filter: adding a blurred layer on right-click
+       re-composites the other blurred surfaces and flashes the whole window. */
+    background: var(--color-overlay-white-95);
+    color: var(--bitfun-agent-companion-bubble-fg);
+    box-shadow: 0 6px 18px rgba(var(--color-overlay-slate-rgb), 0.18);
+    pointer-events: auto;
+
+    /* Context menus are placed at the cursor. */
+    &--anchored {
+      position: absolute;
+      z-index: 3;
+    }
+  }
+
+  &__menu {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  &__menu-item {
+    appearance: none;
+    width: 100%;
+    box-sizing: border-box;
+    padding: 5px 8px;
+    border: 0;
+    border-radius: 6px;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    font-size: 11px;
+    line-height: 1.3;
+    text-align: left;
+    /* Wrap rather than spill: the window can be as narrow as the pet sprite. */
+    white-space: normal;
+    overflow-wrap: anywhere;
+    cursor: pointer;
+
+    &:hover {
+      background: var(--color-overlay-slate-08);
+    }
+
+    &:focus-visible {
+      outline: 2px solid color-mix(in srgb, var(--color-accent-600) 70%, transparent);
+      outline-offset: -2px;
+    }
+  }
+
+  /* Input bar shown inside the bubble the user replied from. */
+  &__bubble-composer {
+    flex: 0 0 auto;
+    align-self: stretch;
+    width: 100%;
+    margin-top: 5px;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 4px;
+  }
+
+  &__bubble-composer-input {
+    appearance: none;
+    -webkit-appearance: none;
+    flex: 1 1 auto;
+    min-width: 0;
+    height: 21px;
+    box-sizing: border-box;
+    padding: 2px 5px;
+    border: 1px solid var(--color-overlay-slate-12);
+    border-radius: 5px;
+    background: var(--color-overlay-white-95);
+    color: inherit;
+    font: inherit;
+    font-size: 10px;
+    line-height: 1.3;
+    user-select: text;
+    -webkit-user-select: text;
+
+    &:focus,
+    &:focus-visible {
+      outline: none;
+      outline-offset: 0;
+      box-shadow: none;
+    }
+  }
+
+  &__bubble-composer-send,
+  &__bubble-composer-cancel {
+    appearance: none;
+    flex-shrink: 0;
+    width: 21px;
+    height: 21px;
+    padding: 0;
+    display: grid;
+    place-items: center;
+    border: 1px solid var(--color-overlay-slate-12);
+    border-radius: 5px;
+    background: var(--color-overlay-slate-04);
+    color: inherit;
+    cursor: pointer;
+
+    &:hover:not(:disabled) {
+      background: var(--color-overlay-slate-08);
+    }
+
+    &:disabled {
+      opacity: 0.45;
+      cursor: default;
+    }
+
+    &:focus-visible {
+      outline: 2px solid color-mix(in srgb, var(--color-accent-600) 70%, transparent);
+      outline-offset: 1px;
+    }
   }
 
   &__pet {
@@ -93,8 +253,9 @@
   &__bubbles {
     position: relative;
     flex-shrink: 0;
-    width: 146px;
-    max-width: 146px;
+    width: 180px;
+    max-width: 180px;
+    min-height: 0;
     max-height: 100vh;
     display: flex;
     flex-direction: column;
@@ -121,11 +282,66 @@
     }
   }
 
+  /* Wraps one bubble so the hover compose button can sit on top of it without
+     nesting a button inside the bubble button. */
+  &__bubble-shell {
+    position: relative;
+    isolation: isolate;
+    flex-shrink: 0;
+    width: 180px;
+    max-width: 100%;
+
+    &--single {
+      height: min(var(--bitfun-agent-companion-pet-height), 100vh);
+    }
+  }
+
+  &__bubble-compose {
+    appearance: none;
+    position: absolute;
+    z-index: 2;
+    right: 5px;
+    bottom: 5px;
+    width: 18px;
+    height: 18px;
+    padding: 0;
+    display: grid;
+    place-items: center;
+    border: 1px solid var(--color-overlay-slate-12);
+    border-radius: 50%;
+    background: var(--color-overlay-white-95);
+    color: var(--bitfun-agent-companion-bubble-fg);
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition:
+      opacity 120ms ease,
+      visibility 0s linear 120ms;
+    cursor: pointer;
+
+    &:hover {
+      background: var(--color-overlay-slate-08);
+    }
+
+    &:focus-visible {
+      outline: 2px solid color-mix(in srgb, var(--color-accent-600) 70%, transparent);
+      outline-offset: 1px;
+    }
+  }
+
+  &--native-hover &__bubble-shell:hover &__bubble-compose,
+  &__bubble-shell--hovered &__bubble-compose {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+    transition-delay: 0s;
+  }
+
   &__bubble {
     appearance: none;
     text-align: left;
     font: inherit;
-    width: 146px;
+    width: 180px;
     max-width: 100%;
     box-sizing: border-box;
     padding: 7px 10px;
@@ -136,6 +352,7 @@
     backdrop-filter: blur(10px);
     cursor: pointer;
     position: relative;
+    z-index: 0;
 
     &:hover {
       transform: translateY(-1px);
@@ -151,6 +368,33 @@
       display: flex;
       flex-direction: column;
       overflow: hidden;
+    }
+
+    /* Replying turns the bubble into its own composer, so it must not react to
+       hover like a clickable bubble any more. */
+    &--composing {
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+      cursor: default;
+
+      &:hover {
+        transform: none;
+      }
+
+      /* Only the output yields space to the input row; letting the title and
+         status shrink too would clip their glyphs. */
+      .bitfun-agent-companion-window__bubble-title,
+      .bitfun-agent-companion-window__bubble-status {
+        flex: 0 0 auto;
+      }
+
+      /* Two whole lines: a flexible height would leave a half-clipped line
+         under the input row. */
+      .bitfun-agent-companion-window__bubble-output {
+        flex: 0 0 calc(12px * 2);
+        height: calc(12px * 2);
+      }
     }
   }
 

--- a/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.test.tsx
+++ b/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.test.tsx
@@ -1,0 +1,423 @@
+// @vitest-environment jsdom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { createInstance, type i18n as I18nInstance } from 'i18next';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentCompanionActivityPayload, AgentCompanionTaskStatus } from '@/flow_chat/utils/agentCompanionActivity';
+import { AgentCompanionDesktopPet } from './AgentCompanionDesktopPet';
+
+const emitMock = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+const listenMock = vi.hoisted(() => vi.fn());
+const invokeMock = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+const cursorPositionMock = vi.hoisted(() => vi.fn(() => Promise.resolve({ x: 0, y: 0 })));
+/** Backs the Tauri IPC bridge, so window resize requests are observable. */
+const hostInvokeMock = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  emit: emitMock,
+  listen: listenMock,
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: invokeMock,
+}));
+
+vi.mock('@tauri-apps/api/window', () => ({
+  cursorPosition: cursorPositionMock,
+  getCurrentWindow: () => ({
+    hide: vi.fn(() => Promise.resolve()),
+    setFocus: vi.fn(() => Promise.resolve()),
+    startDragging: vi.fn(() => Promise.resolve()),
+    outerPosition: vi.fn(() => Promise.resolve({ x: 0, y: 0 })),
+    scaleFactor: vi.fn(() => Promise.resolve(1)),
+    onMoved: vi.fn(() => Promise.resolve(() => {})),
+    onScaleChanged: vi.fn(() => Promise.resolve(() => {})),
+  }),
+}));
+
+vi.mock('@/infrastructure/config/services/AIExperienceConfigService', () => ({
+  aiExperienceConfigService: {
+    getSettings: () => ({ agent_companion_pet: null }),
+    getSettingsAsync: () => Promise.resolve({
+      enable_agent_companion: true,
+      agent_companion_display_mode: 'desktop',
+      agent_companion_pet: null,
+    }),
+  },
+}));
+
+vi.mock('@/flow_chat/components/ChatInputPixelPet', () => ({
+  ChatInputPixelPet: () => <div data-testid="pixel-pet" />,
+}));
+
+const PET_COMMAND_EVENT = 'agent-companion://pet-command';
+const ACTIVITY_EVENT = 'agent-companion://activity-updated';
+
+let i18n: I18nInstance;
+
+function task(overrides: Partial<AgentCompanionTaskStatus> = {}): AgentCompanionTaskStatus {
+  return {
+    sessionId: 'session-1',
+    title: 'Refactor login',
+    mood: 'working',
+    state: 'running',
+    labelKey: 'agentCompanion.activity.working',
+    defaultLabel: 'Working',
+    startedAt: 1,
+    updatedAt: 2,
+    canReply: true,
+    ...overrides,
+  };
+}
+
+/**
+ * React caches the last value it saw on the element instance, so assigning
+ * `input.value` directly is invisible to `onChange`. Going through the prototype
+ * setter bypasses that cache and makes the input event look like real typing.
+ */
+function typeInto(input: HTMLInputElement, value: string): void {
+  const nativeValueSetter = Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype,
+    'value',
+  )?.set;
+  act(() => {
+    nativeValueSetter?.call(input, value);
+    input.dispatchEvent(new window.Event('input', { bubbles: true }));
+  });
+}
+
+beforeAll(async () => {
+  // The pet resizes its own window through `invoke`; the dynamic import inside
+  // the component reaches the real Tauri core module, so stub the IPC bridge.
+  (window as unknown as { __TAURI_INTERNALS__: unknown }).__TAURI_INTERNALS__ = {
+    invoke: hostInvokeMock,
+    transformCallback: (callback: unknown) => callback,
+  };
+
+  i18n = createInstance();
+  await i18n.use(initReactI18next).init({
+    lng: 'en-US',
+    fallbackLng: 'en-US',
+    resources: {
+      'en-US': {
+        'flow-chat': {
+          agentCompanion: {
+            activity: { working: 'Working', completed: 'Completed' },
+            menu: { closePet: 'Close pet', closeBubble: 'Close this bubble' },
+            composer: {
+              openTitle: 'Send a message to this session',
+              ariaLabel: 'Send a message to this session',
+              placeholder: 'Type a message, Enter to send',
+              cancel: 'Cancel',
+              send: 'Send',
+            },
+          },
+        },
+      },
+    },
+    interpolation: { escapeValue: false },
+  });
+});
+
+describe('AgentCompanionDesktopPet', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let pushActivity: (payload: AgentCompanionActivityPayload) => void;
+
+  const query = <T extends Element>(selector: string): T | null =>
+    container.querySelector<T>(selector);
+
+  const dispatch = (element: Element, type: string, at?: { clientX: number; clientY: number }) => {
+    act(() => {
+      element.dispatchEvent(new window.MouseEvent(type, {
+        bubbles: true,
+        cancelable: true,
+        ...at,
+      }));
+    });
+  };
+
+  beforeEach(async () => {
+    emitMock.mockClear();
+    invokeMock.mockClear();
+    hostInvokeMock.mockClear();
+    cursorPositionMock.mockReset();
+    cursorPositionMock.mockResolvedValue({ x: 0, y: 0 });
+    listenMock.mockReset();
+
+    const activityListeners: Array<(event: { payload: AgentCompanionActivityPayload }) => void> = [];
+    listenMock.mockImplementation((eventName: string, handler: (event: { payload: unknown }) => void) => {
+      if (eventName === ACTIVITY_EVENT) {
+        activityListeners.push(handler as (event: { payload: AgentCompanionActivityPayload }) => void);
+      }
+      return Promise.resolve(() => {});
+    });
+    pushActivity = payload => {
+      act(() => {
+        activityListeners.forEach(handler => handler({ payload }));
+      });
+    };
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    await act(async () => {
+      root = createRoot(container);
+      root.render(
+        <I18nextProvider i18n={i18n}>
+          <AgentCompanionDesktopPet />
+        </I18nextProvider>
+      );
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('closes the desktop pet from the pet context menu', () => {
+    const hitbox = query('.bitfun-agent-companion-window__pet-hitbox');
+    expect(hitbox).not.toBeNull();
+
+    dispatch(hitbox!, 'contextmenu', { clientX: 300, clientY: 200 });
+
+    const menuItem = query<HTMLButtonElement>('.bitfun-agent-companion-window__menu-item');
+    expect(menuItem?.textContent).toBe('Close pet');
+
+    act(() => {
+      menuItem!.click();
+    });
+
+    expect(emitMock).toHaveBeenCalledWith(PET_COMMAND_EVENT, { type: 'close-desktop-pet' });
+    expect(query('.bitfun-agent-companion-window__menu-item')).toBeNull();
+  });
+
+  it('anchors the context menu to the cursor position', () => {
+    dispatch(query('.bitfun-agent-companion-window__pet-hitbox')!, 'contextmenu', {
+      clientX: 300,
+      clientY: 200,
+    });
+
+    const menu = query<HTMLDivElement>('.bitfun-agent-companion-window__overlay--anchored');
+    expect(menu).not.toBeNull();
+    // The anchor is measured from the bottom-right corner, which the host keeps
+    // fixed while the window grows for the menu.
+    expect(menu!.style.right).toBe(`${window.innerWidth - 300}px`);
+    expect(menu!.style.bottom).toBe(`${window.innerHeight - 200}px`);
+    expect(menu!.style.visibility).toBe('visible');
+  });
+
+  it('does not resize the window for a context menu', async () => {
+    pushActivity({ mood: 'working', tasks: [task()], sequence: 1, emittedAt: 1 });
+    // Let the bubble's own resize request settle before watching for new ones.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    hostInvokeMock.mockClear();
+
+    dispatch(query('.bitfun-agent-companion-window__bubble-shell')!, 'contextmenu');
+    dispatch(query('.bitfun-agent-companion-window__pet-hitbox')!, 'contextmenu');
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Resizing moves every bottom-right anchored element for a frame, which
+    // reads as the pet and bubbles flashing.
+    expect(hostInvokeMock).not.toHaveBeenCalledWith(
+      'resize_agent_companion_desktop_pet',
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it('sends a message from the bubble composer', async () => {
+    pushActivity({ mood: 'working', tasks: [task()], sequence: 1, emittedAt: 1 });
+
+    const composeButton = query<HTMLButtonElement>('.bitfun-agent-companion-window__bubble-compose');
+    expect(composeButton).not.toBeNull();
+
+    act(() => {
+      composeButton!.click();
+    });
+
+    // The input bar belongs to the bubble itself; no extra bubble or panel.
+    expect(container.querySelectorAll('.bitfun-agent-companion-window__bubble')).toHaveLength(1);
+    const input = query<HTMLInputElement>('.bitfun-agent-companion-window__bubble .bitfun-agent-companion-window__bubble-composer-input');
+    expect(input).not.toBeNull();
+    expect(input!.hasAttribute('data-mouse-glow-ignore')).toBe(true);
+    expect(query('.bitfun-agent-companion-window__bubble--composing')).not.toBeNull();
+    expect(query('.bitfun-agent-companion-window__bubble-compose')).toBeNull();
+
+    typeInto(input!, '  ship it  ');
+    act(() => {
+      query<HTMLButtonElement>('.bitfun-agent-companion-window__bubble-composer-send')!.click();
+    });
+
+    expect(emitMock).toHaveBeenCalledWith(PET_COMMAND_EVENT, {
+      type: 'send-message',
+      sessionId: 'session-1',
+      message: 'ship it',
+    });
+
+    // The bar closes once the command has been handed to the main window.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(query('.bitfun-agent-companion-window__bubble-composer-input')).toBeNull();
+    expect(query('.bitfun-agent-companion-window__bubble-compose')).not.toBeNull();
+  });
+
+  it('reveals the bubble entry from cursor polling before the pet window is clicked', async () => {
+    pushActivity({ mood: 'working', tasks: [task()], sequence: 1, emittedAt: 1 });
+
+    const bubbleShell = query<HTMLElement>('.bitfun-agent-companion-window__bubble-shell');
+    expect(bubbleShell).not.toBeNull();
+    vi.spyOn(bubbleShell!, 'getBoundingClientRect').mockReturnValue({
+      x: 10,
+      y: 10,
+      left: 10,
+      top: 10,
+      right: 110,
+      bottom: 80,
+      width: 100,
+      height: 70,
+      toJSON: () => ({}),
+    });
+    cursorPositionMock.mockResolvedValue({ x: 40, y: 40 });
+
+    // No mouseover is dispatched: the transparent, inactive desktop window
+    // must discover this hover through the same global cursor poll as the pet.
+    await act(async () => {
+      await new Promise(resolve => window.setTimeout(resolve, 150));
+    });
+
+    expect(bubbleShell!.classList).toContain('bitfun-agent-companion-window__bubble-shell--hovered');
+
+    cursorPositionMock.mockResolvedValue({ x: 200, y: 200 });
+    await act(async () => {
+      await new Promise(resolve => window.setTimeout(resolve, 150));
+    });
+
+    expect(bubbleShell!.classList).not.toContain('bitfun-agent-companion-window__bubble-shell--hovered');
+  });
+
+  it('sends the composer message on Enter', () => {
+    pushActivity({ mood: 'working', tasks: [task()], sequence: 1, emittedAt: 1 });
+
+    act(() => {
+      query<HTMLButtonElement>('.bitfun-agent-companion-window__bubble-compose')!.click();
+    });
+    const input = query<HTMLInputElement>('.bitfun-agent-companion-window__bubble-composer-input')!;
+    typeInto(input, 'run the tests');
+
+    act(() => {
+      input.dispatchEvent(new window.KeyboardEvent('keydown', {
+        key: 'Enter',
+        bubbles: true,
+        cancelable: true,
+      }));
+    });
+
+    expect(emitMock).toHaveBeenCalledWith(PET_COMMAND_EVENT, {
+      type: 'send-message',
+      sessionId: 'session-1',
+      message: 'run the tests',
+    });
+  });
+
+  it('cancels the bubble composer without sending its draft', () => {
+    pushActivity({ mood: 'working', tasks: [task()], sequence: 1, emittedAt: 1 });
+
+    act(() => {
+      query<HTMLButtonElement>('.bitfun-agent-companion-window__bubble-compose')!.click();
+    });
+    const input = query<HTMLInputElement>('.bitfun-agent-companion-window__bubble-composer-input')!;
+    typeInto(input, 'keep this draft local');
+
+    act(() => {
+      query<HTMLButtonElement>('.bitfun-agent-companion-window__bubble-composer-cancel')!.click();
+    });
+
+    expect(query('.bitfun-agent-companion-window__bubble-composer-input')).toBeNull();
+    expect(query('.bitfun-agent-companion-window__bubble-compose')).not.toBeNull();
+    expect(emitMock).not.toHaveBeenCalledWith(
+      PET_COMMAND_EVENT,
+      expect.objectContaining({ type: 'send-message' }),
+    );
+  });
+
+  it('hides the composer entry for sessions that cannot be replied to directly', () => {
+    pushActivity({
+      mood: 'working',
+      tasks: [task({ canReply: false })],
+      sequence: 1,
+      emittedAt: 1,
+    });
+
+    expect(query('.bitfun-agent-companion-window__bubble')).not.toBeNull();
+    expect(query('.bitfun-agent-companion-window__bubble-compose')).toBeNull();
+  });
+
+  it('closes a finished bubble and acknowledges it in the main window', () => {
+    pushActivity({
+      mood: 'rest',
+      tasks: [task({ state: 'completed', labelKey: 'agentCompanion.activity.completed', defaultLabel: 'Completed' })],
+      sequence: 1,
+      emittedAt: 1,
+    });
+
+    dispatch(query('.bitfun-agent-companion-window__bubble-shell')!, 'contextmenu');
+
+    const menuItem = query<HTMLButtonElement>('.bitfun-agent-companion-window__menu-item');
+    expect(menuItem?.textContent).toBe('Close this bubble');
+    // The bubble menu shows the action only, not the session title.
+    expect(query('.bitfun-agent-companion-window__overlay--anchored .bitfun-agent-companion-window__overlay-title')).toBeNull();
+
+    act(() => {
+      menuItem!.click();
+    });
+
+    expect(query('.bitfun-agent-companion-window__bubble')).toBeNull();
+    expect(emitMock).toHaveBeenCalledWith(PET_COMMAND_EVENT, {
+      type: 'dismiss-task',
+      sessionId: 'session-1',
+    });
+  });
+
+  it('keeps a silenced running bubble hidden but restores it once the task needs attention', () => {
+    const runningTask = task();
+    pushActivity({ mood: 'working', tasks: [runningTask], sequence: 1, emittedAt: 1 });
+
+    dispatch(query('.bitfun-agent-companion-window__bubble-shell')!, 'contextmenu');
+    act(() => {
+      query<HTMLButtonElement>('.bitfun-agent-companion-window__menu-item')!.click();
+    });
+
+    expect(query('.bitfun-agent-companion-window__bubble')).toBeNull();
+    // A running bubble is not an unread notice, so nothing is acknowledged.
+    expect(emitMock).not.toHaveBeenCalledWith(PET_COMMAND_EVENT, expect.objectContaining({
+      type: 'dismiss-task',
+    }));
+
+    // Still running: stays silenced.
+    pushActivity({
+      mood: 'working',
+      tasks: [task({ updatedAt: 3 })],
+      sequence: 2,
+      emittedAt: 2,
+    });
+    expect(query('.bitfun-agent-companion-window__bubble')).toBeNull();
+
+    pushActivity({
+      mood: 'rest',
+      tasks: [task({ state: 'completed', labelKey: 'agentCompanion.activity.completed', defaultLabel: 'Completed' })],
+      sequence: 3,
+      emittedAt: 3,
+    });
+    expect(query('.bitfun-agent-companion-window__bubble')).not.toBeNull();
+  });
+});

--- a/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.tsx
+++ b/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.tsx
@@ -1,11 +1,16 @@
-import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { emit, listen } from '@tauri-apps/api/event';
 import { cursorPosition, getCurrentWindow } from '@tauri-apps/api/window';
 import { aiExperienceConfigService, type AgentCompanionPetSelection, type AIExperienceSettings } from '@/infrastructure/config/services/AIExperienceConfigService';
 import { ChatInputPixelPet, type ChatInputPixelPetMood } from '@/flow_chat/components/ChatInputPixelPet';
 import type { ChatInputPetMood } from '@/flow_chat/utils/chatInputPetMood';
-import type { AgentCompanionActivityPayload, AgentCompanionTaskStatus } from '@/flow_chat/utils/agentCompanionActivity';
+import type {
+  AgentCompanionActivityPayload,
+  AgentCompanionTaskState,
+  AgentCompanionTaskStatus,
+} from '@/flow_chat/utils/agentCompanionActivity';
+import type { AgentCompanionPetCommand } from '@/app/services/agentCompanionPetCommands';
 import { createLogger } from '@/shared/utils/logger';
 import './AgentCompanionDesktopPet.scss';
 
@@ -18,17 +23,70 @@ const WINDOW_MAX_HEIGHT = 240;
 const WINDOW_HORIZONTAL_GAP = 8;
 const MAX_VISIBLE_BUBBLES = 2;
 const BUBBLE_GAP = 6;
-const BUBBLE_WIDTH = 146;
+const BUBBLE_WIDTH = 180;
 const BUBBLE_OUTPUT_TYPEWRITER_INTERVAL_MS = 28;
 const WINDOW_EDGE_BUFFER = 4;
 const POINTER_HOVER_POLL_INTERVAL_MS = 120;
 /** Clicks shorter/smaller than this use `show_main_window`; beyond it we start a native drag. */
 const PET_DRAG_THRESHOLD_PX = 8;
 const IS_WINDOWS_WEBVIEW = /\bWindows\b/i.test(window.navigator.userAgent);
+const PET_COMMAND_EVENT = 'agent-companion://pet-command';
+const MENU_EDGE_MARGIN = 4;
 
 interface TypewriterOutputState {
   target: string;
   visible: string;
+}
+
+/**
+ * Which surface is layered above the pet dock. Only one may be open at a time so
+ * the window never has to grow for two panels.
+ */
+type PetOverlayState =
+  | { kind: 'pet-menu' }
+  | { kind: 'bubble-menu'; sessionId: string }
+  | { kind: 'composer'; sessionId: string }
+  | null;
+
+/**
+ * Bubbles are derived from live session activity, so "close this bubble" cannot
+ * simply delete an item. It records which kind of bubble was dismissed instead:
+ * silencing a working bubble keeps it hidden while the task runs, but a later
+ * notice (needs input / finished / failed) still gets through.
+ */
+type BubbleDismissBucket = 'active' | 'notice';
+
+/**
+ * Where a context menu was opened, measured from the window's bottom-right
+ * corner. The host keeps that corner fixed while the window grows to make room
+ * for the menu, so this anchor survives the resize while `clientX`/`clientY`
+ * would not.
+ */
+interface MenuAnchor {
+  right: number;
+  bottom: number;
+}
+
+function menuAnchorFromEvent(event: React.MouseEvent): MenuAnchor {
+  return {
+    right: Math.max(0, window.innerWidth - event.clientX),
+    bottom: Math.max(0, window.innerHeight - event.clientY),
+  };
+}
+
+function bubbleDismissBucket(state: AgentCompanionTaskState): BubbleDismissBucket {
+  return state === 'running' || state === 'waiting' ? 'active' : 'notice';
+}
+
+function isAcknowledgeableTaskState(state: AgentCompanionTaskState): boolean {
+  return state === 'completed' || state === 'error' || state === 'interrupted';
+}
+
+function rectContainsPoint(rect: DOMRect, x: number, y: number): boolean {
+  return x >= rect.left
+    && x <= rect.right
+    && y >= rect.top
+    && y <= rect.bottom;
 }
 
 function seedTypewriterOutput(target: string): string {
@@ -64,8 +122,17 @@ export const AgentCompanionDesktopPet: React.FC = () => {
   const [isHoveringPet, setIsHoveringPet] = useState(false);
   const [isDraggingPet, setIsDraggingPet] = useState(false);
   const [petFrameSize, setPetFrameSize] = useState<{ width: number; height: number } | null>(null);
+  const [overlay, setOverlay] = useState<PetOverlayState>(null);
+  const [menuAnchor, setMenuAnchor] = useState<MenuAnchor | null>(null);
+  const [menuPosition, setMenuPosition] = useState<MenuAnchor | null>(null);
+  const [dismissedBubbles, setDismissedBubbles] = useState<Record<string, BubbleDismissBucket>>({});
+  const [composerValue, setComposerValue] = useState('');
+  const [isSendingComposer, setIsSendingComposer] = useState(false);
+  const [hoveredBubbleSessionId, setHoveredBubbleSessionId] = useState<string | null>(null);
   const dockRef = useRef<HTMLDivElement>(null);
   const bubblesRef = useRef<HTMLDivElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const composerInputRef = useRef<HTMLInputElement>(null);
   const outputRefs = useRef<Map<string, HTMLSpanElement>>(new Map());
   const lastActivitySequenceRef = useRef(0);
   const lastActivityEmittedAtRef = useRef(0);
@@ -75,7 +142,11 @@ export const AgentCompanionDesktopPet: React.FC = () => {
     startY: number;
     dragStarted: boolean;
   } | null>(null);
-  const displayTasks = [...tasks].reverse();
+  const visibleTasks = useMemo(
+    () => tasks.filter(task => dismissedBubbles[task.sessionId] !== bubbleDismissBucket(task.state)),
+    [dismissedBubbles, tasks],
+  );
+  const displayTasks = [...visibleTasks].reverse();
   const activePetSize = pet && petFrameSize
     ? petFrameSize
     : pet
@@ -175,11 +246,48 @@ export const AgentCompanionDesktopPet: React.FC = () => {
     };
   }, []);
 
+  // Drop dismissals whose bubble kind changed (a silenced task now needs
+  // attention or finished) or whose session left the activity payload.
+  useEffect(() => {
+    setDismissedBubbles(previous => {
+      const previousSessionIds = Object.keys(previous);
+      if (previousSessionIds.length === 0) {
+        return previous;
+      }
+
+      const next: Record<string, BubbleDismissBucket> = {};
+      tasks.forEach(task => {
+        const dismissedBucket = previous[task.sessionId];
+        if (dismissedBucket && dismissedBucket === bubbleDismissBucket(task.state)) {
+          next[task.sessionId] = dismissedBucket;
+        }
+      });
+
+      // Kept entries always carry the same bucket, so the count is enough.
+      return Object.keys(next).length === previousSessionIds.length ? previous : next;
+    });
+  }, [tasks]);
+
+  // Never leave a bubble menu or composer floating over a bubble that is gone.
+  useEffect(() => {
+    setOverlay(previous => {
+      if (!previous || previous.kind === 'pet-menu') {
+        return previous;
+      }
+      return visibleTasks.some(task => task.sessionId === previous.sessionId) ? previous : null;
+    });
+    setHoveredBubbleSessionId(previous => (
+      previous && !visibleTasks.some(task => task.sessionId === previous)
+        ? null
+        : previous
+    ));
+  }, [visibleTasks]);
+
   useEffect(() => {
     setTypedOutputBySessionId(previous => {
       const next: Record<string, TypewriterOutputState> = {};
 
-      tasks.forEach(task => {
+      visibleTasks.forEach(task => {
         if (!task.latestOutput) {
           return;
         }
@@ -195,7 +303,7 @@ export const AgentCompanionDesktopPet: React.FC = () => {
 
       return next;
     });
-  }, [tasks]);
+  }, [visibleTasks]);
 
   useEffect(() => {
     const hasTypingOutput = Object.values(typedOutputBySessionId)
@@ -231,7 +339,7 @@ export const AgentCompanionDesktopPet: React.FC = () => {
   }, [typedOutputBySessionId]);
 
   useLayoutEffect(() => {
-    const bubbleCount = tasks.length;
+    const bubbleCount = visibleTasks.length;
     const bubbleElements = Array.from(bubblesRef.current?.children ?? [])
       .slice(0, MAX_VISIBLE_BUBBLES);
     const visibleBubbleHeight = bubbleElements.reduce(
@@ -276,7 +384,7 @@ export const AgentCompanionDesktopPet: React.FC = () => {
       .catch(error => {
         log.warn('Failed to resize Agent companion window', error);
       });
-  }, [activePetSize.height, activePetSize.width, tasks]);
+  }, [activePetSize.height, activePetSize.width, overlay, visibleTasks]);
 
   useEffect(() => {
     if (IS_WINDOWS_WEBVIEW) {
@@ -287,6 +395,7 @@ export const AgentCompanionDesktopPet: React.FC = () => {
     let disposed = false;
     let windowPosition: { x: number; y: number } | null = null;
     let scaleFactor = 1;
+    let pointerPollInFlight = false;
     let removeWindowMovedListener: (() => void) | null = null;
     let removeScaleChangedListener: (() => void) | null = null;
 
@@ -333,6 +442,10 @@ export const AgentCompanionDesktopPet: React.FC = () => {
     });
 
     const pollPointerHover = async () => {
+      if (pointerPollInFlight) {
+        return;
+      }
+      pointerPollInFlight = true;
       try {
         if (!windowPosition) {
           windowPosition = await tauriWindow.outerPosition();
@@ -343,24 +456,34 @@ export const AgentCompanionDesktopPet: React.FC = () => {
           return;
         }
 
-        const hitbox = dockRef.current?.querySelector<HTMLElement>('.bitfun-agent-companion-window__pet-hitbox');
+        const dock = dockRef.current;
+        const hitbox = dock?.querySelector<HTMLElement>('.bitfun-agent-companion-window__pet-hitbox');
         if (!hitbox) {
           setIsHoveringPet(false);
-          return;
         }
 
-        const hitboxRect = hitbox.getBoundingClientRect();
         const safeScaleFactor = Number.isFinite(scaleFactor) && scaleFactor > 0 ? scaleFactor : 1;
         const pointerX = (pointer.x - windowPosition.x) / safeScaleFactor;
         const pointerY = (pointer.y - windowPosition.y) / safeScaleFactor;
-        const isPointerInsideHitbox = pointerX >= hitboxRect.left
-          && pointerX <= hitboxRect.right
-          && pointerY >= hitboxRect.top
-          && pointerY <= hitboxRect.bottom;
+        const isPointerInsideHitbox = hitbox
+          ? rectContainsPoint(hitbox.getBoundingClientRect(), pointerX, pointerY)
+          : false;
+        const hoveredBubble = Array.from(
+          dock?.querySelectorAll<HTMLElement>('[data-agent-companion-session-id]') ?? [],
+        ).find(element => rectContainsPoint(
+          element.getBoundingClientRect(),
+          pointerX,
+          pointerY,
+        ));
 
         setIsHoveringPet(isPointerInsideHitbox);
+        setHoveredBubbleSessionId(
+          hoveredBubble?.dataset.agentCompanionSessionId ?? null,
+        );
       } catch (error) {
         log.warn('Failed to poll Agent companion pointer hover state', error);
+      } finally {
+        pointerPollInFlight = false;
       }
     };
 
@@ -390,6 +513,158 @@ export const AgentCompanionDesktopPet: React.FC = () => {
     event.preventDefault();
   }, []);
 
+  const closeOverlay = useCallback(() => {
+    setOverlay(null);
+  }, []);
+
+  const sendPetCommand = useCallback(async (command: AgentCompanionPetCommand) => {
+    await emit(PET_COMMAND_EVENT, command);
+  }, []);
+
+  const onPetContextMenu = useCallback((event: React.MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setMenuAnchor(menuAnchorFromEvent(event));
+    setOverlay(previous => (previous?.kind === 'pet-menu' ? null : { kind: 'pet-menu' }));
+  }, []);
+
+  const onBubbleContextMenu = useCallback((event: React.MouseEvent, sessionId: string) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setMenuAnchor(menuAnchorFromEvent(event));
+    setOverlay(previous => (
+      previous?.kind === 'bubble-menu' && previous.sessionId === sessionId
+        ? null
+        : { kind: 'bubble-menu', sessionId }
+    ));
+  }, []);
+
+  const closeDesktopPet = useCallback(() => {
+    setOverlay(null);
+    void sendPetCommand({ type: 'close-desktop-pet' })
+      .catch(error => {
+        log.warn('Failed to request Agent companion desktop pet close', error);
+      });
+  }, [sendPetCommand]);
+
+  const closeBubble = useCallback((task: AgentCompanionTaskStatus) => {
+    setOverlay(null);
+    setDismissedBubbles(previous => ({
+      ...previous,
+      [task.sessionId]: bubbleDismissBucket(task.state),
+    }));
+
+    if (!isAcknowledgeableTaskState(task.state)) {
+      return;
+    }
+    // Finished / failed / interrupted bubbles are pure "unread" notices, so tell
+    // the main window the user has seen this one.
+    void sendPetCommand({ type: 'dismiss-task', sessionId: task.sessionId })
+      .catch(error => {
+        log.warn('Failed to acknowledge Agent companion task', {
+          sessionId: task.sessionId,
+          error,
+        });
+      });
+  }, [sendPetCommand]);
+
+  const openBubbleComposer = useCallback((sessionId: string) => {
+    setComposerValue('');
+    setIsSendingComposer(false);
+    setOverlay({ kind: 'composer', sessionId });
+    void getCurrentWindow().setFocus()
+      .catch(error => {
+        log.warn('Failed to focus Agent companion window for composer', error);
+      });
+  }, []);
+
+  const cancelBubbleComposer = useCallback(() => {
+    setComposerValue('');
+    setOverlay(null);
+  }, []);
+
+  const submitBubbleComposer = useCallback(async () => {
+    const sessionId = overlay?.kind === 'composer' ? overlay.sessionId : null;
+    const message = composerValue.trim();
+    if (!sessionId || !message || isSendingComposer) {
+      return;
+    }
+
+    setIsSendingComposer(true);
+    try {
+      await sendPetCommand({ type: 'send-message', sessionId, message });
+      setComposerValue('');
+      setOverlay(null);
+    } catch (error) {
+      log.warn('Failed to send Agent companion message from pet composer', {
+        sessionId,
+        error,
+      });
+    } finally {
+      setIsSendingComposer(false);
+    }
+  }, [composerValue, isSendingComposer, overlay, sendPetCommand]);
+
+  const onComposerKeyDown = useCallback((event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      cancelBubbleComposer();
+      return;
+    }
+    if (event.key === 'Enter' && !event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey) {
+      event.preventDefault();
+      void submitBubbleComposer();
+    }
+  }, [cancelBubbleComposer, submitBubbleComposer]);
+
+  useEffect(() => {
+    if (overlay?.kind !== 'composer') {
+      return;
+    }
+    const frameId = window.requestAnimationFrame(() => {
+      composerInputRef.current?.focus();
+    });
+    return () => window.cancelAnimationFrame(frameId);
+  }, [overlay]);
+
+  const isMenuOverlay = overlay?.kind === 'pet-menu' || overlay?.kind === 'bubble-menu';
+
+  // Place the menu at the cursor, kept fully inside the window. The window is
+  // deliberately not resized for a menu: growing it moves every anchored
+  // element for a frame, which reads as the whole pet flashing.
+  useLayoutEffect(() => {
+    if (!isMenuOverlay || !menuAnchor) {
+      setMenuPosition(null);
+      return;
+    }
+
+    const placeMenu = () => {
+      // Fractional sizes matter here: rounding up can push the menu a pixel
+      // outside the window.
+      const menuBox = menuRef.current?.getBoundingClientRect();
+      const menuWidth = menuBox?.width ?? 0;
+      const menuHeight = menuBox?.height ?? 0;
+      const right = Math.min(
+        Math.max(menuAnchor.right, MENU_EDGE_MARGIN),
+        Math.max(0, window.innerWidth - menuWidth),
+      );
+      const bottom = Math.min(
+        Math.max(menuAnchor.bottom, MENU_EDGE_MARGIN),
+        Math.max(0, window.innerHeight - menuHeight),
+      );
+      setMenuPosition(previous => (
+        previous && previous.right === right && previous.bottom === bottom
+          ? previous
+          : { right, bottom }
+      ));
+    };
+
+    placeMenu();
+    // A bubble arriving while the menu is open still resizes the window.
+    window.addEventListener('resize', placeMenu);
+    return () => window.removeEventListener('resize', placeMenu);
+  }, [isMenuOverlay, menuAnchor]);
+
   const clearPetPointerSession = (target: HTMLDivElement, pointerId: number) => {
     const session = petPointerSessionRef.current;
     if (!session || session.pointerId !== pointerId) {
@@ -406,6 +681,11 @@ export const AgentCompanionDesktopPet: React.FC = () => {
   const onPetPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
     if (event.button !== 0) {
       return;
+    }
+    // The bubble composer stays interactive while open (it lives inside a
+    // bubble), so touching the pet is what dismisses it.
+    if (overlay?.kind === 'composer') {
+      setOverlay(null);
     }
     petPointerSessionRef.current = {
       pointerId: event.pointerId,
@@ -493,82 +773,215 @@ export const AgentCompanionDesktopPet: React.FC = () => {
     '--bitfun-agent-companion-pet-height': `${activePetSize.height}px`,
     '--bitfun-agent-companion-gap': `${WINDOW_HORIZONTAL_GAP}px`,
   } as React.CSSProperties;
-  const isSingleTask = tasks.length === 1;
-  const hasAttentionTask = tasks.some(task => task.state === 'attention');
+  const isSingleTask = visibleTasks.length === 1;
+  const hasAttentionTask = visibleTasks.some(task => task.state === 'attention');
+  const overlayTask = overlay && overlay.kind !== 'pet-menu'
+    ? visibleTasks.find(task => task.sessionId === overlay.sessionId) ?? null
+    : null;
+  const menuItem = overlay?.kind === 'pet-menu'
+    ? { label: t('agentCompanion.menu.closePet'), onClick: closeDesktopPet }
+    : overlay?.kind === 'bubble-menu' && overlayTask
+      ? { label: t('agentCompanion.menu.closeBubble'), onClick: () => closeBubble(overlayTask) }
+      : null;
 
   return (
     <main
-      className="bitfun-agent-companion-window"
+      className={`bitfun-agent-companion-window${isMenuOverlay ? ' bitfun-agent-companion-window--menu-open' : ''}${IS_WINDOWS_WEBVIEW ? ' bitfun-agent-companion-window--native-hover' : ''}`}
       onContextMenu={onContextMenu}
     >
-      <div
-        ref={dockRef}
-        className="bitfun-agent-companion-window__dock"
-        style={dockVars}
-      >
-        {tasks.length > 0 && (
-          <div
-            ref={bubblesRef}
-            className={`bitfun-agent-companion-window__bubbles${isSingleTask ? ' bitfun-agent-companion-window__bubbles--single' : ''}`}
-            aria-live="polite"
-            onDoubleClick={event => event.stopPropagation()}
-          >
-            {displayTasks.map(task => (
-              <button
-                type="button"
-                key={task.sessionId}
-                className={`bitfun-agent-companion-window__bubble bitfun-agent-companion-window__bubble--${task.state}${isSingleTask ? ' bitfun-agent-companion-window__bubble--single' : ''}`}
-                onClick={() => void openTaskSession(task)}
-              >
-                <span className="bitfun-agent-companion-window__bubble-title">
-                  {task.title}
-                </span>
-                <span className="bitfun-agent-companion-window__bubble-status">
-                  {t(task.labelKey, { defaultValue: task.defaultLabel })}
-                </span>
-                {isSingleTask && task.latestOutput && (() => {
-                  const typedOutput = typedOutputBySessionId[task.sessionId];
-                  const visibleOutput = typedOutput?.visible ?? seedTypewriterOutput(task.latestOutput);
-                  const targetOutput = typedOutput?.target ?? task.latestOutput;
-                  const isTyping = visibleOutput !== targetOutput;
-                  const sessionId = task.sessionId;
-
-                  return (
-                    <span
-                      ref={element => {
-                        if (element) {
-                          outputRefs.current.set(sessionId, element);
-                        } else {
-                          outputRefs.current.delete(sessionId);
-                        }
-                      }}
-                      className={`bitfun-agent-companion-window__bubble-output${isTyping ? ' bitfun-agent-companion-window__bubble-output--typing' : ''}`}
-                    >
-                      {visibleOutput}
-                    </span>
-                  );
-                })()}
-              </button>
-            ))}
-          </div>
-        )}
+      {overlay && (
         <div
-          className={`bitfun-agent-companion-window__pet-hitbox${hasAttentionTask ? ' bitfun-agent-companion-window__pet-hitbox--needs-attention' : ''}`}
-          onPointerEnter={() => setIsHoveringPet(true)}
-          onPointerLeave={() => setIsHoveringPet(false)}
-          onPointerDown={onPetPointerDown}
-          onPointerMove={onPetPointerMove}
-          onPointerUp={onPetPointerUp}
-          onPointerCancel={onPetPointerCancel}
+          className="bitfun-agent-companion-window__backdrop"
+          onPointerDown={closeOverlay}
+        />
+      )}
+      {menuItem && (
+        <div
+          ref={menuRef}
+          className="bitfun-agent-companion-window__overlay bitfun-agent-companion-window__overlay--anchored"
+          style={{
+            right: `${menuPosition?.right ?? MENU_EDGE_MARGIN}px`,
+            bottom: `${menuPosition?.bottom ?? MENU_EDGE_MARGIN}px`,
+            visibility: menuPosition ? 'visible' : 'hidden',
+          }}
         >
-          <ChatInputPixelPet
-            mood={displayMood}
-            pet={pet}
-            nativePetdexSize
-            petdexScale={PETDEX_DESKTOP_SCALE}
-            onPetFrameSizeChange={handlePetFrameSizeChange}
-            className="bitfun-agent-companion-window__pet"
-          />
+          <div className="bitfun-agent-companion-window__menu" role="menu">
+            <button
+              type="button"
+              role="menuitem"
+              className="bitfun-agent-companion-window__menu-item"
+              onClick={menuItem.onClick}
+            >
+              {menuItem.label}
+            </button>
+          </div>
+        </div>
+      )}
+      <div className="bitfun-agent-companion-window__stack" style={dockVars}>
+        <div
+          ref={dockRef}
+          className="bitfun-agent-companion-window__dock"
+        >
+          {visibleTasks.length > 0 && (
+            <div
+              ref={bubblesRef}
+              className={`bitfun-agent-companion-window__bubbles${isSingleTask ? ' bitfun-agent-companion-window__bubbles--single' : ''}`}
+              aria-live="polite"
+              onDoubleClick={event => event.stopPropagation()}
+            >
+              {displayTasks.map(task => {
+                const isComposingTask = overlay?.kind === 'composer'
+                  && overlay.sessionId === task.sessionId;
+                const isHoveredTask = hoveredBubbleSessionId === task.sessionId;
+                const bubbleClassName = `bitfun-agent-companion-window__bubble bitfun-agent-companion-window__bubble--${task.state}${isSingleTask ? ' bitfun-agent-companion-window__bubble--single' : ''}${isComposingTask ? ' bitfun-agent-companion-window__bubble--composing' : ''}`;
+                const bubbleBody = (
+                  <>
+                    <span className="bitfun-agent-companion-window__bubble-title">
+                      {task.title}
+                    </span>
+                    <span className="bitfun-agent-companion-window__bubble-status">
+                      {t(task.labelKey, { defaultValue: task.defaultLabel })}
+                    </span>
+                    {isSingleTask && task.latestOutput && (() => {
+                      const typedOutput = typedOutputBySessionId[task.sessionId];
+                      const visibleOutput = typedOutput?.visible ?? seedTypewriterOutput(task.latestOutput);
+                      const targetOutput = typedOutput?.target ?? task.latestOutput;
+                      const isTyping = visibleOutput !== targetOutput;
+                      const sessionId = task.sessionId;
+
+                      return (
+                        <span
+                          ref={element => {
+                            if (element) {
+                              outputRefs.current.set(sessionId, element);
+                            } else {
+                              outputRefs.current.delete(sessionId);
+                            }
+                          }}
+                          className={`bitfun-agent-companion-window__bubble-output${isTyping ? ' bitfun-agent-companion-window__bubble-output--typing' : ''}`}
+                        >
+                          {visibleOutput}
+                        </span>
+                      );
+                    })()}
+                  </>
+                );
+
+                return (
+                  <div
+                    key={task.sessionId}
+                    data-agent-companion-session-id={task.sessionId}
+                    className={`bitfun-agent-companion-window__bubble-shell${isSingleTask ? ' bitfun-agent-companion-window__bubble-shell--single' : ''}${isHoveredTask ? ' bitfun-agent-companion-window__bubble-shell--hovered' : ''}`}
+                    onContextMenu={event => onBubbleContextMenu(event, task.sessionId)}
+                  >
+                    {isComposingTask ? (
+                      // The bubble itself becomes the composer: no extra panel,
+                      // and the window keeps its size.
+                      <div className={bubbleClassName}>
+                        {bubbleBody}
+                        <div className="bitfun-agent-companion-window__bubble-composer">
+                          <input
+                            ref={composerInputRef}
+                            type="text"
+                            data-mouse-glow-ignore
+                            className="bitfun-agent-companion-window__bubble-composer-input"
+                            value={composerValue}
+                            placeholder={t('agentCompanion.composer.placeholder')}
+                            aria-label={t('agentCompanion.composer.ariaLabel')}
+                            onChange={event => setComposerValue(event.target.value)}
+                            onKeyDown={onComposerKeyDown}
+                          />
+                          <button
+                            type="button"
+                            className="bitfun-agent-companion-window__bubble-composer-cancel"
+                            title={t('agentCompanion.composer.cancel')}
+                            aria-label={t('agentCompanion.composer.cancel')}
+                            onClick={cancelBubbleComposer}
+                          >
+                            <svg width="11" height="11" viewBox="0 0 16 16" aria-hidden="true">
+                              <path
+                                d="M4 4l8 8M12 4l-8 8"
+                                fill="none"
+                                stroke="currentColor"
+                                strokeWidth="1.5"
+                                strokeLinecap="round"
+                              />
+                            </svg>
+                          </button>
+                          <button
+                            type="button"
+                            className="bitfun-agent-companion-window__bubble-composer-send"
+                            title={t('agentCompanion.composer.send')}
+                            aria-label={t('agentCompanion.composer.send')}
+                            disabled={!composerValue.trim() || isSendingComposer}
+                            onClick={() => void submitBubbleComposer()}
+                          >
+                            <svg width="11" height="11" viewBox="0 0 16 16" aria-hidden="true">
+                              <path
+                                d="M8 13V3.6M4 7.6 8 3.4l4 4.2"
+                                fill="none"
+                                stroke="currentColor"
+                                strokeWidth="1.6"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                      </div>
+                    ) : (
+                      <button
+                        type="button"
+                        className={bubbleClassName}
+                        onClick={() => void openTaskSession(task)}
+                      >
+                        {bubbleBody}
+                      </button>
+                    )}
+                    {task.canReply !== false && !isComposingTask && (
+                      <button
+                        type="button"
+                        className="bitfun-agent-companion-window__bubble-compose"
+                        title={t('agentCompanion.composer.openTitle')}
+                        aria-label={t('agentCompanion.composer.openTitle')}
+                        onClick={() => openBubbleComposer(task.sessionId)}
+                      >
+                        <svg width="11" height="11" viewBox="0 0 16 16" aria-hidden="true">
+                          <path
+                            d="M10.6 2.6a1.4 1.4 0 0 1 2 2L6 11.2l-3 .8.8-3 6.8-6.4zM3.5 14h9"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="1.4"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          />
+                        </svg>
+                      </button>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+          <div
+            className={`bitfun-agent-companion-window__pet-hitbox${hasAttentionTask ? ' bitfun-agent-companion-window__pet-hitbox--needs-attention' : ''}`}
+            onPointerEnter={() => setIsHoveringPet(true)}
+            onPointerLeave={() => setIsHoveringPet(false)}
+            onPointerDown={onPetPointerDown}
+            onPointerMove={onPetPointerMove}
+            onPointerUp={onPetPointerUp}
+            onPointerCancel={onPetPointerCancel}
+            onContextMenu={onPetContextMenu}
+          >
+            <ChatInputPixelPet
+              mood={displayMood}
+              pet={pet}
+              nativePetdexSize
+              petdexScale={PETDEX_DESKTOP_SCALE}
+              onPetFrameSizeChange={handlePetFrameSizeChange}
+              className="bitfun-agent-companion-window__pet"
+            />
+          </div>
         </div>
       </div>
     </main>

--- a/src/web-ui/src/app/services/agentCompanionPetCommands.test.ts
+++ b/src/web-ui/src/app/services/agentCompanionPetCommands.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { handleAgentCompanionPetCommand } from './agentCompanionPetCommands';
+
+const sendMessageMock = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+const sessionsMock = vi.hoisted(() => new Map<string, unknown>());
+const clearSessionUnreadCompletionMock = vi.hoisted(() => vi.fn());
+const getSettingsAsyncMock = vi.hoisted(() => vi.fn());
+const saveSettingsMock = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+
+vi.mock('@/flow_chat/services/FlowChatManager', () => ({
+  FlowChatManager: {
+    getInstance: () => ({
+      getFlowChatState: () => ({ sessions: sessionsMock }),
+      sendMessage: sendMessageMock,
+    }),
+  },
+}));
+
+vi.mock('@/flow_chat/store/FlowChatStore', () => ({
+  FlowChatStore: {
+    getInstance: () => ({
+      clearSessionUnreadCompletion: clearSessionUnreadCompletionMock,
+    }),
+  },
+}));
+
+vi.mock('@/infrastructure/config/services/AIExperienceConfigService', () => ({
+  aiExperienceConfigService: {
+    getSettingsAsync: getSettingsAsyncMock,
+    saveSettings: saveSettingsMock,
+  },
+}));
+
+describe('handleAgentCompanionPetCommand', () => {
+  beforeEach(() => {
+    sendMessageMock.mockClear();
+    clearSessionUnreadCompletionMock.mockClear();
+    saveSettingsMock.mockClear();
+    sessionsMock.clear();
+    getSettingsAsyncMock.mockReset();
+    getSettingsAsyncMock.mockResolvedValue({
+      enable_agent_companion: true,
+      agent_companion_display_mode: 'desktop',
+    });
+  });
+
+  it('turns the companion off and keeps the display mode when the pet is closed', async () => {
+    await handleAgentCompanionPetCommand({ type: 'close-desktop-pet' });
+
+    expect(saveSettingsMock).toHaveBeenCalledWith({
+      enable_agent_companion: false,
+      agent_companion_display_mode: 'desktop',
+    });
+  });
+
+  it('does not rewrite settings when the companion is already off', async () => {
+    getSettingsAsyncMock.mockResolvedValue({
+      enable_agent_companion: false,
+      agent_companion_display_mode: 'desktop',
+    });
+
+    await handleAgentCompanionPetCommand({ type: 'close-desktop-pet' });
+
+    expect(saveSettingsMock).not.toHaveBeenCalled();
+  });
+
+  it('clears the unread completion mark for a dismissed bubble', async () => {
+    await handleAgentCompanionPetCommand({ type: 'dismiss-task', sessionId: 'session-1' });
+
+    expect(clearSessionUnreadCompletionMock).toHaveBeenCalledWith('session-1');
+  });
+
+  it('sends a bubble message into its own session', async () => {
+    sessionsMock.set('session-1', { sessionId: 'session-1' });
+
+    await handleAgentCompanionPetCommand({
+      type: 'send-message',
+      sessionId: 'session-1',
+      message: '  ship it  ',
+    });
+
+    expect(sendMessageMock).toHaveBeenCalledWith('ship it', 'session-1');
+    expect(clearSessionUnreadCompletionMock).toHaveBeenCalledWith('session-1');
+  });
+
+  it('ignores a bubble message for an unknown session', async () => {
+    await handleAgentCompanionPetCommand({
+      type: 'send-message',
+      sessionId: 'missing-session',
+      message: 'hello',
+    });
+
+    expect(sendMessageMock).not.toHaveBeenCalled();
+  });
+
+  it('ignores a blank bubble message', async () => {
+    sessionsMock.set('session-1', { sessionId: 'session-1' });
+
+    await handleAgentCompanionPetCommand({
+      type: 'send-message',
+      sessionId: 'session-1',
+      message: '   ',
+    });
+
+    expect(sendMessageMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/web-ui/src/app/services/agentCompanionPetCommands.ts
+++ b/src/web-ui/src/app/services/agentCompanionPetCommands.ts
@@ -1,0 +1,103 @@
+import { FlowChatManager } from '@/flow_chat/services/FlowChatManager';
+import { FlowChatStore } from '@/flow_chat/store/FlowChatStore';
+import { aiExperienceConfigService } from '@/infrastructure/config/services/AIExperienceConfigService';
+import { createLogger } from '@/shared/utils/logger';
+
+const log = createLogger('AgentCompanionPetCommands');
+
+/**
+ * Commands the desktop pet window asks the main window to run on its behalf.
+ *
+ * The pet window renders a minimal React tree (no workspace/session stores, no
+ * config write path wired to the main window listeners), so every action that
+ * touches product state is forwarded here through
+ * `agent-companion://pet-command`.
+ */
+export type AgentCompanionPetCommand =
+  /** Right-click menu: turn the companion off ("Show Agent companion"). */
+  | { type: 'close-desktop-pet' }
+  /** Bubble right-click menu: the user acknowledged this bubble. */
+  | { type: 'dismiss-task'; sessionId: string }
+  /** Bubble composer: send a message straight into the bubble's session. */
+  | { type: 'send-message'; sessionId: string; message: string };
+
+/**
+ * Close the companion by turning off the "Show Agent companion" setting.
+ *
+ * Persisting it is what makes the close stick: the settings change listener in
+ * `App` runs `syncAgentCompanionDesktopWindow`, which destroys the pet window.
+ * The display mode is left alone so re-enabling the setting brings the pet back
+ * where the user had it.
+ */
+async function closeAgentCompanionDesktopPet(): Promise<void> {
+  const settings = await aiExperienceConfigService.getSettingsAsync();
+  if (!settings.enable_agent_companion) {
+    log.debug('Skipped closing Agent companion: it is already disabled');
+    return;
+  }
+
+  await aiExperienceConfigService.saveSettings({
+    ...settings,
+    enable_agent_companion: false,
+  });
+  log.info('Agent companion disabled from pet context menu');
+}
+
+/**
+ * Clear the unread completion mark so the acknowledged bubble does not come
+ * back with the next activity payload. Attention marks (`ask_user`,
+ * `tool_confirm`) are left untouched: the session really is blocked, so the
+ * pet only hides that bubble locally.
+ */
+function dismissAgentCompanionTask(sessionId: string): void {
+  FlowChatStore.getInstance().clearSessionUnreadCompletion(sessionId);
+}
+
+async function sendAgentCompanionMessage(sessionId: string, message: string): Promise<void> {
+  const trimmedMessage = message.trim();
+  if (!trimmedMessage) {
+    return;
+  }
+
+  const flowChatManager = FlowChatManager.getInstance();
+  const session = flowChatManager.getFlowChatState().sessions.get(sessionId);
+  if (!session) {
+    log.warn('Skipped Agent companion message: session not found', { sessionId });
+    return;
+  }
+
+  // `sendMessage` owns the busy-session decision: it queues into the pending
+  // queue while a dialog turn is still running, exactly like the main composer.
+  await flowChatManager.sendMessage(trimmedMessage, sessionId);
+  FlowChatStore.getInstance().clearSessionUnreadCompletion(sessionId);
+  log.info('Agent companion message sent from pet bubble composer', {
+    sessionId,
+    textLength: trimmedMessage.length,
+  });
+}
+
+export async function handleAgentCompanionPetCommand(
+  command: AgentCompanionPetCommand | null | undefined,
+): Promise<void> {
+  if (!command) {
+    return;
+  }
+
+  switch (command.type) {
+    case 'close-desktop-pet':
+      await closeAgentCompanionDesktopPet();
+      return;
+    case 'dismiss-task':
+      if (command.sessionId) {
+        dismissAgentCompanionTask(command.sessionId);
+      }
+      return;
+    case 'send-message':
+      if (command.sessionId) {
+        await sendAgentCompanionMessage(command.sessionId, command.message ?? '');
+      }
+      return;
+    default:
+      log.warn('Ignored unknown Agent companion pet command', { command });
+  }
+}

--- a/src/web-ui/src/flow_chat/utils/agentCompanionActivity.ts
+++ b/src/web-ui/src/flow_chat/utils/agentCompanionActivity.ts
@@ -29,6 +29,12 @@ export interface AgentCompanionTaskStatus {
   latestOutput?: string;
   startedAt: number;
   updatedAt: number;
+  /**
+   * Whether the desktop pet may send a plain message straight into this
+   * session. Only normal sessions qualify; /btw and review threads need the
+   * parent turn context that only the main window composer can supply.
+   */
+  canReply?: boolean;
 }
 
 export interface AgentCompanionActivityPayload {
@@ -368,10 +374,11 @@ export function buildAgentCompanionActivity(): AgentCompanionActivityPayload {
     const mood = hasActiveTrackedTurn(session, snapshot)
       ? deriveChatInputPetMood(snapshot)
       : 'rest';
+    const canReply = resolveSessionRelationship(session).kind === 'normal';
 
     const attention = resolveAttentionTask(session, snapshot);
     if (attention) {
-      tasks.push(attention);
+      tasks.push({ ...attention, canReply });
       return;
     }
 
@@ -388,13 +395,14 @@ export function buildAgentCompanionActivity(): AgentCompanionActivityPayload {
         latestOutput: latestAssistantSnippet(turn),
         startedAt: snapshot?.context.stats.startTime || session.lastActiveAt || session.updatedAt || session.createdAt,
         updatedAt: snapshot?.context.lastUpdateTime || session.updatedAt || session.lastActiveAt || session.createdAt,
+        canReply,
       });
       return;
     }
 
     const completion = completionTask(session);
     if (completion) {
-      tasks.push(completion);
+      tasks.push({ ...completion, canReply });
     }
   });
 

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -411,6 +411,17 @@
       "completed": "Completed",
       "failed": "Failed",
       "interrupted": "Interrupted"
+    },
+    "menu": {
+      "closePet": "Close pet",
+      "closeBubble": "Close this bubble"
+    },
+    "composer": {
+      "openTitle": "Send a message to this session",
+      "ariaLabel": "Send a message to this session",
+      "placeholder": "Type a message, Enter to send",
+      "cancel": "Cancel",
+      "send": "Send"
     }
   },
   "session": {

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -411,6 +411,17 @@
       "completed": "已完成",
       "failed": "执行失败",
       "interrupted": "已中断"
+    },
+    "menu": {
+      "closePet": "关闭宠物",
+      "closeBubble": "关闭该气泡"
+    },
+    "composer": {
+      "openTitle": "发送消息到该会话",
+      "ariaLabel": "发送消息到该会话",
+      "placeholder": "输入消息，回车发送",
+      "cancel": "取消",
+      "send": "发送"
     }
   },
   "session": {

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -411,6 +411,17 @@
       "completed": "已完成",
       "failed": "執行失敗",
       "interrupted": "已中斷"
+    },
+    "menu": {
+      "closePet": "關閉寵物",
+      "closeBubble": "關閉該氣泡"
+    },
+    "composer": {
+      "openTitle": "傳送訊息到該工作階段",
+      "ariaLabel": "傳送訊息到該工作階段",
+      "placeholder": "輸入訊息，Enter 送出",
+      "cancel": "取消",
+      "send": "傳送"
     }
   },
   "session": {


### PR DESCRIPTION
## Summary

- add an inline composer to Agent companion task bubbles with send, cancel, Enter, and Escape interactions
- make the composer affordance appear reliably before the transparent pet window is focused by extending the existing cursor-position hover polling to bubbles
- add pet and bubble context-menu actions, task dismissal handling, and a main-window command bridge
- widen bubbles to 180px, align composer controls with bubble copy, and add localized labels for supported locales
- add focused component and command-handler coverage

Fixes #987

## Type and Areas

Type:

Feature / bug fix / UI/UX / test

Areas:

Web UI, desktop Agent companion window, flow-chat activity, i18n

## Motivation / Impact

Users can reply directly from a desktop pet task bubble without opening the main BitFun window. The hover affordance now works while the transparent pet window is inactive, disappears reliably when the pointer leaves, and the inline composer provides explicit send and cancel controls. Context menus also allow closing the pet or dismissing individual task bubbles.

## Verification

- `pnpm --dir src/web-ui run test:run src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.test.tsx src/app/services/agentCompanionPetCommands.test.ts src/flow_chat/services/AgentCompanionActivityBridge.test.ts src/infrastructure/mouse-glow/core/MouseGlowService.test.ts` — 4 files, 31 tests passed
- `pnpm run type-check:web` — passed
- `pnpm run i18n:audit` — passed with 0 warnings
- `pnpm --dir src/web-ui exec sass src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.scss /tmp/bitfun-agent-pet-cancel.css` — passed
- `git diff --check` — passed

## Reviewer Notes

- macOS/Linux use cursor-position polling for hover because an inactive transparent pet window does not reliably receive native hover events; Windows retains native hover behavior.
- Direct replies are limited to normal sessions; child/review contexts continue to open in the main window.
- AI-assisted implementation; fully locally verified with the commands above.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.
