### PR TITLE
refactor(flow-chat): reuse the session surface in both floating chat surfaces

### DIFF
--- a/src/web-ui/src/app/layout/FloatingMiniChat.scss
+++ b/src/web-ui/src/app/layout/FloatingMiniChat.scss
@@ -14,10 +14,21 @@ $fmc-close-duration: 0.25s;
 
 $button-size: 44px;
 $button-offset: 28px;
-$panel-width: 380px;
-$panel-height: 620px;
+// Sized for the full session composer (workspace strip, model/permission
+// controls, action row) rather than the single-line input it replaced.
+$panel-width: 440px;
+$panel-height: 680px;
 
 // ─── Root container ────────────────────────────────────────
+// Children opt into pointer events individually. A blanket `& > *` override
+// here used to decide, by source order alone, whether the collapsed panel or
+// the trigger under it received the press — too fragile for the one control
+// that has to work on the first try.
+//
+// Stacking inside this context, bottom to top: backdrop (0), panel (1),
+// trigger (2). The trigger therefore always sits above the collapsed panel
+// that overlaps it, and is removed from hit testing by `visibility` — not by
+// pointer-events alone — once the panel is open.
 .bitfun-fmc {
   position: fixed;
   bottom: $button-offset;
@@ -27,10 +38,6 @@ $panel-height: 620px;
   transition:
     right $motion-base $easing-decelerate,
     bottom $motion-base $easing-decelerate;
-
-  & > * {
-    pointer-events: auto;
-  }
 
   &--miniapp-customizing {
     right: calc(clamp(380px, 38vw, 560px) + #{$button-offset + 16px});
@@ -42,10 +49,14 @@ $panel-height: 620px;
   position: fixed;
   inset: 0;
   z-index: 0;
+  pointer-events: auto;
 }
 
 // ─── Circular trigger button ───────────────────────────────
 .bitfun-fmc__button {
+  position: relative;
+  z-index: 2;
+  pointer-events: auto;
   width: $button-size;
   height: $button-size;
   border-radius: 50%;
@@ -80,11 +91,18 @@ $panel-height: 620px;
     transform: scale(0.94);
   }
 
-  // Hide when panel is open
+  // Hide when the panel is open. `visibility` (delayed until the fade-out
+  // finishes) is what actually removes it from hit testing; opacity alone
+  // would leave an invisible but clickable trigger under the panel.
   .bitfun-fmc--open & {
     opacity: 0;
     transform: scale(0.5);
+    visibility: hidden;
     pointer-events: none;
+    transition:
+      transform 0.2s $fmc-ease,
+      opacity $fmc-close-duration $fmc-ease,
+      visibility 0s linear $fmc-close-duration;
   }
 }
 
@@ -109,22 +127,28 @@ $panel-height: 620px;
   flex-direction: column;
   box-sizing: border-box;
 
-  // Pre-open state: collapsed into the button position
+  // Pre-open state: collapsed into the button position. The collapsed panel
+  // still overlaps the trigger, so it is hidden outright once the close
+  // animation ends rather than relying on pointer-events alone.
   transform-origin: bottom right;
   opacity: 0;
   transform: scale(0.15);
+  visibility: hidden;
   pointer-events: none;
   transition:
     opacity $fmc-close-duration $fmc-ease,
-    transform $fmc-close-duration $fmc-ease;
+    transform $fmc-close-duration $fmc-ease,
+    visibility 0s linear $fmc-close-duration;
 
   &--open {
     opacity: 1;
     transform: scale(1);
+    visibility: visible;
     pointer-events: auto;
     transition:
       opacity $fmc-open-duration $fmc-ease,
-      transform $fmc-open-duration $fmc-ease;
+      transform $fmc-open-duration $fmc-ease,
+      visibility 0s linear 0s;
   }
 
   // ── State borders ──
@@ -151,30 +175,11 @@ $panel-height: 620px;
     }
   }
 
-  &--error {
-    border-color: var(--color-error-border);
-  }
-
-  &--confirm {
-    border-color: var(--color-warning-border);
-    animation: fmc-pulse 1s ease-in-out infinite;
-  }
 }
 
 @keyframes fmc-progress {
   0% { background-position: 200% 0; }
   100% { background-position: -200% 0; }
-}
-
-@keyframes fmc-pulse {
-  0%, 100% {
-    box-shadow: 0 4px 12px var(--color-overlay-black-30),
-      0 0 0 1px var(--color-warning-border);
-  }
-  50% {
-    box-shadow: 0 4px 12px var(--color-overlay-black-30),
-      0 0 0 2px var(--color-warning);
-  }
 }
 
 // ─── Header ────────────────────────────────────────────────
@@ -211,144 +216,61 @@ $panel-height: 620px;
     transform: scale(0.92);
   }
 
-  &--confirm {
-    color: var(--color-success);
-    &:hover { background: var(--color-success-bg); }
-  }
-
-  &--reject {
-    color: var(--color-error);
-    &:hover { background: var(--color-error-bg); }
-  }
-
-  &--stop {
-    color: var(--color-error);
-    &:hover { background: var(--color-error-bg); }
-  }
-
   &--close:hover {
     background: var(--color-error-bg);
     color: var(--color-error);
   }
 }
 
-// ─── Title / session picker ────────────────────────────────
+// ─── Title ─────────────────────────────────────────────────
+// Plain display. Session switching lives in the shared SessionMenu ("+"),
+// matching floating window mode.
 .bitfun-fmc__title-wrapper {
   flex: 1;
   min-width: 0;
-  position: relative;
 }
 
-.bitfun-fmc__title-btn {
+.bitfun-fmc__title-display {
   width: 100%;
+  min-width: 0;
   display: flex;
   align-items: center;
-  gap: 4px;
   padding: 4px 8px;
-  border: none;
-  background: transparent;
+  box-sizing: border-box;
   color: var(--color-text-primary);
-  font-size: 12px;
-  font-weight: 500;
-  cursor: pointer;
-  border-radius: 6px;
-  transition: background 0.15s ease;
-
-  &:hover {
-    background: var(--element-bg-base);
-  }
-
-  svg {
-    flex-shrink: 0;
-    color: var(--color-text-muted);
-  }
+  font-size: var(--flowchat-font-size-xs);
+  font-weight: var(--font-weight-medium);
+  border-radius: var(--size-radius-sm);
 }
 
 .bitfun-fmc__title-text {
   flex: 1;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   text-align: left;
-}
-
-.bitfun-fmc__title-chevron {
-  flex-shrink: 0;
-  opacity: 0;
-  transition: transform 0.2s ease, opacity 0.15s ease;
-
-  .bitfun-fmc__title-btn:hover & {
-    opacity: 1;
-  }
-
-  &--open {
-    opacity: 1;
-    transform: rotate(180deg);
-  }
-}
-
-.bitfun-fmc__session-dropdown {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  right: 0;
-  margin-top: 4px;
-  max-height: 220px;
-  overflow-y: auto;
-  background: var(--color-bg-elevated);
-  border: 1px solid var(--border-medium);
-  border-radius: 8px;
-  box-shadow: 0 8px 24px var(--color-overlay-black-50);
-  z-index: 100;
-  animation: fmc-dropdown-in 0.18s $fmc-ease;
-  transform-origin: top center;
-  scrollbar-width: none;
-
-  &::-webkit-scrollbar { display: none; }
-}
-
-@keyframes fmc-dropdown-in {
-  from { opacity: 0; transform: translateY(-6px) scale(0.98); }
-  to   { opacity: 1; transform: translateY(0) scale(1); }
-}
-
-.bitfun-fmc__session-item {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  padding: 7px 12px;
-  border: none;
-  background: transparent;
-  color: var(--color-text-secondary);
-  font-size: 12px;
-  text-align: left;
-  cursor: pointer;
-  transition: background 0.1s ease;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-
-  &:hover {
-    background: var(--element-bg-soft);
-    color: var(--color-text-primary);
-  }
-
-  &--active {
-    background: var(--color-accent-200);
-    color: var(--color-accent-500);
-  }
 }
 
 // ─── FlowChat body ─────────────────────────────────────────
+// Host for the reused main-window session surface (ChatPane: conversation +
+// ChatInput). Only sizing is adjusted here — the surface keeps the main
+// window's own look and behavior.
 .bitfun-fmc__body {
   flex: 1;
   min-height: 0;
+  min-width: 0;
   overflow: hidden;
   display: flex;
   flex-direction: column;
 
+  .bitfun-chat-pane__content {
+    flex: 1;
+    min-height: 0;
+    background: transparent;
+  }
+
   .modern-flowchat-container {
-    height: 100%;
     border: none;
     border-radius: 0;
     background: transparent;
@@ -356,93 +278,6 @@ $panel-height: 620px;
 
     > .flowchat-header {
       display: none;
-    }
-  }
-}
-
-// ─── Input bar ─────────────────────────────────────────────
-.bitfun-fmc__input-bar {
-  flex-shrink: 0;
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 8px 10px;
-  border-top: 1px solid var(--border-subtle);
-  background: var(--element-bg-subtle);
-}
-
-.bitfun-fmc__input-wrapper {
-  flex: 1;
-  min-width: 0;
-}
-
-.bitfun-fmc__input-btn {
-  flex-shrink: 0;
-  border: none;
-  outline: none;
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  transition: all 0.2s ease;
-
-  &--send {
-    width: 24px;
-    height: 24px;
-    border-radius: 50%;
-    border: 1px solid var(--color-accent-300);
-    background: var(--color-accent-200);
-    color: var(--color-accent-300);
-
-    &:not(:disabled) {
-      background: linear-gradient(135deg,
-        color-mix(in srgb, var(--color-accent-500) 85%, transparent),
-        color-mix(in srgb, var(--color-purple-500) 90%, transparent));
-      border: 1px solid color-mix(in srgb, var(--color-accent-500) 60%, transparent);
-      color: var(--color-static-white);
-      box-shadow:
-        0 2px 8px color-mix(in srgb, var(--color-accent-500) 40%, transparent),
-        0 0 12px color-mix(in srgb, var(--color-purple-500) 25%, transparent);
-    }
-
-    &:hover:not(:disabled) {
-      background: linear-gradient(135deg,
-        color-mix(in srgb, var(--color-accent-500) 94%, var(--color-static-white)),
-        color-mix(in srgb, var(--color-purple-500) 92%, var(--color-static-white)));
-      border-color: color-mix(in srgb, var(--color-accent-500) 80%, transparent);
-      color: var(--color-static-white);
-      transform: scale(1.12);
-      box-shadow:
-        0 6px 20px color-mix(in srgb, var(--color-accent-500) 55%, transparent),
-        0 0 24px color-mix(in srgb, var(--color-purple-500) 40%, transparent);
-    }
-
-    &:active:not(:disabled) {
-      transform: scale(0.95);
-    }
-
-    &:disabled {
-      background: var(--color-accent-100);
-      border-color: var(--color-accent-200);
-      color: var(--color-accent-400);
-      opacity: 0.35;
-      cursor: default;
-    }
-  }
-
-  &--stop {
-    width: 24px;
-    height: 24px;
-    border-radius: 50%;
-    background: var(--color-error-bg);
-    color: var(--color-error);
-
-    &:hover {
-      background: var(--color-error-border);
-    }
-
-    &:active {
-      transform: scale(0.93);
     }
   }
 }

--- a/src/web-ui/src/app/layout/FloatingMiniChat.tsx
+++ b/src/web-ui/src/app/layout/FloatingMiniChat.tsx
@@ -1,90 +1,62 @@
 /**
- * Floating mini chat — circular button in bottom-right that expands to an
- * always-expanded ToolbarMode-style conversation panel with FlowChat.
- * Used in non-agent scenes only; agent scene uses centered ChatInput.
+ * Floating mini chat — circular button in bottom-right that expands to a panel
+ * hosting the main window session surface. Used in non-agent scenes only; the
+ * agent scene already shows that surface as its own scene.
  *
- * When opened the button disappears and the panel springs into view;
- * closing reverses the animation and restores the button.
+ * The panel renders ChatPane verbatim — same conversation view, same full
+ * composer as the session scene — so it never lags behind the main chat UI and
+ * carries no second conversation/composer implementation of its own. Only the
+ * bubble chrome (trigger, open/close animation, session header) lives here.
  */
 
 import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  MessageSquare,
-  X,
-  Check,
-  Square,
-  ArrowUp,
-  ChevronDown,
-  Plus
-} from 'lucide-react';
+import { MessageSquare, X } from 'lucide-react';
 import { flowChatStore } from '../../flow_chat/store/FlowChatStore';
 import { syncSessionToModernStore } from '../../flow_chat/services/storeSync';
