### PR TITLE
fix(desktop): keep the DeepSeek bridge off the compile path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
       # exist during check/test; distributable assets remain frontend-build's owner.
       - name: Create Tauri resource directories
         shell: bash
-        run: mkdir -p dist src/mobile-web/dist packages/dsh-acp/dist-profile
+        run: mkdir -p dist src/mobile-web/dist
 
       - name: Install Linux system dependencies (Tauri)
         if: runner.os == 'Linux'
@@ -279,12 +279,13 @@ jobs:
         run: "cargo test --locked -p tool-runtime --lib search::"
 
   # ── DeepSeek Harness bridge: profile packaging on Windows ──────────
-  # `prepare:dsh-profile` runs only inside `frontend:build-all`, which no CI job
-  # invokes — so until now its first Windows execution ever was a release build,
-  # and it failed there (`spawnSync npm ENOENT`: npm is a `.cmd` shim Node will
-  # not spawn without a shell). This job is the cheapest thing that exercises
-  # the whole packaging path — npm install, tsc, `npm pack`, tar, tree copy — on
-  # the platform whose path and process rules differ.
+  # `prepare:dsh-profile` runs from `frontend:build-all` / official desktop
+  # packaging, not from desktop:dev or cargo check. Until this job existed,
+  # its first Windows execution ever was a release build, and it failed there
+  # (`spawnSync npm ENOENT`: npm is a `.cmd` shim Node will not spawn without
+  # a shell). This job is the cheapest thing that exercises the whole
+  # packaging path — npm install, tsc, `npm pack`, tar, tree copy — on the
+  # platform whose path and process rules differ.
   dsh-profile-windows:
     name: DSH Profile Packaging (windows-latest)
     runs-on: windows-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,10 +42,6 @@ The check detects:
   bitfun-desktop Tauri build script references this directory as a resource,
   so `cargo check -p bitfun-desktop` and `cargo check --workspace` fail
   without it)
