### PR TITLE
feat(release): deploy latest binaries with mirror fallback

### DIFF
--- a/docs/architecture/detached-task-dispatch.md
+++ b/docs/architecture/detached-task-dispatch.md
@@ -218,8 +218,12 @@ version equality is not evidence of this behavior.
 
 `probe` is read-only and never installs software. Immediately before SSH
 provisioning, submission probes again and automatically installs or upgrades a
-compatible prebuilt `bitfun` release when needed. Release resolution stays
-bound to the expected OS and architecture; the controller verifies the
+compatible latest prebuilt `bitfun` release when needed. Release resolution
+stays bound to the expected OS and architecture. GitHub is the default byte
+source; when its measured transfer rate is below 512 KiB/s, OpenBitFun is tried
+first and GitHub remains the fallback. The same policy applies whether the SSH
+target downloads directly or the controller has to push the archive. The
+controller verifies the
 checksum sidecar, its publisher signature when present, and the mandatory
 archive signature, pins the SHA-256 passed to the installer, waits with a
 bounded deadline, and probes the installed binary again before continuing.

--- a/scripts/generate-linux-binaries-manifest.mjs
+++ b/scripts/generate-linux-binaries-manifest.mjs
@@ -55,6 +55,10 @@ function asset(filename) {
     url: `${releaseBase}/${filename}`,
     sha256Url: `${releaseBase}/${checksum}`,
   };
+  const checksumSignature = `${checksum}.sig`;
+  if (fs.existsSync(path.join(assetsDir, checksumSignature))) {
+    entry.sha256SigUrl = `${releaseBase}/${checksumSignature}`;
+  }
   // Signature is optional: forks build without the release key. A checksum
   // proves only that the transfer was intact, since whoever serves the archive
   // serves the checksum too; the signature is what a mirror cannot forge.

--- a/scripts/linux-binaries-manifest.test.mjs
+++ b/scripts/linux-binaries-manifest.test.mjs
@@ -78,6 +78,10 @@ test('publishes sigUrl when a signature is present, omits it otherwise', () => {
     path.join(assets, 'bitfun-cli-1.2.3-x86_64-unknown-linux-gnu.tar.gz.sig'),
     ''
   );
+  fs.writeFileSync(
+    path.join(assets, 'bitfun-cli-1.2.3-x86_64-unknown-linux-gnu.tar.gz.sha256.sig'),
+    ''
+  );
 
   const result = spawnSync(
     process.execPath,
@@ -98,7 +102,12 @@ test('publishes sigUrl when a signature is present, omits it otherwise', () => {
     manifest.platforms['linux-x86_64'].cli.sigUrl,
     /bitfun-cli-1\.2\.3-x86_64-unknown-linux-gnu\.tar\.gz\.sig$/
   );
+  assert.match(
+    manifest.platforms['linux-x86_64'].cli.sha256SigUrl,
+    /bitfun-cli-1\.2\.3-x86_64-unknown-linux-gnu\.tar\.gz\.sha256\.sig$/
+  );
   assert.equal(manifest.platforms['linux-x86_64'].relay.sigUrl, undefined);
+  assert.equal(manifest.platforms['linux-x86_64'].relay.sha256SigUrl, undefined);
   assert.equal(manifest.platforms['linux-aarch64'].cli.sigUrl, undefined);
 });
 
@@ -149,9 +158,15 @@ test('openbitfun sync mirrors both products and their checksums', () => {
 
   assert.match(syncScript, /linux-binaries\.json/);
   assert.match(syncScript, /for product in \("cli", "relay"\)/);
-  assert.match(syncScript, /for key in \("url", "sha256Url", "sigUrl"\)/);
+  assert.match(
+    syncScript,
+    /for key in \("url", "sha256Url", "sha256SigUrl", "sigUrl"\)/
+  );
   assert.match(syncScript, /OPENBITFUN_BASE_URL/);
   assert.match(syncScript, /WEBSITE_RELEASE_DIR.*linux-binaries\.json/);
+  assert.match(syncScript, /mirror_dispatch_macos_cli_archives/);
+  assert.match(syncScript, /x86_64-apple-darwin aarch64-apple-darwin/);
+  assert.match(syncScript, /WEBSITE_RELEASE_DIR.*relay-image\.json/);
 });
 
 test('openbitfun sync mirrors the website installer from the exact updater release', () => {
@@ -188,6 +203,60 @@ test('openbitfun sync mirrors the website installer from the exact updater relea
   assert.deepEqual(downloads, [
     `https://github.com/GCWing/BitFun/releases/download/v1.2.3/bitfun-installer.exe\t${versionDir}/bitfun-installer.exe`,
     `https://github.com/GCWing/BitFun/releases/download/v1.2.3/bitfun-installer.exe.sig\t${versionDir}/bitfun-installer.exe.sig`,
+  ]);
+});
+
+test('openbitfun sync mirrors complete signed macOS CLI sets for Dispatch', () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'bitfun-macos-cli-mirror-'));
+  const versionDir = path.join(temp, 'release', '1.2.3');
+  const calls = path.join(temp, 'download-calls.tsv');
+  const checksums = path.join(temp, 'checksum-list.txt');
+  fs.mkdirSync(versionDir, { recursive: true });
+
+  const result = spawnSync(
+    'bash',
+    ['-c', `
+      source "$SYNC_SCRIPT"
+      VERSION="1.2.3"
+      VERSION_DIR="$TEST_VERSION_DIR"
+      RELEASE_ASSET_BASE_URL="https://github.com/GCWing/BitFun/releases/download/v1.2.3"
+      curl() { return 0; }
+      download_asset() {
+        printf '%s\\t%s\\n' "$1" "$2" >> "$DOWNLOAD_CALLS"
+      }
+      verify_mirrored_checksums() {
+        cat > "$CHECKSUM_LIST"
+      }
+      mirror_dispatch_macos_cli_archives
+    `],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        CHECKSUM_LIST: checksums,
+        DOWNLOAD_CALLS: calls,
+        SYNC_SCRIPT: path.join(repoRoot, 'scripts/openbitfun-release-sync.sh'),
+        TEST_VERSION_DIR: versionDir,
+      },
+    }
+  );
+  assert.equal(result.status, 0, result.stderr);
+
+  const downloads = fs.readFileSync(calls, 'utf8').trim().split('\n');
+  assert.equal(downloads.length, 8);
+  for (const target of ['x86_64-apple-darwin', 'aarch64-apple-darwin']) {
+    const archive = `bitfun-cli-1.2.3-${target}.tar.gz`;
+    for (const suffix of ['', '.sha256', '.sha256.sig', '.sig']) {
+      assert.ok(
+        downloads.includes(
+          `https://github.com/GCWing/BitFun/releases/download/v1.2.3/${archive}${suffix}\t${versionDir}/${archive}${suffix}`
+        )
+      );
+    }
+  }
+  assert.deepEqual(fs.readFileSync(checksums, 'utf8').trim().split('\n'), [
+    'bitfun-cli-1.2.3-x86_64-apple-darwin.tar.gz.sha256',
+    'bitfun-cli-1.2.3-aarch64-apple-darwin.tar.gz.sha256',
   ]);
 });
 
@@ -282,9 +351,8 @@ test('the mirror retains enough releases for older Desktop builds', () => {
   );
   const keep = /^KEEP_VERSIONS=(\d+)$/m.exec(syncScript);
   assert.ok(keep, 'KEEP_VERSIONS must be set');
-  // One-click Relay deploy asks the mirror for the version baked into the
-  // running Desktop binary; too few kept versions sends older installs into a
-  // 20-minute source rebuild.
+  // Dispatch confirms an exact release before installation; keep that version
+  // available long enough for a later click or retry to finish safely.
   assert.ok(
     Number(keep[1]) >= 4,
     `KEEP_VERSIONS must retain several releases, got ${keep[1]}`

--- a/scripts/openbitfun-release-sync.sh
+++ b/scripts/openbitfun-release-sync.sh
@@ -51,9 +51,8 @@ LOCK_FILE="/root/repos/BitFun-AutoUpdate/sync.lock"
 WINDOWS_INSTALLER_FILENAME="bitfun-installer.exe"
 WEBSITE_DOWNLOADS_MANIFEST="downloads.json"
 # Keep enough releases that the mirror still serves a Desktop build a few
-# versions behind. One-click Relay deploy asks the mirror for the version baked
-# into the running Desktop binary, so retaining too few removes its descriptor
-# fallback when GitHub metadata is temporarily unreachable.
+# versions behind and SSH Dispatch can finish an already-confirmed install even
+# after a newer release becomes current.
 KEEP_VERSIONS=6
 CONNECT_TIMEOUT=30
 MAX_TIME=1800          # per-request ceiling (30 min; installer packages can be large)
@@ -273,9 +272,9 @@ seen = set()
 for platform in data.get("platforms", {}).values():
     for product in ("cli", "relay"):
         entry = platform.get(product, {})
-        # sigUrl too: without the signature the mirrored copy cannot be verified
-        # as anything stronger than "not corrupted in transit".
-        for key in ("url", "sha256Url", "sigUrl"):
+        # Signatures too: without them the mirrored copy cannot be verified as
+        # anything stronger than "not corrupted in transit".
+        for key in ("url", "sha256Url", "sha256SigUrl", "sigUrl"):
             url = entry.get(key)
             if not url:
                 continue
@@ -311,7 +310,7 @@ version_base = f"{base}/{data['version']}"
 for platform in data.get("platforms", {}).values():
     for product in ("cli", "relay"):
         entry = platform.get(product, {})
-        for key in ("url", "sha256Url", "sigUrl"):
+        for key in ("url", "sha256Url", "sha256SigUrl", "sigUrl"):
             if entry.get(key):
                 entry[key] = f"{version_base}/{entry[key].rsplit('/', 1)[-1]}"
 with open(dest, "w", encoding="utf-8") as f:
@@ -331,6 +330,60 @@ PY
     # one-click Relay deploy both fall back to this file, so a single flaky run
     # must not take it offline for the next 10 minutes.
     log "WARN: Linux binaries manifest unreachable this run; keeping the published mirror."
+  fi
+}
+
+# macOS SSH Dispatch uses the standalone CLI archives published by the CLI
+# workflow after the Desktop release exists. They are not represented by
+# linux-binaries.json, so mirror the deterministic names separately. Missing
+# files are normal while that second workflow is still publishing; a later cron
+# run completes the set atomically enough for clients (every install verifies
+# the signed checksum before using an archive).
+mirror_dispatch_macos_cli_archives() {
+  local target filename base_url suffix ready failed checksum_list
+  checksum_list=""
+  for target in x86_64-apple-darwin aarch64-apple-darwin; do
+    filename="bitfun-cli-${VERSION}-${target}.tar.gz"
+    base_url="${RELEASE_ASSET_BASE_URL}/${filename}"
+    ready=1
+    for suffix in "" .sha256 .sha256.sig .sig; do
+      if ! curl -fsSIL \
+        --connect-timeout "$CONNECT_TIMEOUT" \
+        --max-time "$MAX_TIME" \
+        "${base_url}${suffix}" >/dev/null; then
+        ready=0
+        break
+      fi
+    done
+    if [ "$ready" -ne 1 ]; then
+      log "  macOS Dispatch CLI set is not complete yet: $filename"
+      continue
+    fi
+
+    failed=0
+    for suffix in "" .sha256 .sha256.sig .sig; do
+      log "  Mirroring macOS Dispatch CLI asset: ${filename}${suffix}"
+      if ! download_asset \
+        "${base_url}${suffix}" \
+        "${VERSION_DIR}/${filename}${suffix}"; then
+        failed=1
+        break
+      fi
+    done
+    if [ "$failed" -ne 0 ]; then
+      rm -f \
+        "${VERSION_DIR}/${filename}" \
+        "${VERSION_DIR}/${filename}.sha256" \
+        "${VERSION_DIR}/${filename}.sha256.sig" \
+        "${VERSION_DIR}/${filename}.sig"
+      log "WARN: incomplete macOS Dispatch CLI set removed; retrying next sync."
+      continue
+    fi
+    checksum_list="${checksum_list}${filename}.sha256"$'\n'
+  done
+
+  if [ -n "$checksum_list" ]; then
+    printf '%s' "$checksum_list" | verify_mirrored_checksums || exit 1
   fi
 }
 
@@ -386,6 +439,12 @@ PY
 
   mv "$descriptor_tmp" "${VERSION_DIR}/relay-image.json"
   mv "$signature_tmp" "${VERSION_DIR}/relay-image.json.sig"
+  publish_file_atomically \
+    "${VERSION_DIR}/relay-image.json" \
+    "${WEBSITE_RELEASE_DIR}/relay-image.json"
+  publish_file_atomically \
+    "${VERSION_DIR}/relay-image.json.sig" \
+    "${WEBSITE_RELEASE_DIR}/relay-image.json.sig"
   log "Published signed Relay image descriptor for $VERSION"
 }
 
