### PR TITLE
fix(miniapp): restore strict WebKit rendering and floating chat

### DIFF
--- a/src/apps/desktop/src/theme.rs
+++ b/src/apps/desktop/src/theme.rs
@@ -1,5 +1,6 @@
 //! Theme System
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{OnceLock, RwLock};
 use std::time::Instant;
 
@@ -8,7 +9,7 @@ use bitfun_core::service::config::types::GlobalConfig;
 use dark_light::Mode;
 use log::{debug, error, warn};
 use tauri::webview::PageLoadEvent;
-use tauri::{Manager, WebviewUrl};
+use tauri::{Manager, Url, WebviewUrl};
 
 use crate::startup_trace::DesktopStartupTrace;
 
@@ -24,6 +25,29 @@ static AGENT_COMPANION_WINDOW_LAST_POSITION: OnceLock<RwLock<Option<tauri::Logic
 static STARTUP_THEME_BOOTSTRAP_MANIFEST: OnceLock<StartupThemeBootstrapManifest> = OnceLock::new();
 
 const STARTUP_THEME_BOOTSTRAP_JSON: &str = include_str!("generated/startup_theme_bootstrap.json");
+
+struct MainWebviewNavigationPolicy {
+    first_page_navigation: AtomicBool,
+}
+
+impl MainWebviewNavigationPolicy {
+    fn new() -> Self {
+        Self {
+            first_page_navigation: AtomicBool::new(true),
+        }
+    }
+
+    fn should_allow(&self, url: &Url) -> bool {
+        // Wry invokes the same callback for top-level and iframe navigations on
+        // macOS, but it does not expose the target frame here. MiniApps use
+        // parent-created Blob documents, while srcdoc/empty iframe documents
+        // use the two local about: targets below. Allowing only these local
+        // document URLs keeps network and app reloads behind the one-shot gate.
+        let is_embedded_document = url.scheme() == "blob"
+            || (url.scheme() == "about" && matches!(url.path(), "blank" | "srcdoc"));
+        is_embedded_document || self.first_page_navigation.swap(false, Ordering::SeqCst)
+    }
+}
 
 fn agent_companion_window_ops() -> &'static tokio::sync::Mutex<()> {
     AGENT_COMPANION_WINDOW_OPS.get_or_init(|| tokio::sync::Mutex::new(()))
