### PR TITLE
docs: tighten promotion claims and onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 ![BitFun](./png/BitFun_title.png)
 
-### An open-source desktop AI agent that turns every task into an app you can open
+### A desktop AI agent that turns every task into an app you can open
 
-Writes code, produces documents, drives the desktop. The Mini Apps, the runtime, and the device-sync server are all yours. MIT.
+Writes code, produces documents, and drives the desktop — with Mini Apps, a Rust runtime, and a self-hostable device-sync server.
 
 [**⬇ Download for macOS · Windows · Linux**](https://github.com/GCWing/BitFun/releases/latest)
 
@@ -15,7 +15,7 @@ Writes code, produces documents, drives the desktop. The Mini Apps, the runtime,
 [![GitHub release](https://img.shields.io/github/v/release/GCWing/BitFun?style=flat-square&color=blue)](https://github.com/GCWing/BitFun/releases)
 [![Downloads](https://img.shields.io/github/downloads/GCWing/BitFun/total?style=flat-square&color=brightgreen)](https://github.com/GCWing/BitFun/releases)
 [![Stars](https://img.shields.io/github/stars/GCWing/BitFun?style=flat-square&color=yellow)](https://github.com/GCWing/BitFun/stargazers)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow?style=flat-square)](https://github.com/GCWing/BitFun/blob/main/LICENSE)
+[![Core code: MIT](https://img.shields.io/badge/core_code-MIT-yellow?style=flat-square)](https://github.com/GCWing/BitFun/blob/main/LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-blue?style=flat-square)](https://github.com/GCWing/BitFun/releases)
 
 [![Trendshift](https://trendshift.io/api/badge/repositories/44672)](https://trendshift.io/repositories/44672)
@@ -40,7 +40,7 @@ Writes code, produces documents, drives the desktop. The Mini Apps, the runtime,
 | **Desktop execution** | Browser, terminal, desktop applications, the filesystem, and remote workspaces |
 | **Four tiers of customization** | Custom Agents → MCP / Skills / Hooks → Mini Apps → source-level changes |
 | **Performance** | 98.67% average KV cache hit rate; flashgrep searches Chromium-scale trees ~36x faster |
-| **Cross-platform and open** | Windows, macOS, and Linux. MIT. Model-agnostic — you choose what it runs on |
+| **Cross-platform and model-agnostic** | Windows, macOS, and Linux. You choose what it runs on |
 
 ---
 
@@ -49,6 +49,8 @@ Writes code, produces documents, drives the desktop. The Mini Apps, the runtime,
 **Agentic Mini Apps.** Most agents push every task through the same chat box. BitFun builds the task its own interface instead — a chart, a board, a form, a panel — and binds a conversation to that interface's live state. You ask about what is on screen rather than re-describing it. Community builds already range from market dashboards to domain-specific tools.
 
 ![Mini Apps gallery](./png/miniapps_gallery.png)
+
+[Browse the public Mini Apps gallery →](https://market.openbitfun.com/miniapp/)
 
 **Self-hosted multi-device control.** Account login, cross-device session and settings sync, and controlling one signed-in device from another all run through a relay *you* deploy. Nothing is brokered by a vendor's cloud — the distinction that decides whether this is allowed inside a company network at all. The relay is zero-knowledge: clients derive keys locally, and the server only ever holds Argon2id hashes and AES-GCM-wrapped material.
 
@@ -72,6 +74,13 @@ pnpm run desktop:dev
 ```
 
 Prerequisites: [Node.js](https://nodejs.org/) 22.12+ (LTS recommended), [pnpm](https://pnpm.io/) 10.15.0 via Corepack, the [Rust toolchain](https://rustup.rs/), and the [Tauri prerequisites](https://v2.tauri.app/start/prerequisites/). More detail in [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+### First run
+
+1. Launch BitFun, click **Open** on the Welcome tab, and choose a project folder.
+2. Open **More options (…) → Settings → Models → Create First Configuration**.
+3. Choose a provider, enter its API key, select one or more models, and click **Save**. BitFun makes the first saved model primary and tests the connection automatically.
+4. Return to the **Session** tab, type a concrete task, and press Enter or click **Send**.
 
 ---
 
@@ -99,7 +108,7 @@ The data below evaluates BitFun's core Agent capabilities, all measured with **D
 > [!NOTE]
 > These are BitFun's initial evaluation results, with each case run once. Benchmarks fluctuate with task sampling, model versions, runtime environment, and single-run variance, so treat these as an initial sanity signal that the Agent is already reasonably capable — not as a fixed ranking claim or a final ceiling. Full benchmark details will follow.
 
-**1. Completion results** — BitFun leads Open Code and Claude Code on both **SWE-Bench-Pro** (complex software engineering) and **SWE-Bench-Verified** (human-verified GitHub issue fixes).
+**1. Initial completion snapshot** — The chart below compares the current single-run results on **SWE-Bench-Pro** (complex software engineering) and **SWE-Bench-Verified** (human-verified GitHub issue fixes).
 
 ![Agent benchmark scores](./png/agent_benchmark_scores.svg)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,9 +4,9 @@
 
 ![BitFun](./png/BitFun_title.png)
 
-### 开源桌面 AI Agent —— 每个任务，都给你一个能打开的应用
+### 桌面 AI Agent —— 每个任务，都给你一个能打开的应用
 
-能写代码、能做文档、能操控桌面。小应用、Runtime、多设备互控的服务器，全部归你。MIT。
+能写代码、能做文档、能操控桌面，并提供小应用、Rust Runtime 和可自部署的多设备互控服务器。
 
 [**⬇ 下载 macOS · Windows · Linux 版**](https://github.com/GCWing/BitFun/releases/latest)
 
@@ -15,7 +15,7 @@
 [![GitHub release](https://img.shields.io/github/v/release/GCWing/BitFun?style=flat-square&color=blue)](https://github.com/GCWing/BitFun/releases)
 [![Downloads](https://img.shields.io/github/downloads/GCWing/BitFun/total?style=flat-square&color=brightgreen)](https://github.com/GCWing/BitFun/releases)
 [![Stars](https://img.shields.io/github/stars/GCWing/BitFun?style=flat-square&color=yellow)](https://github.com/GCWing/BitFun/stargazers)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow?style=flat-square)](https://github.com/GCWing/BitFun/blob/main/LICENSE)
+[![Core code: MIT](https://img.shields.io/badge/core_code-MIT-yellow?style=flat-square)](https://github.com/GCWing/BitFun/blob/main/LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-blue?style=flat-square)](https://github.com/GCWing/BitFun/releases)
 
 [![Trendshift](https://trendshift.io/api/badge/repositories/44672)](https://trendshift.io/repositories/44672)
@@ -40,7 +40,7 @@
 | **桌面执行层** | 浏览器、终端、桌面软件、文件系统、远程工作区 |
 | **四层可定制** | 自定义 Agent → MCP / Skills / Hooks → Mini App → 源码级改造 |
 | **性能** | KV Cache 平均命中率 98.67%；flashgrep 在千万行仓库上搜索平均快约 36 倍 |
-| **跨平台开源** | Windows、macOS、Linux 三端。MIT。模型自选，不绑定厂商 |
+| **跨平台、模型自选** | Windows、macOS、Linux 三端，不绑定模型厂商 |
 
 ---
 
@@ -49,6 +49,8 @@
 **Agentic Mini App。** 多数 Agent 把所有任务都挤进同一个对话框，BitFun 选择为任务造一个专属界面——图表、看板、表单、面板——并让对话绑定这个界面的实时状态。你问的是眼前看到的东西，不必再把它复述一遍。社区已经做出从行情面板到各类垂直领域工具的版本。
 
 ![小应用 Gallery](./png/miniapps_gallery_CN.png)
+
+[浏览公开 Mini App Gallery →](https://market.openbitfun.com/miniapp/)
 
 **自部署的多设备互联互控。** 账号登录、跨设备会话与配置同步、用一台设备操控另一台已登录设备，全部走**你自己部署**的 relay，不经任何第三方云中转——这往往直接决定了它在企业内网里能不能用。relay 是零知识设计：密钥在客户端本地派生，服务端只保存 Argon2id 哈希和 AES-GCM 封装后的材料。
 
@@ -72,6 +74,13 @@ pnpm run desktop:dev
 ```
 
 前置依赖：[Node.js](https://nodejs.org/) 22.12+（推荐 LTS）、[pnpm](https://pnpm.io/) 10.15.0（建议通过 Corepack 使用）、[Rust 工具链](https://rustup.rs/)、[Tauri 前置依赖](https://v2.tauri.app/start/prerequisites/)。更多说明见 [CONTRIBUTING_CN.md](./CONTRIBUTING_CN.md)。
+
+### 第一次运行
+
+1. 启动 BitFun，在欢迎页点击**打开**，选择一个项目文件夹。
+2. 打开**更多选项（…）→ 设置 → 模型 → 创建第一个配置**。
+3. 选择服务商，填写 API Key，选择一个或多个模型，然后点击**保存**。第一个保存的模型会自动成为主模型，并自动测试连接。
+4. 回到**会话**页，输入一个具体任务，按 Enter 或点击**发送**。
 
 ---
 
@@ -99,7 +108,7 @@ pnpm run desktop:dev
 > [!NOTE]
 > 当前数据为每个 case 跑 1 次得到的 BitFun 初始评测结果。评测会受到任务抽样、模型版本、运行环境和单次执行偶然性的影响，存在一定波动；这组数据仅用于说明当前 Agent 已具备可用的基础竞争力，并不代表固定排名或最终上限。后续会持续优化并放出完整评测详情。
 
-**1. 完成效果** —— BitFun 在 **SWE-Bench-Pro**（复杂软件工程）和 **SWE-Bench-Verified**（人工验证的 GitHub issue 修复）上均领先 Open Code 与 Claude Code。
+**1. 初始完成效果快照** —— 下图对比了 **SWE-Bench-Pro**（复杂软件工程）和 **SWE-Bench-Verified**（人工验证的 GitHub issue 修复）当前的单次运行结果。
 
 ![Agent benchmark scores](./png/agent_benchmark_scores.svg)
 


### PR DESCRIPTION
## Summary

- focus the README headline on the product instead of an overbroad repository-wide license claim
- qualify the MIT badge as core code and align the benchmark heading with the existing single-run caveat
- add a direct Mini Apps gallery link and a source-verified four-step first-run path in English and Chinese

## Verification

- git diff --check
- both READMEs have zero missing local links

No product behavior or video assets are changed.

## Owner-only follow-up

The contributor account cannot edit repository About metadata. After review, please align it with the README:

- Description: Desktop AI agent that turns tasks into live Mini Apps. Rust runtime, real repositories, browser/terminal/remote workspaces, and a self-hostable encrypted relay.
- Website: https://openbitfun.com/