### PR TITLE
feat(ai): support OpenCode Zen and Go subscriptions

### DIFF
--- a/src/crates/adapters/ai-adapters/src/subscription_auth/mod.rs
+++ b/src/crates/adapters/ai-adapters/src/subscription_auth/mod.rs
@@ -1,7 +1,7 @@
 //! In-app subscription authentication.
 //!
 //! Lets BitFun sign in to another product's subscription (Codex/ChatGPT,
-//! Antigravity/Google, OpenCode Zen) with an OpenCode-style in-app OAuth flow,
+//! Antigravity/Google, OpenCode) with an OpenCode-style in-app OAuth flow,
 //! and use the resulting tokens to authenticate AI requests. Secret material
 //! is stored in the operating-system credential vault; the local JSON file
 //! contains non-secret account metadata only.
@@ -66,7 +66,7 @@ impl SubscriptionProvider {
         match self {
             Self::Codex => "Codex (ChatGPT)",
             Self::Antigravity => "Antigravity (Google)",
-            Self::Opencode => "OpenCode Zen",
+            Self::Opencode => "OpenCode",
         }
         .to_string()
     }
@@ -78,6 +78,40 @@ impl SubscriptionProvider {
             Self::Opencode => opencode::suggested(),
         }
     }
+}
+
+/// Billing/API product selected for an OpenCode-backed model.
+///
+/// The OAuth identity is shared by both plans; this value only chooses the
+/// trusted API namespace used for model discovery and inference.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OpenCodePlan {
+    Zen,
+    Go,
+}
+
+/// One model exposed by an OpenCode plan + wire-format offering.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SubscriptionOfferingModel {
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+}
+
+/// A homogeneous group of models that share one OpenCode plan and wire format.
+///
+/// OpenCode's catalog mixes Chat Completions, Responses, and Messages models
+/// within the same plan. Keeping those groups separate lets the UI create a
+/// model configuration whose protocol and endpoint are always paired.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SubscriptionApiOffering {
+    pub plan: OpenCodePlan,
+    pub format: String,
+    pub base_url: String,
+    pub suggested_model: String,
+    #[serde(default)]
+    pub models: Vec<SubscriptionOfferingModel>,
 }
 
 /// A subscription account entry surfaced to the UI.
@@ -100,6 +134,10 @@ pub struct SubscriptionAccount {
     pub suggested_format: String,
     pub suggested_base_url: String,
     pub suggested_model: String,
+    /// OpenCode plan/format groups available through this single account.
+    /// Empty for subscription providers that expose only one fixed endpoint.
+    #[serde(default)]
+    pub api_offerings: Vec<SubscriptionApiOffering>,
 }
 
 /// Structured sign-out result. Metadata removal determines connection state;
