### PR TITLE
feat(nav): add a dismissible GitHub star invite to the nav footer

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/NavPanel.scss
+++ b/src/web-ui/src/app/components/NavPanel/NavPanel.scss
@@ -1607,6 +1607,104 @@ $_section-header-height: 24px;
 }
 
 // ──────────────────────────────────────────────
+// GitHub star invite — retires itself after one click
+// ──────────────────────────────────────────────
+
+.bitfun-nav-panel__footer-star {
+  display: flex;
+  align-items: center;
+  height: 28px;
+  padding-right: 2px;
+  border: 1px solid var(--bf-appearance-token-border-subtle);
+  border-radius: $size-radius-sm;
+  flex-shrink: 1;
+  min-width: 0;
+  overflow: hidden;
+  transition: border-color $motion-fast $easing-standard,
+              background $motion-fast $easing-standard;
+
+  &:hover,
+  &:focus-within {
+    border-color: var(--bf-appearance-token-color-warning-border);
+    background: var(--bf-appearance-token-color-warning-bg);
+  }
+}
+
+.bitfun-nav-panel__footer-star-btn {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  height: 100%;
+  min-width: 0;
+  padding: 0 4px 0 $size-gap-1;
+  border: none;
+  background: transparent;
+  color: var(--bf-appearance-token-color-text-muted);
+  font-size: var(--bf-appearance-token-font-size-xs);
+  line-height: 1;
+  cursor: pointer;
+  transition: color $motion-fast $easing-standard;
+
+  .bitfun-nav-panel__footer-btn-icon-swap {
+    width: 14px;
+    height: 14px;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--bf-appearance-token-color-accent-500);
+    outline-offset: -2px;
+  }
+}
+
+.bitfun-nav-panel__footer-star:hover .bitfun-nav-panel__footer-star-btn,
+.bitfun-nav-panel__footer-star-btn:focus-visible {
+  color: var(--bf-appearance-token-color-warning);
+}
+
+.bitfun-nav-panel__footer-star-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+// Dismiss keeps its slot reserved so revealing it never shifts the footer row.
+.bitfun-nav-panel__footer-star-dismiss {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  padding: 0;
+  border: none;
+  border-radius: $size-radius-sm;
+  background: transparent;
+  color: var(--bf-appearance-token-color-text-muted);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity $motion-fast $easing-standard,
+              color $motion-fast $easing-standard,
+              background $motion-fast $easing-standard;
+
+  &:hover {
+    color: var(--bf-appearance-token-color-text-primary);
+    background: var(--bf-appearance-token-element-bg-soft);
+  }
+
+  &:focus-visible {
+    opacity: 1;
+    outline: 2px solid var(--bf-appearance-token-color-accent-500);
+    outline-offset: -1px;
+  }
+}
+
+.bitfun-nav-panel__footer-star:hover .bitfun-nav-panel__footer-star-dismiss,
+.bitfun-nav-panel__footer-star:focus-within .bitfun-nav-panel__footer-star-dismiss {
+  opacity: 1;
+}
+
+// ──────────────────────────────────────────────
 // More-options popup menu
 // ──────────────────────────────────────────────
 
@@ -2438,6 +2536,14 @@ $_section-header-height: 24px;
 .bitfun-nav-panel__footer-btn--icon:active,
 .bitfun-nav-panel__footer .bitfun-notification-btn:active {
   transform: scale(0.94);
+}
+
+.bitfun-nav-panel__footer-star:active {
+  transform: scale(0.96);
+  transition:
+    transform 120ms cubic-bezier(0.23, 1, 0.32, 1),
+    border-color 120ms ease,
+    background 120ms ease;
 }
 
 .bitfun-nav-panel__workspace-menu,

