### PR TITLE
feat(ai): add TokenDance model provider

### DIFF
--- a/BitFun-Installer/src/i18n/locales/en.json
+++ b/BitFun-Installer/src/i18n/locales/en.json
@@ -147,6 +147,10 @@
       "openrouter": {
         "name": "OpenRouter",
         "description": "OpenRouter Model Platform"
+      },
+      "tokendance": {
+        "name": "TokenDance",
+        "description": "Unified AI model gateway"
       }
     },
     "modelNameSelectPlaceholder": "Select model",

--- a/BitFun-Installer/src/i18n/locales/zh-TW.json
+++ b/BitFun-Installer/src/i18n/locales/zh-TW.json
@@ -147,6 +147,10 @@
       "openrouter": {
         "name": "OpenRouter",
         "description": "OpenRouter 大模型平臺"
+      },
+      "tokendance": {
+        "name": "詞元跳動",
+        "description": "統一的大模型 API 閘道"
       }
     },
     "modelNameSelectPlaceholder": "選擇模型",

--- a/BitFun-Installer/src/i18n/locales/zh.json
+++ b/BitFun-Installer/src/i18n/locales/zh.json
@@ -147,6 +147,10 @@
       "openrouter": {
         "name": "OpenRouter",
         "description": "OpenRouter 大模型平台"
+      },
+      "tokendance": {
+        "name": "词元跳动",
+        "description": "统一的大模型 API 网关"
       }
     },
     "modelNameSelectPlaceholder": "选择模型",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -894,7 +894,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-app-server-client"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "bitfun-app-server-protocol"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "agent-client-protocol",
  "bitfun-core-types",

--- a/src/crates/assembly/core/src/infrastructure/ai/provider_catalog.rs
+++ b/src/crates/assembly/core/src/infrastructure/ai/provider_catalog.rs
@@ -543,7 +543,7 @@ mod tests {
     #[test]
     fn overlay_is_valid_and_keeps_product_endpoint_decisions() {
         let overlay = parse_overlay().expect("valid overlay");
-        assert_eq!(overlay.providers.len(), 12);
+        assert_eq!(overlay.providers.len(), 13);
         let openbitfun = overlay
             .providers
             .iter()
@@ -580,6 +580,37 @@ mod tests {
                 .find(|endpoint| endpoint.is_default)
                 .map(|endpoint| endpoint.base_url.as_str()),
             Some("https://dashscope.aliyuncs.com/compatible-mode/v1")
+        );
+        let tokendance = overlay
+            .providers
+            .iter()
+            .find(|provider| provider.id == "tokendance")
+            .expect("tokendance");
+        assert_eq!(
+            tokendance.help_url.as_deref(),
+            Some("https://tokendance.space/keys")
+        );
+        assert_eq!(
+            tokendance
+                .endpoints
+                .iter()
+                .map(|endpoint| (
+                    endpoint.id.as_str(),
+                    endpoint.base_url.as_str(),
+                    endpoint.api_format.as_str(),
+                    endpoint.is_default,
+                ))
+                .collect::<Vec<_>>(),
+            [(
+                "default",
+                "https://tokendance.space/gateway/v1",
+                "openai",
+                true,
+            )]
+        );
+        assert_eq!(
+            tokendance.model_policy.curated_models,
+            ["glm-5.2", "deepseek-v4-flash", "deepseek-v4-pro"]
         );
     }
 
@@ -734,7 +765,7 @@ mod tests {
             "bundle".to_string(),
             ProviderCatalogSource::Bundle,
         );
-        assert_eq!(resolved.providers.len(), 12);
+        assert_eq!(resolved.providers.len(), 13);
         assert!(resolved
             .providers
             .iter()
@@ -815,6 +846,15 @@ mod tests {
                 &relayed,
             ),
             Some(("deepseek".to_string(), "deepseek-v4-flash".to_string()))
+        );
+        assert_eq!(
+            trusted_models_dev_binding(
+                "openai",
+                "https://tokendance.space/gateway/v1/chat/completions",
+                "GLM-5.2",
+                &relayed,
+            ),
+            Some(("zhipuai".to_string(), "glm-5.2".to_string()))
         );
         assert_eq!(
             trusted_models_dev_binding(

--- a/src/shared/ai-provider-catalog/providers.json
+++ b/src/shared/ai-provider-catalog/providers.json
@@ -251,6 +251,36 @@
         "curated_models": [],
         "additional_models": []
       }
+    },
+    {
+      "id": "tokendance",
+      "display_order": 120,
+      "name": "TokenDance",
+      "description": "TokenDance unified AI model gateway",
+      "help_url": "https://tokendance.space/keys",
+      "requires_api_key": true,
+      "catalog_provider_ids": [],
+      "endpoints": [
+        {
+          "id": "default",
+          "base_url": "https://tokendance.space/gateway/v1",
+          "api_format": "openai",
+          "label": "default",
+          "is_default": true,
+          "trusted_for_auto_detection": true,
+          "catalog_provider_ids": [],
+          "reasoning_catalog_bindings": [
+            { "model_id": "glm-5.2", "source_provider_id": "zhipuai", "source_model_id": "glm-5.2" },
+            { "model_id": "deepseek-v4-flash", "source_provider_id": "deepseek", "source_model_id": "deepseek-v4-flash" },
+            { "model_id": "deepseek-v4-pro", "source_provider_id": "deepseek", "source_model_id": "deepseek-v4-pro" }
+          ]
+        }
+      ],
+      "model_policy": {
+        "mode": "curated",
+        "curated_models": ["glm-5.2", "deepseek-v4-flash", "deepseek-v4-pro"],
+        "additional_models": []
+      }
     }
   ]
 }

