### PR TITLE
fix(market): label installed MiniApps with their marketplace release

### DIFF
--- a/src/apps/desktop/src/api/miniapp_market_api.rs
+++ b/src/apps/desktop/src/api/miniapp_market_api.rs
@@ -21,6 +21,7 @@ use bitfun_services_integrations::miniapp_market::{
     RatingAggregate, ValidatedMarketPackage,
 };
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use tauri::{AppHandle, Emitter, Manager, State, WebviewWindow};
 use tokio::io::AsyncWriteExt;
@@ -248,15 +249,7 @@ pub async fn miniapp_market_installed_status(
         .await
         .map_err(|error| error.to_string())?;
     for app in apps {
-        let Some(metadata) = state
-            .miniapp_manager
-            .load_customization_metadata(&app.id)
-            .await
-            .map_err(|error| error.to_string())?
-        else {
-            continue;
-        };
-        let Some(origin) = metadata.origin.market else {
+        let Some((origin, local_override)) = load_market_origin(&state, &app.id).await? else {
             continue;
         };
         if origin.listing_id == request.listing_id {
@@ -265,11 +258,56 @@ pub async fn miniapp_market_installed_status(
                 app_version: app.version,
                 permissions: app.permissions,
                 origin,
-                local_override: metadata.local_override,
+                local_override,
             }));
         }
     }
     Ok(None)
+}
+
+/// Marketplace origins of every installed MiniApp, keyed by local app id.
+///
+/// The local `MiniApp::version` counter tracks edits to the installed copy and
+/// is deliberately independent from the marketplace release number, so any
+/// surface that wants to name the release a user installed has to read it from
+/// the origin instead of from the app itself.
+#[tauri::command]
+pub async fn miniapp_market_installed_origins(
+    state: State<'_, AppState>,
+) -> Result<HashMap<String, InstalledMarketOrigin>, String> {
+    let apps = state
+        .miniapp_manager
+        .list()
+        .await
+        .map_err(|error| error.to_string())?;
+    let mut origins = HashMap::new();
+    for app in apps {
+        if let Some((origin, _)) = load_market_origin(&state, &app.id).await? {
+            origins.insert(app.id, origin);
+        }
+    }
+    Ok(origins)
+}
+
+/// Reads an app's marketplace origin plus its local-override flag, or `None`
+/// when the app did not come from the marketplace.
+async fn load_market_origin(
+    state: &AppState,
+    app_id: &str,
+) -> Result<Option<(InstalledMarketOrigin, bool)>, String> {
+    let Some(metadata) = state
+        .miniapp_manager
+        .load_customization_metadata(app_id)
+        .await
+        .map_err(|error| error.to_string())?
+    else {
+        return Ok(None);
+    };
+    let local_override = metadata.local_override;
+    Ok(metadata
+        .origin
+        .market
+        .map(|origin| (origin, local_override)))
 }
 
 #[tauri::command]

--- a/src/apps/desktop/src/api/remote_workspace_policy.rs
+++ b/src/apps/desktop/src/api/remote_workspace_policy.rs
@@ -1150,6 +1150,10 @@ pub const REMOTE_WORKSPACE_COMMAND_POLICIES: &[(&str, RemoteWorkspacePolicy)] = 
     ),
     ("miniapp_market_install", RemoteWorkspacePolicy::LocalOnly),
     (
+        "miniapp_market_installed_origins",
+        RemoteWorkspacePolicy::LocalOnly,
+    ),
+    (
         "miniapp_market_installed_status",
         RemoteWorkspacePolicy::LocalOnly,
     ),

