### PR TITLE
feat(web): add primary assistant session action

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/MainNav.tsx
+++ b/src/web-ui/src/app/components/NavPanel/MainNav.tsx
@@ -29,6 +29,7 @@ import { useMyAgentStore } from '../../scenes/my-agent/myAgentStore';
 import { useMiniAppCatalogSync } from '../../scenes/miniapps/hooks/useMiniAppCatalogSync';
 import { flowChatManager } from '@/flow_chat/services/FlowChatManager';
 import { resolveAgentTypeForSessionCreation } from '@/flow_chat/services/flow-chat-manager';
+import { openMainSession } from '@/flow_chat/services/sessionActivation';
 import { workspaceManager } from '@/infrastructure/services/business/workspaceManager';
 import { useWorkspaceContext } from '@/infrastructure/contexts/WorkspaceContext';
 import { createLogger } from '@/shared/utils/logger';
@@ -37,6 +38,7 @@ import { WorkspaceKind, isRemoteWorkspace } from '@/shared/types';
 import {
   findReusableEmptySessionId,
   flowChatSessionConfigForWorkspace,
+  pickPrimaryAssistantWorkspace,
   pickWorkspaceForProjectChatSession,
 } from '@/app/utils/projectSessionWorkspace';
 import { getRecentWorkspaceLineParts } from '@/shared/utils/recentWorkspaceDisplay';
