### PR TITLE
fix(miniapp): allow TUN fake-IP DNS targets

### DIFF
--- a/src/crates/services/services-integrations/src/miniapp/host_dispatch.rs
+++ b/src/crates/services/services-integrations/src/miniapp/host_dispatch.rs
@@ -704,7 +704,6 @@ fn is_private_ipv4(address: Ipv4Addr) -> bool {
         || a == 0
         || (a == 100 && (64..=127).contains(&b))
         || (a == 192 && b == 0)
-        || (a == 198 && (b == 18 || b == 19))
         || a >= 240
 }
 
@@ -767,6 +766,18 @@ mod tests {
         assert!(!is_private_network_address("1.1.1.1".parse().unwrap()));
         assert!(!is_private_network_address(
             "2606:4700:4700::1111".parse().unwrap()
+        ));
+    }
+
+    #[test]
+    fn ssrf_filter_allows_tun_proxy_fake_ip_range() {
+        // TUN proxies commonly synthesize DNS records from RFC 2544's
+        // benchmarking block. The request still has to pass the MiniApp domain
+        // allowlist and remains pinned to the resolved address with the
+        // original hostname used for TLS.
+        assert!(!is_private_network_address("198.18.0.108".parse().unwrap()));
+        assert!(!is_private_network_address(
+            "198.19.255.254".parse().unwrap()
         ));
     }
 


### PR DESCRIPTION
## Summary

- allow RFC 2544 benchmark-range addresses used by TUN fake-IP DNS to pass the MiniApp outbound-network address check
- keep hostname/domain permission checks, DNS pinning, and blocking of loopback, link-local, RFC 1918, CGNAT, and other local/private ranges unchanged
- add regression coverage for both halves of `198.18.0.0/15`

## Reproduction

With a TUN proxy enabled, an approved public hostname can resolve to a synthetic `198.18.x.x` address. The MiniApp bridge rejected that address before the HTTP client could send the request, while other BitFun network paths continued to work.

## Verification

- `pnpm run fmt:rs`
- `cargo test -p bitfun-services-integrations --features miniapp-runtime host_dispatch --lib`
- `cargo check --workspace`