### PR TITLE
fix(web): exclude worktree workspaces from recent workspaces list

### DIFF
--- a/src/web-ui/src/shared/types/global-state.ts
+++ b/src/web-ui/src/shared/types/global-state.ts
@@ -393,7 +393,9 @@ function mapApplicationState(state: APIApplicationState): ApplicationState {
 function mapWorkspaceStartupStateSnapshot(
   snapshot: APIWorkspaceStartupStateSnapshot
 ): WorkspaceStartupState {
-  const recentWorkspaces = snapshot.recentWorkspaces.map(mapWorkspaceInfo);
+  const recentWorkspaces = snapshot.recentWorkspaces
+    .map(mapWorkspaceInfo)
+    .filter(ws => !isLinkedWorktreeWorkspace(ws));
   return {
     cleanupRemovedCount: snapshot.cleanupRemovedCount,
     currentWorkspace: snapshot.currentWorkspace ? mapWorkspaceInfo(snapshot.currentWorkspace) : null,
@@ -565,7 +567,9 @@ export function createGlobalStateAPI(): GlobalStateAPI {
     },
 
     async getRecentWorkspaces(): Promise<WorkspaceInfo[]> {
-      const workspaces = (await globalAPI.getRecentWorkspaces()).map(mapWorkspaceInfo);
+      const workspaces = (await globalAPI.getRecentWorkspaces())
+        .map(mapWorkspaceInfo)
+        .filter(ws => !isLinkedWorktreeWorkspace(ws));
       logger.debug('getRecentWorkspaces returned', summarizeWorkspacesForLog(workspaces));
       return workspaces;
     },


### PR DESCRIPTION
## Summary

Worktree 工作区路径不应该出现在「最近的工作区」列表中。

Linked worktree directories (e.g. `BitFun-f85383a7` at `~/.bitfun/worktrees/...`) were showing up in both the Welcome page recent workspaces list and the nav sidebar workspace switcher menu. These are temporary working directories created by code sessions and should not appear in recent history.

## Changes

In `src/web-ui/src/shared/types/global-state.ts`:
- Filter out linked worktree workspaces (non-main) in `mapWorkspaceStartupStateSnapshot` (startup path)
- Filter out linked worktree workspaces in `getRecentWorkspaces()` (refresh path)

Uses the existing `isLinkedWorktreeWorkspace()` helper which checks `workspace.worktree && !workspace.worktree.isMain`.

## Testing

- TypeScript type check passes
- `global-state.test.ts` passes (2/2)
- `workspaceManager.test.ts` passes (9/9)