### PR TITLE
fix(agent): recover transient model routing and goal worktrees

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,8 +197,13 @@ jobs:
 
       - uses: swatinem/rust-cache@v2
         with:
-          shared-key: "ci-check-v3-${{ runner.os }}-no-cargo-bin-v1"
+          shared-key: "ci-check-v4-${{ runner.os }}-no-cargo-bin-v1-sherpa-native-v1"
           cache-bin: false
+          # sherpa-onnx-sys stores downloaded native archives beside Cargo's
+          # normal artifacts. Preserve that directory with the build-script
+          # fingerprints that reference it, or restored test builds cannot link.
+          cache-directories: |
+            target/sherpa-onnx-prebuilt
           # PR caches are scoped to merge refs; trusted main pushes own shared
           # refreshes and retain completed dependency builds after late test failures.
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/scripts/check-github-config.test.mjs
+++ b/scripts/check-github-config.test.mjs
@@ -251,6 +251,15 @@ test('keeps Rust CI independent, restore-only on PRs, and target-focused', () =>
     assert.equal(cache?.with?.['cache-on-failure'], trustedMain);
   }
 
+  const rustCache = rustJob.steps.find((step) =>
+    step.uses?.startsWith('swatinem/rust-cache@'),
+  );
+  assert.equal(
+    rustCache?.with?.['cache-directories'],
+    'target/sherpa-onnx-prebuilt\n',
+    'Rust CI must restore sherpa native libraries with the Cargo fingerprints that reference them',
+  );
+
   const commandByStep = new Map(
     rustJob.steps.map((step) => [step.name, step.run]),
   );

--- a/src/crates/adapters/ai-adapters/src/client/sse.rs
+++ b/src/crates/adapters/ai-adapters/src/client/sse.rs
@@ -105,6 +105,77 @@ fn is_retryable_http_status(status: StatusCode) -> bool {
     status.is_server_error() || matches!(status.as_u16(), 408 | 409 | 425 | 429)
 }
 
