### PR TITLE
fix(web-ui): align remote workspace hostname

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSection.scss
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSection.scss
@@ -482,6 +482,7 @@
     gap: 5px;
     min-width: 0;
     max-width: 100%;
+    margin-left: -6px;
     padding: 0 5px 0 6px;
     border-radius: 999px;
     background: color-mix(in srgb, var(--element-bg-medium) 62%, transparent);

--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSectionLayout.test.ts
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSectionLayout.test.ts
@@ -100,8 +100,11 @@ describe('WorkspaceListSection layout styles', () => {
 
   it('keeps remote connection metadata inside the sidebar with the status dot on the right', () => {
     const stylesheet = readWorkspaceListStylesheet();
+    const remoteChip = extractBlock(stylesheet, '&__workspace-item-remote');
     const remoteName = extractBlock(stylesheet, '&__workspace-item-remote-name');
 
+    expect(remoteChip).toContain('margin-left: -6px;');
+    expect(remoteChip).toContain('padding: 0 5px 0 6px;');
     expect(remoteName).toContain('flex: 0 1 auto;');
     expect(remoteName).toContain('max-width: 160px;');
     expect(remoteName).toContain('overflow: hidden;');


### PR DESCRIPTION
## Summary

- offset the remote metadata chip by its left inset so the hostname aligns with the workspace title
- preserve the chip padding, truncation, and right-side status dot
- extend the workspace layout regression test with the alignment contract

## Testing

- `pnpm run type-check:web`
- `pnpm --dir src/web-ui run test:run src/app/components/NavPanel/sections/workspaces/WorkspaceListSectionLayout.test.ts`
- `git diff --check`