### PR TITLE
fix(peer): keep a running session alive across a device switch

### DIFF
--- a/src/web-ui/src/flow_chat/services/FlowChatManager.ts
+++ b/src/web-ui/src/flow_chat/services/FlowChatManager.ts
@@ -48,6 +48,7 @@ import {
   cancelSessionTask as cancelSessionTaskModule,
   installPendingQueueDrainListener,
   drainPendingQueue,
+  waitForInFlightSubmissions,
   initializeEventListeners,
   processBatchedEvents,
   addDialogTurn as addDialogTurnModule,
@@ -461,6 +462,20 @@ export class FlowChatManager {
       this.eventListenerInitialized = false;
     }
     this.eventListenerInitializationPromise = null;
+  }
+
+  /**
+   * Let submissions that already created a projection turn hand it to their
+   * host before the surface is cleared.
+   *
+   * Without this, a switch during the async window in `startTurn` (state
+   * transition, worktree binding, model sync) resumes against a store that no
+   * longer holds the session, and the turn is lost before `start_dialog_turn`
+   * ever runs. A timeout is safe: `sendMessage` detects the surface change and
+   * re-queues the message.
+   */
+  public async waitForInFlightSubmissions(timeoutMs: number): Promise<boolean> {
+    return waitForInFlightSubmissions(timeoutMs);
   }
 
   /**

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/MessageModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/MessageModule.test.ts
@@ -140,6 +140,7 @@ describe('MessageModule Session mutation admission', () => {
     };
     const context: any = {
       flowChatStore: {
+        getSurfaceGeneration: () => 0,
         getState: () => ({ sessions: new Map([[session.sessionId, session]]) }),
       },
     };
@@ -176,6 +177,7 @@ describe('MessageModule session writer conflict', () => {
       session,
       context: {
         flowChatStore: {
+          getSurfaceGeneration: () => 0,
           getState: () => ({ sessions: new Map([[sessionId, session]]) }),
           addDialogTurn: vi.fn((_id: string, turn: any) => session.dialogTurns.push(turn)),
           deleteDialogTurn: vi.fn((_id: string, turnId: string) => {
@@ -225,6 +227,7 @@ describe('MessageModule session writer conflict', () => {
     };
     const context: any = {
       flowChatStore: {
+        getSurfaceGeneration: () => 0,
         getState: () => ({ sessions: new Map([['session-1', session]]) }),
         deleteDialogTurn: vi.fn(),
       },
@@ -444,6 +447,7 @@ describe('MessageModule cancellation', () => {
     const activeTextItems = new Map([['btw-child', new Map([['round-1', 'item-1']])]]);
     const context: any = {
       flowChatStore: {
+        getSurfaceGeneration: () => 0,
         getState: () => ({
           activeSessionId: 'parent',
           sessions: new Map([['btw-child', session]]),
@@ -486,6 +490,7 @@ describe('MessageModule cancellation', () => {
     const activeTextItems = new Map([[session.sessionId, new Map([['round-1', 'item-1']])]]);
     const context: any = {
       flowChatStore: {
+        getSurfaceGeneration: () => 0,
         getState: () => ({ sessions: new Map([[session.sessionId, session]]) }),
       },
       userCancelledSessionIds: new Set<string>(),
@@ -516,6 +521,7 @@ describe('MessageModule cancellation', () => {
     };
     const context: any = {
       flowChatStore: {
+        getSurfaceGeneration: () => 0,
         getState: () => ({ sessions: new Map([[session.sessionId, session]]) }),
       },
       userCancelledSessionIds: new Set([session.sessionId]),
@@ -541,6 +547,7 @@ describe('MessageModule cancellation', () => {
     }]);
     const context: any = {
       flowChatStore: {
+        getSurfaceGeneration: () => 0,
         getState: () => ({
           sessions: new Map([['session-1', {
             sessionId: 'session-1',
@@ -567,6 +574,7 @@ describe('MessageModule cancellation', () => {
     };
     const context: any = {
       flowChatStore: {
+        getSurfaceGeneration: () => 0,
         getState: () => ({ sessions: new Map([[session.sessionId, session]]) }),
       },
     };
@@ -615,6 +623,7 @@ describe('MessageModule cancellation', () => {
     };
     const context: any = {
       flowChatStore: {
+        getSurfaceGeneration: () => 0,
         getState: () => ({ sessions: new Map([[session.sessionId, session]]) }),
         addDialogTurn: vi.fn((_sessionId: string, turn: any) => session.dialogTurns.push(turn)),
         deleteDialogTurn: vi.fn((_sessionId: string, turnId: string) => {
@@ -667,6 +676,7 @@ describe('MessageModule cancellation', () => {
     };
     const context: any = {
       flowChatStore: {
+        getSurfaceGeneration: () => 0,
         getState: () => ({ sessions: new Map([[session.sessionId, session]]) }),
       },
       userCancelledSessionIds: new Set<string>(),
@@ -739,6 +749,7 @@ describe('MessageModule detached dispatch', () => {
       session,
       context: {
         flowChatStore: {
+          getSurfaceGeneration: () => 0,
           getState: () => ({
             activeSessionId: session.sessionId,
             sessions: new Map([[session.sessionId, session]]),
@@ -920,6 +931,7 @@ describe('MessageModule model synchronization', () => {
     const updateSessionMaxContextTokens = vi.fn();
     const context: any = {
       flowChatStore: {
+        getSurfaceGeneration: () => 0,
         getState: () => ({ sessions: new Map([['session-auto', session]]) }),
         updateSessionModelName,
         updateSessionMaxContextTokens,
@@ -951,6 +963,7 @@ describe('MessageModule model synchronization', () => {
     const updateSessionMaxContextTokens = vi.fn();
     const context: any = {
       flowChatStore: {
+        getSurfaceGeneration: () => 0,
         getState: () => ({ sessions: new Map([['legacy-session', session]]) }),
         updateSessionModelName,
         updateSessionMaxContextTokens,
@@ -970,5 +983,123 @@ describe('MessageModule model synchronization', () => {
       remoteSshHost: undefined,
       includeInternal: false,
     });
+  });
+});
+
+describe('MessageModule device surface switch', () => {
+  /**
+   * A device-surface switch clears every session projection. A submission
+   * caught in `startTurn`'s async window (state transition, worktree bind,
+   * model sync) used to resume against an empty store and throw
+   * "Session lost after adding dialog turn" — reported as a turn failure even
+   * though the turn had never reached a host, so the message was lost.
+   */
+  function switchingContext(sessionId: string, options?: { switchAfterTransition?: boolean }) {
+    const session = {
+      sessionId,
+      mode: 'agentic',
+      dialogTurns: [] as any[],
+      config: { modelName: 'auto', workspacePath: '/repo' },
+      titleStatus: 'generated',
+      maxContextTokens: 32000,
+    };
+    const sessions = new Map<string, any>([[sessionId, session]]);
+    let surfaceGeneration = 0;
+
+    const switchSurface = () => {
+      surfaceGeneration += 1;
+      sessions.clear();
+    };
+
+    if (options?.switchAfterTransition) {
+      // The switch lands while the state machine transition is awaited, which
+      // is exactly where the reported failure happened.
+      mockTransition.mockImplementation(async () => {
+        switchSurface();
+        return true;
+      });
+    }
+
+    return {
+      session,
+      switchSurface,
+      context: {
+        flowChatStore: {
+          getSurfaceGeneration: () => surfaceGeneration,
+          getState: () => ({ sessions }),
+          addDialogTurn: vi.fn((_id: string, turn: any) => session.dialogTurns.push(turn)),
+          deleteDialogTurn: vi.fn(),
+          updateSessionLastSubmittedMode: vi.fn(),
+          updateSessionMode: vi.fn(),
+          updateSessionModelName: vi.fn(),
+          updateSessionMaxContextTokens: vi.fn(),
+        },
+        processingManager: {
+          registerStatus: vi.fn(),
+          clearSessionStatus: vi.fn(),
+        },
+        pendingHistoryLoads: new Map(),
+        contentBuffers: new Map(),
+        activeTextItems: new Map(),
+      } as any,
+    };
+  }
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockGetCurrentState.mockReturnValue('idle');
+    mockGetStateMachine.mockReturnValue(null);
+    mockTransition.mockResolvedValue(true);
+    mockUpdateSessionModel.mockResolvedValue(undefined);
+    mockStartDialogTurn.mockResolvedValue(undefined);
+    mockPendingList.mockReturnValue([]);
+    mockPendingEnqueue.mockReturnValue({ id: 'requeued' });
+    mockEnsureBackendSession.mockResolvedValue(undefined);
+  });
+
+  it('does not report a turn failure when the surface switched mid-submission', async () => {
+    const { context } = switchingContext('session-switch', { switchAfterTransition: true });
+
+    await expect(
+      sendMessage(context, 'keep working', 'session-switch'),
+    ).resolves.toBeUndefined();
+
+    expect(mockNotificationError).not.toHaveBeenCalled();
+  });
+
+  it('re-queues the message when the host never accepted the turn', async () => {
+    const { context } = switchingContext('session-switch', { switchAfterTransition: true });
+
+    await sendMessage(context, 'keep working', 'session-switch');
+
+    expect(mockStartDialogTurn).not.toHaveBeenCalled();
+    expect(mockPendingEnqueue).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'session-switch', content: 'keep working' }),
+    );
+  });
+
+  it('leaves an accepted turn alone when the surface switches after submission', async () => {
+    const { context, switchSurface } = switchingContext('session-accepted');
+    // The host takes the turn, and only then does the user switch device.
+    mockStartDialogTurn.mockImplementation(async () => {
+      switchSurface();
+    });
+
+    await sendMessage(context, 'already running', 'session-accepted');
+
+    expect(mockStartDialogTurn).toHaveBeenCalledTimes(1);
+    expect(mockPendingEnqueue).not.toHaveBeenCalled();
+    expect(mockNotificationError).not.toHaveBeenCalled();
+  });
+
+  it('still reports ordinary failures when the surface did not change', async () => {
+    const { context } = switchingContext('session-normal');
+    mockStartDialogTurn.mockRejectedValue(new Error('backend exploded'));
+
+    await expect(
+      sendMessage(context, 'boom', 'session-normal'),
+    ).rejects.toThrow('backend exploded');
+
+    expect(mockNotificationError).toHaveBeenCalled();
   });
 });

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/MessageModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/MessageModule.ts
@@ -62,6 +62,118 @@ function completeSessionSend(
   retrySuccess?.();
 }
 