+fn is_retryable_error_category(category: &ErrorCategory) -> bool {
+    matches!(
+        category,
+        ErrorCategory::Network
+            | ErrorCategory::RateLimit
+            | ErrorCategory::Timeout
+            | ErrorCategory::ProviderUnavailable
+    )
+}
+
+fn provider_error_message(body: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_str(body).ok()?;
+    let error = value.get("error").unwrap_or(&value);
+    error
+        .get("message")
+        .or_else(|| error.get("error"))
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+}
+
+/// Some OpenAI-compatible gateways occasionally lose their resolved model
+/// while routing an otherwise valid request, then report `model=None` or
+/// `model=null` as a 400. Treat that response as transient only when it
+/// contradicts the concrete model BitFun actually sent. A genuine invalid
+/// model name still remains a non-retryable client error.
+fn provider_lost_request_model(
+    status: StatusCode,
+    request_body: &serde_json::Value,
+    error_text: &str,
+) -> bool {
+    if status != StatusCode::BAD_REQUEST {
+        return false;
+    }
+
+    let has_concrete_model = request_body
+        .get("model")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|model| {
+            !model.is_empty()
+                && !model.eq_ignore_ascii_case("none")
+                && !model.eq_ignore_ascii_case("null")
+        })
+        .is_some();
+    if !has_concrete_model {
+        return false;
+    }
+
+    let Some(message) = provider_error_message(error_text) else {
+        return false;
+    };
+    let message = message.to_ascii_lowercase();
+    let reports_missing_model = ["model=none", "model = none", "model=null", "model = null"]
+        .iter()
+        .any(|marker| message.contains(marker));
+
+    reports_missing_model
+        && (message.contains("invalid model") || message.contains("missing model"))
+}
+
+fn is_retryable_http_failure(
+    status: StatusCode,
+    request_body: &serde_json::Value,
+    error_text: &str,
+    provider_error: &AiProviderError,
+) -> bool {
+    is_retryable_http_status(status)
+        || is_retryable_error_category(&provider_error.category)
+        || provider_lost_request_model(status, request_body, error_text)
+}
+
 fn provider_error_code(body: &str) -> Option<String> {
     let value: serde_json::Value = serde_json::from_str(body).ok()?;
     let error = value.get("error").unwrap_or(&value);
@@ -271,26 +342,6 @@ where
                 let http_version = resp.version();
                 let headers = resp.headers().clone();
 
-                if status.is_client_error() && !is_retryable_http_status(status) {
-                    let error_text = resp
-                        .text()
-                        .await
-                        .unwrap_or_else(|e| format!("Failed to read error response: {}", e));
-                    let provider_error =
-                        http_provider_error(label, status, &error_text, "client error");
-                    if let Some(trace) = trace.as_ref() {
-                        trace
-                            .sink
-                            .request_attempt_failed(
-                                trace_handle.as_ref(),
-                                &provider_error.to_string(),
-                            )
-                            .await;
-                    }
-                    error!("{}", provider_error);
-                    return Err(anyhow!(provider_error));
-                }
-
                 if status.is_success() {
                     debug!(
                         "{} request connected: {}ms, status: {}, protocol: {:?}, transport_attempt: {}/{}",
@@ -307,8 +358,21 @@ where
                         .text()
                         .await
                         .unwrap_or_else(|e| format!("Failed to read error response: {}", e));
-                    let provider_error = http_provider_error(label, status, &error_text, "error");
-                    if provider_error.category == ErrorCategory::ContextOverflow {
+                    let error_kind =
+                        if status.is_client_error() && !is_retryable_http_status(status) {
+                            "client error"
+                        } else {
+                            "error"
+                        };
+                    let provider_error =
+                        http_provider_error(label, status, &error_text, error_kind);
+                    let retryable = is_retryable_http_failure(
+                        status,
+                        request_body,
+                        &error_text,
+                        &provider_error,
+                    );
+                    if provider_error.category == ErrorCategory::ContextOverflow || !retryable {
                         if let Some(trace) = trace.as_ref() {
                             trace
                                 .sink
@@ -457,11 +521,43 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::extract::State;
+    use axum::response::IntoResponse;
+    use axum::routing::post;
+    use axum::{Json, Router};
     use reqwest::header::HeaderValue;
     use std::sync::{
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc,
     };
+
+    #[derive(Clone)]
+    struct RetryFixtureState {
+        attempts: Arc<AtomicUsize>,
+    }
+
+    async fn invalid_model_then_success(
+        State(state): State<RetryFixtureState>,
+        Json(body): Json<serde_json::Value>,
+    ) -> impl IntoResponse {
+        assert_eq!(body["model"], "configured-model");
+        if state.attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "error": {
+                        "message": "/chat/completions: Invalid model name passed in model=None. Call `/v1/models` to view available models for your key.",
+                        "type": "None",
+                        "param": "None",
+                        "code": "400"
+                    }
+                })),
+            )
+                .into_response()
+        } else {
+            StatusCode::OK.into_response()
+        }
+    }
 
     #[test]
     fn http_error_uses_structured_code_before_generic_message() {
@@ -546,6 +642,101 @@ mod tests {
         assert!(!is_retryable_http_status(StatusCode::UNAUTHORIZED));
         assert!(!is_retryable_http_status(StatusCode::BAD_REQUEST));
         assert!(!is_retryable_http_status(StatusCode::NOT_FOUND));
+    }
+
+    #[test]
+    fn provider_model_loss_requires_a_contradictory_concrete_request_model() {
+        let error_text = serde_json::json!({
+            "error": {
+                "message": "Invalid model name passed in model=None",
+                "code": "400"
+            }
+        })
+        .to_string();
+
+        assert!(provider_lost_request_model(
+            StatusCode::BAD_REQUEST,
+            &serde_json::json!({"model": "configured-model"}),
+            &error_text,
+        ));
+        assert!(!provider_lost_request_model(
+            StatusCode::BAD_REQUEST,
+            &serde_json::json!({"model": "None"}),
+            &error_text,
+        ));
+        assert!(!provider_lost_request_model(
+            StatusCode::BAD_REQUEST,
+            &serde_json::json!({}),
+            &error_text,
+        ));
+        assert!(!provider_lost_request_model(
+            StatusCode::NOT_FOUND,
+            &serde_json::json!({"model": "configured-model"}),
+            &error_text,
+        ));
+    }
+
+    #[test]
+    fn structured_transient_code_overrides_a_nonstandard_client_status() {
+        let error_text =
+            r#"{"error":{"code":"server_error","message":"temporary routing failure"}}"#;
+        let provider_error = http_provider_error(
+            "OpenAI Streaming API",
+            StatusCode::BAD_REQUEST,
+            error_text,
+            "client error",
+        );
+
+        assert_eq!(provider_error.category, ErrorCategory::ProviderUnavailable);
+        assert!(is_retryable_http_failure(
+            StatusCode::BAD_REQUEST,
+            &serde_json::json!({"model": "configured-model"}),
+            error_text,
+            &provider_error,
+        ));
+    }
+
+    #[tokio::test]
+    async fn contradictory_missing_model_response_uses_existing_retry_loop() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let app = Router::new()
+            .route("/chat/completions", post(invalid_model_then_success))
+            .with_state(RetryFixtureState {
+                attempts: Arc::clone(&attempts),
+            });
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind retry fixture");
+        let address = listener.local_addr().expect("retry fixture address");
+        let server_task = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("retry fixture should run");
+        });
+        let url = format!("http://{address}/chat/completions");
+        let client = reqwest::Client::new();
+        let request_body = serde_json::json!({"model": "configured-model"});
+
+        let result = execute_sse_request(
+            "OpenAI Streaming API",
+            &url,
+            &request_body,
+            2,
+            None,
+            None,
+            || client.post(&url),
+            |_response, tx, _tx_raw, _remaining_ttft_timeout| async move {
+                drop(tx);
+            },
+        )
+        .await;
+
+        server_task.abort();
+        assert!(
+            result.is_ok(),
+            "the second transport attempt should succeed"
+        );
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
     }
 
     #[test]