-- Missing `packages/dsh-acp/dist-profile` (fix: `pnpm run prepare:dsh-profile`
-  — the DeepSeek Harness bridge, referenced as a Tauri resource the same way;
-  `BITFUN_SKIP_DSH_PROFILE=1` writes a placeholder instead if you do not need
-  the bridge)
 - Missing sherpa-onnx prebuilt libs (the sherpa-onnx-sys build script
   downloads from GitHub at build time; if the download fails on poor
   connectivity, set `SHERPA_ONNX_LIB_DIR` to the prebuilt lib directory
@@ -62,6 +58,7 @@ pnpm install
 ```bash
 # Desktop (recommended for daily development)
 pnpm run desktop:dev                # full hot-reload: Vite HMR + Rust auto-rebuild & restart
+pnpm run prepare:dsh-profile        # optional: compile the DeepSeek Harness bridge for local sessions
 
 # Desktop (lightweight preview, no Rust auto-rebuild)
 pnpm run desktop:preview:debug      # reuse pre-built binary + Vite HMR; Rust changes require manual restart

--- a/CONTRIBUTING_CN.md
+++ b/CONTRIBUTING_CN.md
@@ -39,9 +39,6 @@ pnpm run check:build-prereqs -- --fix  # 尝试自动修复缺失的前置依赖
 - 缺少 `src/mobile-web/dist`（修复：`pnpm run prepare:mobile-web` —
   bitfun-desktop 的 Tauri 构建脚本将该目录作为资源引用，缺失时
   `cargo check -p bitfun-desktop` 和 `cargo check --workspace` 会失败）
-- 缺少 `packages/dsh-acp/dist-profile`（修复：`pnpm run prepare:dsh-profile` —
-  DeepSeek Harness bridge，同样以 Tauri 资源方式引用；不需要该 bridge 时可用
-  `BITFUN_SKIP_DSH_PROFILE=1` 写一个占位目录）
 - 缺少 sherpa-onnx 预编译库（sherpa-onnx-sys 构建脚本会在构建时从
   GitHub 下载；若网络连通性差导致下载失败，设置
   `SHERPA_ONNX_LIB_DIR` 指向 `target/sherpa-onnx-prebuilt/` 下的预编译
@@ -58,6 +55,7 @@ pnpm install
 ```bash
 # Desktop（日常开发推荐）
 pnpm run desktop:dev                # 完整热更新：Vite HMR + Rust 自动重编译并重启
+pnpm run prepare:dsh-profile        # 可选：编译 DeepSeek Harness 桥，供本地会话使用
 
 # Desktop（轻量预览，无 Rust 自动重编译）
 pnpm run desktop:preview:debug      # 复用预构建二进制 + Vite HMR；Rust 改动需手动重启

--- a/packages/dsh-acp/README.md
+++ b/packages/dsh-acp/README.md
@@ -99,8 +99,9 @@ npm test                             # vitest
 ```
 
 `pnpm run prepare:dsh-profile` from the repository root does the install and
-both build steps, and Tauri ships `dist-profile/` as a resource. A failure
-there fails the desktop build: an app that silently ships no bridge is
+both build steps. Official `desktop:build` ships `dist-profile/` as a Tauri
+resource; `desktop:dev` and `cargo check` do not compile it. A failure during
+packaging fails the desktop build: an app that silently ships no bridge is
 indistinguishable from a working one until a user starts a DeepSeek session.
 `BITFUN_SKIP_DSH_PROFILE=1` opts out on purpose.
 

--- a/scripts/check-build-prereqs.mjs
+++ b/scripts/check-build-prereqs.mjs
@@ -57,19 +57,7 @@ function runChecks(rootDir) {
     });
   }
 
-  // --- Check 3: dsh bridge profile (also a bitfun-desktop Tauri resource) ---
-  // Only the directory has to exist for code generation; what is inside it is
-  // the bundle's problem, not cargo's.
-  if (!existsSync(join(rootDir, 'packages', 'dsh-acp', 'dist-profile'))) {
-    errors.push({
-      name: 'dsh bridge profile',
-      message:
-        "packages/dsh-acp/dist-profile is missing. The bitfun-desktop Tauri build script references it as a resource, so 'cargo check -p bitfun-desktop' and 'cargo check --workspace' will fail with \"resource path doesn't exist\". Set BITFUN_SKIP_DSH_PROFILE=1 for a placeholder if you do not need the DeepSeek bridge.",
-      fix: ['pnpm', 'run', 'prepare:dsh-profile'],
-    });
-  }
-
-  // --- Check 4: sherpa-onnx prebuilt libs ---
+  // --- Check 3: sherpa-onnx prebuilt libs ---
   // sherpa-onnx-sys build.rs auto-detects target/sherpa-onnx-prebuilt/<version>/lib/
   // and returns immediately without downloading. Only warn for the first-build
   // scenario where no prebuilt cache exists yet.

--- a/scripts/check-build-prereqs.test.mjs
+++ b/scripts/check-build-prereqs.test.mjs
@@ -15,7 +15,6 @@ const scriptPath = path.join(repoRoot, 'scripts/check-build-prereqs.mjs');
 function createTestRoot({
   nodeModules = false,
   mobileWebDist = false,
-  dshProfile = false,
   sherpaOnnx = null,
 } = {}) {
   const root = mkdtempSync(path.join(tmpdir(), 'bitfun-build-prereqs-'));
@@ -28,12 +27,6 @@ function createTestRoot({
     const distDir = path.join(root, 'src', 'mobile-web', 'dist');
     mkdirSync(distDir, { recursive: true });
     writeFileSync(path.join(distDir, 'index.html'), '<html></html>');
-  }
-
-  if (dshProfile) {
-    mkdirSync(path.join(root, 'packages', 'dsh-acp', 'dist-profile'), {
-      recursive: true,
-    });
   }
 
   if (sherpaOnnx) {
@@ -66,8 +59,6 @@ if (args[0] === 'install') {
 } else if (args[0] === 'run' && args[1] === 'prepare:mobile-web') {
   mkdirSync('src/mobile-web/dist', { recursive: true });
   writeFileSync('src/mobile-web/dist/index.html', '<html></html>');
-} else if (args[0] === 'run' && args[1] === 'prepare:dsh-profile') {
-  mkdirSync('packages/dsh-acp/dist-profile', { recursive: true });
 }
 `,
   );