+/**
+ * Submissions that have created a projection turn but have not yet handed the
+ * turn to a host.
+ *
+ * Switching the rendered device surface clears every session projection. A
+ * submission caught mid-flight would resume against a store that no longer
+ * holds its session — and because the throw lands before `start_dialog_turn`,
+ * the user's message would never reach any host. The surface switch therefore
+ * waits for this to drain first.
+ */
+let inFlightSubmissions = 0;
+const inFlightSubmissionWaiters = new Set<() => void>();
+
+function beginSubmission(): void {
+  inFlightSubmissions += 1;
+}
+
+function endSubmission(): void {
+  inFlightSubmissions = Math.max(0, inFlightSubmissions - 1);
+  if (inFlightSubmissions === 0 && inFlightSubmissionWaiters.size > 0) {
+    for (const notify of Array.from(inFlightSubmissionWaiters)) {
+      notify();
+    }
+    inFlightSubmissionWaiters.clear();
+  }
+}
+
+export function inFlightSubmissionCount(): number {
+  return inFlightSubmissions;
+}
+
+/**
+ * Salvage a submission that lost the race against a device-surface switch.
+ *
+ * When the host never accepted the turn the message exists nowhere, so it goes
+ * back onto the session's pending queue — queues are keyed by session id and
+ * survive a surface switch, so returning to that device drains it. When the
+ * host did accept it, the turn is already running there and nothing is owed.
+ */
+function recoverSubmissionAfterSurfaceSwitch(
+  sessionId: string,
+  turnTracker: TurnTracker,
+  draft: {
+    message: string;
+    displayMessage?: string;
+    agentType?: string;
+    options?: SendMessageOptions;
+  },
+): void {
+  if (turnTracker.hostAcceptedTurn) {
+    log.info('Device surface switched after the host accepted the turn; it keeps running there', {
+      sessionId,
+    });
+    return;
+  }
+  try {
+    pendingQueueManager.enqueue({
+      sessionId,
+      content: draft.message,
+      displayMessage: draft.displayMessage,
+      agentType: draft.agentType,
+      imageContexts: draft.options?.imageContexts,
+      imageDisplayData: draft.options?.imageDisplayData,
+      userMessageMetadata: draft.options?.userMessageMetadata,
+    });
+    log.info('Device surface switched before submit reached the host; message re-queued', {
+      sessionId,
+    });
+  } catch (error) {
+    // A full queue is the only expected failure, and dropping the message
+    // silently would be worse than the original error toast.
+    log.error('Failed to re-queue a message after a device surface switch', {
+      sessionId,
+      error,
+    });
+    notificationService.error(
+      i18nService.t('flow-chat:session.surfaceSwitchDropped'),
+      { title: i18nService.t('flow-chat:session.surfaceSwitchDroppedTitle'), duration: 6000 },
+    );
+  }
+}
+
+/**
+ * Wait until no submission is mid-flight, or until `timeoutMs` elapses.
+ *
+ * Returns whether the wait drained. A timeout is not fatal: `sendMessage`
+ * detects the surface change and recovers the message onto the pending queue.
+ */
+export function waitForInFlightSubmissions(timeoutMs: number): Promise<boolean> {
+  if (inFlightSubmissions === 0) {
+    return Promise.resolve(true);
+  }
+  return new Promise<boolean>((resolve) => {
+    let settled = false;
+    // `endSubmission` clears the waiter set before notifying, so the drained
+    // path does not have to unregister itself; only a timeout leaves a stale
+    // waiter behind.
+    const notify = (): void => {
+      if (settled) return;
+      settled = true;
+      resolve(true);
+    };
+    inFlightSubmissionWaiters.add(notify);
+    setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      inFlightSubmissionWaiters.delete(notify);
+      resolve(false);
+    }, timeoutMs);
+  });
+}
+
 function acpClientIdFromMode(mode: string | undefined): string | null {
   const value = mode?.trim();
   if (!value?.startsWith('acp:')) return null;
@@ -169,7 +281,11 @@ export async function sendMessage(
     }));
   }
 