@@ -443,6 +502,7 @@ print(bases.pop())
   # 4. Mirror small trust metadata and Linux archives first.
   mirror_relay_image_descriptor
   mirror_linux_binaries
+  mirror_dispatch_macos_cli_archives
 
   # 5. Download all platform installer packages
   #    Extract "<url>\t<filename>" pairs, then curl each one.

--- a/src/apps/cli/src/self_update.rs
+++ b/src/apps/cli/src/self_update.rs
@@ -17,16 +17,18 @@ const OPENBITFUN_MANIFEST: &str = "https://openbitfun.com/release/linux-binaries
 const AUTO_CHECK_INTERVAL: Duration = Duration::from_secs(6 * 60 * 60);
 const DEPRECATION_WARNING: &str = "Warning: `bitfun-cli` is deprecated; use `bitfun` instead.";
 
-/// Ranked-source download tuning. Mirrors the relay deploy path in
+/// Source-selection tuning. Mirrors the relay deploy path in
 /// `src/crates/services/services-integrations/src/remote_ssh/relay_deploy.rs`,
 /// which solves the same problem on the server side; keep the two in step.
 ///
-/// A fixed-length ranged request measures throughput: bytes delivered inside
-/// the window *is* the speed estimate, so one probe per source ranks them all.
+/// A fixed-length ranged request measures GitHub throughput: bytes delivered
+/// inside the window *is* the speed estimate used to keep GitHub first or move
+/// the synchronized mirror ahead of it.
 const PROBE_WINDOW: Duration = Duration::from_secs(10);
 const PROBE_BYTES: u64 = 4 * 1024 * 1024;
-/// A source at or above this is used without hesitation.
-const HEALTHY_THROUGHPUT: u64 = 128 * 1024;
+/// GitHub stays first at or above this rate. Below it, a synchronized
+/// OpenBitFun copy is preferred and GitHub remains the fallback.
+const HEALTHY_THROUGHPUT: u64 = 512 * 1024;
 /// Sustained below this counts as a dead link and we fail over. Deliberately
 /// far under the healthy bar: a genuinely slow but only available source must
 /// still be allowed to finish rather than loop forever.
