### PR TITLE
fix(chat): make remote workspace file mentions reliable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,6 +1592,7 @@ dependencies = [
  "oxc",
  "qrcode",
  "rand 0.8.7",
+ "regex",
  "reqwest",
  "rmcp",
  "russh",

--- a/docs/architecture/remote-workspace-transport.md
+++ b/docs/architecture/remote-workspace-transport.md
@@ -138,6 +138,26 @@ omit an entry or follow a link outside the selected tree.
 Host bind mounts are not path-translated. A host path is visible only at the
 path mounted inside the container.
 
+Workspace-facing file requests are scoped by the remote connection id together
+with the POSIX workspace path whenever that id is known. A path alone is only a
+legacy compatibility fallback: the same path may exist on multiple SSH hosts,
+so new browse and search callers must carry the session or workspace connection
+id through the platform adapter. One product surface must use the same scope for
+directory browsing and filename search instead of consulting mutable global
+workspace state between requests.
+An explicit connection id is exact target identity, not a best-effort hint. If
+that connection is unavailable or does not own the requested path, the request
+fails without reading the controller filesystem or another registered host.
+
+Recursive remote filename searches publish cancellable progress as matches are
+discovered. Product surfaces render those partial results before traversal
+completes and preserve a distinct error state; a transport or routing failure
+must not be presented as an empty search result.
+The transport adapter advertises whether command-scoped search events reach the
+current surface. Peer Device controllers without a negotiated search-event
+contract use the response-based command on the peer host; they never fall back
+to searching the controller filesystem.
+
 ## Authentication and secrets
 
 Supported target methods are password, private key, private key plus OpenSSH

--- a/src/apps/desktop/src/api/commands.rs
+++ b/src/apps/desktop/src/api/commands.rs
@@ -16,20 +16,19 @@ use crate::api::search_api::{
 use crate::api::workspace_activation::spawn_workspace_background_warmup;
 use crate::startup_trace::DesktopStartupTrace;
 use bitfun_core::infrastructure::{
-    BatchedFileSearchProgressSink, FileSearchOutcome, FileSearchProgressSink, FileSearchResult,
-    FileSearchResultGroup, FileTreeNode, SearchMatchType,
+    BatchedFileSearchProgressSink, FileSearchResult, FileSearchResultGroup, FileTreeNode,
+    SearchMatchType,
 };
 use bitfun_core::service::file_watch;
 use bitfun_core::service::remote_ssh::get_remote_workspace_manager;
 use bitfun_core::service::remote_ssh::workspace_state::is_remote_path;
 use bitfun_core::service::remote_ssh::{
-    shell_quote_posix, RemoteDirEntry, RemoteFileService, RemoteWorkspaceEntry,
+    search_remote_file_names, shell_quote_posix, RemoteFileNameSearch,
 };
 use bitfun_core::service::workspace::{
     ScanOptions, WorkspaceInfo, WorkspaceKind, WorkspaceOpenOptions,
 };
 use log::{debug, error, info, warn};
-use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
@@ -582,6 +581,8 @@ pub struct SearchFilenamesRequest {
     pub root_path: String,
     pub pattern: String,
     #[serde(default)]
+    pub remote_connection_id: Option<String>,
+    #[serde(default)]
     pub search_id: Option<String>,
     #[serde(default)]
     pub case_sensitive: bool,
@@ -593,6 +594,38 @@ pub struct SearchFilenamesRequest {
     pub max_results: Option<usize>,
     #[serde(default = "default_include_directories")]
     pub include_directories: bool,
+}
+
+#[cfg(test)]
+mod search_filenames_request_tests {
+    use super::SearchFilenamesRequest;
+
+    #[test]
+    fn legacy_payload_without_remote_scope_remains_readable() {
+        let request: SearchFilenamesRequest = serde_json::from_value(serde_json::json!({
+            "rootPath": "/workspace",
+            "pattern": "src"
+        }))
+        .expect("deserialize legacy filename search request");
+
+        assert_eq!(request.remote_connection_id, None);
+        assert!(request.include_directories);
+    }
+
+    #[test]
+    fn remote_scope_is_deserialized_when_supplied() {
+        let request: SearchFilenamesRequest = serde_json::from_value(serde_json::json!({
+            "rootPath": "/workspace",
+            "pattern": "src",
+            "remoteConnectionId": "remote-connection-1"
+        }))
+        .expect("deserialize scoped filename search request");
+
+        assert_eq!(
+            request.remote_connection_id.as_deref(),
+            Some("remote-connection-1")
+        );
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -630,208 +663,6 @@ fn resolve_search_limit(requested: Option<usize>, fallback: usize) -> usize {
     requested
         .unwrap_or(fallback)
         .clamp(1, HARD_MAX_SEARCH_RESULTS)
-}
-
-fn compile_filename_search_regex(
-    pattern: &str,
-    case_sensitive: bool,
-    use_regex: bool,
-    whole_word: bool,
-) -> Result<Regex, String> {
-    let mut pattern = if use_regex {
-        pattern.to_string()
-    } else {
-        regex::escape(pattern)
-    };
-
-    if whole_word {
-        pattern = format!(r"\b(?:{})\b", pattern);
-    }
-
-    if !case_sensitive {
-        pattern = format!("(?i){}", pattern);
-    }
-
-    Regex::new(&pattern).map_err(|error| format!("Invalid search pattern: {}", error))
-}
-
-fn should_skip_remote_search_directory(name: &str) -> bool {
-    matches!(
-        name,
-        ".git"
-            | ".svn"
-            | ".hg"
-            | "node_modules"
-            | "target"
-            | "dist"
-            | "build"
-            | ".next"
-            | ".nuxt"
-            | ".cache"
-            | ".turbo"
-    )
-}
-
-fn should_skip_remote_search_file(name: &str) -> bool {
-    let lower = name.to_ascii_lowercase();
-    matches!(
-        lower.rsplit_once('.').map(|(_, ext)| ext),
-        Some(
-            "png"
-                | "jpg"
-                | "jpeg"
-                | "gif"
-                | "webp"
-                | "ico"
-                | "pdf"
-                | "zip"
-                | "tar"
-                | "gz"
-                | "rar"
-                | "7z"
-                | "exe"
-                | "dll"
-                | "so"
-                | "dylib"
-        )
-    )
-}
-
-fn remote_filename_search_result(entry: &RemoteDirEntry) -> FileSearchResult {
-    FileSearchResult {
-        path: entry.path.clone(),
-        name: entry.name.clone(),
-        is_directory: entry.is_dir,
-        match_type: SearchMatchType::FileName,
-        line_number: None,
-        matched_content: None,
-        preview_before: None,
-        preview_inside: None,
-        preview_after: None,
-    }
-}
-
-struct RemoteFilenameSearch {
-    remote_fs: RemoteFileService,
-    entry: RemoteWorkspaceEntry,
-    root_path: String,
-    pattern: String,
-    case_sensitive: bool,
-    use_regex: bool,
-    whole_word: bool,
-    include_directories: bool,
-    limit: usize,
-    cancel_flag: Option<Arc<AtomicBool>>,
-    progress_sink: Option<Arc<dyn FileSearchProgressSink>>,
-}
-
-async fn search_remote_file_names_with_progress(
-    search: RemoteFilenameSearch,
-) -> Result<FileSearchOutcome, String> {
-    let RemoteFilenameSearch {
-        remote_fs,
-        entry,
-        root_path,
-        pattern,
-        case_sensitive,
-        use_regex,
-        whole_word,
-        include_directories,
-        limit,
-        cancel_flag,
-        progress_sink,
-    } = search;
-    let matcher = compile_filename_search_regex(&pattern, case_sensitive, use_regex, whole_word)?;
-    let mut stack = vec![root_path];
-    let mut results = Vec::new();
-    let mut truncated = false;
-
-    while let Some(directory) = stack.pop() {
-        if cancel_flag
-            .as_ref()
-            .is_some_and(|flag| flag.load(Ordering::Relaxed))
-        {
-            break;
-        }
-
-        let mut entries = remote_fs
-            .read_dir(&entry.connection_id, &directory)
-            .await
-            .map_err(|error| format!("Failed to read remote directory: {}", error))?;
-        entries.sort_by(|a, b| match (a.is_dir, b.is_dir) {
-            (true, false) => std::cmp::Ordering::Less,
-            (false, true) => std::cmp::Ordering::Greater,
-            _ => a.name.cmp(&b.name),
-        });
-
-        for child in entries {
-            if cancel_flag
-                .as_ref()
-                .is_some_and(|flag| flag.load(Ordering::Relaxed))
-            {
-                break;
-            }
-
-            if child.is_dir {
-                if should_skip_remote_search_directory(&child.name) {
-                    continue;
-                }
-
-                if include_directories && matcher.is_match(&child.name) {
-                    let result = remote_filename_search_result(&child);
-                    if let Some(sink) = progress_sink.as_ref() {
-                        sink.report(FileSearchResultGroup {
-                            path: result.path.clone(),
-                            name: result.name.clone(),
-                            is_directory: result.is_directory,
-                            file_name_match: Some(result.clone()),
-                            content_matches: Vec::new(),
-                        });
-                    }
-                    results.push(result);
-                    if results.len() >= limit {
-                        truncated = true;
-                        break;
-                    }
-                }
-
-                stack.push(child.path);
-                continue;
-            }
-
-            if !child.is_file || should_skip_remote_search_file(&child.name) {
-                continue;
-            }
-
-            if matcher.is_match(&child.name) {
-                let result = remote_filename_search_result(&child);
-                if let Some(sink) = progress_sink.as_ref() {
-                    sink.report(FileSearchResultGroup {
-                        path: result.path.clone(),
-                        name: result.name.clone(),
-                        is_directory: result.is_directory,
-                        file_name_match: Some(result.clone()),
-                        content_matches: Vec::new(),
-                    });
-                }
-                results.push(result);
-                if results.len() >= limit {
-                    truncated = true;
-                    break;
-                }
-            }
-        }
-
-        if truncated {
-            break;
-        }
-    }
-
-    if let Some(sink) = progress_sink.as_ref() {
-        sink.flush();
-    }
-
-    Ok(FileSearchOutcome { results, truncated })
 }
 
 #[derive(Debug, Deserialize)]
@@ -4679,14 +4510,20 @@ pub async fn search_filenames(
         include_directories: request.include_directories,
     };
 
-    let result = match resolve_desktop_path_target(&state, &request.root_path, None).await {
+    let result = match resolve_desktop_path_target(
+        &state,
+        &request.root_path,
+        request.remote_connection_id.as_deref(),
+    )
+    .await
+    {
         Ok(DesktopPathTarget::Remote {
             requested_path,
             entry,
         }) => match state.get_remote_file_service_async().await {
-            Ok(remote_fs) => search_remote_file_names_with_progress(RemoteFilenameSearch {
+            Ok(remote_fs) => search_remote_file_names(RemoteFileNameSearch {
                 remote_fs,
-                entry,
+                workspace: entry,
                 root_path: requested_path,
                 pattern: request.pattern.clone(),
                 case_sensitive: request.case_sensitive,
@@ -4824,27 +4661,32 @@ pub async fn start_search_filenames_stream(
         include_directories: request.include_directories,
     };
 
-    let remote_search_target =
-        match resolve_desktop_path_target(&state, &request.root_path, None).await {
-            Ok(DesktopPathTarget::Remote {
-                requested_path,
-                entry,
-            }) => {
-                let remote_fs = match state.get_remote_file_service_async().await {
-                    Ok(remote_fs) => remote_fs,
-                    Err(error) => {
-                        unregister_search(&state, Some(&search_id));
-                        return Err(format!("Remote file service not available: {}", error));
-                    }
-                };
-                Some((remote_fs, entry, requested_path))
-            }
-            Ok(DesktopPathTarget::Local { .. }) => None,
-            Err(error) => {
-                unregister_search(&state, Some(&search_id));
-                return Err(error);
-            }
-        };
+    let remote_search_target = match resolve_desktop_path_target(
+        &state,
+        &request.root_path,
+        request.remote_connection_id.as_deref(),
+    )
+    .await
+    {
+        Ok(DesktopPathTarget::Remote {
+            requested_path,
+            entry,
+        }) => {
+            let remote_fs = match state.get_remote_file_service_async().await {
+                Ok(remote_fs) => remote_fs,
+                Err(error) => {
+                    unregister_search(&state, Some(&search_id));
+                    return Err(format!("Remote file service not available: {}", error));
+                }
+            };
+            Some((remote_fs, entry, requested_path))
+        }
+        Ok(DesktopPathTarget::Local { .. }) => None,
+        Err(error) => {
+            unregister_search(&state, Some(&search_id));
+            return Err(error);
+        }
+    };
 
     let filesystem_service = state.filesystem_service.clone();
     let active_searches = state.active_searches.clone();
@@ -4872,9 +4714,9 @@ pub async fn start_search_filenames_stream(
 
     tokio::spawn(async move {
         let result = if let Some((remote_fs, entry, requested_path)) = remote_search_target {
-            search_remote_file_names_with_progress(RemoteFilenameSearch {
+            search_remote_file_names(RemoteFileNameSearch {
                 remote_fs,
-                entry,
+                workspace: entry,
                 root_path: requested_path,
                 pattern: pattern.clone(),
                 case_sensitive,

--- a/src/apps/desktop/src/api/path_target.rs
+++ b/src/apps/desktop/src/api/path_target.rs
@@ -122,12 +122,15 @@ async fn lookup_remote_entry_for_path(
     }
 
     let manager = get_remote_workspace_manager()?;
+    if let Some(connection_id) = request_preferred {
+        return manager.lookup_scoped_connection(path, connection_id).await;
+    }
+
     let legacy = app_state
         .get_remote_workspace_async()
         .await
         .map(|workspace| workspace.connection_id);
-    let preferred = request_preferred.map(|s| s.to_string()).or(legacy);
-    manager.lookup_connection(path, preferred.as_deref()).await
+    manager.lookup_connection(path, legacy.as_deref()).await
 }
 
 fn should_force_local_assistant_path(
@@ -151,13 +154,23 @@ pub async fn resolve_desktop_path_target(
         });
     }
 
+    let explicit_connection_id = preferred_remote_connection_id
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
     if let Some(entry) =
-        lookup_remote_entry_for_path(app_state, raw_path, preferred_remote_connection_id).await
+        lookup_remote_entry_for_path(app_state, raw_path, explicit_connection_id).await
     {
         return Ok(DesktopPathTarget::Remote {
             requested_path: raw_path.to_string(),
             entry,
         });
+    }
+
+    if let Some(connection_id) = explicit_connection_id {
+        return Err(format!(
+            "Remote workspace connection '{}' is unavailable or does not own path '{}'; local filesystem fallback was not attempted",
+            connection_id, raw_path
+        ));
     }
 
     Ok(DesktopPathTarget::Local {

--- a/src/apps/desktop/src/api/remote_workspace_policy.rs
+++ b/src/apps/desktop/src/api/remote_workspace_policy.rs
@@ -461,13 +461,10 @@ pub const REMOTE_WORKSPACE_COMMAND_POLICIES: &[(&str, RemoteWorkspacePolicy)] = 
         "expand_external_prompt_command_command",
         RemoteWorkspacePolicy::RemoteUnsupported,
     ),
-    (
-        "explorer_get_children",
-        RemoteWorkspacePolicy::LegacyUnaudited,
-    ),
+    ("explorer_get_children", RemoteWorkspacePolicy::RemoteRouted),
     (
         "explorer_get_children_paginated",
-        RemoteWorkspacePolicy::LegacyUnaudited,
+        RemoteWorkspacePolicy::RemoteRouted,
     ),
     (
         "explorer_get_file_tree",
@@ -572,11 +569,11 @@ pub const REMOTE_WORKSPACE_COMMAND_POLICIES: &[(&str, RemoteWorkspacePolicy)] = 
     ),
     (
         "get_directory_children",
-        RemoteWorkspacePolicy::LegacyUnaudited,
+        RemoteWorkspacePolicy::RemoteRouted,
     ),
     (
         "get_directory_children_paginated",
-        RemoteWorkspacePolicy::LegacyUnaudited,
+        RemoteWorkspacePolicy::RemoteRouted,
     ),
     (
         "get_external_hook_catalog",
@@ -1687,7 +1684,7 @@ pub const REMOTE_WORKSPACE_COMMAND_POLICIES: &[(&str, RemoteWorkspacePolicy)] = 
         "search_file_contents",
         RemoteWorkspacePolicy::LegacyUnaudited,
     ),
-    ("search_filenames", RemoteWorkspacePolicy::LegacyUnaudited),
+    ("search_filenames", RemoteWorkspacePolicy::RemoteRouted),
     ("search_files", RemoteWorkspacePolicy::LegacyUnaudited),
     (
         "search_referenceable_sessions",
@@ -1903,7 +1900,7 @@ pub const REMOTE_WORKSPACE_COMMAND_POLICIES: &[(&str, RemoteWorkspacePolicy)] = 
     ),
     (
         "start_search_filenames_stream",
-        RemoteWorkspacePolicy::LegacyUnaudited,
+        RemoteWorkspacePolicy::RemoteRouted,
     ),
     ("start_subscription_login", RemoteWorkspacePolicy::LocalOnly),
     ("startup_window_control", RemoteWorkspacePolicy::LocalOnly),
@@ -2299,8 +2296,6 @@ mod tests {
         "editor_ai_stream",
         "ensure_coordinator_session",
         "execute_tool",
-        "explorer_get_children",
-        "explorer_get_children_paginated",
         "explorer_get_file_tree",
         "export_config",
         "export_diagnostics_bundle",
@@ -2326,8 +2321,6 @@ mod tests {
         "get_current_workspace",
         "get_custom_agent_detail",
         "get_default_review_team_definition",
-        "get_directory_children",
-        "get_directory_children_paginated",
         "get_file_change_history",
         "get_file_diff",
         "get_file_editor_sync_hash",
@@ -2525,7 +2518,6 @@ mod tests {
         "save_session_turn",
         "scan_workspace_info",
         "search_file_contents",
-        "search_filenames",
         "search_files",
         "search_skill_market",
         "send_background_command_input",
@@ -2546,7 +2538,6 @@ mod tests {
         "start_mcp_remote_oauth",
         "start_mcp_server",
         "start_search_file_contents_stream",
-        "start_search_filenames_stream",
         "steer_dialog_turn",
         "stop_acp_client",
         "stop_file_watch",

--- a/src/crates/assembly/core/src/service/filesystem/service.rs
+++ b/src/crates/assembly/core/src/service/filesystem/service.rs
@@ -23,11 +23,30 @@ async fn read_remote_directory_contents(
     path: &str,
     preferred_remote_connection_id: Option<&str>,
 ) -> Option<BitFunResult<Vec<FileTreeNode>>> {
-    let entry = crate::service::remote_ssh::workspace_state::lookup_remote_connection_with_hint(
-        path,
-        preferred_remote_connection_id,
-    )
-    .await?;
+    let explicit_connection_id = preferred_remote_connection_id
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let remote_entry = if let Some(connection_id) = explicit_connection_id {
+        crate::service::remote_ssh::workspace_state::lookup_remote_connection_scoped(
+            path,
+            connection_id,
+        )
+        .await
+    } else {
+        crate::service::remote_ssh::workspace_state::lookup_remote_connection_with_hint(path, None)
+            .await
+    };
+    let entry = match remote_entry {
+        Some(entry) => entry,
+        None if explicit_connection_id.is_some() => {
+            return Some(Err(BitFunError::service(format!(
+                "Remote workspace connection '{}' is unavailable or does not own path '{}'; local filesystem fallback was not attempted",
+                explicit_connection_id.unwrap_or_default(),
+                path
+            ))));
+        }
+        None => return None,
+    };
 
     let Some(manager) = crate::service::remote_ssh::workspace_state::get_remote_workspace_manager()
     else {
@@ -516,6 +535,41 @@ mod tests {
                 .to_string()
                 .contains("Remote file service is unavailable"),
             "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn explicit_remote_scope_never_falls_back_to_a_local_directory() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let remote_root = temp.path().to_string_lossy().to_string();
+        let registered_connection_id = "filesystem-exact-scope-registered";
+        let requested_connection_id = "filesystem-exact-scope-requested";
+        let manager = init_remote_workspace_manager();
+        manager
+            .register_remote_workspace(
+                remote_root.clone(),
+                registered_connection_id.to_string(),
+                "Other remote".to_string(),
+                "other-remote-host".to_string(),
+            )
+            .await;
+
+        let error = FileSystemService::default()
+            .get_directory_contents_with_remote_hint(&remote_root, Some(requested_connection_id))
+            .await
+            .expect_err("an explicit remote scope must not read the controller filesystem");
+
+        manager
+            .unregister_remote_workspace(registered_connection_id, &remote_root)
+            .await;
+        let message = error.to_string();
+        assert!(
+            message.contains(requested_connection_id),
+            "unexpected error: {message}"
+        );
+        assert!(
+            message.contains("local filesystem fallback was not attempted"),
+            "unexpected error: {message}"
         );
     }
 }

--- a/src/crates/assembly/core/src/service/remote_ssh/mod.rs
+++ b/src/crates/assembly/core/src/service/remote_ssh/mod.rs
@@ -13,7 +13,9 @@ pub mod remote_terminal;
 pub mod types;
 pub mod workspace_state;
 
-pub use bitfun_services_integrations::remote_ssh::{build_remote_git_command, shell_quote_posix};
+pub use bitfun_services_integrations::remote_ssh::{
+    build_remote_git_command, search_remote_file_names, shell_quote_posix, RemoteFileNameSearch,
+};
 #[cfg(feature = "ssh-remote")]
 pub use bitfun_services_integrations::remote_ssh::{dispatch_ssh, relay_deploy};
 #[cfg(not(feature = "ssh-remote"))]

--- a/src/crates/assembly/core/src/service/remote_ssh/workspace_state.rs
+++ b/src/crates/assembly/core/src/service/remote_ssh/workspace_state.rs
@@ -221,6 +221,18 @@ impl RemoteWorkspaceStateManager {
             .await
     }
 
+    /// Resolve an exact `(connection_id, path)` workspace scope without
+    /// selecting a different connection through legacy hint behavior.
+    pub async fn lookup_scoped_connection(
+        &self,
+        path: &str,
+        connection_id: &str,
+    ) -> Option<RemoteWorkspaceEntry> {
+        self.registry
+            .lookup_scoped_connection(path, connection_id)
+            .await
+    }
+
     /// True if `path` could belong to **any** registered remote root (before disambiguation).
     pub async fn is_remote_path(&self, path: &str) -> bool {
         if get_path_manager_arc().is_local_assistant_workspace_path(path) {
@@ -400,6 +412,15 @@ pub async fn lookup_remote_connection_with_hint(
     manager
         .lookup_connection(path, preferred_connection_id)
         .await
+}
+
+/// Look up an exact `(connection_id, path)` remote workspace scope.
+pub async fn lookup_remote_connection_scoped(
+    path: &str,
+    connection_id: &str,
+) -> Option<RemoteWorkspaceEntry> {
+    let manager = get_remote_workspace_manager()?;
+    manager.lookup_scoped_connection(path, connection_id).await
 }
 
 /// Look up using path only (uses active hint when ambiguous).

--- a/src/crates/services/services-integrations/Cargo.toml
+++ b/src/crates/services/services-integrations/Cargo.toml
@@ -49,6 +49,7 @@ notify = { workspace = true, optional = true }
 oxc = { workspace = true, optional = true }
 qrcode = { workspace = true, features = ["image", "svg"], optional = true }
 rand = { workspace = true, optional = true }
+regex = { workspace = true, optional = true }
 reqwest = { workspace = true, features = ["http2"], optional = true }
 semver = { workspace = true, optional = true }
 rmcp = { workspace = true, optional = true }
@@ -299,6 +300,7 @@ remote-ssh = [
     "bitfun-runtime-ports/remote-exec-port",
     "bitfun-runtime-ports/remote-workspace-ports",
     "bitfun-runtime-ports/workspace-ports",
+    "regex",
     "sha2",
     "terminal-core",
     "thiserror",

--- a/src/crates/services/services-integrations/src/remote_ssh/file_name_search.rs
+++ b/src/crates/services/services-integrations/src/remote_ssh/file_name_search.rs
@@ -1,0 +1,249 @@
+use super::{RemoteDirEntry, RemoteFileService, RemoteWorkspaceEntry};
+use bitfun_services_core::filesystem::{
+    FileSearchOutcome, FileSearchProgressSink, FileSearchResult, FileSearchResultGroup,
+    SearchMatchType,
+};
+use regex::Regex;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+/// One remote filename search routed to an already-resolved workspace.
+///
+/// Target resolution remains with the caller because a POSIX path alone does
+/// not identify a remote workspace when multiple SSH connections expose the
+/// same root. This service owns only the reusable remote filesystem traversal.
+pub struct RemoteFileNameSearch {
+    pub remote_fs: RemoteFileService,
+    pub workspace: RemoteWorkspaceEntry,
+    pub root_path: String,
+    pub pattern: String,
+    pub case_sensitive: bool,
+    pub use_regex: bool,
+    pub whole_word: bool,
+    pub include_directories: bool,
+    pub limit: usize,
+    pub cancel_flag: Option<Arc<AtomicBool>>,
+    pub progress_sink: Option<Arc<dyn FileSearchProgressSink>>,
+}
+
+fn compile_file_name_search_regex(
+    pattern: &str,
+    case_sensitive: bool,
+    use_regex: bool,
+    whole_word: bool,
+) -> Result<Regex, String> {
+    let mut pattern = if use_regex {
+        pattern.to_string()
+    } else {
+        regex::escape(pattern)
+    };
+
+    if whole_word {
+        pattern = format!(r"\b(?:{})\b", pattern);
+    }
+
+    if !case_sensitive {
+        pattern = format!("(?i){}", pattern);
+    }
+
+    Regex::new(&pattern).map_err(|error| format!("Invalid search pattern: {}", error))
+}
+
+fn should_skip_directory(name: &str) -> bool {
+    matches!(
+        name,
+        ".git"
+            | ".svn"
+            | ".hg"
+            | "node_modules"
+            | "target"
+            | "dist"
+            | "build"
+            | ".next"
+            | ".nuxt"
+            | ".cache"
+            | ".turbo"
+    )
+}
+
+fn should_skip_file(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    matches!(
+        lower.rsplit_once('.').map(|(_, ext)| ext),
+        Some(
+            "png"
+                | "jpg"
+                | "jpeg"
+                | "gif"
+                | "webp"
+                | "ico"
+                | "pdf"
+                | "zip"
+                | "tar"
+                | "gz"
+                | "rar"
+                | "7z"
+                | "exe"
+                | "dll"
+                | "so"
+                | "dylib"
+        )
+    )
+}
+
+fn search_result(entry: &RemoteDirEntry) -> FileSearchResult {
+    FileSearchResult {
+        path: entry.path.clone(),
+        name: entry.name.clone(),
+        is_directory: entry.is_dir,
+        match_type: SearchMatchType::FileName,
+        line_number: None,
+        matched_content: None,
+        preview_before: None,
+        preview_inside: None,
+        preview_after: None,
+    }
+}
+
+/// Searches a remote workspace through its file provider and reports matches
+/// as soon as they are discovered. The progress contract is important for
+/// high-latency workspaces: callers must not wait for the entire recursive walk
+/// before showing an early match.
+pub async fn search_remote_file_names(
+    search: RemoteFileNameSearch,
+) -> Result<FileSearchOutcome, String> {
+    let RemoteFileNameSearch {
+        remote_fs,
+        workspace,
+        root_path,
+        pattern,
+        case_sensitive,
+        use_regex,
+        whole_word,
+        include_directories,
+        limit,
+        cancel_flag,
+        progress_sink,
+    } = search;
+    let matcher = compile_file_name_search_regex(&pattern, case_sensitive, use_regex, whole_word)?;
+    let mut stack = vec![root_path];
+    let mut results = Vec::new();
+    let mut truncated = false;
+
+    while let Some(directory) = stack.pop() {
+        if cancel_flag
+            .as_ref()
+            .is_some_and(|flag| flag.load(Ordering::Relaxed))
+        {
+            break;
+        }
+
+        let mut entries = match remote_fs
+            .read_dir(&workspace.connection_id, &directory)
+            .await
+        {
+            Ok(entries) => entries,
+            Err(error) => {
+                if let Some(sink) = progress_sink.as_ref() {
+                    sink.flush();
+                }
+                return Err(format!("Failed to read remote directory: {}", error));
+            }
+        };
+        entries.sort_by(|a, b| match (a.is_dir, b.is_dir) {
+            (true, false) => std::cmp::Ordering::Less,
+            (false, true) => std::cmp::Ordering::Greater,
+            _ => a.name.cmp(&b.name),
+        });
+
+        for child in entries {
+            if cancel_flag
+                .as_ref()
+                .is_some_and(|flag| flag.load(Ordering::Relaxed))
+            {
+                break;
+            }
+
+            if child.is_dir {
+                if should_skip_directory(&child.name) {
+                    continue;
+                }
+
+                if include_directories && matcher.is_match(&child.name) {
+                    let result = search_result(&child);
+                    if let Some(sink) = progress_sink.as_ref() {
+                        sink.report(FileSearchResultGroup {
+                            path: result.path.clone(),
+                            name: result.name.clone(),
+                            is_directory: result.is_directory,
+                            file_name_match: Some(result.clone()),
+                            content_matches: Vec::new(),
+                        });
+                    }
+                    results.push(result);
+                    if results.len() >= limit {
+                        truncated = true;
+                        break;
+                    }
+                }
+
+                stack.push(child.path);
+                continue;
+            }
+
+            if !child.is_file || should_skip_file(&child.name) {
+                continue;
+            }
+
+            if matcher.is_match(&child.name) {
+                let result = search_result(&child);
+                if let Some(sink) = progress_sink.as_ref() {
+                    sink.report(FileSearchResultGroup {
+                        path: result.path.clone(),
+                        name: result.name.clone(),
+                        is_directory: result.is_directory,
+                        file_name_match: Some(result.clone()),
+                        content_matches: Vec::new(),
+                    });
+                }
+                results.push(result);
+                if results.len() >= limit {
+                    truncated = true;
+                    break;
+                }
+            }
+        }
+
+        if truncated {
+            break;
+        }
+    }
+
+    if let Some(sink) = progress_sink.as_ref() {
+        sink.flush();
+    }
+
+    Ok(FileSearchOutcome { results, truncated })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{compile_file_name_search_regex, should_skip_directory, should_skip_file};
+
+    #[test]
+    fn literal_search_matches_unicode_directory_names() {
+        let matcher = compile_file_name_search_regex("手写", false, false, false)
+            .expect("compile literal matcher");
+        assert!(matcher.is_match("手写笔画标注项目"));
+        assert!(!matcher.is_match("框球项目"));
+    }
+
+    #[test]
+    fn traversal_filters_keep_existing_search_contract() {
+        assert!(should_skip_directory("node_modules"));
+        assert!(should_skip_directory(".git"));
+        assert!(!should_skip_directory("src"));
+        assert!(should_skip_file("archive.zip"));
+        assert!(!should_skip_file("README.md"));
+    }
+}

--- a/src/crates/services/services-integrations/src/remote_ssh/mod.rs
+++ b/src/crates/services/services-integrations/src/remote_ssh/mod.rs
@@ -3,6 +3,7 @@
 //! `bitfun-core::service::remote_ssh` remains as the compatibility facade for
 //! the legacy public path.
 
+mod file_name_search;
 pub mod paths;
 pub mod remote_git;
 mod shell;
@@ -35,6 +36,7 @@ pub mod remote_fs;
 #[cfg(feature = "remote-ssh-concrete")]
 pub mod remote_terminal;
 
+pub use file_name_search::{search_remote_file_names, RemoteFileNameSearch};
 pub use paths::*;
 pub use remote_git::{build_remote_git_command, shell_quote_posix};
 #[cfg(feature = "remote-ssh-concrete")]

--- a/src/crates/services/services-integrations/src/remote_ssh/workspace_registry.rs
+++ b/src/crates/services/services-integrations/src/remote_ssh/workspace_registry.rs
@@ -128,12 +128,11 @@ impl RemoteWorkspaceRegistry {
             .filter(|r| registration_matches_path(r, &path_norm))
             .collect();
 
-        // Only use preferred_connection_id to disambiguate when multiple
-        // path-matching candidates exist. When there is exactly one match,
-        // the path is unambiguous and the preferred hint must not override it.
+        // Keep the legacy hint semantics for existing callers: only use the
+        // preferred id to disambiguate multiple path-matching registrations.
         if candidates.len() > 1 {
-            if let Some(pref) = preferred_connection_id {
-                candidates.retain(|r| r.connection_id == pref);
+            if let Some(preferred) = preferred_connection_id {
+                candidates.retain(|registration| registration.connection_id == preferred);
             }
         }
 
@@ -154,6 +153,32 @@ impl RemoteWorkspaceRegistry {
         }
 
         None
+    }
+
+    /// Looks up one exact `(connection_id, path)` scope.
+    ///
+    /// Unlike [`Self::lookup_connection`], this never treats the connection id
+    /// as a best-effort hint and never selects another registered host.
+    pub async fn lookup_scoped_connection(
+        &self,
+        path: &str,
+        connection_id: &str,
+    ) -> Option<RemoteWorkspaceEntry> {
+        let connection_id = connection_id.trim();
+        if connection_id.is_empty() {
+            return None;
+        }
+
+        let path_norm = normalize_remote_workspace_path(path);
+        let guard = self.registrations.read().await;
+        guard
+            .iter()
+            .filter(|registration| {
+                registration.connection_id == connection_id
+                    && registration_matches_path(registration, &path_norm)
+            })
+            .max_by_key(|registration| registration.remote_root.len())
+            .map(entry_from_registration)
     }
 
     /// True if `path` could belong to any registered remote root before disambiguation.

--- a/src/crates/services/services-integrations/tests/remote_ssh_contracts/remote_ssh_contracts.rs
+++ b/src/crates/services/services-integrations/tests/remote_ssh_contracts/remote_ssh_contracts.rs
@@ -318,6 +318,33 @@ async fn remote_workspace_registry_preserves_ambiguous_root_resolution_contract(
 }
 
 #[tokio::test]
+async fn remote_workspace_registry_treats_explicit_connection_as_exact_identity() {
+    let registry = RemoteWorkspaceRegistry::new();
+    registry
+        .register_remote_workspace(
+            "/workspace".to_string(),
+            "conn-a".to_string(),
+            "Server A".to_string(),
+            "host-a".to_string(),
+        )
+        .await;
+
+    assert!(
+        registry
+            .lookup_scoped_connection("/workspace/project", "conn-b")
+            .await
+            .is_none(),
+        "an explicit connection must never route to a different registered host"
+    );
+
+    let legacy_hint = registry
+        .lookup_connection("/workspace/project", Some("conn-b"))
+        .await
+        .expect("the compatibility lookup keeps its unique-path hint behavior");
+    assert_eq!(legacy_hint.connection_id, "conn-a");
+}
+
+#[tokio::test]
 async fn remote_workspace_registry_preserves_legacy_state_and_clear_contract() {
     let registry = RemoteWorkspaceRegistry::new();
     assert!(!registry.has_any().await);

--- a/src/web-ui/src/app/layout/FloatingMiniChat.tsx
+++ b/src/web-ui/src/app/layout/FloatingMiniChat.tsx
@@ -211,6 +211,9 @@ export const FloatingMiniChat: React.FC = () => {
       // Registration presence makes this an isolated workspace even when the
       // hidden session has no path, so the normal project never leaks in.
       workspacePath: displayedSession?.workspacePath || '',
+      remoteConnectionId:
+        displayedSession?.remoteConnectionId
+        || displayedSession?.config.remoteConnectionId,
       draft: composerPrefill
         ? { id: composerPrefill.id, text: composerPrefill.text }
         : undefined,
@@ -222,6 +225,8 @@ export const FloatingMiniChat: React.FC = () => {
     activeMiniAppName,
     bubbleCustomization?.composer?.placeholder,
     composerPrefill,
+    displayedSession?.config.remoteConnectionId,
+    displayedSession?.remoteConnectionId,
     displayedSession?.workspacePath,
     handleMiniAppDraftConsumed,
     handleMiniAppSubmit,

--- a/src/web-ui/src/app/layout/FloatingMiniChat.tsx
+++ b/src/web-ui/src/app/layout/FloatingMiniChat.tsx
@@ -213,7 +213,7 @@ export const FloatingMiniChat: React.FC = () => {
       workspacePath: displayedSession?.workspacePath || '',
       remoteConnectionId:
         displayedSession?.remoteConnectionId
-        || displayedSession?.config.remoteConnectionId,
+        || displayedSession?.config?.remoteConnectionId,
       draft: composerPrefill
         ? { id: composerPrefill.id, text: composerPrefill.text }
         : undefined,
@@ -225,7 +225,7 @@ export const FloatingMiniChat: React.FC = () => {
     activeMiniAppName,
     bubbleCustomization?.composer?.placeholder,
     composerPrefill,
-    displayedSession?.config.remoteConnectionId,
+    displayedSession?.config?.remoteConnectionId,
     displayedSession?.remoteConnectionId,
     displayedSession?.workspacePath,
     handleMiniAppDraftConsumed,

--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -104,6 +104,7 @@ import {
   sessionWorktreeBindingSubscriptionKey,
 } from '../utils/sessionWorktree';
 import { isRemoteWorkspaceSession, sessionProjectWorkspacePath } from '../utils/sessionWorkspace';
+import { findWorkspaceForSession } from '../utils/workspaceScope';
 import { isTauriRuntime } from '@/infrastructure/runtime';
 import { Tooltip, IconButton, confirmDanger, confirmWarning } from '@/component-library';
 import { PendingQueuePanel } from './PendingQueuePanel';
@@ -950,6 +951,20 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   const workspacePathRef = useRef(sessionBoundWorkspacePath);
   workspacePathRef.current = sessionBoundWorkspacePath;
   const { openedWorkspaces } = useWorkspaceContext();
+  const mentionWorkspace = useMemo(() => (
+    effectiveTargetSession
+      ? findWorkspaceForSession(effectiveTargetSession, openedWorkspaces.values())
+      : workspace ?? undefined
+  ), [effectiveTargetSession, openedWorkspaces, workspace]);
+  const sessionBoundRemoteConnectionId = (
+    hasRegisteredWorkspace
+      ? registration?.remoteConnectionId
+      : (
+          effectiveTargetSession?.remoteConnectionId
+          || effectiveTargetSession?.config.remoteConnectionId
+          || mentionWorkspace?.connectionId
+        )
+  )?.trim() || undefined;
 
   const chatStripRepositoryPath = useMemo(() => {
     const fromSession = hasRegisteredWorkspace
@@ -5630,9 +5645,10 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                 isOpen={mentionState.isActive}
                 searchQuery={mentionState.query}
                 workspacePath={sessionBoundWorkspacePath}
+                remoteConnectionId={sessionBoundRemoteConnectionId}
                 workspaceId={hasRegisteredWorkspace
                   ? undefined
-                  : effectiveTargetSession?.workspaceId || workspace?.id}
+                  : effectiveTargetSession?.workspaceId || mentionWorkspace?.id}
                 excludeSessionId={effectiveTargetSessionId || undefined}
                 anchorRef={mentionAnchorRef}
                 onSelect={(context: FileContext | DirectoryContext | SessionReferenceContext) => {

--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -961,7 +961,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       ? registration?.remoteConnectionId
       : (
           effectiveTargetSession?.remoteConnectionId
-          || effectiveTargetSession?.config.remoteConnectionId
+          || effectiveTargetSession?.config?.remoteConnectionId
           || mentionWorkspace?.connectionId
         )
   )?.trim() || undefined;

--- a/src/web-ui/src/flow_chat/components/FileMentionPicker.appearance.ts
+++ b/src/web-ui/src/flow_chat/components/FileMentionPicker.appearance.ts
@@ -10,5 +10,6 @@ export const fileMentionPickerAppearanceDescriptor: AppearanceSurfaceDescriptor 
   states: [
     { id: 'selected', selector: { kind: 'self', suffix: '[data-bf-state~="selected"]' } },
     { id: 'loading', selector: { kind: 'self', suffix: '[data-bf-state~="loading"]' } },
+    { id: 'error', selector: { kind: 'self', suffix: '[data-bf-state~="error"]' } },
   ],
 };

--- a/src/web-ui/src/flow_chat/components/FileMentionPicker.tsx
+++ b/src/web-ui/src/flow_chat/components/FileMentionPicker.tsx
@@ -22,7 +22,7 @@ import {
 } from '@/infrastructure/api/service-api/ExternalSourcesAPI';
 import type {
   ExplorerNodeDto,
-  FileSearchResult,
+  FileSearchResultGroup,
 } from '@/infrastructure/api/service-api/tauri-commands';
 import type { SessionReferenceCandidate } from '@/infrastructure/api/service-api/SessionAPI';
 import type {
@@ -49,6 +49,8 @@ export interface FileMentionPickerProps {
   searchQuery: string;
   workspacePath?: string;
   workspaceId?: string;
+  /** Disambiguates identical POSIX workspace paths on different remote hosts. */
+  remoteConnectionId?: string;
   /** The composing session itself must not appear as a reference candidate. */
   excludeSessionId?: string;
   onSelect: (context: FileContext | DirectoryContext | SessionReferenceContext) => void;
@@ -63,11 +65,37 @@ type MentionItem =
   | { kind: 'file'; item: FileItem }
   | { kind: 'session'; item: SessionReferenceCandidate };
 
+function mergeFileSearchResults(
+  previous: FileItem[],
+  groups: FileSearchResultGroup[],
+  getRelativePath: (path: string) => string,
+): FileItem[] {
+  const byPath = new Map(previous.map(item => [item.path, item]));
+  for (const group of groups) {
+    const result = group.fileNameMatch;
+    if (!result) continue;
+    byPath.set(result.path, {
+      path: result.path,
+      name: result.name,
+      isDirectory: result.isDirectory || false,
+      relativePath: getRelativePath(result.path),
+    });
+  }
+
+  return Array.from(byPath.values())
+    .sort((a, b) => {
+      if (a.isDirectory !== b.isDirectory) return a.isDirectory ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    })
+    .slice(0, FILE_MENTION_MAX_RESULTS);
+}
+
 export const FileMentionPicker: React.FC<FileMentionPickerProps> = ({
   isOpen,
   searchQuery,
   workspacePath,
   workspaceId,
+  remoteConnectionId,
   excludeSessionId,
   onSelect,
   onClose,
@@ -79,8 +107,11 @@ export const FileMentionPicker: React.FC<FileMentionPickerProps> = ({
   const [sessionResults, setSessionResults] = useState<SessionReferenceCandidate[]>([]);
   const [workspaceReferences, setWorkspaceReferences] = useState<WorkspaceReferenceEntry[]>([]);
   const [currentFiles, setCurrentFiles] = useState<FileItem[]>([]);
-  const [isFileLoading, setIsFileLoading] = useState(false);
+  const [isDirectoryLoading, setIsDirectoryLoading] = useState(false);
+  const [isFileSearchLoading, setIsFileSearchLoading] = useState(false);
   const [isSessionLoading, setIsSessionLoading] = useState(false);
+  const [directoryLoadError, setDirectoryLoadError] = useState(false);
+  const [fileSearchError, setFileSearchError] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [currentPath, setCurrentPath] = useState<string>('');
   const [pathHistory, setPathHistory] = useState<string[]>([]);
@@ -110,13 +141,19 @@ export const FileMentionPicker: React.FC<FileMentionPickerProps> = ({
   const loadDirectory = useCallback(async (dirPath: string, targetSelectedPath?: string | null) => {
     if (!workspacePath) {
       setCurrentFiles([]);
+      setIsDirectoryLoading(false);
+      setDirectoryLoadError(false);
       return;
     }
 
     const requestId = ++directoryLoadRequestIdRef.current;
-    setIsFileLoading(true);
+    setIsDirectoryLoading(true);
+    setDirectoryLoadError(false);
     try {
-      const children = await workspaceAPI.getDirectoryChildren(dirPath || workspacePath);
+      const children = await workspaceAPI.getDirectoryChildren(
+        dirPath || workspacePath,
+        remoteConnectionId,
+      );
       const items: FileItem[] = children
         .filter((entry: ExplorerNodeDto) => {
           const name = entry.name || '';
@@ -141,11 +178,14 @@ export const FileMentionPicker: React.FC<FileMentionPickerProps> = ({
       setSelectedIndex(targetIndex >= 0 ? targetIndex : 0);
     } catch (error) {
       log.error('Failed to load directory', error);
-      if (requestId === directoryLoadRequestIdRef.current) setCurrentFiles([]);
+      if (requestId === directoryLoadRequestIdRef.current) {
+        setCurrentFiles([]);
+        setDirectoryLoadError(true);
+      }
     } finally {
-      if (requestId === directoryLoadRequestIdRef.current) setIsFileLoading(false);
+      if (requestId === directoryLoadRequestIdRef.current) setIsDirectoryLoading(false);
     }
-  }, [workspacePath, getRelativePath]);
+  }, [workspacePath, remoteConnectionId, getRelativePath]);
 
   const enterDirectory = useCallback((item: FileItem) => {
     if (!item.isDirectory) return;
@@ -173,11 +213,13 @@ export const FileMentionPicker: React.FC<FileMentionPickerProps> = ({
     setCurrentFiles([]);
     setResults([]);
     setSessionResults([]);
+    setDirectoryLoadError(false);
+    setFileSearchError(false);
     setSelectedIndex(0);
     selectedItemHistoryRef.current = [];
     targetSelectedPathRef.current = null;
     loadDirectory('', null);
-  }, [isOpen, workspacePath, loadDirectory]);
+  }, [isOpen, workspacePath, remoteConnectionId, loadDirectory]);
 
   useEffect(() => {
     if (!isOpen || !workspacePath) {
@@ -218,37 +260,44 @@ export const FileMentionPicker: React.FC<FileMentionPickerProps> = ({
   ) => {
     if (!workspacePath) {
       setResults([]);
+      setIsFileSearchLoading(false);
       return;
     }
     try {
-      const searchResults = await workspaceAPI.searchFilenamesOnly(
-        workspacePath, query, false, false, false, controller.signal,
+      await workspaceAPI.searchFilenamesOnlyStreamDetailed(
+        workspacePath,
+        query,
+        false,
+        false,
+        false,
+        undefined,
+        FILE_MENTION_MAX_RESULTS,
+        true,
+        {
+          onProgress: (event) => {
+            if (
+              requestId !== fileSearchRequestIdRef.current
+              || controller.signal.aborted
+            ) return;
+
+            setResults(previous => mergeFileSearchResults(previous, event.results, getRelativePath));
+          },
+        },
+        controller.signal,
+        remoteConnectionId,
       );
-      if (requestId !== fileSearchRequestIdRef.current || controller.signal.aborted) return;
-      const items = searchResults.map((result: FileSearchResult) => ({
-        path: result.path,
-        name: result.name,
-        isDirectory: result.isDirectory || false,
-        relativePath: getRelativePath(result.path),
-      }));
-      items.sort((a, b) => {
-        if (a.isDirectory !== b.isDirectory) return a.isDirectory ? -1 : 1;
-        return a.name.localeCompare(b.name);
-      });
-      setResults(items.slice(0, FILE_MENTION_MAX_RESULTS));
-      setSelectedIndex(0);
     } catch (error) {
       if (!(error instanceof DOMException && error.name === 'AbortError')) {
         log.error('File mention search failed', error);
+        if (requestId === fileSearchRequestIdRef.current) setFileSearchError(true);
       }
-      if (requestId === fileSearchRequestIdRef.current) setResults([]);
     } finally {
       if (requestId === fileSearchRequestIdRef.current && fileAbortControllerRef.current === controller) {
         fileAbortControllerRef.current = null;
-        setIsFileLoading(false);
+        setIsFileSearchLoading(false);
       }
     }
-  }, [workspacePath, getRelativePath]);
+  }, [workspacePath, remoteConnectionId, getRelativePath]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -264,14 +313,18 @@ export const FileMentionPicker: React.FC<FileMentionPickerProps> = ({
       fileSearchRequestIdRef.current += 1;
       setResults([]);
       setSelectedIndex(0);
-      setIsFileLoading(false);
+      setIsFileSearchLoading(false);
+      setFileSearchError(false);
       return;
     }
 
     const requestId = ++fileSearchRequestIdRef.current;
     const controller = new AbortController();
     fileAbortControllerRef.current = controller;
-    setIsFileLoading(true);
+    setResults([]);
+    setSelectedIndex(0);
+    setIsFileSearchLoading(true);
+    setFileSearchError(false);
     fileSearchDebounceTimerRef.current = window.setTimeout(() => {
       fileSearchDebounceTimerRef.current = null;
       void searchFiles(query, controller, requestId);
@@ -325,6 +378,10 @@ export const FileMentionPicker: React.FC<FileMentionPickerProps> = ({
   }, [excludeSessionId, isOpen, searchQuery]);
 
   const isSearchMode = searchQuery.trim().length > 0;
+  const isFileLoading = isSearchMode ? isFileSearchLoading : isDirectoryLoading;
+  const fileLoadError = isSearchMode
+    ? (fileSearchError ? 'search' : null)
+    : (directoryLoadError ? 'directory' : null);
   const referenceItems = useMemo(
     () => workspaceReferenceItems(workspaceReferences, isSearchMode ? searchQuery : ''),
     [isSearchMode, searchQuery, workspaceReferences],
@@ -509,7 +566,13 @@ export const FileMentionPicker: React.FC<FileMentionPickerProps> = ({
         )}
       </div>
       <div data-bf-component="file-mention-picker" data-bf-part="content" className="file-mention-picker__content">
-        {displayItems.length === 0 && isLoading ? (
+        {displayItems.length === 0 && fileLoadError ? (
+          <div data-bf-component="file-mention-picker" data-bf-part="error" className="file-mention-picker__empty">
+            <span>{t(fileLoadError === 'search'
+              ? 'fileMention.searchUnavailable'
+              : 'fileMention.browseUnavailable')}</span>
+          </div>
+        ) : displayItems.length === 0 && isLoading ? (
           <div data-bf-component="file-mention-picker" data-bf-part="loading" className="file-mention-picker__loading"><Loader2 size={14} className="file-mention-picker__spinner" /><span>{t('fileMention.loading')}</span></div>
         ) : displayItems.length === 0 ? (
           <div data-bf-component="file-mention-picker" data-bf-part="empty" className="file-mention-picker__empty"><span>{isSearchMode ? t('fileMention.noMatchingFiles') : t('fileMention.emptyDirectory')}</span></div>
@@ -563,6 +626,19 @@ export const FileMentionPicker: React.FC<FileMentionPickerProps> = ({
                 </div>
               );
             })}
+            {isLoading && (
+              <div data-bf-component="file-mention-picker" data-bf-part="loading" className="file-mention-picker__loading">
+                <Loader2 size={14} className="file-mention-picker__spinner" />
+                <span>{t('fileMention.loading')}</span>
+              </div>
+            )}
+            {fileLoadError && (
+              <div data-bf-component="file-mention-picker" data-bf-part="error" className="file-mention-picker__empty">
+                <span>{t(fileLoadError === 'search'
+                  ? 'fileMention.searchUnavailable'
+                  : 'fileMention.browseUnavailable')}</span>
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/src/web-ui/src/flow_chat/components/FileMentionPicker.tsx
+++ b/src/web-ui/src/flow_chat/components/FileMentionPicker.tsx
@@ -567,7 +567,7 @@ export const FileMentionPicker: React.FC<FileMentionPickerProps> = ({
       </div>
       <div data-bf-component="file-mention-picker" data-bf-part="content" className="file-mention-picker__content">
         {displayItems.length === 0 && fileLoadError ? (
-          <div data-bf-component="file-mention-picker" data-bf-part="error" className="file-mention-picker__empty">
+          <div data-bf-component="file-mention-picker" data-bf-part="empty" data-bf-state="error" className="file-mention-picker__empty">
             <span>{t(fileLoadError === 'search'
               ? 'fileMention.searchUnavailable'
               : 'fileMention.browseUnavailable')}</span>
@@ -633,7 +633,7 @@ export const FileMentionPicker: React.FC<FileMentionPickerProps> = ({
               </div>
             )}
             {fileLoadError && (
-              <div data-bf-component="file-mention-picker" data-bf-part="error" className="file-mention-picker__empty">
+              <div data-bf-component="file-mention-picker" data-bf-part="empty" data-bf-state="error" className="file-mention-picker__empty">
                 <span>{t(fileLoadError === 'search'
                   ? 'fileMention.searchUnavailable'
                   : 'fileMention.browseUnavailable')}</span>

--- a/src/web-ui/src/flow_chat/components/FileMentionPickerOverlay.test.tsx
+++ b/src/web-ui/src/flow_chat/components/FileMentionPickerOverlay.test.tsx
@@ -126,9 +126,9 @@ describe('FileMentionPicker overlay', () => {
       await Promise.resolve();
     });
 
-    expect(document.querySelector('[data-bf-part="error"]')?.textContent)
+    expect(document.querySelector('[data-bf-part="empty"][data-bf-state~="error"]')?.textContent)
       .toBe('fileMention.browseUnavailable');
-    expect(document.querySelector('[data-bf-part="empty"]')).toBeNull();
+    expect(document.querySelector('[data-bf-part="empty"]:not([data-bf-state~="error"])')).toBeNull();
   });
 
   it('shows streamed remote matches before the recursive search completes', async () => {

--- a/src/web-ui/src/flow_chat/components/FileMentionPickerOverlay.test.tsx
+++ b/src/web-ui/src/flow_chat/components/FileMentionPickerOverlay.test.tsx
@@ -22,7 +22,13 @@ vi.mock('@/infrastructure/api', () => ({
   },
   workspaceAPI: {
     getDirectoryChildren: vi.fn().mockResolvedValue([]),
-    searchFilenamesOnly: vi.fn().mockResolvedValue([]),
+    searchFilenamesOnlyStreamDetailed: vi.fn().mockResolvedValue({
+      searchId: 'search-1',
+      searchKind: 'filenames',
+      limit: 30,
+      truncated: false,
+      totalResults: 0,
+    }),
   },
 }));
 
@@ -32,15 +38,19 @@ vi.mock('@/infrastructure/api/service-api/ExternalSourcesAPI', () => ({
   },
 }));
 
-const Harness: React.FC = () => {
+const Harness: React.FC<{
+  searchQuery?: string;
+  remoteConnectionId?: string;
+}> = ({ searchQuery = '', remoteConnectionId = 'remote-connection-1' }) => {
   const anchorRef = useRef<HTMLButtonElement>(null);
   return (
     <div>
       <button ref={anchorRef} type="button">anchor</button>
       <FileMentionPicker
         isOpen
-        searchQuery=""
+        searchQuery={searchQuery}
         workspacePath="/workspace"
+        remoteConnectionId={remoteConnectionId}
         anchorRef={anchorRef}
         onSelect={vi.fn()}
         onClose={vi.fn()}
@@ -61,6 +71,7 @@ describe('FileMentionPicker overlay', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     act(() => root.unmount());
     document.querySelector('[data-bf-overlay-host="true"]')?.remove();
     container.remove();
@@ -76,6 +87,10 @@ describe('FileMentionPicker overlay', () => {
     const picker = document.querySelector<HTMLElement>('.file-mention-picker--overlay');
     expect(picker?.parentElement?.getAttribute('data-bf-overlay-host')).toBe('true');
     expect(picker?.style.visibility).toBe('visible');
+    expect(workspaceAPI.getDirectoryChildren).toHaveBeenCalledWith(
+      '/workspace',
+      'remote-connection-1',
+    );
   });
 
   it('shows the workspace-relative path after the file name', async () => {
@@ -99,5 +114,108 @@ describe('FileMentionPicker overlay', () => {
     expect(itemName?.classList.contains('file-mention-picker__item-name--with-path')).toBe(true);
     expect(itemPath?.textContent).toBe('src/App.tsx');
     expect(itemPath?.classList.contains('file-mention-picker__item-path')).toBe(true);
+  });
+
+  it('does not present a remote browse failure as an empty directory', async () => {
+    vi.mocked(workspaceAPI.getDirectoryChildren).mockRejectedValueOnce(
+      new Error('remote connection unavailable'),
+    );
+
+    await act(async () => {
+      root.render(<Harness />);
+      await Promise.resolve();
+    });
+
+    expect(document.querySelector('[data-bf-part="error"]')?.textContent)
+      .toBe('fileMention.browseUnavailable');
+    expect(document.querySelector('[data-bf-part="empty"]')).toBeNull();
+  });
+
+  it('shows streamed remote matches before the recursive search completes', async () => {
+    vi.useFakeTimers();
+    let reportProgress: ((event: {
+      searchId: string;
+      searchKind: 'filenames';
+      results: Array<{
+        path: string;
+        name: string;
+        isDirectory: boolean;
+        fileNameMatch: {
+          path: string;
+          name: string;
+          isDirectory: boolean;
+          matchType: 'fileName';
+        };
+        contentMatches: [];
+      }>;
+    }) => void) | undefined;
+    let finishSearch: (() => void) | undefined;
+
+    vi.mocked(workspaceAPI.searchFilenamesOnlyStreamDetailed).mockImplementationOnce((
+      _rootPath,
+      _pattern,
+      _caseSensitive,
+      _useRegex,
+      _wholeWord,
+      _searchIdOrSignal,
+      _maxResults,
+      _includeDirectories,
+      callbacks,
+    ) => {
+      reportProgress = callbacks.onProgress;
+      return new Promise(resolve => {
+        finishSearch = () => resolve({
+          searchId: 'search-remote-1',
+          searchKind: 'filenames',
+          limit: 30,
+          truncated: false,
+          totalResults: 1,
+        });
+      });
+    });
+
+    await act(async () => {
+      root.render(<Harness searchQuery="手写" />);
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+
+    expect(workspaceAPI.searchFilenamesOnlyStreamDetailed).toHaveBeenCalled();
+    expect(
+      vi.mocked(workspaceAPI.searchFilenamesOnlyStreamDetailed).mock.calls[0]?.[10],
+    ).toBe('remote-connection-1');
+
+    await act(async () => {
+      reportProgress?.({
+        searchId: 'search-remote-1',
+        searchKind: 'filenames',
+        results: [{
+          path: '/workspace/手写笔画标注项目',
+          name: '手写笔画标注项目',
+          isDirectory: true,
+          fileNameMatch: {
+            path: '/workspace/手写笔画标注项目',
+            name: '手写笔画标注项目',
+            isDirectory: true,
+            matchType: 'fileName',
+          },
+          contentMatches: [],
+        }],
+      });
+      await Promise.resolve();
+    });
+
+    expect(document.querySelector('[data-bf-part="itemName"]')?.textContent)
+      .toBe('手写笔画标注项目');
+    expect(document.querySelector('[data-bf-part="root"]')?.getAttribute('data-bf-state'))
+      .toBe('loading');
+
+    await act(async () => {
+      finishSearch?.();
+      await Promise.resolve();
+    });
+    vi.useRealTimers();
   });
 });

--- a/src/web-ui/src/flow_chat/components/chatInputRegistration.ts
+++ b/src/web-ui/src/flow_chat/components/chatInputRegistration.ts
@@ -40,6 +40,8 @@ export interface ChatInputRegistration {
    * explicit isolated workspace and must not fall back to the active project.
    */
   workspacePath?: string;
+  /** Remote connection that owns `workspacePath`; paths alone are ambiguous across hosts. */
+  remoteConnectionId?: string;
   draft?: ChatInputDraftRegistration;
   onDraftConsumed?: (id: number) => void;
   onSubmit?: (submission: ChatInputSubmission) => void | Promise<void>;

--- a/src/web-ui/src/flow_chat/components/modern/UserMessageEditComposer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/UserMessageEditComposer.tsx
@@ -25,6 +25,7 @@ interface UserMessageEditComposerProps {
   presentation?: ComposerPresentation | null;
   workspacePath?: string;
   workspaceId?: string;
+  remoteConnectionId?: string;
   excludeSessionId?: string;
 }
 
@@ -44,6 +45,7 @@ const RichUserMessageEditComposer: React.FC<RichUserMessageEditComposerProps> = 
   presentation,
   workspacePath,
   workspaceId,
+  remoteConnectionId,
   excludeSessionId,
 }) => {
   const editorRef = useRef<RichTextInputElement>(null);
@@ -133,6 +135,7 @@ const RichUserMessageEditComposer: React.FC<RichUserMessageEditComposerProps> = 
           searchQuery={mentionState.query}
           workspacePath={workspacePath}
           workspaceId={workspaceId}
+          remoteConnectionId={remoteConnectionId}
           excludeSessionId={excludeSessionId}
           anchorRef={mentionAnchorRef}
           onSelect={handleSelectContext}
@@ -183,6 +186,7 @@ export const UserMessageEditComposer: React.FC<UserMessageEditComposerProps> = (
   presentation,
   workspacePath,
   workspaceId,
+  remoteConnectionId,
   excludeSessionId,
 }) => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -229,6 +233,7 @@ export const UserMessageEditComposer: React.FC<UserMessageEditComposerProps> = (
         presentation={presentation}
         workspacePath={workspacePath}
         workspaceId={workspaceId}
+        remoteConnectionId={remoteConnectionId}
         excludeSessionId={excludeSessionId}
       />
     );

--- a/src/web-ui/src/flow_chat/components/modern/UserMessageItem.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/UserMessageItem.tsx
@@ -532,7 +532,7 @@ export const UserMessageItem = React.memo<UserMessageItemProps>(
             workspaceId={currentSession?.workspaceId}
             remoteConnectionId={
               currentSession?.remoteConnectionId
-              || currentSession?.config.remoteConnectionId
+              || currentSession?.config?.remoteConnectionId
             }
             excludeSessionId={resolvedSessionId}
           />

--- a/src/web-ui/src/flow_chat/components/modern/UserMessageItem.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/UserMessageItem.tsx
@@ -530,6 +530,10 @@ export const UserMessageItem = React.memo<UserMessageItemProps>(
             presentation={composerPresentation}
             workspacePath={currentSession?.workspacePath}
             workspaceId={currentSession?.workspaceId}
+            remoteConnectionId={
+              currentSession?.remoteConnectionId
+              || currentSession?.config.remoteConnectionId
+            }
             excludeSessionId={resolvedSessionId}
           />
         ) : (

--- a/src/web-ui/src/flow_chat/utils/workspaceScope.test.ts
+++ b/src/web-ui/src/flow_chat/utils/workspaceScope.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import type { WorkspaceInfo } from '@/shared/types';
+import { findWorkspaceForSession } from './workspaceScope';
+
+function remoteWorkspace(id: string, connectionId: string): WorkspaceInfo {
+  return {
+    id,
+    rootPath: '/workspace',
+    connectionId,
+    sshHost: `${connectionId}.example.test`,
+  } as WorkspaceInfo;
+}
+
+describe('findWorkspaceForSession', () => {
+  it('uses remote identity instead of an ambiguous POSIX path', () => {
+    const first = remoteWorkspace('workspace-a', 'connection-a');
+    const second = remoteWorkspace('workspace-b', 'connection-b');
+
+    expect(findWorkspaceForSession({
+      workspacePath: '/workspace',
+      remoteConnectionId: 'connection-b',
+    }, [first, second])).toBe(second);
+  });
+});

--- a/src/web-ui/src/infrastructure/api/adapters/base.ts
+++ b/src/web-ui/src/infrastructure/api/adapters/base.ts
@@ -16,6 +16,9 @@ export interface ITransportAdapter {
    * transport have settled. Synchronous transports can keep the default no-op.
    */
   waitForListenerRegistrations?(): Promise<void>;
+
+  /** Whether command-scoped file-search progress events reach this surface. */
+  supportsSearchStreamEvents?(): boolean;
   
    
   disconnect(): Promise<void>;
@@ -57,5 +60,4 @@ export interface ToolEvent extends StreamEvent {
     data?: any;
   };
 }
-
 

--- a/src/web-ui/src/infrastructure/api/adapters/peer-device-adapter.test.ts
+++ b/src/web-ui/src/infrastructure/api/adapters/peer-device-adapter.test.ts
@@ -13,6 +13,12 @@ import {
 } from './peer-device-adapter';
 
 describe('isPeerLocalOnlyCommand', () => {
+  it('keeps file-search streaming on the negotiated response path', () => {
+    const adapter = new PeerDeviceTransportAdapter('peer-1', vi.fn());
+    expect(adapter.supportsSearchStreamEvents()).toBe(false);
+    expect(isPeerLocalOnlyCommand('search_filenames')).toBe(false);
+  });
+
   it('keeps local speech capture and model events on the controller device', () => {
     expect(isPeerLocalOnlyCommand('speech_list_models')).toBe(true);
     expect(isPeerLocalOnlyCommand('speech_start_input_session')).toBe(true);

--- a/src/web-ui/src/infrastructure/api/adapters/peer-device-adapter.ts
+++ b/src/web-ui/src/infrastructure/api/adapters/peer-device-adapter.ts
@@ -409,6 +409,15 @@ export class PeerDeviceTransportAdapter implements ITransportAdapter {
     private readonly maxConcurrent: number = PEER_HOST_INVOKE_MAX_CONCURRENT,
   ) {}
 
+  /**
+   * Search progress is not part of the negotiated Peer DeviceEvent contract.
+   * Use the response-based search command so older peers remain compatible and
+   * results never fall back to the controller's filesystem.
+   */
+  supportsSearchStreamEvents(): boolean {
+    return false;
+  }
+
   getTargetDeviceId(): string {
     return this.targetDeviceId;
   }

--- a/src/web-ui/src/infrastructure/api/adapters/tauri-adapter.ts
+++ b/src/web-ui/src/infrastructure/api/adapters/tauri-adapter.ts
@@ -35,6 +35,10 @@ export class TauriTransportAdapter implements ITransportAdapter {
   private initPromise: Promise<void> | null = null;
   private listenerRegistrationPromises = new Set<Promise<void>>();
 
+  supportsSearchStreamEvents(): boolean {
+    return true;
+  }
+
   // Lazy initialize Tauri API
   private async ensureInitialized() {
     if (this.invokeFn) return;

--- a/src/web-ui/src/infrastructure/api/service-api/WorkspaceAPI.test.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/WorkspaceAPI.test.ts
@@ -2,11 +2,18 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { workspaceAPI } from './WorkspaceAPI';
 
 const invokeMock = vi.hoisted(() => vi.fn());
+const listenMock = vi.hoisted(() => vi.fn(() => vi.fn()));
+const waitForListenerRegistrationsMock = vi.hoisted(() => vi.fn());
+const streamCapabilityMock = vi.hoisted(() => ({ supported: false }));
 
 vi.mock('./ApiClient', () => ({
   api: {
     invoke: invokeMock,
-    listen: vi.fn(),
+    listen: listenMock,
+    waitForListenerRegistrations: waitForListenerRegistrationsMock,
+    getAdapter: () => ({
+      supportsSearchStreamEvents: () => streamCapabilityMock.supported,
+    }),
   },
 }));
 
@@ -14,6 +21,11 @@ describe('WorkspaceAPI', () => {
   beforeEach(() => {
     invokeMock.mockReset();
     invokeMock.mockResolvedValue('file content');
+    listenMock.mockReset();
+    listenMock.mockImplementation(() => vi.fn());
+    waitForListenerRegistrationsMock.mockReset();
+    waitForListenerRegistrationsMock.mockResolvedValue(undefined);
+    streamCapabilityMock.supported = false;
   });
 
   it('reads text through the registered command with remote routing context', async () => {
@@ -48,5 +60,170 @@ describe('WorkspaceAPI', () => {
         remoteConnectionId: 'remote-connection-1',
       },
     });
+  });
+
+  it('browses a directory through the explicit remote workspace scope', async () => {
+    invokeMock.mockResolvedValueOnce([]);
+
+    await workspaceAPI.getDirectoryChildren('/workspace', 'remote-connection-1');
+
+    expect(invokeMock).toHaveBeenCalledWith('get_directory_children', {
+      request: {
+        path: '/workspace',
+        remoteConnectionId: 'remote-connection-1',
+      },
+    });
+  });
+
+  it('searches filenames through the same explicit remote workspace scope', async () => {
+    invokeMock.mockResolvedValueOnce({ results: [], limit: 30, truncated: false });
+
+    await workspaceAPI.searchFilenamesOnlyDetailed(
+      '/workspace',
+      '手写',
+      false,
+      false,
+      false,
+      undefined,
+      30,
+      true,
+      undefined,
+      'remote-connection-1',
+    );
+
+    expect(invokeMock).toHaveBeenCalledWith('search_filenames', {
+      request: expect.objectContaining({
+        rootPath: '/workspace',
+        pattern: '手写',
+        maxResults: 30,
+        includeDirectories: true,
+        remoteConnectionId: 'remote-connection-1',
+      }),
+    });
+  });
+
+  it('uses response-based filename search when transport events are unavailable', async () => {
+    invokeMock.mockResolvedValueOnce({
+      results: [{
+        path: '/workspace/手写笔画标注项目',
+        name: '手写笔画标注项目',
+        isDirectory: true,
+        matchType: 'fileName',
+      }],
+      limit: 30,
+      truncated: false,
+    });
+    const onProgress = vi.fn();
+
+    await workspaceAPI.searchFilenamesOnlyStreamDetailed(
+      '/workspace',
+      '手写',
+      false,
+      false,
+      false,
+      undefined,
+      30,
+      true,
+      { onProgress },
+      undefined,
+      'remote-connection-1',
+    );
+
+    expect(invokeMock).toHaveBeenCalledWith('search_filenames', {
+      request: expect.objectContaining({
+        remoteConnectionId: 'remote-connection-1',
+      }),
+    });
+    expect(invokeMock).not.toHaveBeenCalledWith(
+      'start_search_filenames_stream',
+      expect.anything(),
+    );
+    expect(onProgress).toHaveBeenCalledWith(expect.objectContaining({
+      results: [expect.objectContaining({ name: '手写笔画标注项目' })],
+    }));
+  });
+
+  it('starts scoped streaming only after transport listeners are registered', async () => {
+    streamCapabilityMock.supported = true;
+    const listeners = new Map<string, (event: any) => void>();
+    listenMock.mockImplementation((event: string, callback: (payload: any) => void) => {
+      listeners.set(event, callback);
+      return vi.fn();
+    });
+    invokeMock.mockImplementationOnce(async (command: string, args: {
+      request: { searchId: string };
+    }) => {
+      expect(command).toBe('start_search_filenames_stream');
+      listeners.get('file-search://progress')?.({
+        searchId: args.request.searchId,
+        searchKind: 'filenames',
+        results: [],
+      });
+      listeners.get('file-search://complete')?.({
+        searchId: args.request.searchId,
+        searchKind: 'filenames',
+        limit: 30,
+        truncated: false,
+        totalResults: 0,
+      });
+      return { searchId: args.request.searchId, limit: 30 };
+    });
+
+    await workspaceAPI.searchFilenamesOnlyStreamDetailed(
+      '/workspace',
+      '手写',
+      false,
+      false,
+      false,
+      undefined,
+      30,
+      true,
+      {},
+      undefined,
+      'remote-connection-1',
+    );
+
+    expect(invokeMock).toHaveBeenCalledWith('start_search_filenames_stream', {
+      request: expect.objectContaining({
+        rootPath: '/workspace',
+        remoteConnectionId: 'remote-connection-1',
+      }),
+    });
+    expect(waitForListenerRegistrationsMock).toHaveBeenCalledOnce();
+  });
+
+  it('does not start an orphaned stream when aborted during listener registration', async () => {
+    streamCapabilityMock.supported = true;
+    let finishListenerRegistration: (() => void) | undefined;
+    waitForListenerRegistrationsMock.mockReturnValueOnce(new Promise<void>(resolve => {
+      finishListenerRegistration = resolve;
+    }));
+    const controller = new AbortController();
+
+    const search = workspaceAPI.searchFilenamesOnlyStreamDetailed(
+      '/workspace',
+      '手写',
+      false,
+      false,
+      false,
+      undefined,
+      30,
+      true,
+      {},
+      controller.signal,
+      'remote-connection-1',
+    );
+    await vi.waitFor(() => {
+      expect(waitForListenerRegistrationsMock).toHaveBeenCalledOnce();
+    });
+
+    controller.abort();
+    finishListenerRegistration?.();
+
+    await expect(search).rejects.toMatchObject({ name: 'AbortError' });
+    await Promise.resolve();
+    expect(invokeMock.mock.calls.some(([command]) => (
+      command === 'start_search_filenames_stream'
+    ))).toBe(false);
   });
 });

--- a/src/web-ui/src/infrastructure/api/service-api/WorkspaceAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/WorkspaceAPI.ts
@@ -357,13 +357,19 @@ export class WorkspaceAPI {
   }
 
    
-  async getDirectoryChildren(path: string): Promise<ExplorerNodeDto[]> {
+  async getDirectoryChildren(
+    path: string,
+    remoteConnectionId?: string,
+  ): Promise<ExplorerNodeDto[]> {
     try {
       return await api.invoke('get_directory_children', { 
-        request: { path } 
+        request: { path, remoteConnectionId }
       });
     } catch (error) {
-      throw createTauriCommandError('get_directory_children', error, { path });
+      throw createTauriCommandError('get_directory_children', error, {
+        path,
+        remoteConnectionId,
+      });
     }
   }
 
@@ -490,7 +496,7 @@ export class WorkspaceAPI {
   }
 
   private supportsSearchStreamEvents(): boolean {
-    return typeof window !== 'undefined' && '__TAURI__' in window;
+    return api.getAdapter().supportsSearchStreamEvents?.() === true;
   }
 
   private async runSearchStream(
@@ -505,6 +511,7 @@ export class WorkspaceAPI {
       wholeWord: boolean;
       maxResults?: number;
       includeDirectories?: boolean;
+      remoteConnectionId?: string;
     },
     callbacks: FileSearchStreamCallbacks = {},
     signal?: AbortSignal
@@ -517,8 +524,6 @@ export class WorkspaceAPI {
       await this.cancelSearch(request.searchId);
       throw new DOMException(`${commandName} aborted`, 'AbortError');
     }
-
-    const { listen } = await import('@tauri-apps/api/event');
 
     return await new Promise<FileSearchCompleteEvent>((resolve, reject) => {
       let settled = false;
@@ -570,8 +575,7 @@ export class WorkspaceAPI {
       }
 
       void (async () => {
-        cleanupCallbacks.push(await listen<FileSearchProgressEvent>(FILE_SEARCH_PROGRESS_EVENT, (tauriEvent) => {
-          const event = tauriEvent.payload;
+        cleanupCallbacks.push(api.listen<FileSearchProgressEvent>(FILE_SEARCH_PROGRESS_EVENT, (event) => {
           if (event.searchId !== request.searchId || event.searchKind !== searchKind) {
             return;
           }
@@ -579,8 +583,7 @@ export class WorkspaceAPI {
           callbacks.onProgress?.(event);
         }));
 
-        cleanupCallbacks.push(await listen<FileSearchCompleteEvent>(FILE_SEARCH_COMPLETE_EVENT, (tauriEvent) => {
-          const event = tauriEvent.payload;
+        cleanupCallbacks.push(api.listen<FileSearchCompleteEvent>(FILE_SEARCH_COMPLETE_EVENT, (event) => {
           if (event.searchId !== request.searchId || event.searchKind !== searchKind) {
             return;
           }
@@ -588,8 +591,7 @@ export class WorkspaceAPI {
           settleResolve(event);
         }));
 
-        cleanupCallbacks.push(await listen<FileSearchErrorEvent>(FILE_SEARCH_ERROR_EVENT, (tauriEvent) => {
-          const event = tauriEvent.payload;
+        cleanupCallbacks.push(api.listen<FileSearchErrorEvent>(FILE_SEARCH_ERROR_EVENT, (event) => {
           if (event.searchId !== request.searchId || event.searchKind !== searchKind) {
             return;
           }
@@ -597,6 +599,10 @@ export class WorkspaceAPI {
           settleReject(new Error(event.error));
         }));
 
+        await api.waitForListenerRegistrations();
+        if (settled || signal?.aborted) {
+          return;
+        }
         await api.invoke<FileSearchStreamStartResponse>(commandName, { request });
       })().catch((error) => {
         settleReject(
@@ -668,7 +674,8 @@ export class WorkspaceAPI {
     searchIdOrSignal?: string | AbortSignal,
     maxResults?: number,
     includeDirectories: boolean = true,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    remoteConnectionId?: string,
   ): Promise<FileSearchResult[]> {
     const response = await this.searchFilenamesOnlyDetailed(
       rootPath,
@@ -679,7 +686,8 @@ export class WorkspaceAPI {
       searchIdOrSignal,
       maxResults,
       includeDirectories,
-      signal
+      signal,
+      remoteConnectionId,
     );
     return response.results;
   }
@@ -693,11 +701,16 @@ export class WorkspaceAPI {
     searchIdOrSignal?: string | AbortSignal,
     maxResults?: number,
     includeDirectories: boolean = true,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    remoteConnectionId?: string,
   ): Promise<FileSearchResponse> {
     const effectiveSignal = searchIdOrSignal instanceof AbortSignal ? searchIdOrSignal : signal;
     const effectiveSearchId =
       typeof searchIdOrSignal === 'string' ? searchIdOrSignal : this.createSearchId('filenames');
+
+    if (effectiveSignal?.aborted) {
+      throw new DOMException('search_filenames aborted', 'AbortError');
+    }
 
     try {
       const resultPromise = api.invoke<FileSearchResponse>('search_filenames', {
@@ -710,6 +723,7 @@ export class WorkspaceAPI {
           wholeWord,
           maxResults,
           includeDirectories,
+          remoteConnectionId,
         }
       });
 
@@ -728,6 +742,7 @@ export class WorkspaceAPI {
         wholeWord,
         maxResults,
         includeDirectories,
+        remoteConnectionId,
       });
     }
   }
@@ -742,7 +757,8 @@ export class WorkspaceAPI {
     maxResults?: number,
     includeDirectories: boolean = true,
     callbacks: FileSearchStreamCallbacks = {},
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    remoteConnectionId?: string,
   ): Promise<FileSearchCompleteEvent> {
     const effectiveSignal = searchIdOrSignal instanceof AbortSignal ? searchIdOrSignal : signal;
     const effectiveSearchId =
@@ -758,7 +774,8 @@ export class WorkspaceAPI {
         effectiveSearchId,
         maxResults,
         includeDirectories,
-        effectiveSignal
+        effectiveSignal,
+        remoteConnectionId,
       );
       const groupedResults = groupSearchResultsByFile(response.results);
       const event: FileSearchCompleteEvent = {
@@ -790,6 +807,7 @@ export class WorkspaceAPI {
         wholeWord,
         maxResults,
         includeDirectories,
+        remoteConnectionId,
       },
       callbacks,
       effectiveSignal

--- a/src/web-ui/src/infrastructure/api/service-api/tauri-commands.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/tauri-commands.ts
@@ -155,6 +155,7 @@ export interface SearchFilesRequest {
 export interface SearchFilenamesRequest {
   rootPath: string;
   pattern: string;
+  remoteConnectionId?: string;
   searchId?: string;
   caseSensitive?: boolean;
   useRegex?: boolean;

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -889,6 +889,8 @@
   "fileMention": {
     "searchResults": "Search Results",
     "loading": "Loading...",
+    "browseUnavailable": "Workspace files are unavailable. Check the connection and try again.",
+    "searchUnavailable": "Workspace search is unavailable. Check the connection and try again.",
     "noMatchingFiles": "No matching files found",
     "emptyDirectory": "Empty directory",
     "rootDirectory": "Root",

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -889,6 +889,8 @@
   "fileMention": {
     "searchResults": "搜索结果",
     "loading": "加载中...",
+    "browseUnavailable": "无法加载工作区文件，请检查连接后重试。",
+    "searchUnavailable": "无法搜索工作区，请检查连接后重试。",
     "noMatchingFiles": "没有找到匹配的文件",
     "emptyDirectory": "空目录",
     "rootDirectory": "根目录",

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -889,6 +889,8 @@
   "fileMention": {
     "searchResults": "搜尋結果",
     "loading": "載入中...",
+    "browseUnavailable": "無法載入工作區檔案，請檢查連線後重試。",
+    "searchUnavailable": "無法搜尋工作區，請檢查連線後重試。",
     "noMatchingFiles": "沒有找到匹配的檔案",
     "emptyDirectory": "空目錄",
     "rootDirectory": "根目錄",


### PR DESCRIPTION
## Summary

- scope chat `@` browse and filename-search requests by the session remote connection id plus POSIX workspace path, with exact routing and fail-closed behavior instead of mutable active-workspace or local-filesystem fallback
- move reusable recursive SSH filename traversal into the remote service layer and stream cancellable matches as they are discovered, so early remote results render before a high-latency walk finishes
- keep transport behavior explicit: Tauri uses progress events, Peer Device stays on the peer response path until search events are negotiated, and cancellation during listener setup cannot leave orphaned searches
- separate browse/search loading and error states, preserve partial results, and add localized unavailable states instead of presenting transport failures as empty results

## Verification

- `pnpm --dir src/web-ui exec vitest run src/flow_chat/components/FileMentionPickerOverlay.test.tsx src/infrastructure/api/service-api/WorkspaceAPI.test.ts src/infrastructure/api/adapters/peer-device-adapter.test.ts src/flow_chat/utils/workspaceScope.test.ts` (34 passed)
- `pnpm run type-check:web`
- `pnpm run i18n:audit`
- targeted frontend ESLint (0 errors; test files are ignored by repository config)
- `cargo check -p bitfun-services-integrations --no-default-features`
- `cargo test -p bitfun-services-integrations --no-default-features --features remote-ssh --test remote_ssh_contracts` (12 passed)
- focused remote filename-search and exact-scope service tests
- `cargo check -p bitfun-desktop`
- `cargo test -p bitfun-desktop` (311 passed, 4 ignored)
- `pnpm run check:core-boundaries`
- `pnpm run check:repo-hygiene`

## Remote scenarios

- Remote workspace: covered by exact `(connection id, POSIX path)` routing contracts, remote traversal tests, frontend progressive-result tests, and desktop checks. No live SSH host was available for manual UI exercise.
- Peer Device Mode: covered by adapter tests proving filename search remains peer-proxied and uses the response fallback when progress events are unavailable. No live two-device exercise was performed.
- Remote control and Detached Dispatch: no behavior or protocol was changed; not exercised for this UI-specific fix.
