### PR TITLE
fix(agent): include goal lifecycle tools in Cowork

### DIFF
--- a/src/crates/assembly/core/src/agentic/agents/definitions/modes/cowork.rs
+++ b/src/crates/assembly/core/src/agentic/agents/definitions/modes/cowork.rs
@@ -30,6 +30,9 @@ impl CoworkMode {
                 // Clarification + planning helpers
                 "AskUserQuestion".to_string(),
                 "TodoWrite".to_string(),
+                "get_goal".to_string(),
+                "create_goal".to_string(),
+                "update_goal".to_string(),
                 "Task".to_string(),
                 "ListModels".to_string(),
                 "AgentWait".to_string(),
@@ -108,6 +111,14 @@ impl Agent for CoworkMode {
 mod tests {
     use super::CoworkMode;
     use crate::agentic::agents::Agent;
+
+    #[test]
+    fn cowork_mode_includes_goal_lifecycle_tools_in_defaults() {
+        let tools = CoworkMode::new().default_tools();
+        for tool in ["get_goal", "create_goal", "update_goal"] {
+            assert!(tools.contains(&tool.to_string()));
+        }
+    }
 
     #[test]
     fn cowork_mode_includes_miniapp_lifecycle_tools_in_defaults() {


### PR DESCRIPTION
## Summary

- Add `get_goal`, `create_goal`, and `update_goal` to the Cowork default tool set.
- Add regression coverage for the complete goal lifecycle tool bundle.

Fixes #2009

## Type and Areas

Type: Bug fix

Areas: Rust core, Agent runtime assembly

## Motivation / Impact

Cowork sessions can create a thread goal through the product UI, independently of the tools exposed to the model. Without `update_goal` in the default tool set, an active goal cannot be completed and the automatic continuation loop keeps running. Cowork now exposes the same complete goal lifecycle bundle as the shared coding modes.

## Verification

- `pnpm run fmt:rs`
- `cargo test -p bitfun-core --no-default-features --features agent-runtime --lib agentic::agents::definitions::modes::cowork::tests` — 2 passed
- `git diff --check`

## Reviewer Notes

This is a clean replacement for #2036, based on current `main`; that PR contains unrelated commits and is currently conflicting.

AI-assisted; fully tested for the changed Cowork default-tool behavior.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable; no copy changes are required.