-import { activateMainSession } from '../../flow_chat/services/sessionActivation';
-import { useToolbarModeContext } from '../../flow_chat/components/toolbar-mode/ToolbarModeContext';
-import type { FlowChatState } from '../../flow_chat/types/flow-chat';
-import { compareSessionsForDisplay } from '../../flow_chat/utils/sessionOrdering';
-import { ModernFlowChatContainer } from '../../flow_chat/components/modern/ModernFlowChatContainer';
-import { Tooltip, Input } from '@/component-library';
-import { useImeEnterGuard } from '../../flow_chat/hooks/useImeEnterGuard';
-import { i18nService } from '@/infrastructure/i18n';
-import { resolveSessionTitle } from '../../flow_chat/utils/sessionTitle';
+import ChatPane from '@/app/scenes/session/ChatPane';
+import { Tooltip } from '@/component-library';
+import { useCurrentWorkspace } from '@/infrastructure/contexts/WorkspaceContext';
+import { SessionMenu, useFlowChatSessions } from '../../flow_chat/components/session-menu';
 import { useSceneStore } from '@/app/stores/sceneStore';
 import { useMiniAppStore } from '@/app/scenes/miniapps/miniAppStore';
 import './FloatingMiniChat.scss';
 
+/**
+ * Panel lifecycle. `opening` covers the scale-up transition, during which the
+ * panel's hit area is still smaller than its final rect — see the backdrop
+ * below for why that distinction matters.
+ */
+type PanelPhase = 'closed' | 'opening' | 'open';
+
+/** Fallback for a transitionend that never arrives (reduced motion, interrupted
+ *  transition). Must stay >= $fmc-open-duration in FloatingMiniChat.scss. */
+const PANEL_OPEN_SETTLE_MS = 600;
+
 export const FloatingMiniChat: React.FC = () => {
   const { t } = useTranslation('flow-chat');
-  const { toolbarState } = useToolbarModeContext();
   const activeTabId = useSceneStore((state) => state.activeTabId);
   const customizingAppIds = useMiniAppStore((state) => state.customizingAppIds);
+  const { workspacePath } = useCurrentWorkspace();
 
-  const [isOpen, setIsOpen] = useState(false);
-  const [inputValue, setInputValue] = useState('');
-  const [showSessionPicker, setShowSessionPicker] = useState(false);
-  const [flowChatState, setFlowChatState] = useState<FlowChatState>(() =>
-    flowChatStore.getState()
-  );
-  const { isImeEnter, handleCompositionStart, handleCompositionEnd } = useImeEnterGuard();
+  const [phase, setPhase] = useState<PanelPhase>('closed');
+  const [surfaceMounted, setSurfaceMounted] = useState(false);
+  const isOpen = phase !== 'closed';
   const panelRef = useRef<HTMLDivElement>(null);
-  const sessionPickerRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    const unsubscribe = flowChatStore.subscribe((state) => {
-      setFlowChatState(state);
-    });
-    return () => unsubscribe();
-  }, []);
+  const { activeSession, sessionTitle } = useFlowChatSessions();
 
-  const sessionTitle = useMemo(() => {
-    const activeSession = flowChatState.activeSessionId
-      ? flowChatState.sessions.get(flowChatState.activeSessionId)
-      : undefined;
-    return resolveSessionTitle(activeSession, (key, options) => i18nService.t(key, options));
-  }, [flowChatState]);
-
-  const sessions = useMemo(() => {
-    return Array.from(flowChatState.sessions.values())
-      .sort(compareSessionsForDisplay)
-      .slice(0, 10);
-  }, [flowChatState]);
-
-  const currentStreamState = useMemo(() => {
-    const activeSession = flowChatState.activeSessionId
-      ? flowChatState.sessions.get(flowChatState.activeSessionId)
-      : undefined;
-
+  const isStreaming = useMemo(() => {
     if (!activeSession || !activeSession.dialogTurns || activeSession.dialogTurns.length === 0) {
-      return { isStreaming: false };
+      return false;
     }
-
     const lastTurn = activeSession.dialogTurns[activeSession.dialogTurns.length - 1];
-    const isStreaming =
+    return (
       lastTurn.status === 'processing' ||
       lastTurn.status === 'finishing' ||
-      lastTurn.status === 'image_analyzing';
-    return { isStreaming };
-  }, [flowChatState]);
+      lastTurn.status === 'image_analyzing'
+    );
+  }, [activeSession]);
 
   const activeMiniAppId = useMemo(
     () => (typeof activeTabId === 'string' && activeTabId.startsWith('miniapp:')
@@ -96,113 +68,90 @@ export const FloatingMiniChat: React.FC = () => {
     activeMiniAppId && customizingAppIds.includes(activeMiniAppId)
   );
 
+  // Idempotent so it is safe to fire from several input paths at once, and so a
+  // repeat press during the open animation can never toggle the panel back.
+  //
+  // Keeping this commit cheap matters too: flipping the panel open is all it
+  // does, so the open transition is committed on the very next frame. Store
+  // sync and the session surface mount are deferred below — doing them here
+  // blocks the main thread before the browser ever starts the transition.
   const handleOpen = useCallback(() => {
-    // Sync the active session into modernFlowChatStore so the panel shows
-    // up-to-date content (it may have been streaming while the panel was closed).
-    const state = flowChatStore.getState();
-    if (state.activeSessionId) {
-      syncSessionToModernStore(state.activeSessionId);
-    }
-    setIsOpen(true);
+    setPhase((prev) => (prev === 'closed' ? 'opening' : prev));
   }, []);
 
   const handleClose = useCallback(() => {
-    setIsOpen(false);
-    setShowSessionPicker(false);
+    setPhase('closed');
   }, []);
 
-  const handleSwitchSession = useCallback((e: React.MouseEvent, sessionId: string) => {
-    e.stopPropagation();
-    e.preventDefault();
-    void activateMainSession(sessionId).then((activated) => {
-      if (activated) {
-        setShowSessionPicker(false);
-      }
-    });
-  }, []);
+  // Open on pointer press, not on click. A click only fires when pointerdown
+  // and pointerup land on the same element, so anything that moves or replaces
+  // the trigger between the two (a re-render from a streaming session, the
+  // panel animation, a stray pointer move on a trackpad) silently swallows the
+  // press — which is what made the button need several tries. onClick is kept
+  // for keyboard and assistive activation, where no pointer events fire.
+  const handleTriggerPointerDown = useCallback((e: React.PointerEvent) => {
+    if (e.button !== 0) return;
+    handleOpen();
+  }, [handleOpen]);
 
-  const handleCancel = useCallback(() => {
-    window.dispatchEvent(new CustomEvent('toolbar-cancel-task'));
-  }, []);
-
-  const handleConfirm = useCallback(() => {
-    if (toolbarState.pendingToolId) {
-      window.dispatchEvent(
-        new CustomEvent('toolbar-tool-confirm', { detail: { toolId: toolbarState.pendingToolId } })
-      );
-    }
-  }, [toolbarState.pendingToolId]);
-
-  const handleReject = useCallback(() => {
-    if (toolbarState.pendingToolId) {
-      window.dispatchEvent(
-        new CustomEvent('toolbar-tool-reject', { detail: { toolId: toolbarState.pendingToolId } })
-      );
-    }
-  }, [toolbarState.pendingToolId]);
-
-  const handleCreateSession = useCallback(() => {
-    window.dispatchEvent(new CustomEvent('toolbar-create-session'));
-  }, []);
-
-  const handleSendMessage = useCallback(() => {
-    const message = inputValue.trim();
-    if (message) {
-      window.dispatchEvent(
-        new CustomEvent('toolbar-send-message', {
-          detail: { message, sessionId: flowChatState.activeSessionId }
-        })
-      );
-      setInputValue('');
-    }
-  }, [inputValue, flowChatState.activeSessionId]);
-
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === 'Enter' && !e.shiftKey) {
-        if (isImeEnter(e)) return;
-        e.preventDefault();
-        handleSendMessage();
-      }
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        if (showSessionPicker) {
-          setShowSessionPicker(false);
-        } else {
-          handleClose();
-        }
-      }
-    },
-    [handleSendMessage, showSessionPicker, handleClose, isImeEnter]
-  );
-
-  // Close session picker when clicking outside it
+  // Mount the session surface only once the open transition has been handed to
+  // the compositor, so ChatPane's mount cost can no longer stall the animation.
   useEffect(() => {
-    if (!isOpen || !showSessionPicker) return;
+    if (!isOpen) {
+      setSurfaceMounted(false);
+      return;
+    }
 
-    const handleClickOutside = (e: MouseEvent) => {
-      const target = e.target as HTMLElement | null;
-      if (!target) return;
-      if (sessionPickerRef.current?.contains(target)) return;
-      if (target.closest?.('.bitfun-fmc__title-btn')) return;
-      setShowSessionPicker(false);
-    };
+    let innerFrame = 0;
+    const outerFrame = requestAnimationFrame(() => {
+      innerFrame = requestAnimationFrame(() => {
+        // Sync the active session into modernFlowChatStore so the panel shows
+        // up-to-date content (it may have streamed while the panel was closed).
+        const { activeSessionId } = flowChatStore.getState();
+        if (activeSessionId) {
+          syncSessionToModernStore(activeSessionId);
+        }
+        setSurfaceMounted(true);
+      });
+    });
 
-    const timer = setTimeout(() => {
-      document.addEventListener('mousedown', handleClickOutside);
-    }, 0);
     return () => {
-      clearTimeout(timer);
-      document.removeEventListener('mousedown', handleClickOutside);
+      cancelAnimationFrame(outerFrame);
+      cancelAnimationFrame(innerFrame);
     };
-  }, [isOpen, showSessionPicker]);
+  }, [isOpen]);
+
+  // Settle `opening` → `open` once the panel reaches full size.
+  useEffect(() => {
+    if (phase !== 'opening') return;
+    const timer = window.setTimeout(() => setPhase('open'), PANEL_OPEN_SETTLE_MS);
+    return () => window.clearTimeout(timer);
+  }, [phase]);
+
+  const handlePanelTransitionEnd = useCallback((e: React.TransitionEvent) => {
+    if (e.target !== panelRef.current || e.propertyName !== 'transform') return;
+    setPhase((prev) => (prev === 'opening' ? 'open' : prev));
+  }, []);
+
+  const handlePanelKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      // Inside the reused session surface Escape belongs to the chat scope
+      // (dismiss slash/mention popups, stop generation) exactly as it does in
+      // the main window, so only bubble chrome handles it here. SessionMenu
+      // stops propagation while its dropdown is open.
+      const target = e.target as HTMLElement | null;
+      if (target?.closest?.('[data-shortcut-scope="chat"]')) return;
+      e.preventDefault();
+      handleClose();
+    },
+    [handleClose]
+  );
 
   const panelClassName = [
     'bitfun-fmc__panel',
     isOpen && 'bitfun-fmc__panel--open',
-    currentStreamState.isStreaming && 'bitfun-fmc__panel--processing',
-    toolbarState.hasError && 'bitfun-fmc__panel--error',
-    toolbarState.hasPendingConfirmation && 'bitfun-fmc__panel--confirm'
+    isStreaming && 'bitfun-fmc__panel--processing'
   ]
     .filter(Boolean)
     .join(' ');
@@ -213,97 +162,56 @@ export const FloatingMiniChat: React.FC = () => {
       isOpen && 'bitfun-fmc--open',
       shouldAvoidMiniAppCustomizer && 'bitfun-fmc--miniapp-customizing',
     ].filter(Boolean).join(' ')}>
