### PR TITLE
fix(web): stop a stale model-migration notice from reverting the picked model

### DIFF
--- a/src/web-ui/src/flow_chat/components/ModelSelector.tsx
+++ b/src/web-ui/src/flow_chat/components/ModelSelector.tsx
@@ -20,6 +20,7 @@ import { getEffectiveReasoningMode, isReasoningVisiblyEnabled } from '@/infrastr
 import { globalEventBus } from '@/infrastructure/event-bus';
 import type { AIModelConfig, AgentModelDefaultsConfig, DefaultModelsConfig } from '@/infrastructure/config/types';
 import { Switch, Tooltip } from '@/component-library';
+import { notificationService } from '@/shared/notification-system';
 import { FlowChatStore } from '../store/FlowChatStore';
 import { getModelMaxTokens } from '../services/flow-chat-manager/SessionModule';
 import { acpClientIdFromAgentType } from '../utils/acpSession';
@@ -570,6 +571,15 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
     setLoading(true);
     setDropdownOpen(false);
 
+    // The optimistic session write below must be undone when the backend
+    // rejects the switch; otherwise the selector keeps showing a model the
+    // session never adopted, and the next send pushes it to the backend.
+    const store = FlowChatStore.getInstance();
+    const previousSessionModelName = sessionId
+      ? store.getState().sessions.get(sessionId)?.config.modelName
+      : undefined;
+    let sessionModelWrittenOptimistically = false;
+
     try {
       if (externalSelection) {
         await externalSelection.onSelect(modelId);
@@ -586,7 +596,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
         });
         setAcpOptions(options);
         syncAcpContextUsageToStore(sessionId, options);
-        FlowChatStore.getInstance().updateSessionModelName(sessionId, modelId);
+        store.updateSessionModelName(sessionId, modelId);
         log.info('ACP session model updated', { sessionId, acpClientId, modelId });
         return;
       }
@@ -594,10 +604,10 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
       const updateTargetSessionModel = async () => {
         if (!sessionId) return;
 
-        const store = FlowChatStore.getInstance();
         // Update the frontend session model immediately so the UI reflects the
         // switch without waiting for the backend IPC round-trip.
         store.updateSessionModelName(sessionId, modelId);
+        sessionModelWrittenOptimistically = true;
         const maxContextTokens = await getModelMaxTokens(modelId, currentMode);
         store.updateSessionMaxContextTokens(sessionId, maxContextTokens);
         const session = store.getState().sessions.get(sessionId);
@@ -628,6 +638,13 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
       globalEventBus.emit('mode:config:updated');
     } catch (error) {
       log.error('Failed to switch model', error);
+      // Only a previously pinned selection can be restored: the store has no
+      // way to express "never pinned", and forcing 'auto' there would claim a
+      // binding the session does not have either.
+      if (sessionId && sessionModelWrittenOptimistically && previousSessionModelName) {
+        store.updateSessionModelName(sessionId, previousSessionModelName);
+      }
+      notificationService.error(t('modelSelector.switchFailed'));
     } finally {
       setLoading(false);
     }
@@ -642,6 +659,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
     isAcpSession,
     loading,
     sessionId,
