### PR TITLE
fix(session): recover corrupt session indexes

### DIFF
--- a/src/crates/assembly/core/src/agentic/persistence/manager.rs
+++ b/src/crates/assembly/core/src/agentic/persistence/manager.rs
@@ -4111,6 +4111,7 @@ mod tests {
     };
     use crate::BitFunError;
     use bitfun_runtime_ports::SessionTurnWindowRequest;
+    use std::collections::HashSet;
     use std::path::{Path, PathBuf};
     use std::sync::Arc;
     use std::time::Instant;
@@ -6767,6 +6768,123 @@ mod tests {
         assert_ne!(manager.project_sessions_dir(&runtime_root), runtime_root);
 
         let _ = std::fs::remove_dir_all(&test_root);
+    }
+
+    #[tokio::test]
+    async fn corrupt_remote_index_does_not_block_history_updates_or_new_sessions() {
+        let workspace = TestWorkspace::new();
+        let path_manager = workspace.path_manager();
+        let manager = PersistenceManager::new(path_manager.clone()).expect("persistence manager");
+        let sessions_dir = crate::service::WorkspaceRuntimeService::new(path_manager)
+            .context_for_remote_workspace("dev-host", "/home/wsp/project")
+            .sessions_dir;
+        let config = SessionConfig {
+            workspace_path: Some("/home/wsp/project".to_string()),
+            remote_connection_id: Some("ssh-1".to_string()),
+            remote_ssh_host: Some("dev-host".to_string()),
+            ..Default::default()
+        };
+        let historical_id = Uuid::new_v4().to_string();
+        let historical = Session::new_with_id(
+            historical_id.clone(),
+            "Historical remote session".to_string(),
+            "agentic".to_string(),
+            config.clone(),
+        );
+        manager
+            .create_session_if_absent(&sessions_dir, &historical)
+            .await
+            .expect("historical remote session should persist");
+        let first_turn = DialogTurnData::new(
+            "turn-0".to_string(),
+            0,
+            historical_id.clone(),
+            UserMessageData {
+                id: "user-0".to_string(),
+                content: "before restart".to_string(),
+                timestamp: 1,
+                metadata: None,
+            },
+        );
+        manager
+            .save_dialog_turn(&sessions_dir, &first_turn)
+            .await
+            .expect("historical remote turn should persist");
+        let state_path = sessions_dir.join(&historical_id).join("state.json");
+        let first_turn_path = sessions_dir
+            .join(&historical_id)
+            .join("turns")
+            .join("turn-0000.json");
+        let state_before = std::fs::read(&state_path).expect("historical state should exist");
+        let first_turn_before =
+            std::fs::read(&first_turn_path).expect("historical turn should exist");
+
+        std::fs::write(sessions_dir.join("index.json"), b"")
+            .expect("simulate an empty remote index after abnormal restart");
+        let restored = manager
+            .load_session(&sessions_dir, &historical_id)
+            .await
+            .expect("history must open even before the derived index is repaired");
+        assert_eq!(restored.dialog_turn_ids, vec!["turn-0"]);
+
+        let second_turn = DialogTurnData::new(
+            "turn-1".to_string(),
+            1,
+            historical_id.clone(),
+            UserMessageData {
+                id: "user-1".to_string(),
+                content: "after restart".to_string(),
+                timestamp: 2,
+                metadata: None,
+            },
+        );
+        manager
+            .save_dialog_turn(&sessions_dir, &second_turn)
+            .await
+            .expect("the historical Session must accept a new turn with a corrupt index");
+
+        std::fs::write(sessions_dir.join("index.json"), b"{")
+            .expect("simulate another interrupted index write before Session creation");
+        let new_session_id = Uuid::new_v4().to_string();
+        let new_session = Session::new_with_id(
+            new_session_id.clone(),
+            "New remote session".to_string(),
+            "agentic".to_string(),
+            config,
+        );
+        manager
+            .create_session_if_absent(&sessions_dir, &new_session)
+            .await
+            .expect("a corrupt remote index must not block new Session creation");
+
+        std::fs::write(sessions_dir.join("index.json"), b" ")
+            .expect("simulate a corrupt index before listing");
+        let listed = manager
+            .list_session_metadata(&sessions_dir)
+            .await
+            .expect("remote Session listing should rebuild its derived index");
+        let listed_ids = listed
+            .iter()
+            .map(|metadata| metadata.session_id.as_str())
+            .collect::<HashSet<_>>();
+        assert_eq!(
+            listed_ids,
+            HashSet::from([historical_id.as_str(), new_session_id.as_str()])
+        );
+
+        let restored = manager
+            .load_session(&sessions_dir, &historical_id)
+            .await
+            .expect("updated historical Session should remain restorable");
+        assert_eq!(restored.dialog_turn_ids, vec!["turn-0", "turn-1"]);
+        assert_eq!(
+            std::fs::read(state_path).expect("historical state remains readable"),
+            state_before
+        );
+        assert_eq!(
+            std::fs::read(first_turn_path).expect("historical turn remains readable"),
+            first_turn_before
+        );
     }
 
     #[tokio::test]

