### PR TITLE
feat(acp): add native DeepSeek Harness support

### DIFF
--- a/src/crates/interfaces/acp/src/client/builtin_clients.rs
+++ b/src/crates/interfaces/acp/src/client/builtin_clients.rs
@@ -8,6 +8,7 @@ const LEGACY_CLAUDE_ACP_ARGS: &[&str] = &["--yes", "@zed-industries/claude-code-
 const CODEX_ACP_PACKAGE: &str = "@agentclientprotocol/codex-acp";
 const CODEX_ACP_ARGS: &[&str] = &["--yes", "@agentclientprotocol/codex-acp@latest"];
 const LEGACY_CODEX_ACP_ARGS: &[&str] = &["--yes", "@zed-industries/codex-acp@latest"];
+const DSH_ACP_PACKAGE: &str = "@deepseek-ai/dsh-acp-demo@next";
 
 pub(crate) struct BuiltinAcpClientPreset {
     pub(crate) id: &'static str,
@@ -29,6 +30,19 @@ const BUILTIN_ACP_CLIENT_PRESETS: &[BuiltinAcpClientPreset] = &[
         args: &["acp"],
         tool_command: "opencode",
         install_package: Some("opencode-ai"),
+        adapter_package: None,
+        adapter_bin: None,
+    },
+    // DeepSeek Harness exposes its automation surface as a native ACP server
+    // through the `dsh-acp-demo` bin. The server reads `./cordis.yml` by
+    // default; users can override that path in the preset arguments. The ACP
+    // package follows DSH's developer-preview `next` release channel.
+    BuiltinAcpClientPreset {
+        id: "dsh",
+        command: "dsh-acp-demo",
+        args: &[],
+        tool_command: "dsh-acp-demo",
+        install_package: Some(DSH_ACP_PACKAGE),
         adapter_package: None,
         adapter_bin: None,
     },
@@ -150,6 +164,22 @@ mod tests {
         assert!(config.enabled);
         assert_eq!(config.command, "omp");
         assert_eq!(config.args, vec!["acp"]);
+    }
+
+    #[test]
+    fn dsh_is_a_native_acp_preset() {
+        let preset = builtin_acp_client_preset("dsh").expect("DSH preset registered");
+        assert_eq!(preset.command, "dsh-acp-demo");
+        assert!(preset.args.is_empty());
+        assert_eq!(preset.tool_command, "dsh-acp-demo");
+        assert_eq!(preset.install_package, Some(DSH_ACP_PACKAGE));
+        assert!(preset.adapter_package.is_none());
+        assert!(preset.adapter_bin.is_none());
+
+        let config = default_config_for_builtin_client("dsh").expect("DSH config");
+        assert!(config.enabled);
+        assert_eq!(config.command, "dsh-acp-demo");
+        assert!(config.args.is_empty());
     }
 
     #[test]

--- a/src/crates/interfaces/acp/src/client/manager.rs
+++ b/src/crates/interfaces/acp/src/client/manager.rs
@@ -2721,4 +2721,15 @@ mod tests {
         assert_eq!(resolved.env.get("BASE").map(String::as_str), Some("1"));
         assert!(resolved.enabled);
     }
+
+    #[test]
+    fn resolves_builtin_dsh_config_for_remote_workspace() {
+        let resolved =
+            resolve_config_for_client(&AcpClientConfigFile::default(), "dsh", Some("remote-host"))
+                .expect("built-in DSH config");
+
+        assert_eq!(resolved.command, "dsh-acp-demo");
+        assert!(resolved.args.is_empty());
+        assert!(resolved.enabled);
+    }
 }

--- a/src/web-ui/src/infrastructure/config/components/AcpAgentsConfig.test.tsx
+++ b/src/web-ui/src/infrastructure/config/components/AcpAgentsConfig.test.tsx
@@ -548,6 +548,30 @@ describe('AcpAgentsConfig', () => {
     expect(notifySuccessMock).toHaveBeenCalledWith('notifications.configAddedManualCliRequired');
   });
 
+  it('offers DeepSeek Harness as a native ACP preset', async () => {
+    probeClientRequirementsMock.mockResolvedValue([
+      {
+        id: 'dsh',
+        tool: { name: 'dsh-acp-demo', installed: true, version: '0.1.0-rc.6' },
+        runnable: true,
+        notes: [],
+      },
+    ]);
+
+    await act(async () => {
+      root.render(<AcpAgentsConfig />);
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain('DeepSeek Harness');
+    expect(container.textContent).toContain('dsh-acp-demo');
+    expect(container.textContent).not.toContain('registry.acpMissing');
+  });
+
   it('does not downgrade enabled agents on transient probe timeouts during refresh', async () => {
     probeClientRequirementsMock
       .mockResolvedValueOnce([

--- a/src/web-ui/src/infrastructure/config/components/AcpAgentsConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/AcpAgentsConfig.tsx
@@ -90,7 +90,7 @@ interface AcpClientPreset {
 
 // Presets that speak ACP natively and therefore need no separate adapter
 // package (their CLI binary is launched directly).
-const NATIVE_ACP_PRESET_IDS = new Set(['opencode', 'omp']);
+const NATIVE_ACP_PRESET_IDS = new Set(['opencode', 'dsh', 'omp']);
 
 // Presets BitFun cannot install on the user's behalf — the agent must be
 // installed manually (e.g. omp targets bun and ships via its own installer).
@@ -104,6 +104,13 @@ const PRESETS: AcpClientPreset[] = [
     description: 'Native ACP coding agent.',
     command: 'opencode',
     args: ['acp'],
+  },
+  {
+    id: 'dsh',
+    name: 'DeepSeek Harness',
+    description: 'Native ACP server (dsh-acp-demo); add --config with an absolute DSH cordis.yml path.',
+    command: 'dsh-acp-demo',
+    args: [],
   },
   {
     id: 'omp',


### PR DESCRIPTION
## Summary

- register DeepSeek Harness (`dsh`) as a built-in native ACP client
- launch the official `dsh-acp-demo` stdio server directly, with no protocol adapter
- let BitFun install `@deepseek-ai/dsh-acp-demo@next` locally or on a remote workspace host
- expose the preset in ACP settings and call out the absolute `--config` path needed for a DSH `cordis.yml`
- cover built-in metadata, Web UI rendering, and remote-workspace default resolution

## Validation

- `cargo test -p bitfun-acp` (114 passed)
- `cargo check -p bitfun-acp --no-default-features --features client`
- `cargo check -p bitfun-acp --no-default-features --features server`
- `pnpm --dir src/web-ui run test:run src/infrastructure/config/components/AcpAgentsConfig.test.tsx` (11 passed)
- `pnpm run type-check:web`
- `pnpm run check:repo-hygiene`
- real local cross-project smoke: BitFun `AcpClientService` launched published `dsh-acp-demo` 0.1.0-rc.6 and completed `initialize -> session/new -> session/prompt`, receiving the replayed `PONG` response

## Remote scenarios

- local workspace: exercised with a real DSH ACP subprocess and prompt round trip
- remote workspace: built-in config fallback is covered by a focused regression test; no live SSH host was exercised
- remote control, Peer Device Mode, and Detached Dispatch: unchanged and not exercised