--- a/src/crates/assembly/core/src/service/worktree/session_binding.rs
+++ b/src/crates/assembly/core/src/service/worktree/session_binding.rs
@@ -62,6 +62,16 @@ pub struct WorktreeSessionBindingResult {
 struct SessionBindingContext {
     project_workspace_path: String,
     execution_target: SessionExecutionTarget,
+    /// Why an actual transition is forbidden. An already-satisfied binding
+    /// request remains a safe, read-only no-op even when this is set.
+    transition_blocker: Option<WorktreeError>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SessionBindingAction {
+    AlreadyBound,
+    Enable,
+    Disable,
 }
 
 fn error(code: WorktreeErrorCode, message: impl Into<String>) -> WorktreeError {
@@ -84,46 +94,51 @@ async fn load_binding_context(
     let session_manager = coordinator.get_session_manager();
     let session = session_manager.get_session(&request.session_id);
 
-    let (workspace_path, project_workspace_path, execution_target) = if let Some(session) = session
-    {
-        if !session.dialog_turn_ids.is_empty() {
-            return Err(error(
-                WorktreeErrorCode::WorktreeBusy,
-                "Worktree isolation can only be changed before the session's first message",
-            ));
-        }
-        if !matches!(session.state, crate::agentic::core::SessionState::Idle) {
-            return Err(error(
-                WorktreeErrorCode::WorktreeBusy,
-                "Worktree isolation cannot be changed while the session is processing",
-            ));
-        }
-        if session.config.remote_connection_id.is_some() {
-            return Err(error(
-                WorktreeErrorCode::RemoteUnsupported,
-                "Managed worktrees are not supported for remote SSH workspaces yet",
-            ));
-        }
+    let (workspace_path, project_workspace_path, execution_target, mut transition_blocker) =
+        if let Some(session) = session {
+            let transition_blocker = if !session.dialog_turn_ids.is_empty() {
+                Some(error(
+                    WorktreeErrorCode::WorktreeBusy,
+                    "Worktree isolation can only be changed before the session's first message",
+                ))
+            } else if !matches!(session.state, crate::agentic::core::SessionState::Idle) {
+                Some(error(
+                    WorktreeErrorCode::WorktreeBusy,
+                    "Worktree isolation cannot be changed while the session is processing",
+                ))
+            } else if session.config.remote_connection_id.is_some() {
+                Some(error(
+                    WorktreeErrorCode::RemoteUnsupported,
+                    "Managed worktrees are not supported for remote SSH workspaces yet",
+                ))
+            } else {
+                None
+            };
 
-        let workspace_path = session.config.workspace_path.clone().ok_or_else(|| {
-            error(
-                WorktreeErrorCode::InvalidPath,
-                "Session is not bound to a workspace",
+            let workspace_path = session.config.workspace_path.clone().ok_or_else(|| {
+                error(
+                    WorktreeErrorCode::InvalidPath,
+                    "Session is not bound to a workspace",
+                )
+            })?;
+            let project_workspace_path = session
+                .config
+                .project_workspace_path
+                .clone()
+                .unwrap_or_else(|| workspace_path.clone());
+            let execution_target = session
+                .config
+                .execution_target
+                .clone()
+                .unwrap_or_else(|| SessionExecutionTarget::local(workspace_path.clone()));
+            (
+                workspace_path,
+                project_workspace_path,
+                execution_target,
+                transition_blocker,
             )
-        })?;
-        let project_workspace_path = session
-            .config
-            .project_workspace_path
-            .clone()
-            .unwrap_or_else(|| workspace_path.clone());
-        let execution_target = session
-            .config
-            .execution_target
-            .clone()
-            .unwrap_or_else(|| SessionExecutionTarget::local(workspace_path.clone()));
-        (workspace_path, project_workspace_path, execution_target)
-    } else {
-        let project_workspace_path = request
+        } else {
+            let project_workspace_path = request
                 .project_workspace_path
                 .as_deref()
                 .map(str::trim)
@@ -138,45 +153,53 @@ async fn load_binding_context(
                     )
                 })?
                 .to_string();
-        let metadata = session_manager
-            .load_session_metadata(Path::new(&project_workspace_path), &request.session_id)
+            let metadata = session_manager
+                .load_session_metadata(Path::new(&project_workspace_path), &request.session_id)
+                .await
+                .map_err(|metadata_error| {
+                    error(
+                        WorktreeErrorCode::IoFailed,
+                        format!("Failed to load session metadata: {metadata_error}"),
+                    )
+                })?
+                .ok_or_else(|| {
+                    error(
+                        WorktreeErrorCode::WorktreeNotFound,
+                        format!("Session not found: {}", request.session_id),
+                    )
+                })?;
+            let transition_blocker = (metadata.turn_count > 0).then(|| {
+                error(
+                    WorktreeErrorCode::WorktreeBusy,
+                    "Worktree isolation can only be changed before the session's first message",
+                )
+            });
+
+            let workspace_path = metadata
+                .workspace_path
+                .clone()
+                .unwrap_or_else(|| project_workspace_path.clone());
+            let persisted_project_path = metadata
+                .project_workspace_path
+                .clone()
+                .unwrap_or(project_workspace_path);
+            let execution_target = metadata
+                .execution_target
+                .clone()
+                .unwrap_or_else(|| SessionExecutionTarget::local(workspace_path.clone()));
+            (
+                workspace_path,
+                persisted_project_path,
+                execution_target,
+                transition_blocker,
+            )
+        };
+
+    if transition_blocker.is_none()
+        && crate::service::remote_ssh::workspace_state::is_remote_path(&project_workspace_path)
             .await
-            .map_err(|metadata_error| {
-                error(
-                    WorktreeErrorCode::IoFailed,
-                    format!("Failed to load session metadata: {metadata_error}"),
-                )
-            })?
-            .ok_or_else(|| {
-                error(
-                    WorktreeErrorCode::WorktreeNotFound,
-                    format!("Session not found: {}", request.session_id),
-                )
-            })?;
-        if metadata.turn_count > 0 {
-            return Err(error(
-                WorktreeErrorCode::WorktreeBusy,
-                "Worktree isolation can only be changed before the session's first message",
-            ));
-        }
-
-        let workspace_path = metadata
-            .workspace_path
-            .clone()
-            .unwrap_or_else(|| project_workspace_path.clone());
-        let persisted_project_path = metadata
-            .project_workspace_path
-            .clone()
-            .unwrap_or(project_workspace_path);
-        let execution_target = metadata
-            .execution_target
-            .clone()
-            .unwrap_or_else(|| SessionExecutionTarget::local(workspace_path.clone()));
-        (workspace_path, persisted_project_path, execution_target)
-    };
-
-    if crate::service::remote_ssh::workspace_state::is_remote_path(&project_workspace_path).await {
-        return Err(error(
+    {
+        transition_blocker = Some(error(
             WorktreeErrorCode::RemoteUnsupported,
             "Managed worktrees are not supported for remote SSH workspaces yet",
         ));
@@ -192,6 +215,27 @@ async fn load_binding_context(
     Ok(SessionBindingContext {
         project_workspace_path,
         execution_target,
+        transition_blocker,
+    })
+}
+
+fn binding_action(
+    context: &SessionBindingContext,
+    enabled: bool,
+) -> Result<SessionBindingAction, WorktreeError> {
+    let is_worktree = context.execution_target.worktree_id.is_some();
+    if enabled == is_worktree {
+        return Ok(SessionBindingAction::AlreadyBound);
+    }
+
+    if let Some(blocker) = context.transition_blocker.as_ref() {
+        return Err(blocker.clone());
+    }
+
+    Ok(if enabled {
+        SessionBindingAction::Enable
+    } else {
+        SessionBindingAction::Disable
     })
 }
 
@@ -262,24 +306,22 @@ impl WorktreeService {
             .map_err(|message| error(WorktreeErrorCode::InvalidPath, message))?;
         let _binding_guard = SESSION_BINDING_LOCKS.lock(&request.session_id).await;
         let context = load_binding_context(&request).await?;
-        let is_worktree = context.execution_target.worktree_id.is_some();
-
-        if request.enabled == is_worktree {
-            // Already in the requested state; report it rather than churn Git.
-            return Ok(WorktreeSessionBindingResult {
-                session_id: request.session_id,
-                workspace_path: context.execution_target.root_path.clone(),
-                project_workspace_path: context.project_workspace_path,
-                workspace_id: current_workspace_id(&context.execution_target.root_path).await,
-                execution_target: context.execution_target,
-                retained_worktree_path: None,
-            });
-        }
-
-        if request.enabled {
-            Self::enable_session_worktree(&request, &context).await
-        } else {
-            Self::disable_session_worktree(&request, &context).await
+        match binding_action(&context, request.enabled)? {
+            SessionBindingAction::AlreadyBound => {
+                // Already in the requested state; report it rather than churn Git.
+                Ok(WorktreeSessionBindingResult {
+                    session_id: request.session_id,
+                    workspace_path: context.execution_target.root_path.clone(),
+                    project_workspace_path: context.project_workspace_path,
+                    workspace_id: current_workspace_id(&context.execution_target.root_path).await,
+                    execution_target: context.execution_target,
+                    retained_worktree_path: None,
+                })
+            }
+            SessionBindingAction::Enable => Self::enable_session_worktree(&request, &context).await,
+            SessionBindingAction::Disable => {
+                Self::disable_session_worktree(&request, &context).await
+            }
         }
     }
 
@@ -395,7 +437,11 @@ impl WorktreeService {
 
 #[cfg(test)]
 mod tests {
-    use super::{WorktreeSessionBindingRequest, SESSION_BINDING_LOCKS};
+    use super::{
+        binding_action, error, SessionBindingAction, SessionBindingContext,
+        WorktreeSessionBindingRequest, SESSION_BINDING_LOCKS,
+    };
+    use bitfun_core_types::{SessionExecutionTarget, WorktreeErrorCode};
     use std::time::Duration;
 
     #[test]
@@ -423,6 +469,29 @@ mod tests {
         assert_eq!(
             request.project_workspace_path.as_deref(),
             Some(r"D:\workspace\BitFun")
+        );
+    }
+
+    #[test]
+    fn already_satisfied_binding_is_a_no_op_after_the_first_message() {
+        let context = SessionBindingContext {
+            project_workspace_path: "/repo".to_string(),
+            execution_target: SessionExecutionTarget::local("/repo"),
+            transition_blocker: Some(error(
+                WorktreeErrorCode::WorktreeBusy,
+                "Worktree isolation can only be changed before the session's first message",
+            )),
+        };
+
+        assert_eq!(
+            binding_action(&context, false),
+            Ok(SessionBindingAction::AlreadyBound)
+        );
+        assert_eq!(
+            binding_action(&context, true)
+                .expect_err("an actual transition must stay blocked")
+                .code,
+            WorktreeErrorCode::WorktreeBusy
         );
     }
 

--- a/src/web-ui/src/flow_chat/services/goalService.test.ts
+++ b/src/web-ui/src/flow_chat/services/goalService.test.ts
@@ -1,0 +1,214 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Session } from '../types/flow-chat';
+import { runGoalCommand } from './goalService';
+
+const mocks = vi.hoisted(() => ({
+  activateSessionGoal: vi.fn(),
+  bindSession: vi.fn(),
+  getSessionThreadGoal: vi.fn(),
+  getState: vi.fn(),
+  pendingList: vi.fn(),
+  pendingRemove: vi.fn(),
+  setSessionWorktreeIsolationRequested: vi.fn(),
+  setThreadGoal: vi.fn(),
+  updateSessionExecutionTarget: vi.fn(),
+  notificationSuccess: vi.fn(),
+}));
+
+vi.mock('@/infrastructure/api/service-api/AgentAPI', () => ({
+  agentAPI: {
+    activateSessionGoal: (params: unknown) => mocks.activateSessionGoal(params),
+    clearSessionThreadGoal: vi.fn(),
+    getSessionThreadGoal: (params: unknown) => mocks.getSessionThreadGoal(params),
+    setSessionThreadGoalStatus: vi.fn(),
+    updateSessionThreadGoalObjective: vi.fn(),
+  },
+}));
+
+vi.mock('@/infrastructure/api/service-api/WorktreeAPI', () => ({
+  worktreeAPI: {
+    bindSession: (...args: unknown[]) => mocks.bindSession(...args),
+  },
+}));
+
+vi.mock('@/shared/notification-system', () => ({
+  notificationService: {
+    error: vi.fn(),
+    info: vi.fn(),
+    success: (...args: unknown[]) => mocks.notificationSuccess(...args),
+  },
+}));
+
+vi.mock('../store/FlowChatStore', () => ({
+  flowChatStore: {
+    getState: () => mocks.getState(),
+    setSessionWorktreeIsolationRequested: (...args: unknown[]) => (
+      mocks.setSessionWorktreeIsolationRequested(...args)
+    ),
+    setThreadGoal: (...args: unknown[]) => mocks.setThreadGoal(...args),
+    updateSessionExecutionTarget: (...args: unknown[]) => (
+      mocks.updateSessionExecutionTarget(...args)
+    ),
+  },
+}));
+
+vi.mock('./flow-chat-manager/PendingQueueModule', () => ({
+  pendingQueueManager: {
+    list: (...args: unknown[]) => mocks.pendingList(...args),
+    remove: (...args: unknown[]) => mocks.pendingRemove(...args),
+  },
+}));
+
+describe('/goal worktree preparation', () => {
+  let currentSession: Session;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    currentSession = {
+      sessionId: 'session-1',
+      dialogTurns: [],
+      status: 'active',
+      config: {
+        workspacePath: '/repo',
+        projectWorkspacePath: '/repo',
+        executionTarget: {
+          kind: 'local',
+          rootPath: '/repo',
+        },
+        worktreeIsolationRequested: true,
+      },
+      workspacePath: '/repo',
+      projectWorkspacePath: '/repo',
+      createdAt: 0,
+      lastActiveAt: 0,
+      error: null,
+      sessionKind: 'normal',
+    };
+
+    mocks.getState.mockImplementation(() => ({
+      sessions: new Map([[currentSession.sessionId, currentSession]]),
+    }));
+    mocks.pendingList.mockReturnValue([]);
+    mocks.getSessionThreadGoal.mockResolvedValue({ goal: null });
+    mocks.bindSession.mockResolvedValue({
+      sessionId: currentSession.sessionId,
+      workspacePath: '/worktrees/wt-1',
+      projectWorkspacePath: '/repo',
+      workspaceId: 'workspace-1',
+      executionTarget: {
+        kind: 'managedWorktree',
+        worktreeId: 'wt-1',
+        rootPath: '/worktrees/wt-1',
+      },
+    });
+    mocks.updateSessionExecutionTarget.mockImplementation((
+      _sessionId: string,
+      binding: {
+        workspacePath: string;
+        projectWorkspacePath: string;
+        workspaceId?: string;
+        executionTarget: Session['config']['executionTarget'];
+      },
+    ) => {
+      currentSession = {
+        ...currentSession,
+        workspacePath: binding.workspacePath,
+        projectWorkspacePath: binding.projectWorkspacePath,
+        workspaceId: binding.workspaceId,
+        config: {
+          ...currentSession.config,
+          workspacePath: binding.workspacePath,
+          projectWorkspacePath: binding.projectWorkspacePath,
+          workspaceId: binding.workspaceId,
+          executionTarget: binding.executionTarget,
+        },
+      };
+    });
+    mocks.setSessionWorktreeIsolationRequested.mockImplementation((
+      _sessionId: string,
+      requested: boolean | undefined,
+    ) => {
+      currentSession = {
+        ...currentSession,
+        config: {
+          ...currentSession.config,
+          worktreeIsolationRequested: requested,
+        },
+      };
+    });
+    mocks.activateSessionGoal.mockResolvedValue({
+      goal: {
+        goalId: 'goal-1',
+        objective: 'finish the task',
+        status: 'active',
+      },
+    });
+  });
+
+  it('materializes the pending worktree before activating a new goal', async () => {
+    const result = await runGoalCommand({
+      session: currentSession,
+      action: { kind: 'set', objective: 'finish the task' },
+      usageMessage: 'usage',
+      failedTitle: 'failed',
+      unknownErrorMessage: 'unknown',
+      activatedTitle: 'activated',
+      clearedTitle: 'cleared',
+      pausedTitle: 'paused',
+      resumedTitle: 'resumed',
+      editedTitle: 'edited',
+    });
+
+    expect(mocks.bindSession).toHaveBeenCalledWith(
+      'session-1',
+      true,
+      expect.any(String),
+      '/repo',
+    );
+    expect(mocks.activateSessionGoal).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      workspacePath: '/repo',
+      remoteConnectionId: undefined,
+      remoteSshHost: undefined,
+      userHint: 'finish the task',
+    });
+    expect(mocks.bindSession.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.activateSessionGoal.mock.invocationCallOrder[0],
+    );
+    expect(currentSession.config.executionTarget?.worktreeId).toBe('wt-1');
+    expect(currentSession.config.worktreeIsolationRequested).toBeUndefined();
+    expect(result).toMatchObject({
+      goalId: 'goal-1',
+      objective: 'finish the task',
+      status: 'active',
+    });
+  });
+
+  it('clears a stale worktree request instead of rebinding a nonempty session', async () => {
+    currentSession = {
+      ...currentSession,
+      totalTurnCount: 1,
+    };
+
+    await runGoalCommand({
+      session: currentSession,
+      action: { kind: 'set', objective: 'finish the task' },
+      usageMessage: 'usage',
+      failedTitle: 'failed',
+      unknownErrorMessage: 'unknown',
+      activatedTitle: 'activated',
+      clearedTitle: 'cleared',
+      pausedTitle: 'paused',
+      resumedTitle: 'resumed',
+      editedTitle: 'edited',
+    });
+
+    expect(mocks.bindSession).not.toHaveBeenCalled();
+    expect(mocks.setSessionWorktreeIsolationRequested).toHaveBeenCalledWith(
+      'session-1',
+      undefined,
+    );
+    expect(mocks.activateSessionGoal).toHaveBeenCalledOnce();
+    expect(currentSession.config.worktreeIsolationRequested).toBeUndefined();
+  });
+});

--- a/src/web-ui/src/flow_chat/services/goalService.ts
+++ b/src/web-ui/src/flow_chat/services/goalService.ts
@@ -1,10 +1,12 @@
 import { agentAPI } from '@/infrastructure/api/service-api/AgentAPI';
+import { worktreeAPI } from '@/infrastructure/api/service-api/WorktreeAPI';
 import { notificationService } from '@/shared/notification-system';
 import type { Session } from '../types/flow-chat';
 import { flowChatStore } from '../store/FlowChatStore';
 import { pendingQueueManager } from './flow-chat-manager/PendingQueueModule';
 import type { GoalCommandAction } from './goalCommandParser';
 import { sessionProjectWorkspacePath } from '../utils/sessionWorkspace';
+import { sessionWorktreeMaterializationPlan } from '../utils/sessionWorktree';
 
 export { isGoalSlashCommand, parseGoalCommand } from './goalCommandParser';
 export type { GoalCommandAction } from './goalCommandParser';
@@ -113,6 +115,39 @@ async function sessionRequestBase(session: Session) {
   };
 }
 
+/**
+ * `/goal` can start backend work without passing through the normal first-message
+ * driver. Materialize the composer's pending worktree choice before any goal
+ * action that can start or steer a turn. For an older session with a stale
+ * pending flag, the plan is intentionally empty and we only clear that flag.
+ */
+async function prepareSessionForGoalTurn(session: Session): Promise<Session> {
+  const sessionId = session.sessionId;
+  const latest = flowChatStore.getState().sessions.get(sessionId) ?? session;
+  if (latest.config.worktreeIsolationRequested === undefined) {
+    return latest;
+  }
+
+  const materialization = sessionWorktreeMaterializationPlan(latest);
+  if (materialization) {
+    const result = await worktreeAPI.bindSession(
+      sessionId,
+      materialization.enabled,
+      globalThis.crypto?.randomUUID?.() ?? `goal-worktree-${Date.now()}`,
+      materialization.projectWorkspacePath,
+    );
+    flowChatStore.updateSessionExecutionTarget(sessionId, {
+      workspacePath: result.workspacePath,
+      projectWorkspacePath: result.projectWorkspacePath,
+      workspaceId: result.workspaceId,
+      executionTarget: result.executionTarget,
+    });
+  }
+
+  flowChatStore.setSessionWorktreeIsolationRequested(sessionId, undefined);
+  return flowChatStore.getState().sessions.get(sessionId) ?? latest;
+}
+
 export async function fetchSessionThreadGoal(
   session: Session
 ): Promise<ThreadGoalSnapshot | null> {
@@ -186,7 +221,12 @@ export async function runGoalCommand(params: GoalCommandParams): Promise<ThreadG
       return snapshot;
     }
     case 'resume': {
-      const goal = await agentAPI.setSessionThreadGoalStatus({ ...base, status: 'active' });
+      const preparedSession = await prepareSessionForGoalTurn(params.session);
+      const preparedBase = await sessionRequestBase(preparedSession);
+      const goal = await agentAPI.setSessionThreadGoalStatus({
+        ...preparedBase,
+        status: 'active',
+      });
       const snapshot = mapGoal(goal);
       syncGoalToStore(params.session.sessionId, snapshot);
       notificationService.success(goal.objective, {
@@ -212,8 +252,10 @@ export async function runGoalCommand(params: GoalCommandParams): Promise<ThreadG
         }
       }
 
+      const preparedSession = await prepareSessionForGoalTurn(params.session);
+      const preparedBase = await sessionRequestBase(preparedSession);
       const activation = await agentAPI.activateSessionGoal({
-        ...base,
+        ...preparedBase,
         userHint: params.action.objective,
       });
 
@@ -289,8 +331,6 @@ export async function saveThreadGoalObjective(
     throw new Error('A workspace is required to use /goal.');
   }
 
-  const base = await sessionRequestBase(session);
-
   if (mode === 'create') {
     return runGoalCommand({
       session,
@@ -309,8 +349,10 @@ export async function saveThreadGoalObjective(
     });
   }
 
+  const preparedSession = await prepareSessionForGoalTurn(session);
+  const preparedBase = await sessionRequestBase(preparedSession);
   const goal = await agentAPI.updateSessionThreadGoalObjective({
-    ...base,
+    ...preparedBase,
     objective: trimmed,
   });
   const snapshot = mapGoal(goal);

--- a/src/web-ui/src/flow_chat/utils/sessionWorktree.test.ts
+++ b/src/web-ui/src/flow_chat/utils/sessionWorktree.test.ts
@@ -83,6 +83,19 @@ describe('session worktree control', () => {
     }))).toBeUndefined();
   });
 
+  it('discards a stale pending change once the session has persisted work', () => {
+    expect(sessionWorktreeMaterializationPlan(session({
+      totalTurnCount: 1,
+      config: {
+        executionTarget: {
+          kind: 'local',
+          rootPath: '/repo',
+        },
+        worktreeIsolationRequested: true,
+      },
+    }))).toBeUndefined();
+  });
+
   it('invalidates the composer subscription after hydrate and rebind', () => {
     const initial = sessionWorktreeBindingSubscriptionKey(session());
     const armed = sessionWorktreeBindingSubscriptionKey(session({

--- a/src/web-ui/src/flow_chat/utils/sessionWorktree.ts
+++ b/src/web-ui/src/flow_chat/utils/sessionWorktree.ts
@@ -47,7 +47,8 @@ export interface SessionWorktreeMaterializationPlan {
 /**
  * Resolve the one transition that must run after a prompt is submitted and
  * before its backend turn starts. `undefined` means the checkbox has not
- * requested a change, or the session is already materialized as requested.
+ * requested a change, the session is already materialized as requested, or
+ * persisted work means it is too late to change the execution root.
  */
 export function sessionWorktreeMaterializationPlan(
   session: SessionWorktreeFacts,
@@ -55,6 +56,7 @@ export function sessionWorktreeMaterializationPlan(
   const requested = session.config.worktreeIsolationRequested;
   if (
     requested === undefined
+    || isSessionWorktreeBindingLocked(session, false)
     || requested === isSessionWorktreeMaterialized(session)
   ) {
     return undefined;


### PR DESCRIPTION
## Summary

- route contradictory OpenAI-compatible `model=None` 400 responses and structured transient provider errors through the existing bounded retry loop
- materialize pending worktree isolation before `/goal` actions can start or steer a turn
- clear stale pending worktree choices on nonempty sessions and make already-satisfied backend bindings true no-ops
- preserve sherpa-onnx native artifacts alongside restored Cargo fingerprints so macOS/Windows CI can link reliably
- add transport, goal-service, worktree-state, backend binding, and CI configuration regressions

## Type and Areas

Type: regression fix

Areas: AI adapters, Rust core worktree service, Web UI goal/session flow, CI cache

## Motivation / Impact

A provider gateway can occasionally lose a concrete model while routing and return HTTP 400 with `model=None`. BitFun previously rejected every nonstandard 400 before its existing retry loop, terminating `/goal` sessions on a transient provider fault. The new classification remains narrow: ordinary invalid request and invalid model errors are still non-retryable.

`/goal` starts backend work outside the ordinary first-message driver. That bypass left a composer-only worktree request unmaterialized; after a failed goal turn, continuing the session tried to change isolation after history existed and raised `Worktree isolation can only be changed before the session first message`. Goal actions now prepare the requested worktree first, stale projected choices are discarded once work exists, and same-state backend requests are idempotent without weakening real transition guards.

The first PR CI run also reproduced an existing failure from current `main` on macOS and Windows: the Rust cache restored sherpa-onnx build fingerprints without the native library directory they reference. Rust CI now caches that directory and uses a fresh cache namespace.

## Verification

- `cargo test -p bitfun-ai-adapters` — 252 passed
- `cargo test -p bitfun-agent-stream` — 66 passed
- `cargo test -p bitfun-core --no-default-features --features agent-runtime,git --lib service::worktree::session_binding::tests` — 4 passed
- `pnpm --dir src/web-ui exec vitest run src/flow_chat/services/goalService.test.ts src/flow_chat/utils/sessionWorktree.test.ts` — 9 passed
- `pnpm run type-check:web` — passed
- `pnpm run check:github-config` — 11 passed
- focused ESLint on changed Web UI sources — passed (test files are ignored by repository ESLint configuration)
- `git diff --check` — passed

AI-assisted: yes. Testing level: fully tested for the changed paths.

## Reviewer Notes

The retry does not blanket-retry HTTP 400. It requires either an existing structured transient category or a response that reports `model=None`/`model=null` while the outgoing JSON contains a concrete model.

The sherpa cache repair is included because the user-required green CI exposed the same failure already present on the base `main` run.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable (no copy changes).