### PR TITLE
fix(dispatch): reopen the observer drain gate when a follow-up is accepted

### DIFF
--- a/src/web-ui/src/features/dispatch/DispatchJobObserver.test.ts
+++ b/src/web-ui/src/features/dispatch/DispatchJobObserver.test.ts
@@ -575,6 +575,104 @@ describe('DispatchJobObserver', () => {
     cleanup();
   });
 
+  it('resumes draining after the target accepts a follow-up on a terminal job', async () => {
+    registerRunningJob();
+    mocks.status
+      .mockResolvedValueOnce(status({
+        state: 'succeeded',
+        cursor: 12,
+        events: [{
+          type: 'jobState',
+          timestamp: '2026-07-28T00:00:00Z',
+          state: 'succeeded',
+        }],
+      }))
+      .mockResolvedValueOnce(status({
+        state: 'succeeded',
+        cursor: 12,
+        events: [],
+      }));
+    const cleanup = installDispatchJobObserver(createContext());
+
+    await vi.advanceTimersByTimeAsync(0);
+    requestDispatchJobRefresh('job-1');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(dispatchJobStore.getState().jobs['job-1'].terminalDrained).toBe(true);
+    expect(mocks.status).toHaveBeenCalledTimes(2);
+
+    // Regression: the drained terminal job accepts a follow-up turn. The
+    // target re-queues, runs it, and appends its events, but a renderer that
+    // keeps the job pinned terminal-and-drained never pulls another page and
+    // the follow-up's response silently never renders.
+    dispatchJobStore.getState().markFollowUpAccepted('job-1', 'queued');
+    mocks.listJobs.mockResolvedValue([{
+      ...runningOutboundRecord(),
+      lastState: 'queued' as const,
+    }]);
+    mocks.status
+      .mockResolvedValueOnce(status({
+        state: 'running',
+        cursor: 30,
+        events: [{
+          type: 'agentEvent',
+          timestamp: '2026-07-28T00:01:00Z',
+          event: {
+            id: 'event-follow-up',
+            frontendEventName: 'agentic://text-chunk',
+            frontendPayload: {
+              sessionId: 'session-1',
+              turnId: 'turn-2',
+              roundId: 'round-2',
+              text: 'follow-up answer',
+            },
+          },
+        }],
+      }))
+      .mockResolvedValueOnce(status({
+        state: 'succeeded',
+        cursor: 34,
+        events: [{
+          type: 'jobState',
+          timestamp: '2026-07-28T00:01:05Z',
+          state: 'succeeded',
+        }],
+      }))
+      .mockResolvedValue(status({
+        state: 'succeeded',
+        cursor: 34,
+        events: [],
+      }));
+
+    requestDispatchJobRefresh('job-1');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(dispatchJobStore.getState().jobs['job-1']).toMatchObject({
+      state: 'running',
+      cursor: 30,
+      terminalDrained: false,
+    });
+    expect(mocks.dispatchExternal).toHaveBeenCalledWith(
+      'agentic://text-chunk',
+      expect.objectContaining({ text: 'follow-up answer' }),
+    );
+
+    requestDispatchJobRefresh('job-1');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(dispatchJobStore.getState().jobs['job-1']).toMatchObject({
+      state: 'succeeded',
+      cursor: 34,
+    });
+
+    requestDispatchJobRefresh('job-1');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(dispatchJobStore.getState().jobs['job-1'].terminalDrained).toBe(true);
+    const settledCalls = mocks.status.mock.calls.length;
+
+    requestDispatchJobRefresh('job-1');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mocks.status).toHaveBeenCalledTimes(settledCalls);
+    cleanup();
+  });
+
   it('does not query a target job before submit acknowledgement', async () => {
     registerRunningJob();
     dispatchJobStore.getState().updateProgress('job-1', { state: 'submitting' });

--- a/src/web-ui/src/features/dispatch/dispatchJobStore.test.ts
+++ b/src/web-ui/src/features/dispatch/dispatchJobStore.test.ts
@@ -94,6 +94,34 @@ describe('dispatchJobStore', () => {
     });
   });
 