@@ -507,13 +531,10 @@ pub fn create_main_window(
     // Keep HTML5 drag-and-drop working inside the webview for desktop UI drag targets.
     builder = builder.disable_drag_drop_handler();
 
-    // Block webview reloads: allow only the first navigation (initial load),
-    // cancel all subsequent navigations (F5 / Ctrl+R / location.reload()).
-    // The app uses state-driven routing, not browser navigation, so there are
-    // no legitimate full-page navigations after the initial load.
-    let first_navigation = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
-    builder = builder
-        .on_navigation(move |_| first_navigation.swap(false, std::sync::atomic::Ordering::SeqCst));
+    // Block top-level webview reloads after the initial page while allowing the
+    // local iframe documents used by sandboxed MiniApps.
+    let navigation_policy = MainWebviewNavigationPolicy::new();
+    builder = builder.on_navigation(move |url| navigation_policy.should_allow(url));
 
     #[cfg(target_os = "macos")]
     {
@@ -926,4 +947,49 @@ pub async fn show_main_window(app: tauri::AppHandle) -> Result<(), String> {
         total_started_at.elapsed().as_millis()
     );
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MainWebviewNavigationPolicy;
+    use tauri::Url;
+
+    fn url(value: &str) -> Url {
+        value.parse().expect("test URL should be valid")
+    }
+
+    #[test]
+    fn main_webview_navigation_allows_only_the_first_page_navigation() {
+        let policy = MainWebviewNavigationPolicy::new();
+
+        assert!(policy.should_allow(&url("http://localhost:1422/")));
+        assert!(!policy.should_allow(&url("http://localhost:1422/")));
+        assert!(!policy.should_allow(&url("https://example.com/")));
+        assert!(!policy.should_allow(&url("data:text/html,blocked")));
+    }
+
+    #[test]
+    fn main_webview_navigation_allows_local_iframe_documents_without_consuming_initial_page() {
+        let policy = MainWebviewNavigationPolicy::new();
+
+        assert!(policy.should_allow(&url(
+            "blob:http://localhost:1422/65b60dd8-a501-47c2-b7fd-aa99af720dc6"
+        )));
+        assert!(policy.should_allow(&url("about:blank")));
+        assert!(policy.should_allow(&url("about:srcdoc")));
+        assert!(policy.should_allow(&url("tauri://localhost/index.html")));
+        assert!(!policy.should_allow(&url("tauri://localhost/index.html")));
+    }
+
+    #[test]
+    fn main_webview_navigation_keeps_iframe_documents_available_after_initial_page() {
+        let policy = MainWebviewNavigationPolicy::new();
+
+        assert!(policy.should_allow(&url("tauri://localhost/index.html")));
+        assert!(policy.should_allow(&url(
+            "blob:tauri://localhost/f5445ef0-5b0b-42b0-9540-276a0012ae56"
+        )));
+        assert!(policy.should_allow(&url("about:blank")));
+        assert!(!policy.should_allow(&url("tauri://localhost/index.html")));
+    }
 }

--- a/src/web-ui/src/app/scenes/miniapps/components/MiniAppRunner.test.tsx
+++ b/src/web-ui/src/app/scenes/miniapps/components/MiniAppRunner.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { MiniApp } from '@/infrastructure/api/service-api/MiniAppAPI';
+import MiniAppRunner from './MiniAppRunner';
+
+const bridgeMock = vi.hoisted(() => ({
+  ready: false,
+  useMiniAppBridge: vi.fn(),
+}));
+
+vi.mock('../hooks/useMiniAppBridge', () => ({
+  useMiniAppBridge: (...args: unknown[]) => {
+    bridgeMock.useMiniAppBridge(...args);
+    return bridgeMock.ready;
+  },
+}));
+
+const app = {
+  id: 'market-lens',
+  name: 'Market Lens',
+  compiled_html: '<!doctype html><html><body>Market Lens</body></html>',
+  permissions: {},
+  source: {},
+} as unknown as MiniApp;
+
+describe('MiniAppRunner strict bridge startup', () => {
+  let container: HTMLDivElement;
+  let root: Root | null;
+  let createObjectURL: ReturnType<typeof vi.fn>;
+  let revokeObjectURL: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    bridgeMock.ready = false;
+    createObjectURL = vi.fn()
+      .mockReturnValueOnce('blob:market-lens-1')
+      .mockReturnValueOnce('blob:market-lens-2');
+    revokeObjectURL = vi.fn();
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL,
+      revokeObjectURL,
+    });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    if (root) {
+      act(() => {
+        root?.unmount();
+      });
+    }
+    container.remove();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('loads strict HTML from a sandboxed blob only after the bridge is listening', async () => {
+    await act(async () => {
+      root?.render(<MiniAppRunner app={app} strictRuntime />);
+    });
+
+    const iframe = container.querySelector('iframe') as HTMLIFrameElement;
+    expect(iframe).toBeTruthy();
+    expect(iframe.getAttribute('src')).toBe('about:blank');
+    expect(iframe.getAttribute('srcdoc')).toBeNull();
+    expect(createObjectURL).not.toHaveBeenCalled();
+
+    bridgeMock.ready = true;
+    await act(async () => {
+      root?.render(<MiniAppRunner app={app} strictRuntime />);
+    });
+
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(createObjectURL.mock.calls[0][0]).toBeInstanceOf(Blob);
+    expect(iframe.getAttribute('src')).toBe('blob:market-lens-1');
+    expect(iframe.getAttribute('srcdoc')).toBeNull();
+    expect(iframe.getAttribute('sandbox')).toBe('allow-scripts');
+
+    const updatedApp = {
+      ...app,
+      compiled_html: '<!doctype html><html><body>Updated</body></html>',
+    };
+    await act(async () => {
+      root?.render(<MiniAppRunner app={updatedApp} strictRuntime />);
+    });
+
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:market-lens-1');
+    expect(iframe.getAttribute('src')).toBe('blob:market-lens-2');
+
+    await act(async () => {
+      root?.unmount();
+    });
+    root = null;
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:market-lens-2');
+  });
+});