+    t,
     targetIsSubagent,
   ]);
 

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
@@ -1181,11 +1181,24 @@ function handleSessionTitleGenerated(event: any): void {
 }
 
 function handleSessionModelAutoMigrated(event: SessionModelAutoMigratedEvent): void {
-  const { sessionId, newModelId } = event;
+  const { sessionId, previousModelId, newModelId, reason } = event;
   if (!sessionId || !newModelId) return;
 
   const store = FlowChatStore.getInstance();
-  store.updateSessionModelName(sessionId, newModelId);
+  const applied = store.applySessionModelAutoMigration(
+    sessionId,
+    previousModelId ?? '',
+    newModelId,
+  );
+  if (!applied) {
+    log.debug('Ignoring stale session model migration', {
+      sessionId,
+      previousModelId,
+      newModelId,
+      reason,
+      currentModelId: store.getState().sessions.get(sessionId)?.config.modelName,
+    });
+  }
 }
 
 /**

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
@@ -1154,6 +1154,73 @@ describe('FlowChatStore session model selection', () => {
 
     expect(flowChatStore.getState().sessions.get(session.sessionId)?.config.modelName).toBe('auto');
   });
+
+  it('applies an auto-migration notice that matches the stored model', () => {
+    const session = createSession({
+      config: { agentType: 'agentic', modelName: 'removed-model' },
+    });
+    flowChatStore.setState(() => ({
+      sessions: new Map([[session.sessionId, session]]),
+      activeSessionId: session.sessionId,
+    }));
+
+    const applied = flowChatStore.applySessionModelAutoMigration(
+      session.sessionId,
+      'removed-model',
+      'auto',
+    );
+
+    expect(applied).toBe(true);
+    expect(flowChatStore.getState().sessions.get(session.sessionId)?.config.modelName).toBe('auto');
+  });
+
+  it('applies an auto-migration notice when the session has no stored model yet', () => {
+    const session = createSession({ config: { agentType: 'agentic' } });
+    flowChatStore.setState(() => ({
+      sessions: new Map([[session.sessionId, session]]),
+      activeSessionId: session.sessionId,
+    }));
+
+    const applied = flowChatStore.applySessionModelAutoMigration(
+      session.sessionId,
+      'removed-model',
+      'auto',
+    );
+
+    expect(applied).toBe(true);
+    expect(flowChatStore.getState().sessions.get(session.sessionId)?.config.modelName).toBe('auto');
+  });
+
+  it('ignores a stale auto-migration notice that would revert a newer selection', () => {
+    // Restore-time migration races the explicit update that triggered the
+    // restore: the composer already stored the picked model when the notice
+    // for the old one lands.
+    const session = createSession({
+      config: { agentType: 'agentic', modelName: 'removed-model' },
+    });
+    flowChatStore.setState(() => ({
+      sessions: new Map([[session.sessionId, session]]),
+      activeSessionId: session.sessionId,
+    }));
+
+    flowChatStore.updateSessionModelName(session.sessionId, 'deepseek-v4-flash');
+    const applied = flowChatStore.applySessionModelAutoMigration(
+      session.sessionId,
+      'removed-model',
+      'auto',
+    );
+
+    expect(applied).toBe(false);
+    expect(flowChatStore.getState().sessions.get(session.sessionId)?.config.modelName).toBe(
+      'deepseek-v4-flash',
+    );
+  });
+
+  it('ignores an auto-migration notice for an unknown session', () => {
+    expect(
+      flowChatStore.applySessionModelAutoMigration('missing-session', 'removed-model', 'auto'),
+    ).toBe(false);
+  });
 });
 
 describe('FlowChatStore historical session hydration state', () => {

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.ts
@@ -2188,6 +2188,38 @@ export class FlowChatStore {
     });
   }
 
+  /**
+   * Apply a backend `SessionModelAutoMigrated` notice as a compare-and-swap.
+   *
+   * The backend emits this while restoring a session whose persisted model is
+   * gone. That restore is frequently triggered by the very model update the
+   * user just made, so the notice can land *after* the composer already stored
+   * the newly picked model. Applying it blindly reverts the user's choice, and
+   * the reverted value is what the next send pushes back to the backend.
+   *
+   * Only migrate while the session still holds the model the backend migrated
+   * away from (or holds no selection yet). Mirrors the CLI guard in
+   * `src/apps/cli/src/modes/chat/selection.rs`.
+   *
+   * Returns whether the migration was applied.
+   */
+  public applySessionModelAutoMigration(
+    sessionId: string,
+    previousModelId: string,
+    newModelId: string,
+  ): boolean {
+    const session = this.state.sessions.get(sessionId);
+    if (!session) return false;
+
+    const currentModelName = session.config.modelName?.trim();
+    if (currentModelName && currentModelName !== previousModelId.trim()) {
+      return false;
+    }
+
+    this.updateSessionModelName(sessionId, newModelId);
+    return true;
+  }
+
   /** Update the target-owned model choice before an observer job is submitted. */
   public updateSessionDispatchModel(sessionId: string, modelName: string): void {
     this.setState(prev => {

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -2357,6 +2357,7 @@
     "fastModel": "Fast Model",
     "fastMode": "Fast mode",
     "fastModeDescription": "1.5x speed with higher credit usage",
+    "switchFailed": "Failed to switch model",
     "modelNotConfigured": "Not Configured",
     "contextUsage": {
       "agentPrompt": "Last request prompt: {{usage}}",

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -2357,6 +2357,7 @@
     "fastModel": "Fast 模型",
     "fastMode": "Fast 模式",
     "fastModeDescription": "1.5 倍速度，消耗更多额度",
+    "switchFailed": "切换模型失败",
     "modelNotConfigured": "未配置",
     "contextUsage": {
       "agentPrompt": "上次请求输入上下文: {{usage}}",

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -2357,6 +2357,7 @@
     "fastModel": "Fast 模型",
     "fastMode": "Fast 模式",
     "fastModeDescription": "1.5 倍速度，消耗更多額度",
+    "switchFailed": "切換模型失敗",
     "modelNotConfigured": "未設定",
     "contextUsage": {
       "agentPrompt": "上次請求輸入上下文: {{usage}}",


### PR DESCRIPTION
## Problem

Picking a model in the composer appears to do nothing on the first switch after client startup — the dropdown closes but the trigger keeps showing the old model. Clicking the same model a second time makes it stick, and every later switch works. Reproduces 100% of the time on the first attempt.

## Root cause

Not a click-handling problem, and not a failed backend switch. It is a client-side ordering race.

The first explicit model update for a session is what pulls that session off disk. If its persisted `model_id` is no longer configured (model deleted or disabled while the session sat on disk), restore repoints it to `"auto"` and broadcasts `SessionModelAutoMigrated`. That notice therefore lands **after** the composer already wrote the newly picked model optimistically, and `handleSessionModelAutoMigrated` applied it unconditionally — reverting the selection.

The second click finds the session already in memory: no restore, no notice, no revert.

From a reproduction (webview.log and app.log aligned):

```
02:38:06.836  [backend]  config ai.agent_model_defaults.mode = deepseek-v4-flash   OK
02:38:06.849  [backend]  Session restore detected stale model_id; migrating to auto:
                         previous_model_id=claude-fable-5
02:38:06.854  [frontend] Session model auto-migrated {newModelId:"auto",
                         reason:"model_unavailable_on_restore"}      <-- clobbers the selection
02:38:06.861  [backend]  Session model id updated: model_id=deepseek-v4-flash      OK
```

The backend switched correctly; only the frontend store was rolled back. That is not merely cosmetic: `syncSessionModelSelection` pushes the store value to the backend before every send, so a revert the user does not notice would overwrite the correct backend model with `"auto"` on the next turn.

## Fix

Apply the migration notice as a **compare-and-swap**: migrate only while the session still holds the model the backend migrated away from (or holds no selection yet). The event carries `previousModelId` already, so no contract change is needed.

The CLI has guarded this way since the event was introduced ([`modes/chat/selection.rs`](https://github.com/GCWing/BitFun/blob/main/src/apps/cli/src/modes/chat/selection.rs) — "Ignoring stale model migration"); the desktop web UI was the only consumer applying these events blindly. Background restores that genuinely need the migration still match and still apply, so the "your model disappeared, falling back to Auto" behavior is preserved.

Also fixes a second, independent defect found in the same handler: `handleSelectModel`'s `catch` only logged, so a genuinely failed switch still rendered as success. It now rolls back the optimistic write and surfaces an error toast.

### Changed

- `FlowChatStore.applySessionModelAutoMigration()` — CAS-guarded application of the notice.
- `EventHandlerModule.handleSessionModelAutoMigrated` — uses it; logs ignored notices at debug.
- `ModelSelector.handleSelectModel` — rollback + `notificationService.error` on failure.
- `modelSelector.switchFailed` added to `en-US` / `zh-CN` / `zh-TW`.

### Considered and rejected

Suppressing the notice backend-side when the restore is driven by an explicit model update. The desktop path restores through `session_application.ensure_session_loaded()` before `update_session_model_id()` ever runs, so covering it would mean threading a suppression flag from the Tauri command through `session_application` → `product_runtime` → `Coordinator` → `SessionManager` — pushing a presentation concern down four layers of public API. The event is not untruthful ("at restore time the persisted model was indeed stale"); reconciling it against newer local state is the consumer's job, which is what the CLI already does.

## Testing

Fully tested at the automated level; the runtime repro was diagnosed from logs and has **not** been manually re-verified in a rebuilt client.

- `pnpm run type-check:web` — clean
- `pnpm run lint:web` — 0 errors (2 pre-existing warnings in untouched files)
- `vitest run src/flow_chat/` — 1333 passed / 166 files
- `pnpm run i18n:contract:test` (37 passed) and `pnpm run i18n:audit` (0 warnings)
- `cargo check -p bitfun-core` — clean (no Rust changes in this PR)

New unit tests in `FlowChatStore.test.ts` cover: notice matches stored model (applies), session has no stored model (applies), notice is stale (ignored), unknown session (ignored).

Manual check for a reviewer: fully quit the client, restart, open an older session whose bound model has since been removed, and switch models once — it should take on the first click.

## Notes

AI-assisted (Claude Code). No UI layout changes, so no screenshots.
