### PR TITLE
feat(agent): read documents with anydoc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb4e440d04be07da1f1bf44fb4495ebd58669372fe0cffa6e48595ac5bd88a3"
 dependencies = [
  "android_log-sys",
- "env_filter",
+ "env_filter 0.1.4",
  "log",
 ]
 
@@ -221,6 +221,23 @@ dependencies = [
  "anstyle",
  "once_cell_polyfill",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anydoc"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d88a76ba2a26a65e133879dee68acd593656e68e306488ebb162b69f37902b"
+dependencies = [
+ "calamine",
+ "cfb 0.14.0",
+ "csv",
+ "encoding_rs",
+ "flate2",
+ "log",
+ "pdf-inspector",
+ "quick-xml 0.41.0",
+ "zip 8.6.0",
 ]
 
 [[package]]
@@ -465,6 +482,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "atoi_simd"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cdb3708a128e559a30fb830e8a77a5022ee6902806925c216658652b452a44"
+dependencies = [
+ "debug_unsafe",
+ "rustversion",
 ]
 
 [[package]]
@@ -1175,7 +1202,7 @@ dependencies = [
  "windows 0.61.3",
  "windows-core 0.61.2",
  "xz2",
- "zip",
+ "zip 4.6.1",
  "zstd",
 ]
 
@@ -1252,7 +1279,7 @@ dependencies = [
  "url",
  "urlencoding",
  "uuid",
- "zip",
+ "zip 4.6.1",
 ]
 
 [[package]]
@@ -1505,7 +1532,7 @@ dependencies = [
  "which 8.0.5",
  "win32job",
  "windows 0.61.3",
- "zip",
+ "zip 4.6.1",
 ]
 
 [[package]]
@@ -1580,7 +1607,7 @@ dependencies = [
  "windows-native-keyring-store",
  "x25519-dalek",
  "zbus-secret-service-keyring-store",
- "zip",
+ "zip 4.6.1",
 ]
 
 [[package]]
@@ -1621,7 +1648,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "zip",
+ "zip 4.6.1",
 ]
 
 [[package]]
@@ -1896,6 +1923,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "calamine"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fa68281b1a76b54a62156474adb06bb380a67e07dd60656e3217152b42183f3"
+dependencies = [
+ "atoi_simd",
+ "byteorder",
+ "chrono",
+ "codepage",
+ "encoding_rs",
+ "fast-float2",
+ "log",
+ "quick-xml 0.41.0",
+ "serde",
+ "zip 8.6.0",
+]
+
+[[package]]
 name = "camino"
 version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1985,7 +2030,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -2181,6 +2226,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
  "thiserror 2.0.19",
+]
+
+[[package]]
+name = "codepage"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f68d061bc2828ae826206326e61251aca94c1e4a5305cf52d9138639c918b4"
+dependencies = [
+ "encoding_rs",
 ]
 
 [[package]]
@@ -2566,6 +2620,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ctor"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2746,6 +2821,43 @@ name = "dconf_rs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7046468a81e6a002061c01e6a7c83139daf91b11c30e66795b13217c2d885c8b"
+
+[[package]]
+name = "debug_unsafe"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eed2c4702fa172d1ce21078faa7c5203e69f5394d48cc436d25928394a867a2"
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.19",
+]
 
 [[package]]
 name = "der"
@@ -3067,6 +3179,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecb"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a8bfa975b1aec2145850fcaa1c6fe269a16578c44705a532ae3edc92b8881c7"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3240,6 +3361,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter 2.0.0",
+ "jiff",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3308,7 +3452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
 dependencies = [
  "futures-core",
- "nom",
+ "nom 7.1.3",
  "pin-project-lite",
 ]
 
@@ -3351,6 +3495,12 @@ dependencies = [
  "regex-automata",
  "regex-syntax",
 ]
+
+[[package]]
+name = "fast-float2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
 
 [[package]]
 name = "fastrand"
@@ -4987,6 +5137,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5464,6 +5667,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "lopdf"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67513274c50a2b51e5f75d9e682fcf4ab064a8a9c9ae2c3c59309084882bb24d"
+dependencies = [
+ "aes",
+ "bitflags 2.11.1",
+ "cbc",
+ "chrono",
+ "ecb",
+ "encoding_rs",
+ "flate2",
+ "getrandom 0.4.3",
+ "indexmap 2.14.0",
+ "itoa",
+ "jiff",
+ "log",
+ "md-5",
+ "nom 8.0.0",
+ "rand 0.10.2",
+ "rangemap",
+ "rayon",
+ "sha2",
+ "stringprep",
+ "thiserror 2.0.19",
+ "time",
+ "ttf-parser",
+ "weezl",
+]
+
+[[package]]
 name = "lru"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5587,6 +5821,16 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
 
 [[package]]
 name = "md5"
@@ -5869,6 +6113,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -7136,6 +7389,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "pdf-inspector"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7475018de0880b394b7cc50f871fac0c010aa411dcd14c64074a3e640a4c05c"
+dependencies = [
+ "env_logger",
+ "include_dir",
+ "log",
+ "lopdf",
+ "once_cell",
+ "rayon",
+ "regex",
+ "thiserror 2.0.19",
+ "ttf-parser",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7449,6 +7720,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "portable-pty"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7699,6 +7985,7 @@ version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
+ "encoding_rs",
  "memchr",
 ]
 
@@ -7864,6 +8151,12 @@ checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core 0.10.1",
 ]
+
+[[package]]
+name = "rangemap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
 name = "ratatui"
@@ -9597,6 +9890,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10169,7 +10473,7 @@ dependencies = [
  "tokio",
  "url",
  "windows-sys 0.60.2",
- "zip",
+ "zip 4.6.1",
 ]
 
 [[package]]