--- a/src/web-ui/src/app/components/NavPanel/components/GithubStarButton.test.tsx
+++ b/src/web-ui/src/app/components/NavPanel/components/GithubStarButton.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const openExternal = vi.hoisted(() => vi.fn());
+
+vi.mock('@/infrastructure/i18n/hooks/useI18n', async () => {
+  const { createTestI18nT } = await import('@/test/i18nTestUtils');
+  return { useI18n: () => ({ t: createTestI18nT('common') }) };
+});
+
+vi.mock('@/component-library', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/infrastructure/api/service-api/SystemAPI', () => ({
+  systemAPI: { openExternal },
+}));
+
+import GithubStarButton from './GithubStarButton';
+import { GITHUB_STAR_CTA_DISMISSED_KEY, GITHUB_STAR_URL } from './githubStarCtaStorage';
+
+let container: HTMLDivElement;
+let root: Root;
+/** This jsdom environment ships no localStorage, so back the storage module with a stub. */
+let store: Map<string, string>;
+
+function render(): void {
+  act(() => {
+    root.render(<GithubStarButton />);
+  });
+}
+
+function click(testId: string): void {
+  const button = container.querySelector<HTMLButtonElement>(`[data-testid="${testId}"]`);
+  expect(button).not.toBeNull();
+  act(() => {
+    button!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+}
+
+const starButton = () => container.querySelector('[data-testid="nav-footer-github-star-btn"]');
+
+describe('GithubStarButton', () => {
+  beforeEach(() => {
+    openExternal.mockReset().mockResolvedValue(undefined);
+    store = new Map();
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => void store.set(key, value),
+    });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders the localized star label until it is retired', () => {
+    render();
+
+    expect(starButton()).not.toBeNull();
+    expect(container.textContent).toContain('Star');
+  });
+
+  it('opens the repository in the system browser and retires itself', () => {
+    render();
+    click('nav-footer-github-star-btn');
+
+    expect(openExternal).toHaveBeenCalledWith(GITHUB_STAR_URL);
+    expect(starButton()).toBeNull();
+    expect(store.get(GITHUB_STAR_CTA_DISMISSED_KEY)).toBe('true');
+  });
+
+  it('retires itself on dismiss without opening the repository', () => {
+    render();
+    click('nav-footer-github-star-dismiss');
+
+    expect(openExternal).not.toHaveBeenCalled();
+    expect(starButton()).toBeNull();
+    expect(store.get(GITHUB_STAR_CTA_DISMISSED_KEY)).toBe('true');
+  });
+
+  it('stays retired on later mounts', () => {
+    store.set(GITHUB_STAR_CTA_DISMISSED_KEY, 'true');
+    render();
+
+    expect(starButton()).toBeNull();
+  });
+});

--- a/src/web-ui/src/app/components/NavPanel/components/GithubStarButton.tsx
+++ b/src/web-ui/src/app/components/NavPanel/components/GithubStarButton.tsx
@@ -1,0 +1,73 @@
+import React, { useCallback, useState } from 'react';
+import { Star, X } from 'lucide-react';
+import { Tooltip } from '@/component-library';
+import { useI18n } from '@/infrastructure/i18n/hooks/useI18n';
+import { systemAPI } from '@/infrastructure/api/service-api/SystemAPI';
+import { createLogger } from '@/shared/utils/logger';
+import {
+  GITHUB_STAR_URL,
+  isGithubStarCtaDismissed,
+  setGithubStarCtaDismissed,
+} from './githubStarCtaStorage';
+
+const log = createLogger('GithubStarButton');
+
+/**
+ * One-shot invitation to star the repo on GitHub. Both starring and the inline
+ * dismiss retire the button for good, so it never becomes a standing nag.
+ */
+const GithubStarButton: React.FC = () => {
+  const { t } = useI18n('common');
+  const [retired, setRetired] = useState(() => isGithubStarCtaDismissed());
+
+  const retire = useCallback(() => {
+    setGithubStarCtaDismissed();
+    setRetired(true);
+  }, []);
+
+  const handleStar = useCallback(() => {
+    systemAPI.openExternal(GITHUB_STAR_URL).catch((error) => {
+      log.error('Failed to open the GitHub repository', { url: GITHUB_STAR_URL, error });
+    });
+    retire();
+  }, [retire]);
+
+  if (retired) return null;
+
+  return (
+    <div className="bitfun-nav-panel__footer-star">
+      <Tooltip content={t('nav.githubStar.tooltip')} placement="top">
+        <button
+          type="button"
+          className="bitfun-nav-panel__footer-star-btn"
+          onClick={handleStar}
+          data-testid="nav-footer-github-star-btn"
+          data-bf-component="nav-panel"
+          data-bf-part="footerButton"
+        >
+          <span className="bitfun-nav-panel__footer-btn-icon-swap" aria-hidden="true">
+            <Star size={14} className="bitfun-nav-panel__footer-btn-icon-swap-default" />
+            <Star size={14} fill="currentColor" className="bitfun-nav-panel__footer-btn-icon-swap-hover" />
+          </span>
+          <span className="bitfun-nav-panel__footer-star-label">{t('nav.githubStar.label')}</span>
+        </button>
+      </Tooltip>
+
+      <Tooltip content={t('nav.githubStar.dismiss')} placement="top">
+        <button
+          type="button"
+          className="bitfun-nav-panel__footer-star-dismiss"
+          aria-label={t('nav.githubStar.dismiss')}
+          onClick={retire}
+          data-testid="nav-footer-github-star-dismiss"
+          data-bf-component="nav-panel"
+          data-bf-part="footerButton"
+        >
+          <X size={11} aria-hidden="true" />
+        </button>
+      </Tooltip>
+    </div>
+  );
+};
+
+export default GithubStarButton;