@@ -269,7 +271,11 @@ impl InstallLock {
         // which two `bitfun update` processes both see no lock, and interleaving
         // their backup/stage/swap renames can leave no working binary at all.
         // Only a stale lock is cleared, and only then is the create retried.
-        match fs::OpenOptions::new().write(true).create_new(true).open(&path) {
+        match fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+        {
             Ok(mut file) => {
                 use std::io::Write as _;
                 let _ = write!(file, "{}", std::process::id());
@@ -365,6 +371,11 @@ async fn update_from_configured_sources(check_only: bool) -> Result<UpdateOutcom
                     canonical_sig_url = asset.sig_url.clone();
                 }
                 candidates.push(AssetCandidate {
+                    source: if *source == "GitHub" {
+                        ReleaseSource::GitHub
+                    } else {
+                        ReleaseSource::OpenBitFun
+                    },
                     url: asset.url.clone(),
                     sha256_url: asset.sha256_url.clone(),
                     sig_url: asset.sig_url.clone(),
@@ -383,12 +394,18 @@ async fn update_from_configured_sources(check_only: bool) -> Result<UpdateOutcom
 
     // Every candidate is the same asset, so any one names the staging file.
     let asset_filename = candidates[0].filename.clone();
-    let ranked = rank_sources(&client, candidates).await;
-    if let Some(fastest) = ranked.first() {
-        if fastest.1 < HEALTHY_THROUGHPUT {
+    let ranked = order_sources(&client, candidates).await;
+    if ranked
+        .first()
+        .is_some_and(|(candidate, _)| candidate.source == ReleaseSource::OpenBitFun)
+    {
+        if let Some((_, github_speed)) = ranked
+            .iter()
+            .find(|(candidate, _)| candidate.source == ReleaseSource::GitHub)
+        {
             eprintln!(
-                "Fastest update source is {} KB/s, under the {} KB/s bar; the download will take a while.",
-                fastest.1 / 1024,
+                "GitHub update speed is {} KiB/s, under the {} KiB/s bar; trying the OpenBitFun mirror first.",
+                github_speed / 1024,
                 HEALTHY_THROUGHPUT / 1024
             );
         }
@@ -554,8 +571,15 @@ impl PartialDownload {
 }
 
 /// One source's copy of the same archive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReleaseSource {
+    GitHub,
+    OpenBitFun,
+}
+
 #[derive(Debug, Clone)]
 struct AssetCandidate {
+    source: ReleaseSource,
     url: String,
     sha256_url: String,
     sig_url: Option<String>,
@@ -664,7 +688,10 @@ async fn probe_throughput(client: &Client, url: &str, window: Duration) -> u64 {
     let started = Instant::now();
     let request = client
         .get(url)
-        .header(reqwest::header::RANGE, format!("bytes=0-{}", PROBE_BYTES - 1))
+        .header(
+            reqwest::header::RANGE,
+            format!("bytes=0-{}", PROBE_BYTES - 1),
+        )
         .send();
     let Ok(Ok(response)) = tokio::time::timeout(window, request).await else {
         return 0;
@@ -694,28 +721,60 @@ async fn probe_throughput(client: &Client, url: &str, window: Duration) -> u64 {
     (received as f64 / elapsed) as u64
 }
 
-/// Order candidates fastest-first. Every source serves the same artifact, so
-/// this only decides who to ask first, never what is acceptable.
-async fn rank_sources(
+/// Keep GitHub first while it clears the healthy floor. If it does not, put the
+/// mirror first and retain GitHub as the final fallback. Every candidate still
+/// carries the same release version and passes the integrity gates below.
+async fn order_sources(
     client: &Client,
     candidates: Vec<AssetCandidate>,
 ) -> Vec<(AssetCandidate, u64)> {
-    rank_sources_with_window(client, candidates, PROBE_WINDOW).await
+    order_sources_with_window(client, candidates, PROBE_WINDOW).await
 }
 
-async fn rank_sources_with_window(
+async fn order_sources_with_window(
     client: &Client,
-    candidates: Vec<AssetCandidate>,
+    mut candidates: Vec<AssetCandidate>,
     window: Duration,
 ) -> Vec<(AssetCandidate, u64)> {
-    let mut ranked = Vec::with_capacity(candidates.len());
-    for candidate in candidates {
-        let speed = probe_throughput(client, &candidate.url, window).await;
-        tracing::debug!("CLI update source probe: {speed} B/s from {}", candidate.url);
-        ranked.push((candidate, speed));
+    let Some(github_index) = candidates
+        .iter()
+        .position(|candidate| candidate.source == ReleaseSource::GitHub)
+    else {
+        return candidates
+            .into_iter()
+            .map(|candidate| (candidate, 0))
+            .collect();
+    };
+    let github_speed = probe_throughput(client, &candidates[github_index].url, window).await;
+    tracing::debug!(
+        "CLI update GitHub probe: {github_speed} B/s from {}",
+        candidates[github_index].url
+    );
+
+    if github_speed >= HEALTHY_THROUGHPUT
+        || !candidates
+            .iter()
+            .any(|candidate| candidate.source == ReleaseSource::OpenBitFun)
+    {
+        candidates.swap(0, github_index);
+    } else if let Some(mirror_index) = candidates
+        .iter()
+        .position(|candidate| candidate.source == ReleaseSource::OpenBitFun)
+    {
+        candidates.swap(0, mirror_index);
     }
-    ranked.sort_by(|left, right| right.1.cmp(&left.1));
-    ranked
+
+    candidates
+        .into_iter()
+        .map(|candidate| {
+            let speed = if candidate.source == ReleaseSource::GitHub {
+                github_speed
+            } else {
+                0
+            };
+            (candidate, speed)
+        })
+        .collect()
 }
 
 /// Stream a body, appending to `buffer`, aborting if throughput stays under
@@ -804,7 +863,6 @@ async fn download_resumable(client: &Client, url: &str, buffer: &mut Vec<u8>) ->
         .with_context(|| format!("download {url}"))?;
     stream_with_stall_guard(response, buffer, url).await
 }
-
 
 async fn download_text(client: &Client, url: &str) -> Result<String> {
     client
@@ -1118,7 +1176,10 @@ fn restart_managed_daemon() {
     // unit to `~/.config` on a host that sets `XDG_CONFIG_HOME` elsewhere; a
     // `try-restart` for a unit systemd does not know is a harmless no-op, while
     // missing one leaves a stale daemon behind.
-    let candidates = [dirs::config_dir(), dirs::home_dir().map(|it| it.join(".config"))];
+    let candidates = [
+        dirs::config_dir(),
+        dirs::home_dir().map(|it| it.join(".config")),
+    ];
     let installed = candidates
         .iter()
         .flatten()
@@ -1187,7 +1248,11 @@ mod tests {
                             return;
                         }
 
-                        let stop = if truncate { slice.len() / 3 } else { slice.len() };
+                        let stop = if truncate {
+                            slice.len() / 3
+                        } else {
+                            slice.len()
+                        };
                         let mut sent = 0usize;
                         while sent < stop {
                             let end = (sent + chunk).min(stop);
@@ -1206,8 +1271,9 @@ mod tests {
             Self { url }
         }
 
-        fn candidate(&self, filename: &str) -> AssetCandidate {
+        fn candidate(&self, source: ReleaseSource, filename: &str) -> AssetCandidate {
             AssetCandidate {
+                source,
                 url: self.url.clone(),
                 sha256_url: format!("{}.sha256", self.url),
                 sig_url: None,
@@ -1221,25 +1287,52 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ranking_prefers_the_faster_source() {
-        let body = payload(256 * 1024);
-        // One origin trickles 2 KB every 20 ms (~100 KB/s); the other is unthrottled.
-        let slow = StubOrigin::spawn(Arc::clone(&body), 2048, Duration::from_millis(20), false).await;
-        let fast = StubOrigin::spawn(Arc::clone(&body), 64 * 1024, Duration::ZERO, false).await;
+    async fn healthy_github_remains_first_even_when_the_mirror_is_available() {
+        let body = payload(1024 * 1024);
+        let github = StubOrigin::spawn(Arc::clone(&body), 64 * 1024, Duration::ZERO, false).await;
+        let mirror = StubOrigin::spawn(Arc::clone(&body), 64 * 1024, Duration::ZERO, false).await;
         let client = build_client().expect("client");
 
-        let ranked = rank_sources_with_window(
+        let ordered = order_sources_with_window(
             &client,
-            vec![slow.candidate("a.tar.gz"), fast.candidate("a.tar.gz")],
+            vec![
+                mirror.candidate(ReleaseSource::OpenBitFun, "a.tar.gz"),
+                github.candidate(ReleaseSource::GitHub, "a.tar.gz"),
+            ],
+            Duration::from_secs(1),
+        )
+        .await;
+
+        assert_eq!(ordered[0].0.source, ReleaseSource::GitHub);
+        assert!(ordered[0].1 >= HEALTHY_THROUGHPUT);
+    }
+
+    #[tokio::test]
+    async fn slow_github_moves_the_mirror_first() {
+        let body = payload(1024 * 1024);
+        // 2 KiB every 20 ms is roughly 100 KiB/s, below the 512 KiB/s floor.
+        let github =
+            StubOrigin::spawn(Arc::clone(&body), 2048, Duration::from_millis(20), false).await;
+        let mirror = StubOrigin::spawn(Arc::clone(&body), 64 * 1024, Duration::ZERO, false).await;
+        let client = build_client().expect("client");
+
+        let ordered = order_sources_with_window(
+            &client,
+            vec![
+                github.candidate(ReleaseSource::GitHub, "a.tar.gz"),
+                mirror.candidate(ReleaseSource::OpenBitFun, "a.tar.gz"),
+            ],
             Duration::from_millis(400),
         )
         .await;
 
-        assert_eq!(
-            ranked[0].0.url, fast.url,
-            "the faster origin must be attempted first, got {ranked:?}"
-        );
-        assert!(ranked[0].1 > ranked[1].1, "speeds must be ordered: {ranked:?}");
+        assert_eq!(ordered[0].0.source, ReleaseSource::OpenBitFun);
+        let github_speed = ordered
+            .iter()
+            .find(|(candidate, _)| candidate.source == ReleaseSource::GitHub)
+            .map(|(_, speed)| *speed)
+            .expect("GitHub candidate");
+        assert!(github_speed < HEALTHY_THROUGHPUT);
     }
 
     /// The regression that made slow links fail outright: a whole-request
@@ -1249,7 +1342,8 @@ mod tests {
     #[tokio::test]
     async fn slow_but_alive_source_completes() {
         let body = payload(128 * 1024);
-        let slow = StubOrigin::spawn(Arc::clone(&body), 4096, Duration::from_millis(15), false).await;
+        let slow =
+            StubOrigin::spawn(Arc::clone(&body), 4096, Duration::from_millis(15), false).await;
         let client = build_client().expect("client");
 
         let mut buffer = Vec::new();
@@ -1262,8 +1356,7 @@ mod tests {
     #[tokio::test]
     async fn partial_download_resumes_across_sources() {
         let body = payload(96 * 1024);
-        let truncating =
-            StubOrigin::spawn(Arc::clone(&body), 8192, Duration::ZERO, true).await;
+        let truncating = StubOrigin::spawn(Arc::clone(&body), 8192, Duration::ZERO, true).await;
         let complete = StubOrigin::spawn(Arc::clone(&body), 8192, Duration::ZERO, false).await;
         let client = build_client().expect("client");
 
@@ -1271,7 +1364,10 @@ mod tests {
         // First source hangs up early, leaving a partial body behind.
         let _ = download_resumable(&client, &truncating.url, &mut buffer).await;
         let partial = buffer.len();
-        assert!(partial > 0 && partial < body.len(), "expected a partial body");
+        assert!(
+            partial > 0 && partial < body.len(),
+            "expected a partial body"
+        );
 
         // Second source must continue from there, not restart.
         download_resumable(&client, &complete.url, &mut buffer)
@@ -1294,9 +1390,8 @@ mod tests {
     #[test]
     fn staged_partial_resumes_and_evicts_other_versions() {
         let dir = tempfile::tempdir().expect("temp dir");
-        let stage = |version: &str, filename: &str| {
-            PartialDownload::open_in(dir.path(), version, filename)
-        };
+        let stage =
+            |version: &str, filename: &str| PartialDownload::open_in(dir.path(), version, filename);
 
         let first = stage("0.2.14", "bitfun-cli-0.2.14-x86_64.tar.gz");
         assert!(first.resume().is_empty(), "nothing staged yet");

--- a/src/apps/desktop/src/api/system_api.rs
+++ b/src/apps/desktop/src/api/system_api.rs
@@ -25,24 +25,32 @@ const OPENBITFUN_UPDATER_ENDPOINT: &str = "https://openbitfun.com/release/latest
 /// `src/apps/relay-server/release-download.sh`).
 const PROBE_WINDOW: std::time::Duration = std::time::Duration::from_secs(10);
 const PROBE_BYTES: u64 = 4 * 1024 * 1024;
-const HEALTHY_THROUGHPUT: u64 = 128 * 1024;
+const HEALTHY_THROUGHPUT: u64 = 512 * 1024;
 
-/// Order the updater endpoints fastest-first.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct UpdaterManifestInfo {
+    version: String,
+    package_url: String,
+}
+
+/// Keep GitHub first while its package clears the healthy floor. A slow or
+/// unreachable GitHub package moves the mirror first only when the mirror has
+/// synchronized the exact same latest version; a stale mirror must never hide
+/// a new release.
 ///
 /// Tauri walks `endpoints` and stops at the first that returns a usable
 /// manifest, then downloads from the URL *inside that manifest*. `latest.json`
 /// is ~2 KB, so a reachable-but-crawling GitHub always wins the race to answer
 /// and then pins an 80-160 MB download to itself — the mirror is only ever tried
-/// when GitHub errors outright. Probing the actual package each origin would
-/// serve, and ordering endpoints by that, makes the slow-link case fall to
-/// whichever origin can actually deliver.
+/// when GitHub errors outright. We therefore probe the actual GitHub package.
 ///
 /// Deliberately still routed through `Update::download`: minisign verification
 /// lives inside it, so fetching bytes by hand and calling `Update::install`
 /// would silently skip signature checking.
-async fn endpoints_fastest_first() -> Vec<tauri::Url> {
+async fn updater_endpoints_by_policy() -> Vec<tauri::Url> {
     let client = match reqwest::Client::builder()
         .connect_timeout(std::time::Duration::from_secs(5))
+        .read_timeout(PROBE_WINDOW)
         .build()
     {
         Ok(client) => client,
@@ -54,32 +62,36 @@ async fn endpoints_fastest_first() -> Vec<tauri::Url> {
     // tells us nothing about an 80-160 MB transfer. Each manifest names its own
     // download URL, which is exactly the thing worth measuring.
     let platform = updater_platform_key();
-    let mut ranked = Vec::new();
-    for endpoint in [GITHUB_UPDATER_ENDPOINT, OPENBITFUN_UPDATER_ENDPOINT] {
-        let Ok(url) = endpoint.parse::<tauri::Url>() else {
-            continue;
-        };
-        let speed = match manifest_package_url(&client, endpoint, &platform).await {
-            Some(package) => probe_endpoint_throughput(&client, &package).await,
-            // Unreachable or no build for this platform: rank last, but still
-            // offer it — Tauri may succeed where a ranged probe did not.
-            None => 0,
-        };
-        log::debug!("Desktop updater probe: {} B/s via {}", speed, endpoint);
-        ranked.push((url, speed));
-    }
-    if ranked.is_empty() {
-        return default_endpoints();
-    }
-    ranked.sort_by(|left, right| right.1.cmp(&left.1));
-    if ranked[0].1 < HEALTHY_THROUGHPUT {
+    let (github_manifest, mirror_manifest) = tokio::join!(
+        fetch_updater_manifest(&client, GITHUB_UPDATER_ENDPOINT, &platform),
+        fetch_updater_manifest(&client, OPENBITFUN_UPDATER_ENDPOINT, &platform),
+    );
+    let Some(github_manifest) = github_manifest else {
+        log::info!("GitHub updater metadata is unavailable; trying the OpenBitFun mirror first");
+        return mirror_first_endpoints();
+    };
+    let github_speed = probe_endpoint_throughput(&client, &github_manifest.package_url).await;
+    log::debug!(
+        "Desktop updater GitHub probe: {} B/s from {}",
+        github_speed,
+        github_manifest.package_url
+    );
+    if prefer_mirror(&github_manifest, mirror_manifest.as_ref(), github_speed) {
         log::info!(
-            "Fastest updater origin is {} KB/s, under the {} KB/s bar; the download will be slow.",
-            ranked[0].1 / 1024,
+            "GitHub updater speed is {} KiB/s, under the {} KiB/s bar; trying the synchronized OpenBitFun mirror first.",
+            github_speed / 1024,
             HEALTHY_THROUGHPUT / 1024
         );
+        return mirror_first_endpoints();
     }
-    ranked.into_iter().map(|(url, _)| url).collect()
+    if github_speed < HEALTHY_THROUGHPUT {
+        log::info!(
+            "GitHub updater speed is {} KiB/s but the mirror has not synchronized {}; keeping GitHub first to preserve latest-version correctness.",
+            github_speed / 1024,
+            github_manifest.version
+        );
+    }
+    default_endpoints()
 }
 
 /// Tauri's `latest.json` platform key for this host, e.g. `darwin-aarch64`.
@@ -94,11 +106,11 @@ fn updater_platform_key() -> String {
 
 /// Read one updater manifest and return the download URL it advertises for this
 /// platform. Cheap: the manifest is a couple of kilobytes.
-async fn manifest_package_url(
+async fn fetch_updater_manifest(
     client: &reqwest::Client,
     endpoint: &str,
     platform: &str,
-) -> Option<String> {
+) -> Option<UpdaterManifestInfo> {
     let manifest = tokio::time::timeout(
         std::time::Duration::from_secs(10),
         client.get(endpoint).send(),
@@ -111,16 +123,37 @@ async fn manifest_package_url(
     .json::<serde_json::Value>()
     .await
     .ok()?;
-    manifest
+    let version = manifest.get("version")?.as_str()?.to_owned();
+    let package_url = manifest
         .get("platforms")?
         .get(platform)?
         .get("url")?
         .as_str()
-        .map(str::to_owned)
+        .map(str::to_owned)?;
+    Some(UpdaterManifestInfo {
+        version,
+        package_url,
+    })
+}
+
+fn prefer_mirror(
+    github: &UpdaterManifestInfo,
+    mirror: Option<&UpdaterManifestInfo>,
+    github_speed: u64,
+) -> bool {
+    github_speed < HEALTHY_THROUGHPUT
+        && mirror.is_some_and(|candidate| candidate.version == github.version)
 }
 
 fn default_endpoints() -> Vec<tauri::Url> {
     [GITHUB_UPDATER_ENDPOINT, OPENBITFUN_UPDATER_ENDPOINT]
+        .iter()
+        .filter_map(|endpoint| endpoint.parse().ok())
+        .collect()
+}
+
+fn mirror_first_endpoints() -> Vec<tauri::Url> {
+    [OPENBITFUN_UPDATER_ENDPOINT, GITHUB_UPDATER_ENDPOINT]
         .iter()
         .filter_map(|endpoint| endpoint.parse().ok())
         .collect()
@@ -166,7 +199,7 @@ async fn probe_endpoint_throughput(client: &reqwest::Client, url: &str) -> u64 {
 /// Build an updater whose endpoints are ordered by measured throughput.
 /// Falls back to the bundled configuration if the builder rejects them.
 async fn ranked_updater(app: &AppHandle) -> Result<tauri_plugin_updater::Updater, String> {
-    let endpoints = endpoints_fastest_first().await;
+    let endpoints = updater_endpoints_by_policy().await;
     let builder = app.updater_builder();
     let builder = match builder.endpoints(endpoints) {
         Ok(builder) => builder,
@@ -875,6 +908,39 @@ mod tests {
             key.starts_with("darwin-"),
             "macOS must map to darwin, got {key}"
         );
+    }
+
+    #[test]
+    fn updater_uses_mirror_only_for_a_slow_github_and_the_same_release() {
+        let github = UpdaterManifestInfo {
+            version: "1.2.3".into(),
+            package_url: "https://github.example/bitfun.tar.gz".into(),
+        };
+        let synchronized_mirror = UpdaterManifestInfo {
+            version: "1.2.3".into(),
+            package_url: "https://mirror.example/bitfun.tar.gz".into(),
+        };
+        let stale_mirror = UpdaterManifestInfo {
+            version: "1.2.2".into(),
+            package_url: "https://mirror.example/old.tar.gz".into(),
+        };
+
+        assert!(prefer_mirror(
+            &github,
+            Some(&synchronized_mirror),
+            HEALTHY_THROUGHPUT - 1
+        ));
+        assert!(!prefer_mirror(
+            &github,
+            Some(&synchronized_mirror),
+            HEALTHY_THROUGHPUT
+        ));
+        assert!(!prefer_mirror(
+            &github,
+            Some(&stale_mirror),
+            HEALTHY_THROUGHPUT - 1
+        ));
+        assert!(!prefer_mirror(&github, None, HEALTHY_THROUGHPUT - 1));
     }
 
     use super::*;

--- a/src/apps/relay-server/README.md
+++ b/src/apps/relay-server/README.md
@@ -82,7 +82,7 @@ Use this checklist on a machine you control (VPS, LAN server, or localhost).
 
 BitFun Desktop can SSH to your host without a manual clone. One click installs
 Docker when necessary, verifies the signed release image descriptor locally,
-pulls the matching amd64/arm64 image through the selected regional route, and
+pulls the latest amd64/arm64 image through the selected network route, and
 starts it by immutable digest. It never builds on the customer server and never
 silently falls back to source compilation. Pull completes before an existing
 Relay is stopped; startup or health failure restores the previous container.
@@ -105,6 +105,9 @@ descriptor fixes the canonical GHCR repository, release tag, amd64/arm64
 platform set, and multi-platform manifest digest. Desktop verifies it on the
 user's machine and sends the digest to the server; Docker then verifies every
 manifest and layer while pulling, even through a third-party accelerator.
+GitHub/GHCR stays first when a 10-second GitHub byte probe reaches 512 KiB/s;
+below that floor, automatic mode tries the NJU and DaoCloud GHCR accelerators
+first while retaining official GHCR as the final fallback.
 
 The raw Relay archives still carry `.sha256` and `.sig` files for direct binary
 use and for constructing the release image in CI.

--- a/src/apps/relay-server/release-download.sh
+++ b/src/apps/relay-server/release-download.sh
@@ -16,6 +16,8 @@
 #   BITFUN_RELAY_IMAGE_DIGEST   sha256:<64 lowercase hex> (required by Desktop)
 #   BITFUN_RELAY_IMAGE_TAG      manual-script fallback tag (default release tag)
 #   BITFUN_IMAGE_PULL_TIMEOUT   per-route pull timeout in seconds (default 900)
+#   BITFUN_GITHUB_PROBE_WINDOW  GitHub throughput probe window (default 10s)
+#   BITFUN_GITHUB_HEALTHY_BPS   keep GitHub first at/above this rate (default 512 KiB/s)
 #   BITFUN_MIRROR_MODE          cn | global
 #   RELAY_PORT                  published/container port (default 9700)
 #   RELAY_HOST_BIND_IP          host bind address (default 0.0.0.0)
@@ -23,6 +25,9 @@
 BITFUN_RELAY_IMAGE="${BITFUN_RELAY_IMAGE:-ghcr.io/gcwing/bitfun-relay-server}"
 BITFUN_RELAY_IMAGE_TAG="${BITFUN_RELAY_IMAGE_TAG:-${BITFUN_RELEASE_TAG:-latest}}"
 BITFUN_IMAGE_PULL_TIMEOUT="${BITFUN_IMAGE_PULL_TIMEOUT:-900}"
+BITFUN_GITHUB_PROBE_WINDOW="${BITFUN_GITHUB_PROBE_WINDOW:-10}"
+BITFUN_GITHUB_HEALTHY_BPS="${BITFUN_GITHUB_HEALTHY_BPS:-524288}"
+BITFUN_GITHUB_RELEASE_BASE="${BITFUN_GITHUB_RELEASE_BASE:-https://github.com/GCWing/BitFun/releases}"
 
 # The embedded Desktop helpers call Docker through bitfun_docker; the manual
 # script exposes docker_cmd. Keep this file independent of either caller.
@@ -87,24 +92,98 @@ bitfun_relay_image_ref() {
   fi
 }
 
-# Pull through the fastest likely route for the selected region. The digest is
-# identical across registry proxies, so changing transport does not change the
-# image Desktop authenticated.
+bitfun_relay_archive_target() {
+  case "$1" in
+    linux/amd64) echo x86_64-unknown-linux-gnu ;;
+    linux/arm64) echo aarch64-unknown-linux-gnu ;;
+    *) return 1 ;;
+  esac
+}
+
+# Measure the GitHub release CDN that carries the exact Relay binary bytes.
+# Relay itself stays a digest-pinned OCI deployment; this byte probe decides
+# whether official GHCR or its accelerators are attempted first.
+bitfun_probe_github_throughput() {
+  local platform="$1" target tag url metrics speed
+  target="$(bitfun_relay_archive_target "$platform")" || {
+    echo 0
+    return 0
+  }
+  tag="${BITFUN_RELEASE_TAG:-latest}"
+  if [ "$tag" = latest ]; then
+    url="${BITFUN_GITHUB_RELEASE_BASE}/latest/download/bitfun-relay-server-${target}.tar.gz"
+  else
+    url="${BITFUN_GITHUB_RELEASE_BASE}/download/${tag}/bitfun-relay-server-${target}.tar.gz"
+  fi
+  if ! command -v curl >/dev/null 2>&1; then
+    echo ">>> GitHub throughput probe skipped: curl is unavailable" >&2
+    echo 0
+    return 0
+  fi
+  case "$BITFUN_GITHUB_PROBE_WINDOW" in
+    '' | *[!0-9]*) BITFUN_GITHUB_PROBE_WINDOW=10 ;;
+  esac
+  case "$BITFUN_GITHUB_HEALTHY_BPS" in
+    '' | *[!0-9]*) BITFUN_GITHUB_HEALTHY_BPS=524288 ;;
+  esac
+  metrics="$(curl -LsS \
+    --range 0-4194303 \
+    --connect-timeout 5 \
+    --max-time "$BITFUN_GITHUB_PROBE_WINDOW" \
+    -o /dev/null \
+    -w '%{http_code} %{size_download} %{time_total}' \
+    "$url" 2>/dev/null || true)"
+  speed="$(printf '%s\n' "$metrics" | awk '
+    ($1 == 200 || $1 == 206) && $3 > 0 { printf "%.0f\n", $2 / $3; ok=1 }
+    END { if (!ok) print 0 }
+  ')"
+  case "$speed" in
+    '' | *[!0-9]*) speed=0 ;;
+  esac
+  echo ">>> GitHub Relay probe: $((speed / 1024)) KiB/s (healthy floor: $((BITFUN_GITHUB_HEALTHY_BPS / 1024)) KiB/s)" >&2
+  echo "$speed"
+}
+
+# GitHub is the default route. In auto mode, a measured GitHub rate below
+# 512 KiB/s moves the registry accelerators first. Explicit cn/global choices
+# remain authoritative. The digest is identical across routes, so transport
+# selection never changes the image Desktop authenticated.
 bitfun_pull_relay_image() {
   local platform="$1" routes route_name repository image_ref selected=""
+  local requested_mode github_speed mirror_first=0
   local pull_timeout="${BITFUN_IMAGE_PULL_TIMEOUT:-900}"
   case "$pull_timeout" in
     '' | *[!0-9]*) pull_timeout=900 ;;
   esac
 
   routes="$(mktemp)"
-  if [ "${BITFUN_MIRROR_MODE:-global}" = "cn" ]; then
+  requested_mode="${BITFUN_MIRROR_REQUESTED_MODE:-${BITFUN_MIRROR_MODE:-auto}}"
+  case "$BITFUN_GITHUB_HEALTHY_BPS" in
+    '' | *[!0-9]*) BITFUN_GITHUB_HEALTHY_BPS=524288 ;;
+  esac
+  case "$requested_mode" in
+    cn) mirror_first=1 ;;
+    global) mirror_first=0 ;;
+    *)
+      github_speed="$(bitfun_probe_github_throughput "$platform")"
+      if [ "$github_speed" -lt "$BITFUN_GITHUB_HEALTHY_BPS" ]; then
+        mirror_first=1
+      fi
+      ;;
+  esac
+
+  if [ "$requested_mode" = global ]; then
+    printf '%s\t%s\n' "official GHCR" "$BITFUN_RELAY_IMAGE" >"$routes"
+  elif [ "$mirror_first" = "1" ]; then
     printf '%s\t%s\n' \
       "NJU GHCR accelerator" "ghcr.nju.edu.cn/${BITFUN_RELAY_IMAGE#ghcr.io/}" \
       "DaoCloud GHCR accelerator" "m.daocloud.io/${BITFUN_RELAY_IMAGE}" \
       "official GHCR fallback" "$BITFUN_RELAY_IMAGE" >"$routes"
   else
-    printf '%s\t%s\n' "official GHCR" "$BITFUN_RELAY_IMAGE" >"$routes"
+    printf '%s\t%s\n' \
+      "official GHCR" "$BITFUN_RELAY_IMAGE" \
+      "NJU GHCR accelerator fallback" "ghcr.nju.edu.cn/${BITFUN_RELAY_IMAGE#ghcr.io/}" \
+      "DaoCloud GHCR accelerator fallback" "m.daocloud.io/${BITFUN_RELAY_IMAGE}" >"$routes"
   fi
 
   while IFS=$'\t' read -r route_name repository; do

--- a/src/crates/services/services-integrations/Cargo.toml
+++ b/src/crates/services/services-integrations/Cargo.toml
@@ -297,6 +297,7 @@ remote-ssh-concrete = [
     "russh",
     "russh-sftp",
     "russh-keys",
+    "semver",
     "shellexpand",
     "ssh_config",
     "terminal-core",

--- a/src/crates/services/services-integrations/src/remote_ssh/dispatch_ssh.rs
+++ b/src/crates/services/services-integrations/src/remote_ssh/dispatch_ssh.rs
@@ -5,8 +5,8 @@
 //! workspaces, sessions, transcripts, process detachment, supervision, and
 //! cancellation semantics.
 //!
-//! `probe` is read-only. Submission may automatically install a matching
-//! prebuilt release when the target is missing a compatible CLI;
+//! `probe` is read-only. Submission may automatically install the latest
+//! compatible prebuilt release when the target is missing a compatible CLI;
 //! `install_cli_start` still verifies the signed SHA256 sidecar and mandatory
 //! archive minisign signature before staging an owner-only installer. Source
 //! builds remain a separate, explicitly confirmed operation.
@@ -31,8 +31,11 @@ use super::release_verify::{
 use super::remote_git::shell_quote_posix;
 use super::types::SSHCommandOptions;
 
-const RELEASE_BASE: &str = "https://github.com/GCWing/BitFun/releases";
-const RELEASE_VERSION: &str = env!("CARGO_PKG_VERSION");
+const GITHUB_RELEASE_BASE: &str = "https://github.com/GCWing/BitFun/releases";
+const OPENBITFUN_RELEASE_BASE: &str = "https://openbitfun.com/release";
+const GITHUB_LATEST_MANIFEST: &str =
+    "https://github.com/GCWing/BitFun/releases/latest/download/latest.json";
+const OPENBITFUN_LATEST_MANIFEST: &str = "https://openbitfun.com/release/latest.json";
 const INSTALL_STATE_DIR: &str = ".bitfun/dispatch/install";
 const REQUEST_STATE_DIR: &str = ".bitfun/dispatch/requests";
 const INSTALL_STEM: &str = "install-cli";
@@ -50,6 +53,9 @@ const CLI_INSTALL_POLL_INTERVAL: Duration = Duration::from_millis(750);
 /// this is a hung target rather than a slow one.
 const CLI_INSTALL_WAIT: Duration = Duration::from_secs(15 * 60);
 const RELEASE_READ_TIMEOUT_SECONDS: u64 = 30;
+const RELEASE_PROBE_WINDOW: Duration = Duration::from_secs(10);
+const RELEASE_PROBE_BYTES: u64 = 4 * 1024 * 1024;
+const GITHUB_HEALTHY_THROUGHPUT: u64 = 512 * 1024;
 const MAX_ARCHIVE_BYTES: usize = 512 * 1024 * 1024;
 /// A result bundle carries only commits since the dispatch baseline, so it is
 /// bounded well below a full repository clone in the usual case.
@@ -196,9 +202,7 @@ enum RemoteDigestTool {
 struct ResolvedRelease {
     public: DispatchCliRelease,
     filename: String,
-    checksum_url: String,
-    checksum_signature_url: String,
-    archive_signature_url: String,
+    sources: Vec<ReleaseArtifactSource>,
     /// Whether `public.sha256` came from a minisign signature this machine
     /// verified, rather than from an unauthenticated sidecar.
     ///
@@ -207,6 +211,26 @@ struct ResolvedRelease {
     /// publisher's. Without that proof the archive's own signature is the only
     /// protection, and only this machine can check it.
     checksum_signature_verified: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReleaseOrigin {
+    GitHub,
+    OpenBitFun,
+}
+
+#[derive(Debug, Clone)]
+struct ReleaseArtifactSource {
+    origin: ReleaseOrigin,
+    url: String,
+    checksum_url: String,
+    checksum_signature_url: String,
+    archive_signature_url: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct LatestReleaseManifest {
+    version: String,
 }
 
 /// Probe the remote OS/architecture and, when present, the target CLI dispatch
@@ -265,16 +289,6 @@ pub async fn probe(
             (
                 None,
                 Some("remote target has no tar executable; install tar and retry".to_string()),
-            )
-        } else if !published_release_supports_required_dispatch_protocol(RELEASE_VERSION) {
-            // The controller is ahead of the latest stable artifact, so no
-            // published binary carries the capabilities it needs. Skip the
-            // release request and say so.
-            (
-                None,
-                Some(format!(
-                    "no published BitFun CLI yet carries the dispatch capabilities this controller requires (controller {RELEASE_VERSION})"
-                )),
             )
         } else {
             match resolve_release(&target.os, &target.arch).await {
@@ -482,7 +496,7 @@ pub fn validate_dispatch_protocol(protocol: &Value, approval_policy: Option<&str
     Ok(())
 }
 
-/// Explicitly install the matching BitFun CLI release on the SSH target.
+/// Explicitly install the latest confirmed BitFun CLI release on the SSH target.
 ///
 /// This function fails closed when the build has no release trust root, a
 /// checksum/signature is absent, or either verification fails. It never uses
@@ -642,11 +656,24 @@ async fn download_archive_on_target(
     let digest_tool = target
         .digest_tool
         .context("target download requires a SHA256 checker")?;
+    let github_url = release
+        .sources
+        .iter()
+        .find(|source| source.origin == ReleaseOrigin::GitHub)
+        .map(|source| source.url.as_str())
+        .context("release has no GitHub source")?;
+    let mirror_url = release
+        .sources
+        .iter()
+        .find(|source| source.origin == ReleaseOrigin::OpenBitFun)
+        .map(|source| source.url.as_str())
+        .unwrap_or("");
     let script = target_download_script(
         downloader,
         digest_tool,
         archive_path,
-        &release.public.url,
+        github_url,
+        mirror_url,
         &release.public.sha256,
     );
     let result = manager
@@ -675,23 +702,51 @@ fn target_download_script(
     downloader: RemoteDownloader,
     digest_tool: RemoteDigestTool,
     archive_path: &str,
-    url: &str,
+    github_url: &str,
+    mirror_url: &str,
     sha256: &str,
 ) -> String {
     // Download to a scratch name and only publish it once the digest matches,
     // so a truncated or tampered body can never be handed to the installer.
     let fetch = match downloader {
         RemoteDownloader::Curl => format!(
-            "curl -fsSL --retry 3 --retry-delay 1 --max-time {timeout} --max-filesize {max} -o \"$PART\" {url}",
+            "curl -fsSL --retry 3 --retry-delay 1 --max-time {timeout} --max-filesize {max} -o \"$PART\" \"$URL\"",
             timeout = TARGET_DOWNLOAD_TIMEOUT_MS / 1000,
             max = MAX_ARCHIVE_BYTES,
-            url = shell_quote_posix(url),
         ),
         // wget has no --max-filesize; the size ceiling is enforced below.
         RemoteDownloader::Wget => format!(
-            "wget -q --tries=3 --timeout={timeout} -O \"$PART\" {url}",
+            "wget -q --tries=3 --timeout={timeout} -O \"$PART\" \"$URL\"",
             timeout = TARGET_DOWNLOAD_TIMEOUT_MS / 1000,
-            url = shell_quote_posix(url),
+        ),
+    };
+    let probe = match downloader {
+        RemoteDownloader::Curl => format!(
+            r#"METRICS=$(curl -LsS --range 0-{probe_end} --connect-timeout 5 --max-time {window} -o /dev/null -w '%{{http_code}} %{{size_download}} %{{time_total}}' "$GITHUB_URL" 2>/dev/null || true)
+GITHUB_SPEED=$(printf '%s\n' "$METRICS" | awk '($1 == 200 || $1 == 206) && $3 > 0 {{ printf "%.0f\n", $2 / $3; ok=1 }} END {{ if (!ok) print 0 }}')"#,
+            probe_end = RELEASE_PROBE_BYTES - 1,
+            window = RELEASE_PROBE_WINDOW.as_secs(),
+        ),
+        RemoteDownloader::Wget => format!(
+            r#"GITHUB_SPEED=0
+PROBE="$ARCHIVE.probe"
+if command -v timeout >/dev/null 2>&1; then
+  rm -f "$PROBE"
+  START=$(date +%s)
+  timeout {window} wget -q --tries=1 --timeout={window} --header='Range: bytes=0-{probe_end}' -O "$PROBE" "$GITHUB_URL" || true
+  END=$(date +%s)
+  ELAPSED=$((END - START))
+  [ "$ELAPSED" -gt 0 ] || ELAPSED=1
+  if [ -f "$PROBE" ]; then
+    BYTES=$(wc -c <"$PROBE" | tr -d '[:space:]')
+  else
+    BYTES=0
+  fi
+  GITHUB_SPEED=$((BYTES / ELAPSED))
+  rm -f "$PROBE"
+fi"#,
+            probe_end = RELEASE_PROBE_BYTES - 1,
+            window = RELEASE_PROBE_WINDOW.as_secs(),
         ),
     };
     let verify = match digest_tool {
@@ -703,25 +758,49 @@ fn target_download_script(
 umask 077
 ARCHIVE={archive}
 PART="$ARCHIVE.part"
+GITHUB_URL={github_url}
+MIRROR_URL={mirror_url}
 EXPECTED={sha}
 MAX={max}
 rm -f "$PART"
 cleanup() {{ rm -f "$PART"; }}
 trap cleanup EXIT
-{fetch}
-SIZE=$(wc -c <"$PART" | tr -d '[:space:]')
-if [ "$SIZE" -gt "$MAX" ]; then
-  echo "ERROR: downloaded archive is larger than $MAX bytes" >&2
-  exit 1
+{probe}
+case "$GITHUB_SPEED" in ''|*[!0-9]*) GITHUB_SPEED=0 ;; esac
+FIRST_URL="$GITHUB_URL"
+SECOND_URL="$MIRROR_URL"
+if [ -n "$MIRROR_URL" ] && [ "$GITHUB_SPEED" -lt {healthy_bps} ]; then
+  echo "GitHub CLI probe: $((GITHUB_SPEED / 1024)) KiB/s; trying OpenBitFun mirror first."
+  FIRST_URL="$MIRROR_URL"
+  SECOND_URL="$GITHUB_URL"
+else
+  echo "GitHub CLI probe: $((GITHUB_SPEED / 1024)) KiB/s; keeping GitHub first."
 fi
-printf '%s  %s\n' "$EXPECTED" "$PART" | {verify}
-mv -f "$PART" "$ARCHIVE"
+INSTALLED=0
+for URL in "$FIRST_URL" "$SECOND_URL"; do
+  [ -n "$URL" ] || continue
+  rm -f "$PART"
+  echo "Downloading BitFun CLI from $URL"
+  if {fetch}; then
+    SIZE=$(wc -c <"$PART" | tr -d '[:space:]')
+    if [ "$SIZE" -le "$MAX" ] && printf '%s  %s\n' "$EXPECTED" "$PART" | {verify}; then
+      mv -f "$PART" "$ARCHIVE"
+      INSTALLED=1
+      break
+    fi
+  fi
+  echo "Download source failed verification; trying the next source." >&2
+done
+[ "$INSTALLED" = "1" ] || {{ echo "ERROR: every BitFun CLI source failed" >&2; exit 1; }}
 chmod 600 "$ARCHIVE"
 trap - EXIT
 "#,
         archive = shell_quote_posix(archive_path),
+        github_url = shell_quote_posix(github_url),
+        mirror_url = shell_quote_posix(mirror_url),
         sha = shell_quote_posix(sha256),
         max = MAX_ARCHIVE_BYTES,
+        healthy_bps = GITHUB_HEALTHY_THROUGHPUT,
     )
 }
 
@@ -2147,41 +2226,135 @@ fi
 async fn resolve_release(os: &str, arch: &str) -> Result<ResolvedRelease> {
     let pubkey = require_release_pubkey()?;
     let target = release_target(os, arch)?;
-    let version = RELEASE_VERSION.split('+').next().unwrap_or(RELEASE_VERSION);
-    let filename = format!("bitfun-cli-{version}-{target}.tar.gz");
-    let tag = release_tag_for_version(RELEASE_VERSION);
-    let url = format!("{RELEASE_BASE}/download/{tag}/{filename}");
-    let checksum_url = format!("{url}.sha256");
-    let checksum_signature_url = format!("{checksum_url}.sig");
-    let archive_signature_url = format!("{url}.sig");
     let client = release_http_client()?;
-    let checksum = fetch_required_text(&client, &checksum_url).await?;
+    let version = fetch_latest_release_version(&client).await?;
+    let filename = format!("bitfun-cli-{version}-{target}.tar.gz");
+    let sources = release_sources(&version, &filename);
     let (sha256, checksum_signature_verified) =
-        match fetch_optional_text(&client, &checksum_signature_url).await? {
-            Some(signature) => (
-                verify_signed_checksum(&checksum, &signature, pubkey, &filename)?,
-                true,
-            ),
-            // Releases published before the CLI checksum sidecars were signed have
-            // no `.sha256.sig`. The digest shown for consent is then provisional;
-            // install still verifies the archive's own minisign signature before
-            // staging anything, so a tampered sidecar can only fail the install.
-            None => (parse_sha256(&checksum, &filename)?, false),
-        };
+        resolve_release_digest(&client, &sources, pubkey, &filename).await?;
+    let canonical_url = sources
+        .iter()
+        .find(|source| source.origin == ReleaseOrigin::GitHub)
+        .map(|source| source.url.clone())
+        .context("release has no canonical GitHub source")?;
 
     Ok(ResolvedRelease {
         public: DispatchCliRelease {
-            version: version.to_string(),
+            version,
             target: target.to_string(),
-            url,
+            url: canonical_url,
             sha256,
         },
         filename,
-        checksum_url,
-        checksum_signature_url,
-        archive_signature_url,
+        sources,
         checksum_signature_verified,
     })
+}
+
+fn release_sources(version: &str, filename: &str) -> Vec<ReleaseArtifactSource> {
+    let tag = release_tag_for_version(version);
+    [
+        (
+            ReleaseOrigin::GitHub,
+            format!("{GITHUB_RELEASE_BASE}/download/{tag}"),
+        ),
+        (
+            ReleaseOrigin::OpenBitFun,
+            format!("{OPENBITFUN_RELEASE_BASE}/{version}"),
+        ),
+    ]
+    .into_iter()
+    .map(|(origin, base)| {
+        let url = format!("{base}/{filename}");
+        ReleaseArtifactSource {
+            origin,
+            checksum_url: format!("{url}.sha256"),
+            checksum_signature_url: format!("{url}.sha256.sig"),
+            archive_signature_url: format!("{url}.sig"),
+            url,
+        }
+    })
+    .collect()
+}
+
+async fn fetch_latest_release_version(client: &reqwest::Client) -> Result<String> {
+    let mut failures = Vec::new();
+    for manifest_url in [GITHUB_LATEST_MANIFEST, OPENBITFUN_LATEST_MANIFEST] {
+        let text = match fetch_required_text(client, manifest_url).await {
+            Ok(text) => text,
+            Err(error) => {
+                failures.push(format!("{manifest_url}: {error:#}"));
+                continue;
+            }
+        };
+        match latest_release_version_from_json(&text, manifest_url) {
+            Ok(version) => return Ok(version),
+            Err(error) => failures.push(format!("{manifest_url}: {error:#}")),
+        }
+    }
+    Err(anyhow!(
+        "could not resolve the latest BitFun release: {}",
+        failures.join("; ")
+    ))
+}
+
+fn latest_release_version_from_json(text: &str, source: &str) -> Result<String> {
+    let manifest: LatestReleaseManifest =
+        serde_json::from_str(text).with_context(|| format!("parse {source}"))?;
+    let version = manifest.version.trim();
+    let parsed = semver::Version::parse(version)
+        .with_context(|| format!("invalid release version {version}"))?;
+    if !parsed.pre.is_empty() || !parsed.build.is_empty() {
+        return Err(anyhow!(
+            "latest release {version} is not a stable asset version"
+        ));
+    }
+    Ok(version.to_string())
+}
+
+async fn resolve_release_digest(
+    client: &reqwest::Client,
+    sources: &[ReleaseArtifactSource],
+    pubkey: &str,
+    filename: &str,
+) -> Result<(String, bool)> {
+    let mut unsigned_digest = None;
+    let mut failures = Vec::new();
+    for source in sources {
+        let checksum = match fetch_required_text(client, &source.checksum_url).await {
+            Ok(checksum) => checksum,
+            Err(error) => {
+                failures.push(format!("{}: {error:#}", source.checksum_url));
+                continue;
+            }
+        };
+        match fetch_optional_text(client, &source.checksum_signature_url).await {
+            Ok(Some(signature)) => {
+                match verify_signed_checksum(&checksum, &signature, pubkey, filename) {
+                    Ok(digest) => return Ok((digest, true)),
+                    Err(error) => {
+                        failures.push(format!("{}: {error:#}", source.checksum_signature_url))
+                    }
+                }
+            }
+            Ok(None) => match parse_sha256(&checksum, filename) {
+                Ok(digest) => {
+                    unsigned_digest.get_or_insert(digest);
+                }
+                Err(error) => failures.push(format!("{}: {error:#}", source.checksum_url)),
+            },
+            Err(error) => failures.push(format!("{}: {error:#}", source.checksum_signature_url)),
+        }
+    }
+    if let Some(digest) = unsigned_digest {
+        // Older releases have only an archive signature. They remain usable,
+        // but must flow through the controller where minisign can be checked.
+        return Ok((digest, false));
+    }
+    Err(anyhow!(
+        "no release source published usable checksum metadata for {filename}: {}",
+        failures.join("; ")
+    ))
 }
 
 fn release_target(os: &str, arch: &str) -> Result<&'static str> {
@@ -2247,28 +2420,152 @@ async fn download_verified_archive(release: &ResolvedRelease) -> Result<Vec<u8>>
 
     // Re-fetch and verify the signed sidecar at install time instead of trusting
     // a possibly stale preflight result.
-    let checksum = fetch_required_text(&client, &release.checksum_url).await?;
-    let expected = match fetch_optional_text(&client, &release.checksum_signature_url).await? {
-        Some(signature) => {
-            verify_signed_checksum(&checksum, &signature, pubkey, &release.filename)?
-        }
-        // No `.sha256.sig` on this release: the confirmed digest and the
-        // mandatory archive minisign check below carry the verification.
-        None => parse_sha256(&checksum, &release.filename)?,
-    };
+    let (expected, _) =
+        resolve_release_digest(&client, &release.sources, pubkey, &release.filename).await?;
     if !expected.eq_ignore_ascii_case(&release.public.sha256) {
         return Err(anyhow!(
             "release checksum changed after preflight; refusing to install"
         ));
     }
 
+    let ordered = ordered_release_sources(&client, release).await;
+    let mut failures = Vec::new();
+    for source in &ordered {
+        let archive = match download_release_bytes(&client, &source.url).await {
+            Ok(archive) => archive,
+            Err(error) => {
+                failures.push(format!("{}: {error:#}", source.url));
+                continue;
+            }
+        };
+        if let Err(error) = verify_sha256(&archive, &expected, &release.filename) {
+            failures.push(format!("{}: {error:#}", source.url));
+            continue;
+        }
+
+        let mut signature_verified = false;
+        for signature_source in std::iter::once(source).chain(
+            ordered
+                .iter()
+                .filter(|candidate| candidate.url != source.url),
+        ) {
+            let signature =
+                match fetch_required_text(&client, &signature_source.archive_signature_url).await {
+                    Ok(signature) => signature,
+                    Err(error) => {
+                        failures.push(format!(
+                            "{}: {error:#}",
+                            signature_source.archive_signature_url
+                        ));
+                        continue;
+                    }
+                };
+            match verify_minisign(&archive, &signature, pubkey) {
+                Ok(()) => {
+                    signature_verified = true;
+                    break;
+                }
+                Err(error) => failures.push(format!(
+                    "{}: {error:#}",
+                    signature_source.archive_signature_url
+                )),
+            }
+        }
+        if signature_verified {
+            return Ok(archive);
+        }
+    }
+
+    Err(anyhow!(
+        "BitFun CLI archive failed from every source: {}",
+        failures.join("; ")
+    ))
+}
+
+async fn ordered_release_sources(
+    client: &reqwest::Client,
+    release: &ResolvedRelease,
+) -> Vec<ReleaseArtifactSource> {
+    let mut sources = release.sources.clone();
+    let Some(github_index) = sources
+        .iter()
+        .position(|source| source.origin == ReleaseOrigin::GitHub)
+    else {
+        return sources;
+    };
+    let github_speed = probe_release_throughput(client, &sources[github_index].url).await;
+    log::debug!(
+        "Dispatch CLI GitHub probe: {} B/s from {}",
+        github_speed,
+        sources[github_index].url
+    );
+    order_release_sources_for_speed(&mut sources, github_speed);
+    sources
+}
+
+fn order_release_sources_for_speed(sources: &mut [ReleaseArtifactSource], github_speed: u64) {
+    let Some(github_index) = sources
+        .iter()
+        .position(|source| source.origin == ReleaseOrigin::GitHub)
+    else {
+        return;
+    };
+    if github_speed >= GITHUB_HEALTHY_THROUGHPUT
+        || !sources
+            .iter()
+            .any(|source| source.origin == ReleaseOrigin::OpenBitFun)
+    {
+        sources.swap(0, github_index);
+    } else if let Some(mirror_index) = sources
+        .iter()
+        .position(|source| source.origin == ReleaseOrigin::OpenBitFun)
+    {
+        sources.swap(0, mirror_index);
+    }
+}
+
+async fn probe_release_throughput(client: &reqwest::Client, url: &str) -> u64 {
+    let started = std::time::Instant::now();
+    let request = client
+        .get(url)
+        .header(
+            reqwest::header::RANGE,
+            format!("bytes=0-{}", RELEASE_PROBE_BYTES - 1),
+        )
+        .send();
+    let Ok(Ok(mut response)) = tokio::time::timeout(RELEASE_PROBE_WINDOW, request).await else {
+        return 0;
+    };
+    if !response.status().is_success() {
+        return 0;
+    }
+    let mut received = 0u64;
+    loop {
+        let Some(remaining) = RELEASE_PROBE_WINDOW.checked_sub(started.elapsed()) else {
+            break;
+        };
+        if remaining.is_zero() {
+            break;
+        }
+        match tokio::time::timeout(remaining, response.chunk()).await {
+            Ok(Ok(Some(chunk))) => received += chunk.len() as u64,
+            _ => break,
+        }
+        if received >= RELEASE_PROBE_BYTES {
+            break;
+        }
+    }
+    (received as f64 / started.elapsed().as_secs_f64().max(0.001)) as u64
+}
+
+async fn download_release_bytes(client: &reqwest::Client, url: &str) -> Result<Vec<u8>> {
     let mut response = client
-        .get(&release.public.url)
+        .get(url)
         .send()
         .await
-        .with_context(|| format!("request {}", release.public.url))?
+        .with_context(|| format!("request {url}"))?
         .error_for_status()
-        .with_context(|| format!("download {}", release.public.url))?;
+        .with_context(|| format!("download {url}"))?;
     if response
         .content_length()
         .is_some_and(|length| length > MAX_ARCHIVE_BYTES as u64)
@@ -2282,14 +2579,10 @@ async fn download_verified_archive(release: &ResolvedRelease) -> Result<Vec<u8>>
     while let Some(chunk) = response
         .chunk()
         .await
-        .with_context(|| format!("read {}", release.public.url))?
+        .with_context(|| format!("read {url}"))?
     {
         extend_bounded_archive(&mut archive, &chunk, MAX_ARCHIVE_BYTES)?;
     }
-    verify_sha256(&archive, &expected, &release.filename)?;
-
-    let archive_signature = fetch_required_text(&client, &release.archive_signature_url).await?;
-    verify_minisign(&archive, &archive_signature, pubkey)?;
     Ok(archive)
 }
 
@@ -2845,18 +3138,29 @@ mod tests {
     }
 
     fn test_release(checksum_signature_verified: bool) -> ResolvedRelease {
+        let github_url = "https://github.example.invalid/bitfun-cli.tar.gz";
+        let mirror_url = "https://mirror.example.invalid/bitfun-cli.tar.gz";
         ResolvedRelease {
             public: DispatchCliRelease {
                 version: "1.2.3".to_string(),
                 target: "x86_64-unknown-linux-gnu".to_string(),
-                url: "https://example.invalid/bitfun-cli.tar.gz".to_string(),
+                url: github_url.to_string(),
                 sha256: "a".repeat(64),
             },
             filename: "bitfun-cli.tar.gz".to_string(),
-            checksum_url: "https://example.invalid/bitfun-cli.tar.gz.sha256".to_string(),
-            checksum_signature_url: "https://example.invalid/bitfun-cli.tar.gz.sha256.sig"
-                .to_string(),
-            archive_signature_url: "https://example.invalid/bitfun-cli.tar.gz.sig".to_string(),
+            sources: [
+                (ReleaseOrigin::GitHub, github_url),
+                (ReleaseOrigin::OpenBitFun, mirror_url),
+            ]
+            .into_iter()
+            .map(|(origin, url)| ReleaseArtifactSource {
+                origin,
+                url: url.to_string(),
+                checksum_url: format!("{url}.sha256"),
+                checksum_signature_url: format!("{url}.sha256.sig"),
+                archive_signature_url: format!("{url}.sig"),
+            })
+            .collect(),
             checksum_signature_verified,
         }
     }
@@ -3095,6 +3399,63 @@ mod tests {
     }
 
     #[test]
+    fn latest_release_manifest_accepts_only_stable_semver() {
+        assert_eq!(
+            latest_release_version_from_json(r#"{"version":"1.2.3"}"#, "fixture").unwrap(),
+            "1.2.3"
+        );
+        assert!(
+            latest_release_version_from_json(r#"{"version":"1.2.4-nightly.1"}"#, "fixture")
+                .is_err()
+        );
+        assert!(latest_release_version_from_json(r#"{"version":"latest"}"#, "fixture").is_err());
+    }
+
+    #[test]
+    fn latest_cli_sources_are_github_then_the_versioned_openbitfun_mirror() {
+        let filename = "bitfun-cli-1.2.3-x86_64-unknown-linux-gnu.tar.gz";
+        let sources = release_sources("1.2.3", filename);
+        assert_eq!(sources[0].origin, ReleaseOrigin::GitHub);
+        assert_eq!(
+            sources[0].url,
+            format!("https://github.com/GCWing/BitFun/releases/download/v1.2.3/{filename}")
+        );
+        assert_eq!(sources[1].origin, ReleaseOrigin::OpenBitFun);
+        assert_eq!(
+            sources[1].url,
+            format!("https://openbitfun.com/release/1.2.3/{filename}")
+        );
+    }
+
+    #[test]
+    fn dispatch_cli_uses_the_mirror_only_below_the_github_speed_floor() {
+        let mut slow = test_release(true).sources;
+        order_release_sources_for_speed(&mut slow, GITHUB_HEALTHY_THROUGHPUT - 1);
+        assert_eq!(slow[0].origin, ReleaseOrigin::OpenBitFun);
+
+        let mut healthy = test_release(true).sources;
+        healthy.swap(0, 1);
+        order_release_sources_for_speed(&mut healthy, GITHUB_HEALTHY_THROUGHPUT);
+        assert_eq!(healthy[0].origin, ReleaseOrigin::GitHub);
+    }
+
+    #[test]
+    fn target_download_script_contains_the_same_speed_policy_and_both_sources() {
+        let script = target_download_script(
+            RemoteDownloader::Curl,
+            RemoteDigestTool::Sha256Sum,
+            "/tmp/bitfun.tar.gz",
+            "https://github.example/bitfun.tar.gz",
+            "https://mirror.example/bitfun.tar.gz",
+            &"a".repeat(64),
+        );
+        assert!(script.contains("524288"));
+        assert!(script.contains("GITHUB_SPEED"));
+        assert!(script.contains("https://github.example/bitfun.tar.gz"));
+        assert!(script.contains("https://mirror.example/bitfun.tar.gz"));
+    }
+
+    #[test]
     fn an_unsigned_checksum_never_lets_the_target_fetch_the_release() {
         // The target can only check a plain digest. If that digest is not
         // provably the publisher's, the archive's own signature is the only
@@ -3185,6 +3546,7 @@ mod tests {
                 digest_tool,
                 &archive.to_string_lossy(),
                 &url,
+                "",
                 sha,
             );
             std::process::Command::new("bash")
@@ -3492,6 +3854,7 @@ mod tests {
                 RemoteDigestTool::Sha256Sum,
                 "/home/user/.bitfun/dispatch/install/archive.tar.gz",
                 "https://example.invalid/archive.tar.gz",
+                "https://openbitfun.example.invalid/archive.tar.gz",
                 &"a".repeat(64),
             ),
             target_download_script(
@@ -3499,6 +3862,7 @@ mod tests {
                 RemoteDigestTool::Shasum,
                 "/home/user/.bitfun/dispatch/install/archive.tar.gz",
                 "https://example.invalid/archive.tar.gz",
+                "https://openbitfun.example.invalid/archive.tar.gz",
                 &"a".repeat(64),
             ),
             install_poll_script(17),

--- a/src/crates/services/services-integrations/src/remote_ssh/relay_deploy.rs
+++ b/src/crates/services/services-integrations/src/remote_ssh/relay_deploy.rs
@@ -49,13 +49,12 @@ const RELAY_CONTAINER_DB: &str = "/app/data/bitfun_relay.db";
 const REPO_GIT_URL: &str = "https://github.com/GCWing/BitFun.git";
 /// Tarball fallback when git is unavailable or clone/fetch fails.
 const REPO_TARBALL_URL: &str = "https://github.com/GCWing/BitFun/archive/refs/heads/main.tar.gz";
-/// Release asset base. Asset names are stable across tags so the embedded
-/// Desktop version can address its matching server build without a GitHub API call.
+/// Release asset bases. GitHub is authoritative; OpenBitFun mirrors the same
+/// signed bytes and is used when GitHub metadata is unavailable.
 const RELEASE_BASE: &str = "https://github.com/GCWing/BitFun/releases";
 const OPENBITFUN_RELEASE_BASE: &str = "https://openbitfun.com/release";
 const RELAY_IMAGE_REPOSITORY: &str = "ghcr.io/gcwing/bitfun-relay-server";
 const RELAY_IMAGE_DESCRIPTOR_ASSET: &str = "relay-image.json";
-const RELEASE_VERSION: &str = env!("CARGO_PKG_VERSION");
 /// Canonical China-mirror helper (shared with `src/apps/relay-server/deploy.sh`).
 /// Embedded so Desktop orchestration can select Docker-install and image routes.
 const RELAY_MIRROR_SH: &str = include_str!(concat!(
@@ -463,8 +462,7 @@ pub async fn start_task(
             // Authenticate the registry digest here, where the compiled-in
             // release trust root exists. The remote host then only needs
             // Docker's normal content-addressed pull verification.
-            let descriptor =
-                verified_relay_image_descriptor(&release_tag_for_version(RELEASE_VERSION)).await?;
+            let descriptor = verified_latest_relay_image_descriptor().await?;
             deploy_body_script_with_image(port, &descriptor)
         }
     };
@@ -1383,14 +1381,12 @@ echo {TASK_DONE_MARKER}
 fn release_binary_deploy_bash() -> String {
     format!(
         r#"
-export BITFUN_RELEASE_TAG="{release_tag}"
 export BITFUN_GITHUB_RELEASE_BASE="{RELEASE_BASE}"
 export BITFUN_OPENBITFUN_RELEASE_BASE="{OPENBITFUN_RELEASE_BASE}"
 # --- begin BitFun relay release-download.sh ---
 {release_download}
 # --- end BitFun relay release-download.sh ---
 "#,
-        release_tag = release_tag_for_version(RELEASE_VERSION),
         RELEASE_BASE = RELEASE_BASE,
         OPENBITFUN_RELEASE_BASE = OPENBITFUN_RELEASE_BASE,
         release_download = RELAY_RELEASE_DOWNLOAD_SH,
@@ -1400,7 +1396,7 @@ export BITFUN_OPENBITFUN_RELEASE_BASE="{OPENBITFUN_RELEASE_BASE}"
 /// Download and authenticate the image descriptor before any remote mutation.
 /// The official release is preferred; openbitfun is a byte mirror and remains
 /// safe because the same compiled-in minisign key must verify its descriptor.
-async fn verified_relay_image_descriptor(release_tag: &str) -> Result<RelayImageDescriptor> {
+async fn verified_latest_relay_image_descriptor() -> Result<RelayImageDescriptor> {
     let pubkey = release_pubkey().ok_or_else(|| {
         anyhow!("this build has no Relay release trust root; refusing image deployment")
     })?;
@@ -1408,10 +1404,10 @@ async fn verified_relay_image_descriptor(release_tag: &str) -> Result<RelayImage
         .connect_timeout(Duration::from_secs(8))
         .timeout(Duration::from_secs(30))
         .build()?;
-    let mut bases = vec![format!("{RELEASE_BASE}/download/{release_tag}")];
-    if let Some(version) = release_tag.strip_prefix('v') {
-        bases.push(format!("{OPENBITFUN_RELEASE_BASE}/{version}"));
-    }
+    let bases = [
+        format!("{RELEASE_BASE}/latest/download"),
+        OPENBITFUN_RELEASE_BASE.to_string(),
+    ];
 
     let mut last_error = String::from("descriptor was unavailable from every source");
     for base in bases {
@@ -1436,7 +1432,7 @@ async fn verified_relay_image_descriptor(release_tag: &str) -> Result<RelayImage
                 continue;
             }
         };
-        if let Err(error) = validate_relay_image_descriptor(&descriptor, release_tag) {
+        if let Err(error) = validate_relay_image_descriptor(&descriptor) {
             last_error = format!("{descriptor_url} is invalid: {error}");
             log::warn!("Relay image descriptor rejected: {last_error}");
             continue;
@@ -1445,14 +1441,11 @@ async fn verified_relay_image_descriptor(release_tag: &str) -> Result<RelayImage
     }
 
     Err(anyhow!(
-        "could not verify the signed Relay image descriptor for {release_tag}: {last_error}"
+        "could not verify the latest signed Relay image descriptor: {last_error}"
     ))
 }
 
-fn validate_relay_image_descriptor(
-    descriptor: &RelayImageDescriptor,
-    release_tag: &str,
-) -> Result<()> {
+fn validate_relay_image_descriptor(descriptor: &RelayImageDescriptor) -> Result<()> {
     if descriptor.schema_version != 1 {
         return Err(anyhow!(
             "unsupported schema version {}",
@@ -1462,17 +1455,13 @@ fn validate_relay_image_descriptor(
     if descriptor.image != RELAY_IMAGE_REPOSITORY {
         return Err(anyhow!("unexpected image repository"));
     }
-    if descriptor.tag != release_tag {
-        return Err(anyhow!(
-            "descriptor tag does not match this Desktop release"
-        ));
+    let version = semver::Version::parse(&descriptor.version)
+        .map_err(|_| anyhow!("image version is not valid SemVer"))?;
+    if !version.pre.is_empty() || !version.build.is_empty() {
+        return Err(anyhow!("latest Relay image must be a stable release"));
     }
-    if let Some(version) = release_tag.strip_prefix('v') {
-        if descriptor.version != version {
-            return Err(anyhow!(
-                "descriptor version does not match this Desktop release"
-            ));
-        }
+    if descriptor.tag != release_tag_for_version(&descriptor.version) {
+        return Err(anyhow!("descriptor tag does not match its version"));
     }
     let digest = descriptor.digest.as_bytes();
     if digest.len() != 71
@@ -1491,9 +1480,6 @@ fn validate_relay_image_descriptor(
         {
             return Err(anyhow!("image does not declare {platform}"));
         }
-    }
-    if descriptor.version.trim().is_empty() {
-        return Err(anyhow!("image version is empty"));
     }
     Ok(())
 }
@@ -1523,6 +1509,8 @@ set -euo pipefail
 {release_binary_deploy}
 export BITFUN_RELAY_IMAGE={image}
 export BITFUN_RELAY_IMAGE_DIGEST={digest}
+export BITFUN_RELEASE_TAG={tag}
+export BITFUN_RELEASE_VERSION={version}
 export BITFUN_REQUIRE_IMAGE_DIGEST=1
 export DOCKER_CONFIG="${{DOCKER_CONFIG:-$HOME/.bitfun/docker-config}}"
 BITFUN_DOCKER_MODE="${{BITFUN_DOCKER_MODE:-direct}}"
@@ -1549,6 +1537,8 @@ echo {TASK_DONE_MARKER}
         release_binary_deploy = release_binary_deploy,
         image = shell_quote_posix(&descriptor.image),
         digest = shell_quote_posix(&descriptor.digest),
+        tag = shell_quote_posix(&descriptor.tag),
+        version = shell_quote_posix(&descriptor.version),
         DEPLOY_STATE_DIR = DEPLOY_STATE_DIR,
         port = port,
         TASK_DONE_MARKER = TASK_DONE_MARKER,
@@ -1570,8 +1560,8 @@ mod tests {
         RelayImageDescriptor {
             schema_version: 1,
             image: RELAY_IMAGE_REPOSITORY.to_string(),
-            tag: release_tag_for_version(super::RELEASE_VERSION),
-            version: super::RELEASE_VERSION.to_string(),
+            tag: "v1.2.3".to_string(),
+            version: "1.2.3".to_string(),
             digest: format!("sha256:{}", "a".repeat(64)),
             platforms: vec!["linux/amd64".into(), "linux/arm64".into()],
         }
@@ -1888,6 +1878,9 @@ sh -c "$(bitfun_shell_join printf '%s\n' 'a b' "it's" '{{{{.State.Running}}}}' '
         assert!(script.contains("m.daocloud.io/${BITFUN_RELAY_IMAGE}"));
         assert!(script.contains("ghcr.nju.edu.cn/${BITFUN_RELAY_IMAGE#ghcr.io/}"));
         assert!(script.contains("official GHCR fallback"));
+        assert!(script.contains("BITFUN_GITHUB_HEALTHY_BPS"));
+        assert!(script.contains("bitfun_probe_github_throughput"));
+        assert!(script.contains("524288"));
         assert!(script.contains("pull --platform"));
         assert!(script.contains("bitfun_restore_previous_relay"));
         assert!(script.contains("--name bitfun-relay"));
@@ -1898,7 +1891,10 @@ sh -c "$(bitfun_shell_join printf '%s\n' 'a b' "it's" '{{{{.State.Running}}}}' '
         assert!(script.contains("name=^bitfun-relay-before-image-"));
         assert!(!script.contains("docker build"));
         assert!(!script.contains("cargo build"));
-        assert!(!script.contains("bitfun-relay-server-${target}.tar.gz"));
+        assert!(
+            !script.contains("tar -x") && !script.contains("docker load"),
+            "the raw archive is only a throughput probe, never an install path"
+        );
     }
 
     /// `docker logs` relays the container's stderr on its own stderr, and the
@@ -1937,7 +1933,7 @@ sh -c "$(bitfun_shell_join printf '%s\n' 'a b' "it's" '{{{{.State.Running}}}}' '
     #[test]
     fn signed_descriptor_is_strictly_bound_to_repository_tag_digest_and_platforms() {
         let descriptor = test_image_descriptor();
-        validate_relay_image_descriptor(&descriptor, &descriptor.tag).unwrap();
+        validate_relay_image_descriptor(&descriptor).unwrap();
 
         for invalid in [
             RelayImageDescriptor {
@@ -1957,7 +1953,7 @@ sh -c "$(bitfun_shell_join printf '%s\n' 'a b' "it's" '{{{{.State.Running}}}}' '
                 ..descriptor.clone()
             },
         ] {
-            assert!(validate_relay_image_descriptor(&invalid, &descriptor.tag).is_err());
+            assert!(validate_relay_image_descriptor(&invalid).is_err());
         }
 
         let body = deploy_body_script_with_image(9700, &descriptor);
@@ -1966,6 +1962,8 @@ sh -c "$(bitfun_shell_join printf '%s\n' 'a b' "it's" '{{{{.State.Running}}}}' '
             "export BITFUN_RELAY_IMAGE_DIGEST={}",
             descriptor.digest
         )));
+        assert!(body.contains("export BITFUN_RELEASE_TAG=v1.2.3"));
+        assert!(body.contains("export BITFUN_RELEASE_VERSION=1.2.3"));
         assert!(body.contains("export BITFUN_REQUIRE_IMAGE_DIGEST=1"));
         assert!(!body.contains("bitfun_sync_source"));
         assert!(!body.contains("bitfun_run_deploy_sh"));
@@ -2060,6 +2058,49 @@ test "$selected" = "m.daocloud.io/ghcr.io/gcwing/bitfun-relay-server@$BITFUN_REL
         assert_eq!(routes.len(), 2);
         assert!(routes[0].contains("ghcr.nju.edu.cn/gcwing/bitfun-relay-server@sha256:"));
         assert!(routes[1].contains("m.daocloud.io/ghcr.io/gcwing/bitfun-relay-server@sha256:"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn automatic_image_pull_keeps_github_when_healthy_and_uses_mirror_when_slow() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let script_path = temp.path().join("release-image.sh");
+        std::fs::write(&script_path, release_binary_deploy_bash()).expect("write image script");
+
+        let output = std::process::Command::new("bash")
+            .arg("-c")
+            .arg(
+                r#"
+set -euo pipefail
+source "$1"
+export BITFUN_MIRROR_REQUESTED_MODE=auto
+export BITFUN_RELAY_IMAGE_DIGEST="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+bitfun_probe_github_throughput() { echo "$MOCK_SPEED"; }
+bitfun_image_docker_with_timeout() { return 0; }
+bitfun_image_docker() {
+  if [ "$1 $2" = "image inspect" ]; then echo amd64; return 0; fi
+  return 1
+}
+
+MOCK_SPEED=524288
+healthy="$(bitfun_pull_relay_image linux/amd64)"
+test "$healthy" = "ghcr.io/gcwing/bitfun-relay-server@$BITFUN_RELAY_IMAGE_DIGEST"
+
+MOCK_SPEED=524287
+slow="$(bitfun_pull_relay_image linux/amd64)"
+test "$slow" = "ghcr.nju.edu.cn/gcwing/bitfun-relay-server@$BITFUN_RELAY_IMAGE_DIGEST"
+"#,
+            )
+            .arg("image-speed-policy")
+            .arg(&script_path)
+            .output()
+            .expect("run image speed harness");
+        assert!(
+            output.status.success(),
+            "image speed harness failed:\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 
     #[cfg(unix)]

--- a/src/web-ui/src/features/relay-deploy/README.md
+++ b/src/web-ui/src/features/relay-deploy/README.md
@@ -25,21 +25,24 @@ Desktop Tauri surface: `src/apps/desktop/src/api/relay_deploy_api.rs`
    and it never silently falls back to those operations. Manual
    `deploy.sh --build-from-source` remains an explicit maintenance escape hatch.
 
-3. **Authenticate the image before touching the server.** Each release publishes
-   `relay-image.json` and `relay-image.json.sig`. Desktop verifies the descriptor
-   using its compiled-in minisign trust root, validates the exact repository,
-   release tag, lowercase SHA256 digest, and both supported platforms, then sends
-   only that trusted repository + digest to the remote script.
+3. **Authenticate the latest image before touching the server.** Desktop reads
+   the latest `relay-image.json` and `relay-image.json.sig`, verifies the
+   descriptor using its compiled-in minisign trust root, validates the exact
+   repository, stable release tag/version, lowercase SHA256 digest, and both
+   supported platforms, then sends only that trusted repository + digest to the
+   remote script. The Desktop package version does not pin Relay deployment.
 
 4. **Always start by digest.** Tags are discovery metadata, not an execution
    identity. One-click deploy sets `BITFUN_REQUIRE_IMAGE_DIGEST=1`; Docker pulls
    and runs `<repository>@sha256:...`, so every manifest and layer remains
    content-addressed.
 
-5. **Regional prefixes are transport, not trust roots.** Global mode pulls
-   `ghcr.io/gcwing/bitfun-relay-server` directly. China mode tries, in order,
-   `ghcr.nju.edu.cn/...`, `m.daocloud.io/ghcr.io/...`, then official GHCR. Every
-   route uses the same signed digest and has a bounded attempt before failover.
+5. **Registry prefixes are transport, not trust roots.** Automatic mode keeps
+   official GHCR first when a 10-second GitHub byte probe reaches 512 KiB/s; a
+   slower or unreachable GitHub moves `ghcr.nju.edu.cn/...` and
+   `m.daocloud.io/ghcr.io/...` ahead of official GHCR. Explicit global/China
+   choices remain authoritative. Every route uses the same signed digest and
+   has a bounded attempt before failover.
 
 6. **The release must be publicly pullable.** `desktop-package.yml` builds one
    amd64/arm64 manifest, signs its descriptor, logs out of GHCR, and verifies an
@@ -104,10 +107,11 @@ Desktop Tauri surface: `src/apps/desktop/src/api/relay_deploy_api.rs`
     covers older arm64 Relay artifacts that required GLIBC 2.38 even though the
     current release builders assert a GLIBC 2.35 ceiling.
 
-20. **Release metadata has a China byte mirror, not a second authority.**
-    `openbitfun-release-sync.sh` mirrors the signed descriptor into the matching
-    version directory. Desktop may fetch those bytes when GitHub is unreachable,
-    but the same built-in minisign key must verify them.
+20. **Release metadata has a byte mirror, not a second authority.**
+    `openbitfun-release-sync.sh` mirrors the signed descriptor into both its
+    version directory and `/release/relay-image.json`. Desktop may fetch those
+    bytes when GitHub is unreachable, but the same built-in minisign key must
+    verify them.
 
 ## Related docs
 


### PR DESCRIPTION
## Summary

- resolve the latest stable CLI and Relay artifacts for SSH one-click deployment instead of pinning the Desktop build version
- keep GitHub first, but prefer the OpenBitFun or registry mirror when the measured GitHub transfer rate is below 512 KiB/s
- apply the same source-selection policy to Desktop updates and CLI background self-updates
- mirror signed CLI sidecars, macOS Dispatch archives, and the signed Relay image descriptor on openbitfun.com

## Safety

- Dispatch still requires signed checksum metadata for target-side downloads and always verifies the archive minisign signature for controller-pushed bytes
- Relay still verifies the signed descriptor locally and deploys by immutable OCI digest
- a stale Desktop updater mirror cannot hide a newer GitHub release

## Verification

- cargo check -p bitfun-cli
- cargo check -p bitfun-desktop
- cargo test -p bitfun-cli self_update
- cargo test -p bitfun-desktop updater
- cargo test -p bitfun-services-integrations --features remote-ssh,remote-ssh-concrete,workspace-search remote_ssh
- node --test scripts/linux-binaries-manifest.test.mjs
- node --test scripts/relay/package-contract.test.mjs
- pnpm run check:core-boundaries
- pnpm run check:repo-hygiene
- bash -n scripts/openbitfun-release-sync.sh
- bash -n src/apps/relay-server/release-download.sh