### PR TITLE
fix(web-ui): remove GitHub Star dismiss button

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/NavPanel.scss
+++ b/src/web-ui/src/app/components/NavPanel/NavPanel.scss
@@ -1739,7 +1739,6 @@ $_section-header-height: 24px;
   display: flex;
   align-items: center;
   height: 28px;
-  padding-right: 2px;
   border: 1px solid var(--bf-appearance-token-border-subtle);
   border-radius: $size-radius-sm;
   flex-shrink: 1;
@@ -1791,42 +1790,6 @@ $_section-header-height: 24px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-// Dismiss keeps its slot reserved so revealing it never shifts the footer row.
-.bitfun-nav-panel__footer-star-dismiss {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 16px;
-  height: 16px;
-  flex-shrink: 0;
-  padding: 0;
-  border: none;
-  border-radius: $size-radius-sm;
-  background: transparent;
-  color: var(--bf-appearance-token-color-text-muted);
-  cursor: pointer;
-  opacity: 0;
-  transition: opacity $motion-fast $easing-standard,
-              color $motion-fast $easing-standard,
-              background $motion-fast $easing-standard;
-
-  &:hover {
-    color: var(--bf-appearance-token-color-text-primary);
-    background: var(--bf-appearance-token-element-bg-soft);
-  }
-
-  &:focus-visible {
-    opacity: 1;
-    outline: 2px solid var(--bf-appearance-token-color-accent-500);
-    outline-offset: -1px;
-  }
-}
-
-.bitfun-nav-panel__footer-star:hover .bitfun-nav-panel__footer-star-dismiss,
-.bitfun-nav-panel__footer-star:focus-within .bitfun-nav-panel__footer-star-dismiss {
-  opacity: 1;
 }
 
 // ──────────────────────────────────────────────

--- a/src/web-ui/src/app/components/NavPanel/components/GithubStarButton.test.tsx
+++ b/src/web-ui/src/app/components/NavPanel/components/GithubStarButton.test.tsx
@@ -68,6 +68,7 @@ describe('GithubStarButton', () => {
 
     expect(starButton()).not.toBeNull();
     expect(container.textContent).toContain('Star');
+    expect(container.querySelector('[data-testid="nav-footer-github-star-dismiss"]')).toBeNull();
   });
 
   it('opens the repository in the system browser and retires itself', () => {
@@ -75,15 +76,6 @@ describe('GithubStarButton', () => {
     click('nav-footer-github-star-btn');
 
     expect(openExternal).toHaveBeenCalledWith(GITHUB_STAR_URL);
-    expect(starButton()).toBeNull();
-    expect(store.get(GITHUB_STAR_CTA_DISMISSED_KEY)).toBe('true');
-  });
-
-  it('retires itself on dismiss without opening the repository', () => {
-    render();
-    click('nav-footer-github-star-dismiss');
-
-    expect(openExternal).not.toHaveBeenCalled();
     expect(starButton()).toBeNull();
     expect(store.get(GITHUB_STAR_CTA_DISMISSED_KEY)).toBe('true');
   });

--- a/src/web-ui/src/app/components/NavPanel/components/GithubStarButton.tsx
+++ b/src/web-ui/src/app/components/NavPanel/components/GithubStarButton.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from 'react';
-import { Star, X } from 'lucide-react';
+import { Star } from 'lucide-react';
 import { Tooltip } from '@/component-library';
 import { useI18n } from '@/infrastructure/i18n/hooks/useI18n';
 import { systemAPI } from '@/infrastructure/api/service-api/SystemAPI';
@@ -13,8 +13,8 @@ import {
 const log = createLogger('GithubStarButton');
 
 /**
- * One-shot invitation to star the repo on GitHub. Both starring and the inline
- * dismiss retire the button for good, so it never becomes a standing nag.
+ * One-shot invitation to star the repo on GitHub. Clicking it retires the
+ * button for good, so it never becomes a standing nag.
  */
 const GithubStarButton: React.FC = () => {
   const { t } = useI18n('common');
@@ -50,20 +50,6 @@ const GithubStarButton: React.FC = () => {
             <Star size={14} fill="currentColor" className="bitfun-nav-panel__footer-btn-icon-swap-hover" />
           </span>
           <span className="bitfun-nav-panel__footer-star-label">{t('nav.githubStar.label')}</span>
-        </button>
-      </Tooltip>
-
-      <Tooltip content={t('nav.githubStar.dismiss')} placement="top">
-        <button
-          type="button"
-          className="bitfun-nav-panel__footer-star-dismiss"
-          aria-label={t('nav.githubStar.dismiss')}
-          onClick={retire}
-          data-testid="nav-footer-github-star-dismiss"
-          data-bf-component="nav-panel"
-          data-bf-part="footerButton"
-        >
-          <X size={11} aria-hidden="true" />
         </button>
       </Tooltip>
     </div>

--- a/src/web-ui/src/locales/en-US/common.json
+++ b/src/web-ui/src/locales/en-US/common.json
@@ -110,8 +110,7 @@
     },
     "githubStar": {
       "label": "Star",
-      "tooltip": "Star BitFun on GitHub",
-      "dismiss": "Don't show again"
+      "tooltip": "Star BitFun on GitHub"
     },
     "displayModes": {
       "pro": "Expert Mode",

--- a/src/web-ui/src/locales/zh-CN/common.json
+++ b/src/web-ui/src/locales/zh-CN/common.json
@@ -110,8 +110,7 @@
     },
     "githubStar": {
       "label": "Star",
-      "tooltip": "在 GitHub 上给 BitFun 点个 Star",
-      "dismiss": "不再显示"
+      "tooltip": "在 GitHub 上给 BitFun 点个 Star"
     },
     "displayModes": {
       "pro": "专业模式",

--- a/src/web-ui/src/locales/zh-TW/common.json
+++ b/src/web-ui/src/locales/zh-TW/common.json
@@ -110,8 +110,7 @@
     },
     "githubStar": {
       "label": "Star",
-      "tooltip": "在 GitHub 上為 BitFun 點個 Star",
-      "dismiss": "不再顯示"
+      "tooltip": "在 GitHub 上為 BitFun 點個 Star"
     },
     "displayModes": {
       "pro": "專業模式",


### PR DESCRIPTION
## Summary

- Remove the inline × dismiss control beside the navigation footer GitHub Star CTA.
- Delete the now-unused dismiss styles and localized copy.
- Keep the existing one-shot behavior: clicking Star opens the repository and permanently retires the CTA.

## Type and Areas

Type: UI/UX / bug fix

Areas: web UI, desktop navigation footer, i18n

## Motivation / Impact

The footer CTA should present one clear Star action without a separate permanent-dismiss affordance beside it. Users can still retire the CTA by clicking Star, preserving the existing one-shot invitation behavior.

## Verification

- `pnpm --dir src/web-ui run test:run src/app/components/NavPanel/components/GithubStarButton.test.tsx` — passed (3 tests).
- `pnpm run i18n:audit` — passed with 0 warnings.
- `git diff --check` — passed.
- `pnpm run type-check:web` — blocked by existing missing exports from `@/generated/api` referenced by `websocket-adapter.ts`; none of the reported errors touch this PR's files.
- Added an explicit DOM assertion that no separate dismiss control renders.

## Reviewer Notes

- No persistence-key migration is included. The existing CTA retirement key and Star-click behavior are unchanged.
- The matching key was cleared once on the developer machine only to enable retesting; that local operation is not part of this commit.
- No screenshot is attached because the automated local-page capture was blocked by the browser's localhost URL policy.
- AI-assisted change; focused component behavior and localization checks completed.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.
