### PR TITLE
fix(miniapp): isolate agentic floating chat sessions

### DIFF
--- a/src/web-ui/src/app/layout/FloatingMiniChat.tsx
+++ b/src/web-ui/src/app/layout/FloatingMiniChat.tsx
@@ -27,12 +27,18 @@ import {
   useMiniAppStore,
   MINIAPP_COMPOSER_MESSAGE_EVENT,
   MINIAPP_COMPOSER_DRAFT_EVENT,
+  type MiniAppComposerClaim,
+  type MiniAppDraftEventDetail,
   type MiniAppComposerMessageDetail,
 } from '@/app/scenes/miniapps/miniAppStore';
 import { pickLocalizedString } from '@/app/scenes/miniapps/utils/pickLocalizedString';
 import { renderMiniAppIcon } from '@/app/scenes/miniapps/utils/miniAppIcons';
 import MiniAppBubbleWelcome from './MiniAppBubbleWelcome';
 import { isFloatingMiniChatSessionExecuting } from './floatingMiniChatActivity';
+import {
+  canRenderFloatingMiniChatSession,
+  isFloatingMiniChatIsolated,
+} from './floatingMiniChatIsolation';
 import './FloatingMiniChat.scss';
 
 /**
@@ -59,6 +65,8 @@ export const FloatingMiniChat: React.FC = () => {
   const [composerPrefill, setComposerPrefill] = useState<{
     id: number;
     text: string;
+    claimToken: string;
+    sessionId?: string;
   } | null>(null);
   const composerPrefillIdRef = useRef(0);
   /** True while a press that may legitimately close the panel is in flight. */
@@ -101,18 +109,25 @@ export const FloatingMiniChat: React.FC = () => {
   const bubbleCustomization = activeComposerClaim?.customization;
   const activeComposerToken = activeComposerClaim?.token;
   const activeComposerSessionId = activeComposerClaim?.sessionId;
+  const isMiniAppBubbleIsolated = isFloatingMiniChatIsolated({
+    activeMiniAppId,
+    permissions: activeMiniApp?.permissions,
+    hasComposerClaim: Boolean(activeComposerClaim),
+  });
   const {
     activeSession,
     trackedSession: activeMiniAppSession,
     sessionTitle,
   } = useFlowChatSessions(activeComposerSessionId);
-  const isMiniAppSessionReady = Boolean(
-    activeComposerSessionId && activeSession?.sessionId === activeComposerSessionId
-  );
-  const displayedSession = activeComposerClaim
+  const isMiniAppSessionReady = canRenderFloatingMiniChatSession({
+    isolated: isMiniAppBubbleIsolated,
+    claimedSessionId: activeComposerSessionId,
+    activeSessionId: activeSession?.sessionId,
+  });
+  const displayedSession = isMiniAppBubbleIsolated
     ? activeMiniAppSession
     : activeSession;
-  const displayedTitle = activeComposerClaim
+  const displayedTitle = isMiniAppBubbleIsolated
     ? (bubbleCustomization?.title || activeMiniAppName)
     : sessionTitle;
 
@@ -144,17 +159,24 @@ export const FloatingMiniChat: React.FC = () => {
     setPhase('closed');
   }, []);
 
