### PR TITLE
docs(readme): rewrite the tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 ![BitFun](./png/BitFun_title.png)
 
-### An open-source desktop agent that builds the interface your task needs.
+### An open-source desktop AI agent that turns every task into an app you can open
 
-Agentic Mini Apps · self-hosted multi-device control · a Rust runtime you can reshape.
+Writes code, produces documents, drives the desktop. The Mini Apps, the runtime, and the device-sync server are all yours. MIT.
 
 [**⬇ Download for macOS · Windows · Linux**](https://github.com/GCWing/BitFun/releases/latest)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,9 +4,9 @@
 
 ![BitFun](./png/BitFun_title.png)
 
-### 开源桌面 Agent —— 它为任务造一个界面，而不是把所有事都塞进一个聊天框。
+### 开源桌面 AI Agent —— 每个任务，都给你一个能打开的应用
 
-Agentic Mini App · 自部署多设备互联互控 · 可以改到底的 Rust Runtime
+能写代码、能做文档、能操控桌面。小应用、Runtime、多设备互控的服务器，全部归你。MIT。
 
 [**⬇ 下载 macOS · Windows · Linux 版**](https://github.com/GCWing/BitFun/releases/latest)
 


### PR DESCRIPTION
## Summary

Rewrites the first two lines of both READMEs. Docs only.

**Before**

> ### An open-source desktop agent that builds the interface your task needs.
> Agentic Mini Apps · self-hosted multi-device control · a Rust runtime you can reshape.

**After**

> ### An open-source desktop AI agent that turns every task into an app you can open
> Writes code, produces documents, drives the desktop. The Mini Apps, the runtime, and the device-sync server are all yours. MIT.

## Type and Areas

Type: docs

Areas: docs

## Motivation / Impact

The old tagline defined BitFun by what it is not — `不是把所有事都塞进一个聊天框` — which spends 30+ characters saying something the reader has to invert before it means anything, and leaves behind no noun they can repeat to someone else. The second line was three feature phrases in a row: a spec sheet, not a pitch.

Every comparable project does the opposite:

| Project | Tagline |
| --- | --- |
| aider (47k) | AI Pair Programming in Your Terminal |
| Zed (88k) | Code at the speed of thought |
| OpenHands (83k) | AI-Driven Development |
| goose (52k) | your native open source AI agent — desktop app, CLI, and API |
| Dyad (21k) | local, open-source AI app builder … like Lovable, v0, or Bolt, but running right on your machine |

All short, all positive, all anchored on a concrete noun. None explains itself by negating a competitor.

The new tagline names the deliverable directly — every task ends as an app you can open — and the subtitle answers the three things a first-time reader needs: what it does, what is yours, what it costs.

## Verification

- Rendered both files through the GitHub Markdown API (`POST /markdown`, mode `gfm`): 3 tables each, parsed, zero unparsed rows
- `node scripts/check-repo-hygiene.mjs` → passed (2 content files scanned, 5898 filenames checked)
- Docs-only change; no build or runtime checks apply

## Reviewer Notes

The repository's GitHub **About** description still reads `BitFun combines a high-performance agent runtime written in Rust with a polished desktop application…`, which now says something different from the README. Worth aligning — that line is what shows in search results and every share card. Needs repo admin, as does uploading `png/og-image.png` as the Social preview and adding the `rust` / `tauri` / `ai-agent` topics.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.