### PR TITLE
docs(readme): lead with Mini Apps and self-hosted device control

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 ![BitFun](./png/BitFun_title.png)
 
-### An open-source desktop AI agent — it ships code in your real repos, and drives your real desktop.
+### An open-source desktop agent that builds the interface your task needs.
 
-Code Agent · Cowork · Computer Use — local-first, on a Rust runtime.
+Agentic Mini Apps · self-hosted multi-device control · a Rust runtime you can reshape.
 
 [**⬇ Download for macOS · Windows · Linux**](https://github.com/GCWing/BitFun/releases/latest)
 
@@ -26,6 +26,20 @@ Code Agent · Cowork · Computer Use — local-first, on a Rust runtime.
      See scripts/record-demo.sh — this is the single highest-impact asset in this README. -->
 
 ![BitFun desktop app](./png/first_screen_screenshot.png)
+
+---
+
+## Why BitFun
+
+**Agentic Mini Apps.** Most agents push every task through the same chat box. BitFun builds the task its own interface instead — a chart, a board, a form, a panel — and binds a conversation to that interface's live state. You ask about what is on screen rather than re-describing it. Community builds already range from market dashboards to domain-specific tools.
+
+**Self-hosted multi-device control.** Account login, cross-device session and settings sync, and controlling one signed-in device from another all run through a relay *you* deploy. Nothing is brokered by a vendor's cloud — the distinction that decides whether this is allowed inside a company network at all. The relay is zero-knowledge: clients derive keys locally, and the server only ever holds Argon2id hashes and AES-GCM-wrapped material.
+
+**A runtime you can reshape.** Four continuous tiers, from a single Markdown file to forking the runtime: custom Agents → MCP / Skills / Codex-compatible Hooks → Mini Apps → source-level changes. You extend BitFun using BitFun.
+
+**KV cache that actually hits.** Agent cost is dominated not by generated tokens but by context re-sent every turn, and a single timestamp or reordered tool list invalidates the cache from that byte onward. Prompt assembly is byte-stable across turns: **98.67%** average cache hit rate over a SWE-Bench-Pro run.
+
+**flashgrep.** An agent re-searches the same repository dozens to hundreds of times per task, and cold traversal on every tool call can cost more than inference itself. A resident cross-turn index cuts search time by up to **94.6%** on Chromium-scale trees — roughly **36x** on average.
 
 ---
 
@@ -55,8 +69,9 @@ Two kinds of complex work: shipping code in real repositories, and turning sourc
 
 **Shared capabilities**
 
-- **Desktop execution layer**: Computer Use, browser operation, desktop apps, the filesystem, terminals, remote workspaces, and Mini Apps let the Agent enter real work environments.
-- **Customization layer**: MCP, Skills, custom Agents, Mini Apps, and source-level extension let BitFun keep growing around your tools, roles, and interfaces.
+- **Interface layer**: Mini Apps give a task its own UI, with the conversation bound to that UI's live state.
+- **Execution layer**: the filesystem, terminals, Git, browser operation, desktop applications, Computer Use, and remote workspaces let the Agent reach the real environment when a task leaves the editor.
+- **Customization layer**: MCP, Skills, Hooks, custom Agents, and source-level extension let BitFun keep growing around your tools, roles, and interfaces.
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,9 +4,9 @@
 
 ![BitFun](./png/BitFun_title.png)
 
-### 开源桌面 AI Agent —— 在真实仓库里交付代码，在真实桌面上动手干活。
+### 开源桌面 Agent —— 它为任务造一个界面，而不是把所有事都塞进一个聊天框。
 
-Code Agent · Cowork · Computer Use —— 本地优先，基于 Rust Runtime。
+Agentic Mini App · 自部署多设备互联互控 · 可以改到底的 Rust Runtime
 
 [**⬇ 下载 macOS · Windows · Linux 版**](https://github.com/GCWing/BitFun/releases/latest)
 
@@ -26,6 +26,20 @@ Code Agent · Cowork · Computer Use —— 本地优先，基于 Rust Runtime�
      录制脚本见 scripts/record-demo.sh —— 这是整个 README 里最值得做的一张图。 -->
 
 ![BitFun 桌面端](./png/first_screen_screenshot_CN.png)
+
+---
+
+## 为什么是 BitFun
+
+**Agentic Mini App。** 多数 Agent 把所有任务都挤进同一个对话框，BitFun 选择为任务造一个专属界面——图表、看板、表单、面板——并让对话绑定这个界面的实时状态。你问的是眼前看到的东西，不必再把它复述一遍。社区已经做出从行情面板到各类垂直领域工具的版本。
+
+**自部署的多设备互联互控。** 账号登录、跨设备会话与配置同步、用一台设备操控另一台已登录设备，全部走**你自己部署**的 relay，不经任何第三方云中转——这往往直接决定了它在企业内网里能不能用。relay 是零知识设计：密钥在客户端本地派生，服务端只保存 Argon2id 哈希和 AES-GCM 封装后的材料。
+
+**可以改到底的 Runtime。** 从一个 Markdown 文件到 fork 整个 Runtime，四层连续：自定义 Agent → MCP / Skills / 兼容 Codex 的 Hooks → Mini App → 源码级改造。你可以用 BitFun 来扩展 BitFun。
+
+**真正命中的 KV Cache。** Agent 的成本大头不是生成的 token，而是每轮重复发送的上下文；而一个时间戳、一次工具列表重排序，就会让缓存从那个字节开始全部失效。运行时保证 prompt 前缀逐字节稳定：一轮 SWE-Bench-Pro 实测平均命中率 **98.67%**。
+
+**flashgrep。** Agent 在一个任务里会把同一个仓库检索几十到上百次，每次工具调用都冷启动遍历，开销可能超过模型推理本身。跨轮次常驻索引在 Chromium 这类千万行仓库上把搜索耗时最高降低 **94.6%**，平均约 **36 倍**。
 
 ---
 
@@ -55,8 +69,9 @@ pnpm run desktop:dev
 
 **通用能力**
 
-- **桌面执行底座**：Computer Use、浏览器操作、桌面应用、文件系统、终端、远程工作区和 Mini App，让 Agent 能进入真实工作环境。
-- **可定制化扩展**：MCP、Skills、Agent 自定义、Mini App 和源码级扩展，让 BitFun 可以按你的工具链、角色和界面继续生长。
+- **界面层**：Mini App 为任务生成专属 UI，并让对话绑定这个 UI 的实时状态。
+- **执行层**：文件系统、终端、Git、浏览器操作、桌面应用、Computer Use 和远程工作区，让任务走出编辑器时 Agent 仍能触达真实环境。
+- **定制层**：MCP、Skills、Hooks、Agent 自定义和源码级扩展，让 BitFun 按你的工具链、角色和界面继续生长。
 
 ---
 


### PR DESCRIPTION
## Summary

Reorders the README pitch so it leads with what actually differentiates BitFun. Docs only — no claims changed, benchmark numbers and their caveats untouched.

## Type and Areas

Type: docs

Areas: docs

## Motivation / Impact

The opening line read `Code Agent · Cowork · Computer Use`, putting Computer Use in the most valuable line of the page. It is a real capability but not a differentiator — plenty of agents can drive a desktop, and leading with it invites a comparison we do not need to have. Meanwhile Mini Apps were mentioned once, in the middle of a bullet, and the self-hosted relay was not mentioned at all.

New order:

1. **Agentic Mini Apps** — a task gets its own interface (chart, board, form, panel) with a conversation bound to that interface's live state, instead of every task going through one chat box
2. **Self-hosted multi-device control** — login, cross-device sync, and device-to-device control run through a relay you deploy; nothing is brokered by a vendor's cloud, which is often what decides whether this is permitted inside a company network at all
3. **A runtime you can reshape** — four continuous tiers, Markdown file through fork
4. **KV cache prefix stability** — 98.67% average hit rate over a SWE-Bench-Pro run
5. **flashgrep** — resident cross-turn index, up to 94.6% less search time on Chromium-scale trees, ~36x average

Changes:

- Rewrite the tagline and subtitle
- Add a `## Why BitFun` section directly above Install, carrying the five points
- Split the old two-bullet capability list into **interface / execution / customization** layers, so Mini Apps lead and Computer Use sits inside the execution layer where it belongs

## Verification

- `node scripts/check-repo-hygiene.mjs` → passed (2 content files scanned, 5894 filenames checked)
- Every relative link and image target in both READMEs resolved against the working tree — 15/15 exist
- `Computer Use` now appears only inside the execution-layer bullet in both files, not in any headline
- Docs-only change; no build or runtime checks apply

## Reviewer Notes

The zero-knowledge description of the relay is taken from `src/apps/relay-server/README.md` (client-side key derivation, Argon2id hashes, AES-GCM-wrapped material) — happy to reword if that summary is too compressed.

Two follow-ups from the earlier README PR are still open and both need repo admin: uploading `png/og-image.png` as the Social preview (Settings → General), and adding the `rust` / `tauri` / `ai-agent` topics.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.