### PR TITLE
fix(agent): unify live model retry budget

### DIFF
--- a/src/apps/cli/src/dispatch/runner.rs
+++ b/src/apps/cli/src/dispatch/runner.rs
@@ -220,27 +220,55 @@ pub(crate) fn process_alive(pid: u32) -> bool {
         return false;
     };
     // SAFETY: signal 0 performs liveness/permission checking only.
-    if unsafe { libc::kill(pid, 0) } == 0 {
-        #[cfg(target_os = "linux")]
-        {
-            // A zombie still answers to kill(0), but it has already exited and
-            // must not be treated as an authenticated leader for escalation.
-            if let Ok(stat) = std::fs::read_to_string(format!("/proc/{pid}/stat")) {
-                if stat
-                    .rsplit_once(") ")
-                    .and_then(|(_, fields)| fields.split_whitespace().next())
-                    == Some("Z")
-                {
-                    return false;
-                }
+    if unsafe { libc::kill(pid, 0) } != 0
+        && !matches!(
+            std::io::Error::last_os_error().raw_os_error(),
+            Some(libc::EPERM)
+        )
+    {
+        return false;
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        // A zombie still answers to kill(0), but it has already exited and
+        // must not be treated as an authenticated leader for escalation.
+        if let Ok(stat) = std::fs::read_to_string(format!("/proc/{pid}/stat")) {
+            if stat
+                .rsplit_once(") ")
+                .and_then(|(_, fields)| fields.split_whitespace().next())
+                == Some("Z")
+            {
+                return false;
             }
         }
-        return true;
     }
-    matches!(
-        std::io::Error::last_os_error().raw_os_error(),
-        Some(libc::EPERM)
-    )
+
+    #[cfg(target_os = "macos")]
+    {
+        // macOS also reports zombies as present to kill(0). Query the process
+        // state before using a leader PID to authenticate SIGKILL escalation;
+        // a failed/empty query means the process disappeared during the check.
+        let output = Command::new("ps")
+            .args(["-p", &pid.to_string(), "-o", "stat="])
+            .output();
+        let Ok(output) = output else {
+            return false;
+        };
+        if !output.status.success() {
+            return false;
+        }
+        return String::from_utf8_lossy(&output.stdout)
+            .trim_start()
+            .chars()
+            .next()
+            .is_some_and(|state| state != 'Z');
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        true
+    }
 }
 
 #[cfg(not(unix))]

--- a/src/apps/cli/tests/cli_command_contracts/exec_cli_contracts.rs
+++ b/src/apps/cli/tests/cli_command_contracts/exec_cli_contracts.rs
@@ -368,6 +368,48 @@ fn stream_json_patch_success_emits_one_success_terminal() {
 }
 
 #[test]
+fn stream_json_malformed_sse_retries_then_completes() {
+    let server = MockOpenAiServer::malformed_sse_then_immediate();
+    let environment = CliTestEnvironment::new();
+    environment.configure_mock_model(server.base_url());
+    let mut command = environment.std_command();
+    command.args([
+        "exec",
+        "exercise malformed provider stream retry",
+        "--output-format",
+        "stream-json",
+    ]);
+    let output = command_output_with_timeout(&mut command, std::time::Duration::from_secs(30));
+    server.assert_chat_completion_requests(2);
+
+    let stdout = stdout(&output);
+    assert!(output.status.success(), "{}\n{stdout}", stderr(&output));
+    let events = jsonl_events(&stdout);
+    assert!(
+        events.iter().any(|value| {
+            value["event"]["type"] == "TextChunk"
+                && value["event"]["text"]
+                    .as_str()
+                    .is_some_and(|text| text.contains(STREAM_COMPLETED_MARKER))
+        }),
+        "retried model stream did not complete: {stdout}"
+    );
+    assert_eq!(
+        events
+            .iter()
+            .filter(|value| is_terminal_event(value))
+            .count(),
+        1,
+        "retried stream must emit exactly one terminal envelope: {stdout}"
+    );
+    assert_eq!(
+        events.last().expect("retried stream terminal event")["event"]["type"],
+        "DialogTurnCompleted",
+        "retried stream terminal must be last: {stdout}"
+    );
+}
+
+#[test]
 fn stream_json_provider_http_403_emits_one_error_terminal() {
     let server = MockOpenAiServer::http_403("provider authorization denied");
     let environment = CliTestEnvironment::new();
@@ -493,7 +535,7 @@ fn stream_json_disconnect_then_exhausted_retry_failure_emits_one_error_terminal(
         "stream-json",
     ]);
     let output = command_output_with_timeout(&mut command, std::time::Duration::from_secs(30));
-    server.assert_chat_completion_requests(11);
+    server.assert_chat_completion_requests(10);
 
     let stdout = stdout(&output);
     assert!(!output.status.success(), "{stdout}");

--- a/src/apps/cli/tests/support/mod.rs
+++ b/src/apps/cli/tests/support/mod.rs
@@ -303,6 +303,7 @@ enum MockModelResponse {
     Gated,
     Http403 { reason: String },
     DisconnectThenHttp403,
+    MalformedSseThenImmediate,
 }
 
 impl MockOpenAiServer {
@@ -322,6 +323,10 @@ impl MockOpenAiServer {
 
     pub(crate) fn disconnect_then_http_403() -> Self {
         Self::spawn(MockModelResponse::DisconnectThenHttp403)
+    }
+
+    pub(crate) fn malformed_sse_then_immediate() -> Self {
+        Self::spawn(MockModelResponse::MalformedSseThenImmediate)
     }
 
     pub(crate) fn base_url(&self) -> &str {
@@ -405,11 +410,14 @@ impl MockOpenAiServer {
                             &disconnect_tx,
                         );
                         attempt += 1;
-                        if matches!(
-                            response,
-                            MockModelResponse::Http403 { .. }
-                                | MockModelResponse::DisconnectThenHttp403
-                        ) {
+                        let accepts_more_requests =
+                            matches!(
+                                response,
+                                MockModelResponse::Http403 { .. }
+                                    | MockModelResponse::DisconnectThenHttp403
+                            ) || (matches!(response, MockModelResponse::MalformedSseThenImmediate)
+                                && attempt < 2);
+                        if accepts_more_requests {
                             continue;
                         }
                         break;
@@ -472,6 +480,13 @@ fn serve_model_response(
             b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n",
         )
         .expect("write mock response headers");
+
+    if matches!(response, MockModelResponse::MalformedSseThenImmediate) && attempt == 0 {
+        write_chunk(stream, b"data: not-json\n\n").expect("write malformed SSE frame");
+        let _ = stream.write_all(b"0\r\n\r\n");
+        let _ = stream.flush();
+        return;
+    }
 
     write_sse_chunk(
         stream,

--- a/src/crates/adapters/ai-adapters/src/client.rs
+++ b/src/crates/adapters/ai-adapters/src/client.rs
@@ -19,6 +19,7 @@ use crate::trace::{
 use crate::types::ProxyConfig;
 use crate::types::*;
 use anyhow::Result;
+use bitfun_core_types::errors::{AiProviderError, ErrorCategory};
 use format::ApiFormat;
 use log::warn;
 use reqwest::Client;
@@ -223,30 +224,36 @@ impl AIClient {
         extra_body: Option<serde_json::Value>,
         trace: Option<ModelExchangeTraceConfig>,
     ) -> Result<StreamResponse> {
-        let max_tries = SEND_MESSAGE_STREAM_ATTEMPTS;
-        match ApiFormat::parse(&self.config.format)? {
-            ApiFormat::OpenAIChat => {
-                openai::chat::send_stream(self, messages, tools, extra_body, max_tries, trace).await
-            }
-            ApiFormat::OpenAIResponses => {
-                openai::responses::send_stream(self, messages, tools, extra_body, max_tries, trace)
-                    .await
-            }
-            ApiFormat::Anthropic => {
-                anthropic::request::send_stream(self, messages, tools, extra_body, max_tries, trace)
-                    .await
-            }
-            ApiFormat::Gemini => {
-                gemini::request::send_stream(self, messages, tools, extra_body, max_tries, trace)
-                    .await
-            }
-            ApiFormat::GeminiCodeAssist => {
-                gemini::code_assist::send_stream(
-                    self, messages, tools, extra_body, max_tries, trace,
-                )
-                .await
-            }
-        }
+        self.send_message_stream_with_extra_body_and_max_attempts(
+            messages,
+            tools,
+            extra_body,
+            SEND_MESSAGE_STREAM_ATTEMPTS,
+            trace,
+        )
+        .await
+    }
+
+    /// Open one model stream without an adapter-owned retry loop.
+    ///
+    /// Runtime owners with a broader attempt lifecycle use this entry point so
+    /// connection, HTTP, TTFT, parsing, and in-stream failures all consume one
+    /// shared retry budget instead of multiplying nested retry loops.
+    pub async fn send_message_stream_once(
+        &self,
+        messages: Vec<Message>,
+        tools: Option<Vec<ToolDefinition>>,
+        trace: Option<ModelExchangeTraceConfig>,
+    ) -> Result<StreamResponse> {
+        let custom_body = self.config.custom_request_body.clone();
+        self.send_message_stream_with_extra_body_and_max_attempts(
+            messages,
+            tools,
+            custom_body,
+            1,
+            trace,
+        )
+        .await
     }
 
     pub async fn send_message(
@@ -306,15 +313,33 @@ impl AIClient {
         max_attempts: usize,
     ) -> Result<GeminiResponse> {
         for attempt in 0..max_attempts {
-            let stream_response = self
+            let stream_response = match self
                 .send_message_stream_with_extra_body_and_max_attempts(
                     messages.clone(),
                     tools.clone(),
                     extra_body.clone(),
-                    max_attempts,
+                    1,
                     trace.clone(),
                 )
-                .await?;
+                .await
+            {
+                Ok(response) => response,
+                Err(error) => {
+                    if attempt == max_attempts - 1 {
+                        return Err(error);
+                    }
+                    let delay_ms = send_message_retry_delay_ms_for_error(attempt, &error);
+                    warn!(
+                        "Retrying AI stream request after error: attempt={}/{}, delay_ms={}, error={}",
+                        attempt + 1,
+                        max_attempts,
+                        delay_ms,
+                        error
+                    );
+                    tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                    continue;
+                }
+            };
             let trace_handle = stream_response.trace_handle.clone();
 
             match response_aggregator::aggregate_stream_response(stream_response).await {
@@ -333,7 +358,7 @@ impl AIClient {
                     if attempt == max_attempts - 1 {
                         return Err(error);
                     }
-                    let delay_ms = send_message_retry_delay_ms(attempt, &error.to_string());
+                    let delay_ms = send_message_retry_delay_ms_for_error(attempt, &error);
                     warn!(
                         "Retrying aggregated AI stream after error: attempt={}/{}, delay_ms={}, error={}",
                         attempt + 1,
@@ -419,15 +444,35 @@ impl AIClient {
     }
 }
 
+#[cfg(test)]
 fn send_message_retry_delay_ms(attempt_index: usize, error_message: &str) -> u64 {
+    send_message_retry_delay_ms_with_provider(attempt_index, error_message, None)
+}
+
+fn send_message_retry_delay_ms_for_error(attempt_index: usize, error: &anyhow::Error) -> u64 {
+    send_message_retry_delay_ms_with_provider(
+        attempt_index,
+        &error.to_string(),
+        error.downcast_ref::<AiProviderError>(),
+    )
+}
+
+fn send_message_retry_delay_ms_with_provider(
+    attempt_index: usize,
+    error_message: &str,
+    provider_error: Option<&AiProviderError>,
+) -> u64 {
     let shift = u32::try_from(attempt_index)
         .unwrap_or(u32::MAX)
         .min(SEND_MESSAGE_MAX_RETRY_EXPONENT_SHIFT);
     let msg = error_message.to_lowercase();
-    let is_rate_limit =
-        msg.contains("429") || msg.contains("rate limit") || msg.contains("too many requests");
+    let is_rate_limit = provider_error
+        .is_some_and(|error| error.category == ErrorCategory::RateLimit)
+        || msg.contains("429")
+        || msg.contains("rate limit")
+        || msg.contains("too many requests");
 
-    if is_rate_limit {
+    let fallback = if is_rate_limit {
         SEND_MESSAGE_RATE_LIMIT_RETRY_BASE_DELAY_MS
             .saturating_mul(1u64 << shift)
             .min(SEND_MESSAGE_MAX_RATE_LIMIT_DELAY_MS)
@@ -435,6 +480,16 @@ fn send_message_retry_delay_ms(attempt_index: usize, error_message: &str) -> u64
         SEND_MESSAGE_RETRY_BASE_DELAY_MS
             .saturating_mul(1u64 << shift)
             .min(SEND_MESSAGE_MAX_EXPONENTIAL_DELAY_MS)
+    };
+
+    match provider_error.and_then(|error| error.retry_after_ms) {
+        Some(retry_after_ms) if is_rate_limit => retry_after_ms
+            .max(fallback)
+            .min(SEND_MESSAGE_MAX_RATE_LIMIT_DELAY_MS),
+        Some(retry_after_ms) if retry_after_ms > 0 => {
+            retry_after_ms.min(SEND_MESSAGE_MAX_RATE_LIMIT_DELAY_MS)
+        }
+        Some(_) | None => fallback,
     }
 }
 

--- a/src/crates/adapters/ai-adapters/src/client/sse.rs
+++ b/src/crates/adapters/ai-adapters/src/client/sse.rs
@@ -118,6 +118,7 @@ fn http_provider_error(
     status: StatusCode,
     error_text: &str,
     error_kind: &str,
+    retry_after_ms: Option<u64>,
 ) -> AiProviderError {
     AiProviderError::from_parts(
         format!("{} {} {}: {}", label, error_kind, status, error_text),
@@ -125,6 +126,7 @@ fn http_provider_error(
         provider_error_code(error_text),
         Some(status.as_u16()),
     )
+    .with_retry_after_ms(retry_after_ms)
 }
 
 fn exponential_retry_delay_ms(attempt: usize) -> u64 {
@@ -288,8 +290,13 @@ where
                     } else {
                         "error"
                     };
-                    let provider_error =
-                        http_provider_error(label, status, &error_text, error_kind);
+                    let provider_error = http_provider_error(
+                        label,
+                        status,
+                        &error_text,
+                        error_kind,
+                        retry_after_delay_ms(&headers),
+                    );
                     let error = anyhow!(provider_error);
                     warn!(
                         "{} request failed: {}ms, transport_attempt {}/{}, error: {}",
@@ -413,14 +420,10 @@ where
         });
     }
 
-    let error_msg = format!(
-        "{} failed after {} attempts: {}",
-        label,
-        max_tries,
-        last_error.unwrap_or_else(|| anyhow!("Unknown error"))
-    );
-    error!("{}", error_msg);
-    Err(anyhow!(error_msg))
+    let last_error = last_error.unwrap_or_else(|| anyhow!("Unknown error"));
+    let error_context = format!("{} failed after {} attempts", label, max_tries);
+    error!("{}: {}", error_context, last_error);
+    Err(last_error.context(error_context))
 }
 
 #[cfg(test)]
@@ -474,6 +477,21 @@ mod tests {
         }
     }
 
+    async fn forbidden_with_retry_after(Json(body): Json<serde_json::Value>) -> impl IntoResponse {
+        assert_eq!(body["model"], "configured-model");
+        (
+            StatusCode::FORBIDDEN,
+            [("retry-after", "7")],
+            Json(serde_json::json!({
+                "error": {
+                    "message": "provider authorization denied",
+                    "type": "permission_error",
+                    "code": "permission_denied"
+                }
+            })),
+        )
+    }
+
     #[test]
     fn http_error_uses_structured_code_before_generic_message() {
         let error = http_provider_error(
@@ -481,6 +499,7 @@ mod tests {
             StatusCode::BAD_REQUEST,
             r#"{"error":{"code":"context_length_exceeded","message":"Request failed"}}"#,
             "client error",
+            None,
         );
 
         assert_eq!(error.category, ErrorCategory::ContextOverflow);
@@ -498,6 +517,7 @@ mod tests {
             StatusCode::BAD_REQUEST,
             "400 status code (no body)",
             "client error",
+            None,
         );
 
         assert_eq!(error.category, ErrorCategory::InvalidRequest);
@@ -588,6 +608,48 @@ mod tests {
             "ordinary and context-overflow 400 responses should both retry"
         );
         assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn single_attempt_preserves_retry_after_metadata_for_outer_budget() {
+        let app = Router::new().route("/chat/completions", post(forbidden_with_retry_after));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind retry-after fixture");
+        let address = listener.local_addr().expect("retry-after fixture address");
+        let server_task = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("retry-after fixture should run");
+        });
+        let url = format!("http://{address}/chat/completions");
+        let client = reqwest::Client::new();
+        let request_body = serde_json::json!({"model": "configured-model"});
+
+        let result = execute_sse_request(
+            "OpenAI Streaming API",
+            &url,
+            &request_body,
+            1,
+            None,
+            None,
+            || client.post(&url),
+            |_response, tx, _tx_raw, _remaining_ttft_timeout| async move {
+                drop(tx);
+            },
+        )
+        .await;
+
+        server_task.abort();
+        let error = match result {
+            Ok(_) => panic!("single forbidden response should fail"),
+            Err(error) => error,
+        };
+        let provider_error = error
+            .downcast_ref::<AiProviderError>()
+            .expect("structured provider error should survive retry context");
+        assert_eq!(provider_error.http_status, Some(403));
+        assert_eq!(provider_error.retry_after_ms, Some(7_000));
     }
 
     #[test]

--- a/src/crates/assembly/core/src/agentic/execution/round_executor.rs
+++ b/src/crates/assembly/core/src/agentic/execution/round_executor.rs
@@ -375,7 +375,7 @@ impl RoundExecutor {
             let request_trace_config = trace_config
                 .clone()
                 .map(|config| config.with_round_attempt(attempt_id.clone(), attempt_number));
-            let send_future = ai_client.send_message_stream(
+            let send_future = ai_client.send_message_stream_once(
                 ai_messages.clone(),
                 tool_definitions.clone(),
                 request_trace_config,
@@ -404,27 +404,24 @@ impl RoundExecutor {
                     error!("AI request failed: {}", e);
                     let provider_error = e.downcast_ref::<AiProviderError>().cloned();
                     let err_msg = e.to_string();
-                    let is_structured_context_overflow = provider_error
-                        .as_ref()
-                        .is_some_and(|error| error.category == ErrorCategory::ContextOverflow);
-                    if !is_structured_context_overflow
-                        && Self::is_transient_network_error(&err_msg)
-                        && local_attempt_index < max_attempts - 1
-                    {
+                    if local_attempt_index < max_attempts - 1 {
                         self.record_retry_diagnostic(
                             &context,
                             &round_id,
                             attempt_id.clone(),
                             attempt_number,
-                            "transient_request_error",
+                            "request_error",
                             Some(err_msg.clone()),
                             &[],
                         )
                         .await;
-                        let delay_ms =
-                            Self::retry_delay_ms_for_error(local_attempt_index, &err_msg);
+                        let delay_ms = Self::retry_delay_ms_for_provider_error(
+                            local_attempt_index,
+                            &err_msg,
+                            provider_error.as_ref(),
+                        );
                         warn!(
-                            "Retrying AI request after connection failure: session_id={}, round_id={}, round_attempt={}, local_retry={}/{}, delay_ms={}, error={}",
+                            "Retrying AI request after error: session_id={}, round_id={}, round_attempt={}, local_retry={}/{}, delay_ms={}, error={}",
                             context.session_id,
                             round_id,
                             attempt_number,
@@ -437,19 +434,6 @@ impl RoundExecutor {
                         local_attempt_index += 1;
                         continue;
                     }
-                    if !is_structured_context_overflow && Self::is_transient_network_error(&err_msg)
-                    {
-                        return Err(BitFunError::AIClient(format!(
-                            "Stream retry budget exhausted after {} attempts: {}",
-                            max_attempts, err_msg
-                        )));
-                    }
-                    // Non-transient errors (429 budget exhausted, context
-                    // overflow, auth, etc.) are returned directly. The error
-                    // message is classified downstream via
-                    // `BitFunError::error_category()` into `ErrorCategory` for
-                    // frontend recovery actions (wait_and_retry, switch_model,
-                    // etc.).
                     let category = provider_error
                         .as_ref()
                         .map(|error| error.category.clone())
@@ -466,9 +450,10 @@ impl RoundExecutor {
                         BitFunError::AIClient(err_msg)
                     };
                     warn!(
-                        "AI request terminal failure: session_id={}, round_id={}, category={:?}, error={}",
+                        "AI request retry budget exhausted: session_id={}, round_id={}, attempts={}, category={:?}, error={}",
                         context.session_id,
                         round_id,
+                        max_attempts,
                         error.error_category(),
                         error
                     );
@@ -529,22 +514,23 @@ impl RoundExecutor {
             {
                 Ok(result) => {
                     let stream_processing_ms = elapsed_ms_u64(stream_started_at);
-                    if Self::has_interrupted_invalid_tool_calls(&result) {
-                        let err_msg = result.partial_recovery_reason.clone().unwrap_or_else(|| {
-                            "Interrupted while streaming tool arguments".to_string()
-                        });
-
-                        if !Self::has_user_visible_assistant_text(&result.full_text)
-                            && local_attempt_index < max_attempts - 1
-                            && Self::is_transient_network_error(&err_msg)
-                        {
+                    let has_interrupted_invalid_tool_calls =
+                        Self::has_interrupted_invalid_tool_calls(&result);
+                    if let Some(partial_recovery_reason) = result.partial_recovery_reason.as_deref()
+                    {
+                        if local_attempt_index < max_attempts - 1 {
+                            let diagnostic_category = if has_interrupted_invalid_tool_calls {
+                                "interrupted_tool_arguments"
+                            } else {
+                                "partial_stream_error"
+                            };
                             self.record_retry_diagnostic(
                                 &context,
                                 &round_id,
                                 attempt_id.clone(),
                                 attempt_number,
-                                "interrupted_tool_arguments",
-                                Some(err_msg.clone()),
+                                diagnostic_category,
+                                Some(partial_recovery_reason.to_string()),
                                 &result.tool_calls,
                             )
                             .await;
@@ -554,31 +540,36 @@ impl RoundExecutor {
                                 Self::trace_response_from_stream_result("partial", &result),
                             )
                             .await;
-                            let delay_ms =
-                                Self::retry_delay_ms_for_error(local_attempt_index, &err_msg);
+                            let delay_ms = Self::retry_delay_ms_for_error(
+                                local_attempt_index,
+                                partial_recovery_reason,
+                            );
                             warn!(
-                                "Retrying stream because tool arguments were interrupted before valid JSON completed: session_id={}, round_id={}, round_attempt={}, local_retry={}/{}, delay_ms={}, invalid_tool_calls={}, error={}",
+                                "Retrying stream after partial recovery error: session_id={}, round_id={}, round_attempt={}, local_retry={}/{}, delay_ms={}, effective_output={}, tool_calls={}, reason={}",
                                 context.session_id,
                                 round_id,
                                 attempt_number,
                                 local_attempt_index + 1,
                                 max_attempts,
                                 delay_ms,
-                                result
-                                    .tool_calls
-                                    .iter()
-                                    .filter(|tool_call| !tool_call.is_valid())
-                                    .count(),
-                                err_msg
+                                result.has_effective_output,
+                                result.tool_calls.len(),
+                                partial_recovery_reason
                             );
                             Self::sleep_with_cancellation(delay_ms, &cancel_token).await?;
                             local_attempt_index += 1;
                             continue;
                         }
+                    }
+
+                    if has_interrupted_invalid_tool_calls {
+                        let err_msg = result.partial_recovery_reason.clone().unwrap_or_else(|| {
+                            "Interrupted while streaming tool arguments".to_string()
+                        });
 
                         if Self::has_user_visible_assistant_text(&result.full_text) {
                             warn!(
-                                "Dropping invalid partial tool calls from interrupted stream; preserving already-streamed assistant text: session_id={}, round_id={}, invalid_tool_calls={}, error={}",
+                                "Dropping invalid partial tool calls after stream retry budget was exhausted; preserving assistant text: session_id={}, round_id={}, invalid_tool_calls={}, error={}",
                                 context.session_id,
                                 round_id,
                                 result
@@ -632,50 +623,6 @@ impl RoundExecutor {
 
                     let no_effective_output = !result.has_effective_output;
                     let is_partial_recovery = result.partial_recovery_reason.is_some();
-                    let partial_recovery_reason =
-                        result.partial_recovery_reason.as_deref().unwrap_or("");
-
-                    if is_partial_recovery
-                        && !Self::has_user_visible_assistant_text(&result.full_text)
-                        && !result.tool_calls.is_empty()
-                        && Self::is_transient_network_error(partial_recovery_reason)
-                        && local_attempt_index < max_attempts - 1
-                    {
-                        self.record_retry_diagnostic(
-                            &context,
-                            &round_id,
-                            attempt_id.clone(),
-                            attempt_number,
-                            "partial_stream_error",
-                            Some(partial_recovery_reason.to_string()),
-                            &result.tool_calls,
-                        )
-                        .await;
-                        Self::complete_model_exchange_trace(
-                            trace_config.as_ref(),
-                            trace_handle.as_ref(),
-                            Self::trace_response_from_stream_result("partial", &result),
-                        )
-                        .await;
-                        let delay_ms = Self::retry_delay_ms_for_error(
-                            local_attempt_index,
-                            partial_recovery_reason,
-                        );
-                        warn!(
-                            "Retrying stream because tool calls arrived on an interrupted network stream without assistant text: session_id={}, round_id={}, round_attempt={}, local_retry={}/{}, delay_ms={}, tool_calls={}, reason={}",
-                            context.session_id,
-                            round_id,
-                            attempt_number,
-                            local_attempt_index + 1,
-                            max_attempts,
-                            delay_ms,
-                            result.tool_calls.len(),
-                            partial_recovery_reason
-                        );
-                        Self::sleep_with_cancellation(delay_ms, &cancel_token).await?;
-                        local_attempt_index += 1;
-                        continue;
-                    }
 
                     if Self::is_invalid_tool_only_without_text(&result) {
                         let err_msg = "Provider returned only invalid tool arguments".to_string();
@@ -739,44 +686,68 @@ impl RoundExecutor {
                         )));
                     }
 
-                    if no_effective_output && local_attempt_index < max_attempts - 1 {
-                        self.record_retry_diagnostic(
-                            &context,
-                            &round_id,
-                            attempt_id.clone(),
-                            attempt_number,
-                            "no_effective_output",
-                            None,
-                            &[],
-                        )
-                        .await;
+                    if no_effective_output {
+                        let err_msg = result
+                            .partial_recovery_reason
+                            .clone()
+                            .unwrap_or_else(|| "No effective output received".to_string());
+                        if local_attempt_index < max_attempts - 1 {
+                            self.record_retry_diagnostic(
+                                &context,
+                                &round_id,
+                                attempt_id.clone(),
+                                attempt_number,
+                                "no_effective_output",
+                                Some(err_msg.clone()),
+                                &result.tool_calls,
+                            )
+                            .await;
+                            Self::complete_model_exchange_trace(
+                                trace_config.as_ref(),
+                                trace_handle.as_ref(),
+                                Self::error_trace_response_from_stream_result(
+                                    "error",
+                                    err_msg.clone(),
+                                    &result,
+                                ),
+                            )
+                            .await;
+                            let delay_ms =
+                                Self::retry_delay_ms_for_error(local_attempt_index, &err_msg);
+                            warn!(
+                                "Retrying stream because no effective output was received: session_id={}, round_id={}, round_attempt={}, local_retry={}/{}, delay_ms={}, error={}",
+                                context.session_id,
+                                round_id,
+                                attempt_number,
+                                local_attempt_index + 1,
+                                max_attempts,
+                                delay_ms,
+                                err_msg
+                            );
+                            Self::sleep_with_cancellation(delay_ms, &cancel_token).await?;
+                            local_attempt_index += 1;
+                            continue;
+                        }
+
                         Self::complete_model_exchange_trace(
                             trace_config.as_ref(),
                             trace_handle.as_ref(),
-                            Self::error_trace_response(
+                            Self::error_trace_response_from_stream_result(
                                 "error",
-                                "No effective output received".to_string(),
+                                err_msg.clone(),
+                                &result,
                             ),
                         )
                         .await;
-                        let delay_ms = Self::retry_delay_ms(local_attempt_index);
-                        warn!(
-                            "Retrying stream because no effective output was received: session_id={}, round_id={}, round_attempt={}, local_retry={}/{}, delay_ms={}",
-                            context.session_id,
-                            round_id,
-                            attempt_number,
-                            local_attempt_index + 1,
-                            max_attempts,
-                            delay_ms
-                        );
-                        Self::sleep_with_cancellation(delay_ms, &cancel_token).await?;
-                        local_attempt_index += 1;
-                        continue;
+                        return Err(BitFunError::AIClient(format!(
+                            "Stream retry budget exhausted after {} attempts: {}",
+                            max_attempts, err_msg
+                        )));
                     }
 
                     if is_partial_recovery {
                         warn!(
-                            "Accepting stream partial recovery without retry: session_id={}, round_id={}, round_attempt={}, local_retry={}/{}, reason={}",
+                            "Accepting useful partial stream output after retry budget was exhausted: session_id={}, round_id={}, round_attempt={}, local_retry={}/{}, reason={}",
                             context.session_id,
                             round_id,
                             attempt_number,
@@ -799,54 +770,59 @@ impl RoundExecutor {
                 Err(stream_err) => {
                     let err_msg = stream_err.error.to_string();
                     let stream_error_category = stream_err.error.error_category();
-                    let can_retry = !stream_err.has_effective_output
-                        && stream_error_category != ErrorCategory::ContextOverflow
-                        && local_attempt_index < max_attempts - 1
-                        && Self::is_transient_network_error(&err_msg);
+                    let provider_error = match &stream_err.error {
+                        BitFunError::AIProvider(error)
+                        | BitFunError::RecoverableContextOverflow(error) => Some(error),
+                        _ => None,
+                    };
                     Self::complete_model_exchange_trace(
                         trace_config.as_ref(),
                         trace_handle.as_ref(),
                         Self::error_trace_response("error", err_msg.clone()),
                     )
                     .await;
-                    if can_retry {
+                    if local_attempt_index < max_attempts - 1 {
                         self.record_retry_diagnostic(
                             &context,
                             &round_id,
                             attempt_id.clone(),
                             attempt_number,
-                            "transient_stream_error",
+                            "stream_error",
                             Some(err_msg.clone()),
                             &[],
                         )
                         .await;
-                        let delay_ms =
-                            Self::retry_delay_ms_for_error(local_attempt_index, &err_msg);
+                        let delay_ms = Self::retry_delay_ms_for_provider_error(
+                            local_attempt_index,
+                            &err_msg,
+                            provider_error,
+                        );
                         warn!(
-                            "Retrying stream after transient error with no effective output: session_id={}, round_id={}, round_attempt={}, local_retry={}/{}, delay_ms={}, error={}",
+                            "Retrying stream after error: session_id={}, round_id={}, round_attempt={}, local_retry={}/{}, delay_ms={}, effective_output={}, category={:?}, error={}",
                             context.session_id,
                             round_id,
                             attempt_number,
                             local_attempt_index + 1,
                             max_attempts,
                             delay_ms,
+                            stream_err.has_effective_output,
+                            stream_error_category,
                             err_msg
                         );
                         Self::sleep_with_cancellation(delay_ms, &cancel_token).await?;
                         local_attempt_index += 1;
                         continue;
                     }
-                    if stream_error_category != ErrorCategory::ContextOverflow
-                        && Self::is_transient_network_error(&err_msg)
-                    {
-                        return Err(BitFunError::AIClient(format!(
-                            "Stream retry budget exhausted after {} attempts: {}",
-                            max_attempts, err_msg
-                        )));
-                    }
-                    if !stream_err.has_effective_output
-                        && stream_error_category == ErrorCategory::ContextOverflow
-                    {
+                    warn!(
+                        "Stream retry budget exhausted: session_id={}, round_id={}, attempts={}, effective_output={}, category={:?}, error={}",
+                        context.session_id,
+                        round_id,
+                        max_attempts,
+                        stream_err.has_effective_output,
+                        stream_error_category,
+                        err_msg
+                    );
+                    if stream_error_category == ErrorCategory::ContextOverflow {
                         let provider_error = match stream_err.error {
                             BitFunError::AIProvider(error)
                             | BitFunError::RecoverableContextOverflow(error) => error,
@@ -1489,14 +1465,25 @@ impl RoundExecutor {
     }
 
     fn retry_delay_ms_for_error(attempt_index: usize, error_message: &str) -> u64 {
+        Self::retry_delay_ms_for_provider_error(attempt_index, error_message, None)
+    }
+
+    fn retry_delay_ms_for_provider_error(
+        attempt_index: usize,
+        error_message: &str,
+        provider_error: Option<&AiProviderError>,
+    ) -> u64 {
         let shift = u32::try_from(attempt_index)
             .unwrap_or(u32::MAX)
             .min(Self::MAX_RETRY_EXPONENT_SHIFT);
         let msg = error_message.to_lowercase();
-        let is_rate_limit =
-            msg.contains("429") || msg.contains("rate limit") || msg.contains("too many requests");
+        let is_rate_limit = provider_error
+            .is_some_and(|error| error.category == ErrorCategory::RateLimit)
+            || msg.contains("429")
+            || msg.contains("rate limit")
+            || msg.contains("too many requests");
 
-        if is_rate_limit {
+        let fallback = if is_rate_limit {
             Self::RATE_LIMIT_RETRY_BASE_DELAY_MS
                 .saturating_mul(1u64 << shift)
                 .min(Self::MAX_RATE_LIMIT_DELAY_MS)
@@ -1504,113 +1491,17 @@ impl RoundExecutor {
             Self::RETRY_BASE_DELAY_MS
                 .saturating_mul(1u64 << shift)
                 .min(Self::MAX_EXPONENTIAL_DELAY_MS)
+        };
+
+        match provider_error.and_then(|error| error.retry_after_ms) {
+            Some(retry_after_ms) if is_rate_limit => retry_after_ms
+                .max(fallback)
+                .min(Self::MAX_RATE_LIMIT_DELAY_MS),
+            Some(retry_after_ms) if retry_after_ms > 0 => {
+                retry_after_ms.min(Self::MAX_RATE_LIMIT_DELAY_MS)
+            }
+            Some(_) | None => fallback,
         }
-    }
-
-    /// Check whether an error message represents a transient (retryable) condition.
-    ///
-    /// Errors that already exhausted the SSE-layer retry budget (e.g. "failed
-    /// after N attempts:" or "Stream retry budget exhausted") are **not**
-    /// transient from the round-executor perspective — the SSE transport layer
-    /// already retried with exponential backoff and `Retry-After` parsing.
-    /// Re-entering the send loop would multiply attempts (10 × 10 = 100) and
-    /// hold the user in a long silent stall.
-    fn is_transient_network_error(error_message: &str) -> bool {
-        let msg = error_message.to_lowercase();
-
-        // The SSE layer already exhausted its own retry budget — do not
-        // re-enter another round of attempts from the round executor.
-        // We require BOTH "failed after " and "attempts:" to co-occur,
-        // which uniquely identifies the SSE/round-executor budget-exhausted
-        // format without catching generic errors like "failed after timeout".
-        if msg.contains("failed after ") && msg.contains("attempts:") {
-            return false;
-        }
-        if msg.contains("retry budget exhausted") {
-            return false;
-        }
-
-        let non_retryable_keywords = [
-            "invalid api key",
-            "unauthorized",
-            "forbidden",
-            "model not found",
-            "unsupported model",
-            "invalid request",
-            "bad request",
-            "prompt is too long",
-            "content policy",
-            "proxy authentication required",
-            "provider quota",
-            "provider billing",
-            "insufficient_quota",
-            "insufficient quota",
-            "insufficient balance",
-            "not_enough_balance",
-            "not enough balance",
-            "余额不足",
-            "无可用资源包",
-            "账户已欠费",
-            "code=1113",
-            "\"code\":\"1113\"",
-            "client error 400",
-            "client error 401",
-            "client error 402",
-            "client error 403",
-            "client error 404",
-            "client error 413",
-            "client error 422",
-            "sse parsing error",
-            "schema error",
-            "unknown api format",
-        ];
-
-        let transient_keywords = [
-            "transport error",
-            "error decoding response body",
-            "stream closed before response completed",
-            "stream processing error",
-            "sse stream error",
-            "sse error",
-            "sse timeout",
-            "stream data timeout",
-            "timeout",
-            "request timeout",
-            "deadline exceeded",
-            "connection reset",
-            "connection closed",
-            "broken pipe",
-            "unexpected eof",
-            "connection refused",
-            "socket closed",
-            "temporarily unavailable",
-            "service unavailable",
-            "bad gateway",
-            "gateway timeout",
-            "overloaded",
-            "proxy",
-            "tunnel",
-            "dns",
-            "network",
-            "econnreset",
-            "econnrefused",
-            "etimedout",
-            "rate limit",
-            "too many requests",
-            "408",
-            "409",
-            "425",
-            "429",
-            "502",
-            "503",
-            "504",
-        ];
-
-        if non_retryable_keywords.iter().any(|k| msg.contains(k)) {
-            return false;
-        }
-
-        transient_keywords.iter().any(|k| msg.contains(k))
     }
 }
 
@@ -2147,16 +2038,6 @@ mod tests {
     }
 
     #[test]
-    fn is_transient_error_treats_rate_limit_as_transient() {
-        assert!(RoundExecutor::is_transient_network_error(
-            "OpenAI Streaming API error 429 Too Many Requests"
-        ));
-        assert!(RoundExecutor::is_transient_network_error(
-            "rate limit exceeded"
-        ));
-    }
-
-    #[test]
     fn retry_delay_grows_beyond_previous_four_second_cap() {
         assert_eq!(RoundExecutor::retry_delay_ms(0), 500);
         assert_eq!(RoundExecutor::retry_delay_ms(3), 4_000);
@@ -2183,43 +2064,37 @@ mod tests {
     }
 
     #[test]
-    fn is_transient_error_treats_network_errors_as_transient() {
-        assert!(RoundExecutor::is_transient_network_error(
-            "connection reset by peer"
-        ));
-        assert!(RoundExecutor::is_transient_network_error("timeout"));
-    }
+    fn provider_retry_after_is_only_a_delay_hint() {
+        let permission_error = bitfun_core_types::errors::AiProviderError::from_parts(
+            "permission denied".to_string(),
+            Some("openai".to_string()),
+            None,
+            Some(403),
+        )
+        .with_retry_after_ms(Some(1_000));
+        assert_eq!(
+            RoundExecutor::retry_delay_ms_for_provider_error(
+                5,
+                &permission_error.message,
+                Some(&permission_error),
+            ),
+            1_000
+        );
 
-    #[test]
-    fn is_transient_error_treats_context_overflow_as_non_transient() {
-        assert!(!RoundExecutor::is_transient_network_error(
-            "prompt is too long"
-        ));
-    }
-
-    #[test]
-    fn is_transient_error_treats_budget_exhausted_as_non_transient() {
-        // After SSE layer exhausts its retry budget, the round executor must
-        // NOT re-enter another round of attempts (would cause 10×10 = 100
-        // retries).
-        assert!(!RoundExecutor::is_transient_network_error(
-            "OpenAI Streaming API failed after 10 attempts: \
-             OpenAI Streaming API error 429 Too Many Requests"
-        ));
-        assert!(!RoundExecutor::is_transient_network_error(
-            "Stream retry budget exhausted after 10 attempts: timeout"
-        ));
-    }
-
-    #[test]
-    fn is_transient_error_does_not_misclassify_failed_after_without_attempts() {
-        // "failed after " without "attempts:" should NOT be treated as budget
-        // exhausted — it may be a legitimately retryable transient error.
-        assert!(RoundExecutor::is_transient_network_error(
-            "stream failed after connection reset"
-        ));
-        assert!(RoundExecutor::is_transient_network_error(
-            "request failed after timeout"
-        ));
+        let rate_limit_error = bitfun_core_types::errors::AiProviderError::from_parts(
+            "too many requests".to_string(),
+            Some("openai".to_string()),
+            None,
+            Some(429),
+        )
+        .with_retry_after_ms(Some(1_000));
+        assert_eq!(
+            RoundExecutor::retry_delay_ms_for_provider_error(
+                3,
+                &rate_limit_error.message,
+                Some(&rate_limit_error),
+            ),
+            16_000
+        );
     }
 }

--- a/src/crates/contracts/core-types/src/errors.rs
+++ b/src/crates/contracts/core-types/src/errors.rs
@@ -69,6 +69,12 @@ pub struct AiProviderError {
     pub provider_code: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub http_status: Option<u16>,
+    /// Provider-requested delay before another attempt, in milliseconds.
+    ///
+    /// This is transport metadata only. Runtime owners decide whether to retry;
+    /// the hint must never be used as retry-admission policy.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retry_after_ms: Option<u64>,
 }
 
 impl AiProviderError {
@@ -85,6 +91,7 @@ impl AiProviderError {
             provider,
             provider_code,
             http_status,
+            retry_after_ms: None,
         }
     }
 
@@ -95,7 +102,13 @@ impl AiProviderError {
             provider: None,
             provider_code: None,
             http_status: None,
+            retry_after_ms: None,
         }
+    }
+
+    pub fn with_retry_after_ms(mut self, retry_after_ms: Option<u64>) -> Self {
+        self.retry_after_ms = retry_after_ms;
+        self
     }
 
     pub fn detail(&self) -> AiErrorDetail {
@@ -639,6 +652,7 @@ mod tests {
         );
 
         assert_eq!(error.category, ErrorCategory::ContextOverflow);
+        assert_eq!(error.retry_after_ms, None);
         let detail = error.detail();
         assert_eq!(detail.provider.as_deref(), Some("openai"));
         assert_eq!(
@@ -646,5 +660,22 @@ mod tests {
             Some("context_length_exceeded")
         );
         assert_eq!(detail.http_status, Some(400));
+    }
+
+    #[test]
+    fn provider_error_preserves_retry_after_hint() {
+        let error = AiProviderError::from_parts(
+            "Request failed".to_string(),
+            Some("openai".to_string()),
+            Some("permission_denied".to_string()),
+            Some(403),
+        )
+        .with_retry_after_ms(Some(1_500));
+
+        assert_eq!(error.retry_after_ms, Some(1_500));
+        assert_eq!(
+            serde_json::to_value(&error).expect("serialize provider error")["retryAfterMs"],
+            1_500
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Make the live Agent round executor own one bounded 10-attempt retry budget across request opening and stream processing.
- Retry every model failure until that budget is exhausted, including HTTP 4xx/5xx responses, TTFT and idle timeouts, malformed SSE/schema errors, structured provider errors, context overflow, and failures after partial output. Cancellation remains immediate.
- Preserve Retry-After only as a backoff hint and prevent adapter retries from multiplying the live Agent budget to 100 requests.
- Add CLI coverage for malformed-SSE recovery and assert that disconnect plus persistent provider failure totals exactly 10 requests.
- Harden macOS dispatch cancellation against zombie leaders after the first CI run exposed that existing race.

## Type and Areas

Type: regression fix

Areas: Rust core, AI adapters, CLI runtime/tests

## Motivation / Impact

Live sessions could terminate immediately for error categories excluded by RoundExecutor string/category checks even though BitFun already had a retry mechanism. At the same time, transport retries could nest with round retries and produce up to 10 x 10 attempts. The live Agent now gives every model error the same single retry budget, improving task completion without unbounded or multiplied requests.

The first CI run also showed that macOS kill(pid, 0) treats an unreaped zombie dispatch leader as present. That could incorrectly authorize SIGKILL escalation after TERM; the guard now requires a non-zombie process state.

## Verification

- cargo test -p bitfun-core-types (32 tests passed across unit/integration targets)
- cargo test -p bitfun-ai-adapters (221 unit tests plus adapter integration tests passed)
- cargo test -p bitfun-agent-stream (66 tests passed)
- cargo test -p bitfun-core --no-default-features --features agent-runtime --lib agentic::execution::round_executor::tests (18 tests passed)
- cargo test -p bitfun-cli --test cli_command_contracts stream_json_malformed_sse_retries_then_completes -- --nocapture
- cargo test -p bitfun-cli --test cli_command_contracts stream_json_provider_ -- --nocapture
- cargo test -p bitfun-cli --test cli_command_contracts stream_json_disconnect_then_exhausted_retry_failure_emits_one_error_terminal -- --nocapture
- cargo test -p bitfun-cli --bin bitfun dispatch::runner::tests -- --nocapture (6 tests passed)
- The formerly failing macOS cancellation test passed 20 additional consecutive direct runs.
- node scripts/check-core-boundaries.mjs
- pnpm run fmt:rs
- git diff --check

## Reviewer Notes

AiProviderError gains an optional retryAfterMs transport hint. It is backward-compatible on the wire and does not affect retry admission. This PR was AI-assisted and is fully tested at the focused unit, adapter-integration, runtime, and CLI end-to-end levels.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable (no user-facing copy changed).