### PR TITLE
fix(worktree): normalize Windows managed paths

### DIFF
--- a/src/crates/assembly/core/src/service/worktree/mod.rs
+++ b/src/crates/assembly/core/src/service/worktree/mod.rs
@@ -1680,6 +1680,13 @@ async fn managed_target_path(
                 format!("Failed to resolve the managed worktree root: {io_error}"),
             )
         })?;
+    // `std::fs::canonicalize` (and Tokio's wrapper) returns a verbatim
+    // `\\?\C:\...` path on Windows. Git for Windows does not accept that form
+    // as a `worktree add` target after the Git adapter normalizes separators,
+    // because it becomes `//?/C:/...`. Keep the resolved path used for the
+    // containment checks, but prefer the ordinary drive-letter representation
+    // whenever it can address the same path.
+    let canonical_root = dunce::simplified(&canonical_root).to_path_buf();
     let repository_root = canonical_root.join(repository_id);
     match tokio::fs::symlink_metadata(&repository_root).await {
         Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
@@ -1715,6 +1722,7 @@ async fn managed_target_path(
                     format!("Failed to resolve the repository worktree root: {io_error}"),
                 )
             })?;
+    let canonical_repository_root = dunce::simplified(&canonical_repository_root).to_path_buf();
     if !canonical_repository_root.starts_with(&canonical_root) {
         return Err(error(
             WorktreeErrorCode::InvalidPath,
@@ -2090,6 +2098,32 @@ mod tests {
             .await
             .expect_err("existing target must be rejected");
         assert_eq!(collision.code, WorktreeErrorCode::InvalidPath);
+    }
+
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn managed_target_path_is_compatible_with_git_for_windows() {
+        let root = tempfile::tempdir().expect("temp root");
+        let settings = WorktreeSettings {
+            root_path: root.path().join("managed-worktrees").display().to_string(),
+            ..WorktreeSettings::default()
+        };
+
+        let target = managed_target_path(
+            &settings,
+            "repository-id",
+            &root.path().join("projects/BitFun"),
+            "48e8b457e87649aebf801b408698f46c",
+        )
+        .await
+        .expect("managed target path");
+        let git_argument = target.to_string_lossy().replace('\\', "/");
+
+        assert!(
+            !git_argument.starts_with("//?/"),
+            "managed worktree targets passed to Git must not use a Windows verbatim path: {}",
+            target.display()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- convert Windows canonical managed-worktree roots from verbatim `\\?\C:\...` form to the compatible drive-letter form before constructing the Git target
- preserve canonical containment and symlink checks
- add a Windows-only regression asserting the target passed to Git never becomes `//?/...`

Fixes #2249

## Root cause

`tokio::fs::canonicalize` returns a verbatim path on Windows. The managed-worktree flow then normalized backslashes for the Git CLI, turning `\\?\C:\...` into `//?/C:/...`; Git for Windows rejected that target while creating the linked worktree `.git` file.

## Verification

- `cargo test -p bitfun-core --no-default-features --features agent-runtime,git --lib service::worktree::tests::` (22 passed on macOS)
- `pnpm run check:repo-hygiene`
- `git diff --check`
- attempted a macOS-to-`x86_64-pc-windows-msvc` check; the host lacks the MSVC C headers required by `libsqlite3-sys`/`libz-sys`, so native Windows CI owns that platform run

Managed worktrees remain explicitly unsupported for remote workspaces, so this change was exercised only in the local-workspace path.

## AI assistance

AI-assisted; locally tested as listed above, with the Windows-specific regression delegated to the native CI matrix.