### PR TITLE
fix(web): make agent cards fill responsive grid

### DIFF
--- a/src/web-ui/src/app/scenes/agents/AgentsScene.test.tsx
+++ b/src/web-ui/src/app/scenes/agents/AgentsScene.test.tsx
@@ -232,6 +232,27 @@ describeWithJsdom('AgentsScene', () => {
     expect(stylesheet).toContain('min-width: 0;');
   });
 
+  it('uses the shared responsive gallery grid and lets agent cards fill each track', () => {
+    const sceneSource = readFileSync(
+      fileURLToPath(new URL('./AgentsScene.tsx', import.meta.url)),
+      'utf8',
+    );
+    const agentCardStyles = readFileSync(
+      fileURLToPath(new URL('./components/AgentCard.scss', import.meta.url)),
+      'utf8',
+    );
+    const coreCardSurfaceStyles = readFileSync(
+      fileURLToPath(new URL('./components/_AgentSurfaceCard.scss', import.meta.url)),
+      'utf8',
+    );
+
+    expect(sceneSource.match(/<GalleryGrid minCardWidth=\{360\}>/g)).toHaveLength(2);
+    expect(agentCardStyles).toMatch(/\.agent-card \{\s+width: 100%;\s+min-width: 0;/);
+    expect(coreCardSurfaceStyles).toMatch(/width: 100%;\s+min-width: 0;/);
+    expect(agentCardStyles).not.toContain('width: 360px;');
+    expect(coreCardSurfaceStyles).not.toContain('width: 360px;');
+  });
+
   it('shows skill grouping and editing for a custom subagent with the Skill tool', async () => {
     const subagent = {
       key: 'user::skill-worker',

--- a/src/web-ui/src/app/scenes/agents/AgentsScene.tsx
+++ b/src/web-ui/src/app/scenes/agents/AgentsScene.tsx
@@ -656,7 +656,12 @@ const AgentsHomeView: React.FC = () => {
           )}
         >
           {loading ? (
-            <GallerySkeleton count={3} cardHeight={160} className="core-agent-skeleton" />
+            <GallerySkeleton
+              count={3}
+              cardHeight={160}
+              minCardWidth={360}
+              className="core-agent-skeleton"
+            />
           ) : coreAgents.length === 0 ? (
             <GalleryEmpty
               icon={<Cpu size={32} strokeWidth={1.5} />}
@@ -664,7 +669,7 @@ const AgentsHomeView: React.FC = () => {
               testId="agent-list-empty"
             />
           ) : (
-            <div className="core-agents-grid">
+            <GalleryGrid minCardWidth={360}>
               {coreAgents.map((agent, index) => (
                 <CoreAgentCard
                   key={agent.id}
@@ -690,7 +695,7 @@ const AgentsHomeView: React.FC = () => {
                   }
                 />
               ))}
-            </div>
+            </GalleryGrid>
           )}
         </GalleryZone>
 

--- a/src/web-ui/src/app/scenes/agents/components/AgentCard.scss
+++ b/src/web-ui/src/app/scenes/agents/components/AgentCard.scss
@@ -2,7 +2,8 @@
 @use '../../../styles/surface-stagger';
 
 .agent-card {
-  width: 360px;
+  width: 100%;
+  min-width: 0;
   height: 200px;
   border-radius: 15px;
   background: var(--element-bg-soft);

--- a/src/web-ui/src/app/scenes/agents/components/CoreAgentCard.scss
+++ b/src/web-ui/src/app/scenes/agents/components/CoreAgentCard.scss
@@ -152,34 +152,11 @@
   }
 }
 
-// ── Grid wrapper (3-col max for core section) ─────────────────────
-
-.core-agents-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
-  gap: $size-gap-2;
-  width: 100%;
-}
-
 // ── Animation ─────────────────────────────────────────────────────
 
 @media (prefers-reduced-motion: reduce) {
   .core-agent-card {
     animation: none;
     transition: none;
-  }
-}
-
-// ── Responsive ────────────────────────────────────────────────────
-
-@media (max-width: 1080px) {
-  .core-agents-grid {
-    grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
-  }
-}
-
-@media (max-width: 640px) {
-  .core-agents-grid {
-    grid-template-columns: 1fr;
   }
 }

--- a/src/web-ui/src/app/scenes/agents/components/_AgentSurfaceCard.scss
+++ b/src/web-ui/src/app/scenes/agents/components/_AgentSurfaceCard.scss
@@ -4,7 +4,8 @@
 @mixin agent-surface-card($gradient, $accent) {
   --agent-surface-shadow-color: rgb(var(--color-overlay-slate-rgb));
 
-  width: 360px;
+  width: 100%;
+  min-width: 0;
   height: 200px;
   border-radius: 15px;
   background: var(--element-bg-soft);


### PR DESCRIPTION
## Summary

- Reuse the shared GalleryGrid for the core agents section, matching the MiniApps gallery behavior.
- Let core and overview agent cards fill their responsive grid tracks instead of staying fixed at 360px.
- Align the core-agent loading skeleton with the same 360px minimum track width.
- Add a focused layout regression test.

## Type and Areas

Type: UI/UX, bug fix

Areas: web UI

## Motivation / Impact

The professional agents gallery placed fixed-width cards inside flexible grid tracks. At wider track sizes this left large gaps inside each column and made the page look sparsely laid out.

Cards now expand to fill each track while the shared gallery grid automatically switches between three, two, and one column layouts.

## Verification

- pnpm run type-check:web: passed
- pnpm --dir src/web-ui run test:run src/app/scenes/agents/AgentsScene.test.tsx: 5 tests passed
- git diff --check: passed
- Manual responsive QA with the real GalleryGrid, CoreAgentCard, and AgentCard components:
  - 1600px viewport: 3 columns at about 399px each; no unused space inside grid tracks
  - 1280px viewport: 2 columns at about 458px each; no unused space inside grid tracks
  - 700px viewport: 1 column
  - 420px viewport: 388px cards with no horizontal overflow

Screenshots are omitted because the original report capture contains local session and workspace names. The measured responsive results are recorded above.

## Reviewer Notes

- No user-facing copy, locale resources, theme tokens, or dependencies changed.
- AI-assisted: yes.
- Testing level: fully tested for the affected frontend scope.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.