### PR TITLE
fix(dispatch): keep deleted session projections dismissed

### DIFF
--- a/src/web-ui/src/features/dispatch/DispatchJobObserver.test.ts
+++ b/src/web-ui/src/features/dispatch/DispatchJobObserver.test.ts
@@ -48,7 +48,31 @@ vi.mock('@/flow_chat/services/AgenticEventListener', () => ({
   },
 }));
 
+function runningOutboundRecord() {
+  return {
+    jobId: 'job-1',
+    sessionId: 'session-1',
+    target: {
+      kind: 'ssh' as const,
+      connectionId: 'ssh-1',
+      workspacePath: '/repo',
+      displayName: 'build-host',
+    },
+    sourceWorkspacePath: '/source',
+    workspacePath: '/repo',
+    promptPreview: 'Dispatch test',
+    title: 'Dispatch test',
+    agentType: 'agentic',
+    approvalPolicy: 'reject-and-report' as const,
+    lastCursor: 0,
+    lastState: 'running' as const,
+    createdAt: '2026-07-28T00:00:00Z',
+    updatedAt: '2026-07-28T00:00:01Z',
+  };
+}
+
 function registerRunningJob(): void {
+  mocks.listJobs.mockResolvedValue([runningOutboundRecord()]);
   dispatchJobStore.getState().registerJob({
     jobId: 'job-1',
     sessionId: 'session-1',
@@ -247,6 +271,14 @@ function status(
   };
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(resolvePromise => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 describe('DispatchJobObserver', () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -409,10 +441,46 @@ describe('DispatchJobObserver', () => {
       ...dispatchJobStore.getState().jobs['job-1'],
       state: 'submitting',
     });
+    mocks.listJobs.mockResolvedValue([]);
     const cleanup = installDispatchJobObserver(createContext());
 
     await vi.advanceTimersByTimeAsync(0);
     expect(mocks.status).not.toHaveBeenCalled();
+    cleanup();
+  });
+
+  it('does not recreate a dismissed projection from an in-flight status response', async () => {
+    registerRunningJob();
+    const deferred = createDeferred<DispatchStatusResponse>();
+    mocks.status.mockReturnValue(deferred.promise);
+    const context = createContext();
+    const cleanup = installDispatchJobObserver(context);
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mocks.status).toHaveBeenCalledWith('job-1', 0);
+
+    dispatchJobStore.getState().dismissJob('job-1');
+    deferred.resolve(status({
+      cursor: 1,
+      events: [{
+        type: 'agentEvent',
+        timestamp: '2026-07-28T00:00:01Z',
+        event: {
+          id: 'event-after-delete',
+          frontendEventName: 'agentic://session-created',
+          frontendPayload: {
+            sessionId: 'session-1',
+            sessionName: 'Dispatch test',
+          },
+        },
+      }],
+    }));
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(mocks.dispatchExternal).not.toHaveBeenCalled();
+    expect(context.flowChatStore.applyDispatchSnapshot).not.toHaveBeenCalled();
+    expect(dispatchJobStore.getState().jobs['job-1']).toBeUndefined();
+    expect(dispatchJobStore.getState().dismissedJobIds).toContain('job-1');
     cleanup();
   });
 

--- a/src/web-ui/src/features/dispatch/DispatchJobObserver.ts
+++ b/src/web-ui/src/features/dispatch/DispatchJobObserver.ts
@@ -27,10 +27,24 @@ const log = createLogger('DispatchJobObserver');
 export const DISPATCH_JOB_POLL_INTERVAL_MS = 1800;
 
 type RefreshRequester = (jobId?: string) => void;
-let installedRefreshRequester: RefreshRequester | null = null;
+
+interface DispatchObserverLease {
+  requestRefresh: RefreshRequester;
+  dispose: () => void;
+}
+
+type DispatchObserverGlobal = typeof globalThis & {
+  __bitfunDispatchJobObserverLease__?: DispatchObserverLease;
+};
+
+function getDispatchObserverGlobal(): DispatchObserverGlobal {
+  return globalThis as DispatchObserverGlobal;
+}
 
 export function requestDispatchJobRefresh(jobId?: string): void {
-  installedRefreshRequester?.(jobId);
+  getDispatchObserverGlobal()
+    .__bitfunDispatchJobObserverLease__
+    ?.requestRefresh(jobId);
 }
 
 const RAW_EVENT_NAMES: Record<string, string> = {
@@ -346,7 +360,14 @@ function reconcileDispatchTerminalRuntime(
   });
 }
 
-async function refreshJob(context: FlowChatContext, requestedJobId: string): Promise<void> {
+async function refreshJob(
+  context: FlowChatContext,
+  requestedJobId: string,
+  isObserverCurrent: () => boolean,
+): Promise<void> {
+  if (!isObserverCurrent()) {
+    return;
+  }
   let job = dispatchJobStore.getState().jobs[requestedJobId];
   if (!job) {
     return;
@@ -372,7 +393,7 @@ async function refreshJob(context: FlowChatContext, requestedJobId: string): Pro
   try {
     response = await dispatchApi.status(job.jobId, requestCursor);
   } catch (error) {
-    if (!isJobStillObserved(job)) {
+    if (!isObserverCurrent() || !isJobStillObserved(job)) {
       return;
     }
     dispatchJobStore.getState().setTransportState(
@@ -385,7 +406,7 @@ async function refreshJob(context: FlowChatContext, requestedJobId: string): Pro
   // Deleting a dispatch session writes a projection tombstone while an
   // already-issued target poll may still be in flight. Never let that stale
   // response project SessionCreated/DialogTurnStarted and recreate the row.
-  if (!isJobStillObserved(job)) {
+  if (!isObserverCurrent() || !isJobStillObserved(job)) {
     return;
   }
   // A successful target status request is the only authoritative signal that
@@ -398,7 +419,7 @@ async function refreshJob(context: FlowChatContext, requestedJobId: string): Pro
   const userCancelledBeforeRefresh =
     context.userCancelledSessionIds?.has(job.sessionId) ?? false;
   for (const event of response.events) {
-    if (!isJobStillObserved(job)) {
+    if (!isObserverCurrent() || !isJobStillObserved(job)) {
       return;
     }
     const eventId = dispatchEventId(event);
@@ -414,7 +435,7 @@ async function refreshJob(context: FlowChatContext, requestedJobId: string): Pro
       appliedEventIds: [eventId],
     });
   }
-  if (!isJobStillObserved(job)) {
+  if (!isObserverCurrent() || !isJobStillObserved(job)) {
     return;
   }
 
@@ -550,13 +571,28 @@ async function refreshJob(context: FlowChatContext, requestedJobId: string): Pro
 }
 
 export function installDispatchJobObserver(context: FlowChatContext): () => void {
+  const observerGlobal = getDispatchObserverGlobal();
+  const previousLease = observerGlobal.__bitfunDispatchJobObserverLease__;
+  if (previousLease) {
+    log.info('Replacing an existing dispatch job observer');
+    previousLease.dispose();
+  }
+
   let disposed = false;
   let inFlight = false;
   let queuedJobId: string | undefined;
   let immediateTimer: ReturnType<typeof setTimeout> | null = null;
+  let interval: ReturnType<typeof setInterval> | null = null;
+  let handleVisibilityChanged: (() => void) | null = null;
+  let lease: DispatchObserverLease;
+
+  const ownsLease = (): boolean => (
+    !disposed
+    && observerGlobal.__bitfunDispatchJobObserverLease__ === lease
+  );
 
   async function run(requestedJobId?: string): Promise<void> {
-    if (disposed || isPeerDeviceModeActive()) return;
+    if (!ownsLease() || isPeerDeviceModeActive()) return;
     if (inFlight) {
       queuedJobId = requestedJobId;
       return;
@@ -565,17 +601,29 @@ export function installDispatchJobObserver(context: FlowChatContext): () => void
     inFlight = true;
     try {
       const records = await dispatchApi.listJobs();
+      if (!ownsLease()) {
+        return;
+      }
       dispatchJobStore.getState().mergeOutboundRecords(records);
       const jobs = Object.values(dispatchJobStore.getState().jobs)
         .filter(job => !requestedJobId || job.jobId === requestedJobId);
       for (const job of jobs) {
+        if (!ownsLease()) {
+          return;
+        }
         try {
-          await refreshJob(context, job.jobId);
+          await refreshJob(context, job.jobId, ownsLease);
         } catch (error) {
+          if (!ownsLease()) {
+            return;
+          }
           log.warn('Dispatch job refresh failed', { jobId: job.jobId, error });
         }
       }
     } catch (error) {
+      if (!ownsLease()) {
+        return;
+      }
       const message = transportErrorMessage(error);
       const jobs = Object.values(dispatchJobStore.getState().jobs)
         .filter(job => (
@@ -593,7 +641,7 @@ export function installDispatchJobObserver(context: FlowChatContext): () => void
       log.warn('Failed to reconcile outbound dispatch jobs', { error });
     } finally {
       inFlight = false;
-      if (queuedJobId !== undefined && !disposed) {
+      if (queuedJobId !== undefined && ownsLease()) {
         const next = queuedJobId;
         queuedJobId = undefined;
         schedule(next);
@@ -602,7 +650,7 @@ export function installDispatchJobObserver(context: FlowChatContext): () => void
   }
 
   function schedule(jobId?: string): void {
-    if (disposed) return;
+    if (!ownsLease()) return;
     if (immediateTimer !== null) {
       clearTimeout(immediateTimer);
     }
@@ -612,11 +660,36 @@ export function installDispatchJobObserver(context: FlowChatContext): () => void
     }, 0);
   }
 
-  installedRefreshRequester = schedule;
-  const interval = setInterval(() => {
+  const dispose = (): void => {
+    if (disposed) {
+      return;
+    }
+    disposed = true;
+    if (observerGlobal.__bitfunDispatchJobObserverLease__ === lease) {
+      delete observerGlobal.__bitfunDispatchJobObserverLease__;
+    }
+    if (immediateTimer !== null) {
+      clearTimeout(immediateTimer);
+      immediateTimer = null;
+    }
+    if (interval !== null) {
+      clearInterval(interval);
+      interval = null;
+    }
+    if (typeof document !== 'undefined' && handleVisibilityChanged) {
+      document.removeEventListener('visibilitychange', handleVisibilityChanged);
+    }
+  };
+  lease = {
+    requestRefresh: schedule,
+    dispose,
+  };
+  observerGlobal.__bitfunDispatchJobObserverLease__ = lease;
+
+  interval = setInterval(() => {
     void run();
   }, DISPATCH_JOB_POLL_INTERVAL_MS);
-  const handleVisibilityChanged = () => {
+  handleVisibilityChanged = () => {
     if (typeof document === 'undefined' || document.visibilityState === 'visible') {
       schedule();
     }
@@ -626,17 +699,5 @@ export function installDispatchJobObserver(context: FlowChatContext): () => void
   }
   schedule();
 
-  return () => {
-    disposed = true;
-    if (installedRefreshRequester === schedule) {
-      installedRefreshRequester = null;
-    }
-    if (immediateTimer !== null) {
-      clearTimeout(immediateTimer);
-    }
-    clearInterval(interval);
-    if (typeof document !== 'undefined') {
-      document.removeEventListener('visibilitychange', handleVisibilityChanged);
-    }
-  };
+  return dispose;
 }

--- a/src/web-ui/src/features/dispatch/DispatchJobObserver.ts
+++ b/src/web-ui/src/features/dispatch/DispatchJobObserver.ts
@@ -172,6 +172,15 @@ function ensureProjection(context: FlowChatContext, job: DispatchObserverJob): b
   const sourceWorkspacePath = job.sourceWorkspacePath?.trim() || undefined;
   const existing = context.flowChatStore.getState().sessions.get(job.sessionId);
   if (existing) {
+    if (existing.config.dispatchJobId !== job.jobId) {
+      log.info('Dispatch diagnostic: observer adopted an existing flow chat session', {
+        jobId: job.jobId,
+        sessionId: job.sessionId,
+        previousDispatchJobId: existing.config.dispatchJobId,
+        wasHistorical: existing.isHistorical,
+        historyState: existing.historyState,
+      });
+    }
     // Reconcile both immutable target identity and controller-side ownership.
     // The observer can start before FlowChat knows its workspace, so a legacy
     // outbound record may only gain its source path on a later poll.
@@ -202,6 +211,12 @@ function ensureProjection(context: FlowChatContext, job: DispatchObserverJob): b
   // renderer process. Rebuild a fresh in-memory projection by replaying from
   // byte zero; never skip straight to that cursor.
   dispatchJobStore.getState().resetReplay(job.jobId);
+  log.info('Dispatch diagnostic: observer created a flow chat projection', {
+    jobId: job.jobId,
+    sessionId: job.sessionId,
+    sourceWorkspaceId: job.sourceWorkspaceId,
+    state: job.state,
+  });
   context.flowChatStore.addExternalSession(
     job.sessionId,
     job.title,

--- a/src/web-ui/src/features/dispatch/DispatchJobObserver.ts
+++ b/src/web-ui/src/features/dispatch/DispatchJobObserver.ts
@@ -154,6 +154,7 @@ function isJobStillObserved(job: DispatchObserverJob): boolean {
   return (
     state.jobs[job.jobId]?.sessionId === job.sessionId
     && !state.dismissedJobIds.includes(job.jobId)
+    && !state.dismissedSessionIds.includes(job.sessionId)
   );
 }
 

--- a/src/web-ui/src/features/dispatch/DispatchJobObserver.ts
+++ b/src/web-ui/src/features/dispatch/DispatchJobObserver.ts
@@ -149,6 +149,14 @@ function transportErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+function isJobStillObserved(job: DispatchObserverJob): boolean {
+  const state = dispatchJobStore.getState();
+  return (
+    state.jobs[job.jobId]?.sessionId === job.sessionId
+    && !state.dismissedJobIds.includes(job.jobId)
+  );
+}
+
 export function dispatchEventId(event: DispatchEvent): string {
   if (event.type === 'agentEvent') {
     const envelope = event.event as DispatchAgentEventEnvelope;
@@ -348,12 +356,21 @@ async function refreshJob(context: FlowChatContext, requestedJobId: string): Pro
   try {
     response = await dispatchApi.status(job.jobId, requestCursor);
   } catch (error) {
+    if (!isJobStillObserved(job)) {
+      return;
+    }
     dispatchJobStore.getState().setTransportState(
       job.jobId,
       'unreachable',
       transportErrorMessage(error),
     );
     throw error;
+  }
+  // Deleting a dispatch session writes a projection tombstone while an
+  // already-issued target poll may still be in flight. Never let that stale
+  // response project SessionCreated/DialogTurnStarted and recreate the row.
+  if (!isJobStillObserved(job)) {
+    return;
   }
   // A successful target status request is the only authoritative signal that
   // clears a transient transport failure. It does not alter the durable job
@@ -365,6 +382,9 @@ async function refreshJob(context: FlowChatContext, requestedJobId: string): Pro
   const userCancelledBeforeRefresh =
     context.userCancelledSessionIds?.has(job.sessionId) ?? false;
   for (const event of response.events) {
+    if (!isJobStillObserved(job)) {
+      return;
+    }
     const eventId = dispatchEventId(event);
     if (dispatchJobStore.getState().hasAppliedEvent(job.jobId, eventId)) {
       continue;
@@ -377,6 +397,9 @@ async function refreshJob(context: FlowChatContext, requestedJobId: string): Pro
     dispatchJobStore.getState().updateProgress(job.jobId, {
       appliedEventIds: [eventId],
     });
+  }
+  if (!isJobStillObserved(job)) {
+    return;
   }
 
   const terminalDrained =

--- a/src/web-ui/src/features/dispatch/dispatchJobStore.test.ts
+++ b/src/web-ui/src/features/dispatch/dispatchJobStore.test.ts
@@ -240,6 +240,7 @@ describe('dispatchJobStore', () => {
         workspacePath: '/repo',
         displayName: 'build-host',
       },
+      sourceWorkspacePath: '/source',
       workspacePath: '/repo',
       promptPreview: 'Dispatch test',
       lastCursor: 10,
@@ -250,6 +251,31 @@ describe('dispatchJobStore', () => {
 
     expect(dispatchJobStore.getState().jobs['job-1']).toBeUndefined();
     expect(dispatchJobStore.getState().dismissedJobIds).toContain('job-1');
+    expect(dispatchJobStore.getState().dismissedSessionIds).toContain('session-1');
+  });
+
+  it('uses a session tombstone when deletion happens before the job id is known', () => {
+    dispatchJobStore.getState().dismissSession('session-late');
+    dispatchJobStore.getState().mergeOutboundRecords([{
+      jobId: 'job-late',
+      sessionId: 'session-late',
+      target: {
+        kind: 'ssh',
+        connectionId: 'ssh-1',
+        workspacePath: '/repo',
+        displayName: 'build-host',
+      },
+      sourceWorkspacePath: '/source',
+      workspacePath: '/repo',
+      promptPreview: 'Dispatch test',
+      lastCursor: 0,
+      lastState: 'running',
+      createdAt: '2026-07-28T00:00:00Z',
+      updatedAt: '2026-07-28T00:00:01Z',
+    }]);
+
+    expect(dispatchJobStore.getState().jobs['job-late']).toBeUndefined();
+    expect(dispatchJobStore.getState().dismissedSessionIds).toContain('session-late');
   });
 
   it('keeps transport reachability transient and separate from authoritative job state', () => {
@@ -271,5 +297,6 @@ describe('dispatchJobStore', () => {
       dispatchJobStore.getState(),
     ) as Record<string, unknown> | undefined;
     expect(persistedState?.transportByJobId).toBeUndefined();
+    expect(persistedState?.dismissedSessionIds).toEqual([]);
   });
 });

--- a/src/web-ui/src/features/dispatch/dispatchJobStore.ts
+++ b/src/web-ui/src/features/dispatch/dispatchJobStore.ts
@@ -2,7 +2,6 @@ import { create } from 'zustand';
 import {
   createJSONStorage,
   persist,
-  type StateStorage,
 } from 'zustand/middleware';
 import type {
   DispatchApprovalPolicy,
@@ -20,9 +19,26 @@ const log = createLogger('DispatchJobStore');
 const MAX_APPLIED_EVENT_IDS = 2048;
 const MAX_DISMISSED_JOB_IDS = 2048;
 const MAX_DISMISSED_SESSION_IDS = 2048;
+const DISPATCH_JOB_STORAGE_KEY = 'bitfun-dispatch-jobs-v1';
+// Keep deletion authority outside the general Zustand snapshot. A stale HMR
+// renderer may still persist its old job cache, but it must never erase a
+// dismissal recorded by the current renderer.
+const DISPATCH_DISMISSAL_LEDGER_KEY = 'bitfun-dispatch-dismissals-v1';
 const reportedSuppressedProjectionKeys = new Set<string>();
 const fallbackStorageValues = new Map<string, string>();
-const fallbackStorage: StateStorage = {
+
+interface SyncStringStorage {
+  getItem: (name: string) => string | null;
+  setItem: (name: string, value: string) => void;
+  removeItem: (name: string) => void;
+}
+
+interface DispatchDismissalLedger {
+  dismissedJobIds: string[];
+  dismissedSessionIds: string[];
+}
+
+const fallbackStorage: SyncStringStorage = {
   getItem: (name) => fallbackStorageValues.get(name) ?? null,
   setItem: (name, value) => {
     fallbackStorageValues.set(name, value);
@@ -31,6 +47,84 @@ const fallbackStorage: StateStorage = {
     fallbackStorageValues.delete(name);
   },
 };
+
+function getDispatchStorage(): SyncStringStorage {
+  return typeof localStorage === 'undefined' ? fallbackStorage : localStorage;
+}
+
+function mergeDismissedIds(
+  current: unknown[],
+  additions: unknown[],
+  limit: number,
+): string[] {
+  return Array.from(new Set(
+    [...current, ...additions]
+      .filter((value): value is string => typeof value === 'string')
+      .map(value => value.trim())
+      .filter(Boolean),
+  )).slice(-limit);
+}
+
+function readDismissalLedger(): DispatchDismissalLedger {
+  try {
+    const raw = getDispatchStorage().getItem(DISPATCH_DISMISSAL_LEDGER_KEY);
+    if (!raw) {
+      return { dismissedJobIds: [], dismissedSessionIds: [] };
+    }
+    const parsed = JSON.parse(raw) as Partial<DispatchDismissalLedger>;
+    return {
+      dismissedJobIds: mergeDismissedIds(
+        [],
+        Array.isArray(parsed.dismissedJobIds) ? parsed.dismissedJobIds : [],
+        MAX_DISMISSED_JOB_IDS,
+      ),
+      dismissedSessionIds: mergeDismissedIds(
+        [],
+        Array.isArray(parsed.dismissedSessionIds) ? parsed.dismissedSessionIds : [],
+        MAX_DISMISSED_SESSION_IDS,
+      ),
+    };
+  } catch (error) {
+    log.warn('Failed to read dispatch dismissal ledger', { error });
+    return { dismissedJobIds: [], dismissedSessionIds: [] };
+  }
+}
+
+function recordDismissals(
+  jobIds: string[],
+  sessionIds: string[],
+): DispatchDismissalLedger {
+  const current = readDismissalLedger();
+  const next = {
+    dismissedJobIds: mergeDismissedIds(
+      current.dismissedJobIds,
+      jobIds,
+      MAX_DISMISSED_JOB_IDS,
+    ),
+    dismissedSessionIds: mergeDismissedIds(
+      current.dismissedSessionIds,
+      sessionIds,
+      MAX_DISMISSED_SESSION_IDS,
+    ),
+  };
+  try {
+    getDispatchStorage().setItem(
+      DISPATCH_DISMISSAL_LEDGER_KEY,
+      JSON.stringify(next),
+    );
+  } catch (error) {
+    log.error('Failed to persist dispatch dismissal ledger', { error });
+  }
+  return next;
+}
+
+function clearDismissalLedger(): void {
+  try {
+    getDispatchStorage().removeItem(DISPATCH_DISMISSAL_LEDGER_KEY);
+  } catch (error) {
+    log.warn('Failed to clear dispatch dismissal ledger', { error });
+  }
+}
 
 export interface DispatchObserverJob {
   jobId: string;
@@ -140,27 +234,40 @@ function requestFromTarget(target: DispatchTarget): DispatchTargetRequest {
   }
 }
 
+const initialDismissalLedger = readDismissalLedger();
+
 export const useDispatchJobStore = create<DispatchJobStoreState>()(
   persist(
     (set, get) => ({
       jobs: {},
       transportByJobId: {},
-      dismissedJobIds: [],
-      dismissedSessionIds: [],
+      dismissedJobIds: initialDismissalLedger.dismissedJobIds,
+      dismissedSessionIds: initialDismissalLedger.dismissedSessionIds,
 
       registerJob: (job) => {
         set(state => {
+          const ledger = readDismissalLedger();
+          const dismissedJobIds = mergeDismissedIds(
+            state.dismissedJobIds,
+            ledger.dismissedJobIds,
+            MAX_DISMISSED_JOB_IDS,
+          );
+          const dismissedSessionIds = mergeDismissedIds(
+            state.dismissedSessionIds,
+            ledger.dismissedSessionIds,
+            MAX_DISMISSED_SESSION_IDS,
+          );
           if (
-            state.dismissedJobIds.includes(job.jobId)
-            || state.dismissedSessionIds.includes(job.sessionId)
+            dismissedJobIds.includes(job.jobId)
+            || dismissedSessionIds.includes(job.sessionId)
           ) {
             log.info('Dispatch diagnostic: job registration suppressed by tombstone', {
               jobId: job.jobId,
               sessionId: job.sessionId,
-              jobTombstoned: state.dismissedJobIds.includes(job.jobId),
-              sessionTombstoned: state.dismissedSessionIds.includes(job.sessionId),
+              jobTombstoned: dismissedJobIds.includes(job.jobId),
+              sessionTombstoned: dismissedSessionIds.includes(job.sessionId),
             });
-            return state;
+            return { dismissedJobIds, dismissedSessionIds };
           }
           const transportByJobId = {
             ...state.transportByJobId,
@@ -178,19 +285,32 @@ export const useDispatchJobStore = create<DispatchJobStoreState>()(
               },
             },
             transportByJobId,
+            dismissedJobIds,
+            dismissedSessionIds,
           };
         });
       },
 
       mergeOutboundRecords: (records) => {
         set(state => {
+          const ledger = readDismissalLedger();
+          const dismissedJobIds = mergeDismissedIds(
+            state.dismissedJobIds,
+            ledger.dismissedJobIds,
+            MAX_DISMISSED_JOB_IDS,
+          );
+          const dismissedSessionIds = mergeDismissedIds(
+            state.dismissedSessionIds,
+            ledger.dismissedSessionIds,
+            MAX_DISMISSED_SESSION_IDS,
+          );
           const jobs = { ...state.jobs };
           const authoritativeJobIds = new Set(records.map(record => record.jobId));
           const prunedJobIds = new Set<string>();
           for (const [jobId, job] of Object.entries(jobs)) {
             if (
-              state.dismissedJobIds.includes(jobId)
-              || state.dismissedSessionIds.includes(job.sessionId)
+              dismissedJobIds.includes(jobId)
+              || dismissedSessionIds.includes(job.sessionId)
               || (
                 !authoritativeJobIds.has(jobId)
                 && job.state !== 'submitting'
@@ -206,8 +326,8 @@ export const useDispatchJobStore = create<DispatchJobStoreState>()(
           }
           for (const record of records) {
             if (
-              state.dismissedJobIds.includes(record.jobId)
-              || state.dismissedSessionIds.includes(record.sessionId)
+              dismissedJobIds.includes(record.jobId)
+              || dismissedSessionIds.includes(record.sessionId)
             ) {
               const projectionKey = `${record.jobId}:${record.sessionId}`;
               if (!reportedSuppressedProjectionKeys.has(projectionKey)) {
@@ -218,8 +338,8 @@ export const useDispatchJobStore = create<DispatchJobStoreState>()(
                 log.info('Dispatch diagnostic: outbound record suppressed by tombstone', {
                   jobId: record.jobId,
                   sessionId: record.sessionId,
-                  jobTombstoned: state.dismissedJobIds.includes(record.jobId),
-                  sessionTombstoned: state.dismissedSessionIds.includes(record.sessionId),
+                  jobTombstoned: dismissedJobIds.includes(record.jobId),
+                  sessionTombstoned: dismissedSessionIds.includes(record.sessionId),
                 });
               }
               continue;
@@ -301,7 +421,12 @@ export const useDispatchJobStore = create<DispatchJobStoreState>()(
           for (const jobId of Object.keys(jobs)) {
             transportByJobId[jobId] ??= { reachability: 'unknown' };
           }
-          return { jobs, transportByJobId };
+          return {
+            jobs,
+            transportByJobId,
+            dismissedJobIds,
+            dismissedSessionIds,
+          };
         });
       },
 
@@ -455,11 +580,19 @@ export const useDispatchJobStore = create<DispatchJobStoreState>()(
         const matchingJobIds = Object.values(get().jobs)
           .filter(job => job.sessionId === sessionId)
           .map(job => job.jobId);
+        const ledger = recordDismissals(
+          [
+            ...matchingJobIds,
+            ...(normalizedKnownJobId ? [normalizedKnownJobId] : []),
+          ],
+          sessionId ? [sessionId] : [],
+        );
         set(state => {
-          const dismissedJobIds = new Set(state.dismissedJobIds);
-          if (normalizedKnownJobId) {
-            dismissedJobIds.add(normalizedKnownJobId);
-          }
+          const dismissedJobIds = new Set(mergeDismissedIds(
+            state.dismissedJobIds,
+            ledger.dismissedJobIds,
+            MAX_DISMISSED_JOB_IDS,
+          ));
           for (const job of Object.values(state.jobs)) {
             if (job.sessionId === sessionId) {
               dismissedJobIds.add(job.jobId);
@@ -478,10 +611,11 @@ export const useDispatchJobStore = create<DispatchJobStoreState>()(
             transportByJobId,
             dismissedJobIds: Array.from(dismissedJobIds)
               .slice(-MAX_DISMISSED_JOB_IDS),
-            dismissedSessionIds: sessionId
-              ? Array.from(new Set([...state.dismissedSessionIds, sessionId]))
-                .slice(-MAX_DISMISSED_SESSION_IDS)
-              : state.dismissedSessionIds,
+            dismissedSessionIds: mergeDismissedIds(
+              state.dismissedSessionIds,
+              ledger.dismissedSessionIds,
+              MAX_DISMISSED_SESSION_IDS,
+            ),
           };
         });
         const state = get();
@@ -493,6 +627,11 @@ export const useDispatchJobStore = create<DispatchJobStoreState>()(
             ? state.dismissedJobIds.includes(normalizedKnownJobId)
             : false,
           persistedSessionTombstone: state.dismissedSessionIds.includes(sessionId),
+          ledgerJobTombstone: normalizedKnownJobId
+            ? ledger.dismissedJobIds.includes(normalizedKnownJobId)
+            : matchingJobIds.length > 0
+              && matchingJobIds.every(jobId => ledger.dismissedJobIds.includes(jobId)),
+          ledgerSessionTombstone: ledger.dismissedSessionIds.includes(sessionId),
           dismissedJobCount: state.dismissedJobIds.length,
           dismissedSessionCount: state.dismissedSessionIds.length,
         });
@@ -514,24 +653,56 @@ export const useDispatchJobStore = create<DispatchJobStoreState>()(
         });
       },
 
-      clear: () => set({
-        jobs: {},
-        transportByJobId: {},
-        dismissedJobIds: [],
-        dismissedSessionIds: [],
-      }),
+      clear: () => {
+        clearDismissalLedger();
+        set({
+          jobs: {},
+          transportByJobId: {},
+          dismissedJobIds: [],
+          dismissedSessionIds: [],
+        });
+      },
     }),
     {
-      name: 'bitfun-dispatch-jobs-v1',
+      name: DISPATCH_JOB_STORAGE_KEY,
       version: 1,
-      storage: createJSONStorage(() => (
-        typeof localStorage === 'undefined' ? fallbackStorage : localStorage
-      )),
+      storage: createJSONStorage(getDispatchStorage),
       partialize: state => ({
         jobs: state.jobs,
         dismissedJobIds: state.dismissedJobIds,
         dismissedSessionIds: state.dismissedSessionIds,
       }),
+      merge: (persistedState, currentState) => {
+        const persisted = (persistedState ?? {}) as Partial<DispatchJobStoreState>;
+        const ledger = recordDismissals(
+          persisted.dismissedJobIds ?? [],
+          persisted.dismissedSessionIds ?? [],
+        );
+        const dismissedJobIds = mergeDismissedIds(
+          persisted.dismissedJobIds ?? [],
+          ledger.dismissedJobIds,
+          MAX_DISMISSED_JOB_IDS,
+        );
+        const dismissedSessionIds = mergeDismissedIds(
+          persisted.dismissedSessionIds ?? [],
+          ledger.dismissedSessionIds,
+          MAX_DISMISSED_SESSION_IDS,
+        );
+        const jobs = Object.fromEntries(
+          Object.entries(persisted.jobs ?? {}).filter(([, job]) => (
+            !dismissedJobIds.includes(job.jobId)
+            && !dismissedSessionIds.includes(job.sessionId)
+          )),
+        );
+        return {
+          ...currentState,
+          ...persisted,
+          jobs,
+          transportByJobId: {},
+          dismissedJobIds,
+          dismissedSessionIds,
+        };
+      },
       onRehydrateStorage: () => (state, error) => {
         if (error) {
           log.error('Dispatch diagnostic: projection state rehydration failed', { error });

--- a/src/web-ui/src/features/dispatch/dispatchJobStore.ts
+++ b/src/web-ui/src/features/dispatch/dispatchJobStore.ts
@@ -17,6 +17,7 @@ import { isDispatchJobTerminal } from './types';
 
 const MAX_APPLIED_EVENT_IDS = 2048;
 const MAX_DISMISSED_JOB_IDS = 2048;
+const MAX_DISMISSED_SESSION_IDS = 2048;
 const fallbackStorageValues = new Map<string, string>();
 const fallbackStorage: StateStorage = {
   getItem: (name) => fallbackStorageValues.get(name) ?? null,
@@ -69,6 +70,11 @@ interface DispatchJobStoreState {
   transportByJobId: Record<string, DispatchTransportState>;
   /** Local projection tombstones. The target job remains durable, but must not reopen in navigation. */
   dismissedJobIds: string[];
+  /**
+   * Session-level tombstones cover incomplete projections where the job id is
+   * temporarily missing when the user deletes the navigation row.
+   */
+  dismissedSessionIds: string[];
   registerJob: (job: DispatchObserverJob) => void;
   mergeOutboundRecords: (records: OutboundDispatchRecord[]) => void;
   updateProgress: (
@@ -96,6 +102,7 @@ interface DispatchJobStoreState {
   updateTitle: (jobId: string, title: string) => void;
   updateModel: (jobId: string, model: string) => void;
   updateApprovalPolicy: (jobId: string, policy: DispatchApprovalPolicy) => void;
+  dismissSession: (sessionId: string, knownJobId?: string) => void;
   dismissJob: (jobId: string) => void;
   removeJob: (jobId: string) => void;
   clear: () => void;
@@ -136,9 +143,16 @@ export const useDispatchJobStore = create<DispatchJobStoreState>()(
       jobs: {},
       transportByJobId: {},
       dismissedJobIds: [],
+      dismissedSessionIds: [],
 
       registerJob: (job) => {
         set(state => {
+          if (
+            state.dismissedJobIds.includes(job.jobId)
+            || state.dismissedSessionIds.includes(job.sessionId)
+          ) {
+            return state;
+          }
           const transportByJobId = {
             ...state.transportByJobId,
             [job.jobId]: state.transportByJobId[job.jobId] ?? {
@@ -155,7 +169,6 @@ export const useDispatchJobStore = create<DispatchJobStoreState>()(
               },
             },
             transportByJobId,
-            dismissedJobIds: state.dismissedJobIds.filter(id => id !== job.jobId),
           };
         });
       },
@@ -167,19 +180,26 @@ export const useDispatchJobStore = create<DispatchJobStoreState>()(
           const prunedJobIds = new Set<string>();
           for (const [jobId, job] of Object.entries(jobs)) {
             if (
-              !authoritativeJobIds.has(jobId)
-              && job.state !== 'submitting'
-              && job.state !== 'submission_unknown'
+              state.dismissedJobIds.includes(jobId)
+              || state.dismissedSessionIds.includes(job.sessionId)
+              || (
+                !authoritativeJobIds.has(jobId)
+                && job.state !== 'submitting'
+                && job.state !== 'submission_unknown'
+              )
             ) {
-              // The controller index is authoritative after acknowledgement.
-              // Remove renderer cache left behind by retention, manual cleanup,
-              // or an older build instead of restoring a ghost projection.
+              // The controller index is authoritative after acknowledgement,
+              // while a tombstone also wins over cache rehydrated by an older
+              // renderer build.
               delete jobs[jobId];
               prunedJobIds.add(jobId);
             }
           }
           for (const record of records) {
-            if (state.dismissedJobIds.includes(record.jobId)) {
+            if (
+              state.dismissedJobIds.includes(record.jobId)
+              || state.dismissedSessionIds.includes(record.sessionId)
+            ) {
               continue;
             }
             const sourceWorkspacePath = record.sourceWorkspacePath?.trim() || undefined;
@@ -401,19 +421,43 @@ export const useDispatchJobStore = create<DispatchJobStoreState>()(
         });
       },
 
-      dismissJob: (jobId) => {
+      dismissSession: (rawSessionId, knownJobId) => {
+        const sessionId = rawSessionId.trim();
+        const normalizedKnownJobId = knownJobId?.trim();
         set(state => {
+          const dismissedJobIds = new Set(state.dismissedJobIds);
+          if (normalizedKnownJobId) {
+            dismissedJobIds.add(normalizedKnownJobId);
+          }
+          for (const job of Object.values(state.jobs)) {
+            if (job.sessionId === sessionId) {
+              dismissedJobIds.add(job.jobId);
+            }
+          }
+
           const jobs = { ...state.jobs };
           const transportByJobId = { ...state.transportByJobId };
-          delete jobs[jobId];
-          delete transportByJobId[jobId];
+          for (const jobId of dismissedJobIds) {
+            delete jobs[jobId];
+            delete transportByJobId[jobId];
+          }
+
           return {
             jobs,
             transportByJobId,
-            dismissedJobIds: Array.from(new Set([...state.dismissedJobIds, jobId]))
+            dismissedJobIds: Array.from(dismissedJobIds)
               .slice(-MAX_DISMISSED_JOB_IDS),
+            dismissedSessionIds: sessionId
+              ? Array.from(new Set([...state.dismissedSessionIds, sessionId]))
+                .slice(-MAX_DISMISSED_SESSION_IDS)
+              : state.dismissedSessionIds,
           };
         });
+      },
+
+      dismissJob: (jobId) => {
+        const sessionId = get().jobs[jobId]?.sessionId ?? '';
+        get().dismissSession(sessionId, jobId);
       },
 
       removeJob: (jobId) => {
@@ -427,7 +471,12 @@ export const useDispatchJobStore = create<DispatchJobStoreState>()(
         });
       },
 
-      clear: () => set({ jobs: {}, transportByJobId: {}, dismissedJobIds: [] }),
+      clear: () => set({
+        jobs: {},
+        transportByJobId: {},
+        dismissedJobIds: [],
+        dismissedSessionIds: [],
+      }),
     }),
     {
       name: 'bitfun-dispatch-jobs-v1',
@@ -438,6 +487,7 @@ export const useDispatchJobStore = create<DispatchJobStoreState>()(
       partialize: state => ({
         jobs: state.jobs,
         dismissedJobIds: state.dismissedJobIds,
+        dismissedSessionIds: state.dismissedSessionIds,
       }),
     },
   ),

--- a/src/web-ui/src/features/dispatch/dispatchJobStore.ts
+++ b/src/web-ui/src/features/dispatch/dispatchJobStore.ts
@@ -14,10 +14,13 @@ import type {
   OutboundDispatchRecord,
 } from './types';
 import { isDispatchJobTerminal } from './types';
+import { createLogger } from '@/shared/utils/logger';
 
+const log = createLogger('DispatchJobStore');
 const MAX_APPLIED_EVENT_IDS = 2048;
 const MAX_DISMISSED_JOB_IDS = 2048;
 const MAX_DISMISSED_SESSION_IDS = 2048;
+const reportedSuppressedProjectionKeys = new Set<string>();
 const fallbackStorageValues = new Map<string, string>();
 const fallbackStorage: StateStorage = {
   getItem: (name) => fallbackStorageValues.get(name) ?? null,
@@ -151,6 +154,12 @@ export const useDispatchJobStore = create<DispatchJobStoreState>()(
             state.dismissedJobIds.includes(job.jobId)
             || state.dismissedSessionIds.includes(job.sessionId)
           ) {
+            log.info('Dispatch diagnostic: job registration suppressed by tombstone', {
+              jobId: job.jobId,
+              sessionId: job.sessionId,
+              jobTombstoned: state.dismissedJobIds.includes(job.jobId),
+              sessionTombstoned: state.dismissedSessionIds.includes(job.sessionId),
+            });
             return state;
           }
           const transportByJobId = {
@@ -200,6 +209,19 @@ export const useDispatchJobStore = create<DispatchJobStoreState>()(
               state.dismissedJobIds.includes(record.jobId)
               || state.dismissedSessionIds.includes(record.sessionId)
             ) {
+              const projectionKey = `${record.jobId}:${record.sessionId}`;
+              if (!reportedSuppressedProjectionKeys.has(projectionKey)) {
+                if (reportedSuppressedProjectionKeys.size >= MAX_DISMISSED_JOB_IDS) {
+                  reportedSuppressedProjectionKeys.clear();
+                }
+                reportedSuppressedProjectionKeys.add(projectionKey);
+                log.info('Dispatch diagnostic: outbound record suppressed by tombstone', {
+                  jobId: record.jobId,
+                  sessionId: record.sessionId,
+                  jobTombstoned: state.dismissedJobIds.includes(record.jobId),
+                  sessionTombstoned: state.dismissedSessionIds.includes(record.sessionId),
+                });
+              }
               continue;
             }
             const sourceWorkspacePath = record.sourceWorkspacePath?.trim() || undefined;
@@ -240,6 +262,12 @@ export const useDispatchJobStore = create<DispatchJobStoreState>()(
               };
               continue;
             }
+            log.info('Dispatch diagnostic: outbound record restored into renderer cache', {
+              jobId: record.jobId,
+              sessionId: record.sessionId,
+              sourceWorkspaceId: record.sourceWorkspaceId,
+              state: record.lastState,
+            });
             jobs[record.jobId] = {
               jobId: record.jobId,
               sessionId: record.sessionId,
@@ -424,6 +452,9 @@ export const useDispatchJobStore = create<DispatchJobStoreState>()(
       dismissSession: (rawSessionId, knownJobId) => {
         const sessionId = rawSessionId.trim();
         const normalizedKnownJobId = knownJobId?.trim();
+        const matchingJobIds = Object.values(get().jobs)
+          .filter(job => job.sessionId === sessionId)
+          .map(job => job.jobId);
         set(state => {
           const dismissedJobIds = new Set(state.dismissedJobIds);
           if (normalizedKnownJobId) {
@@ -452,6 +483,18 @@ export const useDispatchJobStore = create<DispatchJobStoreState>()(
                 .slice(-MAX_DISMISSED_SESSION_IDS)
               : state.dismissedSessionIds,
           };
+        });
+        const state = get();
+        log.info('Dispatch diagnostic: projection dismissed', {
+          sessionId,
+          knownJobId: normalizedKnownJobId,
+          matchingJobIds,
+          persistedJobTombstone: normalizedKnownJobId
+            ? state.dismissedJobIds.includes(normalizedKnownJobId)
+            : false,
+          persistedSessionTombstone: state.dismissedSessionIds.includes(sessionId),
+          dismissedJobCount: state.dismissedJobIds.length,
+          dismissedSessionCount: state.dismissedSessionIds.length,
         });
       },
 
@@ -489,6 +532,17 @@ export const useDispatchJobStore = create<DispatchJobStoreState>()(
         dismissedJobIds: state.dismissedJobIds,
         dismissedSessionIds: state.dismissedSessionIds,
       }),
+      onRehydrateStorage: () => (state, error) => {
+        if (error) {
+          log.error('Dispatch diagnostic: projection state rehydration failed', { error });
+          return;
+        }
+        log.info('Dispatch diagnostic: projection state rehydrated', {
+          jobIds: Object.keys(state?.jobs ?? {}),
+          dismissedJobIds: state?.dismissedJobIds ?? [],
+          dismissedSessionIds: state?.dismissedSessionIds ?? [],
+        });
+      },
     },
   ),
 );

--- a/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStrip.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStrip.tsx
@@ -22,7 +22,6 @@ import { Tooltip, IconButton } from '@/component-library';
 import { useGitState } from '@/tools/git/hooks/useGitState';
 import type { SessionExecutionTarget } from '@/infrastructure/api/service-api/WorktreeAPI';
 import { useI18n } from '@/infrastructure/i18n';
-import { DispatchTargetPicker } from '@/features/dispatch/DispatchTargetPicker';
 import { DispatchResultDialog } from '@/features/dispatch/DispatchResultDialog';
 import type { DispatchSelection, DispatchTarget } from '@/features/dispatch/types';
 import './ChatInputWorkspaceStrip.scss';
@@ -136,8 +135,8 @@ export const ChatInputWorkspaceStrip: React.FC<ChatInputWorkspaceStripProps> = (
   const showUsage = usageReport?.visible && !!usageReport.onOpen;
   const showGoal = threadGoal?.visible && !!threadGoal.onOpen;
   const showPermission = !!permissionControl;
-  const showDispatch = !!dispatchControl;
-  const showRightActions = showDispatch || showPermission || showUsage || showGoal;
+  const showDispatchResult = !!dispatchControl?.completedSnapshotJobId;
+  const showRightActions = showDispatchResult || showPermission || showUsage || showGoal;
   const isWorktree = !!executionTarget?.worktreeId;
   const worktreeEnabled = worktreeControl?.enabled ?? isWorktree;
   const worktreeEnabledRef = useRef(worktreeEnabled);
@@ -326,15 +325,11 @@ export const ChatInputWorkspaceStrip: React.FC<ChatInputWorkspaceStripProps> = (
 
       {showRightActions ? (
         <div className="bitfun-chat-input-workspace-strip__actions">
-          {dispatchControl ? (
-            <DispatchTargetPicker
-              target={dispatchControl.target}
-              sourceWorkspacePath={dispatchControl.sourceWorkspacePath}
-              locked={dispatchControl.locked}
-              onSelectLocal={dispatchControl.onSelectLocal}
-              onSelectTarget={dispatchControl.onSelectTarget}
-            />
-          ) : null}
+          {/*
+           * 0.2.15 release gate: dispatch session creation stays hidden while
+           * its lifecycle semantics stabilize. Restore DispatchTargetPicker
+           * here in a later release; existing result review remains available.
+           */}
           {dispatchControl?.completedSnapshotJobId ? (
             <>
               <Tooltip content={tCommon('dispatch.resultTitle')} placement="top">

--- a/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStripLayout.test.ts
+++ b/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStripLayout.test.ts
@@ -17,13 +17,6 @@ function readWorkspaceStripComponent(): string {
   ).replace(/\r\n/g, '\n');
 }
 
-function readDispatchPickerStylesheet(): string {
-  return readFileSync(
-    fileURLToPath(new URL('../../features/dispatch/DispatchTargetPicker.scss', import.meta.url)),
-    'utf8',
-  ).replace(/\r\n/g, '\n');
-}
-
 describe('ChatInputWorkspaceStrip layout styles', () => {
   it('keeps the session usage action visible without overpowering the strip', () => {
     const stylesheet = readWorkspaceStripStylesheet();
@@ -52,21 +45,14 @@ describe('ChatInputWorkspaceStrip layout styles', () => {
     expect(stylesheet).toContain('display: none;');
   });
 
-  it('places dispatch first in right actions and protects the narrow layout', () => {
+  it('keeps dispatch session creation hidden for the 0.2.15 release', () => {
     const component = readWorkspaceStripComponent();
-    const pickerStylesheet = readDispatchPickerStylesheet();
-    const actionsStart = component.indexOf(
-      '<div className="bitfun-chat-input-workspace-strip__actions">',
-    );
-    const dispatchIndex = component.indexOf('<DispatchTargetPicker', actionsStart);
-    const permissionIndex = component.indexOf('{showPermission ? (', actionsStart);
 
-    expect(actionsStart).toBeGreaterThan(-1);
-    expect(dispatchIndex).toBeGreaterThan(actionsStart);
-    expect(permissionIndex).toBeGreaterThan(dispatchIndex);
-    expect(pickerStylesheet).toContain('max-width: 142px;');
-    expect(pickerStylesheet).toContain('@media (max-width: 560px)');
-    expect(pickerStylesheet).toContain('width: 18px;');
-    expect(pickerStylesheet).toContain('> .dispatch-target-picker__chevron');
+    expect(component).toContain('0.2.15 release gate');
+    expect(component).toContain('Restore DispatchTargetPicker');
+    expect(component).not.toContain('<DispatchTargetPicker');
+    expect(component).not.toContain(
+      "import { DispatchTargetPicker } from '@/features/dispatch/DispatchTargetPicker';",
+    );
   });
 });

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.test.ts
@@ -49,8 +49,9 @@ const stateMachineMocks = vi.hoisted(() => ({
 }));
 
 const dispatchStoreMocks = vi.hoisted(() => ({
+  jobs: {} as Record<string, { sessionId: string }>,
   registerJob: vi.fn(),
-  dismissJob: vi.fn(),
+  dismissSession: vi.fn(),
   updateTitle: vi.fn(),
 }));
 
@@ -513,6 +514,7 @@ describe('reloadSessionTitle', () => {
 describe('SessionModule historical session coordination', () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    dispatchStoreMocks.jobs = {};
   });
 
   afterEach(async () => {
@@ -1055,7 +1057,36 @@ describe('SessionModule historical session coordination', () => {
 
     await deleteChatSession(context, session.sessionId);
 
-    expect(dispatchStoreMocks.dismissJob).toHaveBeenCalledWith('job-1');
+    expect(dispatchStoreMocks.dismissSession).toHaveBeenCalledWith(
+      session.sessionId,
+      'job-1',
+    );
+    expect(flowChatStore.removeSession).toHaveBeenCalledWith(
+      session.sessionId,
+      { nextActiveSessionId: null },
+    );
+    expect(flowChatStore.deleteSession).not.toHaveBeenCalled();
+  });
+
+  it('deletes a dispatch projection found only through the observer job index', async () => {
+    const session = createSession({
+      sessionId: 'dispatch-session',
+      isHistorical: false,
+      config: { agentType: 'agentic' },
+    });
+    dispatchStoreMocks.jobs = {
+      'job-1': { sessionId: session.sessionId },
+    };
+    const { context, flowChatStore } = createContext(session, {
+      activeSessionId: session.sessionId,
+    });
+
+    await deleteChatSession(context, session.sessionId);
+
+    expect(dispatchStoreMocks.dismissSession).toHaveBeenCalledWith(
+      session.sessionId,
+      undefined,
+    );
     expect(flowChatStore.removeSession).toHaveBeenCalledWith(
       session.sessionId,
       { nextActiveSessionId: null },

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.ts
@@ -60,6 +60,31 @@ const log = createLogger('SessionModule');
 const pendingSessionCreations = new Map<string, Promise<string>>();
 const DISPATCH_OBSERVER_MAX_CONTEXT_TOKENS = 128128;
 
+function isDispatchObserverProjection(
+  sessionId: string,
+  session: Session | undefined,
+): boolean {
+  if (
+    isNonLocalDispatchTarget(session?.config.dispatchTarget)
+    || Boolean(session?.config.dispatchJobId?.trim())
+  ) {
+    return true;
+  }
+
+  return Object.values(dispatchJobStore.getState().jobs)
+    .some(job => job.sessionId === sessionId);
+}
+
+function dismissDispatchObserverProjection(
+  sessionId: string,
+  session: Session | undefined,
+): void {
+  dispatchJobStore.getState().dismissSession(
+    sessionId,
+    session?.config.dispatchJobId,
+  );
+}
+
 const getHydrationLocationKey = (
   location: SessionHistoryHydrationLocation | undefined,
 ): string => location?.workspacePath
@@ -993,10 +1018,8 @@ export async function deleteChatSession(
       && removedSessionIdSet.has(stateBeforeDelete.activeSessionId)
     );
     const session = stateBeforeDelete.sessions.get(sessionId);
-    if (isNonLocalDispatchTarget(session?.config.dispatchTarget)) {
-      if (session?.config.dispatchJobId) {
-        dispatchJobStore.getState().dismissJob(session.config.dispatchJobId);
-      }
+    if (isDispatchObserverProjection(sessionId, session)) {
+      dismissDispatchObserverProjection(sessionId, session);
       context.flowChatStore.removeSession(
         sessionId,
         removedActiveSession ? { nextActiveSessionId: null } : undefined,
@@ -1044,10 +1067,8 @@ export async function archiveChatSession(
       && removedSessionIdSet.has(stateBeforeArchive.activeSessionId)
     );
 
-    if (isNonLocalDispatchTarget(session.config.dispatchTarget)) {
-      if (session.config.dispatchJobId) {
-        dispatchJobStore.getState().dismissJob(session.config.dispatchJobId);
-      }
+    if (isDispatchObserverProjection(sessionId, session)) {
+      dismissDispatchObserverProjection(sessionId, session);
       context.flowChatStore.removeSession(
         sessionId,
         removedActiveSession ? { nextActiveSessionId: null } : undefined,

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.ts
@@ -1018,9 +1018,22 @@ export async function deleteChatSession(
       && removedSessionIdSet.has(stateBeforeDelete.activeSessionId)
     );
     const session = stateBeforeDelete.sessions.get(sessionId);
-    if (isDispatchObserverProjection(sessionId, session)) {
+    const observerJobIds = Object.values(dispatchJobStore.getState().jobs)
+      .filter(job => job.sessionId === sessionId)
+      .map(job => job.jobId);
+    const deleteAsDispatchProjection = isDispatchObserverProjection(sessionId, session);
+    log.info('Dispatch diagnostic: session delete evaluated', {
+      sessionId,
+      sessionFound: Boolean(session),
+      dispatchTargetKind: session?.config.dispatchTarget?.kind,
+      dispatchJobId: session?.config.dispatchJobId,
+      observerJobIds,
+      deleteAsDispatchProjection,
+      cascadeSessionIds: removedSessionIds,
+    });
+    if (deleteAsDispatchProjection) {
       dismissDispatchObserverProjection(sessionId, session);
-      context.flowChatStore.removeSession(
+      const locallyRemovedSessionIds = context.flowChatStore.removeSession(
         sessionId,
         removedActiveSession ? { nextActiveSessionId: null } : undefined,
       );
@@ -1029,8 +1042,17 @@ export async function deleteChatSession(
         cleanupSaveState(context, id);
         cleanupSessionBuffers(context, id);
       });
+      log.info('Dispatch diagnostic: projection removed from flow chat store', {
+        sessionId,
+        locallyRemovedSessionIds,
+        activeSessionId: context.flowChatStore.getState().activeSessionId,
+      });
       return;
     }
+    log.info('Dispatch diagnostic: delete routed to persisted backend session', {
+      sessionId,
+      hasWorkspacePath: Boolean(session && sessionProjectWorkspacePath(session)),
+    });
     await context.flowChatStore.deleteSession(
       sessionId,
       removedActiveSession ? { nextActiveSessionId: null } : undefined,

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.ts
@@ -72,8 +72,42 @@ import {
   isDispatchJobTerminal,
   isNonLocalDispatchTarget,
 } from '@/features/dispatch/types';
+import { dispatchJobStore } from '@/features/dispatch/dispatchJobStore';
 
 const log = createLogger('FlowChatStore');
+
+function logPersistedDispatchMetadataOverlap(
+  metadata: Record<string, unknown>,
+  source: 'metadata-page' | 'metadata-list',
+): void {
+  const sessionId =
+    typeof metadata.sessionId === 'string' ? metadata.sessionId : undefined;
+  if (!sessionId) return;
+
+  const dispatchState = dispatchJobStore.getState();
+  const observerJobIds = Object.values(dispatchState.jobs)
+    .filter(job => job.sessionId === sessionId)
+    .map(job => job.jobId);
+  const sessionTombstoned = dispatchState.dismissedSessionIds.includes(sessionId);
+  const metadataDispatchJobId =
+    typeof metadata.dispatchJobId === 'string'
+      ? metadata.dispatchJobId
+      : typeof metadata.dispatch_job_id === 'string'
+        ? metadata.dispatch_job_id
+        : undefined;
+  if (!sessionTombstoned && observerJobIds.length === 0 && !metadataDispatchJobId) {
+    return;
+  }
+
+  log.info('Dispatch diagnostic: persisted backend metadata overlaps observer state', {
+    source,
+    sessionId,
+    metadataDispatchJobId,
+    observerJobIds,
+    sessionTombstoned,
+    dismissedSessionCount: dispatchState.dismissedSessionIds.length,
+  });
+}
 
 function sameDispatchTargetIdentity(
   left: NonNullable<SessionConfig['dispatchTarget']>,
@@ -4070,6 +4104,7 @@ export class FlowChatStore {
 
     const processSession = async (metadata: any) => {
       try {
+        logPersistedDispatchMetadataOverlap(metadata, 'metadata-page');
         if (surfaceGeneration !== this.surfaceGeneration) {
           return;
         }
@@ -4445,6 +4480,7 @@ export class FlowChatStore {
 
       const processSession = async (metadata: any) => {
         try {
+          logPersistedDispatchMetadataOverlap(metadata, 'metadata-list');
           const existingSession = this.state.sessions.get(metadata.sessionId);
           if (existingSession) {
             return;


### PR DESCRIPTION
## Summary

- prevent stale in-flight status responses and incomplete observer projections from recreating deleted Dispatch sessions
- persist dismissal tombstones in an independent ledger so stale renderer snapshots cannot overwrite deletion state
- enforce a single active Dispatch observer per renderer and discard responses from observers that lost ownership
- keep the Dispatch composer entry hidden for the 0.2.15 release while retaining the implementation behind an explanatory comment
- add focused projection lifecycle diagnostics and regression coverage

## Verification

- manually verified deleting the two residual Dispatch sessions
- stopped and restarted `pnpm run desktop:dev` repeatedly
- confirmed the deleted sessions no longer return after restart

Automated checks were not rerun during the final iteration at the request of the verifier.