@@ -275,9 +313,9 @@ fn build_account(
     vault_unavailable: bool,
 ) -> SubscriptionAccount {
     let (format, base_url, model) = provider.suggested();
-    let (connected, account, expires_at) = match entry {
-        None => (false, None, None),
-        Some(StoredCredential::Api { .. }) => (true, None, None),
+    let (connected, account, expires_at, metadata) = match entry {
+        None => (false, None, None, None),
+        Some(StoredCredential::Api { metadata, .. }) => (true, None, None, metadata.as_ref()),
         Some(StoredCredential::Oauth {
             expires,
             account_id,
@@ -290,8 +328,13 @@ fn build_account(
                 .and_then(|value| value.as_str())
                 .map(str::to_string);
             let account = email.or_else(|| account_id.clone());
-            (true, account, Some(expires / 1000))
+            (true, account, Some(expires / 1000), metadata.as_ref())
         }
+    };
+    let api_offerings = if connected && provider == SubscriptionProvider::Opencode {
+        opencode::offerings_from_metadata(metadata)
+    } else {
+        Vec::new()
     };
     SubscriptionAccount {
         provider,
@@ -304,6 +347,7 @@ fn build_account(
         suggested_format: format.to_string(),
         suggested_base_url: base_url.to_string(),
         suggested_model: model.to_string(),
+        api_offerings,
     }
 }
 
@@ -653,9 +697,21 @@ pub async fn resolve(provider: SubscriptionProvider) -> Result<ResolvedCredentia
     }
 }
 
+/// Resolves an OpenCode credential for a concrete plan and request format.
+/// The adapter owns the endpoint mapping so an OAuth token can never be sent
+/// to an arbitrary URL supplied by model configuration.
+pub async fn resolve_opencode(plan: OpenCodePlan, format: &str) -> Result<ResolvedCredential> {
+    opencode::resolve_for(plan, format).await
+}
+
 /// Forces a resolve (which refreshes and saves), then returns the account entry.
 pub async fn refresh_account(provider: SubscriptionProvider) -> Result<SubscriptionAccount> {
-    resolve(provider).await?;
+    match provider {
+        SubscriptionProvider::Opencode => opencode::refresh_profile().await?,
+        _ => {
+            resolve(provider).await?;
+        }
+    }
     Ok(account_snapshot(provider).await)
 }
 

--- a/src/crates/adapters/ai-adapters/src/subscription_auth/opencode.rs
+++ b/src/crates/adapters/ai-adapters/src/subscription_auth/opencode.rs
@@ -1,14 +1,17 @@
-//! OpenCode Zen subscription login and credential resolution.
+//! OpenCode account login, catalog discovery, and credential resolution.
 //!
 //! Uses the OAuth 2.0 Device Authorization Grant against
-//! `console.opencode.ai`, aligned with OpenCode's `provider/opencode.ts`. The
-//! resolved credential targets the OpenAI-compatible Zen endpoint.
+//! `console.opencode.ai`, aligned with OpenCode's `provider/opencode.ts`.
+//! One OAuth identity can authenticate both the Zen and Go API products.
 
 use super::store::{self, StoredCredential};
-use super::{ResolvedCredential, StartedLogin};
+use super::{
+    OpenCodePlan, ResolvedCredential, StartedLogin, SubscriptionApiOffering,
+    SubscriptionOfferingModel,
+};
 use anyhow::{anyhow, Context, Result};
 use serde::Deserialize;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 
@@ -17,9 +20,17 @@ const CLIENT_ID: &str = "opencode-cli";
 const DEVICE_GRANT: &str = "urn:ietf:params:oauth:grant-type:device_code";
 const ZEN_BASE_URL: &str = "https://opencode.ai/zen/v1";
 const ZEN_REQUEST_URL: &str = "https://opencode.ai/zen/v1/chat/completions";
+const ZEN_RESPONSES_URL: &str = "https://opencode.ai/zen/v1/responses";
+const ZEN_MESSAGES_URL: &str = "https://opencode.ai/zen/v1/messages";
+const GO_BASE_URL: &str = "https://opencode.ai/zen/go/v1";
+const GO_REQUEST_URL: &str = "https://opencode.ai/zen/go/v1/chat/completions";
+const GO_RESPONSES_URL: &str = "https://opencode.ai/zen/go/v1/responses";
+const GO_MESSAGES_URL: &str = "https://opencode.ai/zen/go/v1/messages";
 const DEFAULT_MODEL: &str = "gpt-5.4";
 const REFRESH_LEEWAY_MS: i64 = 5 * 60 * 1000;
 const STORE_KEY: &str = "opencode";
+const OFFERINGS_METADATA_KEY: &str = "api_offerings";
+const SUPPORTED_FORMATS: [&str; 3] = ["openai", "responses", "anthropic"];
 
 #[derive(Debug, Deserialize)]
 struct DeviceCodeResponse {
@@ -56,6 +67,54 @@ struct OrgResponse {
     id: Option<String>,
     #[serde(default)]
     name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RemoteConfigResponse {
+    config: RemoteConfig,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RemoteConfig {
+    #[serde(default)]
+    provider: HashMap<String, RemoteProvider>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RemoteProvider {
+    #[serde(default)]
+    npm: Option<String>,
+    #[serde(default)]
+    api: Option<String>,
+    #[serde(default)]
+    models: HashMap<String, RemoteModel>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RemoteModel {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    provider: Option<RemoteModelProvider>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RemoteModelProvider {
+    #[serde(default)]
+    npm: Option<String>,
+    #[serde(default)]
+    api: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct OpenCodeRoute {
+    base_url: &'static str,
+    request_url: &'static str,
+    format: &'static str,
 }
 
 fn http_client() -> Result<reqwest::Client> {
@@ -123,8 +182,266 @@ async fn poll_once(device_code: &str) -> Result<DevicePoll> {
     ))
 }
 
-async fn fetch_metadata(access: &str) -> serde_json::Value {
-    let mut metadata = serde_json::Map::new();
+fn plan_base_url(plan: OpenCodePlan) -> &'static str {
+    match plan {
+        OpenCodePlan::Zen => ZEN_BASE_URL,
+        OpenCodePlan::Go => GO_BASE_URL,
+    }
+}
+
+fn route_for(plan: OpenCodePlan, format: &str) -> Result<OpenCodeRoute> {
+    let normalized = format.trim().to_ascii_lowercase();
+    let route = match (plan, normalized.as_str()) {
+        (OpenCodePlan::Zen, "openai") => OpenCodeRoute {
+            base_url: ZEN_BASE_URL,
+            request_url: ZEN_REQUEST_URL,
+            format: "openai",
+        },
+        (OpenCodePlan::Zen, "response" | "responses") => OpenCodeRoute {
+            base_url: ZEN_BASE_URL,
+            request_url: ZEN_RESPONSES_URL,
+            format: "responses",
+        },
+        (OpenCodePlan::Zen, "anthropic") => OpenCodeRoute {
+            base_url: ZEN_BASE_URL,
+            request_url: ZEN_MESSAGES_URL,
+            format: "anthropic",
+        },
+        (OpenCodePlan::Go, "openai") => OpenCodeRoute {
+            base_url: GO_BASE_URL,
+            request_url: GO_REQUEST_URL,
+            format: "openai",
+        },
+        (OpenCodePlan::Go, "response" | "responses") => OpenCodeRoute {
+            base_url: GO_BASE_URL,
+            request_url: GO_RESPONSES_URL,
+            format: "responses",
+        },
+        (OpenCodePlan::Go, "anthropic") => OpenCodeRoute {
+            base_url: GO_BASE_URL,
+            request_url: GO_MESSAGES_URL,
+            format: "anthropic",
+        },
+        _ => {
+            return Err(anyhow!(
+                "OpenCode {:?} does not support BitFun request format '{}'",
+                plan,
+                format.trim()
+            ));
+        }
+    };
+    Ok(route)
+}
+
+fn empty_offering(plan: OpenCodePlan, format: &str) -> SubscriptionApiOffering {
+    SubscriptionApiOffering {
+        plan,
+        format: format.to_string(),
+        base_url: plan_base_url(plan).to_string(),
+        suggested_model: String::new(),
+        models: Vec::new(),
+    }
+}
+
+fn fallback_offerings() -> Vec<SubscriptionApiOffering> {
+    [OpenCodePlan::Zen, OpenCodePlan::Go]
+        .into_iter()
+        .flat_map(|plan| {
+            SUPPORTED_FORMATS
+                .into_iter()
+                .map(move |format| empty_offering(plan, format))
+        })
+        .collect()
+}
+
+fn canonicalize_offerings(
+    offerings: impl IntoIterator<Item = SubscriptionApiOffering>,
+) -> Vec<SubscriptionApiOffering> {
+    let mut result = fallback_offerings();
+
+    for mut offering in offerings {
+        let normalized_format = offering.format.trim().to_ascii_lowercase();
+        let normalized_format = match normalized_format.as_str() {
+            "response" | "responses" => "responses",
+            "openai" => "openai",
+            "anthropic" => "anthropic",
+            _ => continue,
+        };
+        offering.format = normalized_format.to_string();
+        offering.base_url = plan_base_url(offering.plan).to_string();
+
+        let mut seen = HashSet::new();
+        offering.models.retain(|model| {
+            let id = model.id.trim();
+            !id.is_empty() && seen.insert(id.to_ascii_lowercase())
+        });
+        offering.models.sort_by(|left, right| {
+            left.display_name
+                .as_deref()
+                .unwrap_or(&left.id)
+                .to_ascii_lowercase()
+                .cmp(
+                    &right
+                        .display_name
+                        .as_deref()
+                        .unwrap_or(&right.id)
+                        .to_ascii_lowercase(),
+                )
+                .then_with(|| left.id.cmp(&right.id))
+        });
+        offering.suggested_model = offering
+            .models
+            .first()
+            .map(|model| model.id.clone())
+            .unwrap_or_default();
+
+        if let Some(slot) = result.iter_mut().find(|candidate| {
+            candidate.plan == offering.plan && candidate.format == offering.format
+        }) {
+            *slot = offering;
+        }
+    }
+
+    result
+}
+
+fn plan_for_provider(provider_id: &str) -> Option<OpenCodePlan> {
+    match provider_id {
+        "opencode" => Some(OpenCodePlan::Zen),
+        "opencode-go" => Some(OpenCodePlan::Go),
+        _ => None,
+    }
+}
+
+fn format_for_remote_model(npm: Option<&str>, api: Option<&str>) -> Option<&'static str> {
+    let package = npm.unwrap_or_default().to_ascii_lowercase();
+    if package.contains("openai-compatible") {
+        return Some("openai");
+    }
+    if package.contains("anthropic") {
+        return Some("anthropic");
+    }
+    if package == "@ai-sdk/openai" || package.ends_with("/openai") {
+        return Some("responses");
+    }
+
+    let api = api.unwrap_or_default().trim_end_matches('/');
+    if api.ends_with("/chat/completions") {
+        Some("openai")
+    } else if api.ends_with("/responses") {
+        Some("responses")
+    } else if api.ends_with("/messages") {
+        Some("anthropic")
+    } else {
+        None
+    }
+}
+
+fn offerings_from_remote_config(config: RemoteConfig) -> Vec<SubscriptionApiOffering> {
+    let mut offerings = fallback_offerings();
+
+    for (provider_id, provider) in config.provider {
+        let Some(plan) = plan_for_provider(&provider_id) else {
+            continue;
+        };
+        for (catalog_id, model) in provider.models {
+            if model.status.as_deref() == Some("deprecated") {
+                continue;
+            }
+            let npm = model
+                .provider
+                .as_ref()
+                .and_then(|item| item.npm.as_deref())
+                .or(provider.npm.as_deref());
+            let api = model
+                .provider
+                .as_ref()
+                .and_then(|item| item.api.as_deref())
+                .or(provider.api.as_deref());
+            let Some(format) = format_for_remote_model(npm, api) else {
+                // BitFun does not currently have a compatible adapter for
+                // every AI SDK package returned by OpenCode (for example its
+                // Google-native gateway shape). Do not offer a model with an
+                // endpoint we cannot faithfully reproduce.
+                continue;
+            };
+            let id = model.id.unwrap_or(catalog_id).trim().to_string();
+            if id.is_empty() {
+                continue;
+            }
+            let display_name = model
+                .name
+                .map(|name| name.trim().to_string())
+                .filter(|name| !name.is_empty() && name != &id);
+            if let Some(offering) = offerings
+                .iter_mut()
+                .find(|candidate| candidate.plan == plan && candidate.format == format)
+            {
+                offering
+                    .models
+                    .push(SubscriptionOfferingModel { id, display_name });
+            }
+        }
+    }
+
+    canonicalize_offerings(offerings)
+}
+
+pub(crate) fn offerings_from_metadata(
+    metadata: Option<&serde_json::Value>,
+) -> Vec<SubscriptionApiOffering> {
+    let parsed = metadata
+        .and_then(|value| value.get(OFFERINGS_METADATA_KEY))
+        .cloned()
+        .and_then(|value| serde_json::from_value::<Vec<SubscriptionApiOffering>>(value).ok());
+    canonicalize_offerings(parsed.unwrap_or_default())
+}
+
+async fn fetch_remote_offerings(
+    client: &reqwest::Client,
+    access: &str,
+    org_id: Option<&str>,
+) -> Option<Vec<SubscriptionApiOffering>> {
+    let mut request = client
+        .get(format!("{SERVER}/api/config"))
+        .bearer_auth(access);
+    if let Some(org_id) = org_id {
+        request = request.header("x-org-id", org_id);
+    }
+    let response = match request.send().await {
+        Ok(response) => response,
+        Err(error) => {
+            log::warn!("fetch OpenCode provider catalog failed: {error}");
+            return None;
+        }
+    };
+    // OpenCode treats 404 as "no remote provider override" rather than an
+    // authentication or transport failure. Keep the existing catalog/fallback
+    // without emitting a misleading warning.
+    if response.status() == reqwest::StatusCode::NOT_FOUND {
+        return None;
+    }
+    if !response.status().is_success() {
+        log::warn!(
+            "fetch OpenCode provider catalog failed: status={}",
+            response.status()
+        );
+        return None;
+    }
+    match response.json::<RemoteConfigResponse>().await {
+        Ok(remote) => Some(offerings_from_remote_config(remote.config)),
+        Err(error) => {
+            log::warn!("parse OpenCode provider catalog failed: {error}");
+            None
+        }
+    }
+}
+
+async fn fetch_metadata(access: &str, existing: Option<&serde_json::Value>) -> serde_json::Value {
+    let mut metadata = existing
+        .and_then(serde_json::Value::as_object)
+        .cloned()
+        .unwrap_or_default();
     metadata.insert(
         "server".to_string(),
         serde_json::Value::String(SERVER.to_string()),
@@ -159,9 +476,14 @@ async fn fetch_metadata(access: &str) -> serde_json::Value {
         if let Ok(mut orgs) = resp.json::<Vec<OrgResponse>>().await {
             orgs.sort_by(|a, b| {
                 a.name
-                    .clone()
+                    .as_deref()
                     .unwrap_or_default()
-                    .cmp(&b.name.clone().unwrap_or_default())
+                    .cmp(b.name.as_deref().unwrap_or_default())
+                    .then_with(|| {
+                        a.id.as_deref()
+                            .unwrap_or_default()
+                            .cmp(b.id.as_deref().unwrap_or_default())
+                    })
             });
             if let Some(org) = orgs.into_iter().next() {
                 if let Some(id) = org.id {
@@ -171,6 +493,13 @@ async fn fetch_metadata(access: &str) -> serde_json::Value {
                     metadata.insert("org_name".to_string(), serde_json::Value::String(name));
                 }
             }
+        }
+    }
+
+    let org_id = metadata.get("org_id").and_then(serde_json::Value::as_str);
+    if let Some(offerings) = fetch_remote_offerings(&client, access, org_id).await {
+        if let Ok(value) = serde_json::to_value(offerings) {
+            metadata.insert(OFFERINGS_METADATA_KEY.to_string(), value);
         }
     }
 
@@ -264,7 +593,7 @@ pub(crate) async fn begin_login(
                             // commit lock should cover only the credential
                             // store transaction, never up to 60 seconds of
                             // metadata fetching.
-                            let metadata = fetch_metadata(&tokens.access_token).await;
+                            let metadata = fetch_metadata(&tokens.access_token, None).await;
                             return Ok((tokens, metadata));
                         }
                         DevicePoll::Pending => {
@@ -296,7 +625,7 @@ async fn ensure_fresh() -> Result<String> {
     let snapshot = store::load_entry_with_revision(STORE_KEY).await?;
     let entry = snapshot
         .credential
-        .ok_or_else(|| anyhow!("OpenCode Zen is not connected; sign in first"))?;
+        .ok_or_else(|| anyhow!("OpenCode is not connected; sign in first"))?;
     match entry {
         StoredCredential::Api { key, .. } => Ok(key),
         StoredCredential::Oauth {
@@ -330,17 +659,69 @@ async fn ensure_fresh() -> Result<String> {
     }
 }
 
-/// Resolves the runtime credential (refreshing OAuth tokens if required).
-pub(crate) async fn resolve() -> Result<ResolvedCredential> {
+/// Refreshes account/org/catalog metadata using a fresh credential.
+pub(crate) async fn refresh_profile() -> Result<()> {
+    let access = ensure_fresh().await?;
+    let snapshot = store::load_entry_with_revision(STORE_KEY).await?;
+    let entry = snapshot
+        .credential
+        .ok_or_else(|| anyhow!("OpenCode is not connected; sign in first"))?;
+    let existing_metadata = match &entry {
+        StoredCredential::Oauth { metadata, .. } | StoredCredential::Api { metadata, .. } => {
+            metadata.as_ref()
+        }
+    };
+    let metadata = fetch_metadata(&access, existing_metadata).await;
+    if existing_metadata == Some(&metadata) {
+        return Ok(());
+    }
+
+    let updated = match entry {
+        StoredCredential::Oauth {
+            refresh,
+            access,
+            expires,
+            account_id,
+            ..
+        } => StoredCredential::Oauth {
+            refresh,
+            access,
+            expires,
+            account_id,
+            metadata: Some(metadata),
+        },
+        StoredCredential::Api { key, .. } => StoredCredential::Api {
+            key,
+            metadata: Some(metadata),
+        },
+    };
+    let outcome = store::upsert_if_revision(STORE_KEY, snapshot.revision, updated).await?;
+    super::require_current_store_revision(super::SubscriptionProvider::Opencode, outcome)?;
+    log::info!("opencode account metadata refreshed");
+    Ok(())
+}
+
+async fn resolve_route(route: OpenCodeRoute) -> Result<ResolvedCredential> {
     let api_key = ensure_fresh().await?;
     Ok(ResolvedCredential {
         api_key,
-        base_url: Some(ZEN_BASE_URL.to_string()),
-        request_url: Some(ZEN_REQUEST_URL.to_string()),
-        format: Some("openai".to_string()),
+        base_url: Some(route.base_url.to_string()),
+        request_url: Some(route.request_url.to_string()),
+        format: Some(route.format.to_string()),
         extra_headers: HashMap::new(),
         expires_at: None,
     })
+}
+
+/// Resolves the legacy OpenCode target. Models saved before plan-aware auth
+/// are kept on their historical Zen Chat Completions route.
+pub(crate) async fn resolve() -> Result<ResolvedCredential> {
+    resolve_route(route_for(OpenCodePlan::Zen, "openai")?).await
+}
+
+/// Resolves a concrete OpenCode plan and wire format to a trusted endpoint.
+pub(crate) async fn resolve_for(plan: OpenCodePlan, format: &str) -> Result<ResolvedCredential> {
+    resolve_route(route_for(plan, format)?).await
 }
 
 /// Provider metadata used to seed a new model entry.
@@ -350,7 +731,13 @@ pub(crate) fn suggested() -> (&'static str, &'static str, &'static str) {
 
 #[cfg(test)]
 mod tests {
-    use super::absolute_verification_url;
+    use super::{
+        absolute_verification_url, offerings_from_metadata, offerings_from_remote_config,
+        route_for, OpenCodePlan, RemoteConfig, RemoteModel, RemoteModelProvider, RemoteProvider,
+        GO_MESSAGES_URL, GO_REQUEST_URL, GO_RESPONSES_URL, ZEN_MESSAGES_URL, ZEN_REQUEST_URL,
+        ZEN_RESPONSES_URL,
+    };
+    use std::collections::HashMap;
 
     #[test]
     fn prefixes_relative_device_verification_path() {
@@ -368,5 +755,126 @@ mod tests {
             ),
             "https://console.opencode.ai/device?user_code=ABCD-1234&client_id=opencode-cli"
         );
+    }
+
+    #[test]
+    fn maps_every_supported_plan_and_format_to_a_trusted_endpoint() {
+        let cases = [
+            (OpenCodePlan::Zen, "openai", ZEN_REQUEST_URL, "openai"),
+            (
+                OpenCodePlan::Zen,
+                "responses",
+                ZEN_RESPONSES_URL,
+                "responses",
+            ),
+            (
+                OpenCodePlan::Zen,
+                "anthropic",
+                ZEN_MESSAGES_URL,
+                "anthropic",
+            ),
+            (OpenCodePlan::Go, "openai", GO_REQUEST_URL, "openai"),
+            (OpenCodePlan::Go, "responses", GO_RESPONSES_URL, "responses"),
+            (OpenCodePlan::Go, "anthropic", GO_MESSAGES_URL, "anthropic"),
+        ];
+
+        for (plan, format, request_url, canonical_format) in cases {
+            let route = route_for(plan, format).expect("route should be supported");
+            assert_eq!(route.request_url, request_url);
+            assert_eq!(route.format, canonical_format);
+        }
+        assert!(route_for(OpenCodePlan::Go, "gemini").is_err());
+    }
+
+    #[test]
+    fn groups_remote_catalog_models_by_plan_and_wire_format() {
+        let config = RemoteConfig {
+            provider: HashMap::from([
+                (
+                    "opencode".to_string(),
+                    RemoteProvider {
+                        npm: Some("@ai-sdk/openai-compatible".to_string()),
+                        api: Some("https://opencode.ai/zen/v1".to_string()),
+                        models: HashMap::from([
+                            (
+                                "glm-5.2".to_string(),
+                                RemoteModel {
+                                    name: Some("GLM 5.2".to_string()),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "gpt-5.6-sol".to_string(),
+                                RemoteModel {
+                                    provider: Some(RemoteModelProvider {
+                                        npm: Some("@ai-sdk/openai".to_string()),
+                                        api: Some("https://opencode.ai/zen/v1".to_string()),
+                                    }),
+                                    ..Default::default()
+                                },
+                            ),
+                            (
+                                "gemini-3.6-flash".to_string(),
+                                RemoteModel {
+                                    provider: Some(RemoteModelProvider {
+                                        npm: Some("@ai-sdk/google".to_string()),
+                                        api: Some("https://opencode.ai/zen/v1".to_string()),
+                                    }),
+                                    ..Default::default()
+                                },
+                            ),
+                        ]),
+                    },
+                ),
+                (
+                    "opencode-go".to_string(),
+                    RemoteProvider {
+                        models: HashMap::from([(
+                            "minimax-m3".to_string(),
+                            RemoteModel {
+                                provider: Some(RemoteModelProvider {
+                                    npm: Some("@ai-sdk/anthropic".to_string()),
+                                    api: Some("https://opencode.ai/zen/go/v1".to_string()),
+                                }),
+                                ..Default::default()
+                            },
+                        )]),
+                        ..Default::default()
+                    },
+                ),
+            ]),
+        };
+
+        let offerings = offerings_from_remote_config(config);
+        let zen_chat = offerings
+            .iter()
+            .find(|item| item.plan == OpenCodePlan::Zen && item.format == "openai")
+            .unwrap();
+        assert_eq!(zen_chat.models[0].id, "glm-5.2");
+        assert_eq!(zen_chat.models[0].display_name.as_deref(), Some("GLM 5.2"));
+        let zen_responses = offerings
+            .iter()
+            .find(|item| item.plan == OpenCodePlan::Zen && item.format == "responses")
+            .unwrap();
+        assert_eq!(zen_responses.models[0].id, "gpt-5.6-sol");
+        let go_messages = offerings
+            .iter()
+            .find(|item| item.plan == OpenCodePlan::Go && item.format == "anthropic")
+            .unwrap();
+        assert_eq!(go_messages.models[0].id, "minimax-m3");
+        assert!(!offerings
+            .iter()
+            .flat_map(|item| &item.models)
+            .any(|model| model.id == "gemini-3.6-flash"));
+    }
+
+    #[test]
+    fn legacy_metadata_still_exposes_both_plans() {
+        let offerings = offerings_from_metadata(Some(&serde_json::json!({
+            "email": "user@example.com"
+        })));
+        assert_eq!(offerings.len(), 6);
+        assert!(offerings.iter().any(|item| item.plan == OpenCodePlan::Zen));
+        assert!(offerings.iter().any(|item| item.plan == OpenCodePlan::Go));
     }
 }

--- a/src/crates/assembly/core/src/infrastructure/ai/client_factory.rs
+++ b/src/crates/assembly/core/src/infrastructure/ai/client_factory.rs
@@ -12,9 +12,11 @@ use crate::infrastructure::ai::reasoning_catalog::{
     resolve_default_reasoning_preset,
 };
 use crate::infrastructure::ai::{build_stream_options_for_model, AIClient};
-use crate::infrastructure::subscription_auth::{self, SubscriptionProvider as AdapterProvider};
+use crate::infrastructure::subscription_auth::{
+    self, OpenCodePlan as AdapterOpenCodePlan, SubscriptionProvider as AdapterProvider,
+};
 use crate::service::config::types::{
-    model_runtime_binding_fingerprint, AuthConfig, SubscriptionProvider,
+    model_runtime_binding_fingerprint, AuthConfig, OpenCodePlan, SubscriptionProvider,
 };
 use crate::service::config::{get_global_config_service, ConfigService};
 use crate::util::errors::{BitFunError, BitFunResult};
@@ -433,6 +435,13 @@ fn to_adapter_provider(provider: SubscriptionProvider) -> AdapterProvider {
     }
 }
 
+fn to_adapter_opencode_plan(plan: OpenCodePlan) -> AdapterOpenCodePlan {
+    match plan {
+        OpenCodePlan::Zen => AdapterOpenCodePlan::Zen,
+        OpenCodePlan::Go => AdapterOpenCodePlan::Go,
+    }
+}
+
 /// Resolve a subscription `AuthConfig` and overlay it onto the runtime
 /// `AIConfig`. No-op when `auth == AuthConfig::ApiKey`. Returns the resolved
 /// credential's expiry (Unix seconds) so callers can invalidate cached
@@ -443,16 +452,27 @@ pub async fn apply_subscription_auth(
 ) -> Result<Option<i64>> {
     let resolved = match auth {
         AuthConfig::ApiKey => return Ok(None),
-        AuthConfig::Subscription { provider } => {
-            subscription_auth::resolve(to_adapter_provider(*provider))
-                .await
-                .map_err(|e| {
-                    anyhow!(
-                        "Failed to resolve {provider:?} subscription credential: {e:#}. \
+        AuthConfig::Subscription { provider, plan } => {
+            let resolved = match (*provider, *plan) {
+                (SubscriptionProvider::Opencode, Some(plan)) => {
+                    subscription_auth::resolve_opencode(
+                        to_adapter_opencode_plan(plan),
+                        &ai_config.format,
+                    )
+                    .await
+                }
+                (_, None) => subscription_auth::resolve(to_adapter_provider(*provider)).await,
+                (_, Some(plan)) => Err(anyhow!(
+                    "OpenCode plan {plan:?} cannot be used with provider {provider:?}"
+                )),
+            };
+            resolved.map_err(|e| {
+                anyhow!(
+                    "Failed to resolve {provider:?} subscription credential: {e:#}. \
                      Subscription logins are stored on the local machine and are not \
                      available in remote workspaces."
-                    )
-                })?
+                )
+            })?
         }
     };
 

--- a/src/crates/assembly/core/src/service/config/types.rs
+++ b/src/crates/assembly/core/src/service/config/types.rs
@@ -1432,10 +1432,21 @@ pub enum SubscriptionProvider {
     Opencode,
 }
 
+/// OpenCode API product selected for a subscription-authenticated model.
+/// Zen and Go share one account credential but use different API namespaces.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OpenCodePlan {
+    Zen,
+    Go,
+}
+
 /// Where to obtain the runtime auth material for an `AIModelConfig`.
 ///
 /// Stored on disk as `{"type":"api_key"}` or
 /// `{"type":"subscription","provider":"codex"|"antigravity"|"opencode"}`.
+/// OpenCode models may additionally persist `"plan":"zen"|"go"`; an absent
+/// plan preserves the legacy Zen Chat Completions behavior.
 /// Tokens live in the subscription auth store and are resolved at request time.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -1444,7 +1455,11 @@ pub enum AuthConfig {
     #[default]
     ApiKey,
     /// Use BitFun in-app subscription OAuth for the named provider.
-    Subscription { provider: SubscriptionProvider },
+    Subscription {
+        provider: SubscriptionProvider,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        plan: Option<OpenCodePlan>,
+    },
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
@@ -2000,9 +2015,10 @@ impl AIModelConfig {
 mod tests {
     use super::{
         AIConfig, AIExperienceConfig, AIModelConfig, AgentModelDefaultsConfig, AgentProfileConfig,
-        AgentProfileView, AppConfig, AppLoggingConfig, GlobalConfig, MemoryExternalContextPolicy,
-        ModelExchangeTracingMode, NotificationConfig, SubagentBatchExecutionPolicy,
-        SubagentModelSelection, UserSkillGroupsConfig, UserToolGroupsConfig,
+        AgentProfileView, AppConfig, AppLoggingConfig, AuthConfig, GlobalConfig,
+        MemoryExternalContextPolicy, ModelExchangeTracingMode, NotificationConfig, OpenCodePlan,
+        SubagentBatchExecutionPolicy, SubagentModelSelection, SubscriptionProvider,
+        UserSkillGroupsConfig, UserToolGroupsConfig,
     };
     use bitfun_runtime_ports::ToolPermissionConfig;
 
@@ -2013,6 +2029,40 @@ mod tests {
         let config: AppConfig =
             serde_json::from_value(serde_json::json!({})).expect("empty app config should default");
         assert!(!config.prevent_sleep);
+    }
+
+    #[test]
+    fn subscription_auth_preserves_legacy_opencode_and_roundtrips_go_plan() {
+        let legacy: AuthConfig = serde_json::from_value(serde_json::json!({
+            "type": "subscription",
+            "provider": "opencode"
+        }))
+        .expect("legacy OpenCode auth should deserialize");
+        assert_eq!(
+            legacy,
+            AuthConfig::Subscription {
+                provider: SubscriptionProvider::Opencode,
+                plan: None,
+            }
+        );
+        assert_eq!(
+            serde_json::to_value(&legacy).expect("legacy auth should serialize"),
+            serde_json::json!({
+                "type": "subscription",
+                "provider": "opencode"
+            })
+        );
+
+        let go = AuthConfig::Subscription {
+            provider: SubscriptionProvider::Opencode,
+            plan: Some(OpenCodePlan::Go),
+        };
+        let serialized = serde_json::to_value(&go).expect("Go auth should serialize");
+        assert_eq!(serialized["plan"], "go");
+        assert_eq!(
+            serde_json::from_value::<AuthConfig>(serialized).expect("Go auth should roundtrip"),
+            go
+        );
     }
 
     #[test]

--- a/src/web-ui/src/infrastructure/api/service-api/AIApi.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/AIApi.ts
@@ -5,6 +5,7 @@ import { createTauriCommandError } from '../errors/TauriCommandError';
 import type { SendMessageRequest } from './tauri-commands';
 import type { ConnectionTestMessageCode } from '@/shared/utils/aiConnectionTestMessages';
 import type {
+  OpenCodePlan,
   ReasoningCatalogProjection,
   SubscriptionProvider,
 } from '@/infrastructure/config/types';
@@ -149,6 +150,19 @@ export interface AIModelCatalog {
 
 export type SubscriptionLoginStatus = 'pending' | 'authorized' | 'failed' | 'cancelled';
 
+export interface SubscriptionOfferingModel {
+  id: string;
+  display_name?: string | null;
+}
+
+export interface SubscriptionApiOffering {
+  plan: OpenCodePlan;
+  format: 'openai' | 'responses' | 'anthropic';
+  base_url: string;
+  suggested_model: string;
+  models: SubscriptionOfferingModel[];
+}
+
 export interface SubscriptionAccount {
   provider: SubscriptionProvider;
   display_label: string;
@@ -160,6 +174,7 @@ export interface SubscriptionAccount {
   suggested_format: string;
   suggested_base_url: string;
   suggested_model: string;
+  api_offerings: SubscriptionApiOffering[];
 }
 
 export interface SubscriptionLogoutResult {

--- a/src/web-ui/src/infrastructure/config/components/AIModelConfig.scss
+++ b/src/web-ui/src/infrastructure/config/components/AIModelConfig.scss
@@ -2167,6 +2167,16 @@
     }
   }
 
+  &__opencode-plan {
+    margin-left: var(--bf-appearance-token-size-gap-4);
+    padding-left: var(--bf-appearance-token-size-gap-3);
+    border-left: 2px solid var(--bf-appearance-token-color-accent-200);
+  }
+
+  &__opencode-plan-actions {
+    flex-wrap: wrap;
+  }
+
   &__subscription-migration-notice {
     display: grid;
     grid-template-columns: auto minmax(0, 1fr) auto;
@@ -2274,6 +2284,10 @@
     &__cli-actions {
       justify-content: flex-start;
       flex-wrap: wrap;
+    }
+
+    &__opencode-plan {
+      margin-left: 0;
     }
 
     &__subscription-migration-notice {

--- a/src/web-ui/src/infrastructure/config/components/AIModelConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/AIModelConfig.tsx
@@ -18,8 +18,11 @@ import { normalizeProviderBaseUrl } from '../services/providerCatalog';
 import { supportsResponsesReasoning } from '../utils/reasoning';
 import { canonicalReasoningConfig, validateReasoningConfig } from '../utils/reasoningPresets';
 import { aiApi, systemAPI } from '@/infrastructure/api';
-import type { SubscriptionAccount } from '@/infrastructure/api/service-api/AIApi';
-import type { SubscriptionProvider } from '../types';
+import type {
+  SubscriptionAccount,
+  SubscriptionApiOffering,
+} from '@/infrastructure/api/service-api/AIApi';
+import type { OpenCodePlan, SubscriptionProvider } from '../types';
 import { useNotification } from '@/shared/notification-system';
 import { ConfigPageHeader, ConfigPageLayout, ConfigPageContent, ConfigPageSection, ConfigPageRow, ConfigCollectionItem } from './common';
 import DefaultModelConfig from './DefaultModelConfig';
@@ -234,7 +237,8 @@ function resolveRequestUrl(baseUrl: string, provider: string, _modelName = ''): 
     return trimmed.endsWith('responses') ? trimmed : `${trimmed}/responses`;
   }
   if (provider === 'anthropic') {
-    return trimmed.endsWith('v1/messages') ? trimmed : `${trimmed}/v1/messages`;
+    if (trimmed.endsWith('/messages')) return trimmed;
+    return trimmed.endsWith('/v1') ? `${trimmed}/messages` : `${trimmed}/v1/messages`;
   }
   if (provider === 'gemini') {
     return geminiBaseUrl(trimmed);
@@ -612,6 +616,24 @@ const AIModelConfig: React.FC = () => {
     activeRemoteFetchSignatureRef.current = null;
   }, []);
 
+  const getOpenCodePlanLabel = useCallback((plan: OpenCodePlan): string => (
+    plan === 'go'
+      ? t('subscriptionAuth.openCodePlans.go.label')
+      : t('subscriptionAuth.openCodePlans.zen.label')
+  ), [t]);
+
+  const getOpenCodePlanDescription = useCallback((plan: OpenCodePlan): string => (
+    plan === 'go'
+      ? t('subscriptionAuth.openCodePlans.go.description')
+      : t('subscriptionAuth.openCodePlans.zen.description')
+  ), [t]);
+
+  const getOpenCodeFormatLabel = useCallback((format: SubscriptionApiOffering['format']): string => {
+    if (format === 'responses') return t('subscriptionAuth.openCodeFormats.responses');
+    if (format === 'anthropic') return t('subscriptionAuth.openCodeFormats.messages');
+    return t('subscriptionAuth.openCodeFormats.chatCompletions');
+  }, [t]);
+
   const syncSelectedModelDrafts = (
     modelNames: string[],
     baseConfig?: Partial<AIModelConfigType>,
@@ -891,15 +913,28 @@ const AIModelConfig: React.FC = () => {
     setCreationMode('selection');
   };
 
-  const handleImportFromSubscription = useCallback((account: SubscriptionAccount) => {
+  const handleImportFromSubscription = useCallback((
+    account: SubscriptionAccount,
+    offering?: SubscriptionApiOffering,
+  ) => {
     resetRemoteModelDiscovery();
+    const offeringModels = (offering?.models || []).map((model) => ({
+      id: model.id,
+      display_name: model.display_name || undefined,
+    }));
+    if (offeringModels.length > 0) {
+      setRemoteModelOptions(offeringModels);
+      setHasAttemptedRemoteFetch(true);
+    }
     setManualModelInput('');
     setShowApiKey(false);
     setSelectedProviderId(null);
     setEditingConfig({
-      name: account.display_label,
-      provider: account.suggested_format,
-      base_url: account.suggested_base_url,
+      name: offering
+        ? getOpenCodePlanLabel(offering.plan)
+        : account.display_label,
+      provider: offering?.format || account.suggested_format,
+      base_url: offering?.base_url || account.suggested_base_url,
       // Leave request_url + model_name empty so the user must pick a model
       // from the live list. We never inject a hard-coded default slug.
       request_url: '',
@@ -912,14 +947,18 @@ const AIModelConfig: React.FC = () => {
       recommended_for: [],
       metadata: {},
       inline_think_in_text: true,
-      auth: { type: 'subscription', provider: account.provider },
+      auth: {
+        type: 'subscription',
+        provider: account.provider,
+        ...(offering ? { plan: offering.plan } : {}),
+      },
     });
     setSelectedModelDrafts([]);
     setEditingProviderModelIds(new Set());
     setShowAdvancedSettings(false);
     setCreationMode('form');
     setIsEditing(true);
-  }, [resetRemoteModelDiscovery]);
+  }, [getOpenCodePlanLabel, resetRemoteModelDiscovery]);
 
   const loginCoordinatorRef = React.useRef(new SubscriptionLoginCoordinator());
   const subscriptionLoginMountedRef = React.useRef(true);
@@ -1340,6 +1379,7 @@ const AIModelConfig: React.FC = () => {
       skip_ssl_verify: config.skip_ssl_verify ?? false,
       custom_request_body: config.custom_request_body,
       custom_request_body_mode: config.custom_request_body_mode,
+      auth: config.auth || { type: 'api_key' },
     });
     setSelectedModelDrafts(createDraftsFromConfigs(configuredProviderModels));
     setShowAdvancedSettings(
@@ -2218,14 +2258,22 @@ const AIModelConfig: React.FC = () => {
     const authIsSubscription = authType === 'subscription';
     const selectedSubscriptionProvider: SubscriptionProvider | undefined =
       editingConfig.auth?.type === 'subscription' ? editingConfig.auth.provider : undefined;
+    const selectedOpenCodePlan: OpenCodePlan | undefined =
+      editingConfig.auth?.type === 'subscription'
+      && editingConfig.auth.provider === 'opencode'
+        ? editingConfig.auth.plan || 'zen'
+        : undefined;
     const authSelectValue = authIsSubscription
-      ? `subscription:${selectedSubscriptionProvider || 'codex'}`
+      ? selectedSubscriptionProvider === 'opencode'
+        ? `subscription:opencode:${selectedOpenCodePlan || 'zen'}`
+        : `subscription:${selectedSubscriptionProvider || 'codex'}`
       : 'api_key';
     const authOptions: SelectOption[] = [
       { value: 'api_key', label: t('subscriptionAuth.options.apiKey') },
       { value: 'subscription:codex', label: t('subscriptionAuth.options.codex') },
       { value: 'subscription:antigravity', label: t('subscriptionAuth.options.antigravity') },
-      { value: 'subscription:opencode', label: t('subscriptionAuth.options.opencode') },
+      { value: 'subscription:opencode:zen', label: t('subscriptionAuth.options.opencodeZen') },
+      { value: 'subscription:opencode:go', label: t('subscriptionAuth.options.opencodeGo') },
     ];
     const matchedSubscription = selectedSubscriptionProvider
       ? subscriptionAccounts.find((account) => account.provider === selectedSubscriptionProvider)
@@ -2242,11 +2290,33 @@ const AIModelConfig: React.FC = () => {
                 setEditingConfig((prev) => ({ ...prev, auth: { type: 'api_key' } }));
                 return;
               }
-              const provider = next.replace('subscription:', '') as SubscriptionProvider;
-              setEditingConfig((prev) => ({
-                ...prev,
-                auth: { type: 'subscription', provider },
-              }));
+              const [, providerValue, planValue] = next.split(':');
+              const provider = providerValue as SubscriptionProvider;
+              const plan = provider === 'opencode'
+                ? (planValue || 'zen') as OpenCodePlan
+                : undefined;
+              setEditingConfig((prev) => {
+                if (!prev) return prev;
+                if (provider !== 'opencode') {
+                  return {
+                    ...prev,
+                    auth: { type: 'subscription', provider },
+                  };
+                }
+                const format = ['openai', 'responses', 'anthropic'].includes(prev.provider || '')
+                  ? prev.provider || 'openai'
+                  : 'openai';
+                const baseUrl = plan === 'go'
+                  ? 'https://opencode.ai/zen/go/v1'
+                  : 'https://opencode.ai/zen/v1';
+                return {
+                  ...prev,
+                  provider: format,
+                  base_url: baseUrl,
+                  request_url: resolveRequestUrl(baseUrl, format, prev.model_name || ''),
+                  auth: { type: 'subscription', provider, plan },
+                };
+              });
             }}
             options={authOptions}
             size="small"
@@ -2997,6 +3067,21 @@ const AIModelConfig: React.FC = () => {
                 ? Math.max(0, Math.ceil((loginPanel.deadlineMs - subscriptionLoginClock) / 1000))
                 : 0;
               const countdown = `${Math.floor(remainingSeconds / 60)}:${String(remainingSeconds % 60).padStart(2, '0')}`;
+              const openCodePlanRows = account.provider === 'opencode'
+                ? (['zen', 'go'] as const).map((plan) => {
+                    const planOfferings = (account.api_offerings || [])
+                      .filter((offering) => offering.plan === plan);
+                    const populatedOfferings = planOfferings
+                      .filter((offering) => offering.models.length > 0);
+                    return {
+                      plan,
+                      offerings: populatedOfferings.length > 0
+                        ? populatedOfferings
+                        : planOfferings,
+                    };
+                  }).filter((row) => row.offerings.length > 0)
+                : [];
+              const hasOpenCodeOfferings = openCodePlanRows.length > 0;
               return (
                 <React.Fragment key={account.provider}>
                   <ConfigPageRow
@@ -3031,14 +3116,16 @@ const AIModelConfig: React.FC = () => {
                           >
                             {t('subscriptionAuth.logout')}
                           </Button>
-                          <Button
-                            size="small"
-                            variant="primary"
-                            disabled={anyLoginInProgress}
-                            onClick={() => handleImportFromSubscription(account)}
-                          >
-                            {t('subscriptionAuth.import')}
-                          </Button>
+                          {(account.provider !== 'opencode' || !hasOpenCodeOfferings) && (
+                            <Button
+                              size="small"
+                              variant="primary"
+                              disabled={anyLoginInProgress}
+                              onClick={() => handleImportFromSubscription(account)}
+                            >
+                              {t('subscriptionAuth.import')}
+                            </Button>
+                          )}
                         </>
                       ) : account.vault_unavailable ? (
                         <Button
@@ -3072,6 +3159,39 @@ const AIModelConfig: React.FC = () => {
                       )}
                     </div>
                   </ConfigPageRow>
+
+                  {account.connected && openCodePlanRows.map(({ plan, offerings }) => (
+                    <ConfigPageRow
+                      key={`${account.provider}:${plan}`}
+                      label={getOpenCodePlanLabel(plan)}
+                      description={getOpenCodePlanDescription(plan)}
+                      className="bitfun-ai-model-config__opencode-plan"
+                      align="center"
+                    >
+                      <div className="bitfun-ai-model-config__cli-actions bitfun-ai-model-config__opencode-plan-actions">
+                        {offerings.map((offering) => {
+                          const formatLabel = getOpenCodeFormatLabel(offering.format);
+                          const label = offering.models.length > 0
+                            ? t('subscriptionAuth.useFormatWithCount', {
+                                format: formatLabel,
+                                modelCount: i18nService.formatNumber(offering.models.length),
+                              })
+                            : t('subscriptionAuth.useFormat', { format: formatLabel });
+                          return (
+                            <Button
+                              key={`${offering.plan}:${offering.format}`}
+                              size="small"
+                              variant="secondary"
+                              disabled={anyLoginInProgress}
+                              onClick={() => handleImportFromSubscription(account, offering)}
+                            >
+                              {label}
+                            </Button>
+                          );
+                        })}
+                      </div>
+                    </ConfigPageRow>
+                  ))}
 
                   {loginPanel && (
                     <div

--- a/src/web-ui/src/infrastructure/config/types/index.ts
+++ b/src/web-ui/src/infrastructure/config/types/index.ts
@@ -289,10 +289,18 @@ export interface AIModelConfig {
 /** Subscription provider for in-app OAuth auth. */
 export type SubscriptionProvider = 'codex' | 'antigravity' | 'opencode';
 
+/** OpenCode billing/API product. Both plans reuse the same signed-in account. */
+export type OpenCodePlan = 'zen' | 'go';
+
 /** Authentication source persisted on each model entry. */
 export type AuthConfig =
   | { type: 'api_key' }
-  | { type: 'subscription'; provider: SubscriptionProvider };
+  | {
+      type: 'subscription';
+      provider: SubscriptionProvider;
+      /** Absent on legacy OpenCode configs, which continue to use Zen. */
+      plan?: OpenCodePlan;
+    };
 
 export interface ProxyConfig {
   enabled: boolean;

--- a/src/web-ui/src/locales/en-US/settings/ai-model.json
+++ b/src/web-ui/src/locales/en-US/settings/ai-model.json
@@ -46,7 +46,7 @@
   },
   "subscriptionAuth": {
     "sectionTitle": "Subscription accounts",
-    "sectionDescription": "Sign in to Codex, Antigravity, or OpenCode subscriptions and use them as model APIs",
+    "sectionDescription": "Sign in once to an OpenCode account and use either its Zen or Go API plan, alongside Codex and Antigravity",
     "rescan": "Refresh status",
     "import": "Use as model",
     "login": "Sign in",
@@ -71,8 +71,26 @@
       "apiKey": "API Key",
       "codex": "Codex (ChatGPT subscription)",
       "antigravity": "Antigravity (Google subscription)",
-      "opencode": "OpenCode Zen subscription"
+      "opencodeZen": "OpenCode account · Zen API",
+      "opencodeGo": "OpenCode account · Go API"
     },
+    "openCodePlans": {
+      "zen": {
+        "label": "OpenCode Zen",
+        "description": "Pay-as-you-go and free Zen models available to this OpenCode account"
+      },
+      "go": {
+        "label": "OpenCode Go",
+        "description": "Models billed against the Go subscription on this OpenCode account"
+      }
+    },
+    "openCodeFormats": {
+      "chatCompletions": "Chat Completions",
+      "responses": "Responses",
+      "messages": "Messages"
+    },
+    "useFormat": "Use {{format}}",
+    "useFormatWithCount": "Use {{format}} ({{modelCount}})",
     "detected": "Will use {{label}} ({{account}})",
     "notConnected": "{{kind}} is not signed in; sign in above first",
     "unknownAccount": "current account",

--- a/src/web-ui/src/locales/zh-CN/settings/ai-model.json
+++ b/src/web-ui/src/locales/zh-CN/settings/ai-model.json
@@ -46,7 +46,7 @@
   },
   "subscriptionAuth": {
     "sectionTitle": "订阅账号",
-    "sectionDescription": "登录 Codex / Antigravity / OpenCode 订阅后，可直接作为模型 API 使用",
+    "sectionDescription": "OpenCode 账号只需登录一次，即可分别使用 Zen 或 Go API 套餐；同时支持 Codex 与 Antigravity",
     "rescan": "刷新状态",
     "import": "导入使用",
     "login": "登录",
@@ -71,8 +71,26 @@
       "apiKey": "API Key",
       "codex": "Codex（ChatGPT 订阅）",
       "antigravity": "Antigravity（Google 订阅）",
-      "opencode": "OpenCode Zen 订阅"
+      "opencodeZen": "OpenCode 账号 · Zen API",
+      "opencodeGo": "OpenCode 账号 · Go API"
     },
+    "openCodePlans": {
+      "zen": {
+        "label": "OpenCode Zen",
+        "description": "使用该 OpenCode 账号可用的 Zen 按量计费与免费模型"
+      },
+      "go": {
+        "label": "OpenCode Go",
+        "description": "使用该 OpenCode 账号的 Go 订阅额度请求模型"
+      }
+    },
+    "openCodeFormats": {
+      "chatCompletions": "Chat Completions",
+      "responses": "Responses",
+      "messages": "Messages"
+    },
+    "useFormat": "使用 {{format}}",
+    "useFormatWithCount": "使用 {{format}}（{{modelCount}} 个模型）",
     "detected": "将使用 {{label}}（账号 {{account}}）",
     "notConnected": "尚未登录 {{kind}}，请先在上方完成登录",
     "unknownAccount": "当前登录账号",

--- a/src/web-ui/src/locales/zh-TW/settings/ai-model.json
+++ b/src/web-ui/src/locales/zh-TW/settings/ai-model.json
@@ -46,7 +46,7 @@
   },
   "subscriptionAuth": {
     "sectionTitle": "訂閱賬號",
-    "sectionDescription": "登入 Codex / Antigravity / OpenCode 訂閱後，可直接作為模型 API 使用",
+    "sectionDescription": "OpenCode 帳號只需登入一次，即可分別使用 Zen 或 Go API 方案；同時支援 Codex 與 Antigravity",
     "rescan": "重新整理狀態",
     "import": "匯入使用",
     "login": "登入",
@@ -71,8 +71,26 @@
       "apiKey": "API Key",
       "codex": "Codex（ChatGPT 訂閱）",
       "antigravity": "Antigravity（Google 訂閱）",
-      "opencode": "OpenCode Zen 訂閱"
+      "opencodeZen": "OpenCode 帳號 · Zen API",
+      "opencodeGo": "OpenCode 帳號 · Go API"
     },
+    "openCodePlans": {
+      "zen": {
+        "label": "OpenCode Zen",
+        "description": "使用此 OpenCode 帳號可用的 Zen 按量計費與免費模型"
+      },
+      "go": {
+        "label": "OpenCode Go",
+        "description": "使用此 OpenCode 帳號的 Go 訂閱額度請求模型"
+      }
+    },
+    "openCodeFormats": {
+      "chatCompletions": "Chat Completions",
+      "responses": "Responses",
+      "messages": "Messages"
+    },
+    "useFormat": "使用 {{format}}",
+    "useFormatWithCount": "使用 {{format}}（{{modelCount}} 個模型）",
     "detected": "將使用 {{label}}（賬號 {{account}}）",
     "notConnected": "尚未登入 {{kind}}，請先在上方完成登入",
     "unknownAccount": "目前登入賬號",


### PR DESCRIPTION
## Summary

- treat OpenCode OAuth as one account identity shared by Zen and Go
- discover the authenticated OpenCode provider catalog and group models by plan and wire protocol
- route Zen and Go requests to their exact trusted Chat Completions, Responses, or Anthropic Messages endpoints
- expose plan-aware import and auth choices in the Web UI with en-US, zh-CN, and zh-TW copy
- preserve legacy OpenCode configs without a plan as Zen Chat Completions

## Type and Areas

Type:

Feature / UI/UX

Areas:

AI adapters, Rust core configuration, web UI, i18n

## Motivation / Impact

Previously BitFun labeled the OpenCode account flow as Zen and always resolved it to the Zen Chat Completions endpoint. OpenCode Go subscribers could authenticate but could not configure Go models correctly, and models using Responses or Anthropic Messages could be paired with the wrong protocol.

After this change, one OpenCode login exposes both Zen and Go. BitFun uses the account catalog to offer only model/protocol groups it can reproduce, while OpenCode remains responsible for plan entitlement and quota enforcement.

## Verification

- `cargo test -p bitfun-ai-adapters`
- `cargo test -p bitfun-ai-adapters --features subscription-auth subscription_auth`
- `cargo test -p bitfun-core --no-default-features --features ai-adapter-runtime --lib subscription_auth_preserves_legacy_opencode_and_roundtrips_go_plan`
- `pnpm run type-check:web`
- focused ESLint for the changed TypeScript/TSX files
- `pnpm run i18n:audit`
- `pnpm run theme:color-audit:all`
- `git diff --check`

All passed.

## Reviewer Notes

- Plan-aware resolution ignores configured URLs and forces official OpenCode namespaces so OAuth credentials cannot be redirected to an arbitrary host.
- A missing remote catalog, including the official 404 no-override case, retains safe fallback offerings and previously stored metadata.
- Google-native Zen models are omitted because the current BitFun Gemini adapter cannot faithfully reproduce the model-specific OpenCode gateway shape. Chat Completions, Responses, and Anthropic Messages offerings are supported.
- No live paid-account OAuth or quota request was performed locally.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.