### PR TITLE
fix(peer): stop reconcile from erasing a session after a device switch

### DIFF
--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.test.ts
@@ -118,3 +118,98 @@ describe('PeerSessionRefreshModule', () => {
     cleanup();
   });
 });
+
+describe('PeerSessionRefreshModule re-attach after a surface switch', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    peerModeMock.active = true;
+    vi.stubGlobal('document', {
+      visibilityState: 'visible',
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+    vi.stubGlobal('window', { addEventListener: vi.fn(), removeEventListener: vi.fn() });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  function contextWithSnapshot(
+    refreshPeerSessionSnapshot: ReturnType<typeof vi.fn>,
+  ) {
+    const state = {
+      activeSessionId: 'session-1',
+      sessions: new Map([
+        ['session-1', {
+          sessionId: 'session-1',
+          workspacePath: '/repo/BitFun',
+          historyState: 'ready',
+          isHistorical: false,
+          isTransient: false,
+          dialogTurns: [{
+            id: 'turn-live',
+            status: 'processing',
+            modelRounds: [{ id: 'round-0', items: [] }],
+          }],
+        }],
+      ]),
+    };
+    return {
+      flowChatStore: {
+        getState: () => state,
+        subscribeSelector: vi.fn(() => () => {}),
+        refreshPeerSessionSnapshot,
+      },
+      eventBatcher: { flushNow: vi.fn() },
+      contentBuffers: new Map(),
+      activeTextItems: new Map(),
+    } as any;
+  }
+
+  it('re-attaches an executing turn when the snapshot was refused or unchanged', async () => {
+    // The content-safety guard can refuse a snapshot that would gut the turn.
+    // The host is still executing, so the rebuilt surface must reattach anyway.
+    stateMachineMock.get.mockReturnValue({
+      getCurrentState: () => 'idle',
+      getContext: () => ({ lastUpdateTime: 0, version: 0 }),
+    });
+    const refresh = vi.fn(async () => ({
+      applied: false,
+      backendState: 'Processing { current_turn_id: "turn-live", phase: Streaming }',
+      latestTurnId: 'turn-live',
+      latestTurnStatus: 'processing',
+    }));
+
+    const cleanup = installPeerSessionRefresh(contextWithSnapshot(refresh));
+    await vi.advanceTimersByTimeAsync(1);
+    await vi.advanceTimersByTimeAsync(PEER_SESSION_REFRESH_INTERVAL_MS);
+
+    expect(refresh).toHaveBeenCalled();
+    expect(stateMachineMock.transition).toHaveBeenCalled();
+    cleanup();
+  });
+
+  it('does not churn the state machine while a turn is already streaming', async () => {
+    stateMachineMock.get.mockReturnValue({
+      getCurrentState: () => 'processing',
+      getContext: () => ({ lastUpdateTime: Date.now(), version: 0 }),
+    });
+    const refresh = vi.fn(async () => ({
+      applied: false,
+      backendState: 'Processing { current_turn_id: "turn-live", phase: Streaming }',
+      latestTurnId: 'turn-live',
+      latestTurnStatus: 'processing',
+    }));
+
+    const cleanup = installPeerSessionRefresh(contextWithSnapshot(refresh));
+    await vi.advanceTimersByTimeAsync(1);
+    await vi.advanceTimersByTimeAsync(PEER_SESSION_REFRESH_INTERVAL_MS);
+
+    expect(refresh).toHaveBeenCalled();
+    expect(stateMachineMock.reset).not.toHaveBeenCalled();
+    cleanup();
+  });
+});

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.ts
@@ -183,6 +183,29 @@ export function installPeerSessionRefresh(context: FlowChatContext): () => void 
         },
       );
       if (!result.applied) {
+        // A snapshot that changed nothing — or that was refused because it
+        // would have dropped projected content — still reports whether the
+        // host is executing. After a device-surface switch the rebuilt
+        // projection has no state machine, so an executing turn would render
+        // as static history and later chunks would be dropped. Re-attach on
+        // that narrow case only: while a turn really is streaming the machine
+        // is already processing, so this cannot churn it every tick.
+        const machine = stateMachineManager.get(sessionId);
+        const machineIsIdle =
+          (machine?.getCurrentState() ?? SessionExecutionState.IDLE)
+            === SessionExecutionState.IDLE;
+        if (machineIsIdle && isBackendSessionActivelyProcessing(result.backendState)) {
+          await alignStateMachineWithSnapshot(
+            context,
+            sessionId,
+            result.backendState,
+            result.latestTurnId,
+          );
+          log.debug('Re-attached an executing session after a surface switch', {
+            sessionId,
+            backendState: result.backendState,
+          });
+        }
         return;
       }
       await alignStateMachineWithSnapshot(

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
@@ -5937,3 +5937,152 @@ describe('FlowChatStore historical session hydration state', () => {
     expect(flowChatStore.getState().sessions.get('history-1')?.currentTokenUsage).toBeUndefined();
   });
 });