--- a/src/web-ui/src/app/scenes/miniapps/components/MiniAppRunner.tsx
+++ b/src/web-ui/src/app/scenes/miniapps/components/MiniAppRunner.tsx
@@ -3,7 +3,7 @@
  * Injects the bridge script (already in compiledHtml from Rust compiler)
  * and handles all postMessage RPC via useMiniAppBridge.
  */
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import type { MiniApp } from '@/infrastructure/api/service-api/MiniAppAPI';
 import { useMiniAppBridge } from '../hooks/useMiniAppBridge';
 import type { MiniAppRunScope } from '../customization/miniAppCustomizationTypes';
@@ -16,12 +16,13 @@ interface MiniAppRunnerProps {
 
 const MiniAppRunner: React.FC<MiniAppRunnerProps> = ({ app, runScope, strictRuntime = false }) => {
   const iframeRef = useRef<HTMLIFrameElement>(null);
-  useMiniAppBridge(
+  const bridgeReady = useMiniAppBridge(
     iframeRef,
     app,
     runScope ?? { kind: 'active', appId: app.id },
     strictRuntime,
   );
+  const [strictDocumentUrl, setStrictDocumentUrl] = useState<string>();
 
   const writeCompiledHtml = useCallback(() => {
     const iframe = iframeRef.current;
@@ -70,11 +71,30 @@ const MiniAppRunner: React.FC<MiniAppRunnerProps> = ({ app, runScope, strictRunt
     };
   }, [app.id, app.compiled_html, strictRuntime, writeCompiledHtml]);
 
+  useLayoutEffect(() => {
+    const html = app.compiled_html?.trim();
+    if (!strictRuntime || !bridgeReady || !html) {
+      setStrictDocumentUrl(undefined);
+      return undefined;
+    }
+
+    // Tauri's WKWebView has rendered srcdoc as a blank document in production.
+    // A sandboxed blob navigation is reliable while retaining the strict
+    // runtime's unique opaque origin because allow-same-origin is absent.
+    const documentUrl = URL.createObjectURL(
+      new Blob([html], { type: 'text/html;charset=utf-8' }),
+    );
+    setStrictDocumentUrl(documentUrl);
+    return () => {
+      URL.revokeObjectURL(documentUrl);
+    };
+  }, [app.id, app.compiled_html, bridgeReady, strictRuntime]);
+
   if (strictRuntime) {
     return (
       <iframe
         ref={iframeRef}
-        srcDoc={app.compiled_html}
+        src={strictDocumentUrl ?? 'about:blank'}
         data-app-id={app.id}
         data-run-scope={runScope?.kind ?? 'active'}
         data-runtime-profile="market-strict"

--- a/src/web-ui/src/app/scenes/miniapps/hooks/miniAppAgentVisibility.test.ts
+++ b/src/web-ui/src/app/scenes/miniapps/hooks/miniAppAgentVisibility.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldOpenMiniAppAgentRunInMainScene } from './miniAppAgentVisibility';
+
+describe('shouldOpenMiniAppAgentRunInMainScene', () => {
+  it('keeps compatibility-profile sessions on their existing surface', () => {
+    expect(
+      shouldOpenMiniAppAgentRunInMainScene(
+        false,
+        undefined,
+        'app#1',
+        'session-1',
+        false,
+      ),
+    ).toBe(false);
+  });
+
+  it('opens a strict session in the main scene when no runner owns the composer', () => {
+    expect(
+      shouldOpenMiniAppAgentRunInMainScene(
+        true,
+        undefined,
+        'app#1',
+        'session-1',
+        true,
+      ),
+    ).toBe(true);
+    expect(
+      shouldOpenMiniAppAgentRunInMainScene(
+        true,
+        { token: 'app#2', sessionId: 'session-1' },
+        'app#1',
+        'session-1',
+        true,
+      ),
+    ).toBe(true);
+  });
+
+  it('keeps a strict run in the bubble only after that session is bound', () => {
+    const claim = { token: 'app#1', sessionId: 'session-1' };
+    expect(
+      shouldOpenMiniAppAgentRunInMainScene(
+        true,
+        claim,
+        'app#1',
+        'session-1',
+        true,
+      ),
+    ).toBe(false);
+    expect(
+      shouldOpenMiniAppAgentRunInMainScene(
+        true,
+        claim,
+        'app#1',
+        'session-2',
+        true,
+      ),
+    ).toBe(true);
+    expect(
+      shouldOpenMiniAppAgentRunInMainScene(
+        true,
+        { token: 'app#1' },
+        'app#1',
+        'session-1',
+        true,
+      ),
+    ).toBe(true);
+  });
+
+  it('opens a background MiniApp run in the main scene', () => {
+    expect(
+      shouldOpenMiniAppAgentRunInMainScene(
+        true,
+        { token: 'app#1', sessionId: 'session-1' },
+        'app#1',
+        'session-1',
+        false,
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/web-ui/src/app/scenes/miniapps/hooks/miniAppAgentVisibility.ts
+++ b/src/web-ui/src/app/scenes/miniapps/hooks/miniAppAgentVisibility.ts
@@ -1,0 +1,18 @@
+import type { MiniAppComposerClaim } from '../miniAppStore';
+
+/**
+ * Marketplace Agent sessions must stay visible to the user. A runner-owned
+ * floating composer satisfies that requirement without navigating away from
+ * the MiniApp; otherwise the host falls back to the main session scene.
+ */
+export function shouldOpenMiniAppAgentRunInMainScene(
+  strictRuntime: boolean,
+  claim: MiniAppComposerClaim | undefined,
+  composerToken: string,
+  sessionId: string,
+  isActiveMiniApp: boolean,
+): boolean {
+  if (!strictRuntime) return false;
+  if (!isActiveMiniApp || !claim || claim.token !== composerToken) return true;
+  return claim.sessionId !== sessionId;
+}

--- a/src/web-ui/src/app/scenes/miniapps/hooks/useMiniAppBridge.test.tsx
+++ b/src/web-ui/src/app/scenes/miniapps/hooks/useMiniAppBridge.test.tsx
@@ -1,0 +1,205 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import React, { useRef } from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { MiniApp } from '@/infrastructure/api/service-api/MiniAppAPI';
+import { useMiniAppStore } from '../miniAppStore';
+import { useMiniAppBridge } from './useMiniAppBridge';
+
+const mocks = vi.hoisted(() => ({
+  activeTabId: 'miniapp:market-lens',
+  agentEnsureSession: vi.fn(),
+  agentRun: vi.fn(),
+  apiListen: vi.fn(),
+  openMainSession: vi.fn(),
+  addExternalSession: vi.fn(),
+  loadSessionHistory: vi.fn(),
+}));
+
+vi.mock('@/infrastructure/api/service-api/MiniAppAPI', () => ({
+  miniAppAPI: {
+    agentEnsureSession: mocks.agentEnsureSession,
+    agentRun: mocks.agentRun,
+  },
+}));
+
+vi.mock('@tauri-apps/plugin-dialog', () => ({
+  open: vi.fn(),
+  save: vi.fn(),
+  message: vi.fn(),
+}));
+
+vi.mock('@/infrastructure/contexts/WorkspaceContext', () => ({
+  useCurrentWorkspace: () => ({ workspacePath: '/repo' }),
+}));
+
+vi.mock('@/infrastructure/theme/hooks/useTheme', () => ({
+  useTheme: () => ({ theme: 'dark' }),
+}));
+
+vi.mock('../utils/buildMiniAppThemeVars', () => ({
+  buildMiniAppThemeVars: () => ({}),
+}));
+
+vi.mock('@/infrastructure/api/service-api/ApiClient', () => ({
+  api: {
+    listen: (...args: unknown[]) => mocks.apiListen(...args),
+    invoke: vi.fn(),
+  },
+}));
+
+vi.mock('@/infrastructure/i18n', () => ({
+  useI18n: () => ({ currentLanguage: 'en-US' }),
+}));
+
+vi.mock('@/infrastructure/api/service-api/SystemAPI', () => ({
+  systemAPI: {},
+}));
+
+vi.mock('@/infrastructure/api', () => ({
+  workspaceAPI: {},
+}));
+
+vi.mock('@/flow_chat/store/FlowChatStore', () => ({
+  flowChatStore: {
+    getState: () => ({ sessions: new Map() }),
+    addExternalSession: (...args: unknown[]) => mocks.addExternalSession(...args),
+    loadSessionHistory: (...args: unknown[]) => mocks.loadSessionHistory(...args),
+  },
+}));
+
+vi.mock('@/flow_chat/services/sessionActivation', () => ({
+  openMainSession: (...args: unknown[]) => mocks.openMainSession(...args),
+}));
+
+vi.mock('@/app/stores/sceneStore', () => ({
+  useSceneStore: {
+    getState: () => ({ activeTabId: mocks.activeTabId }),
+  },
+}));
+
+vi.mock('@/shared/utils/logger', () => ({
+  createLogger: () => ({
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+const app = {
+  id: 'market-lens',
+  name: 'Market Lens',
+  permissions: {
+    node: { enabled: false },
+    agent: { enabled: true },
+    host: { chat_composer: true },
+  },
+} as unknown as MiniApp;
+
+function BridgeHarness() {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  useMiniAppBridge(
+    iframeRef,
+    app,
+    { kind: 'active', appId: app.id },
+    true,
+  );
+  return <iframe ref={iframeRef} title="Market Lens test" />;
+}
+
+async function dispatchRpc(
+  iframe: HTMLIFrameElement,
+  id: number,
+  method: string,
+  params: Record<string, unknown> = {},
+) {
+  await act(async () => {
+    window.dispatchEvent(new MessageEvent('message', {
+      data: { jsonrpc: '2.0', id, method, params },
+      source: iframe.contentWindow,
+    }));
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  });
+}
+
+describe('useMiniAppBridge floating Agent routing', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    mocks.activeTabId = 'miniapp:market-lens';
+    mocks.agentEnsureSession.mockResolvedValue({
+      sessionId: 'session-1',
+      created: true,
+      workspacePath: '/repo',
+    });
+    mocks.agentRun.mockResolvedValue({ sessionId: 'session-1' });
+    mocks.openMainSession.mockResolvedValue(undefined);
+    mocks.apiListen.mockImplementation(() => vi.fn());
+    useMiniAppStore.setState({ composerClaims: {} });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    useMiniAppStore.setState({ composerClaims: {} });
+    vi.clearAllMocks();
+  });
+
+  it('keeps a claimed and bound strict Agent run in the floating bubble', async () => {
+    await act(async () => {
+      root.render(<BridgeHarness />);
+    });
+    const iframe = container.querySelector('iframe') as HTMLIFrameElement;
+
+    await dispatchRpc(iframe, 1, 'chat.claimComposer');
+    await dispatchRpc(iframe, 2, 'agent.ensureSession', {
+      sessionName: 'Market Lens',
+      appDataWorkspace: 'chat',
+    });
+
+    expect(mocks.agentEnsureSession).toHaveBeenCalledTimes(1);
+    expect(mocks.openMainSession).not.toHaveBeenCalled();
+
+    await dispatchRpc(iframe, 3, 'chat.focusSession', { sessionId: 'session-1' });
+    expect(useMiniAppStore.getState().composerClaims[app.id]?.sessionId).toBe('session-1');
+
+    await dispatchRpc(iframe, 4, 'agent.run', {
+      sessionId: 'session-1',
+      prompt: 'Summarize the market',
+      displayText: 'Summarize the market',
+    });
+
+    expect(mocks.agentRun).toHaveBeenCalledTimes(1);
+    expect(mocks.openMainSession).not.toHaveBeenCalled();
+  });
+
+  it('opens an unbound strict Agent run in the main session scene', async () => {
+    await act(async () => {
+      root.render(<BridgeHarness />);
+    });
+    const iframe = container.querySelector('iframe') as HTMLIFrameElement;
+
+    await dispatchRpc(iframe, 1, 'chat.claimComposer');
+    await dispatchRpc(iframe, 2, 'agent.ensureSession', {
+      sessionName: 'Market Lens',
+      appDataWorkspace: 'chat',
+    });
+    await dispatchRpc(iframe, 3, 'agent.run', {
+      sessionId: 'session-1',
+      prompt: 'Summarize the market',
+    });
+
+    expect(mocks.openMainSession).toHaveBeenCalledWith('session-1');
+    expect(mocks.agentRun).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/web-ui/src/app/scenes/miniapps/hooks/useMiniAppBridge.ts
+++ b/src/web-ui/src/app/scenes/miniapps/hooks/useMiniAppBridge.ts
@@ -7,7 +7,7 @@
  * clipboard.* → Host navigator.clipboard.
  * Also handles bitfun/request-theme and pushes theme changes to the iframe.
  */
-import { useLayoutEffect, useRef, useEffect, RefObject } from 'react';
+import { useLayoutEffect, useRef, useEffect, useState, RefObject } from 'react';
 import { miniAppAPI } from '@/infrastructure/api/service-api/MiniAppAPI';
 import { open as dialogOpen, save as dialogSave, message as dialogMessage } from '@tauri-apps/plugin-dialog';
 import type { MiniApp } from '@/infrastructure/api/service-api/MiniAppAPI';
@@ -26,6 +26,8 @@ import {
   normalizeMiniAppBubbleCustomization,
   type MiniAppComposerMessageDetail,
 } from '../miniAppStore';
+import { useSceneStore } from '@/app/stores/sceneStore';
+import { shouldOpenMiniAppAgentRunInMainScene } from './miniAppAgentVisibility';
 import { flowChatStore } from '@/flow_chat/store/FlowChatStore';
 import { openMainSession } from '@/flow_chat/services/sessionActivation';
 import { createLogger } from '@/shared/utils/logger';
@@ -54,6 +56,7 @@ export function useMiniAppBridge(
   runScope: MiniAppRunScope,
   strictRuntime = false,
 ) {
+  const [bridgeReady, setBridgeReady] = useState(false);
   const { workspacePath } = useCurrentWorkspace();
   const { theme: currentTheme } = useTheme();
   const { currentLanguage } = useI18n('scenes/miniapp');
@@ -375,9 +378,6 @@ export function useMiniAppBridge(
                 }
               }
             }
-            if (strictRuntimeRef.current) {
-              await openMainSession(result.sessionId);
-            }
             reply(result);
             return;
           }
@@ -392,11 +392,17 @@ export function useMiniAppBridge(
               )
             ) {
               replyError(
-                'Marketplace MiniApps must call agent.ensureSession first so the host can open a visible session.',
+                'Marketplace MiniApps must call agent.ensureSession first so the host can expose a visible session.',
               );
               return;
             }
-            if (strictRuntimeRef.current) {
+            if (shouldOpenMiniAppAgentRunInMainScene(
+              strictRuntimeRef.current,
+              useMiniAppStore.getState().composerClaims[appId],
+              composerTokenRef.current,
+              requestedSessionId,
+              useSceneStore.getState().activeTabId === `miniapp:${appId}`,
+            )) {
               await openMainSession(requestedSessionId);
             }
             const result = await miniAppAPI.agentRun(
@@ -623,29 +629,32 @@ export function useMiniAppBridge(
       }
     };
     window.addEventListener('message', handler);
+    setBridgeReady(true);
     return () => {
       window.removeEventListener('message', handler);
     };
   }, [iframeRef]);
 
   useEffect(() => {
+    if (!bridgeReady) return;
     const payload = buildMiniAppThemeVars(currentTheme);
     if (!payload || !iframeRef.current?.contentWindow) return;
     iframeRef.current.contentWindow.postMessage(
       { type: 'bitfun:event', event: 'themeChange', payload },
       '*',
     );
-  }, [currentTheme, iframeRef]);
+  }, [bridgeReady, currentTheme, iframeRef]);
 
   // Push locale changes to the iframe so MiniApps can re-render their UI strings
   // without reloading. MiniApps subscribe via `app.on('localeChange', fn)`.
   useEffect(() => {
+    if (!bridgeReady) return;
     if (!iframeRef.current?.contentWindow) return;
     iframeRef.current.contentWindow.postMessage(
       { type: 'bitfun:event', event: 'localeChange', payload: { locale: currentLanguage } },
       '*',
     );
-  }, [currentLanguage, iframeRef]);
+  }, [bridgeReady, currentLanguage, iframeRef]);
 
   // Forward submissions from the shared floating ChatInput into the iframe as
   // `chat:userMessage` (consumed via app.chat.onUserMessage). The MiniApp gets
@@ -798,4 +807,6 @@ export function useMiniAppBridge(
       unlisten();
     };
   }, [app.id, iframeRef]);
+
+  return bridgeReady;
 }


### PR DESCRIPTION
## Summary

- load strict marketplace MiniApps from a sandboxed Blob URL after the host bridge is listening, avoiding blank `srcdoc` documents in Tauri WKWebView
- allow only local Blob and `about:blank` / `about:srcdoc` iframe navigations through the desktop navigation policy while preserving main-window reload blocking
- keep strict MiniApp Agent runs visible in the claimed floating composer when its session is bound, with a main-session fallback otherwise
- add frontend integration coverage and desktop navigation-policy regression tests

Fixes: N/A (manual regression report)

## Type and Areas

Type: regression fix

Areas: desktop/Tauri, Web UI, MiniApp runtime, Agent chat bridge

## Motivation / Impact

Reviewed marketplace MiniApps using the strict runtime could open as an entirely blank surface on macOS. Wry forwards subframe navigation actions to Tauri's URL-only navigation callback, so BitFun's one-shot main-window navigation guard also cancelled the MiniApp iframe's Blob navigation.

Strict MiniApps now render reliably in WKWebView without weakening their opaque-origin sandbox. Their contextual Agent workflow can remain in the floating chat composer instead of navigating away from the MiniApp when the active runner owns the bound session.

## Verification

- `pnpm --dir src/web-ui run test:run src/app/scenes/miniapps/components/MiniAppRunner.test.tsx src/app/scenes/miniapps/hooks/miniAppAgentVisibility.test.ts src/app/scenes/miniapps/hooks/useMiniAppBridge.test.tsx` — 3 files, 7 tests passed
- `pnpm run type-check:web` — passed
- `cargo test -p bitfun-desktop` — 249 passed, 2 environment-dependent tests ignored
- `cargo check -p bitfun-desktop` — passed
- `cargo build -p bitfun-desktop` — passed
- `git diff --check` — passed
- Manual macOS desktop smoke test with an imported strict Market Lens package — dashboard rendered; clicking “Ask about this market” opened the floating chat composer and prefilled the contextual question

## Reviewer Notes

- The desktop policy still rejects subsequent `http`, `https`, `tauri`, `data`, and other page navigations. Only local Blob documents plus `about:blank` / `about:srcdoc` bypass the one-shot gate without consuming it.
- The strict iframe remains `sandbox="allow-scripts"`; `allow-same-origin` was not added and the compiled MiniApp CSP is unchanged.
- AI-assisted implementation; fully tested as listed above.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable (no user-facing string or locale changes).
