### PR TITLE
fix(ui): prevent anchored overlays from clipping

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/NavPanel.scss
+++ b/src/web-ui/src/app/components/NavPanel/NavPanel.scss
@@ -1730,16 +1730,20 @@ $_section-header-height: 24px;
 }
 
 .bitfun-nav-panel__footer-menu {
-  position: absolute;
-  bottom: calc(100% + 6px);
-  left: 0;
+  position: fixed;
   min-width: 148px;
+  max-width: calc(100vw - 16px);
+  max-height: calc(100vh - 16px);
+  overflow-y: auto;
   padding: $size-gap-1;
   background: var(--bf-appearance-token-color-bg-elevated);
   border: 1px solid var(--bf-appearance-token-border-subtle);
   border-radius: $size-radius-base;
   box-shadow: 0 4px 12px var(--bf-appearance-token-color-overlay-black-30);
   z-index: 9999;
+  color: var(--bf-appearance-token-color-text-primary);
+  font-family: var(--bf-appearance-token-font-family-sans);
+  font-size: var(--bf-appearance-token-font-size-sm);
   transform-origin: bottom left;
   animation: bitfun-footer-menu-in $motion-fast $easing-decelerate forwards;
 

--- a/src/web-ui/src/app/components/NavPanel/components/PersistentFooterActions.tsx
+++ b/src/web-ui/src/app/components/NavPanel/components/PersistentFooterActions.tsx
@@ -1,4 +1,5 @@
-import React, { lazy, Suspense, useState, useCallback, useEffect } from 'react';
+import React, { lazy, Suspense, useState, useCallback, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import {
   Settings,
   Info,
@@ -30,6 +31,8 @@ import {
   getRemoteConnectDisclaimerAgreed,
   setRemoteConnectDisclaimerAgreed,
 } from '../../RemoteConnectDialog/remoteConnectDisclaimerStorage';
+import { getAppearanceOverlayHost } from '@/infrastructure/appearance/runtime/AppearanceOverlayHost';
+import { useAnchoredPopoverPosition } from '@/shared/utils/useAnchoredPopoverPosition';
 
 const RemoteConnectDialog = lazy(() => import('../../RemoteConnectDialog'));
 const AboutDialog = lazy(() =>
@@ -70,6 +73,16 @@ const PersistentFooterActions: React.FC = () => {
 
   const [menuOpen, setMenuOpen] = useState(false);
   const [menuClosing, setMenuClosing] = useState(false);
+  const menuTriggerRef = useRef<HTMLButtonElement>(null);
+  const menuPopoverRef = useRef<HTMLDivElement>(null);
+  const menuLayout = useAnchoredPopoverPosition({
+    open: menuOpen,
+    anchorRef: menuTriggerRef,
+    popoverRef: menuPopoverRef,
+    preferredPlacement: 'top',
+    alignment: 'start',
+    gap: 6,
+  });
   const [showAbout, setShowAbout] = useState(false);
   const [showRemoteConnect, setShowRemoteConnect] = useState(false);
   const [remoteInitialGroup, setRemoteInitialGroup] = useState<'network' | 'bot' | 'account' | undefined>(undefined);
@@ -183,6 +196,7 @@ const PersistentFooterActions: React.FC = () => {
           <div className="bitfun-nav-panel__footer-more-wrap">
             <Tooltip content={t('nav.moreOptions')} placement="right" followCursor disabled={menuOpen}>
               <button
+                ref={menuTriggerRef}
                 type="button"
                 className={`bitfun-nav-panel__footer-btn bitfun-nav-panel__footer-btn--icon${menuOpen ? ' is-active' : ''}`}
                 aria-label={t('nav.moreOptions')}
@@ -204,19 +218,26 @@ const PersistentFooterActions: React.FC = () => {
               </button>
             </Tooltip>
 
-            {menuOpen && (
+            {menuOpen && createPortal(
               <>
                 <div
                   className="bitfun-nav-panel__footer-backdrop"
                   onClick={closeMenu}
                 />
                 <div
+                  ref={menuPopoverRef}
                   className={`bitfun-nav-panel__footer-menu${menuClosing ? ' is-closing' : ''}`}
                   role="menu"
                   data-testid="nav-footer-menu"
                   data-bf-component="nav-panel"
                   data-bf-part="footerMenu"
                   data-bf-state={menuClosing ? 'closing' : 'open'}
+                  data-bf-placement={menuLayout?.placement ?? 'top'}
+                  style={{
+                    top: `${menuLayout?.top ?? 0}px`,
+                    left: `${menuLayout?.left ?? 0}px`,
+                    visibility: menuLayout ? 'visible' : 'hidden',
+                  }}
                 >
                   <button
                     type="button"
@@ -284,7 +305,8 @@ const PersistentFooterActions: React.FC = () => {
                     <span>{t('header.about')}</span>
                   </button>
                 </div>
-              </>
+              </>,
+              getAppearanceOverlayHost(),
             )}
           </div>
 

--- a/src/web-ui/src/app/components/scheduled-jobs/ScheduledJobsView.scss
+++ b/src/web-ui/src/app/components/scheduled-jobs/ScheduledJobsView.scss
@@ -402,18 +402,6 @@
     color: var(--bf-appearance-token-color-text-muted);
   }
 
-  &__agent-select {
-    .select__dropdown {
-      max-height: 156px;
-    }
-  }
-
-  &__session-select {
-    .select__dropdown {
-      max-height: 156px;
-    }
-  }
-
   &__warning {
     font-size: var(--bf-appearance-token-font-size-xs);
     color: var(--bf-appearance-token-color-error);
@@ -476,6 +464,11 @@
   &__action-btn--ghost.btn {
     color: var(--bf-appearance-token-color-text-secondary);
   }
+}
+
+.asv__agent-select-dropdown,
+.asv__session-select-dropdown {
+  max-height: min(156px, calc(100vh - 16px));
 }
 
 @media (max-width: 760px) {

--- a/src/web-ui/src/app/components/scheduled-jobs/ScheduledJobsView.tsx
+++ b/src/web-ui/src/app/components/scheduled-jobs/ScheduledJobsView.tsx
@@ -1097,6 +1097,7 @@ const ScheduledJobsView: React.FC<ScheduledJobsViewProps> = ({
                 searchable
                 clearable
                 className="asv__session-select"
+                dropdownClassName="asv__session-select-dropdown"
                 onChange={value => {
                   setValidationErrors(current => ({ ...current, sessionId: false }));
                   setDraft(c => ({ ...c, sessionId: String(value) }));
@@ -1118,6 +1119,7 @@ const ScheduledJobsView: React.FC<ScheduledJobsViewProps> = ({
                 error={validationErrors.agentType}
                 disabled={workspaceKind === WorkspaceKind.Assistant}
                 className="asv__agent-select"
+                dropdownClassName="asv__agent-select-dropdown"
                 renderOption={option => (
                   <div className="asv__agent-option">
                     <span className="asv__agent-option-label">{option.label}</span>

--- a/src/web-ui/src/app/scenes/agents/AgentsScene.tsx
+++ b/src/web-ui/src/app/scenes/agents/AgentsScene.tsx
@@ -1116,6 +1116,8 @@ const AgentsHomeView: React.FC = () => {
                     size="small"
                     searchable
                     className="bitfun-agents-scene__subagent-model-select model-select-presentation__select"
+                    dropdownClassName="model-select-presentation__dropdown"
+                    dropdownMode="inline"
                     options={subagentModelOptions}
                     value={selectedSubagentModelValue}
                     onChange={(value) => void handleSubagentModelChange(value)}

--- a/src/web-ui/src/app/scenes/my-agent/InsightsScene.scss
+++ b/src/web-ui/src/app/scenes/my-agent/InsightsScene.scss
@@ -145,10 +145,10 @@ $ins-label:   12px;
     padding-bottom: 5px;
   }
 
-  .select__dropdown {
-    width: 340px;
-    right: auto;
-  }
+}
+
+.insights-scene__model-select-dropdown {
+  width: min(340px, calc(100vw - 48px));
 }
 
 .insights-model-select {
@@ -684,7 +684,6 @@ $ins-label:   12px;
     width: 100%;
     flex: 0 0 100%;
 
-    .select__dropdown { width: 100%; right: 0; }
   }
   .insights-scene__control-label { width: 100%; }
   .insights-meta-card__top { align-items: flex-start; flex-direction: column; }

--- a/src/web-ui/src/app/scenes/my-agent/InsightsScene.tsx
+++ b/src/web-ui/src/app/scenes/my-agent/InsightsScene.tsx
@@ -248,6 +248,8 @@ const InsightsScene: React.FC = () => {
             <span className="insights-scene__control-label">{t('insights.modelLabel')}</span>
             <Select
               className="insights-scene__model-select"
+              dropdownClassName="insights-scene__model-select-dropdown"
+              dropdownMatchTriggerWidth={false}
               value={selectedModel}
               options={modelOptions}
               renderValue={renderModelValue}

--- a/src/web-ui/src/app/scenes/pages/PagesScene.scss
+++ b/src/web-ui/src/app/scenes/pages/PagesScene.scss
@@ -371,8 +371,7 @@ $pages-gutter: clamp(24px, 4vw, 56px);
     }
 
     .select__value,
-    .select__placeholder,
-    .select__option {
+    .select__placeholder {
       font-size: 13px;
     }
   }

--- a/src/web-ui/src/app/scenes/profile/views/AssistantAvatarPicker.test.tsx
+++ b/src/web-ui/src/app/scenes/profile/views/AssistantAvatarPicker.test.tsx
@@ -54,6 +54,7 @@ describe('AssistantAvatarPicker', () => {
   afterEach(() => {
     act(() => root.unmount());
     container.remove();
+    document.querySelector('[data-bf-overlay-host="true"]')?.remove();
   });
 
   it('keeps a combined emoji sequence as one avatar', () => {
@@ -78,9 +79,10 @@ describe('AssistantAvatarPicker', () => {
 
     expect(trigger.getAttribute('aria-expanded')).toBe('true');
     const compassOption = Array.from(
-      container.querySelectorAll<HTMLButtonElement>('.acp-avatar-picker__option'),
+      document.querySelectorAll<HTMLButtonElement>('.acp-avatar-picker__option'),
     ).find((option) => option.textContent === '🧭');
     expect(compassOption).toBeTruthy();
+    expect(document.querySelector('.acp-avatar-picker__popover')?.parentElement?.getAttribute('data-bf-overlay-host')).toBe('true');
 
     act(() => compassOption?.click());
     expect(onChange).toHaveBeenCalledWith('🧭');
@@ -100,7 +102,7 @@ describe('AssistantAvatarPicker', () => {
     const trigger = container.querySelector('.acp-avatar-picker__trigger') as HTMLButtonElement;
     act(() => trigger.click());
 
-    expect(container.querySelector('.acp-avatar-picker__status')?.textContent)
+    expect(document.querySelector('.acp-avatar-picker__status')?.textContent)
       .toContain('identity.avatarSaved');
   });
 });

--- a/src/web-ui/src/app/scenes/profile/views/AssistantAvatarPicker.tsx
+++ b/src/web-ui/src/app/scenes/profile/views/AssistantAvatarPicker.tsx
@@ -1,9 +1,12 @@
 import React, { useEffect, useId, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { Bot, Check, Pencil, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Button, IconButton, Input } from '@/component-library';
 import type { IdentitySaveStatus } from '@/app/scenes/my-agent/useAgentIdentityDocument';
 import { ASSISTANT_AVATAR_PRESETS, firstAvatarGrapheme } from './assistantAvatar';
+import { getAppearanceOverlayHost } from '@/infrastructure/appearance/runtime/AppearanceOverlayHost';
+import { useAnchoredPopoverPosition } from '@/shared/utils/useAnchoredPopoverPosition';
 
 interface AssistantAvatarPickerProps {
   value: string;
@@ -23,9 +26,18 @@ const AssistantAvatarPicker: React.FC<AssistantAvatarPickerProps> = ({
   const titleId = `${pickerId}-title`;
   const rootRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
   const [isOpen, setIsOpen] = useState(false);
   const displayedValue = useMemo(() => firstAvatarGrapheme(value), [value]);
   const [customValue, setCustomValue] = useState(displayedValue);
+  const popoverLayout = useAnchoredPopoverPosition({
+    open: isOpen,
+    anchorRef: triggerRef,
+    popoverRef,
+    preferredPlacement: 'bottom',
+    alignment: 'start',
+    gap: 8,
+  });
 
   useEffect(() => {
     setCustomValue(displayedValue);
@@ -35,7 +47,8 @@ const AssistantAvatarPicker: React.FC<AssistantAvatarPickerProps> = ({
     if (!isOpen) return;
 
     const handlePointerDown = (event: PointerEvent) => {
-      if (!rootRef.current?.contains(event.target as Node)) {
+      const target = event.target as Node;
+      if (!rootRef.current?.contains(target) && !popoverRef.current?.contains(target)) {
         setIsOpen(false);
       }
     };
@@ -93,12 +106,19 @@ const AssistantAvatarPicker: React.FC<AssistantAvatarPickerProps> = ({
         </span>
       </button>
 
-      {isOpen ? (
+      {isOpen ? createPortal(
         <div
+          ref={popoverRef}
           id={pickerId}
           className="acp-avatar-picker__popover"
           role="region"
           aria-labelledby={titleId}
+          data-bf-placement={popoverLayout?.placement ?? 'bottom'}
+          style={{
+            top: `${popoverLayout?.top ?? 0}px`,
+            left: `${popoverLayout?.left ?? 0}px`,
+            visibility: popoverLayout ? 'visible' : 'hidden',
+          }}
         >
           <div className="acp-avatar-picker__header">
             <div className="acp-avatar-picker__heading">
@@ -169,7 +189,8 @@ const AssistantAvatarPicker: React.FC<AssistantAvatarPickerProps> = ({
               {statusContent}
             </span>
           </div>
-        </div>
+        </div>,
+        getAppearanceOverlayHost(),
       ) : null}
     </div>
   );

--- a/src/web-ui/src/app/scenes/profile/views/NurseryView.scss
+++ b/src/web-ui/src/app/scenes/profile/views/NurseryView.scss
@@ -2846,17 +2846,19 @@ $acp-content-top: clamp(40px, 4.5vh, 52px);
   }
 
   &__popover {
-    position: absolute;
-    top: calc(100% + #{$size-gap-2});
-    left: 0;
+    position: fixed;
     z-index: $z-popover;
     width: 328px;
-    max-width: calc(100vw - 48px);
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 16px);
+    overflow-y: auto;
     padding: $size-gap-3;
     border: 1px solid var(--bf-appearance-token-border-subtle);
     border-radius: $size-radius-lg;
     background: var(--bf-appearance-token-color-bg-elevated);
     box-shadow: var(--bf-appearance-token-shadow-lg);
+    color: var(--bf-appearance-token-color-text-primary);
+    font-family: var(--bf-appearance-token-font-family-sans);
   }
 
   &__header {

--- a/src/web-ui/src/app/scenes/shell/ShellNav.scss
+++ b/src/web-ui/src/app/scenes/shell/ShellNav.scss
@@ -201,17 +201,20 @@
   }
 
   &__dropdown-menu {
-    position: absolute;
-    top: calc(100% + 6px);
-    right: 0;
+    position: fixed;
     min-width: 200px;
     max-width: min(280px, calc(100vw - 24px));
+    max-height: calc(100vh - 16px);
+    overflow-y: auto;
     padding: 6px;
     border: 1px solid var(--bf-appearance-token-border-subtle);
     border-radius: 10px;
     background: var(--bf-appearance-token-color-bg-primary);
     box-shadow: 0 10px 28px rgba(var(--bf-appearance-token-color-static-black-rgb), 0.24);
-    z-index: 8;
+    z-index: $z-popover;
+    color: var(--bf-appearance-token-color-text-primary);
+    font-family: var(--bf-appearance-token-font-family-sans);
+    font-size: var(--bf-appearance-token-font-size-xs);
   }
 
   &__dropdown-item {

--- a/src/web-ui/src/app/scenes/shell/ShellNav.tsx
+++ b/src/web-ui/src/app/scenes/shell/ShellNav.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
 import {
   Plus,
   ChevronDown,
@@ -27,6 +28,8 @@ import { Button } from '@/component-library/components/Button';
 import { Tooltip } from '@/component-library/components/Tooltip';
 import ShellNavEntryItem from './components/ShellNavEntryItem';
 import ShellNavWorkspaceSwitcher from './components/ShellNavWorkspaceSwitcher';
+import { getAppearanceOverlayHost } from '@/infrastructure/appearance/runtime/AppearanceOverlayHost';
+import { useAnchoredPopoverPosition } from '@/shared/utils/useAnchoredPopoverPosition';
 import './ShellNav.scss';
 
 function extractShortVersion(version?: string): string {
@@ -73,10 +76,10 @@ const ShellNav: React.FC = () => {
     setWorkspaceMenuOpen,
     workspaceMenuPosition,
     menuRef,
+    menuPopoverRef,
     workspaceMenuRef,
     workspaceTriggerRef,
   } = useShellNavMenuState(hasMultipleWorkspaces);
-
   const loadAvailableShells = useCallback(async () => {
     try {
       const [shells, terminalConfig] = await Promise.all([
@@ -125,6 +128,15 @@ const ShellNav: React.FC = () => {
       })),
     [availableShells, defaultShellType, t],
   );
+  const createMenuLayout = useAnchoredPopoverPosition({
+    open: menuOpen,
+    anchorRef: menuRef,
+    popoverRef: menuPopoverRef,
+    preferredPlacement: 'bottom',
+    alignment: 'end',
+    gap: 6,
+    layoutRevision: shellMenuItems.length,
+  });
 
   const handleToggleWorkspaceMenu = useCallback(() => {
     if (!hasMultipleWorkspaces) {
@@ -286,8 +298,20 @@ const ShellNav: React.FC = () => {
             </Tooltip>
           </div>
 
-          {menuOpen ? (
-            <div data-bf-component="shell-nav" data-bf-part="menu" className="bitfun-shell-nav__dropdown-menu" role="menu">
+          {menuOpen ? createPortal(
+            <div
+              ref={menuPopoverRef}
+              data-bf-component="shell-nav"
+              data-bf-part="menu"
+              data-bf-placement={createMenuLayout?.placement ?? 'bottom'}
+              className="bitfun-shell-nav__dropdown-menu"
+              role="menu"
+              style={{
+                top: `${createMenuLayout?.top ?? 0}px`,
+                left: `${createMenuLayout?.left ?? 0}px`,
+                visibility: createMenuLayout ? 'visible' : 'hidden',
+              }}
+            >
               {shellMenuItems.map((shell) => (
                 <button
                   data-bf-component="shell-nav"
@@ -307,7 +331,8 @@ const ShellNav: React.FC = () => {
                 <RefreshCw size={14} />
                 <span>{t('nav.shell.actions.refresh')}</span>
               </button>
-            </div>
+            </div>,
+            getAppearanceOverlayHost(),
           ) : null}
         </div>
       </div>

--- a/src/web-ui/src/app/scenes/shell/hooks/useShellNavMenuState.ts
+++ b/src/web-ui/src/app/scenes/shell/hooks/useShellNavMenuState.ts
@@ -13,6 +13,7 @@ interface UseShellNavMenuStateReturn {
   setWorkspaceMenuOpen: React.Dispatch<React.SetStateAction<boolean>>;
   workspaceMenuPosition: MenuPosition | null;
   menuRef: React.RefObject<HTMLDivElement>;
+  menuPopoverRef: React.RefObject<HTMLDivElement>;
   workspaceMenuRef: React.RefObject<HTMLDivElement>;
   workspaceTriggerRef: React.RefObject<HTMLButtonElement>;
 }
@@ -25,6 +26,7 @@ export function useShellNavMenuState(
   const [workspaceMenuPosition, setWorkspaceMenuPosition] = useState<MenuPosition | null>(null);
 
   const menuRef = useRef<HTMLDivElement>(null);
+  const menuPopoverRef = useRef<HTMLDivElement>(null);
   const workspaceMenuRef = useRef<HTMLDivElement>(null);
   const workspaceTriggerRef = useRef<HTMLButtonElement>(null);
 
@@ -38,6 +40,7 @@ export function useShellNavMenuState(
       if (
         target &&
         (menuRef.current?.contains(target) ||
+          menuPopoverRef.current?.contains(target) ||
           workspaceMenuRef.current?.contains(target) ||
           workspaceTriggerRef.current?.contains(target))
       ) {
@@ -117,6 +120,7 @@ export function useShellNavMenuState(
     setWorkspaceMenuOpen,
     workspaceMenuPosition,
     menuRef,
+    menuPopoverRef,
     workspaceMenuRef,
     workspaceTriggerRef,
   };

--- a/src/web-ui/src/component-library/components/Select/Select.scss
+++ b/src/web-ui/src/component-library/components/Select/Select.scss
@@ -231,16 +231,18 @@
 
   &__dropdown {
     --select-entry-y: -2px;
-    position: absolute;
-    left: 0;
-    right: 0;
-    max-height: 240px;
+    position: fixed;
+    box-sizing: border-box;
+    max-width: calc(100vw - 16px);
+    max-height: min(240px, calc(100vh - 16px));
     background: var(--bf-appearance-token-color-bg-secondary);
+    color: var(--bf-appearance-token-color-text-primary);
+    font-family: var(--bf-appearance-token-font-family-sans);
     border: 1px solid var(--bf-appearance-token-border-medium);
     border-top: none;
     border-radius: 0 0 var(--bf-appearance-token-size-radius-sm) var(--bf-appearance-token-size-radius-sm);
     box-shadow: 0 4px 12px var(--bf-appearance-token-color-overlay-black-40);
-    z-index: tokens.$z-dropdown;
+    z-index: tokens.$z-popover;
     animation: select-dropdown-appear var(--bf-appearance-token-motion-fast) tokens.$easing-decelerate;
     overflow: hidden;
     display: flex;
@@ -256,13 +258,8 @@
       background: var(--bf-appearance-token-border-subtle);
     }
 
-    &--bottom {
-      top: 100%;
-    }
-
     &--top {
       --select-entry-y: 2px;
-      bottom: 100%;
       border-top: 1px solid var(--bf-appearance-token-border-medium);
       border-bottom: none;
       border-radius: var(--bf-appearance-token-size-radius-sm) var(--bf-appearance-token-size-radius-sm) 0 0;
@@ -272,6 +269,13 @@
         top: auto;
         bottom: 0;
       }
+    }
+
+    &--inline {
+      position: absolute;
+      left: 0;
+      right: 0;
+      z-index: tokens.$z-dropdown;
     }
   }
 
@@ -557,21 +561,11 @@
       font-size: 13px;
     }
 
-    .select__option {
-      padding: 5px 8px;
-      font-size: 13px;
-    }
-
     .select__tag {
       padding: 2px 6px;
       font-size: 12px;
     }
 
-    .select__checkbox {
-      width: 14px;
-      height: 14px;
-      font-size: 10px;
-    }
   }
 
   &--large {
@@ -590,21 +584,45 @@
       font-size: 15px;
     }
 
-    .select__option {
-      padding: 8px 12px;
-      font-size: 15px;
-    }
-
     .select__tag {
       padding: 4px 10px;
       font-size: 13px;
     }
 
-    .select__checkbox {
-      width: 18px;
-      height: 18px;
-      font-size: 12px;
-    }
+  }
+}
+
+.select__dropdown--inline.select__dropdown--bottom {
+  top: 100%;
+}
+
+.select__dropdown--inline.select__dropdown--top {
+  bottom: 100%;
+}
+
+.select__dropdown--small {
+  .select__option {
+    padding: 5px 8px;
+    font-size: 13px;
+  }
+
+  .select__checkbox {
+    width: 14px;
+    height: 14px;
+    font-size: 10px;
+  }
+}
+
+.select__dropdown--large {
+  .select__option {
+    padding: 8px 12px;
+    font-size: 15px;
+  }
+
+  .select__checkbox {
+    width: 18px;
+    height: 18px;
+    font-size: 12px;
   }
 }
 

--- a/src/web-ui/src/component-library/components/Select/Select.test.tsx
+++ b/src/web-ui/src/component-library/components/Select/Select.test.tsx
@@ -33,7 +33,7 @@ describe('Select', () => {
     });
 
     getBoundingClientRectSpy = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function () {
-      if (this instanceof HTMLElement && this.classList.contains('select')) {
+      if (this instanceof HTMLElement && this.classList.contains('select__trigger')) {
         return {
           top: 700,
           bottom: 740,
@@ -76,6 +76,7 @@ describe('Select', () => {
       root.unmount();
     });
     container.remove();
+    document.querySelector('[data-bf-overlay-host="true"]')?.remove();
     getBoundingClientRectSpy.mockRestore();
     offsetHeightSpy.mockRestore();
     vi.restoreAllMocks();
@@ -103,15 +104,19 @@ describe('Select', () => {
     });
 
     const selectRoot = container.querySelector('.select');
-    const dropdown = container.querySelector('.select__dropdown');
+    const dropdown = document.querySelector<HTMLElement>('.select__dropdown');
 
     expect(selectRoot?.className).toContain('select--placement-top');
     expect(dropdown?.className).toContain('select__dropdown--top');
+    expect(dropdown?.parentElement?.getAttribute('data-bf-overlay-host')).toBe('true');
+    expect(dropdown?.style.position).toBe('fixed');
+    expect(dropdown?.style.top).toBe('480px');
+    expect(dropdown?.style.width).toBe('240px');
   });
 
   it('keeps the dropdown downward when there is enough room below', async () => {
     getBoundingClientRectSpy.mockImplementation(function () {
-      if (this instanceof HTMLElement && this.classList.contains('select')) {
+      if (this instanceof HTMLElement && this.classList.contains('select__trigger')) {
         return {
           top: 100,
           bottom: 140,
@@ -161,10 +166,56 @@ describe('Select', () => {
     });
 
     const selectRoot = container.querySelector('.select');
-    const dropdown = container.querySelector('.select__dropdown');
+    const dropdown = document.querySelector<HTMLElement>('.select__dropdown');
 
     expect(selectRoot?.className).toContain('select--placement-bottom');
     expect(dropdown?.className).toContain('select__dropdown--bottom');
+  });
+
+  it('repositions a portalled dropdown when an ancestor scrolls', async () => {
+    let triggerTop = 100;
+    getBoundingClientRectSpy.mockImplementation(function () {
+      if (this instanceof HTMLElement && this.classList.contains('select__trigger')) {
+        return {
+          top: triggerTop,
+          bottom: triggerTop + 40,
+          left: 80,
+          right: 320,
+          width: 240,
+          height: 40,
+          x: 80,
+          y: triggerTop,
+          toJSON() { return this; },
+        } as DOMRect;
+      }
+      return {
+        top: 0,
+        bottom: 0,
+        left: 0,
+        right: 0,
+        width: 0,
+        height: 0,
+        x: 0,
+        y: 0,
+        toJSON() { return this; },
+      } as DOMRect;
+    });
+
+    await act(async () => {
+      root.render(<Select options={[{ value: 'one', label: 'One' }]} />);
+    });
+    const trigger = container.querySelector<HTMLElement>('.select__trigger');
+    await act(async () => trigger?.click());
+    const dropdown = document.querySelector<HTMLElement>('.select__dropdown');
+    expect(dropdown?.style.top).toBe('140px');
+
+    triggerTop = 300;
+    await act(async () => {
+      window.dispatchEvent(new Event('scroll'));
+      await new Promise<void>((resolve) => window.requestAnimationFrame(() => resolve()));
+    });
+
+    expect(dropdown?.style.top).toBe('340px');
   });
 
   it('keeps grouped order stable and skips disabled options during keyboard navigation', async () => {
@@ -192,8 +243,8 @@ describe('Select', () => {
       await Promise.resolve();
     });
 
-    const listbox = container.querySelector('[role="listbox"]') as HTMLElement;
-    const options = Array.from(container.querySelectorAll<HTMLElement>('[role="option"]'));
+    const listbox = document.querySelector('[role="listbox"]') as HTMLElement;
+    const options = Array.from(document.querySelectorAll<HTMLElement>('[role="option"]'));
     expect(options.map((option) => option.textContent)).toEqual([
       'Disabled ungrouped',
       'Group A choice',
@@ -202,7 +253,7 @@ describe('Select', () => {
     expect(trigger.getAttribute('aria-controls')).toBe(listbox.id);
     expect(trigger.getAttribute('aria-activedescendant')).toBe(options[1].id);
     expect(options[1].className).toContain('select__option--highlighted');
-    expect(container.querySelector('[role="group"]')?.getAttribute('aria-label')).toBe('Group A');
+    expect(document.querySelector('[role="group"]')?.getAttribute('aria-label')).toBe('Group A');
 
     await act(async () => {
       trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
@@ -229,8 +280,8 @@ describe('Select', () => {
     });
     const trigger = container.querySelector('.select__trigger') as HTMLElement;
     await act(async () => trigger.click());
-    const input = container.querySelector('.select__search-input') as HTMLInputElement;
-    const listbox = container.querySelector('[role="listbox"]') as HTMLElement;
+    const input = document.querySelector('.select__search-input') as HTMLInputElement;
+    const listbox = document.querySelector('[role="listbox"]') as HTMLElement;
 
     await act(async () => {
       input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
@@ -240,7 +291,44 @@ describe('Select', () => {
     expect(input.getAttribute('aria-controls')).toBe(listbox.id);
     expect(input.getAttribute('aria-label')).toBe('Find a choice');
     expect(input.getAttribute('aria-activedescendant')).toBe(
-      container.querySelectorAll<HTMLElement>('[role="option"]')[1].id,
+      document.querySelectorAll<HTMLElement>('[role="option"]')[1].id,
     );
+  });
+
+  it('keeps portalled interactions inside the Select and closes on a true outside press', async () => {
+    await act(async () => {
+      root.render(<Select options={[{ value: 'one', label: 'One' }]} />);
+    });
+    const trigger = container.querySelector<HTMLElement>('.select__trigger');
+    await act(async () => trigger?.click());
+
+    const dropdown = document.querySelector<HTMLElement>('.select__dropdown');
+    await act(async () => {
+      dropdown?.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    });
+    expect(document.querySelector('.select__dropdown')).not.toBeNull();
+
+    await act(async () => {
+      document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    });
+    expect(document.querySelector('.select__dropdown')).toBeNull();
+  });
+
+  it('retains the explicit inline mode for layout-expanding selectors', async () => {
+    await act(async () => {
+      root.render(
+        <Select
+          dropdownMode="inline"
+          options={[{ value: 'one', label: 'One' }]}
+        />,
+      );
+    });
+    const trigger = container.querySelector<HTMLElement>('.select__trigger');
+    await act(async () => trigger?.click());
+
+    const dropdown = container.querySelector<HTMLElement>('.select__dropdown');
+    expect(dropdown).not.toBeNull();
+    expect(dropdown?.className).toContain('select__dropdown--inline');
+    expect(dropdown?.style.position).toBe('');
   });
 });

--- a/src/web-ui/src/component-library/components/Select/Select.tsx
+++ b/src/web-ui/src/component-library/components/Select/Select.tsx
@@ -6,11 +6,13 @@ import React, {
   useState,
   useRef,
   useEffect,
-  useLayoutEffect,
   useMemo,
   useCallback,
 } from 'react';
+import { createPortal } from 'react-dom';
+import { getAppearanceOverlayHost } from '@/infrastructure/appearance/runtime/AppearanceOverlayHost';
 import { useI18n } from '@/infrastructure/i18n';
+import { useAnchoredPopoverPosition } from '@/shared/utils/useAnchoredPopoverPosition';
 import './Select.scss';
 
 export interface SelectOption {
@@ -56,6 +58,12 @@ export interface SelectProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 
   triggerAriaLabel?: string;
   triggerAriaLabelledBy?: string;
   triggerAriaDescribedBy?: string;
+  /** Additional class applied directly to the dropdown, including when portalled. */
+  dropdownClassName?: string;
+  /** Overlay escapes clipping by default; inline is reserved for layout-expanding selectors. */
+  dropdownMode?: 'overlay' | 'inline';
+  /** Match the trigger width, preserving the historical Select default. */
+  dropdownMatchTriggerWidth?: boolean;
 }
 
 export const Select: React.FC<SelectProps> = ({
@@ -90,6 +98,9 @@ export const Select: React.FC<SelectProps> = ({
   triggerAriaLabel,
   triggerAriaLabelledBy,
   triggerAriaDescribedBy,
+  dropdownClassName = '',
+  dropdownMode = 'overlay',
+  dropdownMatchTriggerWidth = true,
   ...rootProps
 }) => {
   const { t } = useI18n('components');
@@ -104,7 +115,6 @@ export const Select: React.FC<SelectProps> = ({
   const resolvedEmptyText = emptyText ?? t('select.emptyText');
   const resolvedCustomValueHint = customValueHint ?? t('select.customValueHint');
   const [isOpen, setIsOpen] = useState(false);
-  const [resolvedPlacement, setResolvedPlacement] = useState<'bottom' | 'top'>(placement);
   const [selectedValue, setSelectedValue] = useState<string | number | (string | number)[]>(
     value !== undefined ? value : defaultValue !== undefined ? defaultValue : multiple ? [] : ''
   );
@@ -113,6 +123,7 @@ export const Select: React.FC<SelectProps> = ({
   const hasMountedRef = useRef(false);
   
   const selectRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const isKeyboardNavigation = useRef(false);
@@ -133,43 +144,18 @@ export const Select: React.FC<SelectProps> = ({
     );
   }, [options, searchQuery, searchable]);
 
-  useLayoutEffect(() => {
-    if (!isOpen) {
-      setResolvedPlacement(placement);
-      return;
-    }
-
-    const selectElement = selectRef.current;
-    const dropdownElement = dropdownRef.current;
-    if (!selectElement || !dropdownElement || typeof window === 'undefined') {
-      setResolvedPlacement(placement);
-      return;
-    }
-
-    const triggerRect = selectElement.getBoundingClientRect();
-    const dropdownHeight = dropdownElement.offsetHeight || dropdownElement.scrollHeight || 240;
-    const spaceBelow = window.innerHeight - triggerRect.bottom;
-    const spaceAbove = triggerRect.top;
-
-    let nextPlacement: 'bottom' | 'top' = placement;
-    if (placement === 'bottom' && spaceBelow < dropdownHeight && spaceAbove > spaceBelow) {
-      nextPlacement = 'top';
-    } else if (placement === 'top' && spaceAbove < dropdownHeight && spaceBelow > spaceAbove) {
-      nextPlacement = 'bottom';
-    }
-
-    setResolvedPlacement(nextPlacement);
-  }, [
-    isOpen,
-    placement,
-    options.length,
-    searchable,
-    multiple,
-    showSelectAll,
-    allowCustomValue,
-    searchQuery,
-    filteredOptions.length,
-  ]);
+  const dropdownLayout = useAnchoredPopoverPosition({
+    open: isOpen && dropdownMode === 'overlay',
+    anchorRef: triggerRef,
+    popoverRef: dropdownRef,
+    preferredPlacement: placement,
+    gap: 0,
+    matchAnchorWidth: dropdownMatchTriggerWidth,
+    layoutRevision: `${filteredOptions.length}:${searchQuery}:${loading}`,
+  });
+  const resolvedPlacement = dropdownMode === 'inline'
+    ? 'bottom'
+    : dropdownLayout?.placement ?? placement;
 
   const groupedOptions = useMemo(() => {
     const groups: { [key: string]: SelectOption[] } = {};
@@ -365,7 +351,12 @@ export const Select: React.FC<SelectProps> = ({
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (selectRef.current && !selectRef.current.contains(event.target as Node)) {
+      const target = event.target as Node;
+      if (
+        selectRef.current
+        && !selectRef.current.contains(target)
+        && !dropdownRef.current?.contains(target)
+      ) {
         if (allowCustomValue && !multiple && searchQuery.trim()) {
           const trimmedValue = searchQuery.trim();
           const existingOption = options.find(opt => 
@@ -531,11 +522,175 @@ export const Select: React.FC<SelectProps> = ({
     );
   };
 
+  const dropdownNode = (
+    <div
+      id={listboxId}
+      className={[
+        'select__dropdown',
+        `select__dropdown--${resolvedPlacement}`,
+        `select__dropdown--${size}`,
+        `select__dropdown--${dropdownMode}`,
+        dropdownClassName,
+      ].filter(Boolean).join(' ')}
+      ref={dropdownRef}
+      style={dropdownMode === 'overlay' ? {
+        position: 'fixed',
+        top: `${dropdownLayout?.top ?? 0}px`,
+        left: `${dropdownLayout?.left ?? 0}px`,
+        width: dropdownLayout?.width === undefined ? undefined : `${dropdownLayout.width}px`,
+        visibility: dropdownLayout ? 'visible' : 'hidden',
+      } : undefined}
+      role="listbox"
+      aria-multiselectable={multiple || undefined}
+      aria-busy={loading || undefined}
+      data-testid={dropdownTestId}
+      data-bf-component="select"
+      data-bf-part="dropdown"
+      data-bf-placement={resolvedPlacement}
+    >
+      {searchable && (
+        <div className="select__search" data-bf-component="select" data-bf-part="search">
+          <input
+            ref={searchInputRef}
+            type="text"
+            className="select__search-input"
+            role="combobox"
+            aria-label={resolvedSearchPlaceholder}
+            aria-autocomplete="list"
+            aria-expanded={isOpen}
+            aria-controls={listboxId}
+            aria-activedescendant={highlightedIndex >= 0
+              ? `${listboxId}-option-${highlightedIndex}`
+              : undefined}
+            placeholder={resolvedSearchPlaceholder}
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                if (highlightedIndex >= 0 && highlightedIndex < displayOptions.length) {
+                  handleSelect(displayOptions[highlightedIndex]);
+                } else if (allowCustomValue && searchQuery.trim()) {
+                  handleCustomValueSubmit();
+                }
+              } else if (e.key === 'Escape') {
+                e.preventDefault();
+                setIsOpen(false);
+                setSearchQuery('');
+              } else if (e.key === 'ArrowDown') {
+                e.preventDefault();
+                isKeyboardNavigation.current = true;
+                setHighlightedIndex((previous) => moveHighlight(previous, 1));
+              } else if (e.key === 'ArrowUp') {
+                e.preventDefault();
+                isKeyboardNavigation.current = true;
+                setHighlightedIndex((previous) => moveHighlight(
+                  previous < 0 ? displayOptions.length : previous,
+                  -1,
+                ));
+              }
+            }}
+            data-bf-component="select"
+            data-bf-part="searchInput"
+          />
+          {searchQuery && (
+            <button
+              type="button"
+              className="select__search-clear"
+              onClick={(e) => {
+                e.stopPropagation();
+                setSearchQuery('');
+                setHighlightedIndex(-1);
+                searchInputRef.current?.focus();
+              }}
+              aria-label={t('search.clear')}
+            >
+              ×
+            </button>
+          )}
+        </div>
+      )}
+
+      {multiple && showSelectAll && filteredOptions.length > 0 && (
+        <div
+          className="select__select-all"
+          onClick={handleSelectAll}
+          role="option"
+          aria-selected={filteredOptions.filter(opt => !opt.disabled).every(opt => isSelected(opt.value))}
+        >
+          <span className={`select__checkbox ${
+            filteredOptions.filter(opt => !opt.disabled).every(opt => isSelected(opt.value))
+              ? 'select__checkbox--checked' : ''
+          }`}>
+            {filteredOptions.filter(opt => !opt.disabled).every(opt => isSelected(opt.value)) && '✓'}
+          </span>
+          <span>{t('select.selectAll')}</span>
+        </div>
+      )}
+
+      <div className="select__options" data-bf-component="select" data-bf-part="options">
+        {filteredOptions.length === 0 ? (
+          loading ? (
+            <div className="select__empty select__empty--loading" data-bf-component="select" data-bf-part="empty">
+              <span className="select__loading-spinner" aria-hidden="true" />
+              <span>{t('select.loading')}</span>
+            </div>
+          ) : allowCustomValue && searchQuery.trim() ? (
+            <div className="select__custom-value-hint" onClick={() => handleCustomValueSubmit()}>
+              <span className="select__custom-value-text">"{searchQuery.trim()}"</span>
+              <span className="select__custom-value-action">{resolvedCustomValueHint}</span>
+            </div>
+          ) : (
+            <div className="select__empty" data-bf-component="select" data-bf-part="empty">{resolvedEmptyText}</div>
+          )
+        ) : groupedOptions.hasGroups ? (
+          (() => {
+            let globalIndex = 0;
+            return (
+              <>
+                {groupedOptions.ungrouped.map((option) => renderOptionItem(option, globalIndex++))}
+                {Object.entries(groupedOptions.groups).map(([groupName, groupOptions]) => (
+                  <div
+                    key={groupName}
+                    className="select__group"
+                    role="group"
+                    aria-label={groupName}
+                    data-bf-component="select"
+                    data-bf-part="group"
+                  >
+                    <div className="select__group-label" data-bf-component="select" data-bf-part="groupLabel">{groupName}</div>
+                    {groupOptions.map((option) => renderOptionItem(option, globalIndex++))}
+                  </div>
+                ))}
+              </>
+            );
+          })()
+        ) : (
+          <>
+            {filteredOptions.map((option, index) => renderOptionItem(option, index))}
+            {allowCustomValue && searchQuery.trim()
+              && !filteredOptions.some(opt => (
+                opt.label.toLowerCase() === searchQuery.trim().toLowerCase()
+                || String(opt.value).toLowerCase() === searchQuery.trim().toLowerCase()
+              )) && (
+              <div className="select__custom-value-hint" onClick={() => handleCustomValueSubmit()}>
+                <span className="select__custom-value-text">"{searchQuery.trim()}"</span>
+                <span className="select__custom-value-action">{resolvedCustomValueHint}</span>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+
   return (
     <div {...rootProps} className={classNames} ref={selectRef} data-bf-component="select" data-bf-part="root" data-bf-size={size} data-bf-placement={resolvedPlacement} data-bf-multiple={String(multiple)} data-bf-state={[isOpen && 'open', disabled && 'disabled', error && 'error', loading && 'loading'].filter(Boolean).join(' ') || undefined}>
       {label && <div id={labelId} className="select__label" data-bf-component="select" data-bf-part="label">{label}</div>}
-      
+
       <div
+        ref={triggerRef}
         className="select__trigger"
         onClick={() => !disabled && setIsOpen(!isOpen)}
         onKeyDown={handleKeyDown}
@@ -558,7 +713,7 @@ export const Select: React.FC<SelectProps> = ({
         data-bf-part="trigger"
       >
         {renderSelectedValue()}
-        
+
         <div className="select__suffix" data-bf-component="select" data-bf-part="suffix">
           {loading && (
             <span className="select__loading" data-bf-component="select" data-bf-part="loading">
@@ -576,166 +731,10 @@ export const Select: React.FC<SelectProps> = ({
         </div>
       </div>
 
-      {isOpen && (
-        <div
-          id={listboxId}
-          className={`select__dropdown select__dropdown--${resolvedPlacement}`}
-          ref={dropdownRef}
-          role="listbox"
-          aria-multiselectable={multiple || undefined}
-          aria-busy={loading || undefined}
-          data-testid={dropdownTestId}
-          data-bf-component="select"
-          data-bf-part="dropdown"
-          data-bf-placement={resolvedPlacement}
-        >
-          {searchable && (
-            <div className="select__search" data-bf-component="select" data-bf-part="search">
-              <input
-                ref={searchInputRef}
-                type="text"
-                className="select__search-input"
-                role="combobox"
-                aria-label={resolvedSearchPlaceholder}
-                aria-autocomplete="list"
-                aria-expanded={isOpen}
-                aria-controls={listboxId}
-                aria-activedescendant={highlightedIndex >= 0
-                  ? `${listboxId}-option-${highlightedIndex}`
-                  : undefined}
-                placeholder={resolvedSearchPlaceholder}
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                onClick={(e) => e.stopPropagation()}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') {
-                    e.preventDefault();
-                    if (highlightedIndex >= 0 && highlightedIndex < displayOptions.length) {
-                      handleSelect(displayOptions[highlightedIndex]);
-                    } else if (allowCustomValue && searchQuery.trim()) {
-                      handleCustomValueSubmit();
-                    }
-                  } else if (e.key === 'Escape') {
-                    e.preventDefault();
-                    setIsOpen(false);
-                    setSearchQuery('');
-                  } else if (e.key === 'ArrowDown') {
-                    e.preventDefault();
-                    isKeyboardNavigation.current = true;
-                    setHighlightedIndex((previous) => moveHighlight(previous, 1));
-                  } else if (e.key === 'ArrowUp') {
-                    e.preventDefault();
-                    isKeyboardNavigation.current = true;
-                    setHighlightedIndex((previous) => moveHighlight(
-                      previous < 0 ? displayOptions.length : previous,
-                      -1,
-                    ));
-                  }
-                }}
-                data-bf-component="select"
-                data-bf-part="searchInput"
-              />
-              {searchQuery && (
-                <button
-                  type="button"
-                  className="select__search-clear"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setSearchQuery('');
-                    setHighlightedIndex(-1);
-                    searchInputRef.current?.focus();
-                  }}
-                  aria-label={t('search.clear')}
-                >
-                  ×
-                </button>
-              )}
-            </div>
-          )}
-          
-          {multiple && showSelectAll && filteredOptions.length > 0 && (
-            <div
-              className="select__select-all"
-              onClick={handleSelectAll}
-              role="option"
-              aria-selected={filteredOptions.filter(opt => !opt.disabled).every(opt => isSelected(opt.value))}
-            >
-              <span className={`select__checkbox ${
-                filteredOptions.filter(opt => !opt.disabled).every(opt => isSelected(opt.value))
-                  ? 'select__checkbox--checked' : ''
-              }`}>
-                {filteredOptions.filter(opt => !opt.disabled).every(opt => isSelected(opt.value)) && '✓'}
-              </span>
-              <span>{t('select.selectAll')}</span>
-            </div>
-          )}
-          
-          <div className="select__options" data-bf-component="select" data-bf-part="options">
-            {filteredOptions.length === 0 ? (
-              loading ? (
-                <div className="select__empty select__empty--loading" data-bf-component="select" data-bf-part="empty">
-                  <span className="select__loading-spinner" aria-hidden="true" />
-                  <span>{t('select.loading')}</span>
-                </div>
-              ) : allowCustomValue && searchQuery.trim() ? (
-                <div 
-                  className="select__custom-value-hint"
-                  onClick={() => handleCustomValueSubmit()}
-                >
-                  <span className="select__custom-value-text">"{searchQuery.trim()}"</span>
-                  <span className="select__custom-value-action">{resolvedCustomValueHint}</span>
-                </div>
-              ) : (
-                <div className="select__empty" data-bf-component="select" data-bf-part="empty">{resolvedEmptyText}</div>
-              )
-            ) : groupedOptions.hasGroups ? (
-              (() => {
-                let globalIndex = 0;
-                return (
-                  <>
-                    {groupedOptions.ungrouped.map((option) => 
-                      renderOptionItem(option, globalIndex++)
-                    )}
-                    {Object.entries(groupedOptions.groups).map(([groupName, groupOptions]) => (
-                      <div
-                        key={groupName}
-                        className="select__group"
-                        role="group"
-                        aria-label={groupName}
-                        data-bf-component="select"
-                        data-bf-part="group"
-                      >
-                        <div className="select__group-label" data-bf-component="select" data-bf-part="groupLabel">{groupName}</div>
-                        {groupOptions.map((option) => 
-                          renderOptionItem(option, globalIndex++)
-                        )}
-                      </div>
-                    ))}
-                  </>
-                );
-              })()
-            ) : (
-              <>
-                {filteredOptions.map((option, index) => renderOptionItem(option, index))}
-                {allowCustomValue && searchQuery.trim() && 
-                 !filteredOptions.some(opt => (
-                   opt.label.toLowerCase() === searchQuery.trim().toLowerCase() ||
-                   String(opt.value).toLowerCase() === searchQuery.trim().toLowerCase()
-                 )) && (
-                  <div 
-                    className="select__custom-value-hint"
-                    onClick={() => handleCustomValueSubmit()}
-                  >
-                    <span className="select__custom-value-text">"{searchQuery.trim()}"</span>
-                    <span className="select__custom-value-action">{resolvedCustomValueHint}</span>
-                  </div>
-                )}
-              </>
-            )}
-          </div>
-        </div>
-      )}
-      
+      {isOpen && (dropdownMode === 'overlay'
+        ? createPortal(dropdownNode, getAppearanceOverlayHost())
+        : dropdownNode)}
+
       {error && errorMessage && (
         <div className="select__error-message" data-bf-component="select" data-bf-part="message">{errorMessage}</div>
       )}

--- a/src/web-ui/src/features/dispatch/DispatchTargetPicker.scss
+++ b/src/web-ui/src/features/dispatch/DispatchTargetPicker.scss
@@ -64,14 +64,12 @@
   }
 
   &__menu {
-    position: absolute;
-    right: 0;
-    bottom: calc(100% + 7px);
-    z-index: 10;
+    position: fixed;
+    z-index: $z-popover;
     box-sizing: border-box;
     display: flex;
-    width: min(300px, calc(100vw - 24px));
-    max-height: min(410px, calc(100vh - 24px));
+    width: min(300px, calc(100vw - 16px));
+    max-height: min(410px, calc(100vh - 16px));
     flex-direction: column;
     gap: 4px;
     padding: 6px;
@@ -83,6 +81,7 @@
     box-shadow: var(--bf-appearance-token-shadow-lg);
     color: var(--bf-appearance-token-color-text-primary);
     font-family: var(--bf-appearance-token-font-family-sans);
+    font-size: var(--bf-appearance-token-flowchat-font-size-xxs);
     user-select: none;
   }
 

--- a/src/web-ui/src/features/dispatch/DispatchTargetPicker.test.tsx
+++ b/src/web-ui/src/features/dispatch/DispatchTargetPicker.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DispatchTargetPicker } from './DispatchTargetPicker';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('@/component-library', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/infrastructure/i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@/infrastructure/account/useAccountLoginState', () => ({
+  useAccountLoginState: () => ({ loggedIn: false }),
+}));
+
+vi.mock('./useDispatchTargets', () => ({
+  useDispatchTargets: () => ({
+    targets: [],
+    loading: false,
+    error: false,
+    refresh: vi.fn(async () => undefined),
+  }),
+}));
+
+vi.mock('@/features/ssh-remote/SSHConnectionDialog', () => ({
+  SSHConnectionDialog: () => null,
+}));
+
+vi.mock('./DispatchInstallDialog', () => ({
+  DispatchInstallDialog: () => null,
+}));
+
+const rect = (
+  top: number,
+  left: number,
+  width: number,
+  height: number,
+): DOMRect => ({
+  top,
+  bottom: top + height,
+  left,
+  right: left + width,
+  width,
+  height,
+  x: left,
+  y: top,
+  toJSON() { return this; },
+} as DOMRect);
+
+describe('DispatchTargetPicker overlay', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 800 });
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 800 });
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function () {
+      if (this.dataset.testid === 'chat-input-dispatch-trigger') {
+        return rect(500, 420, 120, 40);
+      }
+      if (this.classList.contains('dispatch-target-picker__menu')) {
+        return rect(0, 0, 300, 200);
+      }
+      return rect(0, 0, 0, 0);
+    });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    document.querySelector('[data-bf-overlay-host="true"]')?.remove();
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it('anchors the portalled menu to the actual dispatch trigger', async () => {
+    await act(async () => {
+      root.render(
+        <DispatchTargetPicker
+          target={{ kind: 'local' }}
+          locked={false}
+          onSelectTarget={vi.fn()}
+        />,
+      );
+    });
+
+    const trigger = container.querySelector<HTMLButtonElement>(
+      '[data-testid="chat-input-dispatch-trigger"]',
+    );
+    await act(async () => trigger?.click());
+
+    const menu = document.querySelector<HTMLElement>('[data-testid="dispatch-target-menu"]');
+    expect(menu?.parentElement?.getAttribute('data-bf-overlay-host')).toBe('true');
+    expect(menu?.style.visibility).toBe('visible');
+    expect(menu?.style.left).toBe('240px');
+    expect(menu?.style.top).toBe('293px');
+  });
+});

--- a/src/web-ui/src/features/dispatch/DispatchTargetPicker.tsx
+++ b/src/web-ui/src/features/dispatch/DispatchTargetPicker.tsx
@@ -6,6 +6,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import { createPortal } from 'react-dom';
 import {
   Check,
   ChevronDown,
@@ -19,7 +20,9 @@ import {
 import { Tooltip } from '@/component-library';
 import { SSHConnectionDialog } from '@/features/ssh-remote/SSHConnectionDialog';
 import { useAccountLoginState } from '@/infrastructure/account/useAccountLoginState';
+import { getAppearanceOverlayHost } from '@/infrastructure/appearance/runtime/AppearanceOverlayHost';
 import { useI18n } from '@/infrastructure/i18n';
+import { useAnchoredPopoverPosition } from '@/shared/utils/useAnchoredPopoverPosition';
 import { DispatchInstallDialog } from './DispatchInstallDialog';
 import type {
   DispatchSelection,
@@ -52,12 +55,23 @@ export const DispatchTargetPicker: React.FC<DispatchTargetPickerProps> = ({
 }) => {
   const { t } = useI18n('flow-chat');
   const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
   const [open, setOpen] = useState(false);
   const [configureTarget, setConfigureTarget] = useState<DispatchTargetOption | null>(null);
   const [sshDialogOpen, setSshDialogOpen] = useState(false);
   const [accountDialogOpen, setAccountDialogOpen] = useState(false);
   const { loggedIn } = useAccountLoginState();
   const { targets, loading, error, refresh } = useDispatchTargets(open);
+  const menuLayout = useAnchoredPopoverPosition({
+    open,
+    anchorRef: triggerRef,
+    popoverRef: menuRef,
+    preferredPlacement: 'top',
+    alignment: 'end',
+    gap: 7,
+    layoutRevision: `${targets.length}:${loading}:${error ?? ''}`,
+  });
 
   const displayLabel = target.kind === 'local'
     ? t('chatInput.dispatch.local')
@@ -69,7 +83,11 @@ export const DispatchTargetPicker: React.FC<DispatchTargetPickerProps> = ({
   useEffect(() => {
     if (!open) return;
     const handlePointerDown = (event: PointerEvent) => {
-      if (!rootRef.current?.contains(event.target as Node)) {
+      const targetNode = event.target as Node;
+      if (
+        !rootRef.current?.contains(targetNode)
+        && !menuRef.current?.contains(targetNode)
+      ) {
         setOpen(false);
       }
     };
@@ -101,9 +119,16 @@ export const DispatchTargetPicker: React.FC<DispatchTargetPickerProps> = ({
 
   const menu = open ? (
     <div
+      ref={menuRef}
       className="dispatch-target-picker__menu"
       data-bf-component="dispatch-target-picker"
       data-bf-part="menu"
+      data-bf-placement={menuLayout?.placement ?? 'top'}
+      style={{
+        top: `${menuLayout?.top ?? 0}px`,
+        left: `${menuLayout?.left ?? 0}px`,
+        visibility: menuLayout ? 'visible' : 'hidden',
+      }}
       role="menu"
       aria-label={t('chatInput.dispatch.menuLabel')}
       data-testid="dispatch-target-menu"
@@ -271,6 +296,7 @@ export const DispatchTargetPicker: React.FC<DispatchTargetPickerProps> = ({
       >
         <Tooltip content={tooltip} placement="top">
           <button
+            ref={triggerRef}
             type="button"
             className="dispatch-target-picker__trigger"
             data-bf-component="dispatch-target-picker"
@@ -301,7 +327,7 @@ export const DispatchTargetPicker: React.FC<DispatchTargetPickerProps> = ({
             ) : null}
           </button>
         </Tooltip>
-        {menu}
+        {menu && createPortal(menu, getAppearanceOverlayHost())}
       </div>
 
       <DispatchInstallDialog

--- a/src/web-ui/src/flow_chat/components/ChatInput.scss
+++ b/src/web-ui/src/flow_chat/components/ChatInput.scss
@@ -1303,10 +1303,10 @@
   }
 
   &__mode-dropdown {
-    position: absolute;
-    bottom: calc(100% + 6px);
-    left: 0;
+    position: fixed;
     min-width: 200px;
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 16px);
     background: var(--bf-appearance-token-color-bg-elevated);
     border: 1px solid var(--bf-appearance-token-color-overlay-white-12);
     border-radius: 6px;
@@ -1318,6 +1318,9 @@
       0 0 1px var(--bf-appearance-token-color-overlay-white-12),
       inset 0 1px 0 var(--bf-appearance-token-color-overlay-white-08);
     z-index: $z-dropdown;
+    color: var(--bf-appearance-token-color-text-primary);
+    font-family: var(--bf-appearance-token-font-family-sans);
+    font-size: var(--bf-appearance-token-flowchat-font-size-sm);
     transform-origin: left bottom;
     animation: mode-dropdown-fade-in 180ms cubic-bezier(0.23, 1, 0.32, 1);
 
@@ -1578,11 +1581,9 @@
   }
 
   &__slash-command-picker {
-    position: absolute;
-    bottom: calc(100% + 6px);
-    left: 0;
-    width: 260px;
-    max-height: 280px;
+    position: fixed;
+    width: min(260px, calc(100vw - 16px));
+    max-height: min(280px, calc(100vh - 16px));
     background: var(--bf-appearance-token-color-bg-elevated);
     border: 1px solid var(--bf-appearance-token-border-subtle);
     border-radius: 6px;
@@ -1594,6 +1595,9 @@
       0 0 1px var(--bf-appearance-token-color-overlay-white-12),
       inset 0 1px 0 var(--bf-appearance-token-color-overlay-white-08);
     z-index: $z-dropdown;
+    color: var(--bf-appearance-token-color-text-primary);
+    font-family: var(--bf-appearance-token-font-family-sans);
+    font-size: var(--bf-appearance-token-flowchat-font-size-sm);
     // Slash commands are opened by typing, so their keyboard path is instant.
     animation: none;
   }
@@ -1620,7 +1624,7 @@
   }
 
   &__slash-command-list {
-    max-height: 240px;
+    max-height: min(240px, calc(100vh - 56px));
     overflow-y: auto;
     padding: 4px 0;
 

--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useRef, useCallback, useEffect, useReducer, useState, useMemo, useSyncExternalStore } from 'react';
+import { createPortal } from 'react-dom';
 import path from 'path-browserify';
 import { useTranslation } from 'react-i18next';
 import { ArrowUp, BotMessageSquare, Image, RotateCcw, Plus, X, Sparkles, Loader2, ChevronRight, Files, MessageSquarePlus, Star } from 'lucide-react';
@@ -83,6 +84,8 @@ import { useWorkspaceModeCatalog } from '../hooks/useWorkspaceModeCatalog';
 import { useSessionModeSelection } from '../hooks/useSessionModeSelection';
 import { useComposerDefaultFocus } from '../hooks/useComposerDefaultFocus';
 import { ThreadGoalDialogs } from './thread-goal/ThreadGoalDialogs';
+import { getAppearanceOverlayHost } from '@/infrastructure/appearance/runtime/AppearanceOverlayHost';
+import { useAnchoredPopoverPosition } from '@/shared/utils/useAnchoredPopoverPosition';
 import { FlowChatManager } from '@/flow_chat/services/FlowChatManager';
 import {
   getDeepReviewLaunchErrorMessage,
@@ -414,7 +417,19 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   
   const richTextInputRef = useRef<RichTextInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const mentionAnchorRef = useRef<HTMLDivElement>(null);
   const agentBoostRef = useRef<HTMLDivElement>(null);
+  const boostTriggerRef = useRef<HTMLSpanElement>(null);
+  const boostMenuRef = useRef<HTMLDivElement>(null);
+  const slashCommandPickerRef = useRef<HTMLDivElement>(null);
+  const boostMenuLayout = useAnchoredPopoverPosition({
+    open: modeState.dropdownOpen,
+    anchorRef: boostTriggerRef,
+    popoverRef: boostMenuRef,
+    preferredPlacement: 'top',
+    alignment: 'start',
+    gap: 6,
+  });
   const isImeComposingRef = useRef(false);
   // Ref so the queuedInput sync effect can read the latest value without it being a dep
   const inputValueRef = useRef('');
@@ -1488,6 +1503,15 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     query: '',
     selectedIndex: 0,
   });
+  const slashCommandPickerLayout = useAnchoredPopoverPosition({
+    open: slashCommandState.isActive,
+    anchorRef: mentionAnchorRef,
+    popoverRef: slashCommandPickerRef,
+    preferredPlacement: 'top',
+    alignment: 'start',
+    gap: 6,
+    layoutRevision: `${slashCommandState.kind}:${slashCommandState.query}`,
+  });
 
   const slashPickerWasActiveRef = useRef(false);
   useEffect(() => {
@@ -2473,9 +2497,9 @@ export const ChatInput: React.FC<ChatInputProps> = ({
 
   React.useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (agentBoostRef.current && !agentBoostRef.current.contains(event.target as Node)) {
-        dispatchMode({ type: 'CLOSE_DROPDOWN' });
-      }
+      const target = event.target as Node;
+      if (agentBoostRef.current?.contains(target) || boostMenuRef.current?.contains(target)) return;
+      dispatchMode({ type: 'CLOSE_DROPDOWN' });
     };
 
     if (modeState.dropdownOpen) {
@@ -5142,7 +5166,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                 </button>
               </div>
             )}
-            <div className="bitfun-chat-input__input-area" data-bf-component="chat-input" data-bf-part="area">
+            <div ref={mentionAnchorRef} className="bitfun-chat-input__input-area" data-bf-component="chat-input" data-bf-part="area">
               {imageContexts.length > 0 && (
                 <div
                   className="bitfun-chat-input__image-strip"
@@ -5220,6 +5244,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                   ? undefined
                   : effectiveTargetSession?.workspaceId || workspace?.id}
                 excludeSessionId={effectiveTargetSessionId || undefined}
+                anchorRef={mentionAnchorRef}
                 onSelect={(context: FileContext | DirectoryContext | SessionReferenceContext) => {
                   addContext(context);
                   
@@ -5235,11 +5260,24 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                 }}
               />
               
-              {slashCommandState.isActive && (() => {
+              {slashCommandState.isActive && createPortal((() => {
                 if (slashCommandState.kind === 'actions') {
                   const actions = getFilteredActions();
                   return (
-                    <div data-bf-component="chat-input" data-bf-part="commandPicker" data-bf-command="actions" data-bf-state="open" className="bitfun-chat-input__slash-command-picker">
+                    <div
+                      ref={slashCommandPickerRef}
+                      data-bf-component="chat-input"
+                      data-bf-part="commandPicker"
+                      data-bf-command="actions"
+                      data-bf-state="open"
+                      data-bf-placement={slashCommandPickerLayout?.placement ?? 'top'}
+                      className="bitfun-chat-input__slash-command-picker"
+                      style={{
+                        top: `${slashCommandPickerLayout?.top ?? 0}px`,
+                        left: `${slashCommandPickerLayout?.left ?? 0}px`,
+                        visibility: slashCommandPickerLayout ? 'visible' : 'hidden',
+                      }}
+                    >
                       <div className="bitfun-chat-input__slash-command-header" data-bf-component="chat-input" data-bf-part="commandHeader">
                         <span>{t('chatInput.quickAction')}</span>
                         <span className="bitfun-chat-input__slash-command-hint">{t('chatInput.selectHint')}</span>
@@ -5276,7 +5314,20 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                   const firstModeIndex = items.findIndex(item => item.kind === 'mode');
                   const firstSkillIndex = items.findIndex(item => item.kind === 'skill');
                   return (
-                    <div data-bf-component="chat-input" data-bf-part="commandPicker" data-bf-command="all" data-bf-state="open" className="bitfun-chat-input__slash-command-picker">
+                    <div
+                      ref={slashCommandPickerRef}
+                      data-bf-component="chat-input"
+                      data-bf-part="commandPicker"
+                      data-bf-command="all"
+                      data-bf-state="open"
+                      data-bf-placement={slashCommandPickerLayout?.placement ?? 'top'}
+                      className="bitfun-chat-input__slash-command-picker"
+                      style={{
+                        top: `${slashCommandPickerLayout?.top ?? 0}px`,
+                        left: `${slashCommandPickerLayout?.left ?? 0}px`,
+                        visibility: slashCommandPickerLayout ? 'visible' : 'hidden',
+                      }}
+                    >
                       <div className="bitfun-chat-input__slash-command-header" data-bf-component="chat-input" data-bf-part="commandHeader">
                         <span>{t('chatInput.commands')}</span>
                         <span className="bitfun-chat-input__slash-command-hint">{t('chatInput.selectHint')}</span>
@@ -5374,7 +5425,20 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                 if (slashCommandState.kind === 'skills') {
                   const items = getActiveSlashPickerItems();
                   return (
-                    <div data-bf-component="chat-input" data-bf-part="commandPicker" data-bf-command="skills" data-bf-state="open" className="bitfun-chat-input__slash-command-picker">
+                    <div
+                      ref={slashCommandPickerRef}
+                      data-bf-component="chat-input"
+                      data-bf-part="commandPicker"
+                      data-bf-command="skills"
+                      data-bf-state="open"
+                      data-bf-placement={slashCommandPickerLayout?.placement ?? 'top'}
+                      className="bitfun-chat-input__slash-command-picker"
+                      style={{
+                        top: `${slashCommandPickerLayout?.top ?? 0}px`,
+                        left: `${slashCommandPickerLayout?.left ?? 0}px`,
+                        visibility: slashCommandPickerLayout ? 'visible' : 'hidden',
+                      }}
+                    >
                       <div className="bitfun-chat-input__slash-command-header" data-bf-component="chat-input" data-bf-part="commandHeader">
                         <span>{t('chatInput.boostSkills')}</span>
                         <span className="bitfun-chat-input__slash-command-hint">{t('chatInput.selectHint')}</span>
@@ -5450,7 +5514,20 @@ export const ChatInput: React.FC<ChatInputProps> = ({
 
                 const filteredModes = getFilteredSelectableModes();
                 return (
-                  <div data-bf-component="chat-input" data-bf-part="commandPicker" data-bf-command="modes" data-bf-state="open" className="bitfun-chat-input__slash-command-picker">
+                  <div
+                    ref={slashCommandPickerRef}
+                    data-bf-component="chat-input"
+                    data-bf-part="commandPicker"
+                    data-bf-command="modes"
+                    data-bf-state="open"
+                    data-bf-placement={slashCommandPickerLayout?.placement ?? 'top'}
+                    className="bitfun-chat-input__slash-command-picker"
+                    style={{
+                      top: `${slashCommandPickerLayout?.top ?? 0}px`,
+                      left: `${slashCommandPickerLayout?.left ?? 0}px`,
+                      visibility: slashCommandPickerLayout ? 'visible' : 'hidden',
+                    }}
+                  >
                     <div className="bitfun-chat-input__slash-command-header" data-bf-component="chat-input" data-bf-part="commandHeader">
                       <span>{t('chatInput.addModeMenuTitle')}</span>
                       <span className="bitfun-chat-input__slash-command-hint">{t('chatInput.selectHint')}</span>
@@ -5484,14 +5561,14 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                     </div>
                   </div>
                 );
-              })()}
+              })(), getAppearanceOverlayHost())}
             </div>
             
             <div className="bitfun-chat-input__actions" data-bf-component="chat-input" data-bf-part="actions">
               <div className="bitfun-chat-input__actions-left" data-bf-component="chat-input" data-bf-part="actionsLeft">
                 <div className="bitfun-chat-input__agent-boost" data-bf-component="chat-input" data-bf-part="boost" ref={agentBoostRef}>
                   {!isAcpTargetSession && (
-                    <span data-bf-component="chat-input" data-bf-part="boostTrigger" data-bf-state={modeState.dropdownOpen ? 'open' : undefined}>
+                    <span ref={boostTriggerRef} data-bf-component="chat-input" data-bf-part="boostTrigger" data-bf-state={modeState.dropdownOpen ? 'open' : undefined}>
                       <Tooltip content={t('chatInput.addBoostTooltip')}>
                         <IconButton
                           className="bitfun-chat-input__agent-boost-add"
@@ -5543,8 +5620,20 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                     </div>
                   )}
 
-                  {modeState.dropdownOpen && (
-                    <div className="bitfun-chat-input__mode-dropdown bitfun-chat-input__mode-dropdown--agent-boost" data-bf-component="chat-input" data-bf-part="boostMenu" data-bf-state="open">
+                  {modeState.dropdownOpen && createPortal(
+                    <div
+                      ref={boostMenuRef}
+                      className="bitfun-chat-input__mode-dropdown bitfun-chat-input__mode-dropdown--agent-boost"
+                      data-bf-component="chat-input"
+                      data-bf-part="boostMenu"
+                      data-bf-state="open"
+                      data-bf-placement={boostMenuLayout?.placement ?? 'top'}
+                      style={{
+                        top: `${boostMenuLayout?.top ?? 0}px`,
+                        left: `${boostMenuLayout?.left ?? 0}px`,
+                        visibility: boostMenuLayout ? 'visible' : 'hidden',
+                      }}
+                    >
                       {canSwitchModes && (
                         <>
                           <div className="bitfun-chat-input__boost-section" data-bf-component="chat-input" data-bf-part="boostSection">
@@ -5815,7 +5904,8 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                           <span>{t('chatInput.boostNewSession')}</span>
                         </div>
                       </div>
-                    </div>
+                    </div>,
+                    getAppearanceOverlayHost(),
                   )}
                 </div>
               </div>

--- a/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStrip.scss
+++ b/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStrip.scss
@@ -210,18 +210,20 @@
   }
 
   &__permission-menu {
-    position: absolute;
-    right: 0;
-    bottom: calc(100% + 7px);
-    z-index: 10;
+    position: fixed;
+    z-index: $z-popover;
     box-sizing: border-box;
-    width: min(286px, calc(100vw - 24px));
+    width: min(286px, calc(100vw - 16px));
+    max-height: calc(100vh - 16px);
+    overflow-y: auto;
     padding: 6px;
     border: 1px solid var(--bf-appearance-token-border-subtle);
     border-radius: $size-radius-base;
     background: var(--bf-appearance-token-color-bg-elevated);
     box-shadow: var(--bf-appearance-token-shadow-lg);
     color: var(--bf-appearance-token-color-text-primary);
+    font-family: var(--bf-appearance-token-font-family-sans);
+    font-size: var(--bf-appearance-token-flowchat-font-size-xxs);
     user-select: none;
   }
 

--- a/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStrip.test.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStrip.test.tsx
@@ -49,6 +49,7 @@ describe('ChatInputWorkspaceStrip git refresh behavior', () => {
   let root: Root;
 
   beforeEach(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
@@ -65,6 +66,7 @@ describe('ChatInputWorkspaceStrip git refresh behavior', () => {
       root.unmount();
     });
     container.remove();
+    document.querySelector('[data-bf-overlay-host="true"]')?.remove();
     vi.clearAllMocks();
   });
 
@@ -127,26 +129,30 @@ describe('ChatInputWorkspaceStrip git refresh behavior', () => {
     await act(async () => {
       trigger?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
-    expect(container.querySelector('[data-testid="chat-input-permission-menu"]')).not.toBeNull();
+    const permissionMenu = document.querySelector<HTMLElement>(
+      '[data-testid="chat-input-permission-menu"]',
+    );
+    expect(permissionMenu).not.toBeNull();
+    expect(permissionMenu?.style.visibility).toBe('visible');
 
     await act(async () => {
-      container
+      document
         .querySelector<HTMLButtonElement>('[data-testid="chat-input-permission-option-auto"]')
         ?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     expect(onChange).toHaveBeenCalledWith('auto');
-    expect(container.querySelector('[data-testid="chat-input-permission-menu"]')).toBeNull();
+    expect(document.querySelector('[data-testid="chat-input-permission-menu"]')).toBeNull();
 
     await act(async () => {
       trigger?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     await act(async () => {
-      container
+      document
         .querySelector<HTMLButtonElement>('[data-testid="chat-input-permission-hide-control"]')
         ?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     expect(onHide).toHaveBeenCalledOnce();
-    expect(container.querySelector('[data-testid="chat-input-permission-menu"]')).toBeNull();
+    expect(document.querySelector('[data-testid="chat-input-permission-menu"]')).toBeNull();
   });
 
   it('shows ACP ownership without exposing native permission choices', async () => {
@@ -190,13 +196,13 @@ describe('ChatInputWorkspaceStrip git refresh behavior', () => {
     await act(async () => {
       trigger?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
-    expect(container.textContent).toContain('This dispatched session');
-    expect(container.querySelector(
+    expect(document.body.textContent).toContain('This dispatched session');
+    expect(document.querySelector(
       '[data-testid="chat-input-permission-option-full_access"]',
     )).toBeNull();
 
     await act(async () => {
-      container.querySelector<HTMLButtonElement>(
+      document.querySelector<HTMLButtonElement>(
         '[data-testid="chat-input-permission-option-auto"]',
       )?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });

--- a/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStrip.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStrip.tsx
@@ -3,6 +3,7 @@
  */
 
 import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import {
   Activity,
@@ -21,7 +22,9 @@ import type { ThreadGoalSnapshot } from '../services/goalService';
 import { Tooltip, IconButton } from '@/component-library';
 import { useGitState } from '@/tools/git/hooks/useGitState';
 import type { SessionExecutionTarget } from '@/infrastructure/api/service-api/WorktreeAPI';
+import { getAppearanceOverlayHost } from '@/infrastructure/appearance/runtime/AppearanceOverlayHost';
 import { useI18n } from '@/infrastructure/i18n';
+import { useAnchoredPopoverPosition } from '@/shared/utils/useAnchoredPopoverPosition';
 import { DispatchResultDialog } from '@/features/dispatch/DispatchResultDialog';
 import { DispatchTargetPicker } from '@/features/dispatch/DispatchTargetPicker';
 import type { DispatchSelection, DispatchTarget } from '@/features/dispatch/types';
@@ -108,8 +111,19 @@ export const ChatInputWorkspaceStrip: React.FC<ChatInputWorkspaceStripProps> = (
   const { t: tWorktrees } = useI18n('worktrees');
   const { t: tCommon } = useI18n('common');
   const permissionRootRef = useRef<HTMLDivElement>(null);
+  const permissionTriggerRef = useRef<HTMLButtonElement>(null);
+  const permissionMenuRef = useRef<HTMLDivElement>(null);
   const [permissionMenuOpen, setPermissionMenuOpen] = useState(false);
   const [resultDialogOpen, setResultDialogOpen] = useState(false);
+  const permissionMenuLayout = useAnchoredPopoverPosition({
+    open: permissionMenuOpen,
+    anchorRef: permissionTriggerRef,
+    popoverRef: permissionMenuRef,
+    preferredPlacement: 'top',
+    alignment: 'end',
+    gap: 7,
+    layoutRevision: `${permissionControl?.options?.length ?? 0}:${Boolean(permissionControl?.onHide)}`,
+  });
   const trimmedPath = repositoryPath.trim();
   const label = workspaceLabel.trim();
 
@@ -177,7 +191,11 @@ export const ChatInputWorkspaceStrip: React.FC<ChatInputWorkspaceStripProps> = (
     if (!permissionMenuOpen) return;
 
     const handlePointerDown = (event: PointerEvent) => {
-      if (!permissionRootRef.current?.contains(event.target as Node)) {
+      const target = event.target as Node;
+      if (
+        !permissionRootRef.current?.contains(target)
+        && !permissionMenuRef.current?.contains(target)
+      ) {
         setPermissionMenuOpen(false);
       }
     };
@@ -388,6 +406,7 @@ export const ChatInputWorkspaceStrip: React.FC<ChatInputWorkspaceStripProps> = (
             >
               <Tooltip content={permissionTooltip} placement="top">
                 <button
+                  ref={permissionTriggerRef}
                   type="button"
                   className={[
                     'bitfun-chat-input-workspace-strip__permission-trigger',
@@ -418,12 +437,19 @@ export const ChatInputWorkspaceStrip: React.FC<ChatInputWorkspaceStripProps> = (
                 </button>
               </Tooltip>
 
-              {permissionMenuOpen && permissionMode !== 'acp' ? (
+              {permissionMenuOpen && permissionMode !== 'acp' ? createPortal(
                 <div
+                  ref={permissionMenuRef}
                   data-bf-component="chat-input-workspace-strip"
                   data-bf-part="permissionMenu"
                   data-bf-state="open"
+                  data-bf-placement={permissionMenuLayout?.placement ?? 'top'}
                   className="bitfun-chat-input-workspace-strip__permission-menu"
+                  style={{
+                    top: `${permissionMenuLayout?.top ?? 0}px`,
+                    left: `${permissionMenuLayout?.left ?? 0}px`,
+                    visibility: permissionMenuLayout ? 'visible' : 'hidden',
+                  }}
                   role="menu"
                   aria-label={t('chatInput.permissionMode.menuLabel')}
                   data-testid="chat-input-permission-menu"
@@ -493,7 +519,8 @@ export const ChatInputWorkspaceStrip: React.FC<ChatInputWorkspaceStripProps> = (
                       </button>
                     </>
                   ) : null}
-                </div>
+                </div>,
+                getAppearanceOverlayHost(),
               ) : null}
             </div>
           ) : null}

--- a/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStripLayout.test.ts
+++ b/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStripLayout.test.ts
@@ -39,7 +39,7 @@ describe('ChatInputWorkspaceStrip layout styles', () => {
     expect(stylesheet).toContain('&--ask {');
     expect(stylesheet).toContain('border-color: var(--bf-appearance-token-color-success-border);');
     expect(stylesheet).toContain('background: var(--bf-appearance-token-color-success-bg);');
-    expect(stylesheet).toContain('width: min(286px, calc(100vw - 24px));');
+    expect(stylesheet).toContain('width: min(286px, calc(100vw - 16px));');
     expect(stylesheet).toContain('@media (max-width: 560px)');
     expect(stylesheet).toContain('&__permission-label');
     expect(stylesheet).toContain('display: none;');

--- a/src/web-ui/src/flow_chat/components/FileMentionPicker.scss
+++ b/src/web-ui/src/flow_chat/components/FileMentionPicker.scss
@@ -30,6 +30,17 @@
   flex-direction: column;
   backdrop-filter: blur(20px) saturate(1.2);
   -webkit-backdrop-filter: blur(20px) saturate(1.2);
+
+  &--overlay {
+    position: fixed;
+    z-index: $z-popover;
+    width: min(400px, calc(100vw - 16px));
+    min-width: min(260px, calc(100vw - 16px));
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 16px);
+    color: var(--bf-appearance-token-color-text-primary);
+    font-family: var(--bf-appearance-token-font-family-sans);
+  }
   
   // Entry animation
   animation: mentionPickerSlideUp 0.18s cubic-bezier(0.34, 1.56, 0.64, 1);

--- a/src/web-ui/src/flow_chat/components/FileMentionPicker.tsx
+++ b/src/web-ui/src/flow_chat/components/FileMentionPicker.tsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import {
   File,
@@ -31,6 +32,8 @@ import type {
 } from '@/shared/types/context';
 import { Tooltip } from '@/component-library';
 import { createLogger } from '@/shared/utils/logger';
+import { getAppearanceOverlayHost } from '@/infrastructure/appearance/runtime/AppearanceOverlayHost';
+import { useAnchoredPopoverPosition } from '@/shared/utils/useAnchoredPopoverPosition';
 import {
   workspaceReferenceItems,
   type FileItem,
@@ -50,6 +53,8 @@ export interface FileMentionPickerProps {
   excludeSessionId?: string;
   onSelect: (context: FileContext | DirectoryContext | SessionReferenceContext) => void;
   onClose: () => void;
+  /** Anchor used by the default portalled overlay mode. */
+  anchorRef?: React.RefObject<HTMLElement | null>;
   position?: { top: number; left: number };
   onNavigate?: (direction: 'up' | 'down' | 'enter' | 'escape') => void;
 }
@@ -66,6 +71,7 @@ export const FileMentionPicker: React.FC<FileMentionPickerProps> = ({
   excludeSessionId,
   onSelect,
   onClose,
+  anchorRef,
   position,
 }) => {
   const { t } = useTranslation('flow-chat');
@@ -79,6 +85,7 @@ export const FileMentionPicker: React.FC<FileMentionPickerProps> = ({
   const [currentPath, setCurrentPath] = useState<string>('');
   const [pathHistory, setPathHistory] = useState<string[]>([]);
   const containerRef = useRef<HTMLDivElement>(null);
+  const fallbackAnchorRef = useRef<HTMLElement>(null);
   const fileAbortControllerRef = useRef<AbortController | null>(null);
   const fileSearchDebounceTimerRef = useRef<number | null>(null);
   const sessionSearchDebounceTimerRef = useRef<number | null>(null);
@@ -337,6 +344,16 @@ export const FileMentionPicker: React.FC<FileMentionPickerProps> = ({
   const currentDirName = currentPath
     ? currentPath.replace(/\\/g, '/').split('/').pop() || ''
     : workspacePath?.replace(/\\/g, '/').split('/').pop() || t('fileMention.rootDirectory');
+  const isOverlay = Boolean(anchorRef) && !position;
+  const overlayLayout = useAnchoredPopoverPosition({
+    open: isOpen && isOverlay,
+    anchorRef: anchorRef ?? fallbackAnchorRef,
+    popoverRef: containerRef,
+    preferredPlacement: 'top',
+    alignment: 'start',
+    gap: 8,
+    layoutRevision: `${displayItems.length}:${currentPath}:${isSearchMode}`,
+  });
 
   useEffect(() => () => {
     if (fileSearchDebounceTimerRef.current !== null) window.clearTimeout(fileSearchDebounceTimerRef.current);
@@ -459,11 +476,28 @@ export const FileMentionPicker: React.FC<FileMentionPickerProps> = ({
   }, [displayItems.length, selectedIndex]);
 
   if (!isOpen) return null;
-  const style: React.CSSProperties = position ? { position: 'absolute', top: position.top, left: position.left } : {};
+  const style: React.CSSProperties = position
+    ? { position: 'absolute', top: position.top, left: position.left }
+    : isOverlay
+      ? {
+          top: `${overlayLayout?.top ?? 0}px`,
+          left: `${overlayLayout?.left ?? 0}px`,
+          visibility: overlayLayout ? 'visible' : 'hidden',
+        }
+      : {};
   const isLoading = isFileLoading || isSessionLoading;
 
-  return (
-    <div data-bf-component="file-mention-picker" data-bf-part="root" data-bf-state={isLoading ? 'loading' : undefined} ref={containerRef} className="file-mention-picker" style={style} onMouseDown={event => event.preventDefault()}>
+  const picker = (
+    <div
+      data-bf-component="file-mention-picker"
+      data-bf-part="root"
+      data-bf-state={isLoading ? 'loading' : undefined}
+      data-bf-placement={isOverlay ? overlayLayout?.placement ?? 'top' : undefined}
+      ref={containerRef}
+      className={`file-mention-picker${isOverlay ? ' file-mention-picker--overlay' : ''}`}
+      style={style}
+      onMouseDown={event => event.preventDefault()}
+    >
       <div data-bf-component="file-mention-picker" data-bf-part="header" className="file-mention-picker__header">
         {!isSearchMode && pathHistory.length > 0 && (
           <Tooltip content={t('fileMention.goBack')}>
@@ -524,6 +558,8 @@ export const FileMentionPicker: React.FC<FileMentionPickerProps> = ({
       </div>
     </div>
   );
+
+  return isOverlay ? createPortal(picker, getAppearanceOverlayHost()) : picker;
 };
 
 export default FileMentionPicker;

--- a/src/web-ui/src/flow_chat/components/FileMentionPickerOverlay.test.tsx
+++ b/src/web-ui/src/flow_chat/components/FileMentionPickerOverlay.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+
+import React, { act, useRef } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { FileMentionPicker } from './FileMentionPicker';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/component-library', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/infrastructure/api', () => ({
+  sessionAPI: {
+    searchReferenceableSessions: vi.fn().mockResolvedValue([]),
+  },
+  workspaceAPI: {
+    getDirectoryChildren: vi.fn().mockResolvedValue([]),
+    searchFilenamesOnly: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock('@/infrastructure/api/service-api/ExternalSourcesAPI', () => ({
+  externalSourcesAPI: {
+    getWorkspaceReferences: vi.fn().mockResolvedValue({ references: [] }),
+  },
+}));
+
+const Harness: React.FC = () => {
+  const anchorRef = useRef<HTMLButtonElement>(null);
+  return (
+    <div>
+      <button ref={anchorRef} type="button">anchor</button>
+      <FileMentionPicker
+        isOpen
+        searchQuery=""
+        workspacePath="/workspace"
+        anchorRef={anchorRef}
+        onSelect={vi.fn()}
+        onClose={vi.fn()}
+      />
+    </div>
+  );
+};
+
+describe('FileMentionPicker overlay', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    document.querySelector('[data-bf-overlay-host="true"]')?.remove();
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it('renders above clipped composers through the appearance overlay host', async () => {
+    await act(async () => {
+      root.render(<Harness />);
+      await Promise.resolve();
+    });
+
+    const picker = document.querySelector<HTMLElement>('.file-mention-picker--overlay');
+    expect(picker?.parentElement?.getAttribute('data-bf-overlay-host')).toBe('true');
+    expect(picker?.style.visibility).toBe('visible');
+  });
+});

--- a/src/web-ui/src/flow_chat/components/ModelSelector.scss
+++ b/src/web-ui/src/flow_chat/components/ModelSelector.scss
@@ -155,11 +155,12 @@
   // ==================== Dropdown menu ====================
   
   &__dropdown {
-    position: absolute;
-    bottom: calc(100% + 6px);
-    left: 0;
+    position: fixed;
     min-width: clamp(0px, 220px, calc(100vw - 16px));
     max-width: clamp(0px, 280px, calc(100vw - 16px));
+    color: var(--bf-appearance-token-color-text-primary);
+    font-family: var(--bf-appearance-token-font-family-sans);
+    font-size: var(--bf-appearance-token-flowchat-font-size-sm);
     background: var(--bf-appearance-token-color-bg-elevated);
     border: 1px solid var(--bf-appearance-token-color-overlay-white-12);
     border-radius: 6px;

--- a/src/web-ui/src/flow_chat/components/WelcomePanel.css
+++ b/src/web-ui/src/flow_chat/components/WelcomePanel.css
@@ -234,17 +234,19 @@
 /* ── Dropdown ── */
 
 .welcome-panel__dropdown {
-  position: absolute;
-  top: calc(100% + 4px);
-  left: 0;
-  z-index: 100;
+  position: fixed;
+  z-index: 360;
   min-width: 210px;
-  max-width: 300px;
+  max-width: min(300px, calc(100vw - 16px));
+  max-height: calc(100vh - 16px);
   background: var(--bf-appearance-token-color-bg-elevated);
   border: 1px solid var(--bf-appearance-token-border-base);
   border-radius: calc(var(--bf-appearance-token-flowchat-card-radius) + 2px);
   box-shadow: 0 8px 24px var(--bf-appearance-token-color-overlay-black-15);
-  overflow: hidden;
+  overflow-y: auto;
+  color: var(--bf-appearance-token-color-text-primary);
+  font-family: var(--bf-appearance-token-font-family-sans);
+  font-size: var(--bf-appearance-token-flowchat-font-size-sm);
   transform-origin: left top;
   animation: wp-dropdownIn 180ms cubic-bezier(0.23, 1, 0.32, 1);
 }

--- a/src/web-ui/src/flow_chat/components/WelcomePanel.test.tsx
+++ b/src/web-ui/src/flow_chat/components/WelcomePanel.test.tsx
@@ -84,6 +84,7 @@ describe('WelcomePanel Git summary loading', () => {
     act(() => {
       root.unmount();
     });
+    document.querySelector('[data-bf-overlay-host="true"]')?.remove();
     container.remove();
   });
 
@@ -119,5 +120,19 @@ describe('WelcomePanel Git summary loading', () => {
     expect(gitApiMock.getStatus).toHaveBeenCalledWith('D:/workspace/BitFun', 'welcome_panel');
     expect(container.querySelector('[data-bf-part="workspaceAction"]')).not.toBeNull();
     expect(container.querySelector('[data-bf-part="gitAction"]')).not.toBeNull();
+  });
+
+  it('portals the workspace menu outside the scrollable welcome panel', async () => {
+    gitApiMock.isGitRepository.mockResolvedValue(false);
+    await act(async () => {
+      root.render(<WelcomePanel sessionMode="agentic" />);
+    });
+
+    const trigger = container.querySelector<HTMLButtonElement>('[data-bf-part="workspaceAction"]');
+    await act(async () => trigger?.click());
+
+    const menu = document.querySelector<HTMLElement>('[data-bf-part="workspaceMenu"]');
+    expect(menu?.parentElement?.getAttribute('data-bf-overlay-host')).toBe('true');
+    expect(menu?.style.visibility).toBe('visible');
   });
 });

--- a/src/web-ui/src/flow_chat/components/WelcomePanel.tsx
+++ b/src/web-ui/src/flow_chat/components/WelcomePanel.tsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useEffect, useState, useCallback, useRef, useMemo } from 'react';
+import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { FolderOpen, FolderPlus, ChevronDown, Check, GitBranch } from 'lucide-react';
 import { gitAPI } from '../../infrastructure/api';
@@ -14,6 +15,8 @@ import { useWorkspaceContext } from '@/infrastructure/contexts/WorkspaceContext'
 import type { WorkspaceInfo } from '@/shared/types';
 import CoworkExampleCards from './CoworkExampleCards';
 import { useAgentIdentityDocument } from '@/app/scenes/my-agent/useAgentIdentityDocument';
+import { getAppearanceOverlayHost } from '@/infrastructure/appearance/runtime/AppearanceOverlayHost';
+import { useAnchoredPopoverPosition } from '@/shared/utils/useAnchoredPopoverPosition';
 import './WelcomePanel.css';
 
 const log = createLogger('WelcomePanel');
@@ -38,6 +41,7 @@ export const WelcomePanel: React.FC<WelcomePanelProps> = ({
   const [isSelectingWorkspace, setIsSelectingWorkspace] = useState(false);
   const workspaceDropdownRef = useRef<HTMLDivElement>(null);
   const workspaceTriggerRef = useRef<HTMLButtonElement>(null);
+  const workspaceMenuRef = useRef<HTMLDivElement>(null);
 
   const { switchLeftPanelTab } = useApp();
   const {
@@ -72,6 +76,15 @@ export const WelcomePanel: React.FC<WelcomePanelProps> = ({
     () => openedWorkspacesList.filter(ws => ws.id !== currentWorkspace?.id),
     [openedWorkspacesList, currentWorkspace?.id],
   );
+  const workspaceMenuLayout = useAnchoredPopoverPosition({
+    open: workspaceDropdownOpen,
+    anchorRef: workspaceTriggerRef,
+    popoverRef: workspaceMenuRef,
+    preferredPlacement: 'bottom',
+    alignment: 'start',
+    gap: 4,
+    layoutRevision: otherWorkspaces.length,
+  });
 
   const handleGitClick = useCallback(() => {
     switchLeftPanelTab('git');
@@ -151,7 +164,12 @@ export const WelcomePanel: React.FC<WelcomePanelProps> = ({
   useEffect(() => {
     if (!workspaceDropdownOpen) return;
     const handlePointerDown = (e: MouseEvent) => {
-      if (workspaceDropdownRef.current && !workspaceDropdownRef.current.contains(e.target as Node)) {
+      const target = e.target as Node;
+      if (
+        workspaceDropdownRef.current &&
+        !workspaceDropdownRef.current.contains(target) &&
+        !workspaceMenuRef.current?.contains(target)
+      ) {
         setWorkspaceDropdownOpen(false);
       }
     };
@@ -272,8 +290,19 @@ export const WelcomePanel: React.FC<WelcomePanelProps> = ({
                           className={`welcome-panel__inline-chevron${workspaceDropdownOpen ? ' welcome-panel__inline-chevron--open' : ''}`}
                         />
                       </button>
-                      {workspaceDropdownOpen && (
-                        <div data-bf-component="welcome-panel" data-bf-part="workspaceMenu" className="welcome-panel__dropdown">
+                      {workspaceDropdownOpen && createPortal(
+                        <div
+                          ref={workspaceMenuRef}
+                          data-bf-component="welcome-panel"
+                          data-bf-part="workspaceMenu"
+                          data-bf-placement={workspaceMenuLayout?.placement ?? 'bottom'}
+                          className="welcome-panel__dropdown"
+                          style={{
+                            top: `${workspaceMenuLayout?.top ?? 0}px`,
+                            left: `${workspaceMenuLayout?.left ?? 0}px`,
+                            visibility: workspaceMenuLayout ? 'visible' : 'hidden',
+                          }}
+                        >
                           <button
                             type="button"
                             data-bf-component="welcome-panel"
@@ -311,7 +340,8 @@ export const WelcomePanel: React.FC<WelcomePanelProps> = ({
                               ))}
                             </>
                           )}
-                        </div>
+                        </div>,
+                        getAppearanceOverlayHost(),
                       )}
                     </span>
                     {!isCoworkSession && gitState && (

--- a/src/web-ui/src/flow_chat/components/modern/FlowChatHeader.scss
+++ b/src/web-ui/src/flow_chat/components/modern/FlowChatHeader.scss
@@ -225,11 +225,9 @@
   }
 
   &__background-command-panel {
-    position: absolute;
-    top: calc(100% + 8px);
-    right: 0;
-    width: min(340px, calc(100vw - 32px));
-    max-height: min(360px, calc(100vh - 96px));
+    position: fixed;
+    width: min(340px, calc(100vw - 16px));
+    max-height: min(360px, calc(100vh - 16px));
     display: flex;
     flex-direction: column;
     overflow: hidden;
@@ -239,7 +237,9 @@
     box-shadow: var(--bf-appearance-token-shadow-lg);
     backdrop-filter: blur(16px);
     -webkit-backdrop-filter: blur(16px);
-    z-index: 30;
+    z-index: $z-popover;
+    color: var(--bf-appearance-token-color-text-primary);
+    font-family: var(--bf-appearance-token-font-family-sans);
   }
 
   &__background-command-panel-header {
@@ -377,6 +377,10 @@
       top: auto;
       right: auto;
       z-index: 10000;
+      max-height: calc(100vh - 16px);
+      overflow-y: auto;
+      color: var(--bf-appearance-token-color-text-primary);
+      font-family: var(--bf-appearance-token-font-family-sans);
     }
   }
 

--- a/src/web-ui/src/flow_chat/components/modern/FlowChatHeader.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/FlowChatHeader.test.tsx
@@ -25,21 +25,21 @@ vi.mock('@/component-library', async () => {
     Tooltip: ({ children }: { children: React.ReactNode }) => (
       <ReactModule.Fragment>{children}</ReactModule.Fragment>
     ),
-    IconButton: ({
+    IconButton: ReactModule.forwardRef<HTMLButtonElement, React.ButtonHTMLAttributes<HTMLButtonElement> & {
+      size?: string;
+      tooltip?: string;
+      variant?: string;
+    }>(({
       children,
       size,
       tooltip,
       variant,
       ...props
-    }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
-      size?: string;
-      tooltip?: string;
-      variant?: string;
-    }) => (
-      <button type="button" title={tooltip} {...props}>
+    }, ref) => (
+      <button ref={ref} type="button" title={tooltip} {...props}>
         {children}
       </button>
-    ),
+    )),
     Input: ReactModule.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>((props, ref) => (
       <input ref={ref} {...props} />
     )),
@@ -93,6 +93,7 @@ describe('FlowChatHeader', () => {
     act(() => {
       root.unmount();
     });
+    document.querySelector('[data-bf-overlay-host="true"]')?.remove();
     container.remove();
     vi.restoreAllMocks();
   });
@@ -171,8 +172,10 @@ describe('FlowChatHeader', () => {
       commandButton?.click();
     });
 
-    const panel = container.querySelector('.flowchat-header__background-command-panel');
+    const panel = document.querySelector<HTMLElement>('.flowchat-header__background-command-panel');
     expect(panel?.textContent).toContain('flowChatHeader.backgroundCommandEmpty');
+    expect(panel?.parentElement?.getAttribute('data-bf-overlay-host')).toBe('true');
+    expect(panel?.style.visibility).toBe('visible');
   });
 
   it('renders background command menus in a portal outside the scrollable panel', () => {
@@ -204,7 +207,7 @@ describe('FlowChatHeader', () => {
       commandButton?.click();
     });
 
-    const panel = container.querySelector('.flowchat-header__background-command-panel');
+    const panel = document.querySelector('.flowchat-header__background-command-panel');
     const menuButton = panel?.querySelector<HTMLButtonElement>(
       '.flowchat-header__background-command-panel-header-actions [aria-label="flowChatHeader.backgroundCommandActions"]',
     );
@@ -217,11 +220,12 @@ describe('FlowChatHeader', () => {
     const menu = document.querySelector<HTMLDivElement>('[data-testid="flowchat-header-background-menu"]');
     expect(menu).not.toBeNull();
     expect(panel?.contains(menu ?? null)).toBe(false);
+    expect(menu?.classList.contains('flowchat-header__background-command-menu--portal')).toBe(true);
 
     act(() => {
       menu?.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
     });
-    expect(container.querySelector('.flowchat-header__background-command-panel')).not.toBeNull();
+    expect(document.querySelector('.flowchat-header__background-command-panel')).not.toBeNull();
 
     const stopButton = menu?.querySelector<HTMLButtonElement>('[role="menuitem"]');
     act(() => {

--- a/src/web-ui/src/flow_chat/components/modern/FlowChatHeader.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/FlowChatHeader.tsx
@@ -14,6 +14,7 @@ import { SessionTreePopover, type SessionTreeSelection } from './SessionTreePopo
 import { useWorkspaceContext } from '@/infrastructure/contexts/WorkspaceContext';
 import { getAppearanceOverlayHost } from '@/infrastructure/appearance';
 import { computeFixedPopoverPosition } from '@/shared/utils/fixedPopoverViewport';
+import { useAnchoredPopoverPosition } from '@/shared/utils/useAnchoredPopoverPosition';
 import { createReviewPlatformTab } from '@/shared/utils/tabUtils';
 import './FlowChatHeader.scss';
 
@@ -109,6 +110,8 @@ export const FlowChatHeader: React.FC<FlowChatHeaderProps> = ({
   const headerRef = useRef<HTMLDivElement | null>(null);
   const leftActionsRef = useRef<HTMLDivElement | null>(null);
   const rightActionsRef = useRef<HTMLDivElement | null>(null);
+  const backgroundCommandRootRef = useRef<HTMLDivElement | null>(null);
+  const backgroundCommandTriggerRef = useRef<HTMLButtonElement | null>(null);
   const backgroundCommandPanelRef = useRef<HTMLDivElement | null>(null);
   const backgroundCommandMenuAnchorRef = useRef<HTMLButtonElement | null>(null);
   const backgroundCommandMenuRef = useRef<HTMLDivElement | null>(null);
@@ -137,6 +140,15 @@ export const FlowChatHeader: React.FC<FlowChatHeaderProps> = ({
   const hasOpenBackgroundCommandMenu =
     isBackgroundCommandSectionMenuOpen ||
     openBackgroundCommandMenuId !== null;
+  const backgroundCommandPanelLayout = useAnchoredPopoverPosition({
+    open: isBackgroundCommandPanelOpen,
+    anchorRef: backgroundCommandTriggerRef,
+    popoverRef: backgroundCommandPanelRef,
+    preferredPlacement: 'bottom',
+    alignment: 'end',
+    gap: 8,
+    layoutRevision: backgroundCommandCount,
+  });
 
   const updateBackgroundCommandMenuPosition = useCallback(() => {
     const anchor = backgroundCommandMenuAnchorRef.current;
@@ -164,6 +176,7 @@ export const FlowChatHeader: React.FC<FlowChatHeaderProps> = ({
     const handlePointerDown = (event: MouseEvent) => {
       const target = event.target as Node;
       if (
+        !backgroundCommandRootRef.current?.contains(target) &&
         !backgroundCommandPanelRef.current?.contains(target) &&
         !backgroundCommandMenuRef.current?.contains(target)
       ) {
@@ -401,7 +414,7 @@ export const FlowChatHeader: React.FC<FlowChatHeaderProps> = ({
         {openBackgroundCommandMenuId === command.execSessionKey && backgroundCommandMenuPosition ? createPortal(
           <div
             ref={backgroundCommandMenuRef}
-            className="flowchat-header__background-command-menu"
+            className="flowchat-header__background-command-menu flowchat-header__background-command-menu--portal"
             data-bf-component="flow-chat-header"
             data-bf-part="commandMenu"
             role="menu"
@@ -519,11 +532,12 @@ export const FlowChatHeader: React.FC<FlowChatHeaderProps> = ({
         />
         <div
           className="flowchat-header__background-command-nav"
-          ref={backgroundCommandPanelRef}
+          ref={backgroundCommandRootRef}
           data-bf-component="flow-chat-header"
           data-bf-part="backgroundActivity"
         >
           <IconButton
+            ref={backgroundCommandTriggerRef}
             className={[
               'flowchat-header__background-command-nav-button',
               isBackgroundCommandPanelOpen && 'flowchat-header__background-command-nav-button--active',
@@ -549,13 +563,20 @@ export const FlowChatHeader: React.FC<FlowChatHeaderProps> = ({
             </span>
           </IconButton>
 
-          {isBackgroundCommandPanelOpen && (
+          {isBackgroundCommandPanelOpen && createPortal(
             <div
+              ref={backgroundCommandPanelRef}
               className="flowchat-header__background-command-panel"
               data-bf-component="flow-chat-header"
               data-bf-part="activityPanel"
+              data-bf-placement={backgroundCommandPanelLayout?.placement ?? 'bottom'}
               role="dialog"
               aria-label={backgroundCommandLabel}
+              style={{
+                top: `${backgroundCommandPanelLayout?.top ?? 0}px`,
+                left: `${backgroundCommandPanelLayout?.left ?? 0}px`,
+                visibility: backgroundCommandPanelLayout ? 'visible' : 'hidden',
+              }}
             >
               <div className="flowchat-header__background-command-panel-header">
                 <span>{backgroundCommandLabel}</span>
@@ -580,7 +601,7 @@ export const FlowChatHeader: React.FC<FlowChatHeaderProps> = ({
                   {isBackgroundCommandSectionMenuOpen && backgroundCommandMenuPosition ? createPortal(
                     <div
                       ref={backgroundCommandMenuRef}
-                      className="flowchat-header__background-command-menu"
+                      className="flowchat-header__background-command-menu flowchat-header__background-command-menu--portal"
                       data-bf-component="flow-chat-header"
                       data-bf-part="commandMenu"
                       role="menu"
@@ -640,7 +661,8 @@ export const FlowChatHeader: React.FC<FlowChatHeaderProps> = ({
                   </div>
                 )}
               </div>
-            </div>
+            </div>,
+            getAppearanceOverlayHost(),
           )}
         </div>
 

--- a/src/web-ui/src/flow_chat/components/modern/ModelRoundItem.scss
+++ b/src/web-ui/src/flow_chat/components/modern/ModelRoundItem.scss
@@ -1,5 +1,7 @@
 /* Model round item styles (BEM). */
 
+@use '../../../component-library/styles/tokens.scss' as *;
+
 .model-round-item {
   /*
    * No bottom margin — the inter-round gap is covered by the same line-height rhythm
@@ -316,10 +318,8 @@
 }
 
 .model-round-item__copy-menu {
-  position: absolute;
-  right: 0;
-  bottom: calc(100% + 4px);
-  z-index: 20;
+  position: fixed;
+  z-index: $z-popover;
   display: flex;
   flex-direction: column;
   min-width: 140px;
@@ -328,6 +328,8 @@
   border: 1px solid var(--bf-appearance-token-border-subtle);
   border-radius: 8px;
   background: var(--bf-appearance-token-color-bg-elevated);
+  color: var(--bf-appearance-token-color-text-primary);
+  font-family: var(--bf-appearance-token-font-family-sans);
   box-shadow:
     0 12px 28px var(--bf-appearance-token-color-overlay-black-30),
     0 2px 8px var(--bf-appearance-token-color-overlay-black-12);

--- a/src/web-ui/src/flow_chat/components/modern/ModelRoundItem.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModelRoundItem.tsx
@@ -8,6 +8,7 @@
  */
 
 import React, { useMemo, useState, useCallback, useEffect, useLayoutEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { Copy, Check, CircleAlert } from 'lucide-react';
 import type { ModelRound, ModelRoundAttempt, ModelRoundAttemptDiagnostic, FlowItem, FlowTextItem, FlowToolItem, FlowThinkingItem, TokenUsage, ToolRejectOptions } from '../../types/flow-chat';
@@ -41,6 +42,8 @@ import { buildModelRoundUsageMeta } from '../../utils/tokenUsageDisplay';
 import { buildDialogTurnCopyText } from '../../utils/dialogTurnCopy';
 import type { TranscriptExportScope } from '../../utils/dialogTranscriptExport';
 import { buildTranscriptExportLabels } from '../../utils/transcriptExportLabels';
+import { getAppearanceOverlayHost } from '@/infrastructure/appearance/runtime/AppearanceOverlayHost';
+import { useAnchoredPopoverPosition } from '@/shared/utils/useAnchoredPopoverPosition';
 import './ModelRoundItem.scss';
 import './SubagentItems.scss';
 
@@ -371,6 +374,14 @@ export const ModelRoundItem = React.memo<ModelRoundItemProps>(
     const [isCopyMenuOpen, setIsCopyMenuOpen] = useState(false);
     const copyButtonRef = useRef<HTMLButtonElement>(null);
     const copyMenuRef = useRef<HTMLDivElement>(null);
+    const copyMenuLayout = useAnchoredPopoverPosition({
+      open: isCopyMenuOpen,
+      anchorRef: copyButtonRef,
+      popoverRef: copyMenuRef,
+      preferredPlacement: 'top',
+      alignment: 'end',
+      gap: 4,
+    });
     const renderTraceEnabled = isStartupRenderTraceEnabled();
     const renderTraceStartedAtMs = renderTraceEnabled ? performance.now() : null;
 
@@ -773,12 +784,18 @@ export const ModelRoundItem = React.memo<ModelRoundItemProps>(
                 </button>
               </Tooltip>
 
-              {isCopyMenuOpen && (
+              {isCopyMenuOpen && createPortal(
                 <div
                   ref={copyMenuRef}
                   className="model-round-item__copy-menu"
                   role="menu"
                   data-testid="model-round-copy-menu"
+                  data-bf-placement={copyMenuLayout?.placement ?? 'top'}
+                  style={{
+                    top: `${copyMenuLayout?.top ?? 0}px`,
+                    left: `${copyMenuLayout?.left ?? 0}px`,
+                    visibility: copyMenuLayout ? 'visible' : 'hidden',
+                  }}
                 >
                   <button
                     type="button"
@@ -798,7 +815,8 @@ export const ModelRoundItem = React.memo<ModelRoundItemProps>(
                   >
                     {t('transcriptExport.copyResult')}
                   </button>
-                </div>
+                </div>,
+                getAppearanceOverlayHost(),
               )}
             </div>}
 

--- a/src/web-ui/src/flow_chat/components/modern/SessionFilesBadge.scss
+++ b/src/web-ui/src/flow_chat/components/modern/SessionFilesBadge.scss
@@ -204,12 +204,12 @@
   }
 
   &__review-menu-popover {
-    position: absolute;
-    top: calc(100% + 4px);
-    left: 0;
-    right: auto;
-    z-index: 110;
+    position: fixed;
+    z-index: $z-popover;
     min-width: 150px;
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 16px);
+    overflow-y: auto;
     padding: 4px;
     border: 1px solid var(--bf-appearance-token-border-subtle);
     border-radius: $size-radius-base;
@@ -217,6 +217,8 @@
     box-shadow: 0 4px 16px var(--bf-appearance-token-color-overlay-black-30);
     backdrop-filter: blur(20px) saturate(1.3);
     -webkit-backdrop-filter: blur(20px) saturate(1.3);
+    color: var(--bf-appearance-token-color-text-primary);
+    font-family: var(--bf-appearance-token-font-family-sans);
     animation: session-files-badge-popover-in 0.2s $easing-standard;
   }
 
@@ -307,18 +309,21 @@
 
   // ==================== Popover ====================
   &__popover {
-    position: absolute;
-    top: calc(100% + 4px);
-    left: -4px;
-    z-index: 100;
-    min-width: 260px;
-    max-width: 380px;
+    position: fixed;
+    z-index: $z-popover;
+    width: min(380px, calc(100vw - 16px));
+    min-width: min(260px, calc(100vw - 16px));
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 16px);
+    overflow: hidden;
     background: color-mix(in srgb, var(--bf-appearance-token-color-bg-elevated) 98%, transparent);
     backdrop-filter: blur(20px) saturate(1.3);
     -webkit-backdrop-filter: blur(20px) saturate(1.3);
     border: 1px solid var(--bf-appearance-token-border-subtle);
     border-radius: $size-radius-base;
     box-shadow: 0 4px 16px var(--bf-appearance-token-color-overlay-black-30);
+    color: var(--bf-appearance-token-color-text-primary);
+    font-family: var(--bf-appearance-token-font-family-sans);
     animation: session-files-badge-popover-in 0.2s $easing-standard;
 
     @keyframes session-files-badge-popover-in {
@@ -364,7 +369,7 @@
 
   // ==================== File list ====================
   &__list {
-    max-height: 280px;
+    max-height: min(280px, calc(100vh - 64px));
     overflow-y: auto;
     padding: 4px 6px 6px;
 

--- a/src/web-ui/src/flow_chat/components/modern/SessionFilesBadge.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/SessionFilesBadge.test.tsx
@@ -154,6 +154,7 @@ describe('SessionFilesBadge', () => {
     vi.stubGlobal('window', dom.window);
     vi.stubGlobal('document', dom.window.document);
     vi.stubGlobal('HTMLElement', dom.window.HTMLElement);
+    vi.stubGlobal('HTMLDivElement', dom.window.HTMLDivElement);
     vi.stubGlobal('CustomEvent', dom.window.CustomEvent);
 
     container = dom.window.document.getElementById('root') as HTMLDivElement;
@@ -186,6 +187,7 @@ describe('SessionFilesBadge', () => {
     act(() => {
       root.unmount();
     });
+    dom.window.document.querySelector('[data-bf-overlay-host="true"]')?.remove();
     vi.useRealTimers();
     vi.unstubAllGlobals();
   });
@@ -207,7 +209,10 @@ describe('SessionFilesBadge', () => {
       toggle?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
     });
 
-    expect(container.textContent).toContain('2 files');
+    const filesPopover = dom.window.document.querySelector<HTMLElement>('.session-files-badge__popover');
+    expect(filesPopover?.parentElement?.getAttribute('data-bf-overlay-host')).toBe('true');
+    expect(filesPopover?.style.visibility).toBe('visible');
+    expect(dom.window.document.body.textContent).toContain('2 files');
 
     mocks.files = [
       { filePath: 'src/current-session.ts', sessionId: 'session-1' },
@@ -222,8 +227,8 @@ describe('SessionFilesBadge', () => {
       await Promise.resolve();
     });
 
-    expect(container.textContent).toContain('1 files');
-    expect(container.textContent).not.toContain('stale-session.ts');
+    expect(dom.window.document.body.textContent).toContain('1 files');
+    expect(dom.window.document.body.textContent).not.toContain('stale-session.ts');
   });
 
   it('presents one adaptive Review action instead of asking users to choose a depth', async () => {
@@ -243,9 +248,12 @@ describe('SessionFilesBadge', () => {
       actionsButton?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
     });
 
-    expect(container.textContent).toContain('Review');
-    expect(container.textContent).not.toContain('Review: Strict');
-    expect(container.textContent).not.toContain('Deep review');
+    const reviewPopover = dom.window.document.querySelector<HTMLElement>('.session-files-badge__review-menu-popover');
+    expect(reviewPopover?.parentElement?.getAttribute('data-bf-overlay-host')).toBe('true');
+    expect(reviewPopover?.style.visibility).toBe('visible');
+    expect(dom.window.document.body.textContent).toContain('Review');
+    expect(dom.window.document.body.textContent).not.toContain('Review: Strict');
+    expect(dom.window.document.body.textContent).not.toContain('Deep review');
   });
 
   it('shows a localized error when Review cannot be prepared', async () => {
@@ -264,7 +272,7 @@ describe('SessionFilesBadge', () => {
     await act(async () => {
       actionsButton.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
     });
-    const reviewButton = container.querySelector('[role="menuitem"]') as HTMLButtonElement;
+    const reviewButton = dom.window.document.querySelector('[role="menuitem"]') as HTMLButtonElement;
     await act(async () => {
       reviewButton.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
       await Promise.resolve();

--- a/src/web-ui/src/flow_chat/components/modern/SessionFilesBadge.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/SessionFilesBadge.tsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import {
   FileEdit,
   FilePlus,
@@ -48,6 +49,8 @@ import { resolveQuickActionText } from '@/infrastructure/config/services/quickAc
 import { deriveDeepReviewSessionConcurrencyGuard } from '../../utils/deepReviewCapacityGuard';
 import { scheduleAfterStartupSignal } from '@/shared/utils/startupTaskScheduling';
 import { isTauriRuntime } from '@/infrastructure/runtime';
+import { getAppearanceOverlayHost } from '@/infrastructure/appearance/runtime/AppearanceOverlayHost';
+import { useAnchoredPopoverPosition } from '@/shared/utils/useAnchoredPopoverPosition';
 import './SessionFilesBadge.scss';
 
 const log = createLogger('SessionFilesBadge');
@@ -202,9 +205,29 @@ export const SessionFilesBadge: React.FC<SessionFilesBadgeProps> = ({
   });
 
   const badgeRef = useRef<HTMLDivElement>(null);
-  const popoverRef = useRef<HTMLDivElement>(null);
-  const reviewMenuRef = useRef<HTMLDivElement>(null);
+  const fileTriggerRef = useRef<HTMLButtonElement>(null);
+  const filePopoverRef = useRef<HTMLDivElement>(null);
+  const reviewTriggerRef = useRef<HTMLButtonElement>(null);
+  const reviewPopoverRef = useRef<HTMLDivElement>(null);
   const { confirmDeepReviewLaunch, deepReviewConsentDialog } = useDeepReviewConsent();
+  const reviewPopoverLayout = useAnchoredPopoverPosition({
+    open: isReviewMenuOpen && !isReviewLaunchOrActivityBlocking,
+    anchorRef: reviewTriggerRef,
+    popoverRef: reviewPopoverRef,
+    preferredPlacement: 'bottom',
+    alignment: 'end',
+    gap: 4,
+    layoutRevision: quickActions,
+  });
+  const filePopoverLayout = useAnchoredPopoverPosition({
+    open: isExpanded && fileStats.size > 0,
+    anchorRef: fileTriggerRef,
+    popoverRef: filePopoverRef,
+    preferredPlacement: 'bottom',
+    alignment: 'end',
+    gap: 4,
+    layoutRevision: fileStats,
+  });
 
   const clearReviewReadyGlint = useCallback(() => {
     setShowReviewReadyGlint(false);
@@ -334,8 +357,8 @@ export const SessionFilesBadge: React.FC<SessionFilesBadgeProps> = ({
     const handleClickOutside = (event: MouseEvent) => {
       const target = event.target as Node;
       const clickedBadge = !!badgeRef.current?.contains(target);
-      const clickedFilesPopover = !!popoverRef.current?.contains(target);
-      const clickedReviewMenu = !!reviewMenuRef.current?.contains(target);
+      const clickedFilesPopover = !!filePopoverRef.current?.contains(target);
+      const clickedReviewMenu = !!reviewPopoverRef.current?.contains(target);
       if (!clickedBadge && !clickedFilesPopover && !clickedReviewMenu) {
         setIsExpanded(false);
         setIsReviewMenuOpen(false);
@@ -755,12 +778,12 @@ export const SessionFilesBadge: React.FC<SessionFilesBadgeProps> = ({
         className={`session-files-badge ${isExpanded ? 'session-files-badge--expanded' : ''}`}
       >
       <div
-        ref={reviewMenuRef}
         className="session-files-badge__review-menu"
         data-bf-component="session-files-badge"
         data-bf-part="reviewMenu"
       >
         <button
+          ref={reviewTriggerRef}
           className={[
             'session-files-badge__review-btn',
             showReviewReadyGlint && 'session-files-badge__review-btn--glint',
@@ -803,8 +826,20 @@ export const SessionFilesBadge: React.FC<SessionFilesBadgeProps> = ({
           ) : null}
         </button>
 
-        {isReviewMenuOpen && !isReviewLaunchOrActivityBlocking && (
-          <div className="session-files-badge__review-menu-popover" role="menu" data-bf-component="session-files-badge" data-bf-part="reviewPopover">
+        {isReviewMenuOpen && !isReviewLaunchOrActivityBlocking && createPortal(
+          <div
+            ref={reviewPopoverRef}
+            className="session-files-badge__review-menu-popover"
+            role="menu"
+            data-bf-component="session-files-badge"
+            data-bf-part="reviewPopover"
+            data-bf-placement={reviewPopoverLayout?.placement ?? 'bottom'}
+            style={{
+              top: `${reviewPopoverLayout?.top ?? 0}px`,
+              left: `${reviewPopoverLayout?.left ?? 0}px`,
+              visibility: reviewPopoverLayout ? 'visible' : 'hidden',
+            }}
+          >
             {canLaunchReview && <button
               className="session-files-badge__review-menu-item"
               data-bf-component="session-files-badge"
@@ -843,12 +878,14 @@ export const SessionFilesBadge: React.FC<SessionFilesBadgeProps> = ({
                 </button>
               );
             })}
-          </div>
+          </div>,
+          getAppearanceOverlayHost(),
         )}
       </div>
 
       {showFileStatsSummary ? (
       <button
+        ref={fileTriggerRef}
         className="session-files-badge__button"
         data-bf-component="session-files-badge"
         data-bf-part="trigger"
@@ -888,12 +925,18 @@ export const SessionFilesBadge: React.FC<SessionFilesBadgeProps> = ({
       </button>
       ) : null}
 
-      {showFileStatsSummary && isExpanded && (
+      {showFileStatsSummary && isExpanded && createPortal(
         <div
-          ref={popoverRef}
+          ref={filePopoverRef}
           className="session-files-badge__popover"
           data-bf-component="session-files-badge"
           data-bf-part="popover"
+          data-bf-placement={filePopoverLayout?.placement ?? 'bottom'}
+          style={{
+            top: `${filePopoverLayout?.top ?? 0}px`,
+            left: `${filePopoverLayout?.left ?? 0}px`,
+            visibility: filePopoverLayout ? 'visible' : 'hidden',
+          }}
         >
           <div className="session-files-badge__popover-summary" data-bf-component="session-files-badge" data-bf-part="summary">
             <span className="session-files-badge__popover-summary-count">
@@ -955,7 +998,8 @@ export const SessionFilesBadge: React.FC<SessionFilesBadgeProps> = ({
               </div>
             ))}
           </div>
-        </div>
+        </div>,
+        getAppearanceOverlayHost(),
       )}
       </div>
       {deepReviewConsentDialog}

--- a/src/web-ui/src/flow_chat/components/modern/SessionTreePopover.scss
+++ b/src/web-ui/src/flow_chat/components/modern/SessionTreePopover.scss
@@ -43,11 +43,9 @@
   }
 
   &__panel {
-    position: absolute;
-    top: calc(100% + 8px);
-    right: 0;
-    width: min(380px, calc(100vw - 32px));
-    max-height: min(440px, calc(100vh - 96px));
+    position: fixed;
+    width: min(380px, calc(100vw - 16px));
+    max-height: min(440px, calc(100vh - 16px));
     display: flex;
     flex-direction: column;
     overflow: hidden;
@@ -57,7 +55,9 @@
     box-shadow: var(--bf-appearance-token-shadow-lg);
     backdrop-filter: blur(16px);
     -webkit-backdrop-filter: blur(16px);
-    z-index: 30;
+    z-index: $z-popover;
+    color: var(--bf-appearance-token-color-text-primary);
+    font-family: var(--bf-appearance-token-font-family-sans);
   }
 
   &__header {
@@ -73,7 +73,7 @@
 
   &__body {
     min-height: 42px;
-    max-height: min(390px, calc(100vh - 144px));
+    max-height: min(390px, calc(100vh - 64px));
     padding: $size-gap-1;
     overflow-y: auto;
     scrollbar-gutter: stable;

--- a/src/web-ui/src/flow_chat/components/modern/SessionTreePopover.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/SessionTreePopover.test.tsx
@@ -30,13 +30,15 @@ vi.mock('@/component-library', async () => {
 
   return {
     DotMatrixLoader: () => <span data-testid="dot-matrix-loader" />,
-    IconButton: ({
+    IconButton: ReactModule.forwardRef<HTMLButtonElement, React.ButtonHTMLAttributes<HTMLButtonElement> & {
+      tooltip?: string;
+    }>(({
       children,
       tooltip,
       ...props
-    }: React.ButtonHTMLAttributes<HTMLButtonElement> & { tooltip?: string }) => (
-      <button type="button" title={tooltip} {...props}>{children}</button>
-    ),
+    }, ref) => (
+      <button ref={ref} type="button" title={tooltip} {...props}>{children}</button>
+    )),
   };
 });
 
@@ -78,7 +80,7 @@ describe('SessionTreePopover', () => {
   afterEach(() => {
     act(() => root.unmount());
     container.remove();
-    document.body.querySelector('[data-testid="flowchat-header-session-tree-menu"]')?.remove();
+    document.querySelector('[data-bf-overlay-host="true"]')?.remove();
     vi.restoreAllMocks();
   });
 
@@ -102,11 +104,14 @@ describe('SessionTreePopover', () => {
       await Promise.resolve();
     });
 
-    const actionButton = container.querySelector<HTMLButtonElement>(
+    const panel = document.querySelector<HTMLElement>('.session-tree-popover__panel');
+    expect(panel?.parentElement?.getAttribute('data-bf-overlay-host')).toBe('true');
+    expect(panel?.style.visibility).toBe('visible');
+    const actionButton = panel?.querySelector<HTMLButtonElement>(
       '[aria-label="flowChatHeader.agentTreeActions"]',
     );
     expect(actionButton).not.toBeNull();
-    const childNode = Array.from(container.querySelectorAll('[role="treeitem"]'))
+    const childNode = Array.from(panel?.querySelectorAll('[role="treeitem"]') ?? [])
       .find(node => node.textContent?.includes('Running child'));
     const status = childNode?.querySelector('.session-tree-popover__status');
     expect(childNode).not.toBeUndefined();

--- a/src/web-ui/src/flow_chat/components/modern/SessionTreePopover.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/SessionTreePopover.tsx
@@ -13,6 +13,7 @@ import { DotMatrixLoader, IconButton } from '@/component-library';
 import { sessionAPI, type SessionLineageSnapshot } from '@/infrastructure/api/service-api/SessionAPI';
 import { getAppearanceOverlayHost } from '@/infrastructure/appearance';
 import { computeFixedPopoverPosition } from '@/shared/utils/fixedPopoverViewport';
+import { useAnchoredPopoverPosition } from '@/shared/utils/useAnchoredPopoverPosition';
 import { flowChatStore } from '../../store/FlowChatStore';
 import {
   buildSessionLineageTree,
@@ -74,6 +75,8 @@ export const SessionTreePopover: React.FC<SessionTreePopoverProps> = ({
   const [openActionSessionId, setOpenActionSessionId] = useState<string | null>(null);
   const [cancellingSessionIds, setCancellingSessionIds] = useState<Set<string>>(new Set());
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
   const actionMenuAnchorRef = useRef<HTMLButtonElement | null>(null);
   const actionMenuRef = useRef<HTMLDivElement | null>(null);
   const requestGenerationRef = useRef(0);
@@ -148,6 +151,7 @@ export const SessionTreePopover: React.FC<SessionTreePopoverProps> = ({
     const handlePointerDown = (event: MouseEvent) => {
       if (
         !containerRef.current?.contains(event.target as Node) &&
+        !panelRef.current?.contains(event.target as Node) &&
         !actionMenuRef.current?.contains(event.target as Node)
       ) {
         setIsOpen(false);
@@ -208,6 +212,15 @@ export const SessionTreePopover: React.FC<SessionTreePopoverProps> = ({
     );
   }, [liveRevision, sessionId, snapshot]);
   const descendantCount = countSessionLineageDescendants(tree);
+  const panelLayout = useAnchoredPopoverPosition({
+    open: isOpen,
+    anchorRef: triggerRef,
+    popoverRef: panelRef,
+    preferredPlacement: 'bottom',
+    alignment: 'end',
+    gap: 8,
+    layoutRevision: `${descendantCount}:${isLoading}:${loadFailed}`,
+  });
 
   useEffect(() => {
     if (!tree) return;
@@ -430,6 +443,7 @@ export const SessionTreePopover: React.FC<SessionTreePopoverProps> = ({
       data-bf-part="sessionTree"
     >
       <IconButton
+        ref={triggerRef}
         className={[
           'session-tree-popover__trigger',
           isOpen && 'session-tree-popover__trigger--active',
@@ -459,13 +473,20 @@ export const SessionTreePopover: React.FC<SessionTreePopoverProps> = ({
         </span>
       </IconButton>
 
-      {isOpen ? (
+      {isOpen ? createPortal(
         <div
+          ref={panelRef}
           className="session-tree-popover__panel"
           data-bf-component="flow-chat-header"
           data-bf-part="sessionTreePanel"
+          data-bf-placement={panelLayout?.placement ?? 'bottom'}
           role="dialog"
           aria-label={panelLabel}
+          style={{
+            top: `${panelLayout?.top ?? 0}px`,
+            left: `${panelLayout?.left ?? 0}px`,
+            visibility: panelLayout ? 'visible' : 'hidden',
+          }}
         >
           <div
             className="session-tree-popover__header"
@@ -523,7 +544,8 @@ export const SessionTreePopover: React.FC<SessionTreePopoverProps> = ({
               </div>
             ) : null}
           </div>
-        </div>
+        </div>,
+        getAppearanceOverlayHost(),
       ) : null}
     </div>
   );

--- a/src/web-ui/src/flow_chat/components/modern/UserMessageEditComposer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/UserMessageEditComposer.tsx
@@ -47,6 +47,7 @@ const RichUserMessageEditComposer: React.FC<RichUserMessageEditComposerProps> = 
   excludeSessionId,
 }) => {
   const editorRef = useRef<RichTextInputElement>(null);
+  const mentionAnchorRef = useRef<HTMLDivElement>(null);
   const [contexts, setContexts] = useState<ContextItem[]>(() => (
     composerPresentationContexts(presentation)
   ));
@@ -115,7 +116,7 @@ const RichUserMessageEditComposer: React.FC<RichUserMessageEditComposerProps> = 
 
   return (
     <div className="user-message-edit-composer" data-bf-component="user-message-edit-composer" data-bf-part="root" data-bf-mode="rich" data-bf-state={isSubmitting ? 'submitting' : undefined}>
-      <div className="user-message-edit-composer__rich-input" data-bf-component="user-message-edit-composer" data-bf-part="input">
+      <div ref={mentionAnchorRef} className="user-message-edit-composer__rich-input" data-bf-component="user-message-edit-composer" data-bf-part="input">
         <RichTextInput
           ref={editorRef}
           value={value}
@@ -133,6 +134,7 @@ const RichUserMessageEditComposer: React.FC<RichUserMessageEditComposerProps> = 
           workspacePath={workspacePath}
           workspaceId={workspaceId}
           excludeSessionId={excludeSessionId}
+          anchorRef={mentionAnchorRef}
           onSelect={handleSelectContext}
           onClose={() => editorRef.current?.closeMention?.()}
         />

--- a/src/web-ui/src/flow_chat/components/overlayClippingContract.test.ts
+++ b/src/web-ui/src/flow_chat/components/overlayClippingContract.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+function readSource(relativePath: string): string {
+  return readFileSync(fileURLToPath(new URL(relativePath, import.meta.url)), 'utf8')
+    .replace(/\r\n?/g, '\n');
+}
+
+const ANCHORED_OVERLAYS = [
+  { name: 'shared Select', path: '../../component-library/components/Select/Select.tsx' },
+  { name: 'chat input pickers', path: './ChatInput.tsx' },
+  { name: 'file mention picker', path: './FileMentionPicker.tsx' },
+  { name: 'permission menu', path: './ChatInputWorkspaceStrip.tsx' },
+  { name: 'welcome workspace menu', path: './WelcomePanel.tsx' },
+  { name: 'session menu', path: './session-menu/SessionMenu.tsx' },
+  { name: 'toolbar overflow menu', path: './toolbar-mode/ToolbarMode.tsx' },
+  { name: 'message copy menu', path: './modern/ModelRoundItem.tsx' },
+  { name: 'session file menus', path: './modern/SessionFilesBadge.tsx' },
+  { name: 'session tree panel', path: './modern/SessionTreePopover.tsx' },
+  { name: 'background command panel', path: './modern/FlowChatHeader.tsx' },
+  { name: 'tool timeout menu', path: '../tool-cards/ToolTimeoutIndicator.tsx' },
+  { name: 'dispatch target menu', path: '../../features/dispatch/DispatchTargetPicker.tsx' },
+  { name: 'profile avatar menu', path: '../../app/scenes/profile/views/AssistantAvatarPicker.tsx' },
+  { name: 'shell creation menu', path: '../../app/scenes/shell/ShellNav.tsx' },
+  { name: 'navigation footer menu', path: '../../app/components/NavPanel/components/PersistentFooterActions.tsx' },
+];
+
+describe.each(ANCHORED_OVERLAYS)('$name clipping contract', ({ path }) => {
+  const source = readSource(path);
+
+  it('escapes ancestor overflow and tracks its trigger in the viewport', () => {
+    expect(source).toContain('createPortal');
+    expect(source).toContain('getAppearanceOverlayHost');
+    expect(source).toContain('useAnchoredPopoverPosition');
+  });
+});
+
+describe('existing FlowChat background command menus', () => {
+  it('enables their fixed-position portal modifier at both render sites', () => {
+    const source = readSource('./modern/FlowChatHeader.tsx');
+    expect(source.match(/flowchat-header__background-command-menu--portal/g)).toHaveLength(2);
+  });
+});

--- a/src/web-ui/src/flow_chat/components/session-menu/SessionMenu.scss
+++ b/src/web-ui/src/flow_chat/components/session-menu/SessionMenu.scss
@@ -3,6 +3,8 @@
  * Moved here from ToolbarMode.scss so both surfaces render the same menu.
  */
 
+@use '../../../component-library/styles/tokens' as tokens;
+
 $session-menu-timing: cubic-bezier(0.4, 0, 0.2, 1);
 
 .bitfun-session-menu {
@@ -47,13 +49,11 @@ $session-menu-timing: cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .bitfun-session-menu__dropdown {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  margin-top: 4px;
-  width: max(100%, 220px);
-  max-width: min(360px, calc(100vw - 24px));
-  max-height: min(360px, calc(100vh - 80px));
+  --session-menu-entry-y: -4px;
+  position: fixed;
+  box-sizing: border-box;
+  width: min(220px, calc(100vw - 16px));
+  max-height: min(360px, calc(100vh - 16px));
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -61,9 +61,17 @@ $session-menu-timing: cubic-bezier(0.4, 0, 0.2, 1);
   border: 1px solid var(--bf-appearance-token-border-medium);
   border-radius: var(--bf-appearance-token-size-radius-base);
   box-shadow: var(--bf-appearance-token-shadow-xl);
-  z-index: 100;
+  z-index: tokens.$z-popover;
   animation: session-menu-appear 0.2s $session-menu-timing;
   transform-origin: top left;
+  font-family: var(--bf-appearance-token-font-family-sans);
+  font-size: var(--bf-appearance-token-flowchat-font-size-sm);
+  color: var(--bf-appearance-token-color-text-primary);
+
+  &[data-bf-placement='top'] {
+    --session-menu-entry-y: 4px;
+    transform-origin: bottom left;
+  }
 
   .bitfun-session-menu__actions .bitfun-session-menu__item--new:first-of-type {
     border-radius: 7px 7px 0 0;
@@ -179,7 +187,7 @@ $session-menu-timing: cubic-bezier(0.4, 0, 0.2, 1);
 @keyframes session-menu-appear {
   from {
     opacity: 0;
-    transform: translateY(-4px) scale(0.98);
+    transform: translateY(var(--session-menu-entry-y)) scale(0.98);
   }
   to {
     opacity: 1;

--- a/src/web-ui/src/flow_chat/components/session-menu/SessionMenu.test.tsx
+++ b/src/web-ui/src/flow_chat/components/session-menu/SessionMenu.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SessionMenu } from './SessionMenu';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/component-library', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('./useFlowChatSessions', () => ({
+  resolveDisplayTitle: (session: { title: string }) => session.title,
+  useFlowChatSessions: () => ({
+    activeSessionId: 'session-1',
+    sessions: [
+      { sessionId: 'session-1', title: 'Current session' },
+      { sessionId: 'session-2', title: 'Other session' },
+    ],
+  }),
+}));
+
+vi.mock('../../services/sessionActivation', () => ({
+  activateMainSession: vi.fn().mockResolvedValue(true),
+}));
+
+describe('SessionMenu', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let rectSpy: ReturnType<typeof vi.spyOn>;
+  let widthSpy: ReturnType<typeof vi.spyOn>;
+  let heightSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1000 });
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 800 });
+
+    rectSpy = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function () {
+      if (this instanceof HTMLElement && this.classList.contains('bitfun-session-menu__trigger')) {
+        return {
+          top: 760,
+          bottom: 784,
+          left: 900,
+          right: 924,
+          width: 24,
+          height: 24,
+          x: 900,
+          y: 760,
+          toJSON() { return this; },
+        } as DOMRect;
+      }
+      return {
+        top: 0,
+        bottom: 0,
+        left: 0,
+        right: 0,
+        width: 0,
+        height: 0,
+        x: 0,
+        y: 0,
+        toJSON() { return this; },
+      } as DOMRect;
+    });
+    widthSpy = vi.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockReturnValue(240);
+    heightSpy = vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockReturnValue(180);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    document.querySelector('[data-bf-overlay-host="true"]')?.remove();
+    container.remove();
+    rectSpy.mockRestore();
+    widthSpy.mockRestore();
+    heightSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it('escapes the floating-window clip and flips inside the viewport', async () => {
+    await act(async () => {
+      root.render(<SessionMenu />);
+    });
+
+    const trigger = container.querySelector<HTMLButtonElement>('.bitfun-session-menu__trigger');
+    await act(async () => {
+      trigger!.click();
+      await Promise.resolve();
+    });
+
+    const dropdown = document.querySelector<HTMLElement>('.bitfun-session-menu__dropdown');
+    expect(dropdown?.parentElement?.getAttribute('data-bf-overlay-host')).toBe('true');
+    expect(dropdown?.dataset.bfPlacement).toBe('top');
+    expect(dropdown?.style.visibility).toBe('visible');
+    expect(Number.parseFloat(dropdown?.style.left ?? '')).toBeLessThanOrEqual(752);
+  });
+});

--- a/src/web-ui/src/flow_chat/components/session-menu/SessionMenu.tsx
+++ b/src/web-ui/src/flow_chat/components/session-menu/SessionMenu.tsx
@@ -9,9 +9,12 @@
  */
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { Plus } from 'lucide-react';
 import { Tooltip } from '@/component-library';
+import { getAppearanceOverlayHost } from '@/infrastructure/appearance/runtime/AppearanceOverlayHost';
+import { useAnchoredPopoverPosition } from '@/shared/utils/useAnchoredPopoverPosition';
 import { activateMainSession } from '../../services/sessionActivation';
 import { useFlowChatSessions, resolveDisplayTitle } from './useFlowChatSessions';
 import './SessionMenu.scss';
@@ -25,7 +28,17 @@ export const SessionMenu: React.FC<SessionMenuProps> = ({ onOpenChange }) => {
   const { t } = useTranslation('flow-chat');
   const { activeSessionId, sessions } = useFlowChatSessions();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const dropdownLayout = useAnchoredPopoverPosition({
+    open: isMenuOpen,
+    anchorRef: triggerRef,
+    popoverRef: dropdownRef,
+    preferredPlacement: 'bottom',
+    gap: 4,
+    layoutRevision: sessions.length,
+  });
 
   const setOpen = useCallback((open: boolean) => {
     setIsMenuOpen(open);
@@ -53,8 +66,8 @@ export const SessionMenu: React.FC<SessionMenuProps> = ({ onOpenChange }) => {
     const handleClickOutside = (e: MouseEvent) => {
       const target = e.target as HTMLElement | null;
       if (!target) return;
+      if (rootRef.current?.contains(target)) return;
       if (dropdownRef.current?.contains(target)) return;
-      if (target.closest?.('.bitfun-session-menu__trigger')) return;
       setOpen(false);
     };
 
@@ -77,6 +90,7 @@ export const SessionMenu: React.FC<SessionMenuProps> = ({ onOpenChange }) => {
 
   return (
     <div
+      ref={rootRef}
       className="bitfun-session-menu"
       data-bf-component="session-menu"
       data-bf-part="root"
@@ -85,6 +99,7 @@ export const SessionMenu: React.FC<SessionMenuProps> = ({ onOpenChange }) => {
     >
       <Tooltip content={t('toolCards.toolbar.openSessionMenu')}>
         <button
+          ref={triggerRef}
           type="button"
           className={[
             'bitfun-session-menu__trigger',
@@ -100,12 +115,18 @@ export const SessionMenu: React.FC<SessionMenuProps> = ({ onOpenChange }) => {
         </button>
       </Tooltip>
 
-      {isMenuOpen && (
+      {isMenuOpen && createPortal(
         <div
           className="bitfun-session-menu__dropdown"
           data-bf-component="session-menu"
           data-bf-part="dropdown"
+          data-bf-placement={dropdownLayout?.placement ?? 'bottom'}
           ref={dropdownRef}
+          style={{
+            top: `${dropdownLayout?.top ?? 0}px`,
+            left: `${dropdownLayout?.left ?? 0}px`,
+            visibility: dropdownLayout ? 'visible' : 'hidden',
+          }}
           onMouseDown={(e) => e.stopPropagation()}
         >
           <div className="bitfun-session-menu__actions" data-bf-component="session-menu" data-bf-part="actions">
@@ -177,7 +198,8 @@ export const SessionMenu: React.FC<SessionMenuProps> = ({ onOpenChange }) => {
               </button>
             ))}
           </div>
-        </div>
+        </div>,
+        getAppearanceOverlayHost(),
       )}
     </div>
   );

--- a/src/web-ui/src/flow_chat/components/toolbar-mode/ToolbarMode.scss
+++ b/src/web-ui/src/flow_chat/components/toolbar-mode/ToolbarMode.scss
@@ -3,6 +3,8 @@
  * Compact floating bar with a two-row layout.
  */
 
+@use '../../../component-library/styles/tokens.scss' as *;
+
 $transition-duration: 0.25s;
 $transition-timing: cubic-bezier(0.4, 0, 0.2, 1);
 
@@ -366,16 +368,20 @@ $transition-timing: cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .bitfun-toolbar-mode__overflow-menu {
-  position: absolute;
-  top: calc(100% + 4px);
-  right: 0;
+  position: fixed;
   min-width: 180px;
+  max-width: calc(100vw - 16px);
+  max-height: calc(100vh - 16px);
+  overflow-y: auto;
   padding: 4px;
   background: var(--bf-appearance-token-color-bg-primary);
   border: 1px solid var(--bf-appearance-token-border-medium);
   border-radius: var(--bf-appearance-token-size-radius-base);
   box-shadow: var(--bf-appearance-token-shadow-xl);
-  z-index: 120;
+  z-index: $z-popover;
+  color: var(--bf-appearance-token-color-text-primary);
+  font-family: var(--bf-appearance-token-font-family-sans);
+  font-size: var(--bf-appearance-token-flowchat-font-size-sm);
   animation: dropdown-appear 0.2s $transition-timing;
 }
 

--- a/src/web-ui/src/flow_chat/components/toolbar-mode/ToolbarMode.tsx
+++ b/src/web-ui/src/flow_chat/components/toolbar-mode/ToolbarMode.tsx
@@ -11,6 +11,7 @@
  */
 
 import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import {
@@ -28,6 +29,8 @@ import { projectEffectiveToolItem } from '../../utils/toolInvocationIdentity';
 import { createLogger } from '@/shared/utils/logger';
 import { isMacOSDesktopRuntime } from '@/infrastructure/runtime';
 import { useCurrentWorkspace } from '@/infrastructure/contexts/WorkspaceContext';
+import { getAppearanceOverlayHost } from '@/infrastructure/appearance/runtime/AppearanceOverlayHost';
+import { useAnchoredPopoverPosition } from '@/shared/utils/useAnchoredPopoverPosition';
 import { SessionMenu, useFlowChatSessions } from '../session-menu';
 
 const log = createLogger('ToolbarMode');
@@ -46,7 +49,16 @@ export const ToolbarMode: React.FC = () => {
   } = useToolbarModeContext();
 
   const [showHeaderOverflowMenu, setShowHeaderOverflowMenu] = useState(false);
+  const headerOverflowTriggerRef = useRef<HTMLButtonElement>(null);
   const headerOverflowRef = useRef<HTMLDivElement>(null);
+  const headerOverflowLayout = useAnchoredPopoverPosition({
+    open: showHeaderOverflowMenu,
+    anchorRef: headerOverflowTriggerRef,
+    popoverRef: headerOverflowRef,
+    preferredPlacement: 'bottom',
+    alignment: 'end',
+    gap: 4,
+  });
 
   const isMacOS = useMemo(() => isMacOSDesktopRuntime(), []);
   const { workspacePath } = useCurrentWorkspace();
@@ -239,6 +251,7 @@ export const ToolbarMode: React.FC = () => {
               <>
                 <Tooltip content={t('toolCards.toolbar.moreMenu')}>
                   <button
+                    ref={headerOverflowTriggerRef}
                     type="button"
                     className="toolbar-btn toolbar-btn--overflow bitfun-toolbar-mode__overflow-trigger"
                     data-bf-component="toolbar-mode"
@@ -251,14 +264,20 @@ export const ToolbarMode: React.FC = () => {
                     <MoreVertical size={14} />
                   </button>
                 </Tooltip>
-                {showHeaderOverflowMenu && (
+                {showHeaderOverflowMenu && createPortal(
                   <div
                     ref={headerOverflowRef}
                     className="bitfun-toolbar-mode__overflow-menu"
                     data-bf-component="toolbar-mode"
                     data-bf-part="overflowMenu"
                     data-bf-state="open"
+                    data-bf-placement={headerOverflowLayout?.placement ?? 'bottom'}
                     role="menu"
+                    style={{
+                      top: `${headerOverflowLayout?.top ?? 0}px`,
+                      left: `${headerOverflowLayout?.left ?? 0}px`,
+                      visibility: headerOverflowLayout ? 'visible' : 'hidden',
+                    }}
                     onMouseDown={(e) => e.stopPropagation()}
                   >
                     <button
@@ -289,7 +308,8 @@ export const ToolbarMode: React.FC = () => {
                       <Maximize2 size={14} />
                       <span>{t('session.restoreMain')}</span>
                     </button>
-                  </div>
+                  </div>,
+                  getAppearanceOverlayHost(),
                 )}
               </>
             ) : (

--- a/src/web-ui/src/flow_chat/tool-cards/ToolTimeoutIndicator.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/ToolTimeoutIndicator.scss
@@ -1,3 +1,5 @@
+@use '../../component-library/styles/tokens' as tokens;
+
 .tool-timeout-indicator {
   display: inline-flex;
   align-items: center;
@@ -126,17 +128,19 @@
 }
 
 .timeout-extend-popover {
-  position: absolute;
-  right: 0;
-  top: calc(100% + var(--bf-appearance-token-flowchat-inline-gap));
-  z-index: 10;
+  position: fixed;
+  z-index: tokens.$z-popover;
+  box-sizing: border-box;
   width: max-content;
-  max-width: 150px;
+  max-width: min(150px, calc(100vw - 16px));
+  max-height: calc(100vh - 16px);
+  overflow-y: auto;
   padding: var(--bf-appearance-token-flowchat-inline-gap) 0;
   border-radius: 6px;
   background: var(--bf-appearance-token-color-bg-elevated);
   border: 1px solid var(--bf-appearance-token-border-base);
   box-shadow: 0 4px 12px var(--bf-appearance-token-color-overlay-black-15);
+  font-family: var(--bf-appearance-token-font-family-sans);
 }
 
 .timeout-extend-option {

--- a/src/web-ui/src/flow_chat/tool-cards/ToolTimeoutIndicator.test.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/ToolTimeoutIndicator.test.tsx
@@ -78,6 +78,7 @@ describe('ToolTimeoutIndicator', () => {
     vi.stubGlobal('document', window.document);
     vi.stubGlobal('navigator', window.navigator);
     vi.stubGlobal('HTMLElement', window.HTMLElement);
+    vi.stubGlobal('HTMLDivElement', window.HTMLDivElement);
     vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
 
     container = document.createElement('div');
@@ -92,6 +93,7 @@ describe('ToolTimeoutIndicator', () => {
         root!.unmount();
       });
     }
+    document.querySelector('[data-bf-overlay-host="true"]')?.remove();
     container?.remove();
     dom?.window.close();
     vi.unstubAllGlobals();
@@ -166,5 +168,30 @@ describe('ToolTimeoutIndicator', () => {
     });
 
     expect(setSubagentTimeoutMock).toHaveBeenCalledWith('subagent-session', { type: 'disable' });
+  });
+
+  it('portals the restore options outside clipped tool cards', async () => {
+    await act(async () => {
+      root!.render(withI18n(
+        <ToolTimeoutIndicator
+          startTime={Date.now() - 10_000}
+          isRunning
+          timeoutMs={60_000}
+          showControls
+          subagentSessionId="subagent-session"
+          defaultTimeoutDisabled
+        />,
+      ));
+    });
+
+    const button = container!.querySelector<HTMLButtonElement>('.timeout-ignore-btn');
+    await act(async () => {
+      button!.dispatchEvent(new dom!.window.MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    const popover = document.querySelector<HTMLElement>('.timeout-extend-popover');
+    expect(popover?.parentElement?.getAttribute('data-bf-overlay-host')).toBe('true');
+    expect(popover?.style.visibility).toBe('visible');
   });
 });

--- a/src/web-ui/src/flow_chat/tool-cards/ToolTimeoutIndicator.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/ToolTimeoutIndicator.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import {
   AlertCircle,
   CheckCircle2,
@@ -6,6 +7,8 @@ import {
   Infinity as InfinityIcon,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { getAppearanceOverlayHost } from '@/infrastructure/appearance/runtime/AppearanceOverlayHost';
+import { useAnchoredPopoverPosition } from '@/shared/utils/useAnchoredPopoverPosition';
 import { useLiveElapsedTime } from '../hooks/useLiveElapsedTime';
 import { useSubagentTimeoutControl } from '../hooks/useSubagentTimeoutControl';
 import './ToolTimeoutIndicator.scss';
@@ -95,13 +98,28 @@ export const ToolTimeoutIndicator: React.FC<ToolTimeoutIndicatorProps> = ({
   );
   remainingMsRef.current = remainingMs;
 
+  const controlRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
+  const popoverLayout = useAnchoredPopoverPosition({
+    open: isPopoverOpen,
+    anchorRef: triggerRef,
+    popoverRef,
+    preferredPlacement: 'bottom',
+    alignment: 'end',
+    gap: 4,
+    layoutRevision: remainingAtDisable,
+  });
 
   // Close popover on outside click.
   useEffect(() => {
     if (!isPopoverOpen) return;
     const handleClick = (e: MouseEvent) => {
-      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
+      const target = e.target as Node;
+      if (
+        !controlRef.current?.contains(target)
+        && !popoverRef.current?.contains(target)
+      ) {
         closePopover();
       }
     };
@@ -195,8 +213,9 @@ export const ToolTimeoutIndicator: React.FC<ToolTimeoutIndicatorProps> = ({
       </span>
 
       {canControlTimeout && (
-        <div data-bf-component="tool-timeout-indicator" data-bf-part="controls" className="timeout-control-wrapper" ref={popoverRef}>
+        <div data-bf-component="tool-timeout-indicator" data-bf-part="controls" className="timeout-control-wrapper" ref={controlRef}>
           <button
+            ref={triggerRef}
             type="button"
             data-bf-component="tool-timeout-indicator"
             data-bf-part="toggle"
@@ -220,8 +239,19 @@ export const ToolTimeoutIndicator: React.FC<ToolTimeoutIndicatorProps> = ({
             </span>
           </button>
 
-          {isPopoverOpen && (
-            <div data-bf-component="tool-timeout-indicator" data-bf-part="popover" className="timeout-extend-popover">
+          {isPopoverOpen && createPortal(
+            <div
+              ref={popoverRef}
+              data-bf-component="tool-timeout-indicator"
+              data-bf-part="popover"
+              data-bf-placement={popoverLayout?.placement ?? 'bottom'}
+              className="timeout-extend-popover"
+              style={{
+                top: `${popoverLayout?.top ?? 0}px`,
+                left: `${popoverLayout?.left ?? 0}px`,
+                visibility: popoverLayout ? 'visible' : 'hidden',
+              }}
+            >
               {remainingAtDisable > 0 ? (
                 <button
                   type="button"
@@ -272,7 +302,8 @@ export const ToolTimeoutIndicator: React.FC<ToolTimeoutIndicatorProps> = ({
               >
                 +10m
               </button>
-            </div>
+            </div>,
+            getAppearanceOverlayHost(),
           )}
         </div>
       )}

--- a/src/web-ui/src/infrastructure/config/components/AIFeaturesConfig.scss
+++ b/src/web-ui/src/infrastructure/config/components/AIFeaturesConfig.scss
@@ -152,10 +152,6 @@
     min-height: 38px;
   }
 
-  &__pet-select .select__dropdown {
-    max-height: 320px;
-  }
-
   &__pet-actions {
     display: flex;
     align-items: center;
@@ -370,6 +366,10 @@
     animation: bitfun-config-pet-preview 1.2s steps(6) infinite;
   }
 
+}
+
+.bitfun-func-agent-config__pet-select-dropdown {
+  max-height: min(320px, calc(100vh - 16px));
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/web-ui/src/infrastructure/config/components/AIModelConfig.scss
+++ b/src/web-ui/src/infrastructure/config/components/AIModelConfig.scss
@@ -1405,25 +1405,6 @@
       font-size: 12px;
     }
 
-    .bitfun-ai-model-config__selected-model-category-select {
-      .select__dropdown {
-        left: 0;
-        right: auto;
-        width: max-content;
-        min-width: max(100%, 176px);
-        max-width: min(240px, calc(100vw - 64px));
-      }
-
-      .select__option-text {
-        min-width: max-content;
-      }
-
-      .select__option-label {
-        overflow: visible;
-        text-overflow: clip;
-      }
-    }
-
     &--switch {
       align-items: flex-start;
 
@@ -1842,6 +1823,21 @@
     overflow-y: auto;
     overflow-x: hidden;
     padding: 0;
+  }
+}
+
+.bitfun-ai-model-config__selected-model-category-dropdown {
+  width: max-content;
+  min-width: min(176px, calc(100vw - 16px));
+  max-width: min(240px, calc(100vw - 16px));
+
+  .select__option-text {
+    min-width: max-content;
+  }
+
+  .select__option-label {
+    overflow: visible;
+    text-overflow: clip;
   }
 }
 

--- a/src/web-ui/src/infrastructure/config/components/AIModelConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/AIModelConfig.tsx
@@ -2198,6 +2198,8 @@ const AIModelConfig: React.FC = () => {
                         options={categoryOptions}
                         size="small"
                         className="bitfun-ai-model-config__selected-model-category-select"
+                        dropdownClassName="bitfun-ai-model-config__selected-model-category-dropdown"
+                        dropdownMatchTriggerWidth={false}
                         renderValue={(option) => {
                           if (!option || Array.isArray(option)) {
                             return null;

--- a/src/web-ui/src/infrastructure/config/components/DefaultModelConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/DefaultModelConfig.tsx
@@ -184,6 +184,7 @@ export const DefaultModelConfig: React.FC = () => {
           renderOption={renderModelOption}
           renderValue={renderModelValue}
           className="model-select-presentation__select"
+          dropdownClassName="model-select-presentation__dropdown"
           disabled={enabledModels.length === 0}
           size="small"
         />
@@ -207,6 +208,7 @@ export const DefaultModelConfig: React.FC = () => {
           renderOption={renderModelOption}
           renderValue={renderModelValue}
           className="model-select-presentation__select"
+          dropdownClassName="model-select-presentation__dropdown"
           size="small"
         />
       </ConfigPageRow>
@@ -229,6 +231,7 @@ export const DefaultModelConfig: React.FC = () => {
           renderOption={renderModelOption}
           renderValue={renderModelValue}
           className="model-select-presentation__select"
+          dropdownClassName="model-select-presentation__dropdown"
           size="small"
         />
       </ConfigPageRow>

--- a/src/web-ui/src/infrastructure/config/components/ExternalSourcesConfig.test.tsx
+++ b/src/web-ui/src/infrastructure/config/components/ExternalSourcesConfig.test.tsx
@@ -2439,8 +2439,9 @@ describe('ExternalSourcesConfig', () => {
     expect(updateIntegrationPolicyMock).not.toHaveBeenCalled();
     expect(document.body.textContent).toContain('policy.resetConfirmTitle');
 
-    const confirm = Array.from(document.body.querySelectorAll('button')).filter((button) =>
-      button.textContent === 'policy.backupAndReset').at(-1);
+    const dialog = document.body.querySelector('[role="dialog"]');
+    const confirm = Array.from(dialog?.querySelectorAll('button') ?? []).find((button) =>
+      button.textContent === 'policy.backupAndReset');
     await act(async () => confirm?.click());
     expect(updateIntegrationPolicyMock).toHaveBeenCalledWith('D:/workspace/project', {
       expectedPreferenceRevision: 9,

--- a/src/web-ui/src/infrastructure/config/components/ModelSelectPresentation.scss
+++ b/src/web-ui/src/infrastructure/config/components/ModelSelectPresentation.scss
@@ -14,10 +14,6 @@
       align-self: center;
     }
 
-    .select__option {
-      padding: 8px 10px;
-      border-radius: 6px;
-    }
   }
 
   &__value {
@@ -76,4 +72,9 @@
     height: 11px;
     color: rgba(var(--model-select-thinking-rgb), 0.9);
   }
+}
+
+.model-select-presentation__dropdown .select__option {
+  padding: 8px 10px;
+  border-radius: 6px;
 }

--- a/src/web-ui/src/infrastructure/config/components/SessionConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/SessionConfig.tsx
@@ -915,6 +915,7 @@ const SessionSettingsPanels: React.FC<SessionSettingsPanelsProps> = ({ variant }
           >
             <Select
               className="bitfun-func-agent-config__pet-select"
+              dropdownClassName="bitfun-func-agent-config__pet-select-dropdown"
               size="small"
               options={companionDisplayModeOptions}
               value={settings.agent_companion_display_mode}

--- a/src/web-ui/src/infrastructure/config/components/SubagentModelConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/SubagentModelConfig.tsx
@@ -126,6 +126,7 @@ export const SubagentModelConfig: React.FC = () => {
         size="small"
         searchable
         className="model-select-presentation__select"
+        dropdownClassName="model-select-presentation__dropdown"
         options={modelOptions}
         value={selectionValue(selection)}
         onChange={(value) => void handleChange(value)}

--- a/src/web-ui/src/shared/utils/useAnchoredPopoverPosition.ts
+++ b/src/web-ui/src/shared/utils/useAnchoredPopoverPosition.ts
@@ -1,0 +1,177 @@
+import {
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type RefObject,
+} from 'react';
+import {
+  computeFixedPopoverPositionInViewport,
+  DEFAULT_POPOVER_VIEWPORT_PADDING,
+  type FixedPopoverPlacement,
+} from './fixedPopoverViewport';
+
+export type AnchoredPopoverAlignment = 'start' | 'end';
+
+export interface AnchoredPopoverLayout {
+  top: number;
+  left: number;
+  width?: number;
+  placement: FixedPopoverPlacement;
+}
+
+interface UseAnchoredPopoverPositionOptions {
+  open: boolean;
+  anchorRef: RefObject<HTMLElement | null>;
+  popoverRef: RefObject<HTMLElement | null>;
+  preferredPlacement?: FixedPopoverPlacement;
+  alignment?: AnchoredPopoverAlignment;
+  gap?: number;
+  padding?: number;
+  matchAnchorWidth?: boolean;
+  /** Re-measure after content that can change the popover dimensions updates. */
+  layoutRevision?: unknown;
+}
+
+const sameLayout = (
+  current: AnchoredPopoverLayout | null,
+  next: AnchoredPopoverLayout,
+): boolean => current !== null
+  && current.top === next.top
+  && current.left === next.left
+  && current.width === next.width
+  && current.placement === next.placement;
+
+const resolvePlacement = (
+  top: number,
+  height: number,
+  anchorRect: DOMRect,
+  preferredPlacement: FixedPopoverPlacement,
+): FixedPopoverPlacement => {
+  if (top + height <= anchorRect.top) return 'top';
+  if (top >= anchorRect.bottom) return 'bottom';
+  return preferredPlacement;
+};
+
+/**
+ * Keeps a portalled popover attached to its trigger while escaping ancestor
+ * clipping. Position is refreshed for nested scrolling, viewport resize and
+ * content/anchor resize, and is clamped to the visible viewport.
+ */
+export function useAnchoredPopoverPosition({
+  open,
+  anchorRef,
+  popoverRef,
+  preferredPlacement = 'bottom',
+  alignment = 'start',
+  gap = 6,
+  padding = DEFAULT_POPOVER_VIEWPORT_PADDING,
+  matchAnchorWidth = false,
+  layoutRevision,
+}: UseAnchoredPopoverPositionOptions): AnchoredPopoverLayout | null {
+  const [layout, setLayout] = useState<AnchoredPopoverLayout | null>(null);
+  const frameRef = useRef<number | null>(null);
+
+  const updatePosition = useCallback(() => {
+    const anchor = anchorRef.current;
+    const popover = popoverRef.current;
+    if (!anchor || !popover || typeof window === 'undefined') return;
+
+    const anchorRect = anchor.getBoundingClientRect();
+    const availableWidth = Math.max(0, window.innerWidth - padding * 2);
+    const matchedWidth = matchAnchorWidth
+      ? Math.min(anchorRect.width, availableWidth)
+      : undefined;
+
+    if (matchedWidth !== undefined) {
+      popover.style.width = `${matchedWidth}px`;
+    }
+
+    const popoverRect = popover.getBoundingClientRect();
+    const popoverWidth = popoverRect.width
+      || popover.offsetWidth
+      || matchedWidth
+      || popover.scrollWidth;
+    const popoverHeight = popoverRect.height
+      || popover.offsetHeight
+      || popover.scrollHeight;
+    const preferredLeft = alignment === 'end'
+      ? anchorRect.right - popoverWidth
+      : anchorRect.left;
+    const position = computeFixedPopoverPositionInViewport(
+      {
+        left: preferredLeft,
+        top: anchorRect.top,
+        bottom: anchorRect.bottom,
+      },
+      popoverWidth,
+      popoverHeight,
+      { width: window.innerWidth, height: window.innerHeight },
+      { gap, padding, preferredPlacement },
+    );
+    const nextLayout: AnchoredPopoverLayout = {
+      ...position,
+      width: matchedWidth,
+      placement: resolvePlacement(
+        position.top,
+        popoverHeight,
+        anchorRect,
+        preferredPlacement,
+      ),
+    };
+
+    setLayout(current => sameLayout(current, nextLayout) ? current : nextLayout);
+  }, [
+    alignment,
+    anchorRef,
+    gap,
+    matchAnchorWidth,
+    padding,
+    popoverRef,
+    preferredPlacement,
+  ]);
+
+  const schedulePositionUpdate = useCallback(() => {
+    if (frameRef.current !== null) return;
+    frameRef.current = window.requestAnimationFrame(() => {
+      frameRef.current = null;
+      updatePosition();
+    });
+  }, [updatePosition]);
+
+  useLayoutEffect(() => {
+    if (!open) {
+      setLayout(current => current === null ? current : null);
+      return;
+    }
+
+    updatePosition();
+    window.addEventListener('resize', schedulePositionUpdate, { passive: true });
+    window.addEventListener('scroll', schedulePositionUpdate, {
+      capture: true,
+      passive: true,
+    });
+
+    const resizeObserver = typeof ResizeObserver === 'undefined'
+      ? null
+      : new ResizeObserver(schedulePositionUpdate);
+    if (anchorRef.current) resizeObserver?.observe(anchorRef.current);
+    if (popoverRef.current) resizeObserver?.observe(popoverRef.current);
+
+    return () => {
+      window.removeEventListener('resize', schedulePositionUpdate);
+      window.removeEventListener('scroll', schedulePositionUpdate, { capture: true });
+      resizeObserver?.disconnect();
+      if (frameRef.current !== null) {
+        window.cancelAnimationFrame(frameRef.current);
+        frameRef.current = null;
+      }
+    };
+  }, [anchorRef, open, popoverRef, schedulePositionUpdate, updatePosition]);
+
+  useLayoutEffect(() => {
+    if (open) updatePosition();
+  }, [layoutRevision, open, updatePosition]);
+
+  return layout;
+}


### PR DESCRIPTION
## Summary

- add one viewport-aware anchored popover hook that portals overlays out of clipping ancestors, flips at viewport edges, clamps both axes, and follows nested scrolling
- migrate the shared Select plus active menus and panels across market-adjacent settings, chat input, FlowChat header, navigation, shell, dispatch, profile, welcome, session files, and tool timeout surfaces
- preserve the explicit inline Select mode used by the layout-expanding Agents surface and preserve surface-specific dropdown styling after portalization
- add geometry and clipping regression coverage, including assertions that dispatch and permission menus anchor to their actual trigger buttons
- make the existing ExternalSources confirmation test target its dialog instead of relying on body DOM order after portal hosts are reused

## Verification

- pnpm run type-check:web
- pnpm run lint:web
- pnpm --dir src/web-ui run test:run (408 files, 2772 tests)
- pnpm run build:web
- pnpm run theme:color-audit:all
- pnpm run check:repo-hygiene