@@ -103,7 +94,6 @@ test('passes when all prerequisites are present (including sherpa-onnx prebuilt)
   const root = createTestRoot({
     nodeModules: true,
     mobileWebDist: true,
-    dshProfile: true,
     sherpaOnnx: ['sherpa-onnx-v1.13.4-osx-arm64-static-lib'],
   });
   t.after(() => rmSync(root, { recursive: true, force: true }));
@@ -118,7 +108,6 @@ test('passes when all prerequisites are present (including sherpa-onnx prebuilt)
 test('fails when root node_modules is missing', (t) => {
   const root = createTestRoot({
     mobileWebDist: true,
-    dshProfile: true,
     sherpaOnnx: ['sherpa-onnx-v1.13.4-osx-arm64-static-lib'],
   });
   t.after(() => rmSync(root, { recursive: true, force: true }));
@@ -133,7 +122,6 @@ test('fails when root node_modules is missing', (t) => {
 test('fails when mobile-web dist is missing', (t) => {
   const root = createTestRoot({
     nodeModules: true,
-    dshProfile: true,
     sherpaOnnx: ['sherpa-onnx-v1.13.4-osx-arm64-static-lib'],
   });
   t.after(() => rmSync(root, { recursive: true, force: true }));
@@ -145,7 +133,7 @@ test('fails when mobile-web dist is missing', (t) => {
   assert.match(result.stderr, /Fix: pnpm run prepare:mobile-web/);
 });
 
-test('fails when the dsh bridge profile is missing', (t) => {
+test('does not require the DeepSeek profile for cargo check', (t) => {
   const root = createTestRoot({
     nodeModules: true,
     mobileWebDist: true,
@@ -155,13 +143,13 @@ test('fails when the dsh bridge profile is missing', (t) => {
 
   const result = runCheck(root, { sherpaEnv: '' });
 
-  assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /\[FAIL\] dsh bridge profile/);
-  assert.match(result.stderr, /Fix: pnpm run prepare:dsh-profile/);
+  assert.equal(result.status, 0);
+  assert.doesNotMatch(result.stderr, /dsh bridge profile/);
+  assert.doesNotMatch(result.stderr, /prepare:dsh-profile/);
 });
 
 test('warns when sherpa-onnx prebuilt dir does not exist (first build)', (t) => {
-  const root = createTestRoot({ nodeModules: true, mobileWebDist: true, dshProfile: true });
+  const root = createTestRoot({ nodeModules: true, mobileWebDist: true });
   t.after(() => rmSync(root, { recursive: true, force: true }));
 
   const result = runCheck(root, { sherpaEnv: '' });
@@ -196,7 +184,7 @@ test('--fix runs fix commands, re-verifies, and exits 0 when errors resolved', (
   assert.match(result.stdout, /Attempting fixes/);
   assert.match(result.stdout, /\$ pnpm install/);
   assert.match(result.stdout, /\$ pnpm run prepare:mobile-web/);
-  assert.match(result.stdout, /\$ pnpm run prepare:dsh-profile/);
+  assert.doesNotMatch(result.stdout, /prepare:dsh-profile/);
   assert.match(result.stdout, /Re-checking prerequisites/);
   assert.match(result.stdout, /All errors resolved/);
 });

--- a/scripts/desktop-tauri-build.mjs
+++ b/scripts/desktop-tauri-build.mjs
@@ -229,6 +229,11 @@ export function prepareTauriConfig(
     config.identifier = resolution.assembly.bundleId;
   }
   injectTargetFlashgrepResource(config, desktopDir, flashgrepBinary);
+  // The DeepSeek bridge is not a compile-time resource: cargo check and
+  // desktop:dev must not require packages/dsh-acp/dist-profile. Official
+  // packaging injects it here; frontend:build-all (beforeBuildCommand)
+  // compiles the profile before Tauri copies resources.
+  injectDshProfileResource(config);
 
   const release = releaseChannel
     ?? resolveReleaseChannel(process.env.BITFUN_RELEASE_CHANNEL);
@@ -287,6 +292,18 @@ export function prepareTauriConfig(
   );
   writeFileSync(generatedConfig, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
   return generatedConfig;
+}
+
+const DSH_PROFILE_RESOURCE_SOURCE = '../../../packages/dsh-acp/dist-profile';
+const DSH_PROFILE_RESOURCE_TARGET = 'resources/dsh-profile';
+
+function injectDshProfileResource(config) {
+  const resources = { ...(config.bundle?.resources || {}) };
+  resources[DSH_PROFILE_RESOURCE_SOURCE] = DSH_PROFILE_RESOURCE_TARGET;
+  config.bundle = {
+    ...(config.bundle || {}),
+    resources,
+  };
 }
 
 function injectTargetFlashgrepResource(config, desktopDir, flashgrepBinary) {

--- a/scripts/desktop-tauri-build.test.mjs
+++ b/scripts/desktop-tauri-build.test.mjs
@@ -314,6 +314,45 @@ test('beta Desktop artifacts compile and bundle only beta updater endpoints', ()
   }
 });
 
+test('static desktop Tauri configs do not require the DeepSeek profile at compile time', () => {
+  for (const name of ['tauri.conf.json', 'tauri.dev.conf.json']) {
+    const config = JSON.parse(
+      readFileSync(join(ROOT, 'src', 'apps', 'desktop', name), 'utf8')
+    );
+    assert.equal(
+      config.bundle.resources['../../../packages/dsh-acp/dist-profile'],
+      undefined,
+      `${name} must not list dist-profile as a compile-time resource`,
+    );
+  }
+});
+
+test('official packaging injects the DeepSeek profile resource', () => {
+  const fixture = join(tmpdir(), `bitfun-tauri-dsh-${process.pid}-${Date.now()}`);
+  mkdirSync(fixture, { recursive: true });
+  const baseConfig = join(fixture, 'tauri.conf.json');
+  writeFileSync(baseConfig, JSON.stringify({
+    bundle: { resources: { 'resources/worker_host.js': 'resources/worker_host.js' } },
+  }));
+  try {
+    const generated = prepareTauriConfig(baseConfig, {
+      desktopDir: fixture,
+      flashgrepBinary: join(fixture, 'flashgrep'),
+    });
+    const config = JSON.parse(readFileSync(generated, 'utf8'));
+    assert.equal(
+      config.bundle.resources['../../../packages/dsh-acp/dist-profile'],
+      'resources/dsh-profile',
+    );
+    assert.equal(
+      config.bundle.resources['resources/worker_host.js'],
+      'resources/worker_host.js',
+    );
+  } finally {
+    rmSync(fixture, { force: true, recursive: true });
+  }
+});
+
 test('Desktop release config bundles models.dev notices and provenance', () => {
   const config = JSON.parse(
     readFileSync(join(ROOT, 'src', 'apps', 'desktop', 'tauri.conf.json'), 'utf8')

--- a/scripts/dev.cjs
+++ b/scripts/dev.cjs
@@ -649,7 +649,9 @@ async function main() {
   // Step 1: Run all independent preparation tasks in parallel.
   // copy-monaco / generate-version / mobile-web / flashgrep have no
   // dependencies on each other; each task's output is line-prefixed so the
-  // interleaved logs stay attributable.
+  // interleaved logs stay attributable. The DeepSeek bridge is not prepared
+  // here: it is not a compile-time Tauri resource. Official desktop:build
+  // compiles it; local DeepSeek sessions run `pnpm run prepare:dsh-profile`.
   printStep(
     currentStep++,
     totalSteps,

--- a/scripts/frontend-build-all.mjs
+++ b/scripts/frontend-build-all.mjs
@@ -4,7 +4,7 @@
  * Runs the independent pre-bundle build pipelines in parallel:
  *   - build:web            (type-check + vite build + monaco asset verify)
  *   - prepare:mobile-web   (mobile-web install/build with mtime short-circuit)
- *   - prepare:dsh-profile  (the DeepSeek Harness bridge Tauri ships as a resource)
+ *   - prepare:dsh-profile  (the DeepSeek Harness bridge official desktop:build ships)
  *
  * Used as the Tauri beforeBuildCommand so the stage costs max(…) instead of
  * their sum. Any failure fails the whole script with a non-zero exit code.

--- a/scripts/prepare-dsh-profile.mjs
+++ b/scripts/prepare-dsh-profile.mjs
@@ -20,19 +20,42 @@
  * exactly like an app that ships a working one until a user tries to start a
  * DeepSeek session, and that is the wrong place to find out. Set
  * `BITFUN_SKIP_DSH_PROFILE=1` to opt out deliberately.
+ *
+ * Official `desktop:build` compiles this via `frontend:build-all`. desktop:dev
+ * and cargo check do not: the profile is not a compile-time Tauri resource.
+ * Local DeepSeek sessions run this script explicitly. A stamped profile whose
+ * inputs have not changed is left alone — the same mtime short-circuit
+ * mobile-web uses. Escape hatches: `--force` /
+ * `BITFUN_DSH_PROFILE_FORCE_BUILD=1`.
  */
 
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
-import path from 'node:path';
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import path, { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const PACKAGE_DIR = path.join(ROOT_DIR, 'packages', 'dsh-acp');
 const OUT_DIR = path.join(PACKAGE_DIR, 'dist-profile');
+const STAMP_FILENAME = '.bitfun-bridge.json';
 
 /** One installed harness package is enough to tell a populated tree from a bare one. */
 const DEPS_PROBE = path.join(PACKAGE_DIR, 'node_modules', '@deepseek-ai', 'dsh-app-boot');
+
+const INPUT_IGNORED_DIRS = new Set([
+  'node_modules',
+  'lib',
+  'dist-profile',
+  '.sessions',
+]);
 
 /** Explains an empty dist-profile to whoever finds one in a build tree. */
 const PLACEHOLDER = `This BitFun build ships no DeepSeek Harness bridge.
@@ -45,10 +68,128 @@ To include it: run \`pnpm run prepare:dsh-profile\` without that variable.
 `;
 
 /**
+ * Newest mtime among the profile build inputs (recursively for directories).
+ * @param {string} entryPath
+ * @returns {{ path: string, mtimeMs: number } | null}
+ */
+export function getNewestInputMtime(entryPath) {
+  if (!existsSync(entryPath)) {
+    return null;
+  }
+
+  const stat = lstatSync(entryPath);
+  if (stat.isSymbolicLink()) {
+    return null;
+  }
+
+  if (stat.isFile()) {
+    return { path: entryPath, mtimeMs: stat.mtimeMs };
+  }
+
+  if (!stat.isDirectory()) {
+    return null;
+  }
+
+  let newest = null;
+  for (const entry of readdirSync(entryPath, { withFileTypes: true })) {
+    if (entry.isSymbolicLink()) {
+      continue;
+    }
+    if (entry.isDirectory() && INPUT_IGNORED_DIRS.has(entry.name)) {
+      continue;
+    }
+    const candidate = getNewestInputMtime(path.join(entryPath, entry.name));
+    if (candidate && (!newest || candidate.mtimeMs > newest.mtimeMs)) {
+      newest = candidate;
+    }
+  }
+
+  return newest;
+}
+
+/**
+ * Decide whether the shipped profile needs a rebuild.
+ *
+ * A directory is not enough: Tauri only needs the path to exist, but BitFun's
+ * resolver rejects an unstamped tree. The stamp `.bitfun-bridge.json` is the
+ * same file `scripts/build-profile.mjs` writes and ACP reads.
+ *
+ * @param {{
+ *   packageDir?: string,
+ *   outDir?: string,
+ *   prepareScriptPath?: string,
+ *   force?: boolean,
+ * }} [options]
+ * @returns {{ shouldBuild: boolean, reason: string }}
+ */
+export function getDshProfileRebuildPlan({
+  packageDir = PACKAGE_DIR,
+  outDir = path.join(packageDir, 'dist-profile'),
+  prepareScriptPath = path.join(ROOT_DIR, 'scripts', 'prepare-dsh-profile.mjs'),
+  force = false,
+} = {}) {
+  if (force) {
+    return { shouldBuild: true, reason: 'Force rebuild requested for dsh-profile' };
+  }
+
+  const stampPath = path.join(outDir, STAMP_FILENAME);
+  if (!existsSync(stampPath)) {
+    return { shouldBuild: true, reason: 'dsh-profile stamp is missing' };
+  }
+
+  try {
+    const stamp = JSON.parse(readFileSync(stampPath, 'utf8'));
+    if (
+      typeof stamp.profile !== 'string' ||
+      stamp.profile === '' ||
+      typeof stamp.content !== 'string' ||
+      stamp.content === ''
+    ) {
+      return { shouldBuild: true, reason: 'dsh-profile stamp is incomplete' };
+    }
+  } catch {
+    return { shouldBuild: true, reason: 'dsh-profile stamp is unreadable' };
+  }
+
+  const stampMtimeMs = statSync(stampPath).mtimeMs;
+  const inputs = [
+    path.join(packageDir, 'src'),
+    path.join(packageDir, 'presets'),
+    path.join(packageDir, 'cordis.yml'),
+    path.join(packageDir, 'package.json'),
+    path.join(packageDir, 'package-lock.json'),
+    path.join(packageDir, 'tsconfig.build.json'),
+    path.join(packageDir, 'scripts', 'build-profile.mjs'),
+    prepareScriptPath,
+  ];
+
+  let newestInput = null;
+  for (const input of inputs) {
+    const candidate = getNewestInputMtime(input);
+    if (candidate && (!newestInput || candidate.mtimeMs > newestInput.mtimeMs)) {
+      newestInput = candidate;
+    }
+  }
+
+  if (newestInput && newestInput.mtimeMs > stampMtimeMs) {
+    return {
+      shouldBuild: true,
+      reason: `dsh-profile inputs changed since the last build (${path.relative(ROOT_DIR, newestInput.path)})`,
+    };
+  }
+
+  return {
+    shouldBuild: false,
+    reason:
+      'dsh-profile is up to date; skipping install/build (use --force or BITFUN_DSH_PROFILE_FORCE_BUILD=1 to rebuild)',
+  };
+}
+
+/**
  * Run a command in the bridge package directory.
- * @param command - the executable to run.
- * @param args - its arguments.
- * @returns the exit status, with a missing status treated as a failure.
+ * @param {string} command - the executable to run.
+ * @param {string[]} args - its arguments.
+ * @returns {number} the exit status, with a missing status treated as a failure.
  */
 function run(command, args) {
   const result = spawnSync(command, args, {
@@ -62,8 +203,8 @@ function run(command, args) {
 
 /**
  * Fail the build, saying what to do about it.
- * @param message - what went wrong.
- * @param status - the exit status to propagate.
+ * @param {string} message - what went wrong.
+ * @param {number} status - the exit status to propagate.
  */
 function fail(message, status) {
   process.stderr.write(`[dsh-profile] ${message}\n`);
@@ -73,21 +214,36 @@ function fail(message, status) {
   process.exit(status === 0 ? 1 : status);
 }
 
-if (process.env.BITFUN_SKIP_DSH_PROFILE === '1') {
-  process.stdout.write('[dsh-profile] skipped (this build ships no DeepSeek bridge)\n');
-  mkdirSync(OUT_DIR, { recursive: true });
-  writeFileSync(path.join(OUT_DIR, 'NOT-BUILT.md'), PLACEHOLDER);
-  process.exit(0);
+function main() {
+  if (process.env.BITFUN_SKIP_DSH_PROFILE === '1') {
+    process.stdout.write('[dsh-profile] skipped (this build ships no DeepSeek bridge)\n');
+    mkdirSync(OUT_DIR, { recursive: true });
+    writeFileSync(path.join(OUT_DIR, 'NOT-BUILT.md'), PLACEHOLDER);
+    return;
+  }
+
+  const force =
+    process.argv.includes('--force') || process.env.BITFUN_DSH_PROFILE_FORCE_BUILD === '1';
+  const plan = getDshProfileRebuildPlan({ force });
+  if (!plan.shouldBuild) {
+    process.stdout.write(`[dsh-profile] ${plan.reason}\n`);
+    return;
+  }
+  process.stdout.write(`[dsh-profile] ${plan.reason}\n`);
+
+  if (!existsSync(DEPS_PROBE)) {
+    process.stdout.write('[dsh-profile] installing the harness toolchain from package-lock.json\n');
+    const installed = run('npm', ['ci', '--no-audit', '--no-fund']);
+    if (installed !== 0) fail('npm ci failed', installed);
+  }
+
+  const compiled = run('npm', ['run', 'build']);
+  if (compiled !== 0) fail('tsc failed', compiled);
+
+  const packaged = run('node', ['scripts/build-profile.mjs']);
+  if (packaged !== 0) fail('profile packaging failed', packaged);
 }
 
-if (!existsSync(DEPS_PROBE)) {
-  process.stdout.write('[dsh-profile] installing the harness toolchain from package-lock.json\n');
-  const installed = run('npm', ['ci', '--no-audit', '--no-fund']);
-  if (installed !== 0) fail('npm ci failed', installed);
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
 }
-
-const compiled = run('npm', ['run', 'build']);
-if (compiled !== 0) fail('tsc failed', compiled);
-
-const packaged = run('node', ['scripts/build-profile.mjs']);
-if (packaged !== 0) fail('profile packaging failed', packaged);

--- a/scripts/prepare-dsh-profile.test.mjs
+++ b/scripts/prepare-dsh-profile.test.mjs
@@ -1,0 +1,173 @@
+import assert from 'node:assert/strict';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { getDshProfileRebuildPlan } from './prepare-dsh-profile.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function createPackageTree() {
+  const root = mkdtempSync(path.join(tmpdir(), 'bitfun-dsh-profile-'));
+  const packageDir = path.join(root, 'packages', 'dsh-acp');
+  const outDir = path.join(packageDir, 'dist-profile');
+  const prepareScriptPath = path.join(root, 'scripts', 'prepare-dsh-profile.mjs');
+
+  mkdirSync(path.join(packageDir, 'src'), { recursive: true });
+  mkdirSync(path.join(packageDir, 'presets'), { recursive: true });
+  mkdirSync(path.join(packageDir, 'scripts'), { recursive: true });
+  mkdirSync(path.join(root, 'scripts'), { recursive: true });
+  mkdirSync(outDir, { recursive: true });
+
+  writeFileSync(path.join(packageDir, 'src', 'app.ts'), 'export {}\n');
+  writeFileSync(path.join(packageDir, 'presets', 'preset.yml'), 'name: test\n');
+  writeFileSync(path.join(packageDir, 'cordis.yml'), 'name: test\n');
+  writeFileSync(path.join(packageDir, 'package.json'), '{}\n');
+  writeFileSync(path.join(packageDir, 'package-lock.json'), '{}\n');
+  writeFileSync(path.join(packageDir, 'tsconfig.build.json'), '{}\n');
+  writeFileSync(path.join(packageDir, 'scripts', 'build-profile.mjs'), 'export {}\n');
+  writeFileSync(prepareScriptPath, 'export {}\n');
+
+  return { root, packageDir, outDir, prepareScriptPath };
+}
+
+function writeStamp(outDir, stamp = { profile: 'bitfun-acp', content: 'abc' }) {
+  const stampPath = path.join(outDir, '.bitfun-bridge.json');
+  writeFileSync(stampPath, `${JSON.stringify(stamp)}\n`);
+  return stampPath;
+}
+
+function setMtime(filePath, mtimeMs) {
+  const atime = new Date(mtimeMs);
+  const mtime = new Date(mtimeMs);
+  utimesSync(filePath, atime, mtime);
+}
+
+test('rebuilds when the profile stamp is missing', () => {
+  const { root, packageDir, outDir, prepareScriptPath } = createPackageTree();
+  try {
+    const plan = getDshProfileRebuildPlan({ packageDir, outDir, prepareScriptPath });
+    assert.equal(plan.shouldBuild, true);
+    assert.match(plan.reason, /stamp is missing/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('rebuilds when force is requested', () => {
+  const { root, packageDir, outDir, prepareScriptPath } = createPackageTree();
+  try {
+    const stampPath = writeStamp(outDir);
+    setMtime(stampPath, Date.now() + 60_000);
+    const plan = getDshProfileRebuildPlan({
+      packageDir,
+      outDir,
+      prepareScriptPath,
+      force: true,
+    });
+    assert.equal(plan.shouldBuild, true);
+    assert.match(plan.reason, /Force rebuild/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('rebuilds when the stamp is incomplete', () => {
+  const { root, packageDir, outDir, prepareScriptPath } = createPackageTree();
+  try {
+    writeStamp(outDir, { profile: 'bitfun-acp' });
+    const plan = getDshProfileRebuildPlan({ packageDir, outDir, prepareScriptPath });
+    assert.equal(plan.shouldBuild, true);
+    assert.match(plan.reason, /incomplete/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('rebuilds when an input is newer than the stamp', () => {
+  const { root, packageDir, outDir, prepareScriptPath } = createPackageTree();
+  try {
+    const stampPath = writeStamp(outDir);
+    const older = Date.now() - 60_000;
+    const newer = Date.now();
+    for (const filePath of [
+      path.join(packageDir, 'src', 'app.ts'),
+      path.join(packageDir, 'presets', 'preset.yml'),
+      path.join(packageDir, 'cordis.yml'),
+      path.join(packageDir, 'package.json'),
+      path.join(packageDir, 'package-lock.json'),
+      path.join(packageDir, 'tsconfig.build.json'),
+      path.join(packageDir, 'scripts', 'build-profile.mjs'),
+      prepareScriptPath,
+      stampPath,
+    ]) {
+      setMtime(filePath, older);
+    }
+    setMtime(path.join(packageDir, 'src', 'app.ts'), newer);
+    const plan = getDshProfileRebuildPlan({ packageDir, outDir, prepareScriptPath });
+    assert.equal(plan.shouldBuild, true);
+    assert.match(plan.reason, /inputs changed/);
+    assert.match(plan.reason, /app\.ts/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('skips when a complete stamp is newer than every input', () => {
+  const { root, packageDir, outDir, prepareScriptPath } = createPackageTree();
+  try {
+    const older = Date.now() - 60_000;
+    const newer = Date.now();
+    for (const filePath of [
+      path.join(packageDir, 'src', 'app.ts'),
+      path.join(packageDir, 'presets', 'preset.yml'),
+      path.join(packageDir, 'cordis.yml'),
+      path.join(packageDir, 'package.json'),
+      path.join(packageDir, 'package-lock.json'),
+      path.join(packageDir, 'tsconfig.build.json'),
+      path.join(packageDir, 'scripts', 'build-profile.mjs'),
+      prepareScriptPath,
+    ]) {
+      setMtime(filePath, older);
+    }
+    const stampPath = writeStamp(outDir);
+    setMtime(stampPath, newer);
+    const plan = getDshProfileRebuildPlan({ packageDir, outDir, prepareScriptPath });
+    assert.equal(plan.shouldBuild, false);
+    assert.match(plan.reason, /up to date/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('desktop:dev does not compile the DeepSeek profile', () => {
+  const devScript = readFileSync(path.join(repoRoot, 'scripts', 'dev.cjs'), 'utf8');
+  assert.doesNotMatch(devScript, /runCommandPrefixed\('dsh-profile'/);
+  assert.doesNotMatch(devScript, /\['run', 'prepare:dsh-profile'\]/);
+  assert.match(
+    devScript,
+    /Prepare resources \(parallel: monaco, version, mobile-web, flashgrep\)/,
+  );
+});
+
+test('desktop clippy does not compile the DeepSeek profile', () => {
+  const packageJson = JSON.parse(readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+  assert.doesNotMatch(packageJson.scripts['lint:rs:desktop'], /prepare:dsh-profile/);
+});
+
+test('official frontend packaging still compiles the DeepSeek profile', () => {
+  const frontendBuildAll = readFileSync(
+    path.join(repoRoot, 'scripts', 'frontend-build-all.mjs'),
+    'utf8',
+  );
+  assert.match(frontendBuildAll, /prepare:dsh-profile/);
+});

--- a/src/apps/desktop/AGENTS-CN.md
+++ b/src/apps/desktop/AGENTS-CN.md
@@ -40,6 +40,7 @@ crate；`src/crates/assembly/core` 只保留产品装配与兼容桥接。
 ```bash
 pnpm run desktop:dev
 pnpm run desktop:preview:debug
+pnpm run prepare:dsh-profile   # 可选：本地 DeepSeek Harness 会话
 ```
 
 ## 快速构建

--- a/src/apps/desktop/AGENTS.md
+++ b/src/apps/desktop/AGENTS.md
@@ -49,6 +49,7 @@ the Verification section below.
 ```bash
 pnpm run desktop:dev
 pnpm run desktop:preview:debug
+pnpm run prepare:dsh-profile   # optional: local DeepSeek Harness sessions
 ```
 
 ## Fast builds

--- a/src/apps/desktop/tauri.conf.json
+++ b/src/apps/desktop/tauri.conf.json
@@ -22,8 +22,7 @@
       "resources/worker_host.js": "resources/worker_host.js",
       "../../../THIRD_PARTY_NOTICES.md": "THIRD_PARTY_NOTICES.md",
       "../../crates/services/services-integrations/assets/models-dev.LICENSE.txt": "third-party/models.dev/LICENSE.txt",
-      "../../crates/services/services-integrations/assets/models-dev.provenance.json": "third-party/models.dev/provenance.json",
-      "../../../packages/dsh-acp/dist-profile": "resources/dsh-profile"
+      "../../crates/services/services-integrations/assets/models-dev.provenance.json": "third-party/models.dev/provenance.json"
     },
     "macOS": {
       "dmg": {

--- a/src/apps/desktop/tauri.dev.conf.json
+++ b/src/apps/desktop/tauri.dev.conf.json
@@ -19,7 +19,6 @@
     "resources": {
       "../../mobile-web/dist": "mobile-web/dist",
       "resources/worker_host.js": "resources/worker_host.js",
-      "../../../packages/dsh-acp/dist-profile": "resources/dsh-profile",
       "../../../THIRD_PARTY_NOTICES.md": "THIRD_PARTY_NOTICES.md",
       "../../crates/services/services-integrations/assets/models-dev.LICENSE.txt": "third-party/models.dev/LICENSE.txt",
       "../../crates/services/services-integrations/assets/models-dev.provenance.json": "third-party/models.dev/provenance.json"


### PR DESCRIPTION
## Summary
- Stop treating `packages/dsh-acp/dist-profile` as a compile-time Tauri resource, so `pnpm install && pnpm run desktop:dev` and `cargo check -p bitfun-desktop` no longer fail on a missing DeepSeek Harness profile.
- Official `desktop:build` still compiles the profile via `frontend:build-all` and injects it as `resources/dsh-profile`.
- Local DeepSeek sessions remain opt-in: run `pnpm run prepare:dsh-profile`. An unbuilt tree degrades at session start instead of at compile time.

## Test plan
- [x] `node --test scripts/prepare-dsh-profile.test.mjs scripts/check-build-prereqs.test.mjs scripts/desktop-tauri-build.test.mjs`
- [x] `cargo check -p bitfun-desktop --no-default-features`
- [ ] Fresh clone path: `pnpm install && pnpm run desktop:dev` without a prior `prepare:dsh-profile`
- [ ] Official packaging still ships the stamped profile (`pnpm run desktop:build` / `frontend:build-all`)
- [ ] After `pnpm run prepare:dsh-profile`, a local DeepSeek Harness session still starts