-      {/* Fullscreen backdrop to catch outside clicks */}
+      {/* Fullscreen backdrop to catch outside clicks. It stays inert until the
+          panel has finished scaling up: until then the panel's hit area is
+          still smaller than its final rect, so a click aimed at the panel would
+          land here and close what the user just opened. Rendering it (without
+          the close handler) throughout keeps those clicks from reaching the
+          scene underneath. */}
       {isOpen && (
         <div
           className="bitfun-fmc__backdrop"
-          onMouseDown={handleClose}
+          onMouseDown={phase === 'open' ? handleClose : undefined}
         />
       )}
 
-      {/* Circular trigger button — hidden when panel is open */}
+      {/* Circular trigger — sits above the backdrop and the collapsed panel via
+          an explicit z-index, and is taken out of hit testing with
+          `visibility` (not just pointer-events) while the panel is open. */}
       <button
         type="button"
         className="bitfun-fmc__button"
+        onPointerDown={handleTriggerPointerDown}
         onClick={handleOpen}
+        aria-expanded={isOpen}
         aria-label={t('toolCards.toolbar.startNewChat')}
       >
         <MessageSquare size={20} />
       </button>
 
       {/* Expanded panel */}
-      <div ref={panelRef} className={panelClassName}>
-        {/* Header */}
+      <div
+        ref={panelRef}
+        className={panelClassName}
+        onKeyDown={handlePanelKeyDown}
+        onTransitionEnd={handlePanelTransitionEnd}
+      >
+        {/* Header — same shape as floating window mode: the "+" opens the
+            shared session menu (new code / new cowork / switch), and the title
+            is a plain display rather than a second, differently-behaved
+            switcher. */}
         <div className="bitfun-fmc__header">
-          <Tooltip content={t('session.new')}>
-            <button type="button" className="bitfun-fmc__header-btn" onClick={handleCreateSession}>
-              <Plus size={14} />
-            </button>
-          </Tooltip>
+          <SessionMenu />
 
           <div className="bitfun-fmc__title-wrapper">
-            <Tooltip content={t('session.switchSession')}>
-              <button
-                type="button"
-                className="bitfun-fmc__title-btn"
-                onClick={() => setShowSessionPicker(!showSessionPicker)}
-              >
-                <span className="bitfun-fmc__title-text">{sessionTitle}</span>
-                <ChevronDown
-                  size={12}
-                  className={`bitfun-fmc__title-chevron ${showSessionPicker ? 'bitfun-fmc__title-chevron--open' : ''}`}
-                />
-              </button>
-            </Tooltip>
-
-            {showSessionPicker && (
-              <div
-                className="bitfun-fmc__session-dropdown"
-                ref={sessionPickerRef}
-                onMouseDown={(e) => e.stopPropagation()}
-              >
-                {sessions.map((session) => (
-                  <button
-                    key={session.sessionId}
-                    type="button"
-                    className={`bitfun-fmc__session-item ${
-                      session.sessionId === flowChatState.activeSessionId
-                        ? 'bitfun-fmc__session-item--active'
-                        : ''
-                    }`}
-                    onMouseDown={(e) => handleSwitchSession(e, session.sessionId)}
-                  >
-                    {resolveSessionTitle(session, (key, options) => i18nService.t(key, options))}
-                  </button>
-                ))}
-              </div>
-            )}
+            <div className="bitfun-fmc__title-display" title={sessionTitle}>
+              <span className="bitfun-fmc__title-text">{sessionTitle}</span>
+            </div>
           </div>
 
-          {/* Confirm / reject controls inline in header */}
-          {toolbarState.hasPendingConfirmation && (
-            <>
-              <Tooltip content={t('toolCards.common.confirm')}>
-                <button type="button" className="bitfun-fmc__header-btn bitfun-fmc__header-btn--confirm" onClick={handleConfirm}>
-                  <Check size={14} />
-                </button>
-              </Tooltip>
-              <Tooltip content={t('toolCards.common.cancel')}>
-                <button type="button" className="bitfun-fmc__header-btn bitfun-fmc__header-btn--reject" onClick={handleReject}>
-                  <X size={14} />
-                </button>
-              </Tooltip>
-            </>
-          )}
-
-          {currentStreamState.isStreaming && !toolbarState.hasPendingConfirmation && (
-            <Tooltip content={t('input.stop')}>
-              <button type="button" className="bitfun-fmc__header-btn bitfun-fmc__header-btn--stop" onClick={handleCancel}>
-                <Square size={12} />
-              </button>
-            </Tooltip>
-          )}
-
+          {/* Tool confirmation and stop controls come from the reused session
+              surface (permission panel above ChatInput, ChatInput stop button),
+              so the header only owns bubble chrome. */}
           <Tooltip content={t('planner.cancel')}>
             <button type="button" className="bitfun-fmc__header-btn bitfun-fmc__header-btn--close" onClick={handleClose}>
               <X size={14} />