--- a/src/crates/services/services-core/src/session/metadata_store.rs
+++ b/src/crates/services/services-core/src/session/metadata_store.rs
@@ -235,14 +235,56 @@ impl SessionMetadataStore {
         Ok(count)
     }
 
-    async fn rebuild_index_locked(
+    async fn rebuild_index_snapshot_locked(
         &self,
-    ) -> Result<Vec<SessionMetadata>, SessionMetadataStoreError> {
+    ) -> Result<(StoredSessionIndexFile, Vec<SessionMetadata>), SessionMetadataStoreError> {
         let metadata_list = self.scan_metadata_dirs().await?;
         let (index, visible_sessions) =
             build_session_index_snapshot(metadata_list, current_unix_ms());
         self.write_json_atomic(&self.index_path(), &index).await?;
-        Ok(visible_sessions)
+        Ok((index, visible_sessions))
+    }
+
+    async fn rebuild_index_locked(
+        &self,
+    ) -> Result<Vec<SessionMetadata>, SessionMetadataStoreError> {
+        self.rebuild_index_snapshot_locked()
+            .await
+            .map(|(_, visible_sessions)| visible_sessions)
+    }
+
+    /// Load the rebuildable Session index while the caller owns both index locks.
+    ///
+    /// Per-session `metadata.json` files are authoritative. Older BitFun versions
+    /// can leave `index.json` missing, empty, or truncated if the machine stops
+    /// during the Windows direct-overwrite fallback. Treat only index
+    /// deserialization failures as recoverable; real filesystem errors must still
+    /// reach the caller.
+    async fn read_or_rebuild_index_locked(
+        &self,
+    ) -> Result<(StoredSessionIndexFile, bool), SessionMetadataStoreError> {
+        let index_path = self.index_path();
+        match self
+            .read_json_optional::<StoredSessionIndexFile>(&index_path)
+            .await
+        {
+            Ok(Some(index)) => Ok((index, false)),
+            Ok(None) => self
+                .rebuild_index_snapshot_locked()
+                .await
+                .map(|(index, _)| (index, true)),
+            Err(error) if error.is_deserialization() => {
+                warn!(
+                    "Session index is unreadable; rebuilding from per-session metadata: path={}, error={}",
+                    index_path.display(),
+                    error
+                );
+                self.rebuild_index_snapshot_locked()
+                    .await
+                    .map(|(index, _)| (index, true))
+            }
+            Err(error) => Err(error),
+        }
     }
 
     async fn upsert_index_entry_locked(
@@ -250,23 +292,18 @@ impl SessionMetadataStore {
         metadata: &SessionMetadata,
         metadata_file_created: bool,
     ) -> Result<(), SessionMetadataStoreError> {
-        let index_path = self.index_path();
-        let existing_index = self
-            .read_json_optional::<StoredSessionIndexFile>(&index_path)
-            .await?;
-        let disk_metadata_file_count = if existing_index.is_some() {
-            0
-        } else {
-            self.count_metadata_dirs().await?
-        };
+        let (existing_index, rebuilt) = self.read_or_rebuild_index_locked().await?;
+        if rebuilt {
+            return Ok(());
+        }
         let index = upsert_session_index_entry(
-            existing_index,
+            Some(existing_index),
             metadata,
             metadata_file_created,
-            disk_metadata_file_count,
+            0,
             current_unix_ms(),
         );
-        self.write_json_atomic(&index_path, &index).await
+        self.write_json_atomic(&self.index_path(), &index).await
     }
 
     async fn remove_index_entry_locked(
@@ -274,19 +311,19 @@ impl SessionMetadataStore {
         session_id: &str,
         metadata_file_count_delta: isize,
     ) -> Result<(), SessionMetadataStoreError> {
-        let index_path = self.index_path();
-        let existing_index = self
-            .read_json_optional::<StoredSessionIndexFile>(&index_path)
-            .await?;
+        let (existing_index, rebuilt) = self.read_or_rebuild_index_locked().await?;
+        if rebuilt {
+            return Ok(());
+        }
         let Some(index) = remove_session_index_entry(
-            existing_index,
+            Some(existing_index),
             session_id,
             metadata_file_count_delta,
             current_unix_ms(),
         ) else {
             return Ok(());
         };
-        self.write_json_atomic(&index_path, &index).await
+        self.write_json_atomic(&self.index_path(), &index).await
     }
 
     pub async fn list_metadata(&self) -> Result<Vec<SessionMetadata>, SessionMetadataStoreError> {
@@ -298,37 +335,31 @@ impl SessionMetadataStore {
         let _guard = lock.lock().await;
         let _file_guard = self.lock_index_file().await?;
         let index_path = self.index_path();
-        if let Some(index) = self
-            .read_json_optional::<StoredSessionIndexFile>(&index_path)
-            .await?
-        {
-            let has_stale_entry = index
-                .sessions
-                .iter()
-                .any(|metadata| !self.metadata_path(&metadata.session_id).exists());
-            if has_stale_entry {
-                warn!(
-                    "Session index contains stale entries, rebuilding: {}",
-                    index_path.display()
-                );
-                return self.rebuild_index_locked().await;
-            }
-
-            let disk_count = self.count_metadata_dirs().await?;
-            if index.metadata_file_count != disk_count {
-                warn!(
-                    "Session index incomplete (index: {}, disk: {}), rebuilding: {}",
-                    index.metadata_file_count,
-                    disk_count,
-                    index_path.display()
-                );
-                return self.rebuild_index_locked().await;
-            }
-
-            return Ok(index.sessions);
+        let (index, _) = self.read_or_rebuild_index_locked().await?;
+        let has_stale_entry = index
+            .sessions
+            .iter()
+            .any(|metadata| !self.metadata_path(&metadata.session_id).exists());
+        if has_stale_entry {
+            warn!(
+                "Session index contains stale entries, rebuilding: {}",
+                index_path.display()
+            );
+            return self.rebuild_index_locked().await;
         }
 
-        self.rebuild_index_locked().await
+        let disk_count = self.count_metadata_dirs().await?;
+        if index.metadata_file_count != disk_count {
+            warn!(
+                "Session index incomplete (index: {}, disk: {}), rebuilding: {}",
+                index.metadata_file_count,
+                disk_count,
+                index_path.display()
+            );
+            return self.rebuild_index_locked().await;
+        }
+
+        Ok(index.sessions)
     }
 
     pub async fn list_metadata_page(
@@ -345,23 +376,17 @@ impl SessionMetadataStore {
         let _guard = lock.lock().await;
         let _file_guard = self.lock_index_file().await?;
         let index_path = self.index_path();
-        let indexed_sessions = if let Some(index) = self
-            .read_json_optional::<StoredSessionIndexFile>(&index_path)
-            .await?
-        {
-            if index.metadata_file_count < index.sessions.len() {
-                warn!(
-                    "Session index has invalid metadata count before page read (index: {}, sessions: {}), rebuilding: {}",
-                    index.metadata_file_count,
-                    index.sessions.len(),
-                    index_path.display()
-                );
-                self.rebuild_index_locked().await?
-            } else {
-                index.sessions
-            }
-        } else {
+        let (index, _) = self.read_or_rebuild_index_locked().await?;
+        let indexed_sessions = if index.metadata_file_count < index.sessions.len() {
+            warn!(
+                "Session index has invalid metadata count before page read (index: {}, sessions: {}), rebuilding: {}",
+                index.metadata_file_count,
+                index.sessions.len(),
+                index_path.display()
+            );
             self.rebuild_index_locked().await?
+        } else {
+            index.sessions
         };
 
         let page = build_session_metadata_page(indexed_sessions, cursor, limit);
@@ -597,6 +622,201 @@ mod tests {
         let listed = store.list_metadata().await.expect("list metadata");
         assert_eq!(listed.len(), 1);
         assert_eq!(listed[0].session_id, "session-a");
+    }
+
+    #[tokio::test]
+    async fn metadata_store_recovers_empty_index_while_saving_new_metadata() {
+        let dir = tempdir().expect("tempdir");
+        let store = SessionMetadataStore::new(dir.path());
+        store
+            .save_metadata(&metadata("historical", 20))
+            .await
+            .expect("save historical metadata");
+        let historical_turn = store
+            .session_dir("historical")
+            .join("turns")
+            .join("turn-0000.json");
+        fs::create_dir_all(historical_turn.parent().expect("turn parent"))
+            .await
+            .expect("create historical turns directory");
+        fs::write(&historical_turn, b"historical turn payload")
+            .await
+            .expect("write historical turn sentinel");
+
+        fs::write(store.index_path(), b"")
+            .await
+            .expect("simulate an empty index after an interrupted write");
+        store
+            .save_metadata(&metadata("new-session", 10))
+            .await
+            .expect("a corrupt derived index must not block a new session");
+
+        let listed = store.list_metadata().await.expect("list rebuilt metadata");
+        assert_eq!(
+            listed
+                .iter()
+                .map(|value| value.session_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["historical", "new-session"]
+        );
+        assert_eq!(
+            fs::read(&historical_turn)
+                .await
+                .expect("historical turn must remain readable"),
+            b"historical turn payload"
+        );
+        let rebuilt = store
+            .read_json_optional::<StoredSessionIndexFile>(&store.index_path())
+            .await
+            .expect("read rebuilt index")
+            .expect("rebuilt index exists");
+        assert_eq!(rebuilt.metadata_file_count, 2);
+        assert_eq!(rebuilt.sessions.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn metadata_store_page_recovers_truncated_index() {
+        let dir = tempdir().expect("tempdir");
+        let store = SessionMetadataStore::new(dir.path());
+        store
+            .save_metadata(&metadata("older", 10))
+            .await
+            .expect("save older metadata");
+        store
+            .save_metadata(&metadata("newer", 20))
+            .await
+            .expect("save newer metadata");
+        fs::write(store.index_path(), br#"{"schema_version":2,"updated_at":"#)
+            .await
+            .expect("simulate a truncated index");
+
+        let page = store
+            .list_metadata_page(None, 10)
+            .await
+            .expect("paged listing must rebuild a truncated index");
+
+        assert_eq!(
+            page.sessions
+                .iter()
+                .map(|value| value.session_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["newer", "older"]
+        );
+    }
+
+    #[tokio::test]
+    async fn metadata_store_delete_recovers_corrupt_index_and_preserves_other_sessions() {
+        let dir = tempdir().expect("tempdir");
+        let store = SessionMetadataStore::new(dir.path());
+        store
+            .save_metadata(&metadata("historical", 20))
+            .await
+            .expect("save historical metadata");
+        store
+            .save_metadata(&metadata("partial-create", 10))
+            .await
+            .expect("save partial create metadata");
+        fs::write(store.index_path(), b"")
+            .await
+            .expect("simulate an empty index");
+
+        store
+            .delete_session_dir_and_index("partial-create")
+            .await
+            .expect("cleanup must rebuild the corrupt index");
+
+        assert!(!store.session_dir("partial-create").exists());
+        assert!(store.session_dir("historical").exists());
+        let listed = store.list_metadata().await.expect("list surviving session");
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].session_id, "historical");
+    }
+
+    #[tokio::test]
+    async fn metadata_store_rebuilds_missing_index_before_save_without_hiding_history() {
+        let dir = tempdir().expect("tempdir");
+        let store = SessionMetadataStore::new(dir.path());
+        store
+            .save_metadata(&metadata("historical", 20))
+            .await
+            .expect("save historical metadata");
+        fs::remove_file(store.index_path())
+            .await
+            .expect("simulate the replace gap left by an older version");
+
+        store
+            .save_metadata(&metadata("new-session", 10))
+            .await
+            .expect("save with a missing derived index");
+
+        let listed = store.list_metadata().await.expect("list rebuilt metadata");
+        assert_eq!(
+            listed
+                .iter()
+                .map(|value| value.session_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["historical", "new-session"]
+        );
+    }
+
+    #[tokio::test]
+    async fn metadata_store_rebuilds_legacy_index_without_metadata_file_count() {
+        let dir = tempdir().expect("tempdir");
+        let store = SessionMetadataStore::new(dir.path());
+        let historical = metadata("historical", 20);
+        store
+            .save_metadata(&historical)
+            .await
+            .expect("save historical metadata");
+        let legacy_index = serde_json::json!({
+            "schema_version": 2,
+            "updated_at": 1,
+            "sessions": [historical]
+        });
+        fs::write(
+            store.index_path(),
+            serde_json::to_vec(&legacy_index).expect("serialize legacy index"),
+        )
+        .await
+        .expect("write legacy index");
+
+        let listed = store
+            .list_metadata()
+            .await
+            .expect("legacy index remains upgrade-compatible");
+
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].session_id, "historical");
+        let rebuilt = store
+            .read_json_optional::<StoredSessionIndexFile>(&store.index_path())
+            .await
+            .expect("read upgraded index")
+            .expect("upgraded index exists");
+        assert_eq!(rebuilt.metadata_file_count, 1);
+    }
+
+    #[tokio::test]
+    async fn metadata_store_does_not_treat_index_io_errors_as_corruption() {
+        let dir = tempdir().expect("tempdir");
+        let store = SessionMetadataStore::new(dir.path());
+        store
+            .save_metadata(&metadata("session-a", 10))
+            .await
+            .expect("save metadata");
+        fs::remove_file(store.index_path())
+            .await
+            .expect("remove index file");
+        fs::create_dir(store.index_path())
+            .await
+            .expect("replace index with an unreadable directory");
+
+        let error = store
+            .list_metadata()
+            .await
+            .expect_err("filesystem errors must not be swallowed as corrupt JSON");
+
+        assert!(!error.is_deserialization());
+        assert!(store.index_path().is_dir());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- recover missing, empty, or truncated Session `index.json` files from authoritative per-Session metadata
- cover list, paged list, save/upsert, and delete/rollback paths under the existing process and cross-process index locks
- add a resolved remote-workspace regression covering history restore, appending a new turn, creating a new Session, and preserving existing state/turn files

## Root cause

On Windows, the existing best-effort JSON replacement may fall back to a direct overwrite when another process temporarily blocks replacement. An abnormal machine restart during that overwrite can leave the derived Session index empty or truncated. Session creation then writes its metadata but fails while reading the index; cleanup reads the same corrupt index and fails again, producing `SessionCreateCleanupRequired`.

## Upgrade compatibility

- no Session schema, remote workspace path mapping, migration, credential, or restore-record changes
- `metadata.json`, `state.json`, `turns/*`, and all other historical Session data remain authoritative and untouched by index recovery
- only index deserialization failures are recovered; permission, lock, path, and other real I/O failures still propagate
- preserves the existing Windows best-effort write fallback so upgrading does not turn previously successful writes into failures
- legacy indexes without `metadata_file_count` remain readable and are rebuilt through the existing disk-count contract

## Verification

- `cargo test -p bitfun-services-core --no-default-features --features local-storage --lib`
- `cargo test -p bitfun-services-core --no-default-features --features local-storage --test session_metadata_contracts --test json_store_contracts`
- `cargo test -p bitfun-core --no-default-features --features agent-runtime --lib agentic::persistence::manager::tests::corrupt_remote_index_does_not_block_history_updates_or_new_sessions`
- existing Session creation-failure and title rollback tests
- `git diff --check`

AI-assisted: yes. Testing: focused owner suites and remote persistence regression completed.

Closes #2102