### PR TITLE
fix(workspace): exclude MiniApp workspaces from recent workspaces list

### DIFF
--- a/src/crates/assembly/core/src/service/workspace/service.rs
+++ b/src/crates/assembly/core/src/service/workspace/service.rs
@@ -1748,7 +1748,12 @@ impl WorkspaceService {
                 .recent_workspaces
                 .clone()
                 .into_iter()
-                .filter(|id| manager.get_workspaces().contains_key(id))
+                .filter(|id| {
+                    manager.get_workspaces().get(id).is_some_and(|workspace| {
+                        // Drop MiniApp-owned workspaces recorded before they were excluded.
+                        !self.is_miniapp_owned_path(&workspace.root_path)
+                    })
+                })
                 .collect();
             if filtered_recent != data.recent_workspaces {
                 should_persist_cleaned_history = true;
@@ -2111,7 +2116,18 @@ impl WorkspaceService {
             }
         }
 
+        if self.is_miniapp_owned_path(path) {
+            options.add_to_recent = false;
+        }
+
         options
+    }
+
+    /// MiniApp agent runs and customization drafts work inside directories the
+    /// MiniApp owns under `<userRoot>/data/miniapps/`. They are app storage, not
+    /// user projects, so they must stay out of recent workspace history.
+    fn is_miniapp_owned_path(&self, path: &Path) -> bool {
+        path.starts_with(self.path_manager.miniapps_dir())
     }
 
     async fn discover_assistant_workspaces(
@@ -2576,6 +2592,41 @@ mod tests {
         assert!(
             service.get_current_workspace().await.is_none(),
             "tracked workspace activity should not change the current workspace"
+        );
+    }
+
+    #[tokio::test]
+    async fn track_workspace_activity_keeps_miniapp_workspaces_out_of_recent_history() {
+        let env = TestEnvironment::new();
+        let service = build_test_workspace_service(env.path_manager.clone()).await;
+        let miniapp_workspace_root = env
+            .path_manager
+            .miniapp_dir("builtin-ppt-live")
+            .join("decks")
+            .join("deck-1785130332234");
+        std::fs::create_dir_all(&miniapp_workspace_root)
+            .expect("MiniApp workspace directory should be created");
+
+        let tracked = service
+            .track_workspace_activity(
+                miniapp_workspace_root.clone(),
+                WorkspaceCreateOptions::default(),
+                WorkspaceActivityMode::RefreshMetadata,
+            )
+            .await
+            .expect("MiniApp workspace tracking should succeed");
+
+        assert_eq!(
+            service
+                .get_workspace_by_path(&miniapp_workspace_root)
+                .await
+                .map(|workspace| workspace.id),
+            Some(tracked.id),
+            "MiniApp workspace should still be registered so its agent session can resolve it"
+        );
+        assert!(
+            service.get_recent_workspaces().await.is_empty(),
+            "MiniApp-owned workspaces should never enter recent workspace history"
         );
     }
 

--- a/src/web-ui/src/shared/types/global-state.test.ts
+++ b/src/web-ui/src/shared/types/global-state.test.ts
@@ -99,6 +99,24 @@ describe('createGlobalStateAPI workspace startup bootstrap', () => {
     expect(globalApiMocks.initializeWorkspaceStartupState).toHaveBeenCalledTimes(1);
   });
 
+  it('keeps MiniApp-owned workspaces out of the recent list', async () => {
+    const snapshot = createWorkspaceSnapshot();
+    const miniAppWorkspace = {
+      ...snapshot.recentWorkspaces[0],
+      id: 'workspace-miniapp',
+      name: 'deck-1785130332234-eilik4',
+      rootPath:
+        '/Users/me/Library/Application Support/bitfun/data/miniapps/builtin-ppt-live/decks/deck-1785130332234-eilik4',
+    };
+    snapshot.recentWorkspaces = [...snapshot.recentWorkspaces, miniAppWorkspace];
+    bootstrapGlobals.__BITFUN_BOOTSTRAP_WORKSPACE_STARTUP_STATE__ = snapshot;
+
+    const api = createGlobalStateAPI();
+    const state = await api.initializeWorkspaceStartupState();
+
+    expect(state.recentWorkspaces.map(workspace => workspace.id)).toEqual(['workspace-1']);
+  });
+
   it('falls back to the startup command when the bootstrap snapshot is invalid', async () => {
     bootstrapGlobals.__BITFUN_BOOTSTRAP_WORKSPACE_STARTUP_STATE__ = { recentWorkspaces: [] };
     globalApiMocks.initializeWorkspaceStartupState.mockResolvedValue(createWorkspaceSnapshot());

--- a/src/web-ui/src/shared/types/global-state.ts
+++ b/src/web-ui/src/shared/types/global-state.ts
@@ -11,6 +11,7 @@ import type {
   WorkspaceInfo as APIWorkspaceInfo,
 } from '@/infrastructure/api/service-api/GlobalAPI';
 import { createLogger } from '../utils/logger';
+import { normalizePath } from '../utils/pathUtils';
 
 const logger = createLogger('GlobalStateAPI');
 
@@ -149,6 +150,27 @@ export function isRemoteWorkspace(workspace: WorkspaceInfo | null | undefined): 
 
 export function isLinkedWorktreeWorkspace(workspace: WorkspaceInfo | null | undefined): boolean {
   return Boolean(workspace?.worktree && !workspace.worktree.isMain);
+}
+
+/** MiniApp storage root shared by every platform: `<userRoot>/data/miniapps/`. */
+const MINIAPP_DATA_PATH_SEGMENT = '/data/miniapps/';
+
+/**
+ * MiniApp agent runs work inside directories the MiniApp owns under the app data
+ * dir (`<userRoot>/data/miniapps/<appId>/...`, drafts included). They are MiniApp
+ * storage rather than user projects, so they never belong in workspace history.
+ */
+export function isMiniAppWorkspace(workspace: WorkspaceInfo | null | undefined): boolean {
+  const rootPath = workspace?.rootPath;
+  if (!rootPath) {
+    return false;
+  }
+  return normalizePath(rootPath).includes(MINIAPP_DATA_PATH_SEGMENT);
+}
+
+/** Temporary or app-owned workspaces that must not pollute the recent list. */
+function isExcludedFromRecentWorkspaces(workspace: WorkspaceInfo): boolean {
+  return isLinkedWorktreeWorkspace(workspace) || isMiniAppWorkspace(workspace);
 }
 
 
@@ -395,7 +417,7 @@ function mapWorkspaceStartupStateSnapshot(
 ): WorkspaceStartupState {
   const recentWorkspaces = snapshot.recentWorkspaces
     .map(mapWorkspaceInfo)
-    .filter(ws => !isLinkedWorktreeWorkspace(ws));
+    .filter(ws => !isExcludedFromRecentWorkspaces(ws));
   return {
     cleanupRemovedCount: snapshot.cleanupRemovedCount,
     currentWorkspace: snapshot.currentWorkspace ? mapWorkspaceInfo(snapshot.currentWorkspace) : null,
@@ -569,7 +591,7 @@ export function createGlobalStateAPI(): GlobalStateAPI {
     async getRecentWorkspaces(): Promise<WorkspaceInfo[]> {
       const workspaces = (await globalAPI.getRecentWorkspaces())
         .map(mapWorkspaceInfo)
-        .filter(ws => !isLinkedWorktreeWorkspace(ws));
+        .filter(ws => !isExcludedFromRecentWorkspaces(ws));
       logger.debug('getRecentWorkspaces returned', summarizeWorkspacesForLog(workspaces));
       return workspaces;
     },


### PR DESCRIPTION
## Summary

MiniApp agent runs work inside directories the MiniApp owns under `<userRoot>/data/miniapps/` (deck folders, customization drafts). Those directories were tracked as ordinary workspaces, so they appeared in the recent workspaces list on the Welcome page and in the nav workspace switcher, and could even be auto-opened on startup when no workspace was active.

They are now excluded, following the same approach as #1865 for linked worktrees:

- **Web data source** (`global-state.ts`): new `isMiniAppWorkspace` next to `isLinkedWorktreeWorkspace`, both applied through one `isExcludedFromRecentWorkspaces` predicate in the startup snapshot and `getRecentWorkspaces`. This also hides entries already recorded in a user's local history.
- **Backend** (`workspace/service.rs`): `normalize_workspace_options_for_path` forces `add_to_recent = false` for MiniApp-owned paths, so no new entries accumulate; startup history load drops recent ids persisted before this change. MiniApp workspaces stay registered, so their agent sessions keep resolving them.

## Type and Areas

Type: bug fix

Areas: Rust core, web UI

## Motivation / Impact

Opening a MiniApp that runs an agent (for example the built-in PPT Live decks) polluted the recent workspaces list with one `deck-<timestamp>-<id>` entry per deck. These are MiniApp storage rather than user projects, so they pushed real projects out of the capped recent list, and `AppLayout` could auto-switch into one of them on startup when no workspace was active.

Users now see only real workspaces in the Welcome page list and the nav switcher menu; already-recorded MiniApp entries disappear on next launch and are cleaned out of `workspace_data` at startup. No behavior change for MiniApp agent sessions themselves.

## Verification

```
cd src/web-ui && npx vitest run src/shared/types/global-state.test.ts   # 3 passed (1 new case)
cd src/web-ui && npx tsc --noEmit -p tsconfig.json                      # clean
cargo test -p bitfun-core --lib service::workspace::                    # 13 passed (1 new case)
cargo check -p bitfun-core                                              # clean
```

New tests:
- `global-state.test.ts` — a deck path under `.../bitfun/data/miniapps/builtin-ppt-live/decks/...` is dropped from the startup snapshot's recent list.
- `service.rs::track_workspace_activity_keeps_miniapp_workspaces_out_of_recent_history` — tracking a MiniApp deck path still registers the workspace (resolvable by path) but leaves recent history empty.

Note: `cargo clippy -p bitfun-core --lib --tests` fails on a pre-existing, unrelated `suspicious_open_options` lint in `services-core/src/json_store.rs:346`, untouched by this PR.

## Reviewer Notes

- Detection differs per layer on purpose: the backend compares against `path_manager.miniapps_dir()` with `Path::starts_with` (exact), while the web layer has no app-paths API and matches the `/data/miniapps/` segment on the normalized root path. `user_data_dir` is always `<userRoot>/data`, so that segment holds on macOS, Linux, and Windows, and it covers `.drafts` customization roots as well as agent workspaces.
- Only the recent list is affected; workspace registration, opened workspaces, and the current workspace are untouched.