-  const setMiniAppComposerDraft = useCallback((text: string) => {
+  const setMiniAppComposerDraft = useCallback((
+    text: string,
+    claimToken: string,
+    sessionId?: string,
+  ) => {
     composerPrefillIdRef.current += 1;
     setComposerPrefill({
       id: composerPrefillIdRef.current,
       text,
+      claimToken,
+      sessionId,
     });
   }, []);
 
   const handleMiniAppSuggestion = useCallback((prompt: string) => {
-    setMiniAppComposerDraft(prompt);
-  }, [setMiniAppComposerDraft]);
+    if (!activeComposerToken) return;
+    setMiniAppComposerDraft(prompt, activeComposerToken, activeComposerSessionId);
+  }, [activeComposerSessionId, activeComposerToken, setMiniAppComposerDraft]);
 
   const handleMiniAppDraftConsumed = useCallback((id: number) => {
     setComposerPrefill((current) => (current?.id === id ? null : current));
@@ -189,7 +211,9 @@ export const FloatingMiniChat: React.FC = () => {
       // Registration presence makes this an isolated workspace even when the
       // hidden session has no path, so the normal project never leaks in.
       workspacePath: displayedSession?.workspacePath || '',
-      draft: composerPrefill || undefined,
+      draft: composerPrefill
+        ? { id: composerPrefill.id, text: composerPrefill.text }
+        : undefined,
       onDraftConsumed: handleMiniAppDraftConsumed,
       onSubmit: handleMiniAppSubmit,
     };
@@ -205,8 +229,75 @@ export const FloatingMiniChat: React.FC = () => {
   ]);
 
   useEffect(() => {
-    setComposerPrefill(null);
+    setComposerPrefill((current) => {
+      if (!current) return current;
+      if (current.claimToken !== activeComposerToken) return null;
+      // focusSession and setComposerDraft are two consecutive bridge calls.
+      // React may observe their host-store updates in either order, so keep a
+      // draft that already identifies the newly focused session instead of
+      // clearing it during that transition.
+      if (current.sessionId && current.sessionId !== activeComposerSessionId) {
+        return null;
+      }
+      return current;
+    });
   }, [activeComposerSessionId, activeComposerToken]);
+
+  const activateMiniAppSession = useCallback((claim: MiniAppComposerClaim | undefined) => {
+    const sessionId = claim?.sessionId;
+    if (!sessionId) return false;
+    const state = flowChatStore.getState();
+    if (!state.sessions.has(sessionId)) return false;
+    if (state.activeSessionId !== sessionId) {
+      flowChatStore.switchSession(sessionId);
+    }
+    syncSessionToModernStore(sessionId);
+    return true;
+  }, []);
+
+  const rememberPreviousHostSession = useCallback((claimToken: string) => {
+    if (previousHostSessionRef.current?.claimToken === claimToken) return;
+    const state = flowChatStore.getState();
+    const currentSession = state.activeSessionId
+      ? state.sessions.get(state.activeSessionId)
+      : undefined;
+    previousHostSessionRef.current = {
+      claimToken,
+      sessionId:
+        currentSession && currentSession.sessionKind !== 'miniapp'
+          ? currentSession.sessionId
+          : null,
+    };
+  }, []);
+
+  const restorePreviousHostSession = useCallback((claimToken?: string) => {
+    const previous = previousHostSessionRef.current;
+    if (
+      !previous
+      || (claimToken !== undefined && previous.claimToken !== claimToken)
+    ) return;
+    previousHostSessionRef.current = null;
+    if (!previous.sessionId) return;
+
+    const latest = flowChatStore.getState();
+    if (!latest.sessions.has(previous.sessionId)) return;
+    const currentSession = latest.activeSessionId
+      ? latest.sessions.get(latest.activeSessionId)
+      : undefined;
+    // Do not overwrite an explicit navigation that already selected another
+    // ordinary session while the bubble was closing/unmounting.
+    if (
+      currentSession
+      && currentSession.sessionKind !== 'miniapp'
+      && currentSession.sessionId !== previous.sessionId
+    ) {
+      return;
+    }
+    if (latest.activeSessionId !== previous.sessionId) {
+      flowChatStore.switchSession(previous.sessionId);
+    }
+    syncSessionToModernStore(previous.sessionId);
+  }, []);
 
   // ChatPane is intentionally the shared session surface, so displaying a
   // MiniApp session temporarily switches the shared store. Capture the user's
@@ -215,31 +306,24 @@ export const FloatingMiniChat: React.FC = () => {
   useEffect(() => {
     if (!isOpen || !activeComposerToken) return;
 
-    const state = flowChatStore.getState();
-    const currentSession = state.activeSessionId
-      ? state.sessions.get(state.activeSessionId)
-      : undefined;
-    previousHostSessionRef.current = {
-      claimToken: activeComposerToken,
-      sessionId:
-        currentSession && currentSession.sessionKind !== 'miniapp'
-          ? currentSession.sessionId
-          : null,
-    };
+    rememberPreviousHostSession(activeComposerToken);
 
     return () => {
-      const previous = previousHostSessionRef.current;
-      if (!previous || previous.claimToken !== activeComposerToken) return;
-      previousHostSessionRef.current = null;
-      if (!previous.sessionId) return;
-      const latest = flowChatStore.getState();
-      if (!latest.sessions.has(previous.sessionId)) return;
-      if (latest.activeSessionId !== previous.sessionId) {
-        flowChatStore.switchSession(previous.sessionId);
-      }
-      syncSessionToModernStore(previous.sessionId);
+      restorePreviousHostSession(activeComposerToken);
     };
-  }, [activeComposerToken, isOpen]);
+  }, [
+    activeComposerToken,
+    isOpen,
+    rememberPreviousHostSession,
+    restorePreviousHostSession,
+  ]);
+
+  // setComposerDraft activates the MiniApp session synchronously before the
+  // open-state effect commits. Keep an unconditional unmount fallback so a
+  // simultaneous scene change cannot strand that hidden session globally.
+  useEffect(() => () => {
+    restorePreviousHostSession();
+  }, [restorePreviousHostSession]);
 
   // The claim carries the topic's dedicated session. Activate it only while
   // the bubble is open; if the Agent session has not reached FlowChat yet,
