### PR TITLE
fix(appearance): skip dependency dirs in contract audit walks

### DIFF
--- a/scripts/audit-appearance-contracts.mjs
+++ b/scripts/audit-appearance-contracts.mjs
@@ -80,10 +80,15 @@ if (fs.existsSync(retiredOwnershipFile)) {
   failures.push(`${relative(retiredOwnershipFile)}: directory-level Appearance source ownership is forbidden`);
 }
 
+const ignoredWalkDirectories = new Set(['node_modules', 'dist', 'build']);
+
 function walk(directory) {
   return fs.readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
     const absolute = path.join(directory, entry.name);
-    if (entry.isDirectory()) return walk(absolute);
+    if (entry.isDirectory()) {
+      if (ignoredWalkDirectories.has(entry.name)) return [];
+      return walk(absolute);
+    }
     return /\.(?:css|scss|ts|tsx)$/.test(entry.name) ? [absolute] : [];
   });
 }
@@ -91,7 +96,10 @@ function walk(directory) {
 function walkContractSources(directory) {
   return fs.readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
     const absolute = path.join(directory, entry.name);
-    if (entry.isDirectory()) return walkContractSources(absolute);
+    if (entry.isDirectory()) {
+      if (ignoredWalkDirectories.has(entry.name)) return [];
+      return walkContractSources(absolute);
+    }
     return /\.(?:css|d\.ts|html|js|json|md|rs|scss|ts|tsx)$/.test(entry.name) ? [absolute] : [];
   });
 }


### PR DESCRIPTION
## Summary
- Appearance contract audit recursively walked `MiniApp/` and other cross-boundary roots without skipping dependency/build outputs.
- Local `MiniApp/**/node_modules` (e.g. playwright-core) could contain strings like `ThemeService` and fail `pnpm run desktop:build` / `appearance:contract-audit`.
- Align walkers with `audit-theme-colors.mjs` by ignoring `node_modules`, `dist`, and `build`.

## Test plan
- [x] `pnpm run appearance:contract-audit` passes
- [ ] Re-run `pnpm run desktop:build` (or at least `frontend:build-all`) with a MiniApp demo that has local `node_modules`