### PR TITLE
feat(web-ui): add pet switch settings action

### DIFF
--- a/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.test.tsx
+++ b/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.test.tsx
@@ -105,7 +105,11 @@ beforeAll(async () => {
         'flow-chat': {
           agentCompanion: {
             activity: { working: 'Working', completed: 'Completed' },
-            menu: { closePet: 'Close pet', closeBubble: 'Close this bubble' },
+            menu: {
+              switchPet: 'Switch pet',
+              closePet: 'Close pet',
+              closeBubble: 'Close this bubble',
+            },
             composer: {
               openTitle: 'Send a message to this session',
               ariaLabel: 'Send a message to this session',
@@ -185,7 +189,9 @@ describe('AgentCompanionDesktopPet', () => {
 
     dispatch(hitbox!, 'contextmenu', { clientX: 300, clientY: 200 });
 
-    const menuItem = query<HTMLButtonElement>('.bitfun-agent-companion-window__menu-item');
+    const menuItem = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('.bitfun-agent-companion-window__menu-item'),
+    ).find(item => item.textContent === 'Close pet');
     expect(menuItem?.textContent).toBe('Close pet');
 
     act(() => {
@@ -193,6 +199,25 @@ describe('AgentCompanionDesktopPet', () => {
     });
 
     expect(emitMock).toHaveBeenCalledWith(PET_COMMAND_EVENT, { type: 'close-desktop-pet' });
+    expect(query('.bitfun-agent-companion-window__menu-item')).toBeNull();
+  });
+
+  it('opens the pet settings from the pet context menu', () => {
+    dispatch(query('.bitfun-agent-companion-window__pet-hitbox')!, 'contextmenu', {
+      clientX: 300,
+      clientY: 200,
+    });
+
+    const menuItems = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('.bitfun-agent-companion-window__menu-item'),
+    );
+    expect(menuItems.map(item => item.textContent)).toEqual(['Switch pet', 'Close pet']);
+
+    act(() => {
+      menuItems[0]!.click();
+    });
+
+    expect(emitMock).toHaveBeenCalledWith(PET_COMMAND_EVENT, { type: 'open-pet-settings' });
     expect(query('.bitfun-agent-companion-window__menu-item')).toBeNull();
   });
 

--- a/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.tsx
+++ b/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.tsx
@@ -613,6 +613,14 @@ export const AgentCompanionDesktopPet: React.FC = () => {
       });
   }, [sendPetCommand]);
 
+  const openPetSettings = useCallback(() => {
+    setOverlay(null);
+    void sendPetCommand({ type: 'open-pet-settings' })
+      .catch(error => {
+        log.warn('Failed to request Agent companion pet settings', error);
+      });
+  }, [sendPetCommand]);
+
   const closeBubble = useCallback((task: AgentCompanionTaskStatus) => {
     setOverlay(null);
     setDismissedBubbles(previous => ({
@@ -844,11 +852,18 @@ export const AgentCompanionDesktopPet: React.FC = () => {
   const overlayTask = overlay && overlay.kind !== 'pet-menu'
     ? visibleTasks.find(task => task.sessionId === overlay.sessionId) ?? null
     : null;
-  const menuItem = overlay?.kind === 'pet-menu'
-    ? { label: t('agentCompanion.menu.closePet'), onClick: closeDesktopPet }
+  const menuItems = overlay?.kind === 'pet-menu'
+    ? [
+      { key: 'switch-pet', label: t('agentCompanion.menu.switchPet'), onClick: openPetSettings },
+      { key: 'close-pet', label: t('agentCompanion.menu.closePet'), onClick: closeDesktopPet },
+    ]
     : overlay?.kind === 'bubble-menu' && overlayTask
-      ? { label: t('agentCompanion.menu.closeBubble'), onClick: () => closeBubble(overlayTask) }
-      : null;
+      ? [{
+        key: 'close-bubble',
+        label: t('agentCompanion.menu.closeBubble'),
+        onClick: () => closeBubble(overlayTask),
+      }]
+      : [];
 
   return (
     <main
@@ -863,7 +878,7 @@ export const AgentCompanionDesktopPet: React.FC = () => {
           onPointerDown={closeOverlay}
         />
       )}
-      {menuItem && (
+      {menuItems.length > 0 && (
         <div
           ref={menuRef}
           className="bitfun-agent-companion-window__overlay bitfun-agent-companion-window__overlay--anchored"
@@ -874,14 +889,17 @@ export const AgentCompanionDesktopPet: React.FC = () => {
           }}
         >
           <div className="bitfun-agent-companion-window__menu" role="menu">
-            <button
-              type="button"
-              role="menuitem"
-              className="bitfun-agent-companion-window__menu-item"
-              onClick={menuItem.onClick}
-            >
-              {menuItem.label}
-            </button>
+            {menuItems.map(menuItem => (
+              <button
+                key={menuItem.key}
+                type="button"
+                role="menuitem"
+                className="bitfun-agent-companion-window__menu-item"
+                onClick={menuItem.onClick}
+              >
+                {menuItem.label}
+              </button>
+            ))}
           </div>
         </div>
       )}

--- a/src/web-ui/src/app/services/agentCompanionPetCommands.test.ts
+++ b/src/web-ui/src/app/services/agentCompanionPetCommands.test.ts
@@ -6,6 +6,12 @@ const sessionsMock = vi.hoisted(() => new Map<string, unknown>());
 const clearSessionUnreadCompletionMock = vi.hoisted(() => vi.fn());
 const getSettingsAsyncMock = vi.hoisted(() => vi.fn());
 const saveSettingsMock = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+const openSettingsMock = vi.hoisted(() => vi.fn());
+const invokeMock = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: invokeMock,
+}));
 
 vi.mock('@/flow_chat/services/FlowChatManager', () => ({
   FlowChatManager: {
@@ -31,17 +37,32 @@ vi.mock('@/infrastructure/config/services/AIExperienceConfigService', () => ({
   },
 }));
 
+vi.mock('@/shared/services/ide-control', () => ({
+  quickActions: {
+    openSettings: openSettingsMock,
+  },
+}));
+
 describe('handleAgentCompanionPetCommand', () => {
   beforeEach(() => {
     sendMessageMock.mockClear();
     clearSessionUnreadCompletionMock.mockClear();
     saveSettingsMock.mockClear();
+    openSettingsMock.mockClear();
+    invokeMock.mockClear();
     sessionsMock.clear();
     getSettingsAsyncMock.mockReset();
     getSettingsAsyncMock.mockResolvedValue({
       enable_agent_companion: true,
       agent_companion_display_mode: 'desktop',
     });
+  });
+
+  it('opens the companion personalization settings', async () => {
+    await handleAgentCompanionPetCommand({ type: 'open-pet-settings' });
+
+    expect(openSettingsMock).toHaveBeenCalledWith('session-personalization');
+    expect(invokeMock).toHaveBeenCalledWith('show_main_window');
   });
 
   it('turns the companion off and keeps the display mode when the pet is closed', async () => {

--- a/src/web-ui/src/app/services/agentCompanionPetCommands.ts
+++ b/src/web-ui/src/app/services/agentCompanionPetCommands.ts
@@ -14,6 +14,8 @@ const log = createLogger('AgentCompanionPetCommands');
  * `agent-companion://pet-command`.
  */
 export type AgentCompanionPetCommand =
+  /** Right-click menu: open the companion appearance picker in Settings. */
+  | { type: 'open-pet-settings' }
   /** Right-click menu: turn the companion off ("Show Agent companion"). */
   | { type: 'close-desktop-pet' }
   /** Bubble right-click menu: the user acknowledged this bubble. */
@@ -41,6 +43,16 @@ async function closeAgentCompanionDesktopPet(): Promise<void> {
     enable_agent_companion: false,
   });
   log.info('Agent companion disabled from pet context menu');
+}
+
+async function openAgentCompanionPetSettings(): Promise<void> {
+  const [{ quickActions }, { invoke }] = await Promise.all([
+    import('@/shared/services/ide-control'),
+    import('@tauri-apps/api/core'),
+  ]);
+  quickActions.openSettings('session-personalization');
+  await invoke('show_main_window');
+  log.info('Agent companion settings opened from pet context menu');
 }
 
 /**
@@ -84,6 +96,9 @@ export async function handleAgentCompanionPetCommand(
   }
 
   switch (command.type) {
+    case 'open-pet-settings':
+      await openAgentCompanionPetSettings();
+      return;
     case 'close-desktop-pet':
       await closeAgentCompanionDesktopPet();
       return;

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -413,6 +413,7 @@
       "interrupted": "Interrupted"
     },
     "menu": {
+      "switchPet": "Switch pet",
       "closePet": "Close pet",
       "closeBubble": "Close this bubble"
     },

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -413,6 +413,7 @@
       "interrupted": "已中断"
     },
     "menu": {
+      "switchPet": "切换宠物",
       "closePet": "关闭宠物",
       "closeBubble": "关闭该气泡"
     },

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -413,6 +413,7 @@
       "interrupted": "已中斷"
     },
     "menu": {
+      "switchPet": "切換寵物",
       "closePet": "關閉寵物",
       "closeBubble": "關閉該氣泡"
     },


### PR DESCRIPTION
## Summary

- add a Switch pet action to the desktop companion context menu
- open Settings > Personalization and focus the BitFun main window when selected
- add English, Simplified Chinese, and Traditional Chinese copy plus focused coverage

## Testing

- `pnpm --dir src/web-ui run test:run src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.test.tsx src/app/services/agentCompanionPetCommands.test.ts`
- `pnpm run type-check:web`
- `pnpm run i18n:audit`
- `git diff --check`

AI-assisted: yes. Testing level: fully tested.