### PR TITLE
fix(miniapp): market sign-out button + auto-close detail modal after install

### DIFF
--- a/src/web-ui/src/app/scenes/miniapps/views/MiniAppMarketView.tsx
+++ b/src/web-ui/src/app/scenes/miniapps/views/MiniAppMarketView.tsx
@@ -6,6 +6,7 @@ import {
   ExternalLink,
   Heart,
   Loader2,
+  LogOut,
   PackageCheck,
   RefreshCw,
   ShieldCheck,
@@ -170,6 +171,22 @@ const MiniAppMarketView: React.FC = () => {
     }
   };
 
+  const signOut = async () => {
+    setAuthBusy(true);
+    try {
+      await miniAppMarketAPI.logout();
+      setMe(null);
+      if (detail) {
+        setDetail(await miniAppMarketAPI.getListing(detail.slug));
+      }
+      notification.success(t('market.messages.signedOut'));
+    } catch (authError) {
+      notification.error(t('market.messages.actionFailed', { error: String(authError) }));
+    } finally {
+      setAuthBusy(false);
+    }
+  };
+
   const toggleFavorite = async () => {
     if (!detail) return;
     if (!me) {
@@ -224,7 +241,8 @@ const MiniAppMarketView: React.FC = () => {
         confirmOverwrite: Boolean(installed?.localOverride),
       });
       upsertApp(result.app);
-      setInstalled(await miniAppMarketAPI.installedStatus(detail.listingId));
+      setDetail(undefined);
+      setInstalled(null);
       notification.success(
         t(result.updated ? 'market.messages.updated' : 'market.messages.installed'),
       );
@@ -299,6 +317,17 @@ const MiniAppMarketView: React.FC = () => {
               <div className="miniapp-market-native__identity">
                 <Avatar size={22} src={me.user.avatarUrl} alt={me.user.login} />
                 <span>@{me.user.login}</span>
+                <Button
+                  size="small"
+                  variant="ghost"
+                  iconOnly
+                  onClick={() => void signOut()}
+                  disabled={authBusy}
+                  title={t('market.signOut')}
+                  aria-label={t('market.signOut')}
+                >
+                  {authBusy ? <Loader2 size={14} className="gallery-spinning" /> : <LogOut size={14} />}
+                </Button>
               </div>
             ) : (
               <Button size="small" variant="secondary" onClick={() => void signIn()} disabled={authBusy}>

--- a/src/web-ui/src/locales/en-US/scenes/miniapp.json
+++ b/src/web-ui/src/locales/en-US/scenes/miniapp.json
@@ -42,6 +42,7 @@
     "sortLabel": "Sort by",
     "search": "Search the market…",
     "signIn": "Sign in with GitHub",
+    "signOut": "Sign out",
     "empty": "No reviewed MiniApps have been published yet.",
     "loadMore": "Load more",
     "tabs": {
@@ -117,6 +118,7 @@
     "messages": {
       "detailFailed": "Could not load details: {{error}}",
       "signedIn": "Signed in with GitHub.",
+      "signedOut": "Signed out.",
       "authExpired": "The sign-in authorization expired. Try again.",
       "authFailed": "Sign-in failed: {{error}}",
       "actionFailed": "Action failed: {{error}}",

--- a/src/web-ui/src/locales/zh-CN/scenes/miniapp.json
+++ b/src/web-ui/src/locales/zh-CN/scenes/miniapp.json
@@ -42,6 +42,7 @@
     "sortLabel": "排序方式",
     "search": "搜索市场…",
     "signIn": "使用 GitHub 登录",
+    "signOut": "注销登录",
     "empty": "暂时没有已发布的小应用。",
     "loadMore": "加载更多",
     "tabs": {
@@ -117,6 +118,7 @@
     "messages": {
       "detailFailed": "加载详情失败：{{error}}",
       "signedIn": "GitHub 登录成功。",
+      "signedOut": "已注销登录。",
       "authExpired": "登录授权已过期，请重试。",
       "authFailed": "登录失败：{{error}}",
       "actionFailed": "操作失败：{{error}}",

--- a/src/web-ui/src/locales/zh-TW/scenes/miniapp.json
+++ b/src/web-ui/src/locales/zh-TW/scenes/miniapp.json
@@ -42,6 +42,7 @@
     "sortLabel": "排序方式",
     "search": "搜尋市場…",
     "signIn": "使用 GitHub 登入",
+    "signOut": "登出",
     "empty": "暫時沒有已發佈的小應用。",
     "loadMore": "載入更多",
     "tabs": {
@@ -117,6 +118,7 @@
     "messages": {
       "detailFailed": "載入詳情失敗：{{error}}",
       "signedIn": "GitHub 登入成功。",
+      "signedOut": "已登出。",
       "authExpired": "登入授權已過期，請重試。",
       "authFailed": "登入失敗：{{error}}",
       "actionFailed": "操作失敗：{{error}}",


### PR DESCRIPTION
## Summary
- Add a sign-out button next to the signed-in identity (avatar + username) in the MiniApp market header — previously there was no way to log out after signing in with GitHub. Wired to the existing `miniapp_market_logout` backend command; if a listing detail is open, it is reloaded to drop per-user state (my rating / favorited).
- Auto-close the listing detail modal after a successful install/update. Previously the newly installed MiniApp tab opened while the modal kept hovering over the market view. The now-unnecessary `installedStatus` refetch (which only refreshed the closed modal's button state) is removed.
- Add `market.signOut` / `market.messages.signedOut` strings to zh-CN, zh-TW and en-US locales.

## Test plan
- `tsc --noEmit` passes
- Manual: sign in with GitHub in the market → sign-out button appears next to the identity → clicking it clears the session and restores the sign-in button; install a listing → MiniApp tab opens and the detail modal closes automatically