### PR TITLE
fix(release): move the release mirror out of the website dist

### DIFF
--- a/scripts/openbitfun-release-sync.sh
+++ b/scripts/openbitfun-release-sync.sh
@@ -46,7 +46,12 @@ GITHUB_LATEST_JSON_URL="https://github.com/GCWing/BitFun/releases/latest/downloa
 GITHUB_LINUX_BINARIES_URL="https://github.com/GCWing/BitFun/releases/latest/download/linux-binaries.json"
 GITHUB_RELAY_IMAGE_URL="https://github.com/GCWing/BitFun/releases/latest/download/relay-image.json"
 OPENBITFUN_BASE_URL="https://openbitfun.com/release"
-WEBSITE_RELEASE_DIR="/root/repos/BitFun-Website/dist/release"
+# The mirror deliberately lives outside the website checkout. It used to be
+# BitFun-Website/dist/release, but `npm run build` empties dist/, so every
+# website deploy silently deleted the mirrored installers and manifests —
+# breaking downloads and the updater fallback until someone noticed. nginx
+# serves this directory through a `location ^~ /release/` alias instead.
+WEBSITE_RELEASE_DIR="${WEBSITE_RELEASE_DIR:-/srv/bitfun-release}"
 LOCK_FILE="/root/repos/BitFun-AutoUpdate/sync.lock"
 WINDOWS_INSTALLER_FILENAME="bitfun-installer.exe"
 WEBSITE_DOWNLOADS_MANIFEST="downloads.json"


### PR DESCRIPTION
## 问题

发布镜像目录原本是 `BitFun-Website/dist/release`。`npm run build` 会清空 `dist/`，所以**每次网站部署都会删掉整个镜像**——2.3 GB 的安装包和 `latest.json` / `downloads.json` / `linux-binaries.json` / `relay-image.json` 全部消失。

后果：
- 官网下载按钮 404
- Tauri updater 的 openbitfun.com 兜底端点 404（GitHub 不可达时客户端无法更新）
- 直到下一次 cron 同步（最多 10 分钟）才恢复，且要从 GitHub 重新拉 2.3 GB

今天更新官网时踩到了，已在生产环境验证复现。

## 改动

`WEBSITE_RELEASE_DIR` 改为 `/srv/bitfun-release`（构建产物之外），并允许环境变量覆盖。nginx 通过 `location ^~ /release/` alias 指向该目录，**公开 URL 完全不变**。

`^~` 前缀用于阻止下方 `~* \.(js|css|png|...)$` 那条 immutable 缓存 regex 抢匹配。

## 生产环境已完成的操作

1. 暂停 release-sync cron
2. `mv` 到 `/srv/bitfun-release`（同文件系统，瞬时；迁移前后文件列表+大小逐项比对一致）
3. nginx 加 `location ^~ /release/`，`nginx -t` 通过后 reload
4. 部署本 PR 的脚本（与仓库版本 md5 一致）
5. 手动跑一次同步：exit 0，所有资产 `Already exists`（无丢失、无重新下载）
6. 恢复 cron，与迁移前 `diff` 一致
7. **重新构建网站验证：`/srv/bitfun-release` 完好，`/release/*` 全部 200/206**

## 验证

- `node --test scripts/linux-binaries-manifest.test.mjs` → 9/9 通过
- 线上：首页 200，`/release/latest.json` `/release/downloads.json` `/release/linux-binaries.json` `/release/relay-image.json.sig` 均 200，`/release/0.2.16/bitfun-installer.exe` range 请求 206，目录遍历 403

## 遗留

nginx 站点配置 `/etc/nginx/sites-available/openbit.fun` 目前只存在于服务器上，未纳入任何仓库版本管理（本次改动只能靠这条 PR 描述留痕）。是否要像 `deploy/miniapp-market/` 那样把它收进仓库，另议。