@@ -247,42 +331,61 @@ export const FloatingMiniChat: React.FC = () => {
   useEffect(() => {
     if (!isOpen || !activeComposerToken || !activeComposerSessionId) return;
 
-    const activateDedicatedSession = () => {
-      const state = flowChatStore.getState();
-      if (!state.sessions.has(activeComposerSessionId)) return false;
-      if (state.activeSessionId !== activeComposerSessionId) {
-        flowChatStore.switchSession(activeComposerSessionId);
-      }
-      syncSessionToModernStore(activeComposerSessionId);
-      return true;
-    };
-
-    if (activateDedicatedSession()) return;
+    if (activateMiniAppSession(activeComposerClaim)) return;
     const unsubscribe = flowChatStore.subscribe((state) => {
       if (!state.sessions.has(activeComposerSessionId)) return;
       unsubscribe();
-      activateDedicatedSession();
+      activateMiniAppSession(activeComposerClaim);
     });
     return unsubscribe;
-  }, [activeComposerSessionId, activeComposerToken, isOpen]);
+  }, [
+    activateMiniAppSession,
+    activeComposerClaim,
+    activeComposerSessionId,
+    activeComposerToken,
+    isOpen,
+  ]);
 
   // A MiniApp holding the composer can hand it a prepared prompt (PPT Live's
   // welcome examples). Open the bubble so the user sees what landed there and
   // can edit before sending — this never submits on its own.
   useEffect(() => {
     const claimToken = activeComposerClaim?.token;
-    if (!claimToken) return;
+    if (!claimToken || !activeMiniAppId) return;
     const handler = (e: Event) => {
-      const detail = (e as CustomEvent<{ token?: string; text?: string }>).detail;
+      const detail = (e as CustomEvent<MiniAppDraftEventDetail>).detail;
       if (!detail || detail.token !== claimToken || typeof detail.text !== 'string') return;
-      setMiniAppComposerDraft(detail.text);
+      // focusSession and setComposerDraft can arrive before React commits the
+      // updated claim. Read the live claim, switch synchronously, then open the
+      // panel so its first rendered frame already owns the correct session.
+      const liveClaim = useMiniAppStore.getState().composerClaims[activeMiniAppId];
+      if (liveClaim?.token !== detail.token) return;
+      // The live claim is authoritative if a newer focusSession overtook an
+      // older queued draft event. The event snapshot is only a fallback for
+      // the same host transition.
+      const sessionId = liveClaim.sessionId || detail.sessionId;
+      const draftClaim = sessionId && liveClaim.sessionId !== sessionId
+        ? { ...liveClaim, sessionId }
+        : liveClaim;
+      // The draft path activates the topic before React opens the panel, so
+      // capture the ordinary chat first; closing the bubble must restore it.
+      rememberPreviousHostSession(detail.token);
+      activateMiniAppSession(draftClaim);
+      setMiniAppComposerDraft(detail.text, detail.token, sessionId);
       handleOpen();
     };
     window.addEventListener(MINIAPP_COMPOSER_DRAFT_EVENT, handler);
     return () => {
       window.removeEventListener(MINIAPP_COMPOSER_DRAFT_EVENT, handler);
     };
-  }, [activeComposerClaim?.token, handleOpen, setMiniAppComposerDraft]);
+  }, [
+    activateMiniAppSession,
+    activeComposerClaim?.token,
+    activeMiniAppId,
+    handleOpen,
+    rememberPreviousHostSession,
+    setMiniAppComposerDraft,
+  ]);
 
   // Open on pointer press, not on click. A click only fires when pointerdown
   // and pointerup land on the same element, so anything that moves or replaces