--- a/src/web-ui/src/app/components/NavPanel/components/PersistentFooterActions.tsx
+++ b/src/web-ui/src/app/components/NavPanel/components/PersistentFooterActions.tsx
@@ -24,6 +24,7 @@ import { useNotification } from '@/shared/notification-system';
 import { useAccountLoginState } from '@/infrastructure/account/useAccountLoginState';
 import { remoteConnectAPI } from '@/infrastructure/api/service-api/RemoteConnectAPI';
 import NotificationButton from '../../TitleBar/NotificationButton';
+import GithubStarButton from './GithubStarButton';
 import {
   RemoteConnectDisclaimerContent,
 } from '../../RemoteConnectDialog/RemoteConnectDisclaimer';
@@ -350,6 +351,7 @@ const PersistentFooterActions: React.FC = () => {
         </div>
 
         <div className="bitfun-nav-panel__footer-right">
+          <GithubStarButton />
           <NotificationButton className="bitfun-nav-panel__footer-btn" navFooterHoverIconSwap />
         </div>
       </div>

--- a/src/web-ui/src/app/components/NavPanel/components/githubStarCtaStorage.ts
+++ b/src/web-ui/src/app/components/NavPanel/components/githubStarCtaStorage.ts
@@ -1,0 +1,20 @@
+export const GITHUB_STAR_CTA_DISMISSED_KEY = 'bitfun:nav:github-star-cta:dismissed:v1';
+
+/** GitHub renders the Star control on the repository page itself — no dedicated star route exists. */
+export const GITHUB_STAR_URL = 'https://github.com/GCWing/BitFun';
+
+export const isGithubStarCtaDismissed = (): boolean => {
+  try {
+    return localStorage.getItem(GITHUB_STAR_CTA_DISMISSED_KEY) === 'true';
+  } catch {
+    return false;
+  }
+};
+
+export const setGithubStarCtaDismissed = (): void => {
+  try {
+    localStorage.setItem(GITHUB_STAR_CTA_DISMISSED_KEY, 'true');
+  } catch {
+    // Ignore storage failures — the button still stays hidden for this session.
+  }
+};

--- a/src/web-ui/src/locales/en-US/common.json
+++ b/src/web-ui/src/locales/en-US/common.json
@@ -108,6 +108,11 @@
       "sessionSearchHintDefault": "Type a keyword to search sessions in open workspaces",
       "sessionWorkspaceHint": "in {{workspace}}"
     },
+    "githubStar": {
+      "label": "Star",
+      "tooltip": "Star BitFun on GitHub",
+      "dismiss": "Don't show again"
+    },
     "displayModes": {
       "pro": "Expert Mode",
       "assistant": "Assistant Mode",

--- a/src/web-ui/src/locales/zh-CN/common.json
+++ b/src/web-ui/src/locales/zh-CN/common.json
@@ -108,6 +108,11 @@
       "sessionSearchHintDefault": "输入关键词，搜索已打开工作区内的会话",
       "sessionWorkspaceHint": "位于 {{workspace}}"
     },