@@ -311,52 +219,18 @@ export const FloatingMiniChat: React.FC = () => {
           </Tooltip>
         </div>
 
-        {/* FlowChat body — only mounted while the panel is open to avoid
-            running a second VirtualMessageList and store sync in the background
-            while the agent is actively streaming in another scene. */}
+        {/* Main window session surface, reused as-is. Only mounted while the
+            panel is open to avoid running a second VirtualMessageList and store
+            sync in the background while the agent streams in another scene. */}
         <div className="bitfun-fmc__body">
-          {isOpen && <ModernFlowChatContainer />}
-        </div>
-
-        {/* Input bar */}
-        <div className="bitfun-fmc__input-bar">
-          <Input
-            variant="filled"
-            inputSize="small"
-            className="bitfun-fmc__input-wrapper"
-            value={inputValue}
-            onChange={(e) => setInputValue(e.target.value)}
-            onKeyDown={handleKeyDown}
-            onCompositionStart={handleCompositionStart}
-            onCompositionEnd={handleCompositionEnd}
-            placeholder={
-              currentStreamState.isStreaming
-                ? t('toolCards.toolbar.aiProcessing')
-                : t('toolCards.toolbar.inputMessage')
-            }
-            disabled={currentStreamState.isStreaming}
-          />
-          {currentStreamState.isStreaming ? (
-            <Tooltip content={t('input.stop')}>
-              <button
-                type="button"
-                className="bitfun-fmc__input-btn bitfun-fmc__input-btn--stop"
-                onClick={handleCancel}
-              >
-                <Square size={14} />
-              </button>
-            </Tooltip>
-          ) : (
-            <Tooltip content={t('input.send')}>
-              <button
-                type="button"
-                className="bitfun-fmc__input-btn bitfun-fmc__input-btn--send"
-                onClick={handleSendMessage}
-                disabled={!inputValue.trim()}
-              >
-                <ArrowUp size={14} />
-              </button>
-            </Tooltip>
+          {surfaceMounted && (
+            <ChatPane
+              width={0}
+              isFullscreen={false}
+              isSceneActive
+              workspacePath={workspacePath}
+              showChatInput
+            />
           )}
         </div>
       </div>

--- a/src/web-ui/src/flow_chat/components/session-menu/SessionMenu.scss
+++ b/src/web-ui/src/flow_chat/components/session-menu/SessionMenu.scss
@@ -1,0 +1,188 @@
+/**
+ * Session menu shared by the floating chat surfaces.
+ * Moved here from ToolbarMode.scss so both surfaces render the same menu.
+ */
+
+$session-menu-timing: cubic-bezier(0.4, 0, 0.2, 1);
+
+.bitfun-session-menu {
+  position: relative;
+  pointer-events: auto;
+}
+
+.bitfun-session-menu__trigger {
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: transparent;
+  color: var(--color-text-muted);
+  border-radius: var(--size-radius-sm);
+  cursor: pointer;
+  transition: all 0.2s $session-menu-timing;
+
+  &:hover:not(:disabled) {
+    background: var(--color-accent-200);
+    color: var(--color-accent-500);
+    transform: scale(1.1);
+  }
+
+  &:active:not(:disabled) {
+    transform: scale(0.95);
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: var(--opacity-disabled);
+    transform: none;
+  }
+
+  &--open {
+    background: var(--element-bg-base);
+    color: var(--color-accent-500);
+  }
+}
+
+.bitfun-session-menu__dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  margin-top: 4px;
+  width: max(100%, 220px);
+  max-width: min(360px, calc(100vw - 24px));
+  max-height: min(360px, calc(100vh - 80px));
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--color-bg-primary);
+  border: 1px solid var(--border-medium);
+  border-radius: var(--size-radius-base);
+  box-shadow: var(--shadow-xl);
+  z-index: 100;
+  animation: session-menu-appear 0.2s $session-menu-timing;
+  transform-origin: top left;
+
+  .bitfun-session-menu__actions .bitfun-session-menu__item--new:first-of-type {
+    border-radius: 7px 7px 0 0;
+  }
+
+  .bitfun-session-menu__scroll .bitfun-session-menu__item:last-child {
+    border-radius: 0 0 7px 7px;
+  }
+}
+
+.bitfun-session-menu__actions {
+  flex: 0 0 auto;
+}
+
+.bitfun-session-menu__scroll {
+  flex: 1 1 auto;
+  min-height: 0;
+  /* Only the list is height-capped, so the actions stay pinned. */
+  max-height: min(240px, 38vh);
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--color-text-muted) 45%, transparent) transparent;
+  -ms-overflow-style: auto;
+
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--color-text-muted) 40%, transparent);
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+}
+
+.bitfun-session-menu__item {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  margin: 0;
+  padding: 6px 12px;
+  border: none;
+  background: transparent;
+  color: var(--color-text-secondary);
+  font-size: var(--flowchat-font-size-sm);
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.1s ease;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  &:hover {
+    background: var(--element-bg-soft);
+    color: var(--color-text-primary);
+  }
+
+  &--active {
+    background: var(--color-accent-200);
+    color: var(--color-accent-500);
+  }
+
+  &--new {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-weight: var(--font-weight-medium);
+    color: var(--color-text-primary);
+
+    &:hover .bitfun-session-menu__item-icon {
+      background: var(--color-accent-300);
+      color: var(--color-accent-500);
+    }
+  }
+}
+
+/* Round plus badge on the "new session" rows, matching the sidebar header. */
+.bitfun-session-menu__item-icon {
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-accent-200);
+  color: var(--color-accent-500);
+  transition: background 0.1s ease, color 0.1s ease;
+}
+
+.bitfun-session-menu__item-label {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bitfun-session-menu__divider {
+  height: 1px;
+  margin: 4px 8px;
+  background: var(--border-subtle);
+  flex-shrink: 0;
+}
+
+@keyframes session-menu-appear {
+  from {
+    opacity: 0;
+    transform: translateY(-4px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}

--- a/src/web-ui/src/flow_chat/components/session-menu/SessionMenu.tsx
+++ b/src/web-ui/src/flow_chat/components/session-menu/SessionMenu.tsx
@@ -1,0 +1,162 @@
+/**
+ * Session menu shared by the floating chat surfaces (floating window mode and
+ * the floating chat bubble).
+ *
+ * One "+" trigger opening one dropdown: new code session, new cowork session,
+ * then the recent sessions to switch to. Both surfaces mount this component
+ * rather than each growing its own header affordances, so the interaction stays
+ * identical and there is a single place to change it.
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Plus } from 'lucide-react';
+import { Tooltip } from '@/component-library';
+import { activateMainSession } from '../../services/sessionActivation';
+import { useFlowChatSessions, resolveDisplayTitle } from './useFlowChatSessions';
+import './SessionMenu.scss';
+
+interface SessionMenuProps {
+  /** Notified when the dropdown opens/closes, so hosts can close their own menus. */
+  onOpenChange?: (open: boolean) => void;
+}
+
+export const SessionMenu: React.FC<SessionMenuProps> = ({ onOpenChange }) => {
+  const { t } = useTranslation('flow-chat');
+  const { activeSessionId, sessions } = useFlowChatSessions();
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const setOpen = useCallback((open: boolean) => {
+    setIsMenuOpen(open);
+    onOpenChange?.(open);
+  }, [onOpenChange]);
+
+  const toggleMenu = useCallback(() => setOpen(!isMenuOpen), [isMenuOpen, setOpen]);
+
+  const createSession = useCallback((mode: 'code' | 'cowork') => {
+    window.dispatchEvent(new CustomEvent('toolbar-create-session', { detail: { mode } }));
+    setOpen(false);
+  }, [setOpen]);
+
+  const switchSession = useCallback((e: React.MouseEvent, sessionId: string) => {
+    e.stopPropagation();
+    e.preventDefault();
+    void activateMainSession(sessionId).then((activated) => {
+      if (activated) setOpen(false);
+    });
+  }, [setOpen]);
+
+  useEffect(() => {
+    if (!isMenuOpen) return;
+
+    const handleClickOutside = (e: MouseEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (!target) return;
+      if (dropdownRef.current?.contains(target)) return;
+      if (target.closest?.('.bitfun-session-menu__trigger')) return;
+      setOpen(false);
+    };
+
+    const timer = setTimeout(() => {
+      document.addEventListener('mousedown', handleClickOutside);
+    }, 0);
+    return () => {
+      clearTimeout(timer);
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isMenuOpen, setOpen]);
+
+  // Escape closes the menu rather than the host surface behind it.
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key !== 'Escape' || !isMenuOpen) return;
+    e.preventDefault();
+    e.stopPropagation();
+    setOpen(false);
+  }, [isMenuOpen, setOpen]);
+
+  return (
+    <div className="bitfun-session-menu" onKeyDown={handleKeyDown}>
+      <Tooltip content={t('toolCards.toolbar.openSessionMenu')}>
+        <button
+          type="button"
+          className={[
+            'bitfun-session-menu__trigger',
+            isMenuOpen ? 'bitfun-session-menu__trigger--open' : '',
+          ].filter(Boolean).join(' ')}
+          onClick={toggleMenu}
+          aria-expanded={isMenuOpen}
+          aria-haspopup="listbox"
+        >
+          <Plus size={14} />
+        </button>
+      </Tooltip>
+
+      {isMenuOpen && (
+        <div
+          className="bitfun-session-menu__dropdown"
+          ref={dropdownRef}
+          onMouseDown={(e) => e.stopPropagation()}
+        >
+          <div className="bitfun-session-menu__actions">
+            <button
+              type="button"
+              className="bitfun-session-menu__item bitfun-session-menu__item--new"
+              onMouseDown={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                createSession('code');
+              }}
+            >
+              <span className="bitfun-session-menu__item-icon" aria-hidden>
+                <Plus size={13} strokeWidth={2.25} />
+              </span>
+              <span className="bitfun-session-menu__item-label">
+                {t('toolCards.toolbar.newCodeSessionItem')}
+              </span>
+            </button>
+            <button
+              type="button"
+              className="bitfun-session-menu__item bitfun-session-menu__item--new"
+              onMouseDown={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                createSession('cowork');
+              }}
+            >
+              <span className="bitfun-session-menu__item-icon" aria-hidden>
+                <Plus size={13} strokeWidth={2.25} />
+              </span>
+              <span className="bitfun-session-menu__item-label">
+                {t('toolCards.toolbar.newCoworkSessionItem')}
+              </span>
+            </button>
+            <div className="bitfun-session-menu__divider" role="separator" />
+          </div>
+
+          <div
+            className="bitfun-session-menu__scroll"
+            role="listbox"
+            aria-label={t('session.switchSession')}
+          >
+            {sessions.map((session) => (
+              <button
+                key={session.sessionId}
+                type="button"
+                className={[
+                  'bitfun-session-menu__item',
+                  session.sessionId === activeSessionId ? 'bitfun-session-menu__item--active' : '',
+                ].filter(Boolean).join(' ')}
+                onMouseDown={(e) => switchSession(e, session.sessionId)}
+              >
+                {resolveDisplayTitle(session)}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SessionMenu;

--- a/src/web-ui/src/flow_chat/components/session-menu/index.ts
+++ b/src/web-ui/src/flow_chat/components/session-menu/index.ts
@@ -1,0 +1,7 @@
+export { SessionMenu } from './SessionMenu';
+export {
+  useFlowChatSessions,
+  resolveDisplayTitle,
+  RECENT_SESSION_LIMIT,
+} from './useFlowChatSessions';
+export type { FlowChatSessionsSnapshot } from './useFlowChatSessions';

--- a/src/web-ui/src/flow_chat/components/session-menu/useFlowChatSessions.ts
+++ b/src/web-ui/src/flow_chat/components/session-menu/useFlowChatSessions.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared FlowChat session summary for the floating chat surfaces.
+ *
+ * Both the floating window mode header and the floating chat bubble header need
+ * the same three things — the active session's title, the recent session list,
+ * and the active session itself to derive stream state from. Keeping that in one
+ * hook means one store subscription per surface and one definition of "recent
+ * sessions" instead of two copies drifting apart.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import { flowChatStore } from '../../store/FlowChatStore';
+import type { FlowChatState, Session } from '../../types/flow-chat';
+import { compareSessionsForDisplay } from '../../utils/sessionOrdering';
+import { resolveSessionTitle } from '../../utils/sessionTitle';
+import { i18nService } from '@/infrastructure/i18n';
+
+/** How many recent sessions the session menu offers. */
+export const RECENT_SESSION_LIMIT = 10;
+
+export interface FlowChatSessionsSnapshot {
+  activeSessionId: string | null;
+  activeSession: Session | undefined;
+  sessionTitle: string;
+  sessions: Session[];
+}
+
+export function resolveDisplayTitle(session: Session | undefined): string {
+  return resolveSessionTitle(session, (key, options) => i18nService.t(key, options));
+}
+
+export function useFlowChatSessions(): FlowChatSessionsSnapshot {
+  const [state, setState] = useState<FlowChatState>(() => flowChatStore.getState());
+
+  useEffect(() => {
+    const unsubscribe = flowChatStore.subscribe(setState);
+    return () => unsubscribe();
+  }, []);
+
+  const activeSessionId = state.activeSessionId ?? null;
+  const activeSession = useMemo(
+    () => (activeSessionId ? state.sessions.get(activeSessionId) : undefined),
+    [state, activeSessionId]
+  );
+
+  const sessionTitle = useMemo(() => resolveDisplayTitle(activeSession), [activeSession]);
+
+  const sessions = useMemo(
+    () =>
+      Array.from(state.sessions.values())
+        .sort(compareSessionsForDisplay)
+        .slice(0, RECENT_SESSION_LIMIT),
+    [state]
+  );
+
+  return { activeSessionId, activeSession, sessionTitle, sessions };
+}

--- a/src/web-ui/src/flow_chat/components/toolbar-mode/ToolbarMode.scss
+++ b/src/web-ui/src/flow_chat/components/toolbar-mode/ToolbarMode.scss
@@ -88,16 +88,6 @@ $transition-timing: cubic-bezier(0.4, 0, 0.2, 1);
   pointer-events: none;
 }
 
-.bitfun-toolbar-mode__session-menu-root {
-  position: relative;
-  pointer-events: auto;
-}
-
-.bitfun-toolbar-mode__session-menu-trigger--open {
-  background: var(--element-bg-base);
-  color: var(--color-accent-500);
-}
-
 .bitfun-toolbar-mode__header-right {
   flex: 1 1 auto;
   display: flex;
@@ -122,37 +112,6 @@ $transition-timing: cubic-bezier(0.4, 0, 0.2, 1);
   align-items: center;
   gap: 6px;
   flex-shrink: 0;
-}
-
-.bitfun-toolbar-mode__create-btn {
-  flex-shrink: 0;
-  width: 22px;
-  height: 22px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: none;
-  background: transparent;
-  color: var(--color-text-muted);
-  border-radius: var(--size-radius-sm);
-  cursor: pointer;
-  transition: all 0.2s $transition-timing;
-  
-  &:hover:not(:disabled) {
-    background: var(--color-accent-200);
-    color: var(--color-accent-500);
-    transform: scale(1.1);
-  }
-  
-  &:active:not(:disabled) {
-    transform: scale(0.95);
-  }
-
-  &:disabled {
-    cursor: not-allowed;
-    opacity: var(--opacity-disabled);
-    transform: none;
-  }
 }
 
 .bitfun-toolbar-mode__title-wrapper {
@@ -198,171 +157,6 @@ $transition-timing: cubic-bezier(0.4, 0, 0.2, 1);
   text-overflow: ellipsis;
   white-space: nowrap;
   text-align: center;
-}
-
-.bitfun-toolbar-mode__session-menu {
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-  max-height: inherit;
-}
-
-.bitfun-toolbar-mode__session-menu-actions {
-  flex: 0 0 auto;
-}
-
-.bitfun-toolbar-mode__session-menu-scroll {
-  flex: 1 1 auto;
-  min-height: 0;
-  /* 仅列表区域限高，滚轮 / 触控板滚动 */
-  max-height: min(240px, 38vh);
-  overflow-x: hidden;
-  overflow-y: auto;
-  overscroll-behavior: contain;
-  scrollbar-gutter: stable;
-
-  scrollbar-width: thin;
-  scrollbar-color: color-mix(in srgb, var(--color-text-muted) 45%, transparent) transparent;
-  -ms-overflow-style: auto;
-
-  &::-webkit-scrollbar {
-    width: 6px;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    border-radius: 999px;
-    background: color-mix(in srgb, var(--color-text-muted) 40%, transparent);
-  }
-
-  &::-webkit-scrollbar-track {
-    background: transparent;
-  }
-}
-
-.bitfun-toolbar-mode__session-dropdown {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  margin-top: 4px;
-  width: max(100%, 220px);
-  max-width: min(360px, calc(100vw - 24px));
-  max-height: min(360px, calc(100vh - 80px));
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  background: var(--color-bg-primary);
-  border: 1px solid var(--border-medium);
-  border-radius: var(--size-radius-base);
-  box-shadow: var(--shadow-xl);
-  z-index: 100;
-  animation: dropdown-appear 0.2s $transition-timing;
-  transform-origin: top left;
-
-  .bitfun-toolbar-mode__session-menu {
-    max-height: inherit;
-  }
-
-  .bitfun-toolbar-mode__session-menu-actions .bitfun-toolbar-mode__session-item--new:first-of-type {
-    border-radius: 7px 7px 0 0;
-  }
-
-  .bitfun-toolbar-mode__session-menu-scroll .bitfun-toolbar-mode__session-item:last-child {
-    border-radius: 0 0 7px 7px;
-  }
-}
-
-.bitfun-toolbar-mode__session-picker {
-  flex: 1;
-  width: 100%;
-  min-height: 0;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  overflow-x: hidden;
-  border-bottom: 1px solid var(--border-subtle);
-  animation: session-picker-expand 0.25s $transition-timing;
-
-  .bitfun-toolbar-mode__session-menu {
-    flex: 1;
-    min-height: 0;
-  }
-
-  /* 紧凑窗体：列表占剩余高度，内部滚动 */
-  .bitfun-toolbar-mode__session-menu-scroll {
-    flex: 1 1 auto;
-    min-height: 0;
-    max-height: none;
-  }
-}
-
-.bitfun-toolbar-mode__session-item {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  margin: 0;
-  padding: 6px 12px;
-  border: none;
-  background: transparent;
-  color: var(--color-text-secondary);
-  font-size: var(--flowchat-font-size-sm);
-  text-align: left;
-  cursor: pointer;
-  transition: background 0.1s ease;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  
-  &:hover {
-    background: var(--element-bg-soft);
-    color: var(--color-text-primary);
-  }
-  
-  &--active {
-    background: var(--color-accent-200);
-    color: var(--color-accent-500);
-  }
-
-  &--new {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-weight: var(--font-weight-medium);
-    color: var(--color-text-primary);
-
-    &:hover .bitfun-toolbar-mode__session-item-icon {
-      background: var(--color-accent-300);
-      color: var(--color-accent-500);
-    }
-  }
-}
-
-/* “+ 编程会话”：圆底加号，对齐侧栏顶栏 */
-.bitfun-toolbar-mode__session-item-icon {
-  flex-shrink: 0;
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--color-accent-200);
-  color: var(--color-accent-500);
-  transition: background 0.1s ease, color 0.1s ease;
-}
-
-.bitfun-toolbar-mode__session-item-label {
-  min-width: 0;
-  flex: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.bitfun-toolbar-mode__session-list-divider {
-  height: 1px;
-  margin: 4px 8px;
-  background: var(--border-subtle);
-  flex-shrink: 0;
 }
 
 .bitfun-toolbar-mode__overflow-menu {
@@ -520,31 +314,6 @@ $transition-timing: cubic-bezier(0.4, 0, 0.2, 1);
   gap: 6px;
 }
 
-.bitfun-toolbar-mode__input-field {
-  flex: 1;
-  align-self: center;
-  height: 32px;
-  padding: 0 8px;
-  border: none;
-  border-radius: 0;
-  background: transparent;
-  color: var(--color-text-primary);
-  font-size: var(--flowchat-font-size-sm);
-  outline: none;
-  box-shadow: none;
-  cursor: text;
-  
-  &:focus {
-    border: none;
-    outline: none;
-    box-shadow: none;
-  }
-  
-  &::placeholder {
-    color: var(--color-text-disabled);
-  }
-}
-
 .toolbar-btn {
   flex-shrink: 0;
   align-self: center;
@@ -591,37 +360,6 @@ $transition-timing: cubic-bezier(0.4, 0, 0.2, 1);
     &:hover { background: var(--color-error-border); }
   }
   
-  &--cancel {
-    // Expanded-mode cancel indicator.
-    width: 12px;
-    height: 12px;
-    border-radius: 50% !important;
-    background: var(--color-warning) !important;
-    border: 1px solid var(--color-warning) !important;
-    color: white !important;
-    box-shadow: 0 0 3px var(--color-warning) !important;
-    animation: toolbar-cancel-pulse 2s ease-in-out infinite;
-    position: relative;
-    
-    // Hide icon and use a white dot.
-    svg {
-      display: none;
-    }
-    
-    &::after {
-      content: '';
-      position: absolute;
-      width: 5px;
-      height: 5px;
-      border-radius: 50%;
-      background: white;
-    }
-    
-    &:hover {
-      box-shadow: 0 0 5px var(--color-warning) !important;
-    }
-  }
-  
   &--cancel-compact {
     // Compact-mode stop button.
     width: 22px;
@@ -639,12 +377,6 @@ $transition-timing: cubic-bezier(0.4, 0, 0.2, 1);
     &:hover {
       background: var(--color-error-border) !important;
     }
-  }
-  
-  &--input {
-    background: var(--color-accent-200);
-    color: var(--color-accent-500);
-    &:hover { background: var(--color-accent-300); }
   }
   
   &--expand {
@@ -668,26 +400,6 @@ $transition-timing: cubic-bezier(0.4, 0, 0.2, 1);
       color: var(--color-text-primary);
     }
   }
-  
-  &--send {
-    background: var(--color-accent-600);
-    // Match icon color with the create-session button.
-    color: var(--color-text-muted);
-    
-    svg {
-      color: currentColor;
-    }
-    
-    &:hover:not(:disabled) {
-      background: var(--color-accent-500);
-      color: var(--color-accent-500);
-    }
-    
-    &:disabled {
-      opacity: var(--opacity-disabled);
-      cursor: default;
-    }
-  }
 }
 
 @keyframes toolbar-progress-flow {
@@ -705,21 +417,6 @@ $transition-timing: cubic-bezier(0.4, 0, 0.2, 1);
   50% { box-shadow: var(--shadow-xl), 0 0 0 2px var(--color-warning); }
 }
 
-@keyframes toolbar-slide-up {
-  from { opacity: 0; transform: translateY(4px); }
-  to { opacity: 1; transform: translateY(0); }
-}
-
-@keyframes toolbar-slide-down {
-  from { opacity: 0; transform: translateY(-4px); }
-  to { opacity: 1; transform: translateY(0); }
-}
-
-@keyframes toolbar-fade-in {
-  from { opacity: 0; }
-  to { opacity: 1; }
-}
-
 .animate-spin {
   animation: toolbar-spin 1s linear infinite;
 }
@@ -733,34 +430,30 @@ $transition-timing: cubic-bezier(0.4, 0, 0.2, 1);
   to { transform: rotate(360deg); }
 }
 
-// Cancel button pulse uses opacity only (no scale).
-@keyframes toolbar-cancel-pulse {
-  0%, 100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.7;
-  }
-}
-
 @keyframes toolbar-pulse {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.6; }
 }
 