-  const turnTracker: TurnTracker = { createdLocalTurnId: null };
+  const turnTracker: TurnTracker = { createdLocalTurnId: null, hostAcceptedTurn: false };
+  // A device-surface switch clears every projection. Anything this submission
+  // reads back after an await belongs to the surface captured here.
+  const surfaceGenerationAtSend = context.flowChatStore.getSurfaceGeneration();
+  beginSubmission();
 
   try {
     const refreshedSession = context.flowChatStore.getState().sessions.get(sessionId) ?? session;
@@ -242,6 +358,23 @@ export async function sendMessage(
     );
 
   } catch (error) {
+    // A device-surface switch tore this projection down mid-submission. That is
+    // not a turn failure: the session still exists on its own device, and the
+    // state machine and turn we would "clean up" no longer belong to the
+    // rendered surface. Recover the message instead of reporting an error.
+    if (context.flowChatStore.getSurfaceGeneration() !== surfaceGenerationAtSend) {
+      recoverSubmissionAfterSurfaceSwitch(sessionId, turnTracker, {
+        message,
+        displayMessage,
+        agentType,
+        options,
+      });
+      if (latestSendBySession.get(sessionId) === sendAttempt) {
+        latestSendBySession.delete(sessionId);
+      }
+      return;
+    }
+
     log.error('Failed to send message', { sessionId: sessionId, error });
 
     const errorMessage = error instanceof Error ? error.message : 'Failed to send message';
@@ -322,6 +455,8 @@ export async function sendMessage(
     }
 
     throw error;
+  } finally {
+    endSubmission();
   }
 }
 

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/index.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/index.ts
@@ -48,7 +48,9 @@ export {
   cancelSessionTask,
   markCurrentTurnItemsAsCancelled,
   drainPendingQueue,
-  installPendingQueueDrainListener
+  installPendingQueueDrainListener,
+  inFlightSubmissionCount,
+  waitForInFlightSubmissions
 } from './MessageModule';
 
 export { pendingQueueManager } from './PendingQueueModule';