+    "githubStar": {
+      "label": "Star",
+      "tooltip": "在 GitHub 上给 BitFun 点个 Star",
+      "dismiss": "不再显示"
+    },
     "displayModes": {
       "pro": "专业模式",
       "assistant": "助理模式",

--- a/src/web-ui/src/locales/zh-TW/common.json
+++ b/src/web-ui/src/locales/zh-TW/common.json
@@ -108,6 +108,11 @@
       "sessionSearchHintDefault": "輸入關鍵詞，搜尋已開啟工作區內的會話",
       "sessionWorkspaceHint": "位於 {{workspace}}"
     },
+    "githubStar": {
+      "label": "Star",
+      "tooltip": "在 GitHub 上為 BitFun 點個 Star",
+      "dismiss": "不再顯示"
+    },
     "displayModes": {
       "pro": "專業模式",
       "assistant": "助理模式",


### PR DESCRIPTION
## Summary

Adds a small **Star** pill to the nav footer's empty gap — between the browser entry and the notification bell — that opens `https://github.com/GCWing/BitFun` in the system browser and then retires itself permanently.

It also carries an inline dismiss (`×`, revealed on hover) so users who don't want to star the repo can retire it too. A call-to-action that only disappears once you comply is a standing nag; the dismiss slot is width-reserved, so revealing it never shifts the footer row.

<!-- screenshot: before / after-resting / after-hover — attached below -->

## Type and Areas

Type: Feature (UI/UX)

Areas: Web UI (`src/web-ui` — NavPanel footer), locales

## Motivation / Impact

The nav footer had unused space between the left icon cluster and the notification bell. This puts a low-friction, one-shot ask for a GitHub star there.

User-facing: a new footer button appears once per install. Clicking it opens the repo page (GitHub has no direct "star this" URL — the Star control lives on the repository page). Clicking either the button or its dismiss retires it for good; it never comes back.

## Verification

Ran from `src/web-ui`:

- `vitest run src/app/components/NavPanel/` → **12 files, 62 tests passed**, including 4 new cases in `GithubStarButton.test.tsx`: renders the localized label; click opens the repo URL and unmounts; dismiss unmounts *without* opening the URL; stays retired on later mounts.
- `eslint src/app/components/NavPanel/` → clean
- `tsc --noEmit` → no errors from the changed files. (One pre-existing error remains, `Cannot find module '@/generated/api'` — the ts-rs bindings aren't built in this worktree; unrelated to this change.)

Ran from the repo root:

- `node scripts/audit-appearance-contracts.mjs` → passed, new file not in the warning list
- `node scripts/audit-theme-colors.mjs` → passed (exit 0); all colors go through `--bf-appearance-token-*`
- `node scripts/i18n-audit.mjs` → **passed with 0 warnings**; `nav.githubStar.*` added to zh-CN / zh-TW / en-US

Visual: rendered the compiled `NavPanel.scss` against the real `bitfun-dark` token values, and confirmed placement in the running dev app. Measured in the live app — pill is 28px tall (matching the neighbouring icon buttons) and lands at x 153.5–206, exactly the gap before the bell at 206. Resting and hover widths are identical (66.18px, same right edge), confirming the dismiss reveal causes no layout shift.

## Reviewer Notes

- **Footer idiom.** Reuses the footer's existing `footer-btn-icon-swap` pattern: outline star at rest, filled amber star on hover, with the pill picking up `color-warning-border` / `color-warning-bg`.
- **Persistence.** `localStorage`, behind the same guarded accessor pattern as `remoteConnectDisclaimerStorage.ts`. This matters — the webview does not always expose `localStorage` (the vitest jsdom env doesn't either), and the guards degrade safely instead of throwing.
- **Appearance contract.** The two buttons declare `data-bf-part="footerButton"`, which already exists in the NavPanel descriptor, so no descriptor change was needed. The wrapper `<div>` is pure layout and deliberately carries no contract.
- **Typography.** The label uses `font-size-xs` rather than `font-size-xxs`. Worth flagging: the nav font scope resolves `xxs` to `max(8px, flowchat-xs - 3px)` = **9px**, which is too small to read as a call to action. There are 5 pre-existing `xxs` usages in `NavPanel.scss` — not touched here, but they may deserve a look.
- AI-assisted (Claude Code). Testing level: **fully tested** for the component's behaviour and the repo's governance audits; the end-to-end "opens the system browser" hop goes through `systemAPI.openExternal`, which is mocked in tests and was not exercised against a real desktop build.
