### PR TITLE
fix(remote-ssh): disambiguate NUL escapes in the container stat test

### DIFF
--- a/src/crates/services/services-integrations/src/remote_ssh/manager.rs
+++ b/src/crates/services/services-integrations/src/remote_ssh/manager.rs
@@ -6034,9 +6034,11 @@ mod tests {
 
     #[test]
     fn container_special_files_are_not_reported_as_regular_files() {
-        let entry = parse_container_file_output("pipe\0/workspace/pipe\0o\00\01720000000\0644\0")
-            .unwrap()
-            .unwrap();
+        let entry = parse_container_file_output(
+            "pipe\x00/workspace/pipe\x00o\x000\x001720000000\x00644\x00",
+        )
+        .unwrap()
+        .unwrap();
 
         assert!(!entry.is_file);
         assert!(!entry.is_dir);


### PR DESCRIPTION
## Summary

`cargo clippy -p bitfun-services-integrations --features remote-ssh-concrete --all-targets` failed with three deny-level `clippy::octal_escapes` errors, all on one line in the `#[cfg(test)]` module of `remote_ssh/manager.rs`.

The `parse_container_file_output` fixture separated its NUL-delimited fields with `\0`, which made `\00`, `\01720000000`, and `\0644` look like possibly-mistaken octal escapes. `\0` is always NUL in Rust, so the parsed values were already what the test intended — clippy simply cannot tell that apart from a typo.

The separators are now spelled `\x00`. Since `\x` consumes exactly two hex digits, the digits that follow can no longer be read as part of the escape.

## Type and Areas

Type: bug fix (lint failure)

Areas: Rust core (`services-integrations`, remote SSH)

## Motivation / Impact

No direct user-facing change, and no behavior change at all: the string is byte-for-byte identical, so the test asserts on exactly the same parsed entry.

The value is unblocking `--all-targets` clippy. Because the offending literal sits in a `#[cfg(test)]` module, it is invisible to CI's Rust Build Check, so anyone running the fuller clippy invocation locally hits three hard errors that have nothing to do with their own work. This is pre-existing on `main` rather than a regression from recent work.

For the record, the field layout is unchanged — 6 NUL-separated fields plus a trailing NUL that `parse_container_file_output` pops:

| field | value |
| --- | --- |
| name | `pipe` |
| path | `/workspace/pipe` |
| kind | `o` (not `d`/`f`/`l`, which is the point of the test) |
| size | `0` |
| modified | `1720000000` |
| permissions | `644` |

## Verification

Both run on this branch, rebased on current `main`:

- `cargo clippy -p bitfun-services-integrations --features remote-ssh-concrete --all-targets` — exits 0, zero `octal_escapes` occurrences in the output. Two pre-existing warnings remain and are untouched by this PR: `unnecessary_unwrap` at `remote_ssh/manager.rs:3033` and `field_reassign_with_default` at `remote_ssh/remote_fs.rs:598`.
- `cargo test -p bitfun-services-integrations --lib --features remote-ssh-concrete` — 119 passed, 0 failed, 1 ignored, including `container_special_files_are_not_reported_as_regular_files`.
- `rustfmt --check` on the touched file — clean.

## Reviewer Notes

The multi-line wrapping of the call is rustfmt's own output for the longer literal, not a hand-chosen style.

One thing worth flagging separately: `cargo fmt -p bitfun-services-integrations` currently reformats nine other files in this crate, meaning the crate is not rustfmt-clean on `main`. I deliberately kept those out of this PR to keep the diff focused, so this branch touches only `manager.rs`. Happy to open a separate formatting-only PR if that is wanted.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable. (n/a — test-only change)
