### PR TITLE
fix(web-ui): make miniapp cards fill grid tracks

### DIFF
--- a/src/web-ui/src/app/components/GalleryLayout/GalleryLayout.scss
+++ b/src/web-ui/src/app/components/GalleryLayout/GalleryLayout.scss
@@ -152,7 +152,7 @@ $content-max: 1360px;
   --gallery-skeleton-height: 140px;
 
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(var(--gallery-grid-min), 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(min(var(--gallery-grid-min), 100%), 1fr));
   gap: $size-gap-3;
   align-content: start;
 

--- a/src/web-ui/src/app/scenes/miniapps/components/MiniAppCard.scss
+++ b/src/web-ui/src/app/scenes/miniapps/components/MiniAppCard.scss
@@ -5,7 +5,8 @@
   --miniapp-card-action-bg: color-mix(in srgb, var(--color-static-white) 30%, transparent);
   --miniapp-card-action-hover-bg: color-mix(in srgb, var(--color-static-white) 60%, transparent);
 
-  width: 360px;
+  width: 100%;
+  min-width: 0;
   min-height: 200px;
   border-radius: 15px;
   background: var(--element-bg-soft);
@@ -300,7 +301,6 @@
 // ── Responsive ──
 @media (max-width: 720px) {
   .miniapp-card {
-    width: 100%;
     min-height: 180px;
   }
 }


### PR DESCRIPTION
## 问题

小应用页的应用卡片写死了 `width: 360px`，而 `GalleryGrid` 的列轨道使用 `repeat(auto-fill, minmax(360px, 1fr))` 会随窗口拉伸。两者冲突导致窗口尺寸稍有变化时，卡片不跟随轨道变宽，页面出现大片空白；容器窄于 360px 时卡片还会横向溢出。

## 修复

- `MiniAppCard.scss`：卡片改为 `width: 100%; min-width: 0`，宽度交给网格轨道控制，任意窗口宽度下填满所在列；删除 720px 断点下冗余的宽度覆盖。
- `GalleryLayout.scss`：网格列改为 `minmax(min(var(--gallery-grid-min), 100%), 1fr)`，容器窄于最小卡宽时卡片收缩而非溢出，同时惠及所有使用 `GalleryGrid` 的页面。

网格使用 `auto-fill`（保留空轨道），因此“已启动”区只有一个应用时卡片仍只占一列宽，不会被拉成全宽。

两个 SCSS 文件已通过 sass 编译验证。