--- a/src/web-ui/src/flow_chat/session-drivers/dispatch/DispatchSessionDriver.ts
+++ b/src/web-ui/src/flow_chat/session-drivers/dispatch/DispatchSessionDriver.ts
@@ -768,6 +768,7 @@ export const dispatchSessionDriver: SessionDriver = {
         i18nService.t('flow-chat:chatInput.dispatch.errors.submissionUnconfirmed'),
       );
     }
+    tracker.hostAcceptedTurn = true;
     context.flowChatStore.applyDispatchSnapshot(sessionId, {
       jobId,
       state: response.state,

--- a/src/web-ui/src/flow_chat/session-drivers/local/LocalSessionDriver.test.ts
+++ b/src/web-ui/src/flow_chat/session-drivers/local/LocalSessionDriver.test.ts
@@ -105,6 +105,7 @@ describe('localSessionDriver.startTurn on an ACP session', () => {
 
     await localSessionDriver.startTurn(context, startTurnInput(session), {
       createdLocalTurnId: null,
+      hostAcceptedTurn: false,
     });
 
     expect(mockStartAcpDialogTurn).toHaveBeenCalledTimes(1);
@@ -120,6 +121,7 @@ describe('localSessionDriver.startTurn on an ACP session', () => {
 
     await localSessionDriver.startTurn(context, startTurnInput(session), {
       createdLocalTurnId: null,
+      hostAcceptedTurn: false,
     });
 
     expect(addedTurns[0].storageTurnIndex).toBe(2);
@@ -132,7 +134,7 @@ describe('localSessionDriver.startTurn on an ACP session', () => {
     await localSessionDriver.startTurn(
       context,
       { ...startTurnInput(session), acpClientId: undefined, currentAgentType: 'agentic' },
-      { createdLocalTurnId: null },
+      { createdLocalTurnId: null, hostAcceptedTurn: false },
     );
 
     expect(mockStartAgenticDialogTurn).toHaveBeenCalledTimes(1);

--- a/src/web-ui/src/flow_chat/session-drivers/local/LocalSessionDriver.ts
+++ b/src/web-ui/src/flow_chat/session-drivers/local/LocalSessionDriver.ts
@@ -431,6 +431,7 @@ export const localSessionDriver: SessionDriver = {
         remoteConnectionId: updatedSession.remoteConnectionId,
         remoteSshHost: updatedSession.remoteSshHost,
       });
+      tracker.hostAcceptedTurn = true;
       context.flowChatStore.updateSessionLastSubmittedMode(sessionId, currentAgentType);
     } else {
       try {
@@ -448,6 +449,7 @@ export const localSessionDriver: SessionDriver = {
           userMessageMetadata: options?.userMessageMetadata,
           execution: options?.execution,
         });
+        tracker.hostAcceptedTurn = true;
         context.flowChatStore.updateSessionLastSubmittedMode(sessionId, currentAgentType);
       } catch (error: any) {
         if (error?.message?.includes('Session does not exist') || error?.message?.includes('Not found')) {
@@ -476,6 +478,7 @@ export const localSessionDriver: SessionDriver = {
             userMessageMetadata: options?.userMessageMetadata,
             execution: options?.execution,
           });
+          tracker.hostAcceptedTurn = true;
           context.flowChatStore.updateSessionLastSubmittedMode(sessionId, currentAgentType);
         } else {
           throw error;

--- a/src/web-ui/src/flow_chat/session-drivers/types.ts
+++ b/src/web-ui/src/flow_chat/session-drivers/types.ts
@@ -90,6 +90,12 @@ export interface StartTurnInput {
  */
 export interface TurnTracker {
   createdLocalTurnId: string | null;
+  /**
+   * Set once a host has accepted the turn. Until then the turn exists only as a
+   * local projection, so a submission interrupted by a device-surface switch
+   * must recover the message rather than assume it is running somewhere.
+   */
+  hostAcceptedTurn: boolean;
 }
 
 /**

--- a/src/web-ui/src/infrastructure/peer-device/PeerDeviceContext.tsx
+++ b/src/web-ui/src/infrastructure/peer-device/PeerDeviceContext.tsx
@@ -60,6 +60,13 @@ const log = createLogger('PeerDeviceMode');
 const PEER_PING_INTERVAL_MS = 20_000;
 const PEER_CONTROL_RPC_TIMEOUT_MS = 15_000;
 
+/**
+ * Upper bound on how long a switch waits for in-flight submissions. Long
+ * enough for a worktree bind plus a model-selection sync, short enough that a
+ * wedged submission cannot make the UI feel stuck.
+ */
+const SUBMIT_DRAIN_TIMEOUT_MS = 8_000;
+
 interface PeerAttachment {
   deviceId: string;
   deviceName: string;
@@ -81,6 +88,20 @@ function emitPeerModeChanged(detail: { active: boolean; deviceId?: string }): vo
  * agent work depending on them.
  */
 async function resetProductSurface(): Promise<void> {
+  // A submission that has created its projection turn but not yet reached a
+  // host would otherwise resume against a cleared store and be lost before
+  // `start_dialog_turn` runs. Let it land first; on timeout the submission
+  // recovers its message onto the pending queue instead.
+  try {
+    const drained = await FlowChatManager.getInstance()
+      .waitForInFlightSubmissions(SUBMIT_DRAIN_TIMEOUT_MS);
+    if (!drained) {
+      log.warn('Device surface switch proceeded with a submission still in flight');
+    }
+  } catch (error) {
+    log.warn('Failed to await in-flight submissions before surface switch', error);
+  }
+
   try {
     FlowChatManager.getInstance().resetForPeerModeSwitch();
   } catch (error) {

--- a/src/web-ui/src/infrastructure/peer-device/README.md
+++ b/src/web-ui/src/infrastructure/peer-device/README.md
@@ -18,6 +18,17 @@ Controller-side React/transport layer for Peer Device Mode. Architecture:
      (regression: 2026-08-14 multi-device switch). Use
      `TerminalService.disconnect()` and
      `WorkspaceLspManager.detachAllForSurfaceSwitch()`.
+   - **In-flight submissions must survive the switch.** `startTurn` has an
+     async window between adding the projection turn and re-reading the
+     session (state transition, worktree bind, model sync). Clearing the store
+     inside that window made the submission resume against a missing session
+     and throw `Session lost after adding dialog turn` — before
+     `start_dialog_turn`, so the message reached no host at all (regression:
+     2026-08-15). `resetProductSurface` therefore awaits
+     `waitForInFlightSubmissions` first, and `sendMessage` compares
+     `getSurfaceGeneration()` across the submission: on a change it re-queues
+     the message instead of reporting a turn failure. Any new await added
+     inside a driver's `startTurn` widens that window — keep the guard.
    - **Surface-scoped events must stay routed by source device.** Background
      attachments mean several agent streams share one event bus. The
      controller tags re-emitted peer payloads with `__bitfunSourceDeviceId`

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -455,6 +455,8 @@
     "restoreMain": "Restore Main Window",
     "inUseTitle": "Session open elsewhere",
     "inUseMessage": "This session is open in another BitFun instance. Close it there, then retry.",
+    "surfaceSwitchDroppedTitle": "Message not sent",
+    "surfaceSwitchDropped": "The device switched before this message was sent, and its queue is full. Send it again.",
     "retry": "Retry"
   },
   "scroll": {

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -455,6 +455,8 @@
     "restoreMain": "恢复主窗口",
     "inUseTitle": "会话已在其他实例中打开",
     "inUseMessage": "该会话已在另一个 BitFun 实例中打开。请先在那里关闭，然后重试。",
+    "surfaceSwitchDroppedTitle": "消息未发送",
+    "surfaceSwitchDropped": "消息尚未发出时设备已切换，且该会话的队列已满。请重新发送。",
     "retry": "重试"
   },
   "scroll": {

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -455,6 +455,8 @@
     "restoreMain": "恢復主視窗",
     "inUseTitle": "會話已在其他執行個體中開啟",
     "inUseMessage": "此會話已在另一個 BitFun 執行個體中開啟。請先在該處關閉，然後重試。",
+    "surfaceSwitchDroppedTitle": "訊息未送出",
+    "surfaceSwitchDropped": "訊息尚未送出時裝置已切換，且該會話的佇列已滿。請重新傳送。",
     "retry": "重試"
   },
   "scroll": {


### PR DESCRIPTION
## Summary

Follow-up to #2304. Switching devices while a local session was working reported

```
Session lost after adding dialog turn: 834a2fad-c865-4c99-bf00-85cc67aff250
```

and the message never ran. #2304 kept the *backend* running across a switch, but left frontend work that was in flight over the teardown.

## Type and Areas

Type: Bug fix (regression from #2304's incomplete coverage)

Areas: web UI, locales

## Motivation / Impact

`LocalSessionDriver.startTurn` adds its projection turn and then awaits several things before reading the session back:

```
addDialogTurn(...)                 // projection turn exists
await stateMachineManager.transition(START)
await worktreeAPI.bindSession(...) // optional, slow — git/worktree work
await syncSessionModelSelection(...)
const updatedSession = ...sessions.get(sessionId)
if (!updatedSession) throw new Error(`Session lost after adding dialog turn: ${sessionId}`)
```

A device switch calls `resetProductSurface()` → `clearAllSessionsForPeerSwitch()`, which drops **every** session projection synchronously. A submission caught in that window resumes against an empty store and throws.

The toast is the visible symptom; the real damage is where the throw lands. It is **before `start_dialog_turn`**, so the turn had reached no host — the user's message was lost, not merely rendered on the wrong device. The generic handler then also reported it as a turn failure and ran the error transition, for a session that was fine and simply living on another surface now.

The same window produces the sibling `Session lost before starting dialog turn`; both are covered.

## The fix

Close the window, then survive losing it anyway.

**1. A surface switch waits for in-flight submissions.** `MessageModule` tracks submissions that have created a projection turn but not yet handed it to a host, and `resetProductSurface` awaits `waitForInFlightSubmissions(8s)` before clearing anything. The bound matters: a wedged submission must not make switching feel stuck.

**2. A lost race degrades instead of erroring.** `sendMessage` captures `getSurfaceGeneration()` and re-reads it on failure. A change means the switch caused the failure, not the turn — so skip the error toast and the error state transition, and recover the message:

- host never accepted the turn → re-queue it. Pending queues are keyed by session id and survive a surface switch, so returning to that device drains it.
- host already accepted → nothing owed; it is running there.

`TurnTracker` gains `hostAcceptedTurn`, set at each point a host takes the turn (three in `LocalSessionDriver`, one in `DispatchSessionDriver`), so the recovery distinguishes those two cases instead of guessing.

Ordinary failures with an unchanged surface keep their existing handling untouched.

## Verification

```
pnpm --dir src/web-ui run lint                      # clean
pnpm --dir src/web-ui run type-check                # clean
pnpm --dir src/web-ui exec vitest run               # 3363 passed / 14 pre-existing failures
pnpm run build:web                                  # clean (incl. appearance contract audit)
node scripts/i18n-audit.mjs                         # Passed with 0 warning(s)
node --test scripts/i18n-contract.test.mjs          # 37/37
theme:color-audit:all / :test / theme:visual-contract   # PASS
verify:webkit-compatibility:test                    # PASS
check:repo-hygiene / check:github-config / test:ppt-live # PASS
```

Four regression tests in `MessageModule.test.ts` drive a switch through `mockTransition` — landing it exactly where the reported failure happened — and assert: no error toast, the message is re-queued when the host never accepted it, an accepted turn is left alone, and ordinary failures still report normally.

**These were confirmed non-vacuous**: with the surface-generation guard forced off, the first two fail and the reported error reappears.

Thirteen `flowChatStore` test doubles in `MessageModule.test.ts` gained `getSurfaceGeneration`. They were incomplete stand-ins for the real store; I fixed the doubles rather than making the production guard tolerate a missing method, since silently defaulting would disable the recovery path if the store ever lost it.

The two failing files (`AcpAgentsConfig.test.tsx`, `modelResolution.test.ts`) fail on `localStorage` being unavailable in this local Node build and reproduce on a clean tree; both pass in CI.

## Reviewer Notes

**Why wait *and* recover.** The wait alone would still lose messages whenever it timed out; the recovery alone would leave a race that silently re-queues instead of running work the user expects to start. Together the common path is "switch waits, turn lands", and the rare path is "message goes back on the queue" — never "message vanishes with a scary toast".

**The 8s bound** covers a worktree bind plus a model sync with room to spare. On timeout the switch proceeds and layer 2 catches it, so the bound trades a rare re-queue for a UI that always responds to a device click.

**Invariant recorded.** `src/web-ui/src/infrastructure/peer-device/README.md` invariant 0 gains this case, including the thing that will re-break it: any new await inside a driver's `startTurn` widens the window.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.