-.bitfun-toolbar-mode__flowchat-container {
+// Host for the reused main-window session surface (ChatPane: conversation +
+// ChatInput). Only sizing is adjusted here — the surface keeps the main
+// window's own look and behavior.
+.bitfun-toolbar-mode__session-surface {
   flex: 1;
   min-height: 0;
+  min-width: 0;
   overflow: hidden;
-  overflow-x: hidden;
   display: flex;
   flex-direction: column;
-  
+
   animation: flowchat-expand-in $transition-duration $transition-timing;
-  
-  // Reset inner FlowChat container styles.
+
+  .bitfun-chat-pane__content {
+    flex: 1;
+    min-height: 0;
+  }
+
   .modern-flowchat-container {
-    height: 100%;
     border: none;
     border-radius: 0;
     background: transparent;
@@ -770,47 +463,9 @@ $transition-timing: cubic-bezier(0.4, 0, 0.2, 1);
 
 .bitfun-toolbar-mode--expanded {
   cursor: default;
-  
+
   .bitfun-toolbar-mode__header {
     border-bottom-color: var(--border-base);
-  }
-  
-  .bitfun-toolbar-mode__content-row {
-    animation: content-row-exit $transition-duration $transition-timing forwards;
-  }
-}
-
-
-.bitfun-toolbar-mode__expanded-input {
-  flex-shrink: 0;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  
-  animation: input-slide-up $transition-duration $transition-timing;
-  padding: 8px 12px;
-  border-top: 1px solid var(--border-subtle);
-  background: var(--element-bg-subtle);
-  
-  .bitfun-toolbar-mode__input-field--expanded {
-    flex: 1;
-    height: 36px;
-    padding: 0 12px;
-    border: 1px solid var(--border-base);
-    border-radius: var(--size-radius-base);
-    background: var(--color-bg-primary);
-    color: var(--color-text-primary);
-    font-size: var(--flowchat-font-size-sm);
-    outline: none;
-    transition: border-color 0.15s ease;
-    
-    &:focus {
-      border-color: var(--color-accent-500);
-    }
-    
-    &::placeholder {
-      color: var(--color-text-disabled);
-    }
   }
 }
 
@@ -836,41 +491,6 @@ $transition-timing: cubic-bezier(0.4, 0, 0.2, 1);
     opacity: 1;
     transform: translateY(0);
     max-height: 100vh;
-  }
-}
-
-@keyframes content-row-exit {
-  from {
-    opacity: 1;
-    max-height: 100px;
-  }
-  to {
-    opacity: 0;
-    max-height: 0;
-    padding: 0;
-    overflow: hidden;
-  }
-}
-
-@keyframes input-slide-up {
-  from {
-    opacity: 0;
-    transform: translateY(10px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-@keyframes session-picker-expand {
-  from {
-    opacity: 0;
-    max-height: 0;
-  }
-  to {
-    opacity: 1;
-    max-height: 300px;
   }
 }
 

--- a/src/web-ui/src/flow_chat/components/toolbar-mode/ToolbarMode.tsx
+++ b/src/web-ui/src/flow_chat/components/toolbar-mode/ToolbarMode.tsx
@@ -2,41 +2,37 @@
  * Toolbar Mode component.
  * Single-window morph UI for compact toolbar view.
  *
- * Layout: two rows
- * - Row 1: + / session list only when expanded; collapsed: no left control. Right: ⋮ when expanded, expand when collapsed.
- * - Row 2: streaming content/input + controls
+ * Two window states:
+ * - Collapsed: a compact status strip (latest activity + confirm/cancel controls).
+ * - Expanded: the main window session surface verbatim — ChatPane renders the
+ *   same FlowChat conversation and ChatInput composer the session scene uses, so
+ *   this mode never drifts behind the normal chat UI and needs no parallel
+ *   conversation/composer implementation of its own.
  */
 
 import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getCurrentWindow } from '@tauri-apps/api/window';
-import { 
-  MessageSquare, 
-  Square, 
-  Check, 
-  X, 
-  ArrowUp,
+import {
+  Square,
+  Check,
+  X,
   Maximize2,
   MoreVertical,
   PanelTopOpen,
-  PanelTopClose,
-  Plus
+  PanelTopClose
 } from 'lucide-react';
 import { useToolbarModeContext } from './ToolbarModeContext';
-import { flowChatStore } from '../../store/FlowChatStore';
-import { activateMainSession } from '../../services/sessionActivation';
-import { FlowChatState, type FlowToolItem } from '../../types/flow-chat';
-import { compareSessionsForDisplay } from '../../utils/sessionOrdering';
+import { type FlowToolItem } from '../../types/flow-chat';
 import { projectEffectiveToolItem } from '../../utils/toolInvocationIdentity';
 import { createLogger } from '@/shared/utils/logger';
 import { isMacOSDesktopRuntime } from '@/infrastructure/runtime';
-import { i18nService } from '@/infrastructure/i18n';
-import { resolveSessionTitle } from '../../utils/sessionTitle';
+import { useCurrentWorkspace } from '@/infrastructure/contexts/WorkspaceContext';
+import { SessionMenu, useFlowChatSessions } from '../session-menu';
 
 const log = createLogger('ToolbarMode');
-import { ModernFlowChatContainer } from '../modern/ModernFlowChatContainer';
+import ChatPane from '@/app/scenes/session/ChatPane';
 import { Tooltip } from '@/component-library';
-import { useImeEnterGuard } from '../../hooks/useImeEnterGuard';
 import './ToolbarMode.scss';
 
 export const ToolbarMode: React.FC = () => {
@@ -49,48 +45,18 @@ export const ToolbarMode: React.FC = () => {
     toolbarState
   } = useToolbarModeContext();
   
-  const [showInput, setShowInput] = useState(false);
-  const [inputValue, setInputValue] = useState('');
-  const { isImeEnter, handleCompositionStart, handleCompositionEnd } = useImeEnterGuard();
-  const [showSessionPicker, setShowSessionPicker] = useState(false);
   const [showHeaderOverflowMenu, setShowHeaderOverflowMenu] = useState(false);
-  const [flowChatState, setFlowChatState] = useState<FlowChatState>(() => 
-    flowChatStore.getState()
-  );
-  const sessionPickerRef = useRef<HTMLDivElement>(null);
   const headerOverflowRef = useRef<HTMLDivElement>(null);
 
   const isMacOS = useMemo(() => isMacOSDesktopRuntime(), []);
+  const { workspacePath } = useCurrentWorkspace();
+  const { activeSession, sessionTitle } = useFlowChatSessions();
 
-  useEffect(() => {
-    const unsubscribe = flowChatStore.subscribe((state) => {
-      setFlowChatState(state);
-    });
-    return () => unsubscribe();
-  }, []);
-  
-  const sessionTitle = useMemo(() => {
-    const activeSession = flowChatState.activeSessionId 
-      ? flowChatState.sessions.get(flowChatState.activeSessionId)
-      : undefined;
-    return resolveSessionTitle(activeSession, (key, options) => i18nService.t(key, options));
-  }, [flowChatState]);
-  
-  const sessions = useMemo(() => {
-    return Array.from(flowChatState.sessions.values())
-      .sort(compareSessionsForDisplay)
-      .slice(0, 10); // Limit to 10.
-  }, [flowChatState]);
-  
   const lastMessageContent = useMemo(() => {
-    const activeSession = flowChatState.activeSessionId 
-      ? flowChatState.sessions.get(flowChatState.activeSessionId)
-      : undefined;
-    
     if (!activeSession || !activeSession.dialogTurns || activeSession.dialogTurns.length === 0) {
       return null;
     }
-    
+
     const lastTurn = activeSession.dialogTurns[activeSession.dialogTurns.length - 1];
     
     // Prefer the last text item in the latest model round.
@@ -108,14 +74,10 @@ export const ToolbarMode: React.FC = () => {
     
     // Fallback to the user's latest message.
     return lastTurn.userMessage?.content?.slice(0, 100) || null;
-  }, [flowChatState]);
-  
+  }, [activeSession]);
+
   // Derive current streaming state from session data.
   const currentStreamState = useMemo(() => {
-    const activeSession = flowChatState.activeSessionId 
-      ? flowChatState.sessions.get(flowChatState.activeSessionId)
-      : undefined;
-    
     if (!activeSession || !activeSession.dialogTurns || activeSession.dialogTurns.length === 0) {
       return { isStreaming: false, toolName: null, content: null };
     }
@@ -159,37 +121,13 @@ export const ToolbarMode: React.FC = () => {
     }
     
     return { isStreaming, toolName, content };
-  }, [flowChatState, t]);
+  }, [activeSession, t]);
   
   useEffect(() => {
     if (!isExpanded) {
-      setShowSessionPicker(false);
       setShowHeaderOverflowMenu(false);
     }
   }, [isExpanded]);
-  
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      const target = e.target as HTMLElement;
-      if (sessionPickerRef.current?.contains(target)) {
-        return;
-      }
-      if (target.closest?.('.bitfun-toolbar-mode__session-menu-trigger')) {
-        return;
-      }
-      setShowSessionPicker(false);
-    };
-    
-    if (showSessionPicker) {
-      const timer = setTimeout(() => {
-        document.addEventListener('mousedown', handleClickOutside);
-      }, 0);
-      return () => {
-        clearTimeout(timer);
-        document.removeEventListener('mousedown', handleClickOutside);
-      };
-    }
-  }, [showSessionPicker]);
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
@@ -218,7 +156,7 @@ export const ToolbarMode: React.FC = () => {
     const target = e.target as HTMLElement;
     // Avoid dragging when interacting with UI controls.
     if (target.closest?.(
-      'button, input, .bitfun-toolbar-mode__session-picker, .bitfun-toolbar-mode__session-dropdown, .bitfun-toolbar-mode__overflow-menu, .bitfun-toolbar-mode__stream-content, .bitfun-toolbar-mode__session-item, .bitfun-toolbar-mode__flowchat-container'
+      'button, input, .bitfun-session-menu, .bitfun-toolbar-mode__overflow-menu, .bitfun-toolbar-mode__stream-content, .bitfun-toolbar-mode__session-surface'
     )) {
       return;
     }
@@ -233,16 +171,6 @@ export const ToolbarMode: React.FC = () => {
   const handleExpand = useCallback(async () => {
     await disableToolbarMode();
   }, [disableToolbarMode]);
-  
-  const handleSwitchSession = useCallback((e: React.MouseEvent, sessionId: string) => {
-    e.stopPropagation();
-    e.preventDefault();
-    void activateMainSession(sessionId).then((activated) => {
-      if (activated) {
-        setShowSessionPicker(false);
-      }
-    });
-  }, []);
   
   const handleCancel = useCallback(() => {
     window.dispatchEvent(new CustomEvent('toolbar-cancel-task'));
@@ -264,114 +192,15 @@ export const ToolbarMode: React.FC = () => {
     }
   }, [toolbarState.pendingToolId]);
   
-  const dispatchToolbarCreateSession = useCallback((mode: 'code' | 'cowork') => {
-    window.dispatchEvent(new CustomEvent('toolbar-create-session', { detail: { mode } }));
-    setShowSessionPicker(false);
-  }, []);
-
-  const toggleSessionMenu = useCallback(() => {
-    setShowHeaderOverflowMenu(false);
-    setShowSessionPicker(v => !v);
-  }, []);
-
   const toggleHeaderOverflowMenu = useCallback(() => {
     if (!isExpanded) return;
-    setShowSessionPicker(false);
     setShowHeaderOverflowMenu(v => !v);
   }, [isExpanded]);
-  
-  const handleSendMessage = useCallback(() => {
-    const message = inputValue.trim();
-    if (message) {
-      window.dispatchEvent(new CustomEvent('toolbar-send-message', { 
-        detail: { message, sessionId: flowChatState.activeSessionId } 
-      }));
-      setInputValue('');
-      setShowInput(false);
-    }
-  }, [inputValue, flowChatState.activeSessionId]);
-  
-  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      if (isImeEnter(e)) return;
-      e.preventDefault();
-      handleSendMessage();
-    }
-    if (e.key === 'Escape') {
-      e.preventDefault();
-      if (showInput) {
-        setShowInput(false);
-      } else if (showHeaderOverflowMenu) {
-        setShowHeaderOverflowMenu(false);
-      } else if (showSessionPicker) {
-        setShowSessionPicker(false);
-      } else {
-        handleExpand();
-      }
-    }
-  }, [handleSendMessage, showInput, showSessionPicker, showHeaderOverflowMenu, handleExpand, isImeEnter]);
 