@@ -10266,7 +10570,7 @@ dependencies = [
  "serde_with",
  "swift-rs",
  "thiserror 2.0.19",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",
@@ -10772,6 +11076,7 @@ checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 name = "tool-runtime"
 version = "0.2.16"
 dependencies = [
+ "anydoc",
  "bitfun-agent-tools",
  "bitfun-events",
  "bitfun-runtime-ports",
@@ -10788,6 +11093,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "sha2",
  "tokio",
  "tokio-util",
  "vte",
@@ -10977,6 +11283,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+
+[[package]]
 name = "tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11002,6 +11314,12 @@ checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
 dependencies = [
  "rustc-hash 2.1.3",
 ]
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typeid"
@@ -11051,6 +11369,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-id-start"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11067,6 +11391,21 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -12856,6 +13195,20 @@ dependencies = [
  "flate2",
  "indexmap 2.14.0",
  "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "typed-path",
  "zopfli",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,9 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 
+# Document conversion
+anydoc = "=0.1.6"
+
 # TypeScript binding generation (schema-first; gated by per-crate `ts` features)
 ts-rs = { version = "12", features = ["serde-json-impl", "no-serde-warnings"] }
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,8 +1,8 @@
 # Third-Party Notices
 
-BitFun redistributes selected material from the following third-party project.
-The corresponding license and provenance metadata are included with BitFun's
-Desktop and CLI release packages.
+BitFun redistributes selected material and links libraries from the following
+third-party projects. These notices are included with BitFun's Desktop and CLI
+release packages.
 
 ## models.dev catalog data
 
@@ -21,3 +21,34 @@ complete upstream license text is preserved in `models-dev.LICENSE.txt`, which
 is shipped as `third-party/models.dev/LICENSE.txt`. Source distributions keep
 the canonical copies of both files beside the bundled snapshot under
 `src/crates/services/services-integrations/assets/`.
+
+## anydoc
+
+- Project: anydoc
+- Source: https://github.com/firecrawl/anydoc
+- Version: 0.1.6
+- License: MIT
+- Copyright: Copyright (c) 2026 Sideguide Technologies Inc.
+
+BitFun links anydoc to convert supported office documents, OpenDocument files,
+RTF, EPUB, CSV, and PDFs into Markdown for the Agent Read tool.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/crates/assembly/core/Cargo.toml
+++ b/src/crates/assembly/core/Cargo.toml
@@ -97,6 +97,7 @@ bitfun-product-domains = { path = "../../contracts/product-domains", default-fea
 
 # Tool runtime
 tool-runtime = { path = "../../execution/tool-execution", default-features = false, optional = true, features = [
+    "document-read",
     "web-readable",
 ] }
 

--- a/src/crates/assembly/core/src/agentic/tools/implementations/file_read_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/file_read_tool.rs
@@ -14,10 +14,15 @@ use log::{debug, warn};
 use serde_json::{json, Value};
 use std::convert::TryFrom;
 use std::path::Path;
-use std::time::Instant;
+use std::time::{Duration, Instant};
+use tool_runtime::fs::document::{
+    convert_document_to_markdown, is_supported_document_path, DocumentConversionError,
+    MAX_DOCUMENT_INPUT_BYTES, MAX_DOCUMENT_MARKDOWN_BYTES,
+};
 use tool_runtime::fs::read_file::{
     build_read_file_presentation, build_remote_read_command, build_remote_tail_read_command,
-    parse_remote_read_output, parse_remote_tail_read_output, read_file, read_file_tail,
+    parse_remote_read_output, parse_remote_tail_read_output, read_file, read_file_bytes_bounded,
+    read_file_tail, read_text, read_text_tail, ReadFileResult,
 };
 
 pub struct FileReadTool {
@@ -28,6 +33,21 @@ pub struct FileReadTool {
 
 /// Default cap on characters returned by a single Read call (excluding wrapper text).
 pub const DEFAULT_READ_MAX_TOTAL_CHARS: usize = 64_000;
+// anydoc is synchronous, so this bounds the caller's wait rather than terminating the parser.
+// The worker retains the global conversion permit until it actually exits, keeping failures closed.
+const DOCUMENT_CONVERSION_TIMEOUT: Duration = Duration::from_secs(30);
+
+struct DocumentReadMetadata {
+    source_format: &'static str,
+    source_size_bytes: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ReadRenderMode {
+    Auto,
+    Source,
+    Markdown,
+}
 
 impl Default for FileReadTool {
     fn default() -> Self {
@@ -93,6 +113,23 @@ impl FileReadTool {
         }
 
         Ok(tail)
+    }
+
+    fn read_render_mode(input: &Value) -> Result<ReadRenderMode, String> {
+        match input.get("render") {
+            None => Ok(ReadRenderMode::Auto),
+            Some(Value::String(value)) if value == "auto" => Ok(ReadRenderMode::Auto),
+            Some(Value::String(value)) if value == "source" => Ok(ReadRenderMode::Source),
+            Some(Value::String(value)) if value == "markdown" => Ok(ReadRenderMode::Markdown),
+            Some(_) => Err("render must be one of: auto, source, markdown".to_string()),
+        }
+    }
+
+    fn path_has_csv_extension(path: &str) -> bool {
+        Path::new(path)
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("csv"))
     }
 
     fn optional_line_number(input: &Value, key: &str) -> Result<Option<usize>, String> {
@@ -262,6 +299,139 @@ impl FileReadTool {
 
         Ok(result)
     }
+
+    async fn read_document_window(
+        &self,
+        resolved_path: &str,
+        logical_path: &str,
+        start_line: usize,
+        limit: usize,
+        tail: bool,
+        uses_remote_workspace_backend: bool,
+        context: &ToolUseContext,
+    ) -> BitFunResult<(ReadFileResult, DocumentReadMetadata)> {
+        let bytes = if uses_remote_workspace_backend {
+            let ws_fs = context.ws_fs().ok_or_else(|| {
+                BitFunError::tool("Remote workspace file system is unavailable".to_string())
+            })?;
+            ws_fs
+                .read_file_bounded(resolved_path, MAX_DOCUMENT_INPUT_BYTES)
+                .await
+                .map_err(|error| {
+                    BitFunError::tool(format!(
+                        "Failed to read document {}: {}",
+                        logical_path, error
+                    ))
+                })?
+        } else {
+            read_file_bytes_bounded(resolved_path, MAX_DOCUMENT_INPUT_BYTES)
+                .map_err(BitFunError::tool)?
+        }
+        .ok_or_else(|| {
+            BitFunError::tool(format!(
+                "Document {} is larger than the {} MiB Read limit",
+                logical_path,
+                MAX_DOCUMENT_INPUT_BYTES / (1024 * 1024)
+            ))
+        })?;
+
+        let source_size_bytes = bytes.len();
+        let conversion_started_at = Instant::now();
+        debug!(
+            "Document conversion started: path={}, source_size_bytes={}, session_id={:?}, dialog_turn_id={:?}",
+            logical_path,
+            source_size_bytes,
+            context.session_id,
+            context.dialog_turn_id
+        );
+        let conversion = tokio::time::timeout(
+            DOCUMENT_CONVERSION_TIMEOUT,
+            convert_document_to_markdown(bytes, resolved_path.to_string()),
+        )
+        .await
+        .map_err(|_| {
+            warn!(
+                "Document conversion timed out: path={}, source_size_bytes={}, timeout_ms={}, duration_ms={}",
+                logical_path,
+                source_size_bytes,
+                DOCUMENT_CONVERSION_TIMEOUT.as_millis(),
+                elapsed_ms_u64(conversion_started_at)
+            );
+            BitFunError::tool(format!(
+                "Document conversion did not finish within {} seconds: {}",
+                DOCUMENT_CONVERSION_TIMEOUT.as_secs(),
+                logical_path
+            ))
+        })?;
+        let converted = conversion.map_err(|error| {
+                warn!(
+                    "Document conversion failed: path={}, source_size_bytes={}, duration_ms={}, error_code={}, error={}",
+                    logical_path,
+                    source_size_bytes,
+                    elapsed_ms_u64(conversion_started_at),
+                    error.code(),
+                    error
+                );
+                Self::document_conversion_error(logical_path, resolved_path, error)
+            })?;
+        debug!(
+            "Document conversion completed: path={}, source_format={}, source_size_bytes={}, markdown_size_bytes={}, duration_ms={}",
+            logical_path,
+            converted.source_format,
+            source_size_bytes,
+            converted.markdown.len(),
+            elapsed_ms_u64(conversion_started_at)
+        );
+
+        let read_result = if tail {
+            read_text_tail(
+                &converted.markdown,
+                limit,
+                self.max_line_chars,
+                self.max_total_chars,
+            )
+        } else {
+            read_text(
+                &converted.markdown,
+                start_line,
+                limit,
+                self.max_line_chars,
+                self.max_total_chars,
+            )
+        }
+        .map_err(BitFunError::tool)?;
+
+        Ok((
+            read_result,
+            DocumentReadMetadata {
+                source_format: converted.source_format,
+                source_size_bytes,
+            },
+        ))
+    }
+
+    fn document_conversion_error(
+        logical_path: &str,
+        resolved_path: &str,
+        error: DocumentConversionError,
+    ) -> BitFunError {
+        let ocr_hint = (error.code() == "unsupported"
+            && Path::new(resolved_path)
+                .extension()
+                .and_then(|extension| extension.to_str())
+                .is_some_and(|extension| extension.eq_ignore_ascii_case("pdf")))
+        .then_some(
+            " Text PDFs are supported, but scanned or image-only PDFs require an OCR workflow.",
+        )
+        .unwrap_or_default();
+        BitFunError::tool(format!(
+            "Failed to convert document {} to Markdown ({}): {}.{}",
+            logical_path,
+            error.code(),
+            error,
+            ocr_hint
+        ))
+    }
 }
 
 #[async_trait]
@@ -272,11 +442,14 @@ impl Tool for FileReadTool {
 
     async fn description(&self) -> BitFunResult<String> {
         Ok(format!(
-            r#"Reads a file from the current workspace filesystem. If the User provides a path to a file assume that path is valid. It is okay to read a file that does not exist; an error will be returned.
+            r#"Reads a file from the current workspace filesystem. Office documents, OpenDocument files, RTF, EPUB, and PDFs are converted locally to GitHub-Flavored Markdown before reading. If the User provides a path to a file assume that path is valid. It is okay to read a file that does not exist; an error will be returned.
 
 Usage:
 - The file_path parameter must be workspace-relative, an absolute path inside the current workspace, or an exact `bitfun://...` URI returned by another tool.
 - Do not read host roots or placeholder paths such as `/workspace`.
+- Supported document extensions are .doc, .docx, .docm, .ppt, .pps, .pot, .pptx, .pptm, .ppsx, .ppsm, .xls, .xlsx, .xlsm, .xlsb, .odt, .ods, .odp, .rtf, .epub, .csv, and .pdf. Document input is capped at {} MiB and extracted Markdown at {} MiB. Conversion is offline and never fetches linked resources.
+- render defaults to auto. auto converts supported documents but preserves CSV as exact source text for editing compatibility. Use render=markdown to turn CSV into a Markdown table or to content-detect a document with a missing/wrong extension. Use render=source to bypass conversion for a textual document such as CSV or RTF.
+- For converted documents, offset, limit, tail, line numbers, and total_lines refer to the extracted Markdown, not source pages or rows. The Markdown is a read-only representation; do not use it as exact source text for Edit. Embedded objects are represented by text, and scanned/image-only PDF pages require OCR.
 - By default, it reads up to {} lines starting from the beginning of the file. When you plan to Edit a file, prefer this default full read so you see the exact bytes you will need to match.
 - You can optionally specify an offset and limit. offset is a 1-based line number. Use a range only when you already know the target lines; the range must include every line you will copy into Edit `old_string`.
 - You can set tail=true with limit to read the last N lines. This is useful for command output and logs. Do not combine tail=true with offset.
@@ -288,12 +461,16 @@ Usage:
 - Avoid tiny repeated slices (e.g. 30-100 line chunks). If you need more context, read a larger window that covers the whole block you will edit.
 - Do not use `limit` with a small value (e.g. < 50) to probe file type or structure. Source files typically begin with copyright headers — a probe read returns no useful code.
 "#,
-            self.default_max_lines_to_read, self.max_line_chars, self.max_total_chars
+            MAX_DOCUMENT_INPUT_BYTES / (1024 * 1024),
+            MAX_DOCUMENT_MARKDOWN_BYTES / (1024 * 1024),
+            self.default_max_lines_to_read,
+            self.max_line_chars,
+            self.max_total_chars
         ))
     }
 
     fn short_description(&self) -> String {
-        "Read file contents.".to_string()
+        "Read text files and extract documents.".to_string()
     }
 
     fn input_schema(&self) -> Value {
@@ -303,6 +480,11 @@ Usage:
                 "file_path": {
                     "type": "string",
                     "description": "The file to read. Use a workspace-relative path, an absolute path inside the current workspace, or an exact bitfun:// URI returned by another tool."
+                },
+                "render": {
+                    "type": "string",
+                    "enum": ["auto", "source", "markdown"],
+                    "description": "How to represent the file. auto converts supported documents but preserves CSV source text; source bypasses conversion; markdown forces local anydoc conversion and enables content detection. Defaults to auto."
                 },
                 "offset": {
                     "type": "number",
@@ -367,8 +549,9 @@ Usage:
             }
         };
 
-        if let Err(message) =
-            Self::read_tail_mode(input).and_then(|_| Self::read_window_start_line(input))
+        if let Err(message) = Self::read_tail_mode(input)
+            .and_then(|_| Self::read_window_start_line(input))
+            .and_then(|_| Self::read_render_mode(input))
         {
             return ValidationResult {
                 result: false,
@@ -478,6 +661,7 @@ Usage:
             .ok_or_else(|| BitFunError::tool("file_path is required".to_string()))?;
 
         let tail = Self::read_tail_mode(input).map_err(BitFunError::tool)?;
+        let render_mode = Self::read_render_mode(input).map_err(BitFunError::tool)?;
         let start_line = Self::read_window_start_line(input).map_err(BitFunError::tool)?;
 
         let limit = input
@@ -490,7 +674,17 @@ Usage:
             context,
             &resolved.resolved_path,
         )?;
-        let revision_before_read = if resolved.uses_remote_workspace_backend()
+        let supported_document_path = is_supported_document_path(&resolved.logical_path)
+            || is_supported_document_path(&resolved.resolved_path);
+        let csv_path = Self::path_has_csv_extension(&resolved.logical_path)
+            || Self::path_has_csv_extension(&resolved.resolved_path);
+        let reads_document_representation = match render_mode {
+            ReadRenderMode::Auto => supported_document_path && !csv_path,
+            ReadRenderMode::Source => false,
+            ReadRenderMode::Markdown => true,
+        };
+        let revision_before_read = if reads_document_representation
+            || resolved.uses_remote_workspace_backend()
             || tail
             || !review_read_receipts_enabled(context)
         {
@@ -507,42 +701,69 @@ Usage:
             )]);
         }
 
-        let read_file_result = if resolved.uses_remote_workspace_backend() {
+        let (read_file_result, document_metadata) = if reads_document_representation {
+            let (result, metadata) = self
+                .read_document_window(
+                    &resolved.resolved_path,
+                    &resolved.logical_path,
+                    start_line,
+                    limit,
+                    tail,
+                    resolved.uses_remote_workspace_backend(),
+                    context,
+                )
+                .await?;
+            (result, Some(metadata))
+        } else if resolved.uses_remote_workspace_backend() {
             if tail {
-                self.read_remote_tail_window(&resolved.resolved_path, limit, context)
-                    .await?
+                (
+                    self.read_remote_tail_window(&resolved.resolved_path, limit, context)
+                        .await?,
+                    None,
+                )
             } else {
-                self.read_remote_window(&resolved.resolved_path, start_line, limit, context)
-                    .await?
+                (
+                    self.read_remote_window(&resolved.resolved_path, start_line, limit, context)
+                        .await?,
+                    None,
+                )
             }
         } else if tail {
-            read_file_tail(
-                &resolved.resolved_path,
-                limit,
-                self.max_line_chars,
-                self.max_total_chars,
+            (
+                read_file_tail(
+                    &resolved.resolved_path,
+                    limit,
+                    self.max_line_chars,
+                    self.max_total_chars,
+                )
+                .map_err(BitFunError::tool)?,
+                None,
             )
-            .map_err(BitFunError::tool)?
         } else {
-            read_file(
-                &resolved.resolved_path,
-                start_line,
-                limit,
-                self.max_line_chars,
-                self.max_total_chars,
+            (
+                read_file(
+                    &resolved.resolved_path,
+                    start_line,
+                    limit,
+                    self.max_line_chars,
+                    self.max_total_chars,
+                )
+                .map_err(BitFunError::tool)?,
+                None,
             )
-            .map_err(BitFunError::tool)?
         };
 
-        let timestamp_ms = if resolved.uses_remote_workspace_backend() {
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|duration| duration.as_millis() as u64)
-                .unwrap_or(0)
-        } else {
-            local_file_modification_time_ms(Path::new(&resolved.resolved_path))
-        };
-        record_file_read_state(context, &resolved, &read_file_result, timestamp_ms);
+        if document_metadata.is_none() {
+            let timestamp_ms = if resolved.uses_remote_workspace_backend() {
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|duration| duration.as_millis() as u64)
+                    .unwrap_or(0)
+            } else {
+                local_file_modification_time_ms(Path::new(&resolved.resolved_path))
+            };
+            record_file_read_state(context, &resolved, &read_file_result, timestamp_ms);
+        }
         if let (Some(revision_before), Some(revision_after)) = (
             revision_before_read,
             (!resolved.uses_remote_workspace_backend() && !tail)
@@ -555,20 +776,48 @@ Usage:
         }
 
         let presentation = build_read_file_presentation(&resolved.logical_path, &read_file_result);
+        let mut result_for_assistant = presentation.result_for_assistant;
+        if let Some(metadata) = document_metadata.as_ref() {
+            let extraction_note = if metadata.source_format == "pdf" {
+                " OCR is not performed, so scanned or image-only pages may be omitted."
+            } else {
+                " Embedded images and objects are represented by their available text."
+            };
+            result_for_assistant = format!(
+                "Converted {} from {} to GitHub-Flavored Markdown with anydoc. offset and limit refer to converted Markdown lines.{}\n\n{}",
+                resolved.logical_path,
+                metadata.source_format.to_ascii_uppercase(),
+                extraction_note,
+                result_for_assistant
+            );
+        }
+
+        let mut data = json!({
+            "file_path": resolved.logical_path,
+            "content": read_file_result.content,
+            "total_lines": read_file_result.total_lines,
+            "lines_read": presentation.lines_read,
+            "offset": read_file_result.start_line,
+            "tail": tail,
+            "start_line": read_file_result.start_line,
+            "size": read_file_result.content.len(),
+            "hit_total_char_limit": read_file_result.hit_total_char_limit
+        });
+        if let Some(metadata) = document_metadata {
+            data["representation"] = json!("extracted_markdown");
+            data["source_format"] = json!(metadata.source_format);
+            data["source_size_bytes"] = json!(metadata.source_size_bytes);
+            data["conversion_engine"] = json!("anydoc");
+            data["extraction_warnings"] = if metadata.source_format == "pdf" {
+                json!(["OCR is not performed; scanned or image-only pages may be omitted."])
+            } else {
+                json!(["Embedded images and objects are represented by their available text."])
+            };
+        }
 
         let result = ToolResult::Result {
-            data: json!({
-                "file_path": resolved.logical_path,
-                "content": read_file_result.content,
-                "total_lines": read_file_result.total_lines,
-                "lines_read": presentation.lines_read,
-                "offset": read_file_result.start_line,
-                "tail": tail,
-                "start_line": read_file_result.start_line,
-                "size": read_file_result.content.len(),
-                "hit_total_char_limit": read_file_result.hit_total_char_limit
-            }),
-            result_for_assistant: Some(presentation.result_for_assistant),
+            data,
+            result_for_assistant: Some(result_for_assistant),
             image_attachments: None,
         };
 
@@ -578,9 +827,128 @@ Usage:
 
 #[cfg(test)]
 mod tests {
-    use super::FileReadTool;
-    use crate::agentic::tools::framework::Tool;
+    use super::{FileReadTool, ReadRenderMode, MAX_DOCUMENT_INPUT_BYTES};
+    use crate::agentic::tools::framework::{Tool, ToolResult, ToolUseContext};
+    use crate::agentic::tools::ToolRuntimeRestrictions;
+    use crate::agentic::WorkspaceBinding;
+    use async_trait::async_trait;
+    use bitfun_runtime_ports::{
+        ToolRuntimeHandles, WorkspaceCommandOptions, WorkspaceCommandResult, WorkspaceDirEntry,
+        WorkspaceFileSystem, WorkspaceServices, WorkspaceShell,
+    };
     use serde_json::{json, Value};
+    use std::collections::HashMap;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    fn local_context(root: PathBuf) -> ToolUseContext {
+        ToolUseContext {
+            tool_call_id: None,
+            agent_type: Some("Agent".to_string()),
+            session_id: None,
+            dialog_turn_id: Some("turn-1".to_string()),
+            workspace: Some(WorkspaceBinding::new(
+                Some("read-document-workspace".to_string()),
+                root,
+            )),
+            loaded_deferred_tool_specs: Vec::new(),
+            primary_model_facts: tool_runtime::context::PrimaryModelFacts::default(),
+            custom_data: HashMap::new(),
+            computer_use_host: None,
+            runtime_tool_restrictions: ToolRuntimeRestrictions::default(),
+            runtime_handles: ToolRuntimeHandles::default(),
+        }
+    }
+
+    struct FakeRemoteFs {
+        bytes: Vec<u8>,
+        bounded_limit: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl WorkspaceFileSystem for FakeRemoteFs {
+        async fn read_file(&self, _path: &str) -> anyhow::Result<Vec<u8>> {
+            Ok(self.bytes.clone())
+        }
+
+        async fn read_file_bounded(
+            &self,
+            _path: &str,
+            max_bytes: usize,
+        ) -> anyhow::Result<Option<Vec<u8>>> {
+            self.bounded_limit.store(max_bytes, Ordering::Relaxed);
+            Ok((self.bytes.len() <= max_bytes).then(|| self.bytes.clone()))
+        }
+
+        async fn read_file_text(&self, _path: &str) -> anyhow::Result<String> {
+            Ok(String::from_utf8_lossy(&self.bytes).to_string())
+        }
+
+        async fn write_file(&self, _path: &str, _contents: &[u8]) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn exists(&self, _path: &str) -> anyhow::Result<bool> {
+            Ok(true)
+        }
+
+        async fn is_file(&self, _path: &str) -> anyhow::Result<bool> {
+            Ok(true)
+        }
+
+        async fn is_dir(&self, _path: &str) -> anyhow::Result<bool> {
+            Ok(false)
+        }
+
+        async fn read_dir(&self, _path: &str) -> anyhow::Result<Vec<WorkspaceDirEntry>> {
+            Ok(Vec::new())
+        }
+    }
+
+    struct PanicRemoteShell;
+
+    #[async_trait]
+    impl WorkspaceShell for PanicRemoteShell {
+        async fn exec_with_options(
+            &self,
+            _command: &str,
+            _options: WorkspaceCommandOptions,
+        ) -> anyhow::Result<WorkspaceCommandResult> {
+            panic!("document reads must not require a remote shell or remote anydoc install")
+        }
+    }
+
+    fn remote_context(bytes: Vec<u8>, bounded_limit: Arc<AtomicUsize>) -> ToolUseContext {
+        let root = "/remote/workspace";
+        let session_identity =
+            crate::service::remote_ssh::workspace_state::workspace_session_identity(
+                root,
+                Some("conn-1"),
+                Some("remote-host"),
+            )
+            .expect("remote workspace identity");
+        let mut context = local_context(PathBuf::from(root));
+        context.workspace = Some(WorkspaceBinding::new_remote(
+            Some("read-document-remote".to_string()),
+            PathBuf::from(root),
+            "conn-1".to_string(),
+            "remote-host".to_string(),
+            session_identity,
+        ));
+        context.runtime_handles = ToolRuntimeHandles::new(
+            Some(WorkspaceServices {
+                fs: Arc::new(FakeRemoteFs {
+                    bytes,
+                    bounded_limit,
+                }),
+                shell: Arc::new(PanicRemoteShell),
+            }),
+            None,
+        );
+        context
+    }
 
     #[test]
     fn read_tool_schema_prefers_offset() {
@@ -592,6 +960,10 @@ mod tests {
 
         assert!(properties.contains_key("offset"));
         assert!(properties.contains_key("tail"));
+        assert_eq!(
+            properties["render"]["enum"],
+            json!(["auto", "source", "markdown"])
+        );
     }
 
     #[test]
@@ -619,5 +991,126 @@ mod tests {
         .expect_err("tail and offset should not coexist");
 
         assert_eq!(error, "Do not provide offset when tail is true");
+    }
+
+    #[test]
+    fn read_render_mode_defaults_to_auto_and_rejects_unknown_values() {
+        assert_eq!(
+            FileReadTool::read_render_mode(&json!({})).expect("default render"),
+            ReadRenderMode::Auto
+        );
+        assert_eq!(
+            FileReadTool::read_render_mode(&json!({ "render": "source" })).expect("source render"),
+            ReadRenderMode::Source
+        );
+        assert!(FileReadTool::read_render_mode(&json!({ "render": "html" })).is_err());
+        assert!(FileReadTool::read_render_mode(&json!({ "render": 1 })).is_err());
+    }
+
+    #[tokio::test]
+    async fn read_converts_rtf_to_a_markdown_representation() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let source = br"{\rtf1\ansi Hello from the document}";
+        fs::write(dir.path().join("notes.rtf"), source).expect("write RTF");
+
+        let results = FileReadTool::new()
+            .call_impl(
+                &json!({ "file_path": "notes.rtf" }),
+                &local_context(dir.path().to_path_buf()),
+            )
+            .await
+            .expect("document read should succeed");
+
+        let ToolResult::Result {
+            data,
+            result_for_assistant,
+            ..
+        } = &results[0]
+        else {
+            panic!("expected result");
+        };
+        assert_eq!(data["representation"], "extracted_markdown");
+        assert_eq!(data["source_format"], "rtf");
+        assert_eq!(data["conversion_engine"], "anydoc");
+        assert_eq!(data["source_size_bytes"], source.len());
+        assert!(data["content"]
+            .as_str()
+            .is_some_and(|content| content.contains("Hello from the document")));
+        assert!(result_for_assistant
+            .as_deref()
+            .is_some_and(|result| result.contains("from RTF to GitHub-Flavored Markdown")));
+    }
+
+    #[tokio::test]
+    async fn csv_auto_preserves_source_while_markdown_render_extracts_a_table() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fs::write(
+            dir.path().join("table.csv"),
+            "name,value\nalpha,1\nbeta,2\n",
+        )
+        .expect("write CSV");
+        let context = local_context(dir.path().to_path_buf());
+        let tool = FileReadTool::new();
+
+        let auto = tool
+            .call_impl(&json!({ "file_path": "table.csv" }), &context)
+            .await
+            .expect("source read should succeed");
+        let markdown = tool
+            .call_impl(
+                &json!({ "file_path": "table.csv", "render": "markdown" }),
+                &context,
+            )
+            .await
+            .expect("Markdown read should succeed");
+
+        let ToolResult::Result {
+            data: auto_data, ..
+        } = &auto[0]
+        else {
+            panic!("expected source result");
+        };
+        let ToolResult::Result {
+            data: markdown_data,
+            ..
+        } = &markdown[0]
+        else {
+            panic!("expected Markdown result");
+        };
+        assert!(auto_data.get("representation").is_none());
+        assert!(auto_data["content"]
+            .as_str()
+            .is_some_and(|content| content.contains("name,value")));
+        assert_eq!(markdown_data["representation"], "extracted_markdown");
+        assert_eq!(markdown_data["source_format"], "csv");
+        assert!(markdown_data["content"]
+            .as_str()
+            .is_some_and(|content| content.contains("| name | value |")));
+    }
+
+    #[tokio::test]
+    async fn remote_document_uses_bounded_file_transfer_and_host_side_conversion() {
+        let bounded_limit = Arc::new(AtomicUsize::new(0));
+        let context = remote_context(
+            br"{\rtf1\ansi Hello from remote RTF}".to_vec(),
+            Arc::clone(&bounded_limit),
+        );
+
+        let results = FileReadTool::new()
+            .call_impl(&json!({ "file_path": "notes.rtf" }), &context)
+            .await
+            .expect("remote document read should succeed");
+
+        let ToolResult::Result { data, .. } = &results[0] else {
+            panic!("expected result");
+        };
+        assert_eq!(
+            bounded_limit.load(Ordering::Relaxed),
+            MAX_DOCUMENT_INPUT_BYTES
+        );
+        assert_eq!(data["representation"], "extracted_markdown");
+        assert!(data["content"]
+            .as_str()
+            .is_some_and(|content| content.contains("Hello from remote RTF")));
     }
 }

--- a/src/crates/contracts/runtime-ports/src/lib.rs
+++ b/src/crates/contracts/runtime-ports/src/lib.rs
@@ -305,6 +305,19 @@ pub enum WorkspacePathKind {
 #[async_trait::async_trait]
 pub trait WorkspaceFileSystem: Send + Sync {
     async fn read_file(&self, path: &str) -> anyhow::Result<Vec<u8>>;
+    /// Read binary content up to `max_bytes`.
+    ///
+    /// `Ok(None)` means the file exceeded the bound; missing paths, non-files, and transport
+    /// failures remain errors. Production providers should enforce the bound before or while
+    /// transferring the file.
+    async fn read_file_bounded(
+        &self,
+        path: &str,
+        max_bytes: usize,
+    ) -> anyhow::Result<Option<Vec<u8>>> {
+        let bytes = self.read_file(path).await?;
+        Ok((bytes.len() <= max_bytes).then_some(bytes))
+    }
     async fn read_file_text(&self, path: &str) -> anyhow::Result<String>;
     /// Read UTF-8 text up to `max_bytes`. Production filesystem providers
     /// should enforce the bound before or while transferring the file.

--- a/src/crates/execution/tool-execution/AGENTS.md
+++ b/src/crates/execution/tool-execution/AGENTS.md
@@ -36,6 +36,7 @@ agent-facing tool surface.
 
 ```bash
 cargo test -p tool-runtime
+cargo test -p tool-runtime --features document-read fs::document
 cargo test -p tool-runtime --features web-readable web
 node scripts/check-core-boundaries.mjs
 ```

--- a/src/crates/execution/tool-execution/Cargo.toml
+++ b/src/crates/execution/tool-execution/Cargo.toml
@@ -5,9 +5,11 @@ edition.workspace = true
 
 [features]
 default = []
+document-read = ["dep:anydoc", "dep:sha2"]
 web-readable = ["dep:htmd", "dep:legible", "dep:readability-js", "dep:regex"]
 
 [dependencies]
+anydoc = { workspace = true, optional = true }
 bitfun-agent-tools = { path = "../tool-contracts" }
 bitfun-events = { path = "../../contracts/events" }
 bitfun-runtime-ports = { path = "../../contracts/runtime-ports" }
@@ -23,6 +25,7 @@ log = { workspace = true }
 regex = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+sha2 = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["rt", "sync", "time"] }
 tokio-util = { workspace = true }
 vte = { workspace = true, features = ["ansi"] }

--- a/src/crates/execution/tool-execution/src/fs/document.rs
+++ b/src/crates/execution/tool-execution/src/fs/document.rs
@@ -1,0 +1,286 @@
+//! Local, provider-neutral document-to-Markdown conversion for the Read tool.
+
+use std::collections::VecDeque;
+use std::fmt;
+use std::path::Path;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use anydoc::Format;
+use sha2::{Digest, Sha256};
+use tokio::sync::Semaphore;
+
+/// Maximum source-document size accepted by the Read tool conversion path.
+pub const MAX_DOCUMENT_INPUT_BYTES: usize = 64 * 1024 * 1024;
+
+/// Maximum retained Markdown for one conversion and across the in-memory conversion cache.
+pub const MAX_DOCUMENT_MARKDOWN_BYTES: usize = 16 * 1024 * 1024;
+
+const MAX_DOCUMENT_CACHE_ENTRIES: usize = 4;
+
+/// A document representation that can be paged by the normal Read primitives.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConvertedDocument {
+    pub markdown: Arc<str>,
+    pub source_format: &'static str,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct DocumentCacheKey {
+    source_sha256: [u8; 32],
+    format: Format,
+}
+
+struct DocumentCacheEntry {
+    key: DocumentCacheKey,
+    document: ConvertedDocument,
+}
+
+#[derive(Default)]
+struct DocumentCache {
+    entries: VecDeque<DocumentCacheEntry>,
+    retained_markdown_bytes: usize,
+}
+
+impl DocumentCache {
+    fn get(&mut self, key: DocumentCacheKey) -> Option<ConvertedDocument> {
+        let index = self.entries.iter().position(|entry| entry.key == key)?;
+        let entry = self.entries.remove(index)?;
+        let document = entry.document.clone();
+        self.entries.push_back(entry);
+        Some(document)
+    }
+
+    fn insert(&mut self, key: DocumentCacheKey, document: ConvertedDocument) {
+        let markdown_bytes = document.markdown.len();
+        if markdown_bytes > MAX_DOCUMENT_MARKDOWN_BYTES {
+            return;
+        }
+
+        while self.entries.len() >= MAX_DOCUMENT_CACHE_ENTRIES
+            || self.retained_markdown_bytes.saturating_add(markdown_bytes)
+                > MAX_DOCUMENT_MARKDOWN_BYTES
+        {
+            let Some(evicted) = self.entries.pop_front() else {
+                break;
+            };
+            self.retained_markdown_bytes = self
+                .retained_markdown_bytes
+                .saturating_sub(evicted.document.markdown.len());
+        }
+
+        self.retained_markdown_bytes = self.retained_markdown_bytes.saturating_add(markdown_bytes);
+        self.entries.push_back(DocumentCacheEntry { key, document });
+    }
+}
+
+/// Provider-neutral document conversion failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocumentConversionError {
+    code: &'static str,
+    message: String,
+}
+
+impl DocumentConversionError {
+    fn new(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+
+    pub fn code(&self) -> &'static str {
+        self.code
+    }
+}
+
+impl fmt::Display for DocumentConversionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for DocumentConversionError {}
+
+/// Whether the path extension names a format handled by anydoc.
+pub fn is_supported_document_path(path: &str) -> bool {
+    Format::from_path(Path::new(path)).is_some()
+}
+
+/// Convert document bytes on the blocking pool. Conversion is serialized process-wide because
+/// parsers can temporarily retain substantially more decompressed data than the source file.
+pub async fn convert_document_to_markdown(
+    bytes: Vec<u8>,
+    path_hint: String,
+) -> Result<ConvertedDocument, DocumentConversionError> {
+    if bytes.len() > MAX_DOCUMENT_INPUT_BYTES {
+        return Err(DocumentConversionError::new(
+            "resourceLimit",
+            format!(
+                "document is larger than the {} MiB Read limit",
+                MAX_DOCUMENT_INPUT_BYTES / (1024 * 1024)
+            ),
+        ));
+    }
+
+    let permit = document_conversion_semaphore()
+        .clone()
+        .acquire_owned()
+        .await
+        .map_err(|_| {
+            DocumentConversionError::new(
+                "runtime",
+                "document conversion is unavailable because its worker was closed",
+            )
+        })?;
+
+    tokio::task::spawn_blocking(move || {
+        // Keep the permit inside the blocking task. If the async caller is cancelled, the parser
+        // still occupies its bounded slot until the synchronous conversion actually exits.
+        let _permit = permit;
+        convert_document_to_markdown_sync(&bytes, &path_hint)
+    })
+    .await
+    .map_err(|error| {
+        DocumentConversionError::new(
+            "runtime",
+            format!("document conversion worker failed: {error}"),
+        )
+    })?
+}
+
+fn document_conversion_semaphore() -> &'static Arc<Semaphore> {
+    static SEMAPHORE: OnceLock<Arc<Semaphore>> = OnceLock::new();
+    SEMAPHORE.get_or_init(|| Arc::new(Semaphore::new(1)))
+}
+
+fn convert_document_to_markdown_sync(
+    bytes: &[u8],
+    path_hint: &str,
+) -> Result<ConvertedDocument, DocumentConversionError> {
+    let format = Format::from_bytes(bytes)
+        .or_else(|| Format::from_path(Path::new(path_hint)))
+        .ok_or_else(|| {
+            DocumentConversionError::new(
+                "unsupported",
+                "file content and extension do not identify a supported document format",
+            )
+        })?;
+    let cache_key = DocumentCacheKey {
+        source_sha256: Sha256::digest(bytes).into(),
+        format,
+    };
+    if let Some(document) = document_cache()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(cache_key)
+    {
+        return Ok(document);
+    }
+
+    let source_format = format_name(format);
+    let markdown = anydoc::to_markdown_bytes(bytes, format)
+        .map_err(|error| DocumentConversionError::new(error.code(), error.to_string()))?;
+    if markdown.len() > MAX_DOCUMENT_MARKDOWN_BYTES {
+        return Err(DocumentConversionError::new(
+            "resourceLimit",
+            format!(
+                "converted Markdown is larger than the {} MiB Read limit",
+                MAX_DOCUMENT_MARKDOWN_BYTES / (1024 * 1024)
+            ),
+        ));
+    }
+
+    let document = ConvertedDocument {
+        markdown: Arc::from(markdown),
+        source_format,
+    };
+    document_cache()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .insert(cache_key, document.clone());
+    Ok(document)
+}
+
+fn document_cache() -> &'static Mutex<DocumentCache> {
+    static CACHE: OnceLock<Mutex<DocumentCache>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(DocumentCache::default()))
+}
+
+fn format_name(format: Format) -> &'static str {
+    match format {
+        Format::Doc => "doc",
+        Format::Docx => "docx",
+        Format::Odt => "odt",
+        Format::Pdf => "pdf",
+        Format::Ppt => "ppt",
+        Format::Pptx => "pptx",
+        Format::Rtf => "rtf",
+        Format::Epub => "epub",
+        Format::Excel => "excel",
+        Format::Ods => "ods",
+        Format::Odp => "odp",
+        Format::Csv => "csv",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recognizes_all_supported_extension_families() {
+        for path in [
+            "report.doc",
+            "report.DOCX",
+            "report.docm",
+            "slides.ppt",
+            "slides.ppsx",
+            "sheet.xlsb",
+            "sheet.xlsx",
+            "document.odt",
+            "sheet.ods",
+            "slides.odp",
+            "notes.rtf",
+            "book.epub",
+            "table.csv",
+            "paper.pdf",
+        ] {
+            assert!(is_supported_document_path(path), "{path}");
+        }
+        assert!(!is_supported_document_path("src/lib.rs"));
+        assert!(!is_supported_document_path("README.md"));
+    }
+
+    #[test]
+    fn content_detection_takes_precedence_over_a_wrong_extension_hint() {
+        let converted =
+            convert_document_to_markdown_sync(br"{\rtf1\ansi Hello from RTF}", "mislabelled.pdf")
+                .expect("RTF should convert");
+
+        assert_eq!(converted.source_format, "rtf");
+        assert!(converted.markdown.contains("Hello from RTF"));
+    }
+
+    #[test]
+    fn csv_uses_the_path_hint_because_it_has_no_content_signature() {
+        let converted =
+            convert_document_to_markdown_sync(b"name,value\nalpha,1\nbeta,2\n", "table.csv")
+                .expect("CSV should convert");
+
+        assert_eq!(converted.source_format, "csv");
+        assert!(converted.markdown.contains("| name | value |"));
+        assert!(converted.markdown.contains("| alpha | 1 |"));
+    }
+
+    #[test]
+    fn repeated_conversion_reuses_cached_markdown_for_offset_reads() {
+        let first =
+            convert_document_to_markdown_sync(br"{\rtf1\ansi Cached document}", "cached.rtf")
+                .expect("first conversion");
+        let second =
+            convert_document_to_markdown_sync(br"{\rtf1\ansi Cached document}", "cached.rtf")
+                .expect("second conversion");
+
+        assert!(Arc::ptr_eq(&first.markdown, &second.markdown));
+    }
+}

--- a/src/crates/execution/tool-execution/src/fs/mod.rs
+++ b/src/crates/execution/tool-execution/src/fs/mod.rs
@@ -1,5 +1,7 @@
 pub mod backend;
 pub mod delete_path;
+#[cfg(feature = "document-read")]
+pub mod document;
 pub mod edit_file;
 pub mod list_dir;
 pub mod read_file;

--- a/src/crates/execution/tool-execution/src/fs/read_file.rs
+++ b/src/crates/execution/tool-execution/src/fs/read_file.rs
@@ -1,8 +1,7 @@
 use crate::util::string::{shell_single_quote, truncate_string_by_chars};
 use std::collections::VecDeque;
 use std::fs::File;
-use std::io::BufRead;
-use std::io::BufReader;
+use std::io::{BufRead, BufReader, Read};
 
 const REMOTE_TOTAL_LINES_MARKER: &str = "__BITFUN_TOTAL_LINES__=";
 const REMOTE_HIT_TOTAL_CHAR_LIMIT_MARKER: &str = "__BITFUN_HIT_TOTAL_CHAR_LIMIT__=";
@@ -59,6 +58,30 @@ pub fn build_read_file_presentation(
         result_for_assistant,
         lines_read: read_file_lines_read(result),
     }
+}
+
+/// Read a local file only when it fits within `max_bytes`.
+///
+/// The limit is enforced from handle metadata and again while reading so a growing file cannot
+/// make the caller retain an unbounded buffer.
+pub fn read_file_bytes_bounded(
+    file_path: &str,
+    max_bytes: usize,
+) -> Result<Option<Vec<u8>>, String> {
+    let file = File::open(file_path)
+        .map_err(|error| format!("Failed to read file {file_path}: {error}"))?;
+    let metadata = file
+        .metadata()
+        .map_err(|error| format!("Failed to inspect file {file_path}: {error}"))?;
+    if metadata.len() > max_bytes as u64 {
+        return Ok(None);
+    }
+
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    file.take(max_bytes.saturating_add(1) as u64)
+        .read_to_end(&mut bytes)
+        .map_err(|error| format!("Failed to read file {file_path}: {error}"))?;
+    Ok((bytes.len() <= max_bytes).then_some(bytes))
 }
 
 pub fn build_remote_read_command(
@@ -221,6 +244,45 @@ pub fn read_file(
     max_line_chars: usize,
     max_total_chars: usize,
 ) -> Result<ReadFileResult, String> {
+    let file =
+        File::open(file_path).map_err(|e| format!("Failed to read file {}: {}", file_path, e))?;
+    let source = format!("file {file_path}");
+    read_buffered_text(
+        BufReader::new(file),
+        &source,
+        start_line,
+        limit,
+        max_line_chars,
+        max_total_chars,
+    )
+}
+
+/// Page already-decoded text with the same line numbering and budgets as [`read_file`].
+pub fn read_text(
+    text: &str,
+    start_line: usize,
+    limit: usize,
+    max_line_chars: usize,
+    max_total_chars: usize,
+) -> Result<ReadFileResult, String> {
+    read_buffered_text(
+        BufReader::new(text.as_bytes()),
+        "converted document",
+        start_line,
+        limit,
+        max_line_chars,
+        max_total_chars,
+    )
+}
+
+fn read_buffered_text<R: BufRead>(
+    reader: R,
+    source: &str,
+    start_line: usize,
+    limit: usize,
+    max_line_chars: usize,
+    max_total_chars: usize,
+) -> Result<ReadFileResult, String> {
     if start_line == 0 {
         return Err("`start_line` should start from 1".to_string());
     }
@@ -234,17 +296,13 @@ pub fn read_file(
         .checked_add(limit.saturating_sub(1))
         .ok_or_else(|| "Requested line range is too large".to_string())?;
 
-    let file =
-        File::open(file_path).map_err(|e| format!("Failed to read file {}: {}", file_path, e))?;
-    let reader = BufReader::new(file);
-
     let mut total_lines = 0usize;
     let mut selected_lines = Vec::new();
     let mut selected_chars = 0usize;
     let mut hit_total_char_limit = false;
 
     for line_result in reader.lines() {
-        let line = line_result.map_err(|e| format!("Failed to read file {}: {}", file_path, e))?;
+        let line = line_result.map_err(|e| format!("Failed to read {source}: {e}"))?;
         total_lines += 1;
 
         if total_lines < start_line || total_lines > end_line_inclusive || hit_total_char_limit {
@@ -313,6 +371,41 @@ pub fn read_file_tail(
     max_line_chars: usize,
     max_total_chars: usize,
 ) -> Result<ReadFileResult, String> {
+    let file =
+        File::open(file_path).map_err(|e| format!("Failed to read file {}: {}", file_path, e))?;
+    let source = format!("file {file_path}");
+    read_buffered_text_tail(
+        BufReader::new(file),
+        &source,
+        limit,
+        max_line_chars,
+        max_total_chars,
+    )
+}
+
+/// Read the last lines of already-decoded text with the same budgets as [`read_file_tail`].
+pub fn read_text_tail(
+    text: &str,
+    limit: usize,
+    max_line_chars: usize,
+    max_total_chars: usize,
+) -> Result<ReadFileResult, String> {
+    read_buffered_text_tail(
+        BufReader::new(text.as_bytes()),
+        "converted document",
+        limit,
+        max_line_chars,
+        max_total_chars,
+    )
+}
+
+fn read_buffered_text_tail<R: BufRead>(
+    reader: R,
+    source: &str,
+    limit: usize,
+    max_line_chars: usize,
+    max_total_chars: usize,
+) -> Result<ReadFileResult, String> {
     if limit == 0 {
         return Err("`limit` can't be 0".to_string());
     }
@@ -320,15 +413,11 @@ pub fn read_file_tail(
         return Err("`max_total_chars` can't be 0".to_string());
     }
 
-    let file =
-        File::open(file_path).map_err(|e| format!("Failed to read file {}: {}", file_path, e))?;
-    let reader = BufReader::new(file);
-
     let mut total_lines = 0usize;
     let mut tail_lines = VecDeque::with_capacity(limit);
 
     for line_result in reader.lines() {
-        let line = line_result.map_err(|e| format!("Failed to read file {}: {}", file_path, e))?;
+        let line = line_result.map_err(|e| format!("Failed to read {source}: {e}"))?;
         total_lines += 1;
 
         if tail_lines.len() == limit {
@@ -397,8 +486,8 @@ pub fn read_file_tail(
 #[cfg(test)]
 mod tests {
     use super::{
-        build_read_file_presentation, read_file, read_file_lines_read, read_file_tail,
-        ReadFileResult,
+        build_read_file_presentation, read_file, read_file_bytes_bounded, read_file_lines_read,
+        read_file_tail, read_text, read_text_tail, ReadFileResult,
     };
     use std::fs;
     use std::path::PathBuf;
@@ -448,6 +537,37 @@ mod tests {
         assert_eq!(result.end_line, 3);
         assert!(!result.hit_total_char_limit);
         assert_eq!(result.content, "     1\tone\n     2\ttwo\n     3\tthree");
+    }
+
+    #[test]
+    fn bounded_byte_read_rejects_a_file_before_returning_oversized_content() {
+        let path = write_temp_file("12345");
+
+        let rejected = read_file_bytes_bounded(path.to_str().expect("utf-8 path"), 4)
+            .expect("bounded read should succeed");
+        let accepted = read_file_bytes_bounded(path.to_str().expect("utf-8 path"), 5)
+            .expect("bounded read should succeed");
+
+        fs::remove_file(&path).expect("temp file should be deleted");
+
+        assert!(rejected.is_none());
+        assert_eq!(accepted, Some(b"12345".to_vec()));
+    }
+
+    #[test]
+    fn decoded_text_reuses_normal_window_and_tail_semantics() {
+        let text = "one\ntwo\nthree\nfour\n";
+
+        let window = read_text(text, 2, 2, 50, 100).expect("window should read");
+        let tail = read_text_tail(text, 2, 50, 100).expect("tail should read");
+
+        assert_eq!(window.start_line, 2);
+        assert_eq!(window.end_line, 3);
+        assert_eq!(window.total_lines, 4);
+        assert_eq!(window.content, "     2\ttwo\n     3\tthree");
+        assert_eq!(tail.start_line, 3);
+        assert_eq!(tail.end_line, 4);
+        assert_eq!(tail.content, "     3\tthree\n     4\tfour");
     }
 
     #[test]

--- a/src/crates/services/services-core/src/workspace.rs
+++ b/src/crates/services/services-core/src/workspace.rs
@@ -22,6 +22,24 @@ impl WorkspaceFileSystem for LocalWorkspaceFs {
         Ok(tokio::fs::read(path).await?)
     }
 
+    async fn read_file_bounded(
+        &self,
+        path: &str,
+        max_bytes: usize,
+    ) -> anyhow::Result<Option<Vec<u8>>> {
+        let metadata = tokio::fs::metadata(path).await?;
+        if metadata.len() > max_bytes as u64 {
+            return Ok(None);
+        }
+        let mut bytes = Vec::with_capacity(metadata.len() as usize);
+        tokio::fs::File::open(path)
+            .await?
+            .take(max_bytes.saturating_add(1) as u64)
+            .read_to_end(&mut bytes)
+            .await?;
+        Ok((bytes.len() <= max_bytes).then_some(bytes))
+    }
+
     async fn read_file_text(&self, path: &str) -> anyhow::Result<String> {
         Ok(tokio::fs::read_to_string(path).await?)
     }
@@ -31,20 +49,11 @@ impl WorkspaceFileSystem for LocalWorkspaceFs {
         path: &str,
         max_bytes: usize,
     ) -> anyhow::Result<Option<String>> {
-        let metadata = tokio::fs::metadata(path).await?;
-        if metadata.len() > max_bytes as u64 {
-            return Ok(None);
-        }
-        let mut bytes = Vec::with_capacity(metadata.len() as usize);
-        tokio::fs::File::open(path)
+        self.read_file_bounded(path, max_bytes)
             .await?
-            .take(max_bytes as u64 + 1)
-            .read_to_end(&mut bytes)
-            .await?;
-        if bytes.len() > max_bytes {
-            return Ok(None);
-        }
-        Ok(Some(String::from_utf8(bytes)?))
+            .map(String::from_utf8)
+            .transpose()
+            .map_err(Into::into)
     }
 
     async fn write_file(&self, path: &str, contents: &[u8]) -> anyhow::Result<()> {
@@ -270,6 +279,11 @@ mod tests {
         assert!(fs.exists(&path).await.unwrap());
         assert!(fs.is_file(&path).await.unwrap());
         assert_eq!(fs.read_file_text(&path).await.unwrap(), "hello");
+        assert!(fs.read_file_bounded(&path, 4).await.unwrap().is_none());
+        assert_eq!(
+            fs.read_file_bounded(&path, 5).await.unwrap(),
+            Some(b"hello".to_vec())
+        );
     }
 
     #[tokio::test]

--- a/src/crates/services/services-integrations/src/remote_ssh/workspace_services.rs
+++ b/src/crates/services/services-integrations/src/remote_ssh/workspace_services.rs
@@ -11,8 +11,39 @@ use bitfun_runtime_ports::{
 };
 use std::sync::Arc;
 
-use super::{RemoteFileService, SSHCommandOptions, SSHCommandResult, SSHConnectionManager};
+use super::{
+    RemoteFileEntry, RemoteFileService, SSHCommandOptions, SSHCommandResult, SSHConnectionManager,
+};
 use crate::remote_ssh::shell;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum BoundedReadPreflight {
+    Transfer,
+    TooLarge,
+}
+
+fn bounded_read_preflight(
+    path: &str,
+    entry: Option<&RemoteFileEntry>,
+    max_bytes: usize,
+) -> anyhow::Result<BoundedReadPreflight> {
+    let Some(entry) = entry else {
+        // Let the actual transfer report a precise missing-file or transport error.
+        return Ok(BoundedReadPreflight::Transfer);
+    };
+    if entry.is_symlink {
+        // SFTP stat follows the final symlink while container metadata does not. The transfer
+        // follows it in both backends, and the progress callback still enforces the byte limit.
+        return Ok(BoundedReadPreflight::Transfer);
+    }
+    if !entry.is_file {
+        anyhow::bail!("Remote path is not a file: {path}");
+    }
+    if entry.size.is_some_and(|size| size > max_bytes as u64) {
+        return Ok(BoundedReadPreflight::TooLarge);
+    }
+    Ok(BoundedReadPreflight::Transfer)
+}
 
 /// SSH-backed filesystem implementation of [`WorkspaceFileSystem`].
 pub struct RemoteWorkspaceFs {
@@ -27,12 +58,48 @@ impl RemoteWorkspaceFs {
             file_service,
         }
     }
+
+    async fn transfer_file_bounded(
+        &self,
+        path: &str,
+        max_bytes: usize,
+    ) -> anyhow::Result<Option<Vec<u8>>> {
+        let mut exceeded = false;
+        let bytes = match self
+            .file_service
+            .read_file_with_progress(&self.connection_id, path, &mut |bytes_read, total_size| {
+                let over_limit = bytes_read > max_bytes as u64 || total_size > max_bytes as u64;
+                exceeded |= over_limit;
+                !over_limit
+            })
+            .await
+        {
+            Ok(bytes) => bytes,
+            Err(_) if exceeded => return Ok(None),
+            Err(error) => return Err(error),
+        };
+        Ok((bytes.len() <= max_bytes).then_some(bytes))
+    }
 }
 
 #[async_trait]
 impl WorkspaceFileSystem for RemoteWorkspaceFs {
     async fn read_file(&self, path: &str) -> anyhow::Result<Vec<u8>> {
         self.file_service.read_file(&self.connection_id, path).await
+    }
+
+    async fn read_file_bounded(
+        &self,
+        path: &str,
+        max_bytes: usize,
+    ) -> anyhow::Result<Option<Vec<u8>>> {
+        let entry = self.file_service.stat(&self.connection_id, path).await?;
+        if bounded_read_preflight(path, entry.as_ref(), max_bytes)?
+            == BoundedReadPreflight::TooLarge
+        {
+            return Ok(None);
+        }
+        self.transfer_file_bounded(path, max_bytes).await
     }
 
     async fn read_file_text(&self, path: &str) -> anyhow::Result<String> {
@@ -55,24 +122,10 @@ impl WorkspaceFileSystem for RemoteWorkspaceFs {
         if !entry.is_file || entry.size.is_some_and(|size| size > max_bytes as u64) {
             return Ok(None);
         }
-        let mut exceeded = false;
-        let bytes = match self
-            .file_service
-            .read_file_with_progress(&self.connection_id, path, &mut |bytes_read, total_size| {
-                let over_limit = bytes_read > max_bytes as u64 || total_size > max_bytes as u64;
-                exceeded |= over_limit;
-                !over_limit
-            })
-            .await
-        {
-            Ok(bytes) => bytes,
-            Err(_) if exceeded => return Ok(None),
-            Err(error) => return Err(error),
-        };
-        if bytes.len() > max_bytes {
-            return Ok(None);
-        }
-        Ok(Some(String::from_utf8_lossy(&bytes).to_string()))
+        Ok(self
+            .transfer_file_bounded(path, max_bytes)
+            .await?
+            .map(|bytes| String::from_utf8_lossy(&bytes).to_string()))
     }
 
     async fn write_file(&self, path: &str, contents: &[u8]) -> anyhow::Result<()> {
@@ -153,6 +206,43 @@ impl WorkspaceFileSystem for RemoteWorkspaceFs {
                 is_symlink: entry.is_symlink,
             })
             .collect())
+    }
+}
+
+#[cfg(test)]
+mod bounded_read_tests {
+    use super::*;
+
+    fn entry(is_file: bool, is_symlink: bool, size: Option<u64>) -> RemoteFileEntry {
+        RemoteFileEntry {
+            name: "document.docx".to_string(),
+            path: "/workspace/document.docx".to_string(),
+            is_dir: !is_file && !is_symlink,
+            is_file,
+            is_symlink,
+            size,
+            modified: None,
+            permissions: None,
+        }
+    }
+
+    #[test]
+    fn bounded_binary_preflight_preserves_errors_and_follows_document_symlinks() {
+        assert_eq!(
+            bounded_read_preflight("missing.docx", None, 64).unwrap(),
+            BoundedReadPreflight::Transfer
+        );
+        assert_eq!(
+            bounded_read_preflight("linked.docx", Some(&entry(false, true, Some(4))), 64).unwrap(),
+            BoundedReadPreflight::Transfer
+        );
+        assert_eq!(
+            bounded_read_preflight("large.docx", Some(&entry(true, false, Some(65))), 64).unwrap(),
+            BoundedReadPreflight::TooLarge
+        );
+        assert!(
+            bounded_read_preflight("folder.docx", Some(&entry(false, false, None)), 64).is_err()
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

- embed the pure-Rust anydoc v0.1.6 converter in the Agent Read path
- convert Office, OpenDocument, RTF, EPUB, and text PDF files to paged Markdown while preserving CSV source-read compatibility
- support bounded local and remote-workspace binary reads with host-side conversion
- keep extracted Markdown read-only so it cannot authorize edits to binary source files
- add input/output limits, serialized blocking conversion, a bounded content cache, and a 30-second soft timeout
- pin the dependency and include the upstream MIT notice

## Validation

- cargo test -p tool-runtime --features document-read fs:: --lib
- cargo test -p bitfun-core --no-default-features --features agent-runtime --lib agentic::tools::implementations::file_read_tool::tests
- cargo test -p bitfun-services-core --no-default-features --features workspace-runtime workspace
- cargo test -p bitfun-runtime-ports
- cargo test -p bitfun-services-integrations --no-default-features --features remote-ssh bounded_binary_preflight --lib
- cargo test -p bitfun-services-integrations --features remote-ssh --test remote_ssh_disabled_contracts
- cargo check -p bitfun-services-integrations --no-default-features --features remote-ssh,remote-ssh-concrete
- cargo check -p bitfun-core --features product-full
- pnpm run check:core-boundaries:test
- pnpm run check:core-boundaries
- pnpm run check:repo-hygiene

The broad cargo test -p tool-runtime run also reached two unrelated macOS temporary-path canonicalization assertion failures in untouched glob tests: /var versus /private/var.

## Known limitations

- scanned or image-only PDFs still require OCR
- the in-process synchronous parser has a soft caller timeout; a timed-out worker cannot be forcibly terminated and retains the single conversion permit until it exits