@@ -172,10 +174,13 @@ const MainNav: React.FC<MainNavProps> = ({
   const setSessionMode = useSessionModeStore(s => s.setMode);
   const isAssistantWorkspaceActive = currentWorkspace?.workspaceKind === WorkspaceKind.Assistant;
 
-  const defaultAssistantWorkspace = useMemo(
-    () => assistantWorkspacesList.find(w => !w.assistantId) ?? assistantWorkspacesList[0] ?? null,
+  const primaryAssistantWorkspace = useMemo(
+    () => pickPrimaryAssistantWorkspace(assistantWorkspacesList),
     [assistantWorkspacesList]
   );
+
+  const defaultAssistantWorkspace =
+    primaryAssistantWorkspace ?? assistantWorkspacesList[0] ?? null;
 
   const toggleNavSearch = useCallback(() => {
     setSearchOpen((v) => !v);
@@ -250,6 +255,30 @@ const MainNav: React.FC<MainNavProps> = ({
     setSessionMode('cowork');
     void handleCreateProjectSession('Cowork');
   }, [handleCreateProjectSession, setSessionMode]);
+
+  const handleCreatePrimaryAssistantSession = useCallback(async () => {
+    if (!primaryAssistantWorkspace) {
+      notificationService.warning(t('nav.workspaces.createSessionFailed'), { duration: 4000 });
+      return;
+    }
+
+    try {
+      const sessionId = await flowChatManager.createChatSession(
+        flowChatSessionConfigForWorkspace(primaryAssistantWorkspace),
+        'Claw'
+      );
+      await openMainSession(sessionId, {
+        workspaceId: primaryAssistantWorkspace.id,
+        activateWorkspace: setActiveWorkspace,
+      });
+    } catch (error) {
+      log.error('Failed to create primary assistant session', { error });
+      notificationService.error(
+        error instanceof Error ? error.message : t('nav.workspaces.createSessionFailed'),
+        { duration: 4000 }
+      );
+    }
+  }, [primaryAssistantWorkspace, setActiveWorkspace, t]);
 
   const handleOpenProject = useCallback(async () => {
     try {
@@ -455,6 +484,7 @@ const MainNav: React.FC<MainNavProps> = ({
 
   const createCodeTooltip = t('nav.sessions.newCodeSession');
   const createCoworkTooltip = t('nav.sessions.newCoworkSession');
+  const createAssistantSessionTooltip = t('nav.sessions.newPrimaryAssistantSession');
   const assistantTooltip = t('nav.items.persona');
   const addWorkspaceTooltip = t('nav.tooltips.addWorkspace');
   const isAssistantActive = activeTabId === 'assistant';
@@ -618,6 +648,19 @@ const MainNav: React.FC<MainNavProps> = ({
             collapsible
             isOpen={expandedSections.has('assistant-sessions')}
             onToggle={() => toggleSection('assistant-sessions')}
+            actions={
+              <Tooltip content={createAssistantSessionTooltip} placement="right" followCursor>
+                <button
+                  type="button"
+                  className="bitfun-nav-panel__section-action"
+                  aria-label={createAssistantSessionTooltip}
+                  onClick={() => { void handleCreatePrimaryAssistantSession(); }}
+                  data-testid="nav-primary-assistant-session-add-btn"
+                >
+                  <Plus size={13} />
+                </button>
+              </Tooltip>
+            }
           />
           <div className={`bitfun-nav-panel__collapsible${expandedSections.has('assistant-sessions') ? '' : ' is-collapsed'}`}>
             <div className="bitfun-nav-panel__collapsible-inner">

--- a/src/web-ui/src/app/utils/projectSessionWorkspace.test.ts
+++ b/src/web-ui/src/app/utils/projectSessionWorkspace.test.ts
@@ -2,7 +2,10 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { flowChatStore } from '@/flow_chat/store/FlowChatStore';
 import type { FlowChatState, Session } from '@/flow_chat/types/flow-chat';
 import { WorkspaceKind, type WorkspaceInfo } from '@/shared/types';
-import { findReusableEmptySessionId } from './projectSessionWorkspace';
+import {
+  findReusableEmptySessionId,
+  pickPrimaryAssistantWorkspace,
+} from './projectSessionWorkspace';
 
 const resetStore = () => {
   flowChatStore.setState((): FlowChatState => ({
@@ -56,5 +59,33 @@ describe('findReusableEmptySessionId', () => {
     }));
 
     expect(findReusableEmptySessionId(workspace, 'agentic')).toBeNull();
+  });
+});
+
+describe('pickPrimaryAssistantWorkspace', () => {
+  const createAssistantWorkspace = (
+    id: string,
+    assistantId?: string,
+  ): WorkspaceInfo => ({
+    id,
+    name: id,
+    rootPath: `/assistants/${id}`,
+    workspaceKind: WorkspaceKind.Assistant,
+    assistantId,
+  });
+
+  it('selects the primary assistant even when a named assistant appears first', () => {
+    const namedAssistant = createAssistantWorkspace('named', 'assistant-1');
+    const primaryAssistant = createAssistantWorkspace('primary');
+
+    expect(
+      pickPrimaryAssistantWorkspace([namedAssistant, primaryAssistant])
+    ).toBe(primaryAssistant);
+  });
+
+  it('does not fall back to a named assistant', () => {
+    const namedAssistant = createAssistantWorkspace('named', 'assistant-1');
+
+    expect(pickPrimaryAssistantWorkspace([namedAssistant])).toBeNull();
   });
 });

--- a/src/web-ui/src/app/utils/projectSessionWorkspace.ts
+++ b/src/web-ui/src/app/utils/projectSessionWorkspace.ts
@@ -26,6 +26,21 @@ export function pickWorkspaceForProjectChatSession(
 }
 
 /**
+ * The primary assistant workspace is the built-in assistant without an
+ * assistant id. Named assistants must never receive sessions created from the
+ * global "Assistant Sessions" action.
+ */
+export function pickPrimaryAssistantWorkspace(
+  assistantWorkspacesList: WorkspaceInfo[]
+): WorkspaceInfo | null {
+  return assistantWorkspacesList.find(
+    workspace =>
+      workspace.workspaceKind === WorkspaceKind.Assistant &&
+      !workspace.assistantId
+  ) ?? null;
+}
+
+/**
  * Build create_session config from the live workspace. After Peer Device Mode
  * switch, callers must pass this (not `{}`) so the peer host never sees a
  * stale controller path. See `infrastructure/peer-device/README.md`.

--- a/src/web-ui/src/locales/en-US/common.json
+++ b/src/web-ui/src/locales/en-US/common.json
@@ -178,6 +178,7 @@
       "newCoworkSession": "New Cowork session",
       "newExternalAgentSessionShort": "{{agentName}} Session",
       "newClawSession": "New Claw session",
+      "newPrimaryAssistantSession": "New primary assistant session",
       "modeCode": "Code",
       "modeCowork": "Cowork",
       "noSessions": "No sessions",

--- a/src/web-ui/src/locales/zh-CN/common.json
+++ b/src/web-ui/src/locales/zh-CN/common.json
@@ -178,6 +178,7 @@
       "newCoworkSession": "新建 Cowork 会话",
       "newExternalAgentSessionShort": "{{agentName}} 会话",
       "newClawSession": "新建 Claw 会话",
+      "newPrimaryAssistantSession": "新建主助理会话",
       "modeCode": "Code",
       "modeCowork": "Cowork",
       "noSessions": "暂无会话",

--- a/src/web-ui/src/locales/zh-TW/common.json
+++ b/src/web-ui/src/locales/zh-TW/common.json
@@ -178,6 +178,7 @@
       "newCoworkSession": "新增 Cowork 會話",
       "newExternalAgentSessionShort": "{{agentName}} 會話",
       "newClawSession": "新增 Claw 會話",
+      "newPrimaryAssistantSession": "新增主助理會話",
       "modeCode": "Code",
       "modeCowork": "Cowork",
       "noSessions": "暫無會話",


### PR DESCRIPTION
## Summary

- add a plus action to the Assistant Sessions section header using the existing workspace action styling
- create and open a new Claw session in the primary assistant workspace
- add localized tooltip copy and coverage for primary assistant selection

## Test plan

- `pnpm run type-check:web`
- `pnpm --dir src/web-ui run test:run src/app/utils/projectSessionWorkspace.test.ts`
- `pnpm run i18n:audit`