### PR TITLE
fix(web): stop settings panels flashing on their first open

### DIFF
--- a/src/web-ui/src/app/scenes/nav-registry.ts
+++ b/src/web-ui/src/app/scenes/nav-registry.ts
@@ -14,7 +14,18 @@ import type { SceneTabId } from '../components/SceneBar/types';
 
 type LazyNavComponent = ReturnType<typeof lazy<ComponentType>>;
 
-const loadSettingsNav = () => import('./settings/SettingsNav');
+/**
+ * The settings nav renders every label from the lazy `settings` namespace, so the
+ * chunk and that namespace are loaded together — mounting before it resolves
+ * paints raw i18n keys for a frame.
+ */
+const loadSettingsNav = async () => {
+  const [navModule] = await Promise.all([
+    import('./settings/SettingsNav'),
+    import('./settings/settingsTabI18n').then((m) => m.preloadSettingsShellI18n()),
+  ]);
+  return navModule;
+};
 const loadFileViewerNav = () => import('./file-viewer/FileViewerNav');
 const loadShellNav = () => import('./shell/ShellNav');
 

--- a/src/web-ui/src/app/scenes/settings/SettingsNav.tsx
+++ b/src/web-ui/src/app/scenes/settings/SettingsNav.tsx
@@ -12,6 +12,7 @@
  */
 
 import React, {
+  startTransition,
   useCallback,
   useEffect,
   useMemo,
@@ -185,8 +186,13 @@ function useSettingsNav() {
       const requestId = ++activationRequestRef.current;
       const commit = () => {
         if (activationRequestRef.current !== requestId) return;
-        setActiveTab(tab);
-        clearSearch();
+        // A cached lazy panel still suspends for one promise microtask on its
+        // first mount; inside a transition React keeps the painted panel until
+        // the new one is ready instead of committing the skeleton fallback.
+        startTransition(() => {
+          setActiveTab(tab);
+          clearSearch();
+        });
       };
       void preloadSettingsTabContent(tab).then(commit, commit);
     },
@@ -197,9 +203,10 @@ function useSettingsNav() {
     (tab: ConfigTab) => {
       const requestId = ++activationRequestRef.current;
       const commit = () => {
-        if (activationRequestRef.current === requestId) {
+        if (activationRequestRef.current !== requestId) return;
+        startTransition(() => {
           setActiveTab(tab);
-        }
+        });
       };
       void preloadSettingsTabContent(tab).then(commit, commit);
     },

--- a/src/web-ui/src/app/scenes/settings/SettingsScene.test.tsx
+++ b/src/web-ui/src/app/scenes/settings/SettingsScene.test.tsx
@@ -78,6 +78,20 @@ describe('SettingsScene lazy tab routing', () => {
     vi.useRealTimers();
   });
 
+  /**
+   * The scene holds its very first paint until the active tab's lazy chunk and
+   * i18n namespaces are in memory, so a cold entry cannot flash a skeleton and a
+   * frame of raw i18n keys. Both land off a macrotask, past what act() flushes.
+   */
+  async function waitForPanelContent(testId: string) {
+    for (let attempt = 0; attempt < 50; attempt += 1) {
+      if (container.querySelector(`[data-testid="${testId}"]`)) return;
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    }
+  }
+
   async function renderActiveTab(
     tab: 'mcp-tools' | 'acp-agents' | 'external-sources' | 'voice-input'
   ) {
@@ -85,6 +99,7 @@ describe('SettingsScene lazy tab routing', () => {
     await act(async () => {
       root.render(<SettingsScene />);
     });
+    await waitForPanelContent(`${tab}-config`);
   }
 
   it('renders the lazy MCP tools config tab', async () => {
@@ -115,7 +130,9 @@ describe('SettingsScene lazy tab routing', () => {
     await act(async () => {
       root.render(<SettingsScene />);
     });
+    await waitForPanelContent('basics-config');
 
+    /** Only the cold first paint waits for resources; later switches are synchronous. */
     await act(async () => {
       useSettingsStore.setState({ activeTab: 'appearance' });
       await Promise.resolve();

--- a/src/web-ui/src/app/scenes/settings/SettingsScene.tsx
+++ b/src/web-ui/src/app/scenes/settings/SettingsScene.tsx
@@ -9,6 +9,7 @@
 import React, {
   Suspense,
   useEffect,
+  useState,
 } from 'react';
 import { useSettingsStore } from './settingsStore';
 import type { ConfigTab } from './settingsConfig';
@@ -30,6 +31,8 @@ import {
   SessionPersonalizationConfig,
   VoiceInputConfig,
   WorktreesConfig,
+  isSettingsTabContentReady,
+  preloadSettingsTabContent,
 } from './settingsContentRegistry';
 import './SettingsScene.scss';
 
@@ -81,7 +84,33 @@ const SettingsScene: React.FC = () => {
     }
   }, [activeTab, setActiveTab]);
 
-  const Content = resolveSettingsContent(resolvedTab);
+  /**
+   * Cold entries into the scene (first open after launch, deep links) mount a
+   * panel whose chunk and i18n namespaces are still in flight, which paints the
+   * skeleton and then a frame of raw i18n keys. Hold the first paint until those
+   * resources land — an empty content area for a few ms reads as instant, a
+   * three-stage flash does not. SettingsNav preloads before it flips the active
+   * tab, so tab switches are never gated here.
+   */
+  const [firstPaintReady, setFirstPaintReady] = useState(() =>
+    isSettingsTabContentReady(resolvedTab)
+  );
+
+  useEffect(() => {
+    if (firstPaintReady) return;
+
+    let cancelled = false;
+    const commit = () => {
+      if (!cancelled) setFirstPaintReady(true);
+    };
+    void preloadSettingsTabContent(resolvedTab).then(commit, commit);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [firstPaintReady, resolvedTab]);
+
+  const Content = firstPaintReady ? resolveSettingsContent(resolvedTab) : null;
 
   return (
     <div className="bitfun-settings-scene" data-testid="settings-scene" data-settings-tab={resolvedTab}>

--- a/src/web-ui/src/app/scenes/settings/settingsContentRegistry.ts
+++ b/src/web-ui/src/app/scenes/settings/settingsContentRegistry.ts
@@ -1,5 +1,6 @@
 import { lazy } from 'react';
 import type { ConfigTab } from './settingsConfig';
+import { preloadSettingsTabI18n } from './settingsTabI18n';
 
 const loadAIModelConfig = () => import('../../../infrastructure/config/components/AIModelConfig');
 const loadMcpToolsConfig = () => import('../../../infrastructure/config/components/McpToolsConfig');
@@ -64,6 +65,29 @@ const SETTINGS_CONTENT_LOADERS: Partial<Record<ConfigTab, () => Promise<unknown>
   keyboard: loadKeyboardShortcutsTab,
 };
 
+/**
+ * Tabs whose chunk *and* i18n namespaces are already in memory. Rendering such a
+ * tab is a plain synchronous mount: no Suspense fallback, no frame of raw i18n keys.
+ */
+const readyTabs = new Set<ConfigTab>();
+
+export function isSettingsTabContentReady(tab: ConfigTab): boolean {
+  return readyTabs.has(tab);
+}
+
+/**
+ * Warm everything a tab needs to paint in a single frame: its lazy panel chunk
+ * (with the CSS Vite ships alongside it) and its i18n namespaces. Callers await
+ * this before switching tabs so the panel appears fully rendered instead of
+ * stepping through skeleton → untranslated keys → content.
+ */
 export async function preloadSettingsTabContent(tab: ConfigTab): Promise<void> {
-  await SETTINGS_CONTENT_LOADERS[tab]?.();
+  if (readyTabs.has(tab)) return;
+
+  await Promise.all([
+    SETTINGS_CONTENT_LOADERS[tab]?.(),
+    preloadSettingsTabI18n(tab),
+  ]);
+
+  readyTabs.add(tab);
 }

--- a/src/web-ui/src/app/scenes/settings/settingsTabI18n.test.ts
+++ b/src/web-ui/src/app/scenes/settings/settingsTabI18n.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { i18nService } from '@/infrastructure/i18n/core/I18nService';
+import { SETTINGS_TAB_I18N_NAMESPACES, preloadSettingsShellI18n } from './settingsTabI18n';
+import { isSettingsTabContentReady, preloadSettingsTabContent } from './settingsContentRegistry';
+import { SETTINGS_CATEGORIES } from './settingsConfig';
+
+/**
+ * A namespace that has not resolved yet makes `t(key)` echo the key back, which is
+ * the raw-key frame a panel paints when it mounts ahead of its translations.
+ */
+function resolveKey(namespace: string, key: string): string {
+  return String(i18nService.getI18nInstance().getFixedT(null, namespace)(key));
+}
+
+describe('settings tab i18n preloading', () => {
+  it('covers every nav tab', () => {
+    for (const category of SETTINGS_CATEGORIES) {
+      for (const tab of category.tabs) {
+        expect(SETTINGS_TAB_I18N_NAMESPACES[tab.id]?.length ?? 0).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('resolves a tab namespace before the panel can render', async () => {
+    expect(resolveKey('settings/basics', 'title')).toBe('title');
+
+    await preloadSettingsTabContent('basics');
+
+    expect(isSettingsTabContentReady('basics')).toBe(true);
+    expect(i18nService.getI18nInstance().hasLoadedNamespace('settings/basics')).toBe(true);
+    expect(resolveKey('settings/basics', 'title')).not.toBe('title');
+  });
+
+  it('resolves the shell namespace behind the nav labels', async () => {
+    await preloadSettingsShellI18n();
+
+    expect(resolveKey('settings', 'configCenter.tabs.basics')).not.toBe(
+      'configCenter.tabs.basics'
+    );
+  });
+});

--- a/src/web-ui/src/app/scenes/settings/settingsTabI18n.ts
+++ b/src/web-ui/src/app/scenes/settings/settingsTabI18n.ts
@@ -1,0 +1,60 @@
+/**
+ * settingsTabI18n — i18n namespaces every settings tab renders from.
+ *
+ * Only WEB_UI_BOOTSTRAP_NAMESPACES ship with the initial bundle; everything else
+ * resolves through the lazy namespace backend. A panel mounted before its
+ * namespace lands paints raw i18n keys for a frame (react.useSuspense is off, so
+ * `t()` returns the key) and then swaps to real copy — the visible "flash" on the
+ * first open of a tab. Loading these alongside the tab's lazy chunk makes the
+ * first open look identical to every later one.
+ *
+ * Keep in sync with the `useTranslation(...)` / `useI18n(...)` namespaces used by
+ * each panel and the components it renders.
+ */
+
+import { i18nService } from '@/infrastructure/i18n/core/I18nService';
+import type { I18nNamespace } from '@/infrastructure/i18n/types';
+import type { ConfigTab } from './settingsConfig';
+
+/** Namespace behind the settings shell itself: category labels, tab labels, keyboard tab copy. */
+export const SETTINGS_SHELL_NAMESPACES: readonly I18nNamespace[] = ['settings'];
+
+export const SETTINGS_TAB_I18N_NAMESPACES: Record<ConfigTab, readonly I18nNamespace[]> = {
+  basics: ['settings/basics'],
+  appearance: ['settings/appearance', 'settings/basics'],
+  models: ['settings/ai-model', 'settings/default-model', 'components'],
+  'archived-sessions': ['common'],
+  worktrees: ['worktrees'],
+  // Both session panels live in the same module and share its sub-sections.
+  'session-personalization': ['settings/session-config', 'settings/agentic-tools', 'settings/debug'],
+  'session-permissions': ['settings/session-config', 'settings/agentic-tools', 'settings/debug'],
+  'quick-actions': ['settings/quick-actions'],
+  'voice-input': ['settings/voice-input'],
+  review: ['settings/review'],
+  memories: ['settings/memories'],
+  'mcp-tools': ['settings/mcp-tools', 'settings/mcp', 'shared'],
+  'external-sources': ['settings/external-sources', 'shared'],
+  hooks: ['settings/hooks'],
+  'acp-agents': ['settings/acp-agents'],
+  editor: ['settings/editor'],
+  keyboard: ['settings'],
+};
+
+async function preloadNamespaces(namespaces: readonly I18nNamespace[]): Promise<void> {
+  await Promise.all(
+    namespaces.map((namespace) =>
+      i18nService.loadNamespace(namespace).catch(() => {
+        // A namespace that fails to resolve must not block tab activation;
+        // i18next keeps falling back the same way it does today.
+      })
+    )
+  );
+}
+
+export function preloadSettingsShellI18n(): Promise<void> {
+  return preloadNamespaces(SETTINGS_SHELL_NAMESPACES);
+}
+
+export function preloadSettingsTabI18n(tab: ConfigTab): Promise<void> {
+  return preloadNamespaces(SETTINGS_TAB_I18N_NAMESPACES[tab] ?? []);
+}

--- a/src/web-ui/src/component-library/components/ConfigPage/ConfigPage.scss
+++ b/src/web-ui/src/component-library/components/ConfigPage/ConfigPage.scss
@@ -1,3 +1,8 @@
+@keyframes bitfun-config-page-loading-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
 .bitfun-config-page-loading {
   min-height: 200px;
   display: flex;
@@ -5,6 +10,15 @@
   justify-content: center;
   color: var(--color-text-muted);
   font-size: var(--font-size-sm);
+  /* Mounts only after a grace period (see ConfigPageLoading), so ease it in
+     rather than popping a block of text into an otherwise settled page. */
+  animation: bitfun-config-page-loading-in 140ms cubic-bezier(0.23, 1, 0.32, 1) both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bitfun-config-page-loading {
+    animation: none;
+  }
 }
 
 .bitfun-config-page-message {

--- a/src/web-ui/src/component-library/components/ConfigPage/ConfigPageLoading.tsx
+++ b/src/web-ui/src/component-library/components/ConfigPage/ConfigPageLoading.tsx
@@ -1,19 +1,47 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import './ConfigPage.scss';
+
+/**
+ * Grace period before a section admits it is loading.
+ *
+ * Config sections read their state through ConfigManager, which serves warm paths
+ * from cache and cold ones over IPC. Painting the placeholder unconditionally means
+ * a page full of 200px "loading" blocks appears and collapses within one or two
+ * frames on the first open of a tab. Staying invisible for a beat lets fast reads
+ * land silently; only genuinely slow ones surface a placeholder.
+ */
+const LOADING_VISIBLE_DELAY_MS = 200;
 
 export interface ConfigPageLoadingProps {
   text: string;
   className?: string;
+  /** Override the grace period; 0 paints immediately. */
+  delayMs?: number;
 }
 
 export const ConfigPageLoading: React.FC<ConfigPageLoadingProps> = ({
   text,
   className = '',
+  delayMs = LOADING_VISIBLE_DELAY_MS,
 }) => {
+  const [visible, setVisible] = useState(delayMs <= 0);
+
+  useEffect(() => {
+    if (delayMs <= 0) {
+      setVisible(true);
+      return;
+    }
+
+    setVisible(false);
+    const timer = window.setTimeout(() => setVisible(true), delayMs);
+    return () => window.clearTimeout(timer);
+  }, [delayMs]);
+
+  if (!visible) return null;
+
   return (
     <div className={`bitfun-config-page-loading ${className}`}>
       {text}
     </div>
   );
 };
-

--- a/src/web-ui/src/infrastructure/config/components/ExternalSourcesConfig.test.tsx
+++ b/src/web-ui/src/infrastructure/config/components/ExternalSourcesConfig.test.tsx
@@ -301,6 +301,12 @@ describe('ExternalSourcesConfig', () => {
       '.bitfun-config-page-layout.bitfun-external-sources-config',
     );
     expect(page?.querySelector('.bitfun-config-page-header__title')?.textContent).toBe('title');
+
+    /**
+     * ConfigPageLoading waits out a grace period before admitting it is loading, so
+     * reads served from the ConfigManager cache never flash a placeholder.
+     */
+    await act(async () => vi.advanceTimersByTimeAsync(260));
     expect(page?.querySelector(
       '.bitfun-config-page-content .bitfun-config-page-loading',
     )?.textContent).toBe('loading');


### PR DESCRIPTION
## Summary

Every settings tab flashed once the first time it was opened after launch, then stayed smooth on later opens. Three per-tab resources only load once per process, and all three were being resolved while the panel was already on screen:

1. **Lazy i18n namespaces (main cause).** Only `WEB_UI_BOOTSTRAP_NAMESPACES` ship with the initial bundle and `react.useSuspense` is off, so a panel mounted ahead of its namespace renders raw i18n keys (`title`, `subtitle`, `logging.sections.logging`) and reflows into real copy when the JSON lands. Hits `settings/basics`, `settings/appearance`, `settings/editor`, `worktrees`, and most other panels.
2. **Suspense skeleton stealing a frame.** `lazy()` runs its ctor on first render and throws a thenable even when the chunk is already cached, so `SettingsScene` committed its loading skeleton before the panel. `NavPanel` already works around this with `startTransition`; the settings nav did not.
3. **Per-section loading placeholders.** Each config section reads state over IPC and painted a 200px "loading" block while doing so. On a cold tab that meant a page of placeholders appearing and collapsing within a frame or two; on a warm tab the ConfigManager cache made it invisible — hence "only the first time".

Changes:

- New `settingsTabI18n.ts` maps each tab to the namespaces it renders from; `preloadSettingsTabContent` now warms chunk **and** namespaces, so activation waits for both. Existing hover/focus preloading means a click is usually already warm.
- `settingsContentRegistry` tracks which tabs are fully warm (`isSettingsTabContentReady`).
- Tab activation is wrapped in `startTransition`, so a cached-but-uninitialized lazy panel can no longer commit the skeleton.
- `SettingsScene` holds only its **cold first paint** (first open after launch, deep links) until resources land. Tab switches never pass through that gate, so the existing "switch immediately, do not retain the outgoing panel" behavior is unchanged.
- `nav-registry` loads the `settings` namespace together with the `SettingsNav` chunk, so sidebar labels no longer flash keys either.
- `ConfigPageLoading` waits out a 200ms grace period and fades in over 140ms (`prefers-reduced-motion` respected), so warm reads land silently and only genuinely slow sections surface a placeholder.

## Type and Areas

Type: bug fix (UI/UX)

Areas: web UI (settings scene, config panels, component-library `ConfigPage`, i18n preloading)

## Motivation / Impact

The settings surface looked unfinished on first use: opening any settings item after launch showed a grey skeleton, then untranslated i18n keys, then a page of collapsing loading placeholders, before settling. Users see each tab paint once, fully rendered.

Trade-off worth calling out: a cold tab now waits for its chunk and namespaces before painting instead of painting a placeholder immediately. In exchange for a slightly later first paint (a preloaded tab is unaffected), there is no multi-stage flash. This is the same trade-off `SettingsNav` and `NavPanel` already made for navigation.

No API, config, or locale changes.

## Verification

```
pnpm run type-check:web                # clean
pnpm --dir src/web-ui run lint          # clean
pnpm run i18n:audit                     # passed with 0 warnings
pnpm --dir src/web-ui run test:run      # 359 files / 2373 tests passed
```

New regression test `settingsTabI18n.test.ts` pins the root cause and the fix: before preloading, `t('title')` echoes the key back (the visible flash); after `preloadSettingsTabContent('basics')` the namespace is resolved and real copy comes out. It also asserts the namespace map covers every tab in `SETTINGS_CATEGORIES`, so a new tab cannot silently regress.

Two existing tests were adjusted to the new contract, with their original assertions intact:

- `SettingsScene.test.tsx` — cold first render now waits for resources (chunk + JSON resolve off a macrotask, past what `act()` flushes). The "switches immediately without retaining the outgoing panel" case keeps its single-microtask await and all three assertions, which is what proves switches are still synchronous.
- `ExternalSourcesConfig.test.tsx` — the test asserting the loading placeholder now advances fake timers past the grace period before looking for it.

## Reviewer Notes

- No manual visual confirmation in a running app: the browser tooling in my environment could not reach the dev server. Everything above is code-path analysis plus the executable assertions listed, not an observed recording — so no before/after capture is attached. Worth a quick eyeball on **Basics** (most sections, previously the worst offender) and **Worktrees**.
- The namespace map in `settingsTabI18n.ts` is hand-maintained and must stay in sync with the `useTranslation(...)` / `useI18n(...)` calls in each panel. The coverage test catches a missing *tab*, not a missing namespace on an existing tab.
- The 200ms `ConfigPageLoading` grace period does not eliminate every pathological case: a read finishing at ~250ms will still show a placeholder briefly. Bounding that would need a minimum-display duration, which felt like more machinery than the problem warranted.
- AI-assisted: yes (Claude Code). Testing level: **lightly tested** — automated checks pass in full, no manual UI pass.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable. (No string changes; existing locales now resolve earlier.)