+  it('reopens the drain gate when the target accepts a follow-up turn', () => {
+    registerJob('succeeded');
+
+    dispatchJobStore.getState().markFollowUpAccepted('job-1', 'queued');
+
+    // The follow-up resumes the event log rather than replaying it, so the
+    // cursor and applied events survive while the terminal pin does not.
+    expect(dispatchJobStore.getState().jobs['job-1']).toMatchObject({
+      state: 'queued',
+      cursor: 10,
+      terminalDrained: false,
+    });
+  });
+
+  it('reopens the drain gate even when a retried follow-up already finished', () => {
+    registerJob('succeeded');
+
+    // A retried continue can report a terminal state when the turn ran to
+    // completion before the retry resolved. The reported state applies as-is,
+    // but the gate must still reopen so the missed pages get drained.
+    dispatchJobStore.getState().markFollowUpAccepted('job-1', 'succeeded');
+
+    expect(dispatchJobStore.getState().jobs['job-1']).toMatchObject({
+      state: 'succeeded',
+      terminalDrained: false,
+    });
+  });
+
   it('keeps the renderer cursor independent from controller-wide observer progress', () => {
     registerJob();
     dispatchJobStore.getState().mergeOutboundRecords([{

--- a/src/web-ui/src/features/dispatch/dispatchJobStore.ts
+++ b/src/web-ui/src/features/dispatch/dispatchJobStore.ts
@@ -193,6 +193,13 @@ interface DispatchJobStoreState {
     },
   ) => void;
   hasAppliedEvent: (jobId: string, eventId: string) => boolean;
+  /**
+   * Apply the state the target reported when it accepted a follow-up turn and
+   * reopen the drain gate so the observer resumes polling from the current
+   * cursor. Without this a terminal job stays `terminalDrained` and the
+   * follow-up's events are never pulled.
+   */
+  markFollowUpAccepted: (jobId: string, state: DispatchJobState) => void;
   setTransportState: (
     jobId: string,
     reachability: DispatchReachability,
@@ -219,6 +226,12 @@ interface DispatchJobStoreState {
   clear: () => void;
 }
 
+/**
+ * Terminal states are sticky against passive channels (stale status responses,
+ * lagging outbound records) so a settled job cannot flap. The one legitimate
+ * way back out is an accepted follow-up turn, which goes through
+ * `markFollowUpAccepted` instead of this transition.
+ */
 function nextJobState(
   current: DispatchJobState,
   requested: DispatchJobState | undefined,
@@ -501,6 +514,28 @@ export const useDispatchJobStore = create<DispatchJobStoreState>()(
 
       hasAppliedEvent: (jobId, eventId) =>
         get().jobs[jobId]?.appliedEventIds.includes(eventId) ?? false,
+
+      markFollowUpAccepted: (jobId, state) => {
+        set(current => {
+          const job = current.jobs[jobId];
+          if (!job) return current;
+          return {
+            jobs: {
+              ...current.jobs,
+              [jobId]: {
+                ...job,
+                // The continue response is a fresh read of the target's state
+                // machine, so it is applied directly rather than through the
+                // sticky-terminal transition rules. Cursor and applied events
+                // are kept: the follow-up resumes the log, it does not replay.
+                state,
+                terminalDrained: false,
+                updatedAt: Date.now(),
+              },
+            },
+          };
+        });
+      },
 
       setTransportState: (jobId, reachability, lastTransportError) => {
         set(state => {

--- a/src/web-ui/src/flow_chat/session-drivers/dispatch/DispatchSessionDriver.ts
+++ b/src/web-ui/src/flow_chat/session-drivers/dispatch/DispatchSessionDriver.ts
@@ -245,8 +245,10 @@ async function continueDispatchJob(
         i18nService.t('flow-chat:chatInput.dispatch.errors.followUpRejected'),
       );
     }
-    // The target owns the job state; the refresh below reads it back rather
-    // than this side guessing what the follow-up did to it.
+    // The accepted response reports the target's post-queue state. Applying
+    // it here reopens the observer's drain gate, which stays shut for a
+    // terminal job even after the outbound record leaves its terminal state.
+    dispatchJobStore.getState().markFollowUpAccepted(jobId, response.state);
   } catch (error) {
     context.flowChatStore.deleteDialogTurn(sessionId, optimisticTurnId);
     throw error;
@@ -520,6 +522,9 @@ export const dispatchSessionDriver: SessionDriver = {
           i18nService.t('flow-chat:chatInput.dispatch.errors.compactRejected'),
         );
       }
+      // Same as a prompt follow-up: reopen the observer's drain gate with the
+      // target-reported state, or the compact turn's events are never pulled.
+      dispatchJobStore.getState().markFollowUpAccepted(jobId, response.state);
     } finally {
       releaseSubmissionRetry(COMPACT_RETRY_SCOPE, sessionId, retry.id);
     }


### PR DESCRIPTION
## Problem

Sending a second message in a dispatch session never renders a response. The optimistic user bubble appears, but no thinking block, no turn, nothing — forever.

Verified against a live SSH target: the follow-up itself works end to end on the target. `dispatch_continue` re-queues the job (state flips back to `Queued`), a new detached worker claims the turn, runs it, and appends its events to `events.ndjson`. The controller-side outbound record also leaves its terminal state. The renderer is the only place that never finds out.

## Root cause

The renderer's `dispatchJobStore` pins terminal states on purpose: `nextJobState` refuses any transition out of `succeeded`/`failed`/`cancelled`, and `terminalDrained` stays `true`. That stickiness is what keeps a lagging record or an in-flight stale poll from flapping a settled job — but it also means the observer's drain gate (`refreshJob` skips terminal-and-drained jobs) can never reopen after an accepted follow-up. The follow-up's events sit in the target's event log with nobody polling for them.

Trace from the incident: the observer's cursor stopped advancing at the first turn's terminal page, and every later status response stayed byte-identical except the 2-byte `running`/`succeeded` state toggle while the second turn executed remotely.

## Fix

The accepted continue response already reports the target's post-queue state, so the driver now applies it through a dedicated store transition, `markFollowUpAccepted(jobId, state)`, which also resets `terminalDrained` (cursor and applied-event ids are kept — a follow-up resumes the log, it does not replay it). Both follow-up paths get the call: prompt turns and compact turns (compact requires a terminal job, so it had the same hang).

Passive channels are untouched: status polls and outbound-record merges keep the sticky-terminal rule, so the anti-flap contract pinned by the existing tests still holds. The explicit, target-acknowledged accept is the one door out of terminal.

## Tests

- `dispatchJobStore.test.ts`: gate reopens with the reported state and a kept cursor; reopens even when a retried follow-up already finished terminal.
- `DispatchJobObserver.test.ts`: end-to-end regression mirroring the incident — a drained terminal job accepts a follow-up, the observer resumes polling from its cursor, projects the follow-up's events, then settles and closes the gate again.
- `src/features/dispatch/`: 82/82 passing; `tsc --noEmit` clean.