--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -1679,6 +1679,7 @@ pub async fn run() {
             api::miniapp_market_api::miniapp_market_list_submissions,
             api::miniapp_market_api::miniapp_market_withdraw_submission,
             api::miniapp_market_api::miniapp_market_installed_status,
+            api::miniapp_market_api::miniapp_market_installed_origins,
             api::miniapp_market_api::miniapp_market_install,
             api::miniapp_market_api::miniapp_market_import_package,
             api::miniapp_market_api::miniapp_market_inspect_package,

--- a/src/web-ui/src/app/scenes/miniapps/components/MiniAppCard.tsx
+++ b/src/web-ui/src/app/scenes/miniapps/components/MiniAppCard.tsx
@@ -12,6 +12,13 @@ interface MiniAppCardProps {
   index?: number;
   isRunning?: boolean;
   isCustomizing?: boolean;
+  /**
+   * Marketplace release this copy was installed from, when it came from the
+   * marketplace. It takes over the version label because `app.version` is a
+   * local edit counter that always starts at 1 — showing it made a freshly
+   * installed v2 read as "v1".
+   */
+  marketReleaseNumber?: number;
   onOpenDetails: (app: MiniAppMeta) => void;
   onOpen: (id: string) => void;
   onDelete: (id: string) => void;
@@ -26,6 +33,7 @@ const MiniAppCard: React.FC<MiniAppCardProps> = ({
   index = 0,
   isRunning = false,
   isCustomizing = false,
+  marketReleaseNumber,
   onOpenDetails,
   onOpen,
   onDelete,
@@ -82,7 +90,7 @@ const MiniAppCard: React.FC<MiniAppCardProps> = ({
         </div>
         <div className="miniapp-card__title-group">
           <span className="miniapp-card__name">{localizedName}</span>
-          <span className="miniapp-card__version">v{app.version}</span>
+          <span className="miniapp-card__version">v{marketReleaseNumber ?? app.version}</span>
         </div>
         {(isRunning || isCustomizing) && (
           <span className="miniapp-card__status-dots" aria-hidden="true">

--- a/src/web-ui/src/app/scenes/miniapps/hooks/useMiniAppCatalogSync.ts
+++ b/src/web-ui/src/app/scenes/miniapps/hooks/useMiniAppCatalogSync.ts
@@ -7,6 +7,7 @@ import { miniAppAPI } from '@/infrastructure/api/service-api/MiniAppAPI';
 import { BackgroundTaskCancelledError } from '@/shared/utils/backgroundTaskScheduler';
 import { createLogger } from '@/shared/utils/logger';
 import { useMiniAppStore } from '../miniAppStore';
+import { loadInstalledMarketOrigins } from '../utils/loadInstalledMarketOrigins';
 import { scheduleMiniAppCatalogStartupRefresh } from './miniAppCatalogStartupRefresh';
 
 const log = createLogger('useMiniAppCatalogSync');
@@ -20,6 +21,7 @@ export function useMiniAppCatalogSync(options: UseMiniAppCatalogSyncOptions = {}
   const { enabled = true, initialLoad = 'immediate' } = options;
   const setApps = useMiniAppStore((state) => state.setApps);
   const setLoading = useMiniAppStore((state) => state.setLoading);
+  const setMarketOrigins = useMiniAppStore((state) => state.setMarketOrigins);
   const setRunningWorkerIds = useMiniAppStore((state) => state.setRunningWorkerIds);
   const markWorkerRunning = useMiniAppStore((state) => state.markWorkerRunning);
   const markWorkerStopped = useMiniAppStore((state) => state.markWorkerStopped);
@@ -27,14 +29,18 @@ export function useMiniAppCatalogSync(options: UseMiniAppCatalogSyncOptions = {}
   const refreshApps = useCallback(async () => {
     setLoading(true);
     try {
-      const apps = await miniAppAPI.listMiniApps();
+      const [apps, origins] = await Promise.all([
+        miniAppAPI.listMiniApps(),
+        loadInstalledMarketOrigins(),
+      ]);
       setApps(apps);
+      setMarketOrigins(origins);
     } catch (error) {
       log.error('Failed to load miniapps', error);
     } finally {
       setLoading(false);
     }
-  }, [setApps, setLoading]);
+  }, [setApps, setLoading, setMarketOrigins]);
 
   const refreshRunningWorkers = useCallback(async () => {
     try {

--- a/src/web-ui/src/app/scenes/miniapps/miniAppStore.test.ts
+++ b/src/web-ui/src/app/scenes/miniapps/miniAppStore.test.ts
@@ -13,6 +13,7 @@ describe('miniAppStore customization state', () => {
       runningWorkerIds: [],
       customizingAppIds: [],
       composerClaims: {},
+      marketOrigins: {},
     });
   });
 
@@ -52,6 +53,34 @@ describe('miniAppStore customization state', () => {
     expect(useMiniAppStore.getState().customizingAppIds).toEqual(['gomoku']);
     expect(useMiniAppStore.getState().openedAppIds).toEqual(['gomoku']);
     expect(useMiniAppStore.getState().runningWorkerIds).toEqual(['gomoku']);
+  });
+
+  it('keeps market origins only for apps still in the catalog', () => {
+    const origin = {
+      listingId: 'listing-1',
+      releaseId: 'release-2',
+      releaseNumber: 2,
+      packageSha256: 'a'.repeat(64),
+    };
+    useMiniAppStore.getState().setMarketOrigin('gomoku', origin);
+    useMiniAppStore.getState().setMarketOrigin('removed-app', origin);
+
+    useMiniAppStore.getState().setApps([
+      {
+        id: 'gomoku',
+        name: 'Gomoku',
+        description: '',
+        category: 'game',
+        version: 1,
+        icon: 'box',
+        tags: [],
+        created_at: 1,
+        updated_at: 1,
+        permissions: {},
+      },
+    ]);
+
+    expect(useMiniAppStore.getState().marketOrigins).toEqual({ gomoku: origin });
   });
 
   it('adds and updates an installed app without waiting for a catalog reload', () => {

--- a/src/web-ui/src/app/scenes/miniapps/miniAppStore.ts
+++ b/src/web-ui/src/app/scenes/miniapps/miniAppStore.ts
@@ -3,6 +3,7 @@
  */
 import { create } from 'zustand';
 import type { MiniAppMeta } from '@/infrastructure/api/service-api/MiniAppAPI';
+import type { InstalledMarketOrigin } from '@/infrastructure/api/service-api/MiniAppMarketAPI';
 
 /**
  * Window event dispatched after the shared ChatInput routes a submission to a
@@ -146,10 +147,20 @@ interface MiniAppState {
   customizingAppIds: string[];
   /** Floating bubble registrations, keyed by app ID (`app.chat.claimComposer`). */
   composerClaims: Record<string, MiniAppComposerClaim>;
+  /**
+   * Marketplace origin of each installed app, keyed by app ID. Apps installed
+   * from anywhere else are simply absent. The local `version` counter on a
+   * MiniApp is independent from the marketplace release number, so this is what
+   * the gallery reads to name the release a user actually installed.
+   */
+  marketOrigins: Record<string, InstalledMarketOrigin>;
 
   setApps: (apps: MiniAppMeta[]) => void;
   upsertApp: (app: MiniAppMeta) => void;
   setLoading: (loading: boolean) => void;
+  setMarketOrigins: (origins: Record<string, InstalledMarketOrigin>) => void;
+  /** Records the origin of a single app right after a market install/update. */
+  setMarketOrigin: (appId: string, origin: InstalledMarketOrigin) => void;
   openApp: (id: string) => void;
   closeApp: (id: string) => void;
   setRunningWorkerIds: (ids: string[]) => void;
@@ -173,6 +184,7 @@ export const useMiniAppStore = create<MiniAppState>((set) => ({
   runningWorkerIds: [],
   customizingAppIds: [],
   composerClaims: {},
+  marketOrigins: {},
 
   setApps: (apps) =>
     set((state) => {
@@ -184,6 +196,9 @@ export const useMiniAppStore = create<MiniAppState>((set) => ({
         customizingAppIds: state.customizingAppIds.filter((id) => validIds.has(id)),
         composerClaims: Object.fromEntries(
           Object.entries(state.composerClaims).filter(([id]) => validIds.has(id))
+        ),
+        marketOrigins: Object.fromEntries(
+          Object.entries(state.marketOrigins).filter(([id]) => validIds.has(id))
         ),
       };
     }),
@@ -198,6 +213,9 @@ export const useMiniAppStore = create<MiniAppState>((set) => ({
       return { apps };
     }),
   setLoading: (loading) => set({ loading }),
+  setMarketOrigins: (marketOrigins) => set({ marketOrigins }),
+  setMarketOrigin: (appId, origin) =>
+    set((state) => ({ marketOrigins: { ...state.marketOrigins, [appId]: origin } })),
 
   openApp: (id) =>
     set((state) =>

--- a/src/web-ui/src/app/scenes/miniapps/utils/loadInstalledMarketOrigins.ts
+++ b/src/web-ui/src/app/scenes/miniapps/utils/loadInstalledMarketOrigins.ts
@@ -1,0 +1,25 @@
+import {
+  miniAppMarketAPI,
+  type InstalledMarketOrigin,
+} from '@/infrastructure/api/service-api/MiniAppMarketAPI';
+import { createLogger } from '@/shared/utils/logger';
+
+const log = createLogger('installedMarketOrigins');
+
+/**
+ * Marketplace origins for the installed catalog, keyed by app id.
+ *
+ * Every catalog load pairs with this so version labels can name the release a
+ * user installed instead of the local edit counter. A failure degrades those
+ * labels back to the local counter rather than taking the catalog down with it.
+ */
+export async function loadInstalledMarketOrigins(): Promise<
+  Record<string, InstalledMarketOrigin>
+> {
+  try {
+    return await miniAppMarketAPI.installedOrigins();
+  } catch (error) {
+    log.warn('Failed to read installed MiniApp market origins', error);
+    return {};
+  }
+}

--- a/src/web-ui/src/app/scenes/miniapps/views/MiniAppGalleryView.tsx
+++ b/src/web-ui/src/app/scenes/miniapps/views/MiniAppGalleryView.tsx
@@ -32,6 +32,7 @@ import {
 } from '@/app/components';
 import type { SceneTabId } from '@/app/components/SceneBar/types';
 import { getMiniAppIconGradient, renderMiniAppIcon } from '../utils/miniAppIcons';
+import { loadInstalledMarketOrigins } from '../utils/loadInstalledMarketOrigins';
 import { pickLocalizedString, pickLocalizedTags } from '../utils/pickLocalizedString';
 import { useCurrentWorkspace } from '@/infrastructure/contexts/WorkspaceContext';
 import { useMiniAppStore } from '../miniAppStore';
@@ -47,8 +48,10 @@ const MiniAppGalleryView: React.FC = () => {
   const loading = useMiniAppStore((state) => state.loading);
   const runningWorkerIds = useMiniAppStore((state) => state.runningWorkerIds);
   const customizingAppIds = useMiniAppStore((state) => state.customizingAppIds);
+  const marketOrigins = useMiniAppStore((state) => state.marketOrigins);
   const setApps = useMiniAppStore((state) => state.setApps);
   const setLoading = useMiniAppStore((state) => state.setLoading);
+  const setMarketOrigins = useMiniAppStore((state) => state.setMarketOrigins);
   const setRunningWorkerIds = useMiniAppStore((state) => state.setRunningWorkerIds);
   const markWorkerStopped = useMiniAppStore((state) => state.markWorkerStopped);
   const { workspacePath } = useCurrentWorkspace();
@@ -160,18 +163,20 @@ const MiniAppGalleryView: React.FC = () => {
   const refetchMiniAppGallery = useCallback(async () => {
     setLoading(true);
     try {
-      const [refreshed, running] = await Promise.all([
+      const [refreshed, running, origins] = await Promise.all([
         miniAppAPI.listMiniApps(),
         miniAppAPI.workerListRunning(),
+        loadInstalledMarketOrigins(),
       ]);
       setApps(refreshed);
       setRunningWorkerIds(running);
+      setMarketOrigins(origins);
     } catch (error) {
       log.error('Failed to refresh miniapp gallery', error);
     } finally {
       setLoading(false);
     }
-  }, [setApps, setLoading, setRunningWorkerIds]);
+  }, [setApps, setLoading, setMarketOrigins, setRunningWorkerIds]);
 
   useGallerySceneAutoRefresh({
     sceneId: 'miniapps',
@@ -294,6 +299,7 @@ const MiniAppGalleryView: React.FC = () => {
             index={index}
             isRunning={runningIdSet.has(app.id)}
             isCustomizing={customizingIdSet.has(app.id)}
+            marketReleaseNumber={marketOrigins[app.id]?.releaseNumber}
             onOpenDetails={setSelectedApp}
             onOpen={handleOpenApp}
             onDelete={handleDeleteRequest}
@@ -347,6 +353,7 @@ const MiniAppGalleryView: React.FC = () => {
                   index={index}
                   isRunning
                   isCustomizing={customizingIdSet.has(app.id)}
+                  marketReleaseNumber={marketOrigins[app.id]?.releaseNumber}
                   onOpenDetails={setSelectedApp}
                   onOpen={handleOpenApp}
                   onDelete={handleDeleteRequest}
@@ -400,7 +407,9 @@ const MiniAppGalleryView: React.FC = () => {
         title={selectedApp ? pickLocalizedString(selectedApp, currentLanguage, 'name') : ''}
         badges={selectedApp?.category ? <Badge variant="info">{selectedApp.category}</Badge> : null}
         description={selectedApp ? pickLocalizedString(selectedApp, currentLanguage, 'description') : undefined}
-        meta={selectedApp ? <span>v{selectedApp.version}</span> : null}
+        meta={selectedApp ? (
+          <span>v{marketOrigins[selectedApp.id]?.releaseNumber ?? selectedApp.version}</span>
+        ) : null}
         actions={selectedApp ? (
           <>
             {runningIdSet.has(selectedApp.id) ? (

--- a/src/web-ui/src/app/scenes/miniapps/views/MiniAppMarketView.scss
+++ b/src/web-ui/src/app/scenes/miniapps/views/MiniAppMarketView.scss
@@ -232,6 +232,23 @@
       font-size: var(--font-size-sm);
     }
   }
+
+  &__releases-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: $size-gap-1;
+    margin-top: $size-gap-2;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: var(--color-text-muted);
+    font-size: var(--font-size-xs);
+    cursor: pointer;
+
+    &:hover {
+      color: var(--color-text-secondary);
+    }
+  }
 }
 
 @media (max-width: 720px) {

--- a/src/web-ui/src/app/scenes/miniapps/views/MiniAppMarketView.tsx
+++ b/src/web-ui/src/app/scenes/miniapps/views/MiniAppMarketView.tsx
@@ -3,6 +3,8 @@ import {
   AlertTriangle,
   ArrowUpRight,
   Check,
+  ChevronDown,
+  ChevronUp,
   Download,
   ExternalLink,
   Heart,
@@ -51,6 +53,7 @@ import { useNotification } from '@/shared/notification-system';
 import { getMiniAppIconGradient, renderMiniAppIcon } from '../utils/miniAppIcons';
 import { useMiniAppStore } from '../miniAppStore';
 import { pickLocalizedString } from '../utils/pickLocalizedString';
+import { buildReleaseHistory } from './miniAppReleaseHistory';
 import './MiniAppMarketView.scss';
 
 const log = createLogger('MiniAppMarketView');
@@ -72,6 +75,7 @@ const MiniAppMarketView: React.FC = () => {
   const { workspace } = useCurrentWorkspace();
   const { openScene, activateScene, openTabs } = useSceneManager();
   const upsertApp = useMiniAppStore((state) => state.upsertApp);
+  const setMarketOrigin = useMiniAppStore((state) => state.setMarketOrigin);
   const [query, setQuery] = useState('');
   const [category, setCategory] = useState<(typeof CATEGORIES)[number]>('all');
   const [sort, setSort] = useState<MarketSort>('newest');
@@ -87,6 +91,7 @@ const MiniAppMarketView: React.FC = () => {
   const [authBusy, setAuthBusy] = useState(false);
   const [actionBusy, setActionBusy] = useState(false);
   const [installPrompt, setInstallPrompt] = useState(false);
+  const [releasesExpanded, setReleasesExpanded] = useState(false);
 
   const openTabIds = useMemo(() => new Set(openTabs.map((tab) => tab.id)), [openTabs]);
 
@@ -143,6 +148,7 @@ const MiniAppMarketView: React.FC = () => {
     setDetailLoading(true);
     setDetail(undefined);
     setInstalled(null);
+    setReleasesExpanded(false);
     try {
       const loaded = await miniAppMarketAPI.getListing(summary.slug);
       setDetail(loaded);
@@ -254,6 +260,7 @@ const MiniAppMarketView: React.FC = () => {
         confirmOverwrite: Boolean(installed?.localOverride),
       });
       upsertApp(result.app);
+      setMarketOrigin(result.app.id, result.origin);
       notification.success(
         t(result.updated ? 'market.messages.updated' : 'market.messages.installed'),
       );
@@ -288,6 +295,7 @@ const MiniAppMarketView: React.FC = () => {
       && isRemoteWorkspace(workspace)
       && requiresWorkspace(detail.permissions),
   );
+  const releaseHistory = buildReleaseHistory(detail?.releases ?? [], releasesExpanded);
   const canUpdate = Boolean(installed && detail && detail.latestRelease > installed.origin.releaseNumber);
   // The install button only renders for the actionable states: fresh install or update.
   const installLabel = canUpdate ? t('market.detail.update') : t('market.detail.install');
@@ -561,7 +569,7 @@ const MiniAppMarketView: React.FC = () => {
             <section>
               <h4>{t('market.detail.releases')}</h4>
               <div className="miniapp-market-detail__releases">
-                {detail.releases.map((release) => (
+                {releaseHistory.visible.map((release) => (
                   <div key={release.releaseId}>
                     <span>v{release.releaseNumber}</span>
                     <span>{release.minBitfunVersion}+</span>
@@ -569,6 +577,19 @@ const MiniAppMarketView: React.FC = () => {
                   </div>
                 ))}
               </div>
+              {detail.releases.length > 1 ? (
+                <button
+                  type="button"
+                  className="miniapp-market-detail__releases-toggle"
+                  aria-expanded={releasesExpanded}
+                  onClick={() => setReleasesExpanded((current) => !current)}
+                >
+                  {releasesExpanded ? <ChevronUp size={13} /> : <ChevronDown size={13} />}
+                  {releasesExpanded
+                    ? t('market.detail.releasesCollapse')
+                    : t('market.detail.releasesExpand', { count: releaseHistory.hiddenCount })}
+                </button>
+              ) : null}
             </section>
             {detail.repositoryUrl ? (
               <Button

--- a/src/web-ui/src/app/scenes/miniapps/views/miniAppReleaseHistory.test.ts
+++ b/src/web-ui/src/app/scenes/miniapps/views/miniAppReleaseHistory.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { buildReleaseHistory } from './miniAppReleaseHistory';
+
+describe('MiniApp market release history', () => {
+  it('collapses to the newest release', () => {
+    const history = buildReleaseHistory(
+      [{ releaseNumber: 2 }, { releaseNumber: 1 }],
+      false,
+    );
+
+    expect(history.visible).toEqual([{ releaseNumber: 2 }]);
+    expect(history.hiddenCount).toBe(1);
+  });
+
+  it('shows every release newest-first once expanded', () => {
+    const history = buildReleaseHistory(
+      [{ releaseNumber: 1 }, { releaseNumber: 3 }, { releaseNumber: 2 }],
+      true,
+    );
+
+    expect(history.visible.map((release) => release.releaseNumber)).toEqual([3, 2, 1]);
+    expect(history.hiddenCount).toBe(0);
+  });
+
+  it('keeps the newest release visible when the list arrives out of order', () => {
+    const history = buildReleaseHistory(
+      [{ releaseNumber: 1 }, { releaseNumber: 4 }],
+      false,
+    );
+
+    expect(history.visible).toEqual([{ releaseNumber: 4 }]);
+  });
+
+  it('offers nothing to expand for a single release', () => {
+    const history = buildReleaseHistory([{ releaseNumber: 1 }], false);
+
+    expect(history.visible).toEqual([{ releaseNumber: 1 }]);
+    expect(history.hiddenCount).toBe(0);
+  });
+});

--- a/src/web-ui/src/app/scenes/miniapps/views/miniAppReleaseHistory.ts
+++ b/src/web-ui/src/app/scenes/miniapps/views/miniAppReleaseHistory.ts
@@ -1,0 +1,28 @@
+/** A release entry as far as the version history list is concerned. */
+export interface ReleaseHistoryEntry {
+  releaseNumber: number;
+}
+
+export interface ReleaseHistoryView<T extends ReleaseHistoryEntry> {
+  /** Releases to render, newest first. */
+  visible: T[];
+  /** Older releases folded away while collapsed. */
+  hiddenCount: number;
+}
+
+/**
+ * Only the newest release matters to someone deciding whether to install, so
+ * the history collapses to that single row until it is expanded. The server
+ * already returns releases newest-first, but the order is re-established here
+ * so the visible row is the newest one regardless of how the list arrived.
+ */
+export function buildReleaseHistory<T extends ReleaseHistoryEntry>(
+  releases: T[],
+  expanded: boolean,
+): ReleaseHistoryView<T> {
+  const ordered = [...releases].sort((a, b) => b.releaseNumber - a.releaseNumber);
+  if (expanded || ordered.length <= 1) {
+    return { visible: ordered, hiddenCount: 0 };
+  }
+  return { visible: ordered.slice(0, 1), hiddenCount: ordered.length - 1 };
+}

--- a/src/web-ui/src/infrastructure/api/service-api/MiniAppMarketAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/MiniAppMarketAPI.ts
@@ -281,6 +281,20 @@ export class MiniAppMarketAPI {
     }
   }
 
+  /**
+   * Marketplace origins of every installed MiniApp, keyed by local app id.
+   * Installed apps carry a local version counter that is independent from the
+   * marketplace release number, so surfaces that want to name the installed
+   * release read it from here.
+   */
+  async installedOrigins(): Promise<Record<string, InstalledMarketOrigin>> {
+    try {
+      return await api.invoke('miniapp_market_installed_origins', {});
+    } catch (error) {
+      throw createTauriCommandError('miniapp_market_installed_origins', error);
+    }
+  }
+
   async install(
     slug: string,
     releaseNumber: number,

--- a/src/web-ui/src/locales/en-US/scenes/miniapp.json
+++ b/src/web-ui/src/locales/en-US/scenes/miniapp.json
@@ -80,6 +80,8 @@
       "rating": "Rating",
       "changelog": "What's new",
       "releases": "Version history",
+      "releasesExpand": "Show older releases ({{count}})",
+      "releasesCollapse": "Show only the latest release",
       "yanked": "Permanently yanked",
       "repository": "View public repository",
       "remoteWorkspaceUnsupported": "This app requires {workspace}; installing and running it is unavailable in remote workspaces.",

--- a/src/web-ui/src/locales/zh-CN/scenes/miniapp.json
+++ b/src/web-ui/src/locales/zh-CN/scenes/miniapp.json
@@ -80,6 +80,8 @@
       "rating": "评分",
       "changelog": "版本说明",
       "releases": "版本历史",
+      "releasesExpand": "展开历史版本（{{count}}）",
+      "releasesCollapse": "仅显示最新版本",
       "yanked": "已永久撤回",
       "repository": "查看公开仓库",
       "remoteWorkspaceUnsupported": "此应用需要 {workspace}，远程工作区暂不支持安装或运行。",

--- a/src/web-ui/src/locales/zh-TW/scenes/miniapp.json
+++ b/src/web-ui/src/locales/zh-TW/scenes/miniapp.json
@@ -80,6 +80,8 @@
       "rating": "評分",
       "changelog": "版本說明",
       "releases": "版本歷史",
+      "releasesExpand": "展開歷史版本（{{count}}）",
+      "releasesCollapse": "僅顯示最新版本",
       "yanked": "已永久撤回",
       "repository": "查看公開儲存庫",
       "remoteWorkspaceUnsupported": "此應用需要 {workspace}，遠端工作區暫不支援安裝或執行。",


### PR DESCRIPTION
## Problem

Two issues reported against the MiniApp marketplace:

1. A listing with several releases shows every release in 版本历史 as an equally current row.
2. After installing a listing whose latest release is v2, the installed app card still reads **v1**, which looks like the install fetched an older package.

## Diagnosis

The second one is a labeling bug, not a wrong download.

- The client installs `detail.latestRelease` and downloads `/listings/{slug}/releases/{n}/download`; the server resolves that row by `release_number`, and the desktop side rejects the package unless its sha256, size, and permissions match the reviewed release (`miniapp_market_api.rs`). The v2 package really is what lands on disk.
- The card renders `v{app.version}`, and `app.version` is the *local* edit counter. `build_created_app` hardcodes it to `1`, and `install_strict_package` deliberately discards the package's own version — the marketplace release number lives in the customization metadata's market origin and is documented as independent from the local counter.

So a fresh install of any release always displayed `v1`.

## Changes

- New `miniapp_market_installed_origins` command returning each installed app's marketplace origin keyed by app id (`LocalOnly` remote-workspace policy, registered in `generate_handler!`). `miniapp_market_installed_status` now shares its metadata lookup.
- `miniAppStore` tracks those origins, loaded alongside the catalog in `useMiniAppCatalogSync` and the gallery refetch, and recorded directly after a market install. A failed origins read degrades the labels to the local counter instead of taking the catalog down.
- `MiniAppCard` and the gallery detail modal show the marketplace release number when the app came from the marketplace; other apps keep the local counter.
- The listing detail's version history collapses to the newest release, with a toggle for the older ones (`buildReleaseHistory`, sorted newest-first so it does not depend on server ordering).
- New i18n strings for en-US / zh-CN / zh-TW.

## Testing

- `vitest run src/app/scenes/miniapps` — 15 files, 51 tests pass (includes new `miniAppReleaseHistory` cases and store coverage for origin pruning)
- `tsc --noEmit` on web-ui
- `eslint` on the touched web-ui paths
- `cargo clippy -p bitfun-desktop --all-targets` — no new warnings
- `cargo test -p bitfun-desktop --lib remote_workspace_policy` — 7 pass
- `pnpm run i18n:audit` — 0 warnings