--- a/src/web-ui/src/infrastructure/config/services/modelConfigs.test.ts
+++ b/src/web-ui/src/infrastructure/config/services/modelConfigs.test.ts
@@ -47,6 +47,15 @@ describe('modelConfigs', () => {
     })).toBe('settings/ai-model:providers.zhipu.name');
   });
 
+  it('recognizes the full TokenDance chat completions URL', async () => {
+    const { getProviderDisplayName } = await import('./modelConfigs');
+
+    expect(getProviderDisplayName({
+      base_url: 'https://tokendance.space/gateway/v1/chat/completions',
+      model_name: 'glm-5.2',
+    })).toBe('settings/ai-model:providers.tokendance.name');
+  });
+
   it('allocates readable model config IDs with collision and selector handling', async () => {
     const { allocateModelConfigId } = await import('./modelConfigs');
 

--- a/src/web-ui/src/locales/en-US/settings/ai-model.json
+++ b/src/web-ui/src/locales/en-US/settings/ai-model.json
@@ -228,6 +228,10 @@
     "openrouter": {
       "name": "OpenRouter",
       "description": "OpenRouter Model Platform"
+    },
+    "tokendance": {
+      "name": "TokenDance",
+      "description": "Unified AI model gateway"
     }
   },
   "tabs": {

--- a/src/web-ui/src/locales/zh-CN/settings/ai-model.json
+++ b/src/web-ui/src/locales/zh-CN/settings/ai-model.json
@@ -228,6 +228,10 @@
     "openrouter": {
       "name": "OpenRouter",
       "description": "OpenRouter 大模型平台"
+    },
+    "tokendance": {
+      "name": "词元跳动",
+      "description": "统一的大模型 API 网关"
     }
   },
   "tabs": {

--- a/src/web-ui/src/locales/zh-TW/settings/ai-model.json
+++ b/src/web-ui/src/locales/zh-TW/settings/ai-model.json
@@ -228,6 +228,10 @@
     "openrouter": {
       "name": "OpenRouter",
       "description": "OpenRouter 大模型平臺"
+    },
+    "tokendance": {
+      "name": "詞元跳動",
+      "description": "統一的大模型 API 閘道"
     }
   },
   "tabs": {


### PR DESCRIPTION
## Summary

- add TokenDance as a shared OpenAI-compatible model provider using https://tokendance.space/gateway/v1
- add curated fallback models and trusted reasoning metadata bindings
- localize the provider across Web UI and Installer, with full chat-completions URL recognition coverage
- sync two stale app-server workspace versions in Cargo.lock left by the 0.2.16 release bump so locked CI builds can run

## Verification

- cargo test -p bitfun-core --no-default-features --features ai-adapter-runtime --lib infrastructure::ai::provider_catalog::tests
- cargo check --locked --workspace
- pnpm --dir src/web-ui run test:run src/infrastructure/config/services/modelConfigs.test.ts src/infrastructure/config/services/providerPresets.test.ts
- pnpm run type-check:web
- pnpm --dir BitFun-Installer run type-check
- pnpm run i18n:audit
- pnpm run check:repo-hygiene
- git diff --check
- TokenDance GET /gateway/v1/models smoke check (HTTP 200)