### PR TITLE
fix(web-ui): constrain remote workspace metadata

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceItem.tsx
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceItem.tsx
@@ -1202,10 +1202,6 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
                     data-testid="nav-workspace-remote-meta"
                     data-remote-status={remoteMeta.status}
                   >
-                    <span
-                      className={`bitfun-nav-panel__workspace-item-status-dot is-${remoteMeta.status}`}
-                      aria-hidden="true"
-                    />
                     <span className="bitfun-nav-panel__workspace-item-remote-name">
                       {remoteMeta.connectionLabel}
                     </span>
@@ -1214,6 +1210,10 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
                         {remoteMeta.statusLabel}
                       </span>
                     ) : null}
+                    <span
+                      className={`bitfun-nav-panel__workspace-item-status-dot is-${remoteMeta.status}`}
+                      aria-hidden="true"
+                    />
                   </span>
                 </Tooltip>
               </div>

--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSection.scss
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSection.scss
@@ -482,7 +482,7 @@
     gap: 5px;
     min-width: 0;
     max-width: 100%;
-    padding: 0 6px 0 5px;
+    padding: 0 5px 0 6px;
     border-radius: 999px;
     background: color-mix(in srgb, var(--element-bg-medium) 62%, transparent);
     color: var(--color-text-secondary);
@@ -505,7 +505,9 @@
   }
 
   &__workspace-item-remote-name {
+    flex: 0 1 auto;
     min-width: 0;
+    max-width: 160px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSectionLayout.test.ts
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSectionLayout.test.ts
@@ -10,6 +10,13 @@ function readWorkspaceListStylesheet(): string {
   return stylesheet.replace(/\r\n/g, '\n');
 }
 
+function readWorkspaceItemSource(): string {
+  return readFileSync(
+    fileURLToPath(new URL('./WorkspaceItem.tsx', import.meta.url)),
+    'utf8',
+  ).replace(/\r\n/g, '\n');
+}
+
 function extractBlock(stylesheet: string, selector: string): string {
   const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const match = stylesheet.match(new RegExp(`${escapedSelector}\\s*\\{(?<body>[\\s\\S]*?)\\n\\s*\\}`));
@@ -89,5 +96,25 @@ describe('WorkspaceListSection layout styles', () => {
       expect(block).toContain('width: 20px;');
       expect(block).toContain('height: 20px;');
     }
+  });
+
+  it('keeps remote connection metadata inside the sidebar with the status dot on the right', () => {
+    const stylesheet = readWorkspaceListStylesheet();
+    const remoteName = extractBlock(stylesheet, '&__workspace-item-remote-name');
+
+    expect(remoteName).toContain('flex: 0 1 auto;');
+    expect(remoteName).toContain('max-width: 160px;');
+    expect(remoteName).toContain('overflow: hidden;');
+    expect(remoteName).toContain('text-overflow: ellipsis;');
+
+    const source = readWorkspaceItemSource();
+    const remoteMetaStart = source.indexOf('data-testid="nav-workspace-remote-meta"');
+    const remoteMetaEnd = source.indexOf('</Tooltip>', remoteMetaStart);
+    const remoteMetaMarkup = source.slice(remoteMetaStart, remoteMetaEnd);
+
+    expect(remoteMetaStart).toBeGreaterThanOrEqual(0);
+    expect(remoteMetaEnd).toBeGreaterThan(remoteMetaStart);
+    expect(remoteMetaMarkup.indexOf('workspace-item-remote-name'))
+      .toBeLessThan(remoteMetaMarkup.indexOf('workspace-item-status-dot'));
   });
 });


### PR DESCRIPTION
## Summary

- move the remote workspace status dot to the right side of the hostname
- cap long remote host labels at 160px and preserve ellipsis truncation
- add a layout regression test for dot order and hostname constraints

## Testing

- `pnpm run type-check:web`
- `pnpm --dir src/web-ui run test:run src/app/components/NavPanel/sections/workspaces/WorkspaceListSectionLayout.test.ts`
- `git diff --check`