### PR TITLE
fix(release): mirror website Windows installer

### DIFF
--- a/scripts/linux-binaries-manifest.test.mjs
+++ b/scripts/linux-binaries-manifest.test.mjs
@@ -154,6 +154,109 @@ test('openbitfun sync mirrors both products and their checksums', () => {
   assert.match(syncScript, /WEBSITE_RELEASE_DIR.*linux-binaries\.json/);
 });
 
+test('openbitfun sync mirrors the website installer from the exact updater release', () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'bitfun-windows-installer-mirror-'));
+  const versionDir = path.join(temp, 'release', '1.2.3');
+  const calls = path.join(temp, 'download-calls.tsv');
+  fs.mkdirSync(versionDir, { recursive: true });
+
+  const result = spawnSync(
+    'bash',
+    ['-c', `
+      source "$SYNC_SCRIPT"
+      VERSION_DIR="$TEST_VERSION_DIR"
+      RELEASE_ASSET_BASE_URL="https://github.com/GCWing/BitFun/releases/download/v1.2.3"
+      WINDOWS_INSTALLER_FILENAME="bitfun-installer.exe"
+      download_asset() {
+        printf '%s\\t%s\\n' "$1" "$2" >> "$DOWNLOAD_CALLS"
+      }
+      mirror_windows_installer
+    `],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        DOWNLOAD_CALLS: calls,
+        SYNC_SCRIPT: path.join(repoRoot, 'scripts/openbitfun-release-sync.sh'),
+        TEST_VERSION_DIR: versionDir,
+      },
+    }
+  );
+  assert.equal(result.status, 0, result.stderr);
+
+  const downloads = fs.readFileSync(calls, 'utf8').trim().split('\n');
+  assert.deepEqual(downloads, [
+    `https://github.com/GCWing/BitFun/releases/download/v1.2.3/bitfun-installer.exe\t${versionDir}/bitfun-installer.exe`,
+    `https://github.com/GCWing/BitFun/releases/download/v1.2.3/bitfun-installer.exe.sig\t${versionDir}/bitfun-installer.exe.sig`,
+  ]);
+});
+
+test('website download manifest uses installer while updater manifest keeps setup', () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'bitfun-website-downloads-'));
+  const versionDir = path.join(temp, 'release', '1.2.3');
+  const updaterPath = path.join(versionDir, 'latest.json');
+  fs.mkdirSync(versionDir, { recursive: true });
+
+  const updater = {
+    version: '1.2.3',
+    notes: '',
+    pub_date: '2026-08-05T00:00:00Z',
+    platforms: {
+      'windows-x86_64': {
+        url: 'https://openbitfun.test/release/1.2.3/BitFun_1.2.3_windows-x86_64-setup.exe',
+      },
+      'darwin-aarch64': {
+        url: 'https://openbitfun.test/release/1.2.3/BitFun_1.2.3_darwin-aarch64.app.tar.gz',
+      },
+    },
+  };
+  fs.writeFileSync(updaterPath, `${JSON.stringify(updater, null, 2)}\n`);
+
+  const result = spawnSync(
+    'bash',
+    ['-c', `
+      source "$SYNC_SCRIPT"
+      VERSION_DIR="$TEST_VERSION_DIR"
+      OPENBITFUN_BASE_URL="https://openbitfun.test/release"
+      WINDOWS_INSTALLER_FILENAME="bitfun-installer.exe"
+      WEBSITE_DOWNLOADS_MANIFEST="downloads.json"
+      write_website_download_manifest
+    `],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        SYNC_SCRIPT: path.join(repoRoot, 'scripts/openbitfun-release-sync.sh'),
+        TEST_VERSION_DIR: versionDir,
+      },
+    }
+  );
+  assert.equal(result.status, 0, result.stderr);
+
+  const updaterAfter = JSON.parse(fs.readFileSync(updaterPath, 'utf8'));
+  const website = JSON.parse(
+    fs.readFileSync(path.join(versionDir, 'downloads.json'), 'utf8')
+  );
+  assert.match(
+    updaterAfter.platforms['windows-x86_64'].url,
+    /windows-x86_64-setup\.exe$/
+  );
+  assert.equal(website.schemaVersion, 1);
+  assert.equal(website.version, '1.2.3');
+  assert.equal(
+    website.platforms['windows-x86_64'].url,
+    'https://openbitfun.test/release/1.2.3/bitfun-installer.exe'
+  );
+  assert.equal(
+    website.platforms['windows-x86_64'].signatureUrl,
+    'https://openbitfun.test/release/1.2.3/bitfun-installer.exe.sig'
+  );
+  assert.equal(
+    website.platforms['darwin-aarch64'].url,
+    updater.platforms['darwin-aarch64'].url
+  );
+});
+
 test('Linux archives are mirrored before the much larger Desktop packages', () => {
   const syncScript = fs.readFileSync(
     path.join(repoRoot, 'scripts/openbitfun-release-sync.sh'),

--- a/scripts/openbitfun-release-sync.sh
+++ b/scripts/openbitfun-release-sync.sh
@@ -6,14 +6,18 @@
 #   1. Fetch latest.json from GitHub (follows /releases/latest/download/ redirect)
 #   2. Mirror the signed Relay image descriptor and Linux binary manifest FIRST
 #      (small trust metadata must not queue behind ~700 MB of Desktop packages)
-#   3. Download every Desktop updater package into release/{version}/
-#   4. Rewrite all mirrored URLs to point at openbitfun.com
-#   5. Publish versioned and root manifests
+#   3. Download every Desktop updater package plus the standalone Windows
+#      installer into release/{version}/
+#   4. Rewrite updater URLs and generate a separate website download manifest
+#   5. Atomically publish versioned and root manifests
 #   6. Remove old version dirs, keeping only the most recent KEEP_VERSIONS
 #
 # The published release/latest.json is the Tauri updater fallback endpoint.
 # When GitHub is unreachable, the desktop client automatically falls through
 # to https://openbitfun.com/release/latest.json and downloads from this mirror.
+# The published release/downloads.json is for the website. Its Windows URL
+# points at bitfun-installer.exe while latest.json deliberately keeps the Tauri
+# updater's versioned setup.exe URL.
 #
 # Cron (every 10 minutes):
 #   */10 * * * * /root/repos/BitFun-AutoUpdate/openbitfun-release-sync.sh \
@@ -44,6 +48,8 @@ GITHUB_RELAY_IMAGE_URL="https://github.com/GCWing/BitFun/releases/latest/downloa
 OPENBITFUN_BASE_URL="https://openbitfun.com/release"
 WEBSITE_RELEASE_DIR="/root/repos/BitFun-Website/dist/release"
 LOCK_FILE="/root/repos/BitFun-AutoUpdate/sync.lock"
+WINDOWS_INSTALLER_FILENAME="bitfun-installer.exe"
+WEBSITE_DOWNLOADS_MANIFEST="downloads.json"
 # Keep enough releases that the mirror still serves a Desktop build a few
 # versions behind. One-click Relay deploy asks the mirror for the version baked
 # into the running Desktop binary, so retaining too few removes its descriptor
@@ -87,6 +93,85 @@ download_asset() {
     log "ERROR: Failed to download $filename after $MAX_RETRIES attempts"
     return 1
   fi
+}
+
+# Publish a root manifest without exposing a partially copied JSON file to
+# Nginx. The flock around the full sync guarantees one writer, and rename is
+# atomic because the temporary file lives beside its destination.
+publish_file_atomically() {
+  local source="$1"
+  local dest="$2"
+  local tmp="${dest}.part"
+  cp "$source" "$tmp"
+  mv "$tmp" "$dest"
+}
+
+# Mirror the custom Windows installer used for interactive website installs.
+# RELEASE_ASSET_BASE_URL is derived from latest.json rather than from
+# /releases/latest/download so the installer and setup package cannot come from
+# different releases while GitHub is advancing the latest-release pointer.
+mirror_windows_installer() {
+  local installer_url
+  installer_url="${RELEASE_ASSET_BASE_URL}/${WINDOWS_INSTALLER_FILENAME}"
+
+  log "  Mirroring website Windows installer: ${WINDOWS_INSTALLER_FILENAME}"
+  download_asset \
+    "$installer_url" \
+    "${VERSION_DIR}/${WINDOWS_INSTALLER_FILENAME}" || exit 1
+  download_asset \
+    "${installer_url}.sig" \
+    "${VERSION_DIR}/${WINDOWS_INSTALLER_FILENAME}.sig" || exit 1
+}
+
+# Build a website-only manifest from the already rewritten updater manifest.
+# All non-Windows targets continue to use their mirrored updater packages. The
+# Windows target alone is replaced with the custom installer URL; latest.json
+# is never modified and remains a valid Tauri updater contract.
+write_website_download_manifest() {
+  local output="${VERSION_DIR}/${WEBSITE_DOWNLOADS_MANIFEST}"
+  local output_tmp="${output}.part"
+
+  "$PYTHON" - \
+    "${VERSION_DIR}/latest.json" \
+    "$output_tmp" \
+    "$OPENBITFUN_BASE_URL" \
+    "$WINDOWS_INSTALLER_FILENAME" <<'PY'
+import json, sys
+
+source, dest, base, windows_installer = sys.argv[1:]
+with open(source, encoding="utf-8") as f:
+    updater = json.load(f)
+
+version = updater["version"]
+platforms = {}
+for target, entry in updater.get("platforms", {}).items():
+    url = entry.get("url")
+    if url:
+        platforms[target] = {"url": url}
+
+windows = platforms.get("windows-x86_64")
+if windows is None:
+    raise SystemExit("latest.json is missing windows-x86_64")
+
+version_base = f"{base}/{version}"
+windows["url"] = f"{version_base}/{windows_installer}"
+windows["signatureUrl"] = f"{version_base}/{windows_installer}.sig"
+
+website = {
+    "schemaVersion": 1,
+    "version": version,
+    "platforms": platforms,
+}
+for optional_key in ("notes", "pub_date"):
+    if optional_key in updater:
+        website[optional_key] = updater[optional_key]
+
+with open(dest, "w", encoding="utf-8") as f:
+    json.dump(website, f, indent=2)
+    f.write("\n")
+PY
+  mv "$output_tmp" "$output"
+  log "Saved ${output}"
 }
 
 # Check the mirrored Linux archives against the `.sha256` sidecars mirrored with
@@ -234,7 +319,9 @@ with open(dest, "w", encoding="utf-8") as f:
     f.write("\n")
 PY
     rm -f "$LINUX_MANIFEST_TMP"
-    cp "${VERSION_DIR}/linux-binaries.json" "${WEBSITE_RELEASE_DIR}/linux-binaries.json"
+    publish_file_atomically \
+      "${VERSION_DIR}/linux-binaries.json" \
+      "${WEBSITE_RELEASE_DIR}/linux-binaries.json"
     log "Updated ${WEBSITE_RELEASE_DIR}/linux-binaries.json"
   elif [ "$LINUX_MANIFEST_STATE" = "missing" ]; then
     rm -f "${WEBSITE_RELEASE_DIR}/linux-binaries.json"
@@ -333,6 +420,22 @@ main() {
   }
   log "Latest version: $VERSION"
 
+  # Resolve the exact tagged release directory from the updater URLs. Using
+  # this base for the standalone installer avoids a latest-release race where
+  # latest.json and bitfun-installer.exe could otherwise resolve to different
+  # versions during publication.
+  RELEASE_ASSET_BASE_URL=$(printf '%s' "$LATEST_JSON" | "$PYTHON" -c "
+import json, sys
+data = json.load(sys.stdin)
+bases = {entry['url'].rsplit('/', 1)[0] for entry in data.get('platforms', {}).values() if entry.get('url')}
+if len(bases) != 1:
+    raise SystemExit(f'expected one release asset base, got {sorted(bases)}')
+print(bases.pop())
+") || {
+    log "ERROR: Failed to resolve the release asset base from latest.json"
+    exit 1
+  }
+
   # 3. Create version directory
   VERSION_DIR="${WEBSITE_RELEASE_DIR}/${VERSION}"
   mkdir -p "$VERSION_DIR"
@@ -361,7 +464,12 @@ for p, info in data.get('platforms', {}).items():
     download_asset "$url" "${VERSION_DIR}/${filename}" || exit 1
   done <<< "$ASSET_LIST"
 
+  # latest.json only lists the Tauri setup.exe. Mirror the custom installer
+  # separately for website users while preserving the updater contract.
+  mirror_windows_installer
+
   # 6. Rewrite URLs in latest.json to point at openbitfun.com
+  LATEST_MANIFEST_TMP="${VERSION_DIR}/latest.json.part"
   printf '%s' "$LATEST_JSON" | "$PYTHON" -c "
 import sys, json
 data = json.load(sys.stdin)
@@ -371,12 +479,20 @@ for p, info in data.get('platforms', {}).items():
     fname = info['url'].split('/')[-1]
     info['url'] = base + '/' + fname
 print(json.dumps(data, indent=2))
-" > "${VERSION_DIR}/latest.json"
+" > "$LATEST_MANIFEST_TMP"
+  mv "$LATEST_MANIFEST_TMP" "${VERSION_DIR}/latest.json"
   log "Saved ${VERSION_DIR}/latest.json"
 
-  # 7. Publish root latest.json (Tauri fallback endpoint)
-  cp "${VERSION_DIR}/latest.json" "${WEBSITE_RELEASE_DIR}/latest.json"
+  # 7. Generate the website manifest, then atomically publish both root files.
+  write_website_download_manifest
+  publish_file_atomically \
+    "${VERSION_DIR}/latest.json" \
+    "${WEBSITE_RELEASE_DIR}/latest.json"
   log "Updated ${WEBSITE_RELEASE_DIR}/latest.json"
+  publish_file_atomically \
+    "${VERSION_DIR}/${WEBSITE_DOWNLOADS_MANIFEST}" \
+    "${WEBSITE_RELEASE_DIR}/${WEBSITE_DOWNLOADS_MANIFEST}"
+  log "Updated ${WEBSITE_RELEASE_DIR}/${WEBSITE_DOWNLOADS_MANIFEST}"
 
   # 8. Clean up old versions — keep only the latest KEEP_VERSIONS dirs
   ALL_DIRS=()
@@ -395,4 +511,6 @@ print(json.dumps(data, indent=2))
   log "=== Sync complete: version $VERSION ==="
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi


### PR DESCRIPTION
## Summary
- mirror `bitfun-installer.exe` and its signature alongside the Windows updater setup package
- derive the installer URL from the exact tagged asset base in `latest.json` to avoid latest-release races
- publish an atomic website-only `/release/downloads.json` whose Windows URL uses the installer
- keep `/release/latest.json` unchanged for Tauri auto-update
- make root manifest publication atomic and make the sync script sourceable for focused tests

## Verification
- `bash -n scripts/openbitfun-release-sync.sh`
- `node --test scripts/linux-binaries-manifest.test.mjs` (8 passing)
- `git diff --check`

AI-assisted: yes. Testing level: focused behavior tests plus shell syntax validation.