@@ -396,14 +499,14 @@ export const FloatingMiniChat: React.FC = () => {
         type="button"
         className={[
           'bitfun-fmc__button',
-          activeComposerClaim && 'bitfun-fmc__button--miniapp',
+          isMiniAppBubbleIsolated && 'bitfun-fmc__button--miniapp',
           isMiniAppSessionExecuting && 'bitfun-fmc__button--processing',
         ].filter(Boolean).join(' ')}
         onPointerDown={handleTriggerPointerDown}
         onClick={handleOpen}
         aria-expanded={isOpen}
         aria-busy={isMiniAppSessionExecuting || undefined}
-        aria-label={activeComposerClaim ? displayedTitle : t('toolCards.toolbar.startNewChat')}
+        aria-label={isMiniAppBubbleIsolated ? displayedTitle : t('toolCards.toolbar.startNewChat')}
       >
         {isMiniAppSessionExecuting && (
           <span
@@ -411,7 +514,7 @@ export const FloatingMiniChat: React.FC = () => {
             aria-hidden="true"
           />
         )}
-        {activeComposerClaim ? (
+        {isMiniAppBubbleIsolated ? (
           <span
             className="bitfun-fmc__miniapp-trigger-icon"
             aria-hidden="true"
@@ -430,11 +533,11 @@ export const FloatingMiniChat: React.FC = () => {
         onKeyDown={handlePanelKeyDown}
         onTransitionEnd={handlePanelTransitionEnd}
       >
-        {/* Header — normal chat keeps the shared SessionMenu. A claimed
-            MiniApp bubble replaces that switcher with app identity so the user
-            cannot navigate the dedicated composer back into a normal chat. */}
+        {/* Header — normal chat keeps the shared SessionMenu. An isolated
+            Agentic MiniApp replaces that switcher with app identity, including
+            during claim/session bootstrap, so normal chats are never exposed. */}
         <div className="bitfun-fmc__header">
-          {activeComposerClaim ? (
+          {isMiniAppBubbleIsolated ? (
             <div
               className="bitfun-fmc__miniapp-session-icon"
               aria-hidden="true"
@@ -465,13 +568,13 @@ export const FloatingMiniChat: React.FC = () => {
             panel is open to avoid running a second VirtualMessageList and store
             sync in the background while the agent streams in another scene. */}
         <div className="bitfun-fmc__body">
-          {surfaceMounted && (!activeComposerClaim || isMiniAppSessionReady) && (
+          {surfaceMounted && isMiniAppSessionReady && (
             <ChatPane
               width={0}
               isFullscreen={false}
               isSceneActive
               workspacePath={
-                activeComposerClaim
+                isMiniAppBubbleIsolated
                   ? displayedSession?.workspacePath
                   : workspacePath
               }
@@ -489,7 +592,7 @@ export const FloatingMiniChat: React.FC = () => {
               ) : undefined}
             />
           )}
-          {surfaceMounted && activeComposerClaim && !isMiniAppSessionReady && (
+          {surfaceMounted && isMiniAppBubbleIsolated && !isMiniAppSessionReady && (
             <div className="bitfun-fmc__miniapp-session-pending">
               <div
                 className="bitfun-fmc__miniapp-session-pending-icon"

--- a/src/web-ui/src/app/layout/floatingMiniChatIsolation.test.ts
+++ b/src/web-ui/src/app/layout/floatingMiniChatIsolation.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  canRenderFloatingMiniChatSession,
+  isFloatingMiniChatIsolated,
+} from './floatingMiniChatIsolation';
+
+describe('floating MiniApp chat isolation', () => {
+  it('does not reserve the ordinary floating chat outside a MiniApp scene', () => {
+    expect(isFloatingMiniChatIsolated({
+      activeMiniAppId: null,
+      permissions: undefined,
+      hasComposerClaim: false,
+    })).toBe(false);
+  });
+
+  it('reserves an Agentic composer surface before its iframe claim arrives', () => {
+    expect(isFloatingMiniChatIsolated({
+      activeMiniAppId: 'market-lens',
+      permissions: {
+        agent: { enabled: true },
+      },
+      hasComposerClaim: false,
+    })).toBe(true);
+  });
+
+  it('fails closed while active MiniApp metadata is still loading', () => {
+    expect(isFloatingMiniChatIsolated({
+      activeMiniAppId: 'market-lens',
+      permissions: undefined,
+      hasComposerClaim: false,
+    })).toBe(true);
+  });
+
+  it('keeps a claimed legacy MiniApp isolated regardless of manifest flags', () => {
+    expect(isFloatingMiniChatIsolated({
+      activeMiniAppId: 'legacy-agent-app',
+      permissions: {},
+      hasComposerClaim: true,
+    })).toBe(true);
+  });
+
+  it('leaves the normal bubble available to a known non-Agentic MiniApp', () => {
+    expect(isFloatingMiniChatIsolated({
+      activeMiniAppId: 'regex-playground',
+      permissions: {},
+      hasComposerClaim: false,
+    })).toBe(false);
+  });
+
+  it('never mounts a normal or unrelated session into an isolated surface', () => {
+    expect(canRenderFloatingMiniChatSession({
+      isolated: true,
+      claimedSessionId: 'miniapp-session',
+      activeSessionId: 'normal-session',
+    })).toBe(false);
+    expect(canRenderFloatingMiniChatSession({
+      isolated: true,
+      claimedSessionId: undefined,
+      activeSessionId: 'normal-session',
+    })).toBe(false);
+  });
+
+  it('mounts an isolated surface only for its exact claimed session', () => {
+    expect(canRenderFloatingMiniChatSession({
+      isolated: true,
+      claimedSessionId: 'miniapp-session',
+      activeSessionId: 'miniapp-session',
+    })).toBe(true);
+  });
+
+  it('does not constrain the ordinary floating chat session', () => {
+    expect(canRenderFloatingMiniChatSession({
+      isolated: false,
+      claimedSessionId: undefined,
+      activeSessionId: 'normal-session',
+    })).toBe(true);
+  });
+});

--- a/src/web-ui/src/app/layout/floatingMiniChatIsolation.ts
+++ b/src/web-ui/src/app/layout/floatingMiniChatIsolation.ts
@@ -1,0 +1,49 @@
+interface MiniAppBubblePermissions {
+  agent?: { enabled?: boolean };
+}
+
+interface FloatingMiniChatIsolationInput {
+  activeMiniAppId: string | null;
+  permissions: MiniAppBubblePermissions | undefined;
+  hasComposerClaim: boolean;
+}
+
+/**
+ * Reserves the floating chat surface for an Agentic MiniApp before its iframe
+ * finishes claiming the composer, and keeps it reserved if that claim is
+ * temporarily released during a reload. Unknown metadata is isolated too:
+ * showing a pending surface is safer than flashing an unrelated normal chat.
+ */
+export function isFloatingMiniChatIsolated({
+  activeMiniAppId,
+  permissions,
+  hasComposerClaim,
+}: FloatingMiniChatIsolationInput): boolean {
+  if (!activeMiniAppId) return false;
+  if (hasComposerClaim) return true;
+  if (!permissions) return true;
+  // Agent permission is the only capability signal shared by strict
+  // marketplace apps and compatibility built-ins. A strict app additionally
+  // needs host.chat_composer to claim, but older built-ins such as PPT Live do
+  // not declare that host permission even though they own this bubble.
+  return permissions.agent?.enabled === true;
+}
+
+interface FloatingMiniChatSessionGateInput {
+  isolated: boolean;
+  claimedSessionId: string | undefined;
+  activeSessionId: string | undefined;
+}
+
+/**
+ * An isolated MiniApp surface may mount the shared ChatPane only when the
+ * global session is exactly the session validated and bound by that MiniApp.
+ */
+export function canRenderFloatingMiniChatSession({
+  isolated,
+  claimedSessionId,
+  activeSessionId,
+}: FloatingMiniChatSessionGateInput): boolean {
+  if (!isolated) return true;
+  return Boolean(claimedSessionId && activeSessionId === claimedSessionId);
+}

--- a/src/web-ui/src/app/scenes/miniapps/hooks/useMiniAppBridge.test.tsx
+++ b/src/web-ui/src/app/scenes/miniapps/hooks/useMiniAppBridge.test.tsx
@@ -8,7 +8,11 @@ import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { MiniApp } from '@/infrastructure/api/service-api/MiniAppAPI';
-import { useMiniAppStore } from '../miniAppStore';
+import {
+  MINIAPP_COMPOSER_DRAFT_EVENT,
+  type MiniAppDraftEventDetail,
+  useMiniAppStore,
+} from '../miniAppStore';
 import { useMiniAppBridge } from './useMiniAppBridge';
 
 const mocks = vi.hoisted(() => ({
@@ -181,6 +185,52 @@ describe('useMiniAppBridge floating Agent routing', () => {
 
     expect(mocks.agentRun).toHaveBeenCalledTimes(1);
     expect(mocks.openMainSession).not.toHaveBeenCalled();
+  });
+
+  it('associates a composer draft with the session focused immediately before it', async () => {
+    await act(async () => {
+      root.render(<BridgeHarness />);
+    });
+    const iframe = container.querySelector('iframe') as HTMLIFrameElement;
+    const drafts: MiniAppDraftEventDetail[] = [];
+    const onDraft = (event: Event) => {
+      drafts.push((event as CustomEvent<MiniAppDraftEventDetail>).detail);
+    };
+    window.addEventListener(MINIAPP_COMPOSER_DRAFT_EVENT, onDraft);
+
+    try {
+      await dispatchRpc(iframe, 1, 'chat.claimComposer');
+      await dispatchRpc(iframe, 2, 'agent.ensureSession', {
+        sessionName: 'Market Lens',
+        appDataWorkspace: 'chat',
+      });
+      await dispatchRpc(iframe, 3, 'chat.focusSession', { sessionId: 'session-1' });
+      await dispatchRpc(iframe, 4, 'chat.setComposerDraft', {
+        text: 'Analyze 920130',
+      });
+    } finally {
+      window.removeEventListener(MINIAPP_COMPOSER_DRAFT_EVENT, onDraft);
+    }
+
+    expect(drafts).toEqual([{
+      token: expect.any(String),
+      text: 'Analyze 920130',
+      sessionId: 'session-1',
+    }]);
+  });
+
+  it('refuses to bind the bubble to a session the MiniApp did not create', async () => {
+    await act(async () => {
+      root.render(<BridgeHarness />);
+    });
+    const iframe = container.querySelector('iframe') as HTMLIFrameElement;
+
+    await dispatchRpc(iframe, 1, 'chat.claimComposer');
+    await dispatchRpc(iframe, 2, 'chat.focusSession', {
+      sessionId: 'normal-user-session',
+    });
+
+    expect(useMiniAppStore.getState().composerClaims[app.id]?.sessionId).toBeUndefined();
   });
 
   it('opens an unbound strict Agent run in the main session scene', async () => {

--- a/src/web-ui/src/app/scenes/miniapps/hooks/useMiniAppBridge.ts
+++ b/src/web-ui/src/app/scenes/miniapps/hooks/useMiniAppBridge.ts
@@ -494,7 +494,11 @@ export function useMiniAppBridge(
             }
             window.dispatchEvent(
               new CustomEvent(MINIAPP_COMPOSER_DRAFT_EVENT, {
-                detail: { token: composerTokenRef.current, text: String(params.text ?? '') },
+                detail: {
+                  token: composerTokenRef.current,
+                  text: String(params.text ?? ''),
+                  sessionId: claim.sessionId,
+                },
               }),
             );
             reply(null);

--- a/src/web-ui/src/app/scenes/miniapps/miniAppStore.ts
+++ b/src/web-ui/src/app/scenes/miniapps/miniAppStore.ts
@@ -29,6 +29,13 @@ export interface MiniAppComposerMessageDetail {
  */
 export const MINIAPP_COMPOSER_DRAFT_EVENT = 'miniapp-composer-draft';
 
+export interface MiniAppDraftEventDetail {
+  token: string;
+  text: string;
+  /** Session the draft belongs to when the claim is already topic-bound. */
+  sessionId?: string;
+}
+
 export interface MiniAppBubbleSuggestion {
   label: string;
   prompt: string;

--- a/src/web-ui/src/flow_chat/components/toolbar-mode/toolbarModeSessionSurface.test.ts
+++ b/src/web-ui/src/flow_chat/components/toolbar-mode/toolbarModeSessionSurface.test.ts
@@ -94,15 +94,40 @@ describe('floating mini chat bubble MiniApp registration', () => {
     expect(source).toContain('onDraftConsumed: handleMiniAppDraftConsumed');
   });
 
-  it('shows only the active MiniApp topic session while its claim is active', () => {
-    expect(source).toContain('activeComposerClaim?.sessionId');
-    expect(source).toContain(
-      'activeSession?.sessionId === activeComposerSessionId'
+  it('activates the freshly bound topic before opening a MiniApp draft', () => {
+    expect(source).toContain('const liveClaim = useMiniAppStore.getState().composerClaims');
+    expect(source).toContain('const sessionId = liveClaim.sessionId || detail.sessionId');
+
+    const rememberIndex = source.indexOf('rememberPreviousHostSession(detail.token);');
+    const activateIndex = source.indexOf('activateMiniAppSession(draftClaim);');
+    const draftIndex = source.indexOf(
+      'setMiniAppComposerDraft(detail.text, detail.token, sessionId);',
     );
+    const openIndex = source.indexOf('handleOpen();', draftIndex);
+    expect(rememberIndex).toBeGreaterThan(-1);
+    expect(activateIndex).toBeGreaterThan(rememberIndex);
+    expect(draftIndex).toBeGreaterThan(activateIndex);
+    expect(openIndex).toBeGreaterThan(draftIndex);
+  });
+
+  it('does not clear a draft that already belongs to the newly focused session', () => {
+    expect(source).toContain('claimToken: string');
+    expect(source).toContain('sessionId?: string');
+    expect(source).toContain('current.claimToken !== activeComposerToken');
+    expect(source).toContain('current.sessionId !== activeComposerSessionId');
+  });
+
+  it('fails closed around an Agentic MiniApp and shows only its exact topic session', () => {
+    expect(source).toContain('activeComposerClaim?.sessionId');
+    expect(source).toContain('isFloatingMiniChatIsolated({');
+    expect(source).toContain('canRenderFloatingMiniChatSession({');
+    expect(source).toContain('surfaceMounted && isMiniAppSessionReady');
     expect(source).toContain(
-      'surfaceMounted && (!activeComposerClaim || isMiniAppSessionReady)'
+      'surfaceMounted && isMiniAppBubbleIsolated && !isMiniAppSessionReady'
     );
     expect(source).toContain('previousHostSessionRef');
+    expect(source).toContain('restorePreviousHostSession(activeComposerToken)');
+    expect(source).toContain('restorePreviousHostSession();');
   });
 
   it('renders the MiniApp entry model against the topic session workspace', () => {
@@ -114,7 +139,7 @@ describe('floating mini chat bubble MiniApp registration', () => {
     expect(source).not.toContain('getMiniAppIconGradient');
     // The ordinary project workspace remains valid only for the host session.
     expect(source).toContain(
-      'activeComposerClaim\n                  ? displayedSession?.workspacePath\n                  : workspacePath'
+      'isMiniAppBubbleIsolated\n                  ? displayedSession?.workspacePath\n                  : workspacePath'
     );
   });
 


### PR DESCRIPTION
## Summary

- Bind MiniApp composer drafts to the host-validated topic session and activate that exact session before opening the floating chat.
- Fail closed for Agentic MiniApps during claim/session bootstrap or reload, so the shared `ChatPane` never mounts an ordinary or unrelated session.
- Restore the previous ordinary host session safely when the bubble closes, while preserving explicit navigation and rejecting foreign session bindings.

## Type and Areas

Type: Regression fix / UI behavior / test

Areas: Web UI, MiniApp bridge, floating chat session routing

## Motivation / Impact

Agentic MiniApps own a dedicated floating conversation. A fast `focusSession` + `setComposerDraft` sequence, or a temporary composer-claim gap during loading, could previously expose an unrelated normal conversation or open an empty surface. This change makes the MiniApp session identity authoritative and keeps the surface pending until that exact session is active.

## Verification

- `pnpm run type-check:web` — passed
- `pnpm --dir src/web-ui run test:run src/app/layout/floatingMiniChatIsolation.test.ts src/app/scenes/miniapps/hooks/useMiniAppBridge.test.tsx src/app/scenes/miniapps/miniAppStore.test.ts src/flow_chat/components/toolbar-mode/toolbarModeSessionSurface.test.ts` — 4 files, 40 tests passed
- `git diff --check` — passed

## Reviewer Notes

AI-assisted implementation. The PR is isolated from the unrelated dispatch refactor branch and contains only the seven Web UI files required for this contract fix. No user-facing strings or locale resources changed.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.