### PR TITLE
feat(steering): let any queued message steer a running turn

### DIFF
--- a/src/apps/cli/src/agent/runtime_client.rs
+++ b/src/apps/cli/src/agent/runtime_client.rs
@@ -1543,6 +1543,9 @@ impl ExecAgentRuntimeClient {
             turn_id: turn_id.clone(),
             content,
             display_content,
+            // The CLI steer prompt is text; attachments ride turn submissions.
+            attachments: Vec::new(),
+            metadata: serde_json::Map::new(),
         };
 
         match &self.backend {

--- a/src/apps/cli/src/agent/tui_client.rs
+++ b/src/apps/cli/src/agent/tui_client.rs
@@ -1429,6 +1429,8 @@ impl TuiAgentClient {
                 turn_id,
                 content,
                 display_content,
+                attachments: Vec::new(),
+                metadata: serde_json::Map::new(),
             }))
             .await?
             .steering_id)

--- a/src/apps/cli/src/dispatch/mod.rs
+++ b/src/apps/cli/src/dispatch/mod.rs
@@ -387,7 +387,9 @@ fn answer(request: DispatchAnswerRequest) -> Result<DispatchAnswerResponse> {
 }
 
 fn append(request: DispatchAppendRequest) -> Result<DispatchAppendResponse> {
-    if request.content.trim().is_empty() {
+    // An attachment-only message is a real message; only one with neither text
+    // nor attachments is empty.
+    if request.content.trim().is_empty() && request.attachments.is_empty() {
         bail!("dispatch appended message cannot be empty");
     }
     let total_bytes = request
@@ -397,6 +399,7 @@ fn append(request: DispatchAppendRequest) -> Result<DispatchAppendResponse> {
     if total_bytes > MAX_DISPATCH_TEXT_BYTES {
         bail!("dispatch appended message exceeds the 32 KiB request limit");
     }
+    validate_attachments(&request.attachments)?;
     let message_id = request.message_id.clone();
     let store = DispatchStore::open_default()?;
     let accepted = store.enqueue_append_message(request)?;

--- a/src/apps/cli/src/dispatch/protocol.rs
+++ b/src/apps/cli/src/dispatch/protocol.rs
@@ -165,6 +165,10 @@ pub(crate) struct DispatchAppendRequest {
     pub(crate) content: String,
     #[serde(default)]
     pub(crate) display_content: Option<String>,
+    /// Attachments injected into the running turn with the message. An older
+    /// controller omits the field entirely, which decodes to an empty list.
+    #[serde(default)]
+    pub(crate) attachments: Vec<DispatchAttachment>,
 }
 
 #[derive(Clone, Debug, Serialize, PartialEq, Eq)]

--- a/src/apps/cli/src/dispatch/store.rs
+++ b/src/apps/cli/src/dispatch/store.rs
@@ -2522,6 +2522,7 @@ mod tests {
             message_id: "message-1".to_string(),
             content: "Continue with tests".to_string(),
             display_content: None,
+            attachments: Vec::new(),
         };
 
         assert!(store

--- a/src/apps/cli/src/dispatch/worker.rs
+++ b/src/apps/cli/src/dispatch/worker.rs
@@ -505,6 +505,8 @@ async fn process_mailboxes(
                 turn_id: turn_id.to_string(),
                 content: request.content.clone(),
                 display_content: request.display_content.clone(),
+                attachments: runtime_attachments(&request.attachments),
+                metadata: serde_json::Map::new(),
             })
             .await
             .map_err(|error| anyhow!(error.into_message()))

--- a/src/apps/desktop/src/api/agentic_api.rs
+++ b/src/apps/desktop/src/api/agentic_api.rs
@@ -751,6 +751,14 @@ pub struct SteerDialogTurnRequest {
     /// Original user text for UI rendering (defaults to `content`).
     #[serde(default)]
     pub display_content: Option<String>,
+    /// Images attached to the steering message. Same shape the composer sends
+    /// when it starts a turn — a message keeps its attachments whether it is
+    /// submitted at a turn boundary or injected into a running turn.
+    #[serde(default)]
+    pub image_contexts: Option<Vec<ImageContextData>>,
+    /// Structured metadata carried with the steering message.
+    #[serde(default)]
+    pub user_message_metadata: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Serialize)]
@@ -2749,12 +2757,23 @@ pub async fn steer_dialog_turn(
         dialog_turn_id,
         content,
         display_content,
+        image_contexts,
+        user_message_metadata,
     } = request;
 
-    let trimmed = content.trim();
-    if trimmed.is_empty() {
+    let attachments: Vec<AgentInputAttachment> = image_contexts
+        .unwrap_or_default()
+        .into_iter()
+        .map(desktop_image_attachment)
+        .collect();
+
+    // An image-only steering message is a real message; only a message with
+    // neither text nor attachments is empty.
+    if content.trim().is_empty() && attachments.is_empty() {
         return Err("Steering content cannot be empty".to_string());
     }
+
+    let metadata = desktop_user_message_metadata(user_message_metadata);
 
     let outcome = runtime
         .agent_runtime()
@@ -2763,6 +2782,8 @@ pub async fn steer_dialog_turn(
             turn_id: dialog_turn_id,
             content,
             display_content,
+            attachments,
+            metadata,
         })
         .await
         .map_err(|error| format!("Failed to steer dialog turn: {}", error.into_message()))?;

--- a/src/crates/adapters/agent-runtime-ipc/src/operation.rs
+++ b/src/crates/adapters/agent-runtime-ipc/src/operation.rs
@@ -461,6 +461,8 @@ mod tests {
                 turn_id: "turn-1".to_string(),
                 content: "check tests".to_string(),
                 display_content: None,
+                attachments: Vec::new(),
+                metadata: serde_json::Map::new(),
             },
         };
         let rules = operation.rules();

--- a/src/crates/adapters/agent-runtime-ipc/src/tests/protocol_contracts.rs
+++ b/src/crates/adapters/agent-runtime-ipc/src/tests/protocol_contracts.rs
@@ -142,6 +142,8 @@ fn protocol_round_trips_exact_turn_steering_without_replacing_turn_admission() {
             turn_id: "turn-1".to_string(),
             content: "check tests".to_string(),
             display_content: Some("Check tests".to_string()),
+            attachments: Vec::new(),
+            metadata: serde_json::Map::new(),
         },
     };
     let result = RuntimeIpcOperationResult::TurnSteered {

--- a/src/crates/adapters/agent-runtime-ipc/src/tests/shared_controller.rs
+++ b/src/crates/adapters/agent-runtime-ipc/src/tests/shared_controller.rs
@@ -705,6 +705,8 @@ fn steer_operation(session_id: &str, turn_id: &str) -> RuntimeIpcOperation {
             turn_id: turn_id.to_string(),
             content: "check tests".to_string(),
             display_content: None,
+            attachments: Vec::new(),
+            metadata: serde_json::Map::new(),
         },
     }
 }

--- a/src/crates/assembly/core/src/agentic/coordination/scheduler.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/scheduler.rs
@@ -460,10 +460,16 @@ impl DialogScheduler {
         turn_id: String,
         content: String,
         display_content: Option<String>,
+        attachments: Vec<AgentInputAttachment>,
+        metadata: serde_json::Map<String, serde_json::Value>,
     ) -> Result<DialogSteerOutcome, String> {
-        if content.trim().is_empty() {
+        if content.trim().is_empty() && attachments.is_empty() {
             return Err("Steering content cannot be empty".to_string());
         }
+        // Reject a malformed attachment here rather than at the round boundary:
+        // the caller is still holding the user's message and can surface the
+        // failure, whereas the injection consumer would have to drop it.
+        agent_dialog_turn_image_contexts(&attachments).map_err(|error| error.to_string())?;
         let _operation_guard = self.lock_session_operation(&session_id).await;
         let active_turn_id = match self
             .session_manager
@@ -488,6 +494,8 @@ impl DialogScheduler {
             &turn_id,
             content,
             display_content,
+            attachments,
+            metadata,
             steering_id,
             SystemTime::now(),
         ) {
@@ -2233,7 +2241,7 @@ fn image_context_metadata(attachment: &AgentInputAttachment) -> Option<serde_jso
     }
 }
 
-fn agent_dialog_turn_image_contexts(
+pub(crate) fn agent_dialog_turn_image_contexts(
     attachments: &[AgentInputAttachment],
 ) -> PortResult<Option<Vec<ImageContextData>>> {
     if attachments.is_empty() {
@@ -2413,18 +2421,24 @@ impl AgentDialogTurnPort for DialogScheduler {
         &self,
         request: AgentDialogSteerRequest,
     ) -> PortResult<DialogSteerOutcome> {
-        let empty_content = request.content.trim().is_empty();
+        // An empty-but-attachment-free message and a malformed attachment are
+        // both bad requests; only a live-turn mismatch means "session in use".
+        let invalid_request =
+            request.content.trim().is_empty() && request.attachments.is_empty()
+                || agent_dialog_turn_image_contexts(&request.attachments).is_err();
         DialogScheduler::buffer_steering(
             self,
             request.session_id,
             request.turn_id,
             request.content,
             request.display_content,
+            request.attachments,
+            request.metadata,
         )
         .await
         .map_err(|error| {
             PortError::new(
-                if empty_content {
+                if invalid_request {
                     PortErrorKind::InvalidRequest
                 } else {
                     PortErrorKind::SessionInUse
@@ -3597,6 +3611,8 @@ mod tests {
                 turn_id.to_string(),
                 "check tests".to_string(),
                 None,
+                Vec::new(),
+                serde_json::Map::new(),
             )
             .await
             .expect_err("stale processing state must not accept steering");
@@ -3619,6 +3635,8 @@ mod tests {
                 turn_id: "turn-1".to_string(),
                 content: "  ".to_string(),
                 display_content: None,
+                attachments: Vec::new(),
+                metadata: serde_json::Map::new(),
             },
         )
         .await
@@ -3646,6 +3664,8 @@ mod tests {
                     turn_id.to_string(),
                     "check tests".to_string(),
                     None,
+                    Vec::new(),
+                    serde_json::Map::new(),
                 )
                 .await
         });

--- a/src/crates/assembly/core/src/agentic/core/message.rs
+++ b/src/crates/assembly/core/src/agentic/core/message.rs
@@ -436,15 +436,31 @@ impl Message {
     }
 
     pub fn internal_reminder(reminder_kind: InternalReminderKind, text: impl Into<String>) -> Self {
+        Self::user(Self::render_internal_reminder(text))
+            .with_semantic_kind(MessageSemanticKind::InternalReminder)
+            .with_internal_reminder_kind(reminder_kind)
+    }
+
+    /// An internal reminder that also carries images — used when a message that
+    /// arrives mid-turn (steering) has attachments, so the model sees the same
+    /// multimodal payload it would have seen at a turn boundary.
+    pub fn internal_reminder_multimodal(
+        reminder_kind: InternalReminderKind,
+        text: impl Into<String>,
+        images: Vec<ImageContextData>,
+    ) -> Self {
+        Self::user_multimodal(Self::render_internal_reminder(text), images)
+            .with_semantic_kind(MessageSemanticKind::InternalReminder)
+            .with_internal_reminder_kind(reminder_kind)
+    }
+
+    fn render_internal_reminder(text: impl Into<String>) -> String {
         let text = text.into();
-        let rendered = if crate::agentic::core::has_prompt_markup(&text) {
+        if crate::agentic::core::has_prompt_markup(&text) {
             text
         } else {
             crate::agentic::core::render_system_reminder(&text)
-        };
-        Self::user(rendered)
-            .with_semantic_kind(MessageSemanticKind::InternalReminder)
-            .with_internal_reminder_kind(reminder_kind)
+        }
     }
 
     pub fn user_multimodal(text: String, images: Vec<ImageContextData>) -> Self {

--- a/src/crates/assembly/core/src/agentic/execution/execution_engine.rs
+++ b/src/crates/assembly/core/src/agentic/execution/execution_engine.rs
@@ -13,6 +13,7 @@ use crate::agentic::agents::{
     UserContextPolicy, UserContextSection,
 };
 use crate::agentic::context_profile::{ContextProfilePolicy, ModelCapabilityProfile};
+use crate::agentic::coordination::scheduler::agent_dialog_turn_image_contexts;
 use crate::agentic::core::{
     render_system_reminder, InternalReminderKind, Message, MessageContent, MessageHelper,
     MessageRole, MessageSemanticKind, RequestReasoningTokenPolicy, Session,
@@ -4096,7 +4097,17 @@ impl ExecutionEngine {
                         let wrapped = match injection.kind {
                             RoundInjectionKind::UserSteering => format!(
                                 "<system_reminder>\nThe user sent a new message while this turn was running. You have just finished the previous atomic action; handle this new user message now as the current direction, while preserving the existing conversation and task context. Do not ignore it or wait for a separate future turn.\n\nNew user message:\n{}\n</system_reminder>",
-                                injection.content
+                                // A steering message carries whatever the
+                                // composer carries, so an image-only message is
+                                // legitimate: name the attachment instead of
+                                // injecting empty text.
+                                if injection.content.trim().is_empty()
+                                    && !injection.attachments.is_empty()
+                                {
+                                    "(image attached)"
+                                } else {
+                                    injection.content.as_str()
+                                }
                             ),
                             RoundInjectionKind::BackgroundResult => format!(
                                 "<system_reminder>\nA background task has finished and returned new information while this turn was running. Incorporate it into your current work immediately when relevant. Do not wait for a separate future turn.\n\nBackground result:\n{}\n</system_reminder>",
@@ -4115,8 +4126,27 @@ impl ExecutionEngine {
                                 InternalReminderKind::GoalObjectiveUpdated
                             }
                         };
-                        let user_msg = Message::internal_reminder(reminder_kind, wrapped)
-                            .with_turn_id(context.dialog_turn_id.clone());
+                        // Attachments rebuild into the same multimodal user
+                        // message a turn-boundary submission would have
+                        // produced; a bad payload degrades to text rather than
+                        // dropping the user's steering message entirely.
+                        let images = match agent_dialog_turn_image_contexts(&injection.attachments)
+                        {
+                            Ok(images) => images.unwrap_or_default(),
+                            Err(error) => {
+                                warn!(
+                                    "Dropping unusable steering attachments, injecting text only: session_id={}, steering_id={}, error={}",
+                                    context.session_id, injection_id, error
+                                );
+                                Vec::new()
+                            }
+                        };
+                        let user_msg = if images.is_empty() {
+                            Message::internal_reminder(reminder_kind, wrapped)
+                        } else {
+                            Message::internal_reminder_multimodal(reminder_kind, wrapped, images)
+                        }
+                        .with_turn_id(context.dialog_turn_id.clone());
                         messages.push(user_msg.clone());
                         if let Err(e) = self
                             .session_manager

--- a/src/crates/assembly/core/src/agentic/tools/pipeline/tool_pipeline.rs
+++ b/src/crates/assembly/core/src/agentic/tools/pipeline/tool_pipeline.rs
@@ -4028,6 +4028,8 @@ mod tests {
             target: RoundInjectionTarget::CurrentRunningTurn,
             content: "test injection".to_string(),
             display_content: "test injection".to_string(),
+            attachments: Vec::new(),
+            metadata: serde_json::Map::new(),
             created_at: SystemTime::now(),
         }
     }

--- a/src/crates/assembly/core/src/service/dispatch/controller.rs
+++ b/src/crates/assembly/core/src/service/dispatch/controller.rs
@@ -163,6 +163,10 @@ pub struct DispatchAppendRequest {
     pub content: String,
     #[serde(default)]
     pub display_content: Option<String>,
+    /// Attachments injected with the message into the running turn, under the
+    /// same structural limits as a turn submission's.
+    #[serde(default)]
+    pub attachments: Vec<DispatchAttachmentPayload>,
 }
 
 /// The wire shape and structural limits come from the shared contract; the
@@ -1461,7 +1465,9 @@ pub(super) fn validate_append_request(request: &DispatchAppendRequest) -> anyhow
     if request.message_id.trim().is_empty() || request.message_id.len() > 128 {
         anyhow::bail!("Dispatch messageId must contain 1-128 bytes");
     }
-    if request.content.trim().is_empty() {
+    // An attachment-only message is a real message; only one with neither text
+    // nor attachments is empty.
+    if request.content.trim().is_empty() && request.attachments.is_empty() {
         anyhow::bail!("Dispatch appended message cannot be empty");
     }
     let total_bytes = request
@@ -1471,6 +1477,7 @@ pub(super) fn validate_append_request(request: &DispatchAppendRequest) -> anyhow
     if total_bytes > MAX_DISPATCH_TEXT_BYTES {
         anyhow::bail!("Dispatch appended message exceeds the 32 KiB request limit");
     }
+    validate_attachment_payloads(&request.attachments)?;
     Ok(())
 }
 

--- a/src/crates/assembly/core/src/service/dispatch/device_controller.rs
+++ b/src/crates/assembly/core/src/service/dispatch/device_controller.rs
@@ -465,6 +465,7 @@ pub async fn append_device(
     request: DispatchAppendRequest,
 ) -> anyhow::Result<Value> {
     validate_append_request(&request)?;
+    validate_device_attachment_budget(&request.attachments)?;
     let record = load_device_record(store, &request.job_id).await?;
     let DispatchTarget::Device { device_id, .. } = &record.target else {
         unreachable!("load_device_record validates target kind")

--- a/src/crates/contracts/runtime-ports/src/lib.rs
+++ b/src/crates/contracts/runtime-ports/src/lib.rs
@@ -1666,8 +1666,13 @@ pub struct AgentDialogTurnRequest {
     pub metadata: serde_json::Map<String, serde_json::Value>,
 }
 
-/// Text-only steering request for one exact running dialog turn.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Steering request for one exact running dialog turn.
+///
+/// Carries the same payload shape as a turn submission: a mid-turn steering
+/// message is an ordinary user message that happens to arrive while a turn is
+/// running, so attachments and message metadata ride along with the text
+/// rather than forcing the user to wait for a turn boundary.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct AgentDialogSteerRequest {
     pub session_id: String,
@@ -1675,6 +1680,10 @@ pub struct AgentDialogSteerRequest {
     pub content: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub display_content: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub attachments: Vec<AgentInputAttachment>,
+    #[serde(default, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub metadata: serde_json::Map<String, serde_json::Value>,
 }
 
 impl AgentDialogTurnExecution {
@@ -1964,7 +1973,7 @@ pub enum RoundInjectionTarget {
 
 /// A message to inject into the currently running dialog turn at the next
 /// model-round boundary.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct RoundInjection {
     pub id: String,
     pub kind: RoundInjectionKind,
@@ -1972,6 +1981,13 @@ pub struct RoundInjection {
     pub target: RoundInjectionTarget,
     pub content: String,
     pub display_content: String,
+    /// Attachments that ride into the running turn with the injected message.
+    /// Consumers rebuild them into a multimodal user message, so a steering
+    /// message with images is no different from one sent at a turn boundary.
+    pub attachments: Vec<AgentInputAttachment>,
+    /// Message metadata carried alongside the injected content (same shape as
+    /// a turn submission's `metadata`).
+    pub metadata: serde_json::Map<String, serde_json::Value>,
     pub created_at: std::time::SystemTime,
 }
 
@@ -2236,6 +2252,42 @@ impl AgentInputAttachment {
             "dataUrl".to_string(),
             serde_json::Value::String(data_url.into()),
         );
+
+        Self {
+            kind: "remote_image".to_string(),
+            id: id.into(),
+            metadata,
+        }
+    }
+
+    /// Build a `remote_image` attachment from a renderer image context.
+    ///
+    /// Either `image_path` or `data_url` must be present — consumers reject an
+    /// attachment carrying neither.
+    pub fn image_context(
+        id: impl Into<String>,
+        image_path: Option<String>,
+        data_url: Option<String>,
+        mime_type: impl Into<String>,
+        context_metadata: Option<serde_json::Value>,
+    ) -> Self {
+        let mut metadata = serde_json::Map::new();
+        if let Some(image_path) = image_path {
+            metadata.insert(
+                "imagePath".to_string(),
+                serde_json::Value::String(image_path),
+            );
+        }
+        if let Some(data_url) = data_url {
+            metadata.insert("dataUrl".to_string(), serde_json::Value::String(data_url));
+        }
+        metadata.insert(
+            "mimeType".to_string(),
+            serde_json::Value::String(mime_type.into()),
+        );
+        if let Some(context_metadata) = context_metadata {
+            metadata.insert("metadata".to_string(), context_metadata);
+        }
 
         Self {
             kind: "remote_image".to_string(),
@@ -3717,6 +3769,8 @@ mod tests {
                 target: RoundInjectionTarget::CurrentRunningTurn,
                 content: "result".to_string(),
                 display_content: "result".to_string(),
+                attachments: Vec::new(),
+                metadata: serde_json::Map::new(),
                 created_at: std::time::SystemTime::UNIX_EPOCH,
             },
         };
@@ -3916,11 +3970,22 @@ mod tests {
 
     #[test]
     fn agent_dialog_steer_contract_round_trips_exact_turn_identity() {
+        let mut metadata = serde_json::Map::new();
+        metadata.insert(
+            "kind".to_string(),
+            serde_json::Value::String("steering".to_string()),
+        );
         let request = AgentDialogSteerRequest {
             session_id: "session_1".to_string(),
             turn_id: "turn_1".to_string(),
             content: "Please also check the tests".to_string(),
             display_content: Some("Also check tests".to_string()),
+            attachments: vec![AgentInputAttachment::remote_image(
+                "image-1",
+                "shot.png",
+                "data:image/png;base64,abc",
+            )],
+            metadata,
         };
         let outcome = DialogSteerOutcome::Buffered {
             session_id: "session_1".to_string(),
@@ -3935,6 +4000,9 @@ mod tests {
         assert_eq!(request_json["turnId"], "turn_1");
         assert_eq!(request_json["content"], "Please also check the tests");
         assert_eq!(request_json["displayContent"], "Also check tests");
+        // A steering message carries the same payload a turn submission does.
+        assert_eq!(request_json["attachments"][0]["kind"], "remote_image");
+        assert_eq!(request_json["metadata"]["kind"], "steering");
         assert_eq!(outcome_json["kind"], "buffered");
         assert_eq!(outcome_json["sessionId"], "session_1");
         assert_eq!(outcome_json["turnId"], "turn_1");

--- a/src/crates/execution/agent-runtime/src/runtime.rs
+++ b/src/crates/execution/agent-runtime/src/runtime.rs
@@ -3383,6 +3383,8 @@ mod tests {
                 turn_id: "turn_1".to_string(),
                 content: "check tests".to_string(),
                 display_content: None,
+                attachments: Vec::new(),
+                metadata: serde_json::Map::new(),
             })
             .await
             .expect_err("steering without a dialog-turn provider must fail");
@@ -3433,6 +3435,8 @@ mod tests {
             turn_id: "turn_1".to_string(),
             content: "check tests".to_string(),
             display_content: Some("Check tests".to_string()),
+            attachments: Vec::new(),
+            metadata: serde_json::Map::new(),
         };
 
         let result = runtime
@@ -3492,6 +3496,8 @@ mod tests {
                 turn_id: "turn_1".to_string(),
                 content: "check tests".to_string(),
                 display_content: None,
+                attachments: Vec::new(),
+                metadata: serde_json::Map::new(),
             })
             .await
             .expect_err("provider turn mismatch must fail closed");

--- a/src/crates/execution/agent-runtime/src/scheduler.rs
+++ b/src/crates/execution/agent-runtime/src/scheduler.rs
@@ -4,7 +4,7 @@ use crate::events::turn_outcome_kind;
 use crate::thread_goal::{build_objective_updated_plan, build_thread_goal_continuation_plan};
 use bitfun_runtime_ports::{
     should_skip_agent_session_reply, should_suppress_agent_session_cancelled_reply,
-    AgentSessionReplyRoute, DialogQueuePriority, DialogRoundInjectionSource,
+    AgentInputAttachment, AgentSessionReplyRoute, DialogQueuePriority, DialogRoundInjectionSource,
     DialogSessionStateFact, DialogSteerOutcome, DialogSubmissionPolicy, DialogTriggerSource,
     RoundInjection, RoundInjectionKind, RoundInjectionTarget, RoundInjectionToolPreemption,
     ThreadGoal,
@@ -371,7 +371,7 @@ pub enum AgentSessionReplyAction {
     Forward(AgentSessionReplyPlan),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum DialogSteeringAction {
     Reject {
         error: String,
@@ -700,6 +700,8 @@ pub fn resolve_background_delivery_injection(
         target: RoundInjectionTarget::CurrentRunningTurn,
         content,
         display_content,
+        attachments: Vec::new(),
+        metadata: serde_json::Map::new(),
         created_at,
     }
 }
@@ -937,6 +939,8 @@ pub fn resolve_dialog_steering_action(
     turn_id: &str,
     content: String,
     display_content: Option<String>,
+    attachments: Vec<AgentInputAttachment>,
+    metadata: serde_json::Map<String, serde_json::Value>,
     steering_id: String,
     created_at: SystemTime,
 ) -> DialogSteeringAction {
@@ -957,6 +961,8 @@ pub fn resolve_dialog_steering_action(
             target: RoundInjectionTarget::ExactTurn(turn_id.to_string()),
             content,
             display_content: display,
+            attachments,
+            metadata,
             created_at,
         },
         outcome: DialogSteerOutcome::Buffered {

--- a/src/crates/execution/agent-runtime/tests/agent_session_contracts/scheduler_contracts.rs
+++ b/src/crates/execution/agent-runtime/tests/agent_session_contracts/scheduler_contracts.rs
@@ -11,7 +11,8 @@ use bitfun_agent_runtime::scheduler::{
     DEFAULT_MAX_DIALOG_QUEUE_DEPTH,
 };
 use bitfun_runtime_ports::{
-    AgentSessionReplyRoute, DialogQueuePriority, DialogSessionStateFact, DialogSteerOutcome,
+    AgentInputAttachment, AgentSessionReplyRoute, DialogQueuePriority, DialogSessionStateFact,
+    DialogSteerOutcome,
     DialogSubmissionPolicy, DialogTriggerSource, RoundInjection, RoundInjectionKind,
     RoundInjectionTarget, RoundInjectionToolPreemption, ThreadGoal, ThreadGoalStatus,
 };
@@ -516,6 +517,15 @@ fn dialog_steering_action_buffers_exact_running_turn_with_display_fallback() {
         "turn-1",
         "steer content".to_string(),
         None,
+        vec![AgentInputAttachment::remote_image(
+            "image-1",
+            "shot.png",
+            "data:image/png;base64,abc",
+        )],
+        serde_json::Map::from_iter([(
+            "kind".to_string(),
+            serde_json::Value::String("steering".to_string()),
+        )]),
         "steer-id".to_string(),
         created_at,
     );
@@ -531,6 +541,14 @@ fn dialog_steering_action_buffers_exact_running_turn_with_display_fallback() {
     );
     assert_eq!(injection.content, "steer content");
     assert_eq!(injection.display_content, "steer content");
+    // Attachments and metadata ride the injection so the running turn sees the
+    // same payload a turn-boundary submission would have carried.
+    assert_eq!(injection.attachments.len(), 1);
+    assert_eq!(injection.attachments[0].id, "image-1");
+    assert_eq!(
+        injection.metadata.get("kind").and_then(|v| v.as_str()),
+        Some("steering")
+    );
     assert_eq!(injection.created_at, created_at);
     assert_eq!(
         injection.execution_policy.tool_preemption,
@@ -554,6 +572,8 @@ fn dialog_steering_action_rejects_when_target_turn_is_not_running() {
         "turn-1",
         "steer content".to_string(),
         Some("display".to_string()),
+        Vec::new(),
+        serde_json::Map::new(),
         "steer-id".to_string(),
         SystemTime::UNIX_EPOCH,
     );
@@ -658,6 +678,8 @@ fn exact_turn_msg(turn_id: &str, content: &str) -> RoundInjection {
         target: RoundInjectionTarget::ExactTurn(turn_id.to_string()),
         content: content.to_string(),
         display_content: content.to_string(),
+        attachments: Vec::new(),
+        metadata: serde_json::Map::new(),
         created_at: SystemTime::now(),
     }
 }
@@ -670,6 +692,8 @@ fn current_turn_msg(content: &str) -> RoundInjection {
         target: RoundInjectionTarget::CurrentRunningTurn,
         content: content.to_string(),
         display_content: content.to_string(),
+        attachments: Vec::new(),
+        metadata: serde_json::Map::new(),
         created_at: SystemTime::now(),
     }
 }

--- a/src/crates/interfaces/app-server/tests/agent_kernel.rs
+++ b/src/crates/interfaces/app-server/tests/agent_kernel.rs
@@ -833,6 +833,8 @@ async fn phase2_mutations_route_through_runtime_owner_ports() {
                         turn_id: "turn-active".to_string(),
                         content: "keep going".to_string(),
                         display_content: None,
+                        attachments: Vec::new(),
+                        metadata: serde_json::Map::new(),
                     },
                 ))
                 .await

--- a/src/web-ui/src/features/dispatch/dispatchApi.ts
+++ b/src/web-ui/src/features/dispatch/dispatchApi.ts
@@ -194,6 +194,7 @@ export const dispatchApi = {
     displayContent?: string,
     messageId: string = globalThis.crypto?.randomUUID?.()
       ?? `dispatch-message-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    attachments?: DispatchInlineAttachment[],
   ): Promise<{ accepted: boolean; messageId: string }> {
     return api.invoke<{ accepted: boolean; messageId: string }>('dispatch_append', {
       request: {
@@ -201,6 +202,7 @@ export const dispatchApi = {
         messageId,
         content,
         ...(displayContent?.trim() ? { displayContent } : {}),
+        ...(attachments?.length ? { attachments } : {}),
       },
     });
   },

--- a/src/web-ui/src/flow_chat/components/PendingQueuePanel.tsx
+++ b/src/web-ui/src/flow_chat/components/PendingQueuePanel.tsx
@@ -27,15 +27,12 @@ import { Tooltip, IconButton } from '@/component-library';
 import { agentAPI } from '@/infrastructure/api/service-api/AgentAPI';
 import { stateMachineManager } from '../state-machine';
 import { FlowChatStore } from '../store/FlowChatStore';
-import {
-  pendingQueueManager,
-  queuedMessageHasUnsupportedSteeringPayload,
-} from '../services/flow-chat-manager/PendingQueueModule';
+import { pendingQueueManager } from '../services/flow-chat-manager/PendingQueueModule';
 import { FlowChatManager } from '../services/FlowChatManager';
 import { insertSteeringItemIfAbsent } from '../services/flow-chat-manager/EventHandlerModule';
 import { notificationService } from '../../shared/notification-system';
 import { createLogger } from '@/shared/utils/logger';
-import type { QueuedMessage } from '../types/flow-chat';
+import type { QueuedMessage, SteeringImage } from '../types/flow-chat';
 import { isAcpFlowSession } from '../utils/acpSession';
 import './PendingQueuePanel.scss';
 
@@ -125,76 +122,67 @@ export function PendingQueuePanel({ sessionId, className }: PendingQueuePanelPro
   const handleSendNow = useCallback(
     async (item: QueuedMessage) => {
       if (!sessionId) return;
-      if (isAcpSession) {
-        log.warn('Steering is disabled for ACP sessions', { sessionId, itemId: item.id });
-        return;
-      }
       const machine = stateMachineManager.get(sessionId);
-      const ctx = machine?.getContext();
-      const dialogTurnId = ctx?.currentDialogTurnId ?? null;
+      const dialogTurnId = machine?.getContext().currentDialogTurnId ?? null;
 
-      if (!dialogTurnId) {
-        // Turn already finished — fall back to the regular drain path so the
-        // item starts a new turn instead.
-        log.info('Send now fallback: no active dialog turn, using drain path', {
-          sessionId,
-          itemId: item.id,
-        });
+      // A running turn takes the message through the steering channel, which
+      // carries the whole payload — text, attachments and metadata alike.
+      // ACP agents own their execution loop and expose no mid-turn injection
+      // point, so they take the drain path below instead.
+      if (dialogTurnId && !isAcpSession) {
+        pendingQueueManager.setStatus(sessionId, item.id, 'sending_now');
         try {
-          if (!pendingQueueManager.promoteForExplicitDrain(sessionId, item.id)) {
-            log.warn('Send now fallback item is no longer queued', {
-              sessionId,
-              itemId: item.id,
-            });
-            return;
+          const resp = await agentAPI.steerDialogTurn({
+            sessionId,
+            dialogTurnId,
+            content: item.content,
+            displayContent: item.displayMessage ?? item.content,
+            imageContexts: item.imageContexts,
+            userMessageMetadata: item.userMessageMetadata,
+          });
+          // Optimistically render the steering bubble in the running round so
+          // the user sees their message land immediately. The backend
+          // `UserSteeringInjected` event dedupes by the same `steeringId`.
+          if (resp?.steeringId) {
+            try {
+              insertSteeringItemIfAbsent({
+                sessionId,
+                turnId: dialogTurnId,
+                steeringId: resp.steeringId,
+                content: item.displayMessage ?? item.content,
+                images: item.imageDisplayData as SteeringImage[] | undefined,
+                status: 'pending',
+              });
+            } catch (renderErr) {
+              log.warn('Optimistic steering render failed', { renderErr });
+            }
           }
-          await FlowChatManager.getInstance().drainPendingQueueForSession(sessionId);
+          pendingQueueManager.remove(sessionId, item.id);
+          return;
         } catch (err) {
-          log.error('Send now fallback failed', { sessionId, itemId: item.id, err });
-          notificationService.error(t('pendingQueue.errors.sendNowFailed'), { duration: 4000 });
+          // Most often the turn finished between the click and the request.
+          // Fall through to the drain path rather than reporting a failure the
+          // user cannot act on.
+          log.warn('Steering rejected, falling back to the drain path', {
+            sessionId,
+            itemId: item.id,
+            err,
+          });
+          pendingQueueManager.setStatus(sessionId, item.id, 'queued');
         }
-        return;
       }
 
-      if (queuedMessageHasUnsupportedSteeringPayload(item)) {
-        log.info('Send now kept queued because steering is text-only', {
-          sessionId,
-          itemId: item.id,
-        });
-        notificationService.warning(t('pendingQueue.errors.richContentUnsupported'), {
-          duration: 4000,
-        });
-        return;
-      }
-
-      pendingQueueManager.setStatus(sessionId, item.id, 'sending_now');
+      // No turn to inject into. Move the item to the head and send it at the
+      // first opportunity: right now if the session is idle, otherwise the
+      // IDLE drain listener picks it up the moment the current turn ends.
       try {
-        const resp = await agentAPI.steerDialogTurn({
-          sessionId,
-          dialogTurnId,
-          content: item.content,
-          displayContent: item.displayMessage ?? item.content,
-        });
-        // Optimistically render the steering bubble in the running round so the
-        // user sees their message land immediately. The backend
-        // `UserSteeringInjected` event will dedupe by the same `steeringId`.
-        if (resp?.steeringId) {
-          try {
-            insertSteeringItemIfAbsent({
-              sessionId,
-              turnId: dialogTurnId,
-              steeringId: resp.steeringId,
-              content: item.displayMessage ?? item.content,
-              status: 'pending',
-            });
-          } catch (renderErr) {
-            log.warn('Optimistic steering render failed', { renderErr });
-          }
+        if (!pendingQueueManager.promoteForExplicitDrain(sessionId, item.id)) {
+          log.warn('Send now item is no longer queued', { sessionId, itemId: item.id });
+          return;
         }
-        pendingQueueManager.remove(sessionId, item.id);
+        await FlowChatManager.getInstance().drainPendingQueueForSession(sessionId);
       } catch (err) {
-        log.error('Send now (steering) failed', { sessionId, itemId: item.id, err });
-        pendingQueueManager.setStatus(sessionId, item.id, 'queued');
+        log.error('Send now fallback failed', { sessionId, itemId: item.id, err });
         notificationService.error(t('pendingQueue.errors.sendNowFailed'), { duration: 4000 });
       }
     },
@@ -364,27 +352,25 @@ export function PendingQueuePanel({ sessionId, className }: PendingQueuePanelPro
                         <Pencil size={12} strokeWidth={2.25} />
                       </IconButton>
                     </Tooltip>
-                    {!isAcpSession && (
-                      <Tooltip content={t('pendingQueue.tooltip.sendNow')}>
-                        <IconButton
-                          data-bf-component="pending-queue-panel"
-                          data-bf-part="action"
-                          size="small"
-                          className="bitfun-pending-queue-panel__btn bitfun-pending-queue-panel__btn--primary"
-                          disabled={isSending}
-                          onClick={() => {
-                            void handleSendNow(item);
-                          }}
-                          aria-label={t('pendingQueue.actions.sendNow')}
-                        >
-                          {isSendingNow ? (
-                            <Loader2 size={12} strokeWidth={2.5} className="bitfun-pending-queue-panel__spin" />
-                          ) : (
-                            <ArrowUp size={12} strokeWidth={2.5} />
-                          )}
-                        </IconButton>
-                      </Tooltip>
-                    )}
+                    <Tooltip content={t('pendingQueue.tooltip.sendNow')}>
+                      <IconButton
+                        data-bf-component="pending-queue-panel"
+                        data-bf-part="action"
+                        size="small"
+                        className="bitfun-pending-queue-panel__btn bitfun-pending-queue-panel__btn--primary"
+                        disabled={isSending}
+                        onClick={() => {
+                          void handleSendNow(item);
+                        }}
+                        aria-label={t('pendingQueue.actions.sendNow')}
+                      >
+                        {isSendingNow ? (
+                          <Loader2 size={12} strokeWidth={2.5} className="bitfun-pending-queue-panel__spin" />
+                        ) : (
+                          <ArrowUp size={12} strokeWidth={2.5} />
+                        )}
+                      </IconButton>
+                    </Tooltip>
                     <Tooltip content={t('pendingQueue.actions.delete')}>
                       <IconButton
                         data-bf-component="pending-queue-panel"

--- a/src/web-ui/src/flow_chat/components/UserSteeringBubble.appearance.ts
+++ b/src/web-ui/src/flow_chat/components/UserSteeringBubble.appearance.ts
@@ -1,0 +1,8 @@
+import type { AppearanceSurfaceDescriptor } from '@/infrastructure/appearance';
+
+export const userSteeringBubbleAppearanceDescriptor: AppearanceSurfaceDescriptor = {
+  id: 'user-steering-bubble',
+  parts: [
+    { id: 'images' }, { id: 'image' },
+  ],
+};

--- a/src/web-ui/src/flow_chat/components/UserSteeringBubble.scss
+++ b/src/web-ui/src/flow_chat/components/UserSteeringBubble.scss
@@ -1,0 +1,26 @@
+// Attachments on a steering message, matching the turn-level user message so
+// an image reads the same whether it was sent at a turn boundary or injected
+// into a running turn.
+.bitfun-user-steering-bubble__images {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.bitfun-user-steering-bubble__image {
+  // Attachment-sized, not a hero image: the text stays the primary content.
+  width: 72px;
+  height: 72px;
+  border-radius: 5px;
+  overflow: hidden;
+  border: 1px solid var(--bf-appearance-token-border-base);
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+}

--- a/src/web-ui/src/flow_chat/components/UserSteeringBubble.tsx
+++ b/src/web-ui/src/flow_chat/components/UserSteeringBubble.tsx
@@ -2,7 +2,7 @@
  * Renders a `user-steering` flow item as a normal user message in the
  * conversation flow. The backend confirmation still updates this item by
  * `steeringId`, but the user-facing surface is intentionally identical to a
- * message sent from the composer.
+ * message sent from the composer — attachments included.
  *
  * The item is appended to the *current* model round's items, so it visually
  * sits after whatever thinking / text / tool-call content has already
@@ -12,18 +12,51 @@
  */
 
 import { UserMessage } from './UserMessage';
-import type { FlowUserSteeringItem } from '../types/flow-chat';
+import type { FlowUserSteeringItem, SteeringImage } from '../types/flow-chat';
+import './UserSteeringBubble.scss';
 
 interface UserSteeringBubbleProps {
   item: FlowUserSteeringItem;
 }
 
+function imageSource(image: SteeringImage): string | undefined {
+  if (image.dataUrl) return image.dataUrl;
+  if (image.imagePath) {
+    return `https://asset.localhost/${encodeURIComponent(image.imagePath)}`;
+  }
+  return undefined;
+}
+
 export function UserSteeringBubble({ item }: UserSteeringBubbleProps): JSX.Element {
+  const images = item.images ?? [];
   return (
-    <UserMessage
-      message={item.content}
-      timestamp={item.timestamp}
-    />
+    <>
+      <UserMessage
+        message={item.content}
+        timestamp={item.timestamp}
+      />
+      {images.length > 0 && (
+        <div
+          data-bf-component="user-steering-bubble"
+          data-bf-part="images"
+          className="bitfun-user-steering-bubble__images"
+        >
+          {images.map(image => {
+            const src = imageSource(image);
+            return src ? (
+              <div
+                data-bf-component="user-steering-bubble"
+                data-bf-part="image"
+                key={image.id}
+                className="bitfun-user-steering-bubble__image"
+              >
+                <img src={src} alt={image.name ?? image.id} />
+              </div>
+            ) : null;
+          })}
+        </div>
+      )}
+    </>
   );
 }
 

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
@@ -42,6 +42,7 @@ import { MCPAPI } from '@/infrastructure/api/service-api/MCPAPI';
 import { ACPClientAPI, type AcpPermissionRequestEvent } from '@/infrastructure/api/service-api/ACPClientAPI';
 import { globalEventBus } from '@/infrastructure/event-bus';
 import type { FlowChatContext, DialogTurn, ModelRound, FlowToolItem } from './types';
+import type { SteeringImage } from '../../types/flow-chat';
 import {
   normalizeAiErrorDetail,
   type AiErrorDetail,
@@ -1241,10 +1242,12 @@ export function insertSteeringItemIfAbsent(params: {
   turnId: string;
   steeringId: string;
   content: string;
+  /** Images sent with the steering message, rendered under its text. */
+  images?: SteeringImage[];
   roundIndex?: number;
   status?: 'pending' | 'completed';
 }): boolean {
-  const { sessionId, turnId, steeringId, content } = params;
+  const { sessionId, turnId, steeringId, content, images } = params;
   const roundIndex = typeof params.roundIndex === 'number' ? params.roundIndex : 0;
   const status = params.status ?? 'completed';
 
@@ -1278,6 +1281,7 @@ export function insertSteeringItemIfAbsent(params: {
     status,
     steeringId,
     content,
+    images: images?.length ? images : undefined,
     roundIndex,
   };
 

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/MessageModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/MessageModule.ts
@@ -91,7 +91,7 @@ export async function sendMessage(
   const draft: SubmissionDraft = {
     message,
     displayMessage,
-    hasImages: (options?.imageContexts?.length ?? 0) > 0,
+    imageContexts: options?.imageContexts,
   };
 
   if (!options?.bypassPendingQueue) {

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/PendingQueueModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/PendingQueueModule.test.ts
@@ -1,10 +1,7 @@
 // @vitest-environment jsdom
 
 import { afterEach, describe, expect, it } from 'vitest';
-import {
-  pendingQueueManager,
-  queuedMessageHasUnsupportedSteeringPayload,
-} from './PendingQueueModule';
+import { pendingQueueManager } from './PendingQueueModule';
 
 const sessions: string[] = [];
 
@@ -55,42 +52,5 @@ describe('PendingQueueModule', () => {
     expect(items[0]).toMatchObject(payload);
     expect(items[0].status).toBe('queued');
     expect(items[0].retryCount).toBe(0);
-  });
-
-  it('rejects only payloads that the text-only steering contract would flatten', () => {
-    const plain = {
-      id: 'plain',
-      sessionId: 'session-1',
-      content: 'plain text',
-      timestamp: 1,
-      status: 'queued' as const,
-      retryCount: 0,
-    };
-
-    expect(queuedMessageHasUnsupportedSteeringPayload(plain)).toBe(false);
-    expect(
-      queuedMessageHasUnsupportedSteeringPayload({
-        ...plain,
-        imageContexts: [{ id: 'image-1' }],
-      }),
-    ).toBe(true);
-    expect(
-      queuedMessageHasUnsupportedSteeringPayload({
-        ...plain,
-        userMessageMetadata: { deepReviewRunManifest: { requestId: 'review-1' } },
-      }),
-    ).toBe(true);
-    expect(
-      queuedMessageHasUnsupportedSteeringPayload({
-        ...plain,
-        userMessageMetadata: { sessionReferences: [{ sessionId: 'source' }] },
-      }),
-    ).toBe(true);
-    expect(
-      queuedMessageHasUnsupportedSteeringPayload({
-        ...plain,
-        userMessageMetadata: { composerPresentation: { parts: [] } },
-      }),
-    ).toBe(true);
   });
 });

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/PendingQueueModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/PendingQueueModule.ts
@@ -43,18 +43,6 @@ export interface EnqueueInput {
 
 export type PendingQueueListener = (sessionId: string, items: QueuedMessage[]) => void;
 
-/**
- * The core steering contract is text-only. Keep payloads that need structured
- * attachment/reference metadata queued for the regular turn submission path.
- */
-export function queuedMessageHasUnsupportedSteeringPayload(item: QueuedMessage): boolean {
-  if ((item.imageContexts?.length ?? 0) > 0 || (item.imageDisplayData?.length ?? 0) > 0) {
-    return true;
-  }
-  const metadata = item.userMessageMetadata;
-  return metadata != null && Object.keys(metadata).length > 0;
-}
-
 class PendingQueueManager {
   private static _instance: PendingQueueManager | null = null;
   private queues = new Map<string, QueuedMessage[]>();

--- a/src/web-ui/src/flow_chat/session-drivers/dispatch/DispatchSessionDriver.ts
+++ b/src/web-ui/src/flow_chat/session-drivers/dispatch/DispatchSessionDriver.ts
@@ -136,6 +136,7 @@ async function appendToDispatchJob(
   jobId: string,
   message: string,
   displayMessage: string | undefined,
+  attachments?: import('@/features/dispatch/dispatchApi').DispatchInlineAttachment[],
 ): Promise<void> {
   // Keep the id stable across an ambiguous transport failure. A retry with
   // the same message can then ask the target mailbox for the same idempotent
@@ -154,6 +155,7 @@ async function appendToDispatchJob(
     message,
     displayMessage,
     retry.id,
+    attachments,
   );
   if (!response.accepted) {
     releaseSubmissionRetry(APPEND_RETRY_SCOPE, sessionId, retry.id);
@@ -629,11 +631,7 @@ export const dispatchSessionDriver: SessionDriver = {
     return [];
   },
 
-  planSubmission(
-    context: FlowChatContext,
-    sessionId: string,
-    draft: SubmissionDraft,
-  ): SubmissionPlan {
+  planSubmission(context: FlowChatContext, sessionId: string): SubmissionPlan {
     const session = context.flowChatStore.getState().sessions.get(sessionId);
     if (
       !isNonLocalDispatchTarget(session?.config.dispatchTarget)
@@ -644,16 +642,6 @@ export const dispatchSessionDriver: SessionDriver = {
       )
     ) {
       return { kind: 'queue' };
-    }
-    if (draft.hasImages) {
-      // Steering has no attachment channel; the runtime accepts images only
-      // at turn boundaries.
-      return {
-        kind: 'reject',
-        reason: i18nService.t(
-          'flow-chat:chatInput.dispatch.errors.imagesWhileRunning',
-        ),
-      };
     }
     return { kind: 'steer' };
   },
@@ -670,7 +658,13 @@ export const dispatchSessionDriver: SessionDriver = {
         i18nService.t('flow-chat:chatInput.dispatch.errors.sessionUnavailable'),
       );
     }
-    await appendToDispatchJob(sessionId, jobId, draft.message, draft.displayMessage);
+    await appendToDispatchJob(
+      sessionId,
+      jobId,
+      draft.message,
+      draft.displayMessage,
+      dispatchAttachments(session, draft.imageContexts),
+    );
   },
 
   async startTurn(
@@ -698,15 +692,15 @@ export const dispatchSessionDriver: SessionDriver = {
     }
     const dispatchState = readySession.config.dispatchJobState;
     if (dispatchState === 'queued' || dispatchState === 'running') {
-      if ((options?.imageContexts?.length ?? 0) > 0) {
-        // Steering has no attachment channel; images ride turn boundaries.
-        throw new Error(
-          i18nService.t('flow-chat:chatInput.dispatch.errors.imagesWhileRunning'),
-        );
-      }
       // A turn is already in flight; this message steers it rather than
-      // starting another one underneath it.
-      await appendToDispatchJob(sessionId, jobId, message, displayMessage);
+      // starting another one underneath it. Attachments ride along.
+      await appendToDispatchJob(
+        sessionId,
+        jobId,
+        message,
+        displayMessage,
+        dispatchAttachments(readySession, options?.imageContexts),
+      );
       return 'detached';
     }
     if (dispatchState && isDispatchJobTerminal(dispatchState)) {

--- a/src/web-ui/src/flow_chat/session-drivers/types.ts
+++ b/src/web-ui/src/flow_chat/session-drivers/types.ts
@@ -50,7 +50,12 @@ export interface SendMessageOptions {
 export interface SubmissionDraft {
   message: string;
   displayMessage?: string;
-  hasImages: boolean;
+  /**
+   * Composer image contexts for this submission. Steering carries them just
+   * like a turn submission does, so a message with attachments does not have
+   * to wait for a turn boundary.
+   */
+  imageContexts?: ImageInputContextData[];
 }
 
 /**

--- a/src/web-ui/src/flow_chat/types/flow-chat.ts
+++ b/src/web-ui/src/flow_chat/types/flow-chat.ts
@@ -126,10 +126,21 @@ export interface FlowImageAnalysisItem extends FlowItem {
  * `steer_dialog_turn` Tauri command. Rendered inline inside the running
  * model round so the user can see the message they steered the agent with.
  */
+/** One image attached to a steering message, in display shape. */
+export interface SteeringImage {
+  id: string;
+  name?: string;
+  dataUrl?: string;
+  imagePath?: string;
+  mimeType?: string;
+}
+
 export interface FlowUserSteeringItem extends FlowItem {
   type: 'user-steering';
   steeringId: string;
   content: string;
+  /** Images sent with the steering message, rendered under its text. */
+  images?: SteeringImage[];
   /** Round index reported by the backend at injection time. */
   roundIndex: number;
 }

--- a/src/web-ui/src/infrastructure/api/service-api/AgentAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/AgentAPI.ts
@@ -803,12 +803,18 @@ export class AgentAPI {
    * Mirrors Codex CLI's Esc-to-steer behavior: the message is queued on the
    * Rust side and consumed by the execution engine at the next round boundary
    * without ending the current turn.
+   *
+   * Carries the same payload a turn submission does — attachments and message
+   * metadata included — so a message keeps its content whether it is sent at a
+   * turn boundary or injected into a running turn.
    */
   async steerDialogTurn(request: {
     sessionId: string;
     dialogTurnId: string;
     content: string;
     displayContent?: string;
+    imageContexts?: unknown[];
+    userMessageMetadata?: Record<string, unknown>;
   }): Promise<{ success: boolean; steeringId: string }> {
     try {
       return await api.invoke<{ success: boolean; steeringId: string }>(

--- a/src/web-ui/src/infrastructure/appearance/registry/defaultAppearanceRegistry.ts
+++ b/src/web-ui/src/infrastructure/appearance/registry/defaultAppearanceRegistry.ts
@@ -176,6 +176,7 @@ import { exploreGroupAppearanceDescriptor } from '@/flow_chat/components/modern/
 import { pendingQueuePanelAppearanceDescriptor } from '@/flow_chat/components/PendingQueuePanel.appearance';
 import { subagentProjectionAppearanceDescriptor } from '@/flow_chat/components/subagent/SubagentProjectionView.appearance';
 import { threadGoalDialogsAppearanceDescriptor } from '@/flow_chat/components/thread-goal/ThreadGoalDialogs.appearance';
+import { userSteeringBubbleAppearanceDescriptor } from '@/flow_chat/components/UserSteeringBubble.appearance';
 import { welcomePanelAppearanceDescriptor } from '@/flow_chat/components/WelcomePanel.appearance';
 import { generativeWidgetToolCardAppearanceDescriptor } from '@/flow_chat/tool-cards/GenerativeWidgetToolCard.appearance';
 import { gitToolDisplayAppearanceDescriptor } from '@/flow_chat/tool-cards/GitToolDisplay.appearance';
@@ -461,6 +462,7 @@ export function createDefaultAppearanceRegistry(): AppearanceRegistry {
     .registerComponent(pendingQueuePanelAppearanceDescriptor)
     .registerComponent(subagentProjectionAppearanceDescriptor)
     .registerComponent(threadGoalDialogsAppearanceDescriptor)
+    .registerComponent(userSteeringBubbleAppearanceDescriptor)
     .registerComponent(welcomePanelAppearanceDescriptor)
     .registerComponent(generativeWidgetToolCardAppearanceDescriptor)
     .registerComponent(gitToolDisplayAppearanceDescriptor)

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -678,7 +678,6 @@
         "sessionUnavailable": "Remote task information is incomplete. Reopen the task or create a new one.",
         "compactWhileRunning": "Wait for the current remote task to finish before compacting the context.",
         "compactRejected": "The target could not start compaction. Try again shortly.",
-        "imagesWhileRunning": "Images will be sent with the next turn. Wait for the current remote task to finish and try again.",
         "sessionNotReady": "The remote task is still being prepared. Try sending again shortly.",
         "submissionUnconfirmed": "BitFun cannot yet confirm whether the target received this task. Check the task status shortly."
       }
@@ -2534,7 +2533,6 @@
     },
     "errors": {
       "emptyContent": "Message content cannot be empty",
-      "richContentUnsupported": "Messages with attachments or structured metadata can only be sent after the active turn finishes",
       "sendNowFailed": "Send now failed; please try again"
     }
   },

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -678,7 +678,6 @@
         "sessionUnavailable": "远程任务信息不完整。请重新打开任务，或新建一个任务。",
         "compactWhileRunning": "请等待当前远程任务完成后再压缩上下文。",
         "compactRejected": "目标设备未能开始压缩，请稍后重试。",
-        "imagesWhileRunning": "图片会随下一轮消息发送。请等待当前远程任务完成后再试。",
         "sessionNotReady": "远程任务仍在准备中，请稍后再发送。",
         "submissionUnconfirmed": "暂时无法确认目标是否已接收任务。请稍后检查任务状态。"
       }
@@ -2534,7 +2533,6 @@
     },
     "errors": {
       "emptyContent": "消息内容不能为空",
-      "richContentUnsupported": "包含附件或结构化信息的消息需要等待当前对话完成后发送",
       "sendNowFailed": "立即发送失败，请稍后重试"
     }
   },

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -678,7 +678,6 @@
         "sessionUnavailable": "遠端任務資訊不完整。請重新開啟任務，或建立新任務。",
         "compactWhileRunning": "請等待目前遠端任務完成後再壓縮上下文。",
         "compactRejected": "目標裝置未能開始壓縮，請稍後重試。",
-        "imagesWhileRunning": "圖片會隨下一輪訊息傳送。請等待目前遠端任務完成後再試。",
         "sessionNotReady": "遠端任務仍在準備中，請稍後再傳送。",
         "submissionUnconfirmed": "暫時無法確認目標是否已收到任務。請稍後檢查任務狀態。"
       }
@@ -2534,7 +2533,6 @@
     },
     "errors": {
       "emptyContent": "訊息內容不能為空",
-      "richContentUnsupported": "包含附件或結構化資訊的訊息需要等待目前對話完成後傳送",
       "sendNowFailed": "立即發送失敗，請稍後重試"
     }
   },


### PR DESCRIPTION
## Problem

Clicking "send now" on a queued message refused three separate cases:

- a message with attachments or structured metadata was warned off with *"包含附件或结构化信息的消息需要等待当前对话完成后发送"* and stayed queued;
- ACP sessions had the button hidden entirely;
- dispatch sessions rejected images outright while a turn was running.

All three came from one root cause: the steering channel was text-only, so anything richer had to wait for a turn boundary.

## Approach

Widen the channel instead of gating on it.

`AgentDialogSteerRequest` and `RoundInjection` now carry `attachments` and `metadata` — the same payload shape a turn submission carries. The execution engine rebuilds them into a multimodal user message at the round boundary via the existing `agent_dialog_turn_image_contexts` conversion, so a steering message with images reaches the model exactly as it would have at a turn boundary. A malformed attachment is rejected in `buffer_steering` while the caller still holds the user's message, rather than being dropped later at the round boundary.

The dispatch append path carries attachments end to end too (controller → SSH/device RPC → CLI mailbox → `steer_dialog_turn`), under the same structural and device-inline limits `dispatch_continue` already enforces. `attachments` is `#[serde(default)]` on both request structs, so an older controller talking to a newer target still decodes.

## Client behaviour

"Send now" is now available in every session state:

- a running turn takes the message through steering, payload intact;
- a turn that ended between the click and the request no longer surfaces a failure — it falls through to the drain path;
- ACP agents own their execution loop and expose no mid-turn injection point, so the button moves the message to the head of the queue and the IDLE drain listener sends it the moment the current turn ends.

The steering bubble renders its attachments, so an injected message looks the same as one sent from the composer.

## Notes

- `SubmissionDraft.hasImages` existed only to power the dispatch image rejection and is replaced by `imageContexts`, which the steer path actually forwards.
- An image-only steering message is now valid; only a message with neither text nor attachments is rejected as empty.
- Dead i18n keys `pendingQueue.errors.richContentUnsupported` and `chatInput.dispatch.errors.imagesWhileRunning` are removed from all three locales.

## Verification

- `cargo check --workspace --all-targets`
- `cargo test -p bitfun-core --features product-full --lib` (1959 passed), `-p bitfun-desktop --lib` (311), `-p bitfun-runtime-ports` (284), `-p bitfun-agent-runtime`, `-p bitfun-acp` (112), `-p bitfun-cli` dispatch suites
- web UI: `tsc --noEmit`, `eslint .`, full `vitest run` (2946 passed), `vite build --mode web`
- `i18n:audit`, `i18n:contract:test`, `theme:color-audit`, `theme:visual-contract`, `appearance:contract-audit`

The 12 remaining vitest failures (`modelResolution`, `AcpAgentsConfig`) reproduce identically on `main` and are unrelated.