### PR TITLE
chore: ignore local .design directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,5 @@ external/
 /.bitfun/search/flashgrep-index/
 .agents/
 /.flashgrep-index-engine/
+
+.design/


### PR DESCRIPTION
## Summary
- Ignore the local `.design/` directory so design working assets stay out of the repository.

## Test plan
- [ ] Confirm `.design/` is ignored by `git status`
- [ ] Confirm unrelated ignore rules are unchanged