### PR TITLE
fix(web-ui): shorten hooks docs button label

### DIFF
--- a/src/web-ui/src/locales/en-US/settings/hooks.json
+++ b/src/web-ui/src/locales/en-US/settings/hooks.json
@@ -34,7 +34,7 @@
     "reference": {
       "label": "Event and payload reference",
       "description": "Codex's hooks documentation is the reference for event names, payload fields, and the decision schema.",
-      "open": "Open Codex hooks docs"
+      "open": "Open docs"
     }
   },
   "messages": {

--- a/src/web-ui/src/locales/zh-CN/settings/hooks.json
+++ b/src/web-ui/src/locales/zh-CN/settings/hooks.json
@@ -34,7 +34,7 @@
     "reference": {
       "label": "事件与载荷参考",
       "description": "事件名、载荷字段和决策结构以 Codex 的 Hooks 文档为准。",
-      "open": "打开 Codex Hooks 文档"
+      "open": "打开文档"
     }
   },
   "messages": {

--- a/src/web-ui/src/locales/zh-TW/settings/hooks.json
+++ b/src/web-ui/src/locales/zh-TW/settings/hooks.json
@@ -34,7 +34,7 @@
     "reference": {
       "label": "事件與載荷參考",
       "description": "事件名稱、載荷欄位和決策結構以 Codex 的 Hooks 文件為準。",
-      "open": "開啟 Codex Hooks 文件"
+      "open": "開啟文件"
     }
   },
   "messages": {


### PR DESCRIPTION
## 问题

Hooks 设置页「Codex 兼容 → 事件与载荷参考」卡片的按钮文案 `打开 Codex Hooks 文档` 过长，在窄一点的面板宽度下会折行成两行。

## 改动

卡片标题和说明里已经写明了链接指向 Codex 的 Hooks 文档，按钮不必重复，统一精简为「打开文档」：

| locale | before | after |
| --- | --- | --- |
| zh-CN | 打开 Codex Hooks 文档 | 打开文档 |
| zh-TW | 開啟 Codex Hooks 文件 | 開啟文件 |
| en-US | Open Codex hooks docs | Open docs |

纯文案改动，无逻辑变更。