### PR TITLE
fix(flow-chat): centre single-line user messages in their bubble

### DIFF
--- a/src/web-ui/src/flow_chat/components/modern/UserMessageItem.scss
+++ b/src/web-ui/src/flow_chat/components/modern/UserMessageItem.scss
@@ -7,6 +7,15 @@
 .user-message-item {
   box-sizing: border-box;
   /*
+   * Height of the first text line. The action cluster collapses to this box so
+   * its taller hit targets never drive the row height — see
+   * `.user-message-item__actions`. Variants that restyle the text (e.g.
+   * `--failed`) re-point it to their own line box.
+   */
+  --user-message-line-box: calc(
+    var(--flowchat-font-size-base) * var(--flowchat-text-line-height)
+  );
+  /*
    * Fills the reading column instead of hugging its text: the bubble shares the
    * exact leading and trailing edge as the tool-call bars and body text below
    * it, so a turn reads as one column rather than a right-floating chat bubble.
@@ -110,6 +119,18 @@
   align-items: center;
   gap: 0.125rem;
   flex-shrink: 0;
+  /*
+   * The 28px hit targets are taller than the first-line box, and they keep that
+   * layout box while idle at `opacity: 0`. Left alone the cluster becomes the
+   * tallest item in `.user-message-item__main`, so `align-items: flex-start`
+   * pins a single-line message to the top of an over-tall row and the text
+   * reads as sitting above the bubble's centre. Collapsing the cluster to the
+   * first-line box hands the row height back to the text — restoring the
+   * bubble's symmetric vertical padding — and centres the buttons on the first
+   * line for taller messages.
+   */
+  margin-top: calc((var(--user-message-line-box) - 28px) / 2);
+  margin-bottom: calc((var(--user-message-line-box) - 28px) / 2);
 }
 
 .user-message-item__blocks {
@@ -182,6 +203,8 @@
   --user-message-failed-line-box: calc(
     var(--user-message-failed-font-size) * var(--user-message-failed-line-height)
   );
+  /* Smaller text than the default bubble, so the shared line box follows it. */
+  --user-message-line-box: var(--user-message-failed-line-box);
 
   background: transparent;
   border: none;
@@ -248,8 +271,8 @@
   .user-message-item__actions {
     flex: 0 0 auto;
     align-items: center;
-    /* Match `.user-message-item__copy-btn` height (28px) to first-line box. */
-    margin-top: calc((var(--user-message-failed-line-box) - 28px) / 2);
+    /* Vertical centring on the first line comes from the base rule, which reads
+       the `--user-message-line-box` override above. */
   }
 
   .user-message-item__failed-body .user-message-item__steering-tag {


### PR DESCRIPTION
## Summary

A user message that fits on one line renders with its text sitting above the bubble's vertical centre. This centres it by stopping the idle action buttons from inflating the row.

The action cluster (copy / edit / rollback) keeps its 28px layout box while idle at `opacity: 0` — opacity hides the buttons but does not remove their layout box. That made the cluster taller than the ~22px first-line box and therefore the tallest item in `.user-message-item__main`, whose `align-items: flex-start` then pinned a single-line message to the top of an over-tall row.

## Type and Areas

Type: bug fix (UI/UX)

Areas: web UI (`flow_chat` — user message bubble)

## Motivation / Impact

Single-line messages such as `继续` looked visibly off-centre: 8.36px of space above the text against 14.24px below it, inside a bubble whose padding is a symmetric `0.46rem`. Multi-line messages never showed the problem, because two lines of text (44.23px) already exceed the 28px cluster and the text was driving the row height again — which is why this only reproduced on short messages.

The fix collapses the action cluster to the first-line box, so the text drives the row height and the bubble's symmetric padding is restored. Hit-target size is unchanged (still 28px); the cluster simply stops contributing extra height. The line box is derived from the existing typography tokens rather than hardcoded, so the correction follows the user's font-size preference in both directions.

Two related improvements come along with it:

- The action buttons are now centred on the first text line; they were previously 2.94px low.
- The `--failed` variant already applied this idea but only as a `margin-top`, leaving a residual 2.33px offset. It now re-points the shared `--user-message-line-box` variable and reuses the base rule.

Worth noting as corroboration: the image-export path already excludes `.user-message-item__actions` from the render ([`ExportImageButton.tsx`](../blob/main/src/web-ui/src/flow_chat/components/modern/ExportImageButton.tsx)), so exported conversation images were already tight and centred. The live UI was the odd one out.

## Verification

Measured in-browser against the real compiled stylesheet — `UserMessageItem.scss` and the `apply-design-tokens` mixin compiled together with `sass`, then applied to the component's real DOM structure — rather than reasoning from the source. "Before" was produced by neutralising only the new margins on that same page.

| Metric (single-line message) | Before | After |
| --- | --- | --- |
| Bubble height | 44.72px | 38.84px |
| Space above text | 8.36px | 8.36px |
| Space below text | **14.24px** | 8.37px |
| Text offset from bubble centre | **−2.94px** | **0** |
| Button centre vs first-line centre | −2.94px | 0 |
| Two-line / three-line bubble height | 60.95 / 83.07px | 60.95 / 83.07px (unchanged) |

Also checked with the fix applied: buttons stay inside the bubble (5.42px clearance top and bottom, no clipping), and the pending-steering tag and timestamp variants remain correctly aligned.

Commands run:

- `pnpm run type-check:web` — passes
- `pnpm exec vitest run src/flow_chat/components/modern src/app/startup/startupPerformanceContract.test.ts` — 27 files, 260 tests, all passing
- `node scripts/audit-theme-colors.mjs` — exit 0
- `node scripts/validate-theme-visual-contract.mjs` — 10/10 required surfaces covered

## Reviewer Notes

CSS-only change; no component, markup, or behaviour changes. No new colours, so the theme governance baselines are untouched.

The formula `calc((var(--user-message-line-box) - 28px) / 2)` is deliberately signed: if a larger font preference makes the line box exceed 28px, the margins turn positive and the cluster still matches the first-line box exactly, so the centring holds in both directions.

AI-assisted change. Testing level: fully tested for the layout behaviour it targets (measured before/after plus the focused suites above); not exercised in a running desktop session.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable. (None affected — CSS only.)
