### PR TITLE
fix(config): remove the phantom glow box behind chrome-less settings sections

### DIFF
--- a/src/web-ui/src/infrastructure/config/components/AIModelConfig.scss
+++ b/src/web-ui/src/infrastructure/config/components/AIModelConfig.scss
@@ -64,15 +64,6 @@
     }
   }
 
-  // Model list owns its own provider-group cards; drop the section body chrome.
-  &__models-section {
-    > .bitfun-config-page-section__body {
-      border: 0;
-      border-radius: 0;
-      background: transparent;
-    }
-  }
-
   &__collection {
     display: flex;
     flex-direction: column;

--- a/src/web-ui/src/infrastructure/config/components/AIModelConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/AIModelConfig.tsx
@@ -3146,6 +3146,7 @@ const AIModelConfig: React.FC = () => {
 
         <ConfigPageSection
           className="bitfun-ai-model-config__models-section"
+          mouseGlowSurface={false}
           title={tDefault('tabs.models')}
           description={t('subtitle')}
           extra={(

--- a/src/web-ui/src/infrastructure/config/components/AppearanceConfig.scss
+++ b/src/web-ui/src/infrastructure/config/components/AppearanceConfig.scss
@@ -144,11 +144,10 @@
 }
 
 .appearance-package-config {
+  // Chrome comes off via `mouseGlowSurface={false}`. Padding stays pinned here
+  // because appearance packages are allowed to set it on `sectionBody`.
   > .bitfun-config-page-section__body {
     padding: 0;
-    border: 0;
-    border-radius: 0;
-    background: transparent;
   }
 
   &__file-input {

--- a/src/web-ui/src/infrastructure/config/components/AppearancePackageConfigSection.tsx
+++ b/src/web-ui/src/infrastructure/config/components/AppearancePackageConfigSection.tsx
@@ -280,6 +280,7 @@ export function AppearancePackageConfigSection() {
   return (
     <ConfigPageSection
       className="appearance-package-config"
+      mouseGlowSurface={false}
       title={t('package.title')}
       description={t('package.description')}
       data-bf-component="appearance-config"

--- a/src/web-ui/src/infrastructure/config/components/WorktreesConfig.scss
+++ b/src/web-ui/src/infrastructure/config/components/WorktreesConfig.scss
@@ -57,14 +57,6 @@
     padding-top: var(--bf-appearance-token-size-gap-1);
   }
 
-  &__management-section {
-    > .bitfun-config-page-section__body {
-      border: 0;
-      border-radius: 0;
-      background: transparent;
-    }
-  }
-
   &__projects {
     display: flex;
     flex-direction: column;

--- a/src/web-ui/src/infrastructure/config/components/common/ConfigPageLayout.scss
+++ b/src/web-ui/src/infrastructure/config/components/common/ConfigPageLayout.scss
@@ -117,6 +117,15 @@
   box-shadow: inset 0 1px 0 var(--bf-appearance-token-color-overlay-white-04);
 }
 
+// Sections whose children own their own cards. Every visual boundary has to go,
+// including the inset highlight, or the mouse glow keeps tracing this container.
+.bitfun-config-page-section__body--flush {
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+
 .bitfun-config-page-row {
   --row-grid-cols: minmax(0, 7fr) minmax(0, 3fr);
   display: grid;

--- a/src/web-ui/src/infrastructure/config/components/common/ConfigPageLayout.test.tsx
+++ b/src/web-ui/src/infrastructure/config/components/common/ConfigPageLayout.test.tsx
@@ -50,6 +50,36 @@ describe('ConfigPageLayout', () => {
     expect(stack?.querySelectorAll(':scope > .bitfun-config-page-section')).toHaveLength(2);
   });
 
+  it('strips the body surface chrome when the section opts out of the mouse glow', () => {
+    act(() => {
+      root.render(
+        <ConfigPageSection title="Managed" mouseGlowSurface={false}>
+          <div>Body</div>
+        </ConfigPageSection>,
+      );
+    });
+
+    const section = container.querySelector('.bitfun-config-page-section');
+    const body = container.querySelector('.bitfun-config-page-section__body');
+
+    expect(body?.classList.contains('bitfun-config-page-section__body--flush')).toBe(true);
+    // The prop drives styling only; it must never leak onto the DOM node.
+    expect(section?.hasAttribute('mouseglowsurface')).toBe(false);
+  });
+
+  it('keeps the body surface chrome by default', () => {
+    act(() => {
+      root.render(
+        <ConfigPageSection title="Standard">
+          <div>Body</div>
+        </ConfigPageSection>,
+      );
+    });
+
+    const body = container.querySelector('.bitfun-config-page-section__body');
+    expect(body?.classList.contains('bitfun-config-page-section__body--flush')).toBe(false);
+  });
+
   it('forwards a feature-owned Appearance contract to the real layout nodes', () => {
     act(() => {
       root.render(

--- a/src/web-ui/src/infrastructure/config/components/common/ConfigPageLayout.tsx
+++ b/src/web-ui/src/infrastructure/config/components/common/ConfigPageLayout.tsx
@@ -93,8 +93,16 @@ export const ConfigPageSection: React.FC<ConfigPageSectionProps> = ({
   extra,
   children,
   className = '',
+  mouseGlowSurface = true,
   ...props
 }) => {
+  // A chrome-less body must drop the inset highlight too: the mouse glow treats any
+  // inset shadow as a visual boundary and would trace a box around empty space.
+  const bodyClassName = [
+    'bitfun-config-page-section__body',
+    !mouseGlowSurface && 'bitfun-config-page-section__body--flush',
+  ].filter(Boolean).join(' ');
+
   return (
     <section className={`bitfun-config-page-section ${className}`} data-bf-component="config" data-bf-part="section" {...props}>
       <div className="bitfun-config-page-section__header" data-bf-component="config" data-bf-part="sectionHeader">
@@ -113,7 +121,7 @@ export const ConfigPageSection: React.FC<ConfigPageSectionProps> = ({
           </div>
         )}
       </div>
-      <div className="bitfun-config-page-section__body" data-bf-component="config" data-bf-part="sectionBody">
+      <div className={bodyClassName} data-bf-component="config" data-bf-part="sectionBody">
         {children}
       </div>
     </section>


### PR DESCRIPTION
## 问题

Worktree 设置页「工作区 Worktrees」下方有一个看不见但会被鼠标跟随动效描边的框,顶部还有一条多余的 1px 高光线。

## 根因

`ConfigPageLayout.scss` 给所有 section body 加了 `box-shadow: inset 0 1px 0 …`。三个「子元素自带卡片」的分区(Worktrees / AI 模型列表 / 外观包)各自在 SCSS 里清掉了 `border`、`border-radius`、`background`,**唯独漏了 `box-shadow`**。后果两层:

1. 那条 inset 阴影本身就在本该隐形的容器顶部画了一条高光线。
2. `MouseGlowService.hasInsetBorderShadow()` 把任何 inset 阴影都当成视觉边界,于是这个隐形容器被识别成 glow surface,鼠标划过就绕着空白区域描一整圈边。

Worktrees 页最明显,因为空状态外面套着 `min-height: 176px` 的 `__results` 容器。

另外 `ConfigPageSection` 声明了 `mouseGlowSurface` prop 却从未解构它 —— `WorktreesConfig` 传的 `mouseGlowSurface={false}` 被当作未知属性 spread 到了 `<section>` DOM 上(控制台报 unknown prop 警告),完全没生效。

## 改动

- `ConfigPageSection` 真正消费 `mouseGlowSurface`,为 `false` 时给 body 挂 `--flush` 修饰类,同时不再泄漏到 DOM。
- 新增 `.bitfun-config-page-section__body--flush`,把包括 `box-shadow` 在内的全部视觉边界清干净。
- 三处 per-page SCSS 覆盖收敛到这个类;`AIModelConfig` 和 `AppearancePackageConfigSection` 补上 `mouseGlowSurface={false}`。
- `AppearanceConfig` 保留 `padding: 0` —— 外观包被允许对 `sectionBody` 设置 padding(见 `appearancePropertyProfiles.ts:28`),这行不是死代码。

空状态那个虚线框保留并仍会触发 glow:它有真实的四边 dashed border,和其他卡片行为一致。

## 验证

- `tsc --noEmit` 通过。
- `vitest run` 全量 2788 passed;新增 2 个回归用例(opt-out 时挂 flush 类且不泄漏 DOM 属性;默认保留 chrome)。
- 5 个失败的测试文件在 clean tree 上同样失败,是 worktree 环境问题(缺 gitignore 的 `src/generated`、node 未开 `--localstorage-file`),与本次改动无关。
- ⚠️ 未做运行时视觉验证:本 worktree 缺 `src/generated`,起 dev server 需要先跑 cargo 生成类型 + 后端。三个页面建议 review 时目测一下。