### PR TITLE
fix(dispatch): stop PTY teardown from killing one-click CLI installs

### DIFF
--- a/src/crates/services/services-integrations/src/remote_ssh/dispatch_ssh.rs
+++ b/src/crates/services/services-integrations/src/remote_ssh/dispatch_ssh.rs
@@ -846,19 +846,25 @@ async fn stage_and_launch_installer(
     )
     .await?;
 
-    // The short-lived PTY driver only starts a nohup body and exits. Draining
-    // the channel in the background prevents a server-side channel leak while
-    // keeping the installer independent of the caller process.
+    // The short-lived driver only starts a nohup body and exits, and it must run
+    // without a PTY. sshd tears a PTY down as soon as the driver exits — about a
+    // millisecond after the hand-off — and that teardown races the body it just
+    // spawned. A body still inside bash's startup has not reached its own exit
+    // trap yet, so losing that race kills it silently: no log, no exit file, and
+    // a `.pid` the next poll then reaps as stale. The controller sees an empty
+    // state and reports the install as failed even though nothing went wrong.
+    // A plain exec channel has no controlling terminal, so the hand-off cannot be
+    // interrupted; the installer needs no TTY semantics either, since it never
+    // uses sudo. Draining the channel in the background prevents a server-side
+    // channel leak while keeping the installer independent of the caller process.
     let channel = match manager
-        .open_pty_exec_channel(
+        .open_exec_channel(
             connection_id,
             &format!(
                 "bash {} {}",
                 shell_quote_posix(script_path),
                 shell_quote_posix(install_token)
             ),
-            100,
-            30,
         )
         .await
     {

--- a/src/web-ui/src/features/dispatch/DispatchInstallDialog.tsx
+++ b/src/web-ui/src/features/dispatch/DispatchInstallDialog.tsx
@@ -235,7 +235,15 @@ export const DispatchInstallDialog: React.FC<DispatchInstallDialogProps> = ({
         cursor = poll.cursor;
         if (poll.status === 'succeeded') break;
         if (poll.status === 'failed') {
-          throw new Error('Target CLI installation failed');
+          // Carry the installer's own tail into the error: without it the only
+          // record of the failure is a generic message, and the remote state
+          // that would explain it is cleaned up before anyone can look.
+          const detail = poll.output.trim();
+          throw new Error(
+            detail
+              ? `Target CLI installation failed: ${detail}`
+              : 'Target CLI installation failed with no installer output',
+          );
         }
         await new Promise(resolve => globalThis.setTimeout(resolve, 750));
       }

--- a/src/web-ui/src/shared/utils/logger.test.ts
+++ b/src/web-ui/src/shared/utils/logger.test.ts
@@ -18,6 +18,43 @@ async function importLoggerWithBootstrapLevel(level: unknown) {
   return import('./logger');
 }
 
+describe('error formatting', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // WebKit — what Tauri embeds on macOS — builds `stack` from frames only, so a
+  // logged failure would otherwise arrive with a location and no reason.
+  it('keeps the message when the stack omits it', async () => {
+    const { createLogger } = await importLoggerWithBootstrapLevel('debug');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const error = new Error('Target CLI installation failed');
+    error.stack = '@tauri://localhost/assets/ChatPane.js:96:14836';
+
+    createLogger('DispatchInstallDialog').warn('Failed to prepare SSH dispatch target', {
+      connectionId: 'ssh-a',
+      error,
+    });
+
+    const line = String(warn.mock.calls.at(-1)?.[0] ?? '');
+    expect(line).toContain('Target CLI installation failed');
+    expect(line).toContain('ChatPane.js:96:14836');
+    expect(line).toContain('"connectionId":"ssh-a"');
+  });
+
+  it('does not repeat the message when the stack already carries it', async () => {
+    const { createLogger } = await importLoggerWithBootstrapLevel('debug');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const error = new Error('boom');
+    error.stack = 'Error: boom\n    at somewhere';
+
+    createLogger('Ctx').warn('failed', error);
+
+    const line = String(warn.mock.calls.at(-1)?.[0] ?? '');
+    expect(line).toBe('[Ctx] failed Error: boom\n    at somewhere');
+  });
+});
+
 describe('logger bootstrap level', () => {
   afterEach(() => {
     delete globalThis.__BITFUN_BOOTSTRAP_LOG_LEVEL__;

--- a/src/web-ui/src/shared/utils/logger.ts
+++ b/src/web-ui/src/shared/utils/logger.ts
@@ -49,6 +49,21 @@ export function areSensitiveDiagnosticsEnabled(): boolean {
   return includeSensitiveDiagnostics;
 }
 
+/**
+ * Render an Error without losing its message.
+ *
+ * `stack` alone is not enough: WebKit — which is what Tauri embeds on macOS —
+ * builds a stack out of frames only, so `error.stack` for `new Error('boom')` is
+ * just `@app.js:1:2`. Logging that leaves a failure with a location and no
+ * reason, which is exactly the case a warning exists to explain.
+ */
+function formatError(error: Error): string {
+  const summary = `${error.name}: ${error.message}`;
+  const stack = error.stack;
+  if (!stack) return summary;
+  return stack.includes(error.message) ? stack : `${summary}\n${stack}`;
+}
+
 function formatConsoleArg(value: unknown): string {
   if (value === undefined) return 'undefined';
   if (value === null) return 'null';
@@ -57,7 +72,7 @@ function formatConsoleArg(value: unknown): string {
     return String(value);
   }
   if (typeof value === 'symbol') return value.toString();
-  if (value instanceof Error) return value.stack || `${value.name}: ${value.message}`;
+  if (value instanceof Error) return formatError(value);
   if (typeof value === 'object') {
     try {
       return JSON.stringify(value);
@@ -229,7 +244,7 @@ export async function initLogger(): Promise<void> {
 function formatData(data: unknown): string {
   if (data === undefined || data === null) return '';
   if (data instanceof Error) {
-    return data.stack || data.message;
+    return formatError(data);
   }
   if (typeof data === 'object') {
     try {
@@ -240,7 +255,7 @@ function formatData(data: unknown): string {
       for (const key of Object.keys(data as Record<string, unknown>)) {
         const value = (data as Record<string, unknown>)[key];
         if (value instanceof Error) {
-          errors.push(value.stack || `${value.name}: ${value.message}`);
+          errors.push(formatError(value));
         } else {
           regularData[key] = value;
         }


### PR DESCRIPTION
## Summary

One-click deploy to an SSH target failed with "未能完整部署 BitFun" even though the release had already been downloaded and verified on the target.

The installer launched its driver over a **PTY** exec channel. The driver only spawns a `nohup` body and exits — about a millisecond later — and sshd tears the PTY down the moment it does. That teardown races the body it just spawned: a body still inside bash's startup has not reached its own `trap finish EXIT` yet, so losing the race kills it silently.

Nothing survives to explain it:

- the body writes no log and no `.exit` file,
- the driver's cleanup trap removes the `.preparing` marker,
- the next poll reaps the now-stale `.pid` via its liveness check.

`install_cli_poll` reads an all-empty state, maps it to `Failed`, and the dialog treats the very first poll as fatal.

Fix: launch over a plain exec channel. Without a controlling terminal there is no hangup to race, and the installer needs no TTY semantics anyway — it never uses sudo.

## Type and Areas

Type: bug fix (+ two diagnostics fixes that kept it invisible)

Areas: Rust core (`remote_ssh`/dispatch), web UI

## Motivation / Impact

The failure is probabilistic, which is why the same target sometimes installs fine and sometimes does not. When it loses the race the user gets a generic, unactionable error and a target left with a verified archive and no CLI.

Two diagnostics gaps are fixed alongside it, because together they made the root cause unrecoverable from the logs:

- **`logger.ts`** — WebKit (what Tauri embeds on macOS) builds `Error.stack` from frames only, with no message line. The logger preferred `stack` over the message, so the warning reached `app.log` as `Failed to prepare SSH dispatch target {...}, @tauri://localhost/assets/ChatPane-*.js:96:14836` — a location with no reason. This affects every call site that logs an `Error`.
- **`DispatchInstallDialog.tsx`** — the install-poll failure threw a fixed string and discarded `poll.output`, so even a populated remote installer log never reached the error.

No user-facing string changes.

## Verification

Diagnosed and verified against a real Ubuntu 24.04 aarch64 target over SSH, using a standalone russh 0.45 program that replicates `stage_and_launch_installer` exactly (PTY, background drain, first poll at +52 ms — the timing taken from the failing `app.log`).

Detachment matrix, launching a `nohup`'d background script and letting the channel close:

| launch | result |
| --- | --- |
| PTY + `nohup` + `&` | killed before writing a single line |
| PTY + `setsid` + `nohup` + `&` | killed before writing a single line |
| **non-PTY + `nohup` + `&`** | **survives, runs to completion** |

Measured: the driver runs start→exit in ~1 ms, and a hangup reaches the remote process in ~3 ms — comfortably inside the window before the body installs its traps.

End-to-end with the real staged installer over a non-PTY channel, polling on the app's schedule:

```
poll 0: running=1 preparing=0 size=75  marker=0 exit_recorded=0
poll 1: running=0 preparing=0 size=169 marker=1 exit_recorded=1 exit_code=0
```

Target ends on `bitfun 0.2.16`, install directory clean, archive consumed as designed.

Automated checks:

```bash
cargo test -p bitfun-services-integrations --features remote-ssh-concrete   # 126 passed, 1 ignored
cargo clippy -p bitfun-services-integrations --features remote-ssh-concrete # no new warnings
pnpm --filter web-ui exec vitest run src/shared/utils/logger.test.ts src/features/dispatch/DispatchInstallDialog.test.tsx  # 18 passed
pnpm --filter web-ui exec tsc --noEmit                                      # clean
pnpm --filter web-ui exec eslint <changed files>                            # clean
```

Two regression tests added for the logger's error formatting (stack-without-message, and no duplication when the stack already carries it).

## Reviewer Notes

- The account-sync / daemon-provisioning half of one-click deploy (`provision_account_daemon`) runs through `execute_command_with_options` and has no PTY, so it never had this hazard.
- `open_exec_channel` passes `tty: false` to `workspace_command`, which only matters for Docker-container targets — and `ensure_plain_ssh_target` already rejects those before this point, so the change is a no-op for every path that reaches it.
- The remote installer scripts themselves are unchanged and were confirmed correct: launched with a channel that stays open, they install successfully.
- AI-assisted; **fully tested** — root cause reproduced and the fix verified end-to-end against a live SSH target.