-  const sessionMenuContent = useMemo(
-    () => (
-      <div className="bitfun-toolbar-mode__session-menu">
-        <div className="bitfun-toolbar-mode__session-menu-actions">
-          <button
-            type="button"
-            className="bitfun-toolbar-mode__session-item bitfun-toolbar-mode__session-item--new"
-            onMouseDown={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              dispatchToolbarCreateSession('code');
-            }}
-          >
-            <span className="bitfun-toolbar-mode__session-item-icon" aria-hidden>
-              <Plus size={13} strokeWidth={2.25} />
-            </span>
-            <span className="bitfun-toolbar-mode__session-item-label">
-              {t('toolCards.toolbar.newCodeSessionItem')}
-            </span>
-          </button>
-          <button
-            type="button"
-            className="bitfun-toolbar-mode__session-item bitfun-toolbar-mode__session-item--new"
-            onMouseDown={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              dispatchToolbarCreateSession('cowork');
-            }}
-          >
-            <span className="bitfun-toolbar-mode__session-item-icon" aria-hidden>
-              <Plus size={13} strokeWidth={2.25} />
-            </span>
-            <span className="bitfun-toolbar-mode__session-item-label">
-              {t('toolCards.toolbar.newCoworkSessionItem')}
-            </span>
-          </button>
-          <div className="bitfun-toolbar-mode__session-list-divider" role="separator" />
-        </div>
-        <div
-          className="bitfun-toolbar-mode__session-menu-scroll"
-          role="listbox"
-          aria-label={t('session.switchSession')}
-        >
-          {sessions.map((session) => (
-            <button
-              key={session.sessionId}
-              type="button"
-              className={`bitfun-toolbar-mode__session-item ${
-                session.sessionId === flowChatState.activeSessionId ? 'bitfun-toolbar-mode__session-item--active' : ''
-              }`}
-              onMouseDown={(e) => handleSwitchSession(e, session.sessionId)}
-            >
-              {resolveSessionTitle(session, (key, options) => i18nService.t(key, options))}
-            </button>
-          ))}
-        </div>
-      </div>
-    ),
-    [sessions, flowChatState.activeSessionId, dispatchToolbarCreateSession, handleSwitchSession, t]
-  );
-  
+  const handleSessionMenuOpenChange = useCallback((open: boolean) => {
+    if (open) setShowHeaderOverflowMenu(false);
+  }, []);
+
   if (!isToolbarMode) {
     return null;
   }
@@ -389,34 +218,7 @@ export const ToolbarMode: React.FC = () => {
     <div className={containerClassName} onMouseDown={handleStartDrag}>
       <div className="bitfun-toolbar-mode__header">
         <div className="bitfun-toolbar-mode__header-left">
-          {isExpanded ? (
-            <div className="bitfun-toolbar-mode__session-menu-root">
-              <Tooltip content={t('toolCards.toolbar.openSessionMenu')}>
-                <button
-                  type="button"
-                  className={[
-                    'bitfun-toolbar-mode__create-btn',
-                    'bitfun-toolbar-mode__session-menu-trigger',
-                    showSessionPicker ? 'bitfun-toolbar-mode__session-menu-trigger--open' : '',
-                  ].filter(Boolean).join(' ')}
-                  onClick={toggleSessionMenu}
-                  aria-expanded={showSessionPicker}
-                  aria-haspopup="listbox"
-                >
-                  <Plus size={14} />
-                </button>
-              </Tooltip>
-              {showSessionPicker && (
-                <div 
-                  className="bitfun-toolbar-mode__session-dropdown" 
-                  ref={sessionPickerRef}
-                  onMouseDown={(e) => e.stopPropagation()}
-                >
-                  {sessionMenuContent}
-                </div>
-              )}
-            </div>
-          ) : null}
+          {isExpanded ? <SessionMenu onOpenChange={handleSessionMenuOpenChange} /> : null}
         </div>
 
         <div className="bitfun-toolbar-mode__title-wrapper">
@@ -504,136 +306,65 @@ export const ToolbarMode: React.FC = () => {
       </div>
       
       {isExpanded ? (
-        <>
-          <div className="bitfun-toolbar-mode__flowchat-container">
-            <ModernFlowChatContainer />
-          </div>
-          <div className="bitfun-toolbar-mode__expanded-input">
-            <input
-              type="text"
-              className="bitfun-toolbar-mode__input-field bitfun-toolbar-mode__input-field--expanded"
-              value={inputValue}
-              onChange={(e) => setInputValue(e.target.value)}
-              onKeyDown={handleKeyDown}
-              onCompositionStart={handleCompositionStart}
-              onCompositionEnd={handleCompositionEnd}
-              placeholder={currentStreamState.isStreaming ? t('toolCards.toolbar.aiProcessing') : t('toolCards.toolbar.inputMessage')}
-              disabled={currentStreamState.isStreaming}
-            />
-            {currentStreamState.isStreaming ? (
-              <Tooltip content={t('input.stop')}>
-                <button 
-                  className="toolbar-btn toolbar-btn--cancel"
-                  onClick={handleCancel}
-                >
-                  <Square size={14} />
-                </button>
-              </Tooltip>
+        /* Main window session surface, reused as-is: same conversation view and
+           same full composer, so there is nothing extra to maintain here. */
+        <div className="bitfun-toolbar-mode__session-surface">
+          <ChatPane
+            width={0}
+            isFullscreen={false}
+            isSceneActive
+            workspacePath={workspacePath}
+            showChatInput
+          />
+        </div>
+      ) : (
+        <div className="bitfun-toolbar-mode__content-row">
+          <div className="bitfun-toolbar-mode__stream-content" onClick={toggleExpanded}>
+            {currentStreamState.toolName ? (
+              <div className="bitfun-toolbar-mode__tool">
+                <span className="bitfun-toolbar-mode__tool-name">{currentStreamState.toolName}</span>
+                <span className="bitfun-toolbar-mode__tool-summary">{currentStreamState.content || t('toolCards.toolbar.executing')}</span>
+              </div>
+            ) : toolbarState.todoProgress && toolbarState.todoProgress.total > 0 ? (
+              <div className="bitfun-toolbar-mode__todo">
+                <span className="bitfun-toolbar-mode__todo-progress">
+                  {toolbarState.todoProgress.completed}/{toolbarState.todoProgress.total}
+                </span>
+                <span className="bitfun-toolbar-mode__todo-current">
+                  {toolbarState.todoProgress.current || currentStreamState.content}
+                </span>
+              </div>
             ) : (
-              <Tooltip content={t('input.send')}>
-                <button 
-                  className="toolbar-btn toolbar-btn--send"
-                  onClick={handleSendMessage}
-                  disabled={!inputValue.trim()}
-                >
-                  <ArrowUp size={16} />
+              <span className={`bitfun-toolbar-mode__text ${currentStreamState.isStreaming ? 'bitfun-toolbar-mode__text--streaming' : ''}`}>
+                {currentStreamState.content || (currentStreamState.isStreaming ? t('toolCards.toolbar.processing') : (lastMessageContent || t('toolCards.toolbar.startNewChat')))}
+              </span>
+            )}
+          </div>
+
+          <div className="bitfun-toolbar-mode__controls">
+            {toolbarState.hasPendingConfirmation && (
+              <>
+                <Tooltip content={t('toolCards.common.confirm')}>
+                  <button className="toolbar-btn toolbar-btn--confirm" onClick={handleConfirm}>
+                    <Check size={16} />
+                  </button>
+                </Tooltip>
+                <Tooltip content={t('toolCards.common.cancel')}>
+                  <button className="toolbar-btn toolbar-btn--reject" onClick={handleReject}>
+                    <X size={16} />
+                  </button>
+                </Tooltip>
+              </>
+            )}
+
+            {currentStreamState.isStreaming && !toolbarState.hasPendingConfirmation && (
+              <Tooltip content={t('planner.cancel')}>
+                <button className="toolbar-btn toolbar-btn--cancel-compact" onClick={handleCancel}>
+                  <Square size={12} />
                 </button>
               </Tooltip>
             )}
           </div>
-        </>
-      ) : (
-        <div className="bitfun-toolbar-mode__content-row">
-          {showInput ? (
-            <>
-              <input
-                type="text"
-                className="bitfun-toolbar-mode__input-field"
-                value={inputValue}
-                onChange={(e) => setInputValue(e.target.value)}
-                onKeyDown={handleKeyDown}
-                onCompositionStart={handleCompositionStart}
-                onCompositionEnd={handleCompositionEnd}
-                placeholder={t('input.placeholder')}
-                autoFocus
-              />
-              <Tooltip content={t('input.send')}>
-                <button 
-                  className="toolbar-btn toolbar-btn--send"
-                  onClick={handleSendMessage}
-                  disabled={!inputValue.trim()}
-                >
-                  <ArrowUp size={16} />
-                </button>
-              </Tooltip>
-              <Tooltip content={t('planner.cancel')}>
-                <button 
-                  className="toolbar-btn"
-                  onClick={() => setShowInput(false)}
-                >
-                  <X size={16} />
-                </button>
-              </Tooltip>
-            </>
-          ) : (
-            <>
-              <div className="bitfun-toolbar-mode__stream-content" onClick={toggleExpanded}>
-                {currentStreamState.toolName ? (
-                  <div className="bitfun-toolbar-mode__tool">
-                    <span className="bitfun-toolbar-mode__tool-name">{currentStreamState.toolName}</span>
-                    <span className="bitfun-toolbar-mode__tool-summary">{currentStreamState.content || t('toolCards.toolbar.executing')}</span>
-                  </div>
-                ) : toolbarState.todoProgress && toolbarState.todoProgress.total > 0 ? (
-                  <div className="bitfun-toolbar-mode__todo">
-                    <span className="bitfun-toolbar-mode__todo-progress">
-                      {toolbarState.todoProgress.completed}/{toolbarState.todoProgress.total}
-                    </span>
-                    <span className="bitfun-toolbar-mode__todo-current">
-                      {toolbarState.todoProgress.current || currentStreamState.content}
-                    </span>
-                  </div>
-                ) : (
-                  <span className={`bitfun-toolbar-mode__text ${currentStreamState.isStreaming ? 'bitfun-toolbar-mode__text--streaming' : ''}`}>
-                    {currentStreamState.content || (currentStreamState.isStreaming ? t('toolCards.toolbar.processing') : (lastMessageContent || t('toolCards.toolbar.startNewChat')))}
-                  </span>
-                )}
-              </div>
-              
-              <div className="bitfun-toolbar-mode__controls">
-                {toolbarState.hasPendingConfirmation && (
-                  <>
-                    <Tooltip content={t('toolCards.common.confirm')}>
-                      <button className="toolbar-btn toolbar-btn--confirm" onClick={handleConfirm}>
-                        <Check size={16} />
-                      </button>
-                    </Tooltip>
-                    <Tooltip content={t('toolCards.common.cancel')}>
-                      <button className="toolbar-btn toolbar-btn--reject" onClick={handleReject}>
-                        <X size={16} />
-                      </button>
-                    </Tooltip>
-                  </>
-                )}
-                
-                {currentStreamState.isStreaming && !toolbarState.hasPendingConfirmation && (
-                  <Tooltip content={t('planner.cancel')}>
-                    <button className="toolbar-btn toolbar-btn--cancel-compact" onClick={handleCancel}>
-                      <Square size={12} />
-                    </button>
-                  </Tooltip>
-                )}
-                
-                <Tooltip content={t('input.placeholder')}>
-                  <button 
-                    className="toolbar-btn toolbar-btn--input" 
-                    onClick={() => setShowInput(true)}
-                  >
-                    <MessageSquare size={16} />
-                  </button>
-                </Tooltip>
-              </div>
-            </>
-          )}
         </div>
       )}
     </div>

--- a/src/web-ui/src/flow_chat/components/toolbar-mode/ToolbarModeContext.ts
+++ b/src/web-ui/src/flow_chat/components/toolbar-mode/ToolbarModeContext.ts
@@ -52,9 +52,15 @@ export interface ToolbarModeContextType {
   updateToolbarState: (state: Partial<ToolbarModeState>) => void;
 }
 
+/**
+ * Toolbar window sizes, in logical (CSS) pixels — the same unit the
+ * stylesheets use. resolveToolbarWindowGeometry converts them to the physical
+ * pixels the Tauri window APIs expect.
+ */
 export const TOOLBAR_COMPACT_SIZE = { width: 700, height: 140 };
 export const TOOLBAR_COMPACT_MIN = { width: 400, height: 100 };
-export const TOOLBAR_EXPANDED_SIZE = { width: 700, height: 1400 };
+/** Matches the floating chat bubble panel ($panel-width/$panel-height). */
+export const TOOLBAR_EXPANDED_SIZE = { width: 440, height: 680 };
 export const TOOLBAR_EXPANDED_MIN = { width: 400, height: 500 };
 
 export const ToolbarModeContext = createContext<ToolbarModeContextType | undefined>(undefined);

--- a/src/web-ui/src/flow_chat/components/toolbar-mode/ToolbarModeProvider.tsx
+++ b/src/web-ui/src/flow_chat/components/toolbar-mode/ToolbarModeProvider.tsx
@@ -89,11 +89,6 @@ export const ToolbarModeProvider: React.FC<ToolbarModeProviderProps> = ({ childr
         targetSize: TOOLBAR_EXPANDED_SIZE,
         minSize: TOOLBAR_EXPANDED_MIN,
       });
-      const toolbarMinSize = {
-        width: Math.min(TOOLBAR_EXPANDED_MIN.width, geometry.width),
-        height: Math.min(TOOLBAR_EXPANDED_MIN.height, geometry.height),
-      };
-
       const toolbarWindowOps: Array<Promise<unknown>> = [
         win.setAlwaysOnTop(true),
         win.setSize(new PhysicalSize(geometry.width, geometry.height)),
@@ -111,7 +106,7 @@ export const ToolbarModeProvider: React.FC<ToolbarModeProviderProps> = ({ childr
       }
       await Promise.all(toolbarWindowOps);
 
-      await win.setMinSize(new PhysicalSize(toolbarMinSize.width, toolbarMinSize.height));
+      await win.setMinSize(new PhysicalSize(geometry.minWidth, geometry.minHeight));
     } catch (error) {
       log.error('Failed to enable toolbar mode', error);
       setIsToolbarMode(false);
@@ -218,14 +213,9 @@ export const ToolbarModeProvider: React.FC<ToolbarModeProviderProps> = ({ childr
           y: Math.max(0, currentPosition.y + currentSize.height - targetSize.height),
         },
       });
-      const toolbarMinSize = {
-        width: Math.min(minSize.width, geometry.width),
-        height: Math.min(minSize.height, geometry.height),
-      };
-
       setIsExpanded(newIsExpanded);
 
-      await win.setMinSize(new PhysicalSize(toolbarMinSize.width, toolbarMinSize.height));
+      await win.setMinSize(new PhysicalSize(geometry.minWidth, geometry.minHeight));
       await win.setSize(new PhysicalSize(geometry.width, geometry.height));
       await win.setPosition(new PhysicalPosition(geometry.x, geometry.y));
     } catch (error) {

--- a/src/web-ui/src/flow_chat/components/toolbar-mode/toolbarModeSessionSurface.test.ts
+++ b/src/web-ui/src/flow_chat/components/toolbar-mode/toolbarModeSessionSurface.test.ts
@@ -1,0 +1,59 @@
+/**
+ * The floating chat surfaces must render the main window session surface
+ * itself, never a reduced copy of it. These assertions exist so the parallel
+ * conversation/composer implementations that used to live in each one do not
+ * creep back in — those duplicates were always feature subsets and doubled the
+ * maintenance cost of every chat change.
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+function readSource(relativePath: string): string {
+  return readFileSync(fileURLToPath(new URL(relativePath, import.meta.url)), 'utf8').replace(/\r\n?/g, '\n');
+}
+
+const SURFACES = [
+  { name: 'floating window mode (ToolbarMode)', path: './ToolbarMode.tsx' },
+  { name: 'floating mini chat bubble', path: '../../../app/layout/FloatingMiniChat.tsx' },
+];
+
+describe.each(SURFACES)('$name session surface', ({ path }) => {
+  const source = readSource(path);
+
+  it('renders the main window ChatPane with its full composer', () => {
+    expect(source).toContain("from '@/app/scenes/session/ChatPane'");
+    expect(source).toContain('<ChatPane');
+    expect(source).toContain('showChatInput');
+  });
+
+  it('keeps no private conversation view or composer of its own', () => {
+    expect(source).not.toContain('ModernFlowChatContainer');
+    expect(source).not.toContain('<input');
+    expect(source).not.toContain('toolbar-send-message');
+  });
+
+  it('takes its session affordances from the shared SessionMenu', () => {
+    expect(source).toContain('<SessionMenu');
+    expect(source).toContain('useFlowChatSessions');
+    // The "+" must open the shared menu rather than creating a session
+    // directly, and the title must stay a plain display — the two surfaces
+    // diverged on exactly these before.
+    expect(source).not.toContain('title-btn');
+    expect(source).not.toContain('ChevronDown');
+    expect(source).not.toContain("CustomEvent('toolbar-create-session'");
+    expect(source).toContain('title-display');
+  });
+});
+
+describe('session surface composition', () => {
+  it('reuses the session scene chat surface that ChatPane already composes', () => {
+    const chatPaneSource = readSource('../../../app/scenes/session/ChatPane.tsx');
+
+    expect(chatPaneSource).toContain(
+      "from '../../../flow_chat/components/modern/ModernFlowChatContainer'"
+    );
+    expect(chatPaneSource).toContain("from '../../../flow_chat/components/ChatInput'");
+  });
+});

--- a/src/web-ui/src/flow_chat/components/toolbar-mode/toolbarWindowGeometry.test.ts
+++ b/src/web-ui/src/flow_chat/components/toolbar-mode/toolbarWindowGeometry.test.ts
@@ -6,7 +6,7 @@ import {
 import { resolveToolbarWindowGeometry } from './toolbarWindowGeometry';
 
 describe('resolveToolbarWindowGeometry', () => {
-  it('fits expanded toolbar mode inside a short desktop work area', () => {
+  it('uses the authored logical size when the work area has room', () => {
     const geometry = resolveToolbarWindowGeometry({
       monitor: {
         position: { x: 0, y: 0 },
@@ -23,7 +23,70 @@ describe('resolveToolbarWindowGeometry', () => {
 
     expect(geometry.y).toBeGreaterThanOrEqual(0);
     expect(geometry.y + geometry.height).toBeLessThanOrEqual(728);
-    expect(geometry.height).toBe(688);
+    expect(geometry.width).toBe(TOOLBAR_EXPANDED_SIZE.width);
+    expect(geometry.height).toBe(TOOLBAR_EXPANDED_SIZE.height);
+  });
+
+  it('fits expanded toolbar mode inside a short desktop work area', () => {
+    const geometry = resolveToolbarWindowGeometry({
+      monitor: {
+        position: { x: 0, y: 0 },
+        size: { width: 1365, height: 600 },
+        workArea: {
+          position: { x: 0, y: 0 },
+          size: { width: 1365, height: 560 },
+        },
+        scaleFactor: 1,
+      },
+      targetSize: TOOLBAR_EXPANDED_SIZE,
+      minSize: TOOLBAR_EXPANDED_MIN,
+    });
+
+    expect(geometry.y).toBeGreaterThanOrEqual(0);
+    expect(geometry.y + geometry.height).toBeLessThanOrEqual(560);
+    expect(geometry.height).toBe(520);
+  });
+
+  it('scales the authored logical size to physical pixels on HiDPI displays', () => {
+    const geometry = resolveToolbarWindowGeometry({
+      monitor: {
+        position: { x: 0, y: 0 },
+        size: { width: 3024, height: 1964 },
+        workArea: {
+          position: { x: 0, y: 0 },
+          size: { width: 3024, height: 1866 },
+        },
+        scaleFactor: 2,
+      },
+      targetSize: TOOLBAR_EXPANDED_SIZE,
+      minSize: TOOLBAR_EXPANDED_MIN,
+    });
+
+    // Same apparent size as on a 1x display — this is what keeps the window
+    // matching the floating chat bubble panel rather than rendering half-size.
+    expect(geometry.width).toBe(TOOLBAR_EXPANDED_SIZE.width * 2);
+    expect(geometry.height).toBe(TOOLBAR_EXPANDED_SIZE.height * 2);
+    expect(geometry.minWidth).toBe(TOOLBAR_EXPANDED_MIN.width * 2);
+    expect(geometry.minHeight).toBe(TOOLBAR_EXPANDED_MIN.height * 2);
+  });
+
+  it('never reports a min size larger than the resolved rect', () => {
+    const geometry = resolveToolbarWindowGeometry({
+      monitor: {
+        position: { x: 0, y: 0 },
+        size: { width: 640, height: 480 },
+        workArea: {
+          position: { x: 0, y: 0 },
+          size: { width: 640, height: 400 },
+        },
+        scaleFactor: 1,
+      },
+      targetSize: TOOLBAR_EXPANDED_SIZE,
+      minSize: TOOLBAR_EXPANDED_MIN,
+    });
+
+    expect(geometry.minWidth).toBeLessThanOrEqual(geometry.width);
+    expect(geometry.minHeight).toBeLessThanOrEqual(geometry.height);
   });
 
   it('keeps the toolbar within a secondary monitor work area', () => {

--- a/src/web-ui/src/flow_chat/components/toolbar-mode/toolbarWindowGeometry.ts
+++ b/src/web-ui/src/flow_chat/components/toolbar-mode/toolbarWindowGeometry.ts
@@ -8,6 +8,12 @@ export interface ToolbarWindowRect extends ToolbarWindowSize {
   y: number;
 }
 
+export interface ResolvedToolbarWindowGeometry extends ToolbarWindowRect {
+  /** Physical min size for the resolved rect; never larger than the rect. */
+  minWidth: number;
+  minHeight: number;
+}
+
 interface PhysicalArea {
   position: {
     x: number;
@@ -51,11 +57,28 @@ export const resolveToolbarWindowGeometry = ({
   minSize,
   anchor,
   fallbackPosition = { x: 100, y: 100 },
-}: ResolveToolbarWindowGeometryOptions): ToolbarWindowRect => {
+}: ResolveToolbarWindowGeometryOptions): ResolvedToolbarWindowGeometry => {
+  // Sizes arrive in logical (CSS) pixels — the same unit the stylesheets and
+  // TOOLBAR_WINDOW_EDGE_MARGIN are authored in — while the monitor work area
+  // and the Tauri window APIs are physical. Convert once, here, so the window
+  // is the same apparent size on HiDPI and 1x displays.
+  const scaleFactor = monitor?.scaleFactor ?? 1;
+  const toPhysical = (value: number) => Math.max(1, Math.round(value * scaleFactor));
+  const target = {
+    width: toPhysical(targetSize.width),
+    height: toPhysical(targetSize.height),
+  };
+  const min = {
+    width: toPhysical(minSize.width),
+    height: toPhysical(minSize.height),
+  };
+
   if (!monitor) {
     return {
       ...fallbackPosition,
-      ...targetSize,
+      ...target,
+      minWidth: Math.min(min.width, target.width),
+      minHeight: Math.min(min.height, target.height),
     };
   }
 
@@ -63,14 +86,11 @@ export const resolveToolbarWindowGeometry = ({
     position: monitor.position,
     size: monitor.size,
   };
-  const margin = Math.max(
-    0,
-    Math.round(TOOLBAR_WINDOW_EDGE_MARGIN * (monitor.scaleFactor ?? 1))
-  );
+  const margin = Math.max(0, Math.round(TOOLBAR_WINDOW_EDGE_MARGIN * scaleFactor));
   const availableWidth = workArea.size.width - margin * 2;
   const availableHeight = workArea.size.height - margin * 2;
-  const width = resolveDimension(targetSize.width, minSize.width, availableWidth);
-  const height = resolveDimension(targetSize.height, minSize.height, availableHeight);
+  const width = resolveDimension(target.width, min.width, availableWidth);
+  const height = resolveDimension(target.height, min.height, availableHeight);
 
   const desiredX = anchor
     ? anchor.x + anchor.width - width
@@ -89,5 +109,7 @@ export const resolveToolbarWindowGeometry = ({
     y: maxY >= minY ? clamp(desiredY, minY, maxY) : workArea.position.y,
     width,
     height,
+    minWidth: Math.min(min.width, width),
+    minHeight: Math.min(min.height, height),
   };
 };

--- a/src/web-ui/src/flow_chat/tool-cards/TerminalToolCard.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/TerminalToolCard.scss
@@ -589,7 +589,7 @@
 }
 
 /* ========== Narrow width adaptation (Toolbar mode) ========== */
-.bitfun-toolbar-mode__flowchat-container {
+.bitfun-toolbar-mode__session-surface {
   .terminal-tool-card {
     .tool-card-action {
       display: none;


### PR DESCRIPTION
## Summary

Floating window mode and the floating chat bubble each carried their own conversation view and composer. Both were strict feature subsets of the main window session UI, and both had to be updated by hand whenever the real chat UI changed.

Both now render `ChatPane` — the same component the session scene mounts — so they inherit the full composer and cannot drift behind it again. The two headers, which had also diverged from each other, now share one `SessionMenu`.

Net **-386 lines** while gaining features on both surfaces.

## Type and Areas

Type: Refactor, plus three bug fixes found while doing it (regression fix, UI/UX).

Areas: web UI (`src/web-ui` — `flow_chat`, app layout).

## Motivation / Impact

**Duplicate chat UIs.** Both floating surfaces rendered `ModernFlowChatContainer` plus a single-line `<input>`. Users lost the model selector, attachments, `@`-mentions, slash commands, permission modes, voice input and the pending queue whenever they worked from a floating surface. Both now use the real composer.

**Divergent headers.** Floating window mode opened a menu from `+` and showed a static title; the bubble made the title a session switcher and had `+` create a session immediately. `SessionMenu` + `useFlowChatSessions` replace both with one component and one store subscription.

**Bubble could not create Cowork sessions.** Its `+` dispatched `toolbar-create-session` with no `detail`, so `detail?.mode` was always `undefined` and it fell through to the code branch. The shared menu always passes `{ mode }`.

**Toolbar window was the wrong size on HiDPI displays.** Sizes went to `PhysicalSize` unconverted, while the edge margin in the same helper was already scaled by `scaleFactor`. On a 2x display the window rendered at half the intended size; on 1x it was correct. `resolveToolbarWindowGeometry` now treats the authored sizes as logical pixels, converts once, and returns the matching physical min size so callers stop mixing units. Expanded mode is `440x680`, matching the bubble.

**The bubble trigger often needed several clicks.** Three compounding causes, all fixed:

1. It opened on `click`, which only fires when `pointerdown` and `pointerup` land on the same element — and this trigger hides itself as part of opening, so a re-render from a streaming session was enough to swallow the press. It now opens on `pointerdown` (`click` kept for keyboard/assistive activation) and the handler is idempotent.
2. Mounting `ChatPane` in the same commit that opened the panel stalled the open transition; measured with a synthetic 400 ms mount block, the panel was still at `scale(0.15)` when the block ended and took ~820 ms to reach full size instead of 420 ms. The surface now mounts two frames later, so the transition is already running on the compositor.
3. During the scale-up the backdrop still covered the panel's final rect (measured: ~130 ms at the panel centre, longer once the mount stall is added), so an impatient second click closed what the first one opened. The backdrop is now inert until the panel finishes opening — it still blocks stray clicks from reaching the scene underneath, it just does not close.

The collapsed panel also overlaps the trigger completely, and whether it swallowed the press was decided only by source order between `.bitfun-fmc > *` and `.bitfun-fmc__panel` (identical specificity, `0-1-0`). That happened to resolve correctly today, but moving either rule would have killed the button outright. Pointer events are now declared per child, stacking is explicit (backdrop 0, panel 1, trigger 2), and hidden elements use `visibility` rather than relying on `pointer-events` alone.

**Dead code removed.** `updateToolbarState` has no callers anywhere (confirmed with `git log -S`), so `toolbarState` never leaves its initial value: the bubble's confirm/reject header controls could never render and `toolbar-tool-confirm` / `toolbar-tool-reject` have no listeners. Those controls are gone from the bubble (the reused surface provides them). The `toolbar-tool-*` events and the `ToolbarModeState` fields behind them are still referenced by floating window mode's collapsed strip and were left alone — see Reviewer Notes.

## Verification

```
pnpm run type-check:web        # pass
pnpm run lint:web              # pass
pnpm run build:web             # pass
pnpm run theme:color-audit     # pass
pnpm run i18n:audit            # pass, 0 warnings
pnpm run check:repo-hygiene    # pass
pnpm --dir src/web-ui run test:run \
  src/flow_chat/components/toolbar-mode \
  src/app/startup/startupPerformanceContract.test.ts   # 60 passed
```

All re-run on the current `upstream/main` base.

Behavioural claims above were measured in a browser against a faithful replica of the real DOM and CSS (same rules, same source order), not asserted from reading the code:

- Backdrop vs panel during the open animation — probing `elementFromPoint` at the panel's final centre each frame showed `backdrop` until ~134 ms, then `panel`.
- Mount stall — with the block inline the panel was still at `scale(0.15)` when it ended; deferred by two frames the transition ran to completion on schedule.
- Trigger hit testing — a real synthesised click on the rewritten structure logged `TRIGGER:pointerdown` both from the closed state and mid-close-animation, and notably logged no `click`, which is exactly the failure mode being fixed.
- Collapsed panel `pointer-events` resolved to `none`, confirming the specificity tie currently falls the right way.

**Not verified in the running desktop app.** I could not exercise these surfaces end to end — the browser-only dev server has no Tauri backend, so it cannot reach a scene where either surface renders. Two things are worth a manual pass before merge:

- The window sizing change (`scaleFactor` was inferred from screenshot pixel ratios, not read at runtime).
- `ChatPane`'s first-mount cost inside a 440 px-wide panel — the layout and the `SessionMenu` dropdown clipping against the panel's `overflow: hidden` are the parts I would look at first.

## Reviewer Notes

New contract test `toolbarModeSessionSurface.test.ts` runs over both surfaces and asserts they mount `ChatPane` with `showChatInput`, carry no private conversation view or composer, and take their session affordances from `SessionMenu` — so the duplication cannot quietly come back.

`toolbarWindowGeometry.test.ts` went from 3 cases to 7. Every existing case used `scaleFactor: 1`, which is why the HiDPI sizing bug was invisible to it; there is now explicit 2x coverage.

Two deliberate scope limits:

- Floating window mode's collapsed strip still has the dead `toolbarState` branches (confirm/reject buttons, todo progress). Removing them means deleting `ToolbarModeState` and `updateToolbarState` from the context's public API, which felt like a separate change. Happy to fold it in if preferred.
- `toolbar-send-message` now has no dispatchers and its listener in `AppLayout` is dead. Left in place for the same reason.

One side effect worth flagging: the sizing fix also makes the collapsed toolbar strip DPI-consistent, so on a 2x display it becomes 700 logical px wide instead of the 350 it renders at today (1x displays are unchanged). That matches the authored constant, but it is a visible change — say the word and I will retune the constant.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable. (No new strings — the shared menu reuses the existing `toolCards.toolbar.*` keys; `i18n:audit` passes.)

## Related Issue

Closes #1078