+
+describe('FlowChatStore reconcile snapshot content safety', () => {
+  const HYDRATED_ROUND = {
+    id: 'round-0',
+    turnId: 'turn-0',
+    roundIndex: 0,
+    timestamp: 2,
+    textItems: [{ id: 'text-0', content: 'BitFun is an agentic IDE…', timestamp: 2 }],
+    toolItems: [],
+    thinkingItems: [],
+    startTime: 2,
+    status: 'completed',
+  };
+
+  const hostSession = (state = 'Idle') => ({
+    sessionId: 'history-1',
+    sessionName: 'History 1',
+    agentType: 'agentic',
+    state,
+    turnCount: 1,
+    createdAt: 1,
+  });
+
+  beforeEach(() => {
+    peerModeFlagMock.active = false;
+    apiMocks.restoreSessionView.mockReset();
+    apiMocks.accountFetchSessionTurns.mockResolvedValue(false);
+    vi.stubGlobal('CustomEvent', class {
+      type: string;
+      detail: unknown;
+
+      constructor(type: string, init?: { detail?: unknown }) {
+        this.type = type;
+        this.detail = init?.detail;
+      }
+    });
+    vi.stubGlobal('window', { dispatchEvent: vi.fn() });
+  });
+
+  afterEach(() => {
+    resetStore();
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  async function hydrateSessionWithContent(): Promise<void> {
+    flowChatStore.setState(() => ({
+      sessions: new Map([
+        ['history-1', createSession({
+          sessionId: 'history-1',
+          workspacePath: '/repo/BitFun',
+          isHistorical: true,
+          historyState: 'metadata-only',
+        })],
+      ]),
+      activeSessionId: 'history-1',
+    }));
+    apiMocks.restoreSessionView.mockResolvedValueOnce({
+      session: hostSession(),
+      turns: [{ ...createPersistedTurn(0), modelRounds: [HYDRATED_ROUND], endTime: 3 }],
+      contextRestoreState: 'ready',
+    });
+    await flowChatStore.loadSessionHistory('history-1', '/repo/BitFun');
+  }
+
+  it('keeps a hydrated turn when a wholesale replace snapshot carries none of its work', async () => {
+    // The reported failure: after switching device away and back, the rebuilt
+    // projection has no state machines, so every turn reads as idle and every
+    // snapshot qualifies for wholesale replacement. A windowed snapshot names
+    // the turn but carries no rounds, so replacing it left the user prompt on
+    // screen with the whole response gone.
+    await hydrateSessionWithContent();
+    expect(
+      flowChatStore.getState().sessions.get('history-1')?.dialogTurns[0].modelRounds,
+    ).toHaveLength(1);
+
+    apiMocks.restoreSessionView.mockResolvedValueOnce({
+      session: hostSession(),
+      turns: [{ ...createPersistedTurn(0), modelRounds: [] }],
+      contextRestoreState: 'ready',
+    });
+
+    const result = await flowChatStore.refreshPeerSessionSnapshot(
+      'history-1',
+      '/repo/BitFun',
+      { replaceRunningSnapshot: true, requireActiveSession: true },
+    );
+
+    expect(result.applied).toBe(false);
+    const turn = flowChatStore.getState().sessions.get('history-1')?.dialogTurns[0];
+    expect(turn?.modelRounds).toHaveLength(1);
+    expect(turn?.modelRounds[0].items).toHaveLength(1);
+  });
+
+  it('refuses a replace that would drop a round the projection already shows', async () => {
+    await hydrateSessionWithContent();
+
+    apiMocks.restoreSessionView.mockResolvedValueOnce({
+      session: hostSession(),
+      turns: [{
+        ...createPersistedTurn(0),
+        modelRounds: [{ ...HYDRATED_ROUND, id: 'round-other' }],
+      }],
+      contextRestoreState: 'ready',
+    });
+
+    await flowChatStore.refreshPeerSessionSnapshot(
+      'history-1',
+      '/repo/BitFun',
+      { replaceRunningSnapshot: true, requireActiveSession: true },
+    );
+
+    expect(
+      flowChatStore.getState().sessions.get('history-1')?.dialogTurns[0].modelRounds[0].id,
+    ).toBe('round-0');
+  });
+
+  it('still adopts the host copy when the snapshot carries the projected work', async () => {
+    // The guard must not disable wholesale replacement, which is how a settled
+    // turn picks up the host's authoritative copy.
+    await hydrateSessionWithContent();
+
+    apiMocks.restoreSessionView.mockResolvedValueOnce({
+      session: hostSession(),
+      turns: [{
+        ...createPersistedTurn(0),
+        modelRounds: [{
+          ...HYDRATED_ROUND,
+          textItems: [
+            { id: 'text-0', content: 'BitFun is an agentic IDE…', timestamp: 2 },
+            { id: 'text-1', content: '…with multi-device control.', timestamp: 3 },
+          ],
+        }],
+      }],
+      contextRestoreState: 'ready',
+    });
+
+    const result = await flowChatStore.refreshPeerSessionSnapshot(
+      'history-1',
+      '/repo/BitFun',
+      { replaceRunningSnapshot: true, requireActiveSession: true },
+    );
+
+    expect(result.applied).toBe(true);
+    expect(
+      flowChatStore.getState().sessions.get('history-1')?.dialogTurns[0].modelRounds[0].items,
+    ).toHaveLength(2);
+  });
+});

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.ts
@@ -634,6 +634,45 @@ function isRunningSnapshotForwardProgress(
   return advanced;
 }
 
+/**
+ * Whether replacing `current` with `snapshot` would erase projected content.
+ *
+ * Reconciliation repairs a projection; it must never gut one. The wholesale
+ * replace path exists so a settled turn can adopt the host's authoritative
+ * copy, and it skips the forward-progress comparator to do that. But a turn
+ * carries its identity and user message independently of its rounds, so a
+ * windowed or not-yet-checkpointed snapshot can name the same turn while
+ * carrying none of its work. Replacing then leaves the user prompt on screen
+ * with the entire response gone.
+ *
+ * This is reachable on any surface, and guaranteed right after a device-surface
+ * switch: the rebuilt projection has no state machines, so every turn reads as
+ * idle and every snapshot qualifies for replacement.
+ */
+function snapshotDropsProjectedTurnContent(
+  current: DialogTurn,
+  snapshot: DialogTurn,
+): boolean {
+  if (snapshot.modelRounds.length < current.modelRounds.length) {
+    return true;
+  }
+
+  for (const currentRound of current.modelRounds) {
+    const snapshotRound = snapshot.modelRounds.find(round => round.id === currentRound.id);
+    if (!snapshotRound) {
+      return true;
+    }
+    if (streamProgressEntries(snapshotRound).size < streamProgressEntries(currentRound).size) {
+      return true;
+    }
+    if (toolProgressEntries(snapshotRound).size < toolProgressEntries(currentRound).size) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 function itemMatchesIdentity(item: AnyFlowItem, itemId: string): boolean {
   if (item.id === itemId) {
     return true;
@@ -6822,8 +6861,9 @@ export class FlowChatStore {
           mergedTurns.push(snapshotTurn);
           turnsChanged = true;
         } else if (
-          replaceExistingTurns ||
-          isRunningSnapshotForwardProgress(mergedTurns[existingIndex], snapshotTurn)
+          replaceExistingTurns
+            ? !snapshotDropsProjectedTurnContent(mergedTurns[existingIndex], snapshotTurn)
+            : isRunningSnapshotForwardProgress(mergedTurns[existingIndex], snapshotTurn)
         ) {
           mergedTurns[existingIndex] = snapshotTurn;
           turnsChanged = true;

--- a/src/web-ui/src/infrastructure/peer-device/README.md
+++ b/src/web-ui/src/infrastructure/peer-device/README.md
@@ -29,6 +29,18 @@ Controller-side React/transport layer for Peer Device Mode. Architecture:
      `getSurfaceGeneration()` across the submission: on a change it re-queues
      the message instead of reporting a turn failure. Any new await added
      inside a driver's `startTurn` widens that window — keep the guard.
+   - **Reconciliation repairs a projection, never guts it.** The wholesale
+     replace path (`replaceRunningSnapshot`) skips the forward-progress
+     comparator so a settled turn can adopt the host's copy. A turn keeps its
+     identity and user message independently of its rounds, so a windowed or
+     not-yet-checkpointed snapshot can name the turn while carrying none of its
+     work — and after a surface switch the rebuilt projection has no state
+     machines, so *every* turn reads as idle and qualifies for replacement.
+     That combination erased the whole response and left only the prompt on
+     screen (regression: 2026-08-15). `snapshotDropsProjectedTurnContent` gates
+     the replace; the refresh loop still re-attaches an executing turn when a
+     snapshot is refused, or a rebuilt surface would render it as static
+     history.
    - **Surface-scoped events must stay routed by source device.** Background
      attachments mean several agent streams share one event bus. The
      controller tags re-emitted peer payloads with `__bitfunSourceDeviceId`


### PR DESCRIPTION
## Summary

Follow-up to #2304 and #2309. Switching away from a working local session and back left the prompt on screen with the whole response — its progress, content, and result — gone.

Found by **reproducing the sequence against the real store** rather than by inspection. The projection goes `rounds=1 → rounds=0` across a single reconcile tick.

## Type and Areas

Type: Bug fix (regression from #2304 enabling reconciliation on the local surface)

Areas: web UI

## Motivation / Impact

Active-session reconciliation has a wholesale replace path (`replaceRunningSnapshot`) that deliberately skips the forward-progress comparator, so a settled turn can adopt the host's authoritative copy. Two properties make that unsafe together:

1. **A turn keeps its identity and user message independently of its rounds.** A windowed — or not-yet-checkpointed — snapshot can name the turn while carrying none of its work.
2. **A projection rebuilt by a surface switch has no state machines.** So `machineState` reads `IDLE` for every turn, `replaceRunningSnapshot` is true for every turn, and every snapshot qualifies for wholesale replacement.

Combined: reconciling after a switch overwrote a fully hydrated turn with an empty one. That is precisely the reported screen — user bubble intact, response gone, session idle.

Before #2304 this was unreachable in practice because reconciliation only ran while remoting, where the machine is normally `PROCESSING` and the comparator path applies. Enabling it for the local surface exposed it.

## The fix

**1. Reconciliation repairs a projection, never guts it.** The replace is gated on `snapshotDropsProjectedTurnContent`: a snapshot may correct a turn but must not drop rounds, streams, or tool calls the projection already shows. Forward progress and genuine host copies still replace exactly as before — the guard applies only to the wholesale branch, which previously had no check at all.

**2. Refusing a snapshot must not also cost the re-attach.** The same rebuilt surface that triggers the refusal is the one that needs re-attaching. When a snapshot changes nothing but the host reports an executing turn and the local machine is idle, the state machine is aligned anyway — otherwise a live turn renders as static history and later chunks are dropped. While a turn really is streaming the machine is already `PROCESSING`, so this cannot churn it on every tick; there is a test asserting exactly that.

## Verification

Reproduced first, then fixed:

```
probe BEFORE fix → BEFORE reconcile: rounds = 1 items = 1
                   AFTER  reconcile: applied = true  rounds = 0 items = undefined
probe AFTER  fix → AFTER  reconcile: applied = false rounds = 1 items = 1
```

```
pnpm --dir src/web-ui run lint                      # clean
pnpm --dir src/web-ui run type-check                # clean
pnpm --dir src/web-ui exec vitest run               # 3368 passed / 14 pre-existing failures
pnpm run build:web                                  # clean (incl. appearance contract audit)
node scripts/i18n-audit.mjs                         # Passed with 0 warning(s)
theme:color-audit:all / theme:visual-contract       # PASS
verify:webkit-compatibility:test / check:repo-hygiene # PASS
```

Five new tests. **All confirmed non-vacuous** — each guard was reverted in place and the matching tests fail:

- content-safety guard off → `keeps a hydrated turn when a wholesale replace snapshot carries none of its work` and `refuses a replace that would drop a round the projection already shows` both fail
- re-attach branch off → `re-attaches an executing turn when the snapshot was refused or unchanged` fails

The 105 pre-existing `FlowChatStore` tests, including the peer reconcile suite, still pass — so wholesale replacement is still doing its job.

**What I could not test here:** the real two-device switch needs the Tauri desktop app, a signed-in account, a relay, and a second device, none of which are reproducible in this environment. The dev server boots the bundle cleanly with no console errors, but it does not reach this code path. The evidence above is the reproduction of the failure mechanism itself against the real store, not a UI click-through.

## Reviewer Notes

**Why the guard belongs in the store, not the refresh loop.** The loop cannot know whether a snapshot is impoverished; only the merge sees both sides. Putting it at the merge also covers every other caller of the replace path, not just the surface-switch one.

**Scope of the refusal.** `snapshotDropsProjectedTurnContent` compares round count, then per-round stream and tool entry counts using the existing `streamProgressEntries` / `toolProgressEntries` helpers. It is deliberately conservative: equal content still replaces, so nothing that previously updated stops updating. Targeted rollback goes through `applySessionRollback`, not this path, so intentional truncation is unaffected.

**Invariant recorded** in `src/web-ui/src/infrastructure/peer-device/README.md` invariant 0, including the property that will re-break it: a turn's identity surviving without its rounds.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.
