### PR TITLE
fix(ci): eliminate CLI and WebSocket test flakes

### DIFF
--- a/src/apps/cli/tests/terminal_process_contracts.rs
+++ b/src/apps/cli/tests/terminal_process_contracts.rs
@@ -275,6 +275,7 @@ fn external_editor_restores_the_tui_and_applies_the_edited_draft() {
         Duration::from_secs(30),
         "initial turn did not finish before /editor",
     );
+    process.expect_idle_after_turn(1, Duration::from_secs(30));
 
     process.write(b"/editor");
     process.expect_output(
@@ -288,8 +289,9 @@ fn external_editor_restores_the_tui_and_applies_the_edited_draft() {
         Duration::from_secs(30),
         "edited draft was not rendered after the editor closed",
     );
+    // Ratatui can emit each unchanged-separated word at a different cursor position.
     process.expect_output(
-        "Draft updated from external editor",
+        "updated",
         Duration::from_secs(15),
         "editor completion status was not rendered",
     );
@@ -326,7 +328,7 @@ fn export_dialog_writes_markdown_under_the_local_cli_directory() {
     process.expect_output("\x1b[?2004h", Duration::from_secs(30), "TUI did not start");
     process.write(b"export transcript contract");
     process.expect_output(
-        "transcript contract",
+        "script contract",
         Duration::from_secs(15),
         "startup prompt was not rendered",
     );
@@ -336,6 +338,7 @@ fn export_dialog_writes_markdown_under_the_local_cli_directory() {
         Duration::from_secs(30),
         "initial turn did not finish before /export",
     );
+    process.expect_idle_after_turn(1, Duration::from_secs(30));
 
     process.write(b"/export");
     process.expect_output(
@@ -344,8 +347,9 @@ fn export_dialog_writes_markdown_under_the_local_cli_directory() {
         "export command was not rendered",
     );
     process.write(b"\r");
+    // The title can be split by Ratatui's cursor movement; the file row is contiguous.
     process.expect_output(
-        "Export session",
+        "File: session-",
         Duration::from_secs(15),
         "export dialog did not open",
     );
@@ -695,6 +699,24 @@ impl PtyProcess {
         let output = self.output();
         self.terminate();
         panic!("{context}; output:\n{output}");
+    }
+
+    /// Waits for the status bar to fall back to its idle summary.
+    ///
+    /// `STREAM_COMPLETED_MARKER` is assistant text, so it lands in the transcript while
+    /// `is_processing` is still set. Commands declared `ActionAvailability::Idle` — `/export`
+    /// and `/editor` among them — are refused with a status message rather than opened during
+    /// that window, so gating on the marker alone races the end of the turn. The status bar
+    /// paints the "Thinking..." spinner for as long as `is_processing` holds and only renders
+    /// `Messages: … | Tool calls: …` once it clears, which makes that summary the first point
+    /// where those commands are actually accepted. Match only the idle-only prefix because
+    /// Ratatui can insert cursor movement between unchanged spans later in the status line.
+    fn expect_idle_after_turn(&mut self, messages: usize, timeout: Duration) {
+        self.expect_output(
+            &format!("Messages: {messages}"),
+            timeout,
+            "turn did not return to idle",
+        );
     }
 
     fn resize(&self, size: PtySize) {

--- a/src/web-ui/src/infrastructure/api/adapters/websocket-adapter.test.ts
+++ b/src/web-ui/src/infrastructure/api/adapters/websocket-adapter.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   AGENT_COMMAND_SCHEMA,
   decodeWsNotification,
   decodeResponseBody,
   encodeRequestBody,
   resolveWsMethod,
+  WebSocketTransportAdapter,
 } from './websocket-adapter';
 import type {
   SubmitDialogTurnBody,
@@ -330,5 +331,63 @@ describe('decodeResponseBody', () => {
     const result = { foo: 'bar' };
     expect(decodeResponseBody('some_unknown_action', result)).toBe(result);
     expect(decodeResponseBody('get_config', result)).toBe(result);
+  });
+});
+
+describe('WebSocketTransportAdapter reconnect lifecycle', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('cancels a scheduled reconnect when explicitly disconnected', async () => {
+    vi.useFakeTimers();
+
+    const sockets: MockWebSocket[] = [];
+    class MockWebSocket {
+      static readonly OPEN = 1;
+
+      readyState = 0;
+      onopen: ((event: Event) => void) | null = null;
+      onerror: ((event: Event) => void) | null = null;
+      onclose: ((event: CloseEvent) => void) | null = null;
+      onmessage: ((event: MessageEvent) => void) | null = null;
+
+      constructor(readonly url: string) {
+        sockets.push(this);
+      }
+
+      open(): void {
+        this.readyState = MockWebSocket.OPEN;
+        this.onopen?.({} as Event);
+      }
+
+      closeFromServer(): void {
+        this.readyState = 3;
+        this.onclose?.({} as CloseEvent);
+      }
+
+      close(): void {
+        this.readyState = 3;
+        this.onclose?.({} as CloseEvent);
+      }
+
+      send(): void {}
+    }
+
+    vi.stubGlobal('WebSocket', MockWebSocket);
+    const adapter = new WebSocketTransportAdapter('ws://example.test/ws');
+    const connection = adapter.connect();
+
+    sockets[0].open();
+    await connection;
+    sockets[0].closeFromServer();
+    expect(vi.getTimerCount()).toBe(1);
+
+    await adapter.disconnect();
+    expect(vi.getTimerCount()).toBe(0);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(sockets).toHaveLength(1);
   });
 });

--- a/src/web-ui/src/infrastructure/api/adapters/websocket-adapter.ts
+++ b/src/web-ui/src/infrastructure/api/adapters/websocket-adapter.ts
@@ -387,6 +387,9 @@ export class WebSocketTransportAdapter implements ITransportAdapter {
   private reconnectAttempts = 0;
   private maxReconnectAttempts = 5;
   private reconnectDelay = 1000;
+  // Held so `disconnect()` can cancel a reconnect that is already scheduled; without it a
+  // pending timer reopens the socket after an explicit teardown.
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   
   constructor(url?: string) {
     
@@ -450,14 +453,23 @@ export class WebSocketTransportAdapter implements ITransportAdapter {
     return this.connectPromise;
   }
 
+  private clearReconnectTimer(): void {
+    if (this.reconnectTimer !== null) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+
   private handleDisconnect(): void {
     if (this.reconnectAttempts < this.maxReconnectAttempts) {
       this.reconnectAttempts++;
       const delay = this.reconnectDelay * this.reconnectAttempts;
       
       log.info('Reconnecting', { delay, attempt: this.reconnectAttempts, maxAttempts: this.maxReconnectAttempts });
-      
-      setTimeout(() => {
+
+      this.clearReconnectTimer();
+      this.reconnectTimer = setTimeout(() => {
+        this.reconnectTimer = null;
         this.connect().catch(error => {
           log.error('Reconnection failed', error);
         });
@@ -631,7 +643,11 @@ export class WebSocketTransportAdapter implements ITransportAdapter {
   
    
   async disconnect(): Promise<void> {
-    
+
+    // Before anything else, so a reconnect that is already queued cannot fire after teardown
+    // and reopen the socket we are about to close.
+    this.clearReconnectTimer();
+
     this.pendingRequests.forEach((pending) => {
       clearTimeout(pending.timeout);
       pending.reject(new Error('WebSocket manually disconnected'));


### PR DESCRIPTION
## Summary

- wait for the TUI to return to its idle status before invoking idle-only `/editor` and `/export` actions
- use PTY-stable render markers so Ratatui cursor-diff output cannot split assertions
- retain and cancel scheduled WebSocket reconnect timers during explicit teardown
- cover reconnect cancellation with fake-timer regression coverage

## Verification

- `cargo test -p bitfun-cli --test terminal_process_contracts -- --nocapture` (8 passed)
- `pnpm run type-check:web`
- `pnpm --dir src/web-ui run test:run` (414 files, 2822 tests passed)
- `pnpm run fmt:rs`
- `git diff --check`

AI-assisted: yes. Testing level: fully tested.