### PR TITLE
fix(peer): reattach blocking interactions across device switches

### DIFF
--- a/docs/architecture/peer-device-mode.md
+++ b/docs/architecture/peer-device-mode.md
@@ -78,6 +78,30 @@ rendered, snapshot reconciliation is no longer Peer-only: after this window's
 first surface switch, `isSurfaceReconcileEnabled()` keeps the repair loop
 running for whichever surface is rendered, local included.
 
+### Blocking-interaction reattachment
+
+A push event is a notification, not the owner of an interaction that can block
+an Agent turn. The owning Runtime keeps every native `AskUserQuestion` and
+interactive permission request in a live mailbox until it is answered or
+cancelled; an `AskUserQuestion` registration is also removed if its owning Tool
+future is dropped. `restore_session_view` returns an additive
+`interactionSnapshot` containing the Session-filtered mailbox and monotonic
+revisions. Desktop and CLI Peer Hosts expose the same field; older Hosts may
+omit it and remain on the event-only compatibility path.
+
+The frontend projects that mailbox into the active Surface container. Permission
+requests are retained for inactive Surfaces by source device, while missed
+`AskUserQuestion` cards are reconstructed in their exact Dialog Turn and model
+round. Snapshot responses are fenced by the Surface epoch and by event/revision
+ordering, so an old response cannot erase a newer request or revive one that was
+already answered. Reattachment only repairs presentation state: it never
+restarts, cancels, or moves the Session, Dialog Turn, or Tool future.
+
+This is the contract for any new blocking interaction: its execution owner must
+retain replayable request state and expose it through an attach/snapshot path.
+A one-shot frontend event plus an unresolved channel is not a complete
+multi-device implementation.
+
 ## Cloud account sync vs Peer Remote
 
 | Concern | Account cloud sync | Peer Device Mode |
@@ -172,6 +196,9 @@ FS) and must not be mixed with Peer Device Mode.
   per 2s coalescing window. A controller accepts an active snapshot before the
   stale-stream deadline only when its rounds, streams, and tools provably move
   forward; an older persisted snapshot cannot overwrite newer DeviceEvents.
+  Native blocking interactions are reconciled from the Runtime-owned
+  `interactionSnapshot` independently of Turn checkpoints, because a Turn can
+  wait indefinitely and never produce a newer persisted snapshot on its own.
 - CLI Peer Host forwards only turns submitted through Peer Host and linked
   child turns. A background-result follow-up inherits ownership only when its
   Core-internal metadata identifies the exact tracked parent and source child

--- a/src/apps/cli/src/peer_host/commands/session.rs
+++ b/src/apps/cli/src/peer_host/commands/session.rs
@@ -8,6 +8,7 @@ use serde_json::{json, Value};
 use bitfun_agent_runtime::sdk::{
     AgentSessionModelSelection, AgentSessionModelSelectionUpdateRequest,
     AgentSessionRestoreRequest, AgentSessionRestoreResult, PortErrorKind, RuntimeError,
+    SessionInteractionSnapshot,
 };
 use bitfun_core::agentic::core::Session;
 use bitfun_core::agentic::get_agent_registry;
@@ -20,7 +21,7 @@ use bitfun_runtime_ports::{
 
 use crate::diagnostics::{OUTCOME_UNKNOWN_ERROR_CODE, SESSION_IN_USE_ERROR_CODE};
 use crate::peer_host::args::{get_string, optional_bool, optional_string, request_value};
-use crate::peer_host::state::PeerHostState;
+use crate::peer_host::state::{PeerHostState, PeerTurnTracker};
 
 use super::snapshot::{local_snapshot_session_stats, require_local_snapshot_workspace};
 
@@ -71,6 +72,22 @@ fn validated_session_id(request: &Value) -> Result<String, String> {
     let session_id = get_string(request, "sessionId")?;
     bitfun_agent_runtime::session_control::validate_session_id(&session_id)?;
     Ok(session_id)
+}
+
+fn retain_peer_owned_interactions(
+    turns: &PeerTurnTracker,
+    snapshot: &mut SessionInteractionSnapshot,
+) {
+    snapshot.user_questions.questions.retain(|question| {
+        question
+            .dialog_turn_id
+            .as_deref()
+            .is_some_and(|turn_id| turns.owns(&question.session_id, Some(turn_id)))
+    });
+    snapshot
+        .permissions
+        .requests
+        .retain(|request| turns.owns_permission_request(request));
 }
 
 fn system_time_to_unix_secs(time: SystemTime) -> u64 {
@@ -267,12 +284,21 @@ pub(crate) async fn restore_session_view(
         .loaded_session_snapshot(&session_id)
         .map_err(|e| format!("Failed to read live session state: {e}"))?;
     overlay_live_session_state(&mut session, live_session);
+    let mut interaction_snapshot = state
+        .agent_runtime
+        .session_interaction_snapshot(&session_id);
+    // A CLI Peer controller may only resume interactions owned by turns it
+    // submitted (or their tracked descendants). Keep snapshot recovery inside
+    // the same boundary as permission event fan-out/listing; otherwise a
+    // controller could answer a same-session turn started by another surface.
+    retain_peer_owned_interactions(&state.turns, &mut interaction_snapshot);
 
     let loaded_turn_count = turns.len();
     let is_partial = loaded_turn_count < total_turn_count;
     Ok(json!({
         "session": session_to_json(session, total_turn_count),
         "turns": turns,
+        "interactionSnapshot": interaction_snapshot,
         "turnCatalog": turn_catalog,
         "contextRestoreState": "pending",
         "isPartial": is_partial,
@@ -706,11 +732,13 @@ pub(crate) async fn save_session_turn(
 mod tests {
     use super::{
         overlay_live_session_state, peer_core_session_error, peer_runtime_session_error,
-        restored_session_to_json, session_stats_validation_error,
+        restored_session_to_json, retain_peer_owned_interactions, session_stats_validation_error,
     };
+    use crate::peer_host::state::{PeerTurnKey, PeerTurnTracker};
     use bitfun_agent_runtime::sdk::{
-        AgentSessionRestoreResult, AgentSessionSummary, PortError, PortErrorKind, RuntimeError,
-        SessionState,
+        AgentSessionRestoreResult, AgentSessionSummary, PendingUserQuestion,
+        PendingUserQuestionSnapshot, PortError, PortErrorKind, RuntimeError,
+        SessionInteractionSnapshot, SessionState,
     };
     use bitfun_core::agentic::core::{
         ProcessingPhase, Session as CoreSession, SessionConfig, SessionState as CoreSessionState,
@@ -867,5 +895,48 @@ mod tests {
                 ..
             } if current_turn_id == "turn_1"
         ));
+    }
+
+    #[test]
+    fn view_restore_exposes_only_peer_owned_user_questions() {
+        let tracker = PeerTurnTracker::new();
+        tracker.mark_event_stream_ready();
+        let owned_turn = PeerTurnKey::new("session-1", "peer-turn");
+        tracker
+            .register_root(owned_turn)
+            .expect("register Peer-owned turn");
+        let question = |tool_id: &str, turn_id: Option<&str>| {
+            PendingUserQuestion::new(
+                tool_id,
+                "session-1",
+                turn_id.map(str::to_string),
+                Some("round-1".to_string()),
+                serde_json::json!({"questions": []}),
+            )
+        };
+        let mut snapshot = SessionInteractionSnapshot {
+            session_id: "session-1".to_string(),
+            user_questions: PendingUserQuestionSnapshot {
+                revision: 3,
+                questions: vec![
+                    question("owned", Some("peer-turn")),
+                    question("local", Some("local-turn")),
+                    question("unscoped", None),
+                ],
+            },
+            permissions: Default::default(),
+        };
+
+        retain_peer_owned_interactions(&tracker, &mut snapshot);
+
+        assert_eq!(
+            snapshot
+                .user_questions
+                .questions
+                .iter()
+                .map(|question| question.tool_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["owned"]
+        );
     }
 }

--- a/src/apps/desktop/src/api/agentic_api.rs
+++ b/src/apps/desktop/src/api/agentic_api.rs
@@ -22,7 +22,7 @@ use bitfun_agent_runtime::sdk::{
     AgentSessionModelSelectionUpdateRequest, AgentSessionModelUpdateRequest, AgentSubmissionSource,
     AgentTurnCancellationRequest, AgentTurnInterruptionRequest, DialogSteerOutcome,
     PermissionAuditRecord, PermissionGrant, PermissionGrantKey, PermissionReply, PermissionRequest,
-    RuntimeError,
+    RuntimeError, SessionInteractionSnapshot,
 };
 use bitfun_core::agentic::agents::AgentSource;
 use bitfun_core::agentic::coordination::{
@@ -552,6 +552,7 @@ pub struct RestoreSessionWithTurnsResponse {
 pub struct RestoreSessionViewResponse {
     pub session: SessionResponse,
     pub turns: Vec<DialogTurnData>,
+    pub interaction_snapshot: SessionInteractionSnapshot,
     pub current_context_usage: Option<SessionContextUsage>,
     pub turn_catalog: SessionTurnCatalog,
     pub context_restore_state: String,
@@ -3436,6 +3437,7 @@ pub async fn restore_session_view(
             .map_err(|error| format!("Failed to restore session view: {error}"))?;
         let session = restored.session;
         let mut turns = restored.turns;
+        let interaction_snapshot = restored.interaction_snapshot;
         let current_context_usage = restored.current_context_usage;
         let total_turn_count = restored.total_turn_count;
         let turn_catalog = restored.turn_catalog;
@@ -3489,6 +3491,7 @@ pub async fn restore_session_view(
         Ok(RestoreSessionViewResponse {
             session: session_to_response_with_turn_count(session, total_turn_count),
             turns,
+            interaction_snapshot,
             current_context_usage,
             turn_catalog,
             context_restore_state: "pending".to_string(),

--- a/src/apps/desktop/src/runtime/session_application.rs
+++ b/src/apps/desktop/src/runtime/session_application.rs
@@ -13,7 +13,7 @@ use bitfun_agent_runtime::sdk::{
     AgentLocalCommandTurnRecordRequest, AgentRuntime, AgentSessionArchiveStateRequest,
     AgentSessionDeleteRequest, AgentSessionForkAtTurnRequest, AgentSessionLineageRequest,
     AgentSessionLineageSnapshot, AgentSessionRenameRequest, AgentSessionUsageRequest,
-    PortErrorKind, RuntimeError,
+    PortErrorKind, RuntimeError, SessionInteractionSnapshot,
 };
 use bitfun_core::agentic::coordination::{ConversationCoordinator, DialogScheduler};
 use bitfun_core::agentic::core::Session;
@@ -125,6 +125,7 @@ fn local_command_turn_record_request(
 pub(crate) struct DesktopSessionViewRestore {
     pub session: Session,
     pub turns: Vec<DialogTurnData>,
+    pub interaction_snapshot: SessionInteractionSnapshot,
     pub current_context_usage: Option<SessionContextUsage>,
     pub total_turn_count: usize,
     pub turn_catalog: SessionTurnCatalog,
@@ -787,6 +788,7 @@ impl DesktopSessionApplication {
             .loaded_session_snapshot(session_id)
             .map_err(|error| DesktopSessionApplicationError::Core(error.to_string()))?;
         overlay_live_session_state(&mut session, live_session);
+        let interaction_snapshot = self.agent_runtime.session_interaction_snapshot(session_id);
         let current_context_usage = self
             .compatibility
             .load_persisted_session_metadata(&storage_path, session_id)
@@ -797,6 +799,7 @@ impl DesktopSessionApplication {
         Ok(DesktopSessionViewRestore {
             session,
             turns,
+            interaction_snapshot,
             current_context_usage,
             total_turn_count,
             turn_catalog,

--- a/src/crates/assembly/core/src/agentic/tools/implementations/ask_user_question_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/ask_user_question_tool.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use bitfun_agent_runtime::user_questions::{
     ask_user_question_available_in_context, build_answered_user_question_result,
     build_cancelled_user_question_result, validate_ask_user_question_input, AskUserQuestionInput,
-    USER_INPUT_AVAILABLE_CONTEXT_KEY,
+    PendingUserQuestion, USER_INPUT_AVAILABLE_CONTEXT_KEY, USER_INPUT_MODEL_ROUND_CONTEXT_KEY,
 };
 use log::{debug, warn};
 use serde_json::{json, Value};
@@ -206,25 +206,43 @@ Usage notes:
         // 3. Generate tool ID
         let tool_id = Self::generate_tool_id(context);
 
-        // 4. Create oneshot channel
-        let (tx, rx) = tokio::sync::oneshot::channel();
-
-        // 5. Register to global manager
-        let manager = get_user_input_manager();
-        manager.register_channel(tool_id.clone(), tx);
-
-        // 6. Send backend event to notify frontend to display question card
-        let event_system = get_global_event_system();
         let session_id = context
             .session_id
             .clone()
             .unwrap_or_else(|| "unknown".to_string());
+        let model_round_id = context
+            .custom_data
+            .get(USER_INPUT_MODEL_ROUND_CONTEXT_KEY)
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        let questions = serde_json::to_value(&tool_input).unwrap_or_else(|_| json!({}));
+
+        // 4. Create oneshot channel
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        // 5. Register the channel together with the replayable request before
+        // emitting. The guard removes it if cancellation drops this Tool
+        // future, so later Surface snapshots cannot revive stale questions.
+        let manager = get_user_input_manager();
+        let _registration = manager.register_question(
+            PendingUserQuestion::new(
+                tool_id.clone(),
+                session_id.clone(),
+                context.dialog_turn_id.clone(),
+                model_round_id,
+                questions.clone(),
+            ),
+            tx,
+        );
+
+        // 6. Send backend event to notify frontend to display question card
+        let event_system = get_global_event_system();
 
         // Send complete questions array to frontend
         let event = BackendEvent::ToolAwaitingUserInput {
             tool_id: tool_id.clone(),
             session_id,
-            questions: serde_json::to_value(&tool_input).unwrap_or_else(|_| json!({})),
+            questions,
         };
 
         let _ = event_system.emit(event).await;
@@ -265,6 +283,8 @@ Usage notes:
 mod tests {
     use super::AskUserQuestionTool;
     use crate::agentic::tools::framework::{Tool, ToolUseContext};
+    use crate::agentic::tools::user_input_manager::get_user_input_manager;
+    use bitfun_agent_runtime::user_questions::USER_INPUT_MODEL_ROUND_CONTEXT_KEY;
     use std::collections::HashMap;
 
     fn context_with_custom_data(custom_data: HashMap<String, serde_json::Value>) -> ToolUseContext {
@@ -358,5 +378,83 @@ mod tests {
             .expect("required array")
             .iter()
             .any(|value| value == "multiSelect"));
+    }
+
+    #[tokio::test]
+    async fn pending_question_remains_replayable_until_the_tool_receives_an_answer() {
+        let tool = AskUserQuestionTool::new();
+        let unique = uuid::Uuid::new_v4().to_string();
+        let session_id = format!("session-{unique}");
+        let turn_id = format!("turn-{unique}");
+        let round_id = format!("round-{unique}");
+        let tool_id = format!("tool-{unique}");
+        let mut context = context_with_custom_data(HashMap::from([(
+            USER_INPUT_MODEL_ROUND_CONTEXT_KEY.to_string(),
+            serde_json::json!(round_id),
+        )]));
+        context.session_id = Some(session_id.clone());
+        context.dialog_turn_id = Some(turn_id.clone());
+        context.tool_call_id = Some(tool_id.clone());
+        let input = serde_json::json!({
+            "questions": [{
+                "question": "Continue?",
+                "header": "Continue",
+                "options": [
+                    { "label": "Yes", "description": "Continue" },
+                    { "label": "No", "description": "Stop" }
+                ]
+            }]
+        });
+
+        let call = tool.call(&input, &context);
+        tokio::pin!(call);
+        let mailbox_registration = async {
+            loop {
+                let snapshot = get_user_input_manager().pending_question_snapshot(&session_id);
+                if let Some(question) = snapshot.questions.first() {
+                    assert_eq!(question.tool_id, tool_id);
+                    assert_eq!(question.dialog_turn_id.as_deref(), Some(turn_id.as_str()));
+                    assert_eq!(question.model_round_id.as_deref(), Some(round_id.as_str()));
+                    assert_eq!(
+                        question.questions,
+                        serde_json::json!({
+                            "questions": [{
+                                "question": "Continue?",
+                                "header": "Continue",
+                                "options": [
+                                    { "label": "Yes", "description": "Continue" },
+                                    { "label": "No", "description": "Stop" }
+                                ],
+                                "multiSelect": false
+                            }]
+                        })
+                    );
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        };
+        tokio::pin!(mailbox_registration);
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            tokio::select! {
+                _ = &mut call => panic!("question Tool completed before receiving an answer"),
+                _ = &mut mailbox_registration => {}
+            }
+        })
+        .await
+        .expect("question should enter the Runtime mailbox");
+
+        get_user_input_manager()
+            .send_answer(&tool_id, serde_json::json!({ "0": "Yes" }))
+            .expect("answer should reach the waiting Tool");
+        tokio::time::timeout(std::time::Duration::from_secs(1), &mut call)
+            .await
+            .expect("answered Tool should resume")
+            .expect("answered Tool should succeed");
+
+        assert!(get_user_input_manager()
+            .pending_question_snapshot(&session_id)
+            .questions
+            .is_empty());
     }
 }

--- a/src/crates/assembly/core/src/agentic/tools/tool_context_runtime.rs
+++ b/src/crates/assembly/core/src/agentic/tools/tool_context_runtime.rs
@@ -39,7 +39,9 @@ use bitfun_agent_runtime::checkpoint::{
 };
 use bitfun_agent_runtime::permission::AUTO_APPROVE_ASK_CONTEXT_KEY;
 use bitfun_agent_runtime::remote_file_delivery::TOOL_CONTEXT_REMOTE_FILE_DELIVERY_KEY;
-use bitfun_agent_runtime::user_questions::USER_INPUT_AVAILABLE_CONTEXT_KEY;
+use bitfun_agent_runtime::user_questions::{
+    USER_INPUT_AVAILABLE_CONTEXT_KEY, USER_INPUT_MODEL_ROUND_CONTEXT_KEY,
+};
 use bitfun_agent_tools::{
     LoadedDeferredToolSpec, PortableToolContextProvider, ToolContextFacts, ToolWorkspaceKind,
 };
@@ -325,6 +327,13 @@ fn core_tool_runtime_handles(
 
 fn build_tool_context_custom_data(context: &ToolExecutionContext) -> HashMap<String, Value> {
     let mut extension_custom_data = HashMap::new();
+    // Blocking interactions retain their exact Runtime owner so a Surface
+    // re-attaching after an event gap can reconstruct the request in the
+    // correct model round.
+    extension_custom_data.insert(
+        USER_INPUT_MODEL_ROUND_CONTEXT_KEY.to_string(),
+        Value::String(context.round_id.clone()),
+    );
     let deep_review_parent = context.subagent_parent_info.as_ref().map(|parent_info| {
         tool_context::DeepReviewToolParentContext {
             tool_call_id: parent_info.tool_call_id.as_str(),
@@ -1451,7 +1460,9 @@ mod task_context_tests {
     };
     use crate::agentic::tools::ToolRuntimeRestrictions;
     use bitfun_agent_runtime::permission::AUTO_APPROVE_ASK_CONTEXT_KEY;
-    use bitfun_agent_runtime::user_questions::USER_INPUT_AVAILABLE_CONTEXT_KEY;
+    use bitfun_agent_runtime::user_questions::{
+        USER_INPUT_AVAILABLE_CONTEXT_KEY, USER_INPUT_MODEL_ROUND_CONTEXT_KEY,
+    };
     use bitfun_agent_tools::LoadedDeferredToolSpec;
     use bitfun_runtime_ports::DelegationPolicy;
     use serde_json::json;
@@ -1570,6 +1581,10 @@ mod task_context_tests {
             .custom_data
             .contains_key("primary_model_supports_image_understanding"));
         assert_eq!(context.custom_data["acp_transport"], json!(true));
+        assert_eq!(
+            context.custom_data[USER_INPUT_MODEL_ROUND_CONTEXT_KEY],
+            json!("round_1")
+        );
         assert_eq!(
             context.custom_data[USER_INPUT_AVAILABLE_CONTEXT_KEY],
             json!(false)

--- a/src/crates/execution/agent-runtime/src/permission.rs
+++ b/src/crates/execution/agent-runtime/src/permission.rs
@@ -11,7 +11,7 @@ use bitfun_runtime_ports::{
 use dashmap::DashMap;
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, RwLock as StdRwLock};
 use tokio::sync::{broadcast, oneshot, Mutex};
 
 const PERMISSION_EVENT_CAPACITY: usize = 128;
@@ -173,6 +173,16 @@ pub struct PendingPermissionReceiver {
     receiver: oneshot::Receiver<PermissionWaitOutcome>,
 }
 
+/// Monotonic snapshot used by reconnecting product surfaces to reconcile
+/// permission requests even when the low-latency event stream had a gap.
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PermissionRequestSnapshot {
+    pub revision: u64,
+    #[serde(default)]
+    pub requests: Vec<PermissionRequest>,
+}
+
 impl PendingPermissionReceiver {
     pub fn request_id(&self) -> &str {
         &self.request_id
@@ -222,6 +232,8 @@ struct PendingPermission {
 pub struct PermissionRequestManager {
     pending: Arc<DashMap<String, PendingPermission>>,
     next_registration_sequence: Arc<AtomicU64>,
+    snapshot_revision: Arc<AtomicU64>,
+    snapshot_barrier: Arc<StdRwLock<()>>,
     operations: Arc<Mutex<()>>,
     audit_store: Arc<dyn PermissionAuditStorePort>,
     reply_store: Arc<dyn PermissionReplyStorePort>,
@@ -248,6 +260,8 @@ impl PermissionRequestManager {
         Self {
             pending: Arc::new(DashMap::new()),
             next_registration_sequence: Arc::new(AtomicU64::new(0)),
+            snapshot_revision: Arc::new(AtomicU64::new(0)),
+            snapshot_barrier: Arc::new(StdRwLock::new(())),
             operations: Arc::new(Mutex::new(())),
             audit_store,
             reply_store,
@@ -402,25 +416,32 @@ impl PermissionRequestManager {
 
         let timestamp_ms = self.clock.now_unix_millis();
         let mut receivers = Vec::with_capacity(requests.len());
-        for request in &requests {
-            let (sender, receiver) = oneshot::channel();
-            let registration_sequence = self
-                .next_registration_sequence
-                .fetch_add(1, Ordering::Relaxed);
-            self.pending.insert(
-                request.request_id.clone(),
-                PendingPermission {
-                    request: request.clone(),
-                    dialog_turn_id: dialog_turn_id.clone(),
-                    sender,
-                    interactive,
-                    registration_sequence,
-                },
-            );
-            receivers.push(PendingPermissionReceiver {
-                request_id: request.request_id.clone(),
-                receiver,
-            });
+        {
+            let _snapshot_write = self
+                .snapshot_barrier
+                .write()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            for request in &requests {
+                let (sender, receiver) = oneshot::channel();
+                let registration_sequence = self
+                    .next_registration_sequence
+                    .fetch_add(1, Ordering::Relaxed);
+                self.pending.insert(
+                    request.request_id.clone(),
+                    PendingPermission {
+                        request: request.clone(),
+                        dialog_turn_id: dialog_turn_id.clone(),
+                        sender,
+                        interactive,
+                        registration_sequence,
+                    },
+                );
+                receivers.push(PendingPermissionReceiver {
+                    request_id: request.request_id.clone(),
+                    receiver,
+                });
+            }
+            self.snapshot_revision.fetch_add(1, Ordering::Release);
         }
 
         for request in &requests {
@@ -434,8 +455,16 @@ impl PermissionRequestManager {
                 })
                 .await
             {
+                let _snapshot_write = self
+                    .snapshot_barrier
+                    .write()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                let mut removed = false;
                 for request in &requests {
-                    self.pending.remove(&request.request_id);
+                    removed |= self.pending.remove(&request.request_id).is_some();
+                }
+                if removed {
+                    self.snapshot_revision.fetch_add(1, Ordering::Release);
                 }
                 return Err(PermissionRequestManagerError::AuditStore(error));
             }
@@ -456,6 +485,17 @@ impl PermissionRequestManager {
 
     pub fn interactive_pending_requests(&self) -> Vec<PermissionRequest> {
         self.ordered_pending_requests(|pending| pending.interactive)
+    }
+
+    pub fn interactive_pending_snapshot(&self) -> PermissionRequestSnapshot {
+        let _snapshot_read = self
+            .snapshot_barrier
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        PermissionRequestSnapshot {
+            revision: self.snapshot_revision.load(Ordering::Acquire),
+            requests: self.ordered_pending_requests(|pending| pending.interactive),
+        }
     }
 
     /// Returns the process-local owning Dialog Turn for exact event routing.
@@ -576,18 +616,29 @@ impl PermissionRequestManager {
             .iter()
             .map(|(pending_request, _)| pending_request.request_id.clone())
             .collect::<Vec<_>>();
-        for (pending_request, pending_reply) in resolutions {
-            if let Some((_, pending)) = self.pending.remove(&pending_request.request_id) {
-                let _ = pending
-                    .sender
-                    .send(PermissionWaitOutcome::Replied(pending_reply.clone()));
-                if pending.interactive {
-                    let _ = self.events.send(PermissionRequestEvent::Replied {
-                        request_id: pending_request.request_id,
-                        reply: pending_reply,
-                        source,
-                    });
+        {
+            let _snapshot_write = self
+                .snapshot_barrier
+                .write()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let mut removed = false;
+            for (pending_request, pending_reply) in resolutions {
+                if let Some((_, pending)) = self.pending.remove(&pending_request.request_id) {
+                    removed = true;
+                    let _ = pending
+                        .sender
+                        .send(PermissionWaitOutcome::Replied(pending_reply.clone()));
+                    if pending.interactive {
+                        let _ = self.events.send(PermissionRequestEvent::Replied {
+                            request_id: pending_request.request_id,
+                            reply: pending_reply,
+                            source,
+                        });
+                    }
                 }
+            }
+            if removed {
+                self.snapshot_revision.fetch_add(1, Ordering::Release);
             }
         }
 
@@ -652,17 +703,28 @@ impl PermissionRequestManager {
                 .map_err(PermissionRequestManagerError::AuditStore)?;
         }
 
-        for request in requests {
-            if let Some((_, pending)) = self.pending.remove(&request.request_id) {
-                let _ = pending.sender.send(PermissionWaitOutcome::Cancelled {
-                    reason: reason.clone(),
-                });
-                if pending.interactive {
-                    let _ = self.events.send(PermissionRequestEvent::Cancelled {
-                        request_id: request.request_id,
+        {
+            let _snapshot_write = self
+                .snapshot_barrier
+                .write()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let mut removed = false;
+            for request in requests {
+                if let Some((_, pending)) = self.pending.remove(&request.request_id) {
+                    removed = true;
+                    let _ = pending.sender.send(PermissionWaitOutcome::Cancelled {
                         reason: reason.clone(),
                     });
+                    if pending.interactive {
+                        let _ = self.events.send(PermissionRequestEvent::Cancelled {
+                            request_id: request.request_id,
+                            reason: reason.clone(),
+                        });
+                    }
                 }
+            }
+            if removed {
+                self.snapshot_revision.fetch_add(1, Ordering::Release);
             }
         }
         Ok(())
@@ -800,6 +862,9 @@ mod tests {
             PermissionRequestEvent::Asked { request: request() }
         );
         assert_eq!(manager.pending_requests(), vec![request()]);
+        let asked_snapshot = manager.interactive_pending_snapshot();
+        assert_eq!(asked_snapshot.requests, vec![request()]);
+        assert!(asked_snapshot.revision > 0);
 
         manager
             .reply(
@@ -822,6 +887,9 @@ mod tests {
             PermissionWaitOutcome::Replied(PermissionReply::Once)
         );
         assert!(manager.pending_requests().is_empty());
+        let replied_snapshot = manager.interactive_pending_snapshot();
+        assert!(replied_snapshot.requests.is_empty());
+        assert!(replied_snapshot.revision > asked_snapshot.revision);
 
         let cancelled = manager
             .register(PermissionRequest {

--- a/src/crates/execution/agent-runtime/src/runtime.rs
+++ b/src/crates/execution/agent-runtime/src/runtime.rs
@@ -44,8 +44,11 @@ use bitfun_runtime_ports::{
 use bitfun_runtime_services::RuntimeServices;
 
 use crate::event_source::{AgentEventReceiver, AgentEventSource, AgentSessionEventReceiver};
-use crate::permission::{PermissionRequestEventReceiver, PermissionRequestManager};
+use crate::permission::{
+    PermissionRequestEventReceiver, PermissionRequestManager, PermissionRequestSnapshot,
+};
 use crate::post_call_hooks::RuntimeHookRegistry;
+use crate::user_questions::{get_user_input_manager, PendingUserQuestionSnapshot};
 use bitfun_runtime_ports::{PermissionReply, PermissionReplySource, PermissionRequest};
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -122,6 +125,18 @@ pub struct AgentSessionRestoreRequest {
 pub struct AgentSessionRestoreResult {
     pub session: AgentSessionSummary,
     pub state: crate::session_state::SessionState,
+}
+
+/// Authoritative live interactions required to re-attach a product Surface to
+/// a running Session after missing push events.
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionInteractionSnapshot {
+    pub session_id: String,
+    #[serde(default)]
+    pub user_questions: PendingUserQuestionSnapshot,
+    #[serde(default)]
+    pub permissions: PermissionRequestSnapshot,
 }
 
 #[async_trait::async_trait]
@@ -815,6 +830,32 @@ impl AgentRuntime {
             .as_ref()
             .map(|manager| manager.interactive_pending_requests())
             .ok_or(RuntimeError::MissingPermissionRequestManager)
+    }
+
+    /// Capture every blocking interaction needed to resume rendering one
+    /// Session. Push events remain the low-latency path; this snapshot is the
+    /// gap-recovery contract for reconnecting or device-switching surfaces.
+    pub fn session_interaction_snapshot(&self, session_id: &str) -> SessionInteractionSnapshot {
+        let user_questions = get_user_input_manager().pending_question_snapshot(session_id);
+        let permissions =
+            self.permission_requests
+                .as_ref()
+                .map(|manager| {
+                    let mut snapshot = manager.interactive_pending_snapshot();
+                    snapshot.requests.retain(|request| {
+                        request.session_id == session_id
+                            || request.delegation.as_ref().is_some_and(|delegation| {
+                                delegation.parent_session_id == session_id
+                            })
+                    });
+                    snapshot
+                })
+                .unwrap_or_default();
+        SessionInteractionSnapshot {
+            session_id: session_id.to_string(),
+            user_questions,
+            permissions,
+        }
     }
 
     pub fn permission_request_dialog_turn_id(
@@ -1750,6 +1791,33 @@ mod tests {
         ThreadGoal, ThreadGoalStatus, TranscriptContent, TranscriptMessage, WorkspacePort,
     };
     use bitfun_runtime_services::RuntimeServicesBuilder;
+
+    #[test]
+    fn session_interaction_snapshot_wire_is_additive_and_camel_case() {
+        let legacy: SessionInteractionSnapshot = serde_json::from_value(serde_json::json!({
+            "sessionId": "session-1"
+        }))
+        .expect("older payloads may omit additive mailbox fields");
+        assert!(legacy.user_questions.questions.is_empty());
+        assert!(legacy.permissions.requests.is_empty());
+
+        let encoded = serde_json::to_value(SessionInteractionSnapshot {
+            session_id: "session-1".to_string(),
+            user_questions: PendingUserQuestionSnapshot {
+                revision: 4,
+                questions: Vec::new(),
+            },
+            permissions: PermissionRequestSnapshot {
+                revision: 7,
+                requests: Vec::new(),
+            },
+        })
+        .expect("interaction snapshot should serialize");
+        assert_eq!(encoded["sessionId"], "session-1");
+        assert_eq!(encoded["userQuestions"]["revision"], 4);
+        assert_eq!(encoded["permissions"]["revision"], 7);
+        assert!(encoded.get("user_questions").is_none());
+    }
 
     #[derive(Debug)]
     struct TestRuntimePort {

--- a/src/crates/execution/agent-runtime/src/sdk.rs
+++ b/src/crates/execution/agent-runtime/src/sdk.rs
@@ -38,7 +38,7 @@ pub use crate::context_profile::{ContextProfile, ContextProfilePolicy, ModelCapa
 pub use crate::event_source::{AgentEventReceiver, AgentEventSource, AgentSessionEventReceiver};
 pub use crate::permission::{
     PermissionReplyResolution, PermissionRequestEventReceiver, PermissionRequestManager,
-    PermissionRequestManagerError, AUTO_APPROVE_ASK_CONTEXT_KEY,
+    PermissionRequestManagerError, PermissionRequestSnapshot, AUTO_APPROVE_ASK_CONTEXT_KEY,
 };
 pub use crate::post_call_hooks::{
     RuntimeHookErrorPolicy, RuntimeHookKind, RuntimeHookPlan, RuntimeHookRegistry,
@@ -48,9 +48,10 @@ pub use crate::runtime::{
     AgentEventStream, AgentRunHandle, AgentRunRequest, AgentSessionRestorePort,
     AgentSessionRestoreRequest, AgentSessionRestoreResult, RuntimeAgentRegistry,
     RuntimeAgentRegistryQuery, RuntimeBuildError, RuntimeError, RuntimeToolRegistry,
-    SessionSelector,
+    SessionInteractionSnapshot, SessionSelector,
 };
 pub use crate::session_state::{session_state_label_for_state, ProcessingPhase, SessionState};
+pub use crate::user_questions::{PendingUserQuestion, PendingUserQuestionSnapshot};
 pub use bitfun_agent_tools::{ToolRegistry, ToolRegistryItem};
 pub use bitfun_core_types::SessionUsageReport;
 // Event envelope types re-exported so protocol surfaces (e.g. `bitfun-app-server`)
@@ -742,6 +743,10 @@ impl AgentRuntime {
         request: AgentUserAnswersRequest,
     ) -> Result<(), RuntimeError> {
         self.inner.submit_user_answers(request).await
+    }
+
+    pub fn session_interaction_snapshot(&self, session_id: &str) -> SessionInteractionSnapshot {
+        self.inner.session_interaction_snapshot(session_id)
     }
 
     pub async fn publish_event(&self, event: RuntimeEventEnvelope) -> Result<(), RuntimeError> {

--- a/src/crates/execution/agent-runtime/src/user_questions.rs
+++ b/src/crates/execution/agent-runtime/src/user_questions.rs
@@ -1,10 +1,11 @@
 //! Portable contracts for user-question tool handlers.
 
-use dashmap::DashMap;
 use log::{debug, info, warn};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use std::sync::{Arc, LazyLock};
+use std::collections::HashMap;
+use std::sync::{Arc, LazyLock, Mutex, MutexGuard, Weak};
+use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::oneshot;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -38,6 +39,56 @@ pub struct UserInputResponse {
     pub answers: Value,
 }
 
+/// One blocking user-question interaction owned by the running Agent Runtime.
+///
+/// This is process-local live state, not persisted Session history. Product
+/// surfaces use it to re-attach after an event gap without restarting or
+/// cancelling the Dialog Turn that is waiting for the answer.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct PendingUserQuestion {
+    pub tool_id: String,
+    pub session_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dialog_turn_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_round_id: Option<String>,
+    pub questions: Value,
+    pub registered_at_ms: u64,
+}
+
+impl PendingUserQuestion {
+    pub fn new(
+        tool_id: impl Into<String>,
+        session_id: impl Into<String>,
+        dialog_turn_id: Option<String>,
+        model_round_id: Option<String>,
+        questions: Value,
+    ) -> Self {
+        Self {
+            tool_id: tool_id.into(),
+            session_id: session_id.into(),
+            dialog_turn_id,
+            model_round_id,
+            questions,
+            registered_at_ms: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis()
+                .min(u64::MAX as u128) as u64,
+        }
+    }
+}
+
+/// A coherent, monotonic view of the user-question mailbox for one Session.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct PendingUserQuestionSnapshot {
+    pub revision: u64,
+    #[serde(default)]
+    pub questions: Vec<PendingUserQuestion>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum UserInputSendError {
     #[error("Waiting channel not found: {tool_id}")]
@@ -46,8 +97,53 @@ pub enum UserInputSendError {
     ChannelClosed { tool_id: String },
 }
 
+struct PendingUserInput {
+    sender: oneshot::Sender<UserInputResponse>,
+    question: Option<PendingUserQuestion>,
+    registration_sequence: u64,
+}
+
+#[derive(Default)]
+struct UserInputState {
+    pending: HashMap<String, PendingUserInput>,
+    next_registration_sequence: u64,
+    revision: u64,
+}
+
+/// Drop guard tying a pending mailbox record to the Tool future that waits on
+/// it. Cancelling a Dialog Turn drops the future and therefore removes the
+/// request instead of leaving an unanswerable stale interaction behind.
+#[must_use = "keep the registration alive while awaiting the user response"]
+pub struct UserInputRegistration {
+    state: Weak<Mutex<UserInputState>>,
+    tool_id: String,
+    registration_sequence: u64,
+}
+
+impl Drop for UserInputRegistration {
+    fn drop(&mut self) {
+        let Some(state) = self.state.upgrade() else {
+            return;
+        };
+        let mut state = lock_user_input_state(&state);
+        let belongs_to_registration = state
+            .pending
+            .get(&self.tool_id)
+            .is_some_and(|pending| pending.registration_sequence == self.registration_sequence);
+        if belongs_to_registration {
+            state.pending.remove(&self.tool_id);
+            state.revision = state.revision.saturating_add(1);
+            debug!(
+                "Removed dropped user-input registration: tool_id={}",
+                self.tool_id
+            );
+        }
+    }
+}
+
+#[derive(Clone)]
 pub struct UserInputManager {
-    channels: Arc<DashMap<String, oneshot::Sender<UserInputResponse>>>,
+    state: Arc<Mutex<UserInputState>>,
 }
 
 impl Default for UserInputManager {
@@ -59,21 +155,71 @@ impl Default for UserInputManager {
 impl UserInputManager {
     pub fn new() -> Self {
         Self {
-            channels: Arc::new(DashMap::new()),
+            state: Arc::new(Mutex::new(UserInputState::default())),
         }
     }
 
     pub fn register_channel(&self, tool_id: String, sender: oneshot::Sender<UserInputResponse>) {
         debug!("Registered waiting channel: tool_id={}", tool_id);
-        self.channels.insert(tool_id, sender);
+        self.insert_pending(tool_id, sender, None);
+    }
+
+    /// Register a replayable user question and return the lifetime guard for
+    /// the Tool future that owns it.
+    pub fn register_question(
+        &self,
+        question: PendingUserQuestion,
+        sender: oneshot::Sender<UserInputResponse>,
+    ) -> UserInputRegistration {
+        let tool_id = question.tool_id.clone();
+        debug!(
+            "Registered pending user question: tool_id={}, session_id={}",
+            tool_id, question.session_id
+        );
+        let registration_sequence = self.insert_pending(tool_id.clone(), sender, Some(question));
+        UserInputRegistration {
+            state: Arc::downgrade(&self.state),
+            tool_id,
+            registration_sequence,
+        }
+    }
+
+    fn insert_pending(
+        &self,
+        tool_id: String,
+        sender: oneshot::Sender<UserInputResponse>,
+        question: Option<PendingUserQuestion>,
+    ) -> u64 {
+        let mut state = lock_user_input_state(&self.state);
+        let registration_sequence = state.next_registration_sequence;
+        state.next_registration_sequence = state.next_registration_sequence.saturating_add(1);
+        state.pending.insert(
+            tool_id,
+            PendingUserInput {
+                sender,
+                question,
+                registration_sequence,
+            },
+        );
+        state.revision = state.revision.saturating_add(1);
+        registration_sequence
     }
 
     pub fn send_answer(&self, tool_id: &str, answers: Value) -> Result<(), UserInputSendError> {
         info!("Sending user answer: tool_id={}", tool_id);
 
-        if let Some((_, sender)) = self.channels.remove(tool_id) {
+        let pending = {
+            let mut state = lock_user_input_state(&self.state);
+            let pending = state.pending.remove(tool_id);
+            if pending.is_some() {
+                state.revision = state.revision.saturating_add(1);
+            }
+            pending
+        };
+        if let Some(pending) = pending {
             let response = UserInputResponse { answers };
-            sender
+            pending
+                .sender
                 .send(response)
                 .map_err(|_| UserInputSendError::ChannelClosed {
                     tool_id: tool_id.to_string(),
@@ -90,7 +236,15 @@ impl UserInputManager {
     }
 
     pub fn cancel(&self, tool_id: &str) -> bool {
-        if self.channels.remove(tool_id).is_some() {
+        let removed = {
+            let mut state = lock_user_input_state(&self.state);
+            let removed = state.pending.remove(tool_id).is_some();
+            if removed {
+                state.revision = state.revision.saturating_add(1);
+            }
+            removed
+        };
+        if removed {
             debug!("Cancelled waiting: tool_id={}", tool_id);
             true
         } else {
@@ -99,15 +253,51 @@ impl UserInputManager {
     }
 
     pub fn has_pending(&self, tool_id: &str) -> bool {
-        self.channels.contains_key(tool_id)
+        lock_user_input_state(&self.state)
+            .pending
+            .contains_key(tool_id)
     }
 
     pub fn pending_tool_ids(&self) -> Vec<String> {
-        self.channels
+        let state = lock_user_input_state(&self.state);
+        let mut pending = state
+            .pending
             .iter()
-            .map(|entry| entry.key().clone())
-            .collect()
+            .map(|(tool_id, entry)| (entry.registration_sequence, tool_id.clone()))
+            .collect::<Vec<_>>();
+        pending.sort_by_key(|(sequence, _)| *sequence);
+        pending.into_iter().map(|(_, tool_id)| tool_id).collect()
     }
+
+    pub fn pending_question_snapshot(&self, session_id: &str) -> PendingUserQuestionSnapshot {
+        let state = lock_user_input_state(&self.state);
+        let mut questions = state
+            .pending
+            .values()
+            .filter_map(|pending| {
+                pending
+                    .question
+                    .as_ref()
+                    .filter(|question| question.session_id == session_id)
+                    .cloned()
+                    .map(|question| (pending.registration_sequence, question))
+            })
+            .collect::<Vec<_>>();
+        questions.sort_by_key(|(sequence, _)| *sequence);
+        PendingUserQuestionSnapshot {
+            revision: state.revision,
+            questions: questions
+                .into_iter()
+                .map(|(_, question)| question)
+                .collect(),
+        }
+    }
+}
+
+fn lock_user_input_state(state: &Mutex<UserInputState>) -> MutexGuard<'_, UserInputState> {
+    state
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
 pub static USER_INPUT_MANAGER: LazyLock<UserInputManager> = LazyLock::new(|| {
@@ -120,6 +310,8 @@ pub fn get_user_input_manager() -> &'static UserInputManager {
 }
 
 pub const USER_INPUT_AVAILABLE_CONTEXT_KEY: &str = "user_input_available";
+/// Internal ToolUseContext key carrying the model round that owns a question.
+pub const USER_INPUT_MODEL_ROUND_CONTEXT_KEY: &str = "user_input_model_round_id";
 
 pub fn ask_user_question_available_for_acp_transport(acp_transport: Option<&Value>) -> bool {
     !acp_transport.is_some_and(|value| value == "true" || value == &json!(true))
@@ -261,7 +453,7 @@ fn format_result_for_assistant(questions: &[Question], answers: &Value) -> Strin
 
 #[cfg(test)]
 mod tests {
-    use super::{UserInputManager, UserInputResponse, UserInputSendError};
+    use super::{PendingUserQuestion, UserInputManager, UserInputResponse, UserInputSendError};
     use serde_json::json;
 
     #[tokio::test]
@@ -327,5 +519,59 @@ mod tests {
         manager.register_channel("tool-1".to_string(), sender);
 
         assert_eq!(manager.pending_tool_ids(), vec!["tool-1".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn pending_question_snapshot_survives_event_gaps_until_answered() {
+        let manager = UserInputManager::new();
+        let (sender, receiver) = tokio::sync::oneshot::channel::<UserInputResponse>();
+        let question = PendingUserQuestion::new(
+            "tool-1",
+            "session-1",
+            Some("turn-1".to_string()),
+            Some("round-1".to_string()),
+            json!({"questions": [{"question": "Continue?"}]}),
+        );
+        let registration = manager.register_question(question.clone(), sender);
+
+        let pending = manager.pending_question_snapshot("session-1");
+        assert_eq!(pending.questions, vec![question]);
+        assert!(pending.revision > 0);
+
+        manager
+            .send_answer("tool-1", json!({"0": "yes"}))
+            .expect("answer should be sent");
+        assert_eq!(
+            receiver.await.expect("receiver should get answer").answers,
+            json!({"0": "yes"})
+        );
+        assert!(manager
+            .pending_question_snapshot("session-1")
+            .questions
+            .is_empty());
+        drop(registration);
+    }
+
+    #[test]
+    fn dropping_question_registration_cleans_up_cancelled_turn_state() {
+        let manager = UserInputManager::new();
+        let (sender, _receiver) = tokio::sync::oneshot::channel::<UserInputResponse>();
+        let registration = manager.register_question(
+            PendingUserQuestion::new(
+                "tool-1",
+                "session-1",
+                Some("turn-1".to_string()),
+                Some("round-1".to_string()),
+                json!({"questions": []}),
+            ),
+            sender,
+        );
+        let registered_revision = manager.pending_question_snapshot("session-1").revision;
+
+        drop(registration);
+
+        let after_drop = manager.pending_question_snapshot("session-1");
+        assert!(after_drop.questions.is_empty());
+        assert!(after_drop.revision > registered_revision);
     }
 }

--- a/src/web-ui/src/flow_chat/components/modern/usePermissionRequests.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/usePermissionRequests.test.tsx
@@ -8,6 +8,11 @@ import type {
   PermissionRequest,
 } from '@/infrastructure/api/service-api/AgentAPI';
 import { dispatchJobStore } from '@/features/dispatch/dispatchJobStore';
+import { getActiveSurfaceId } from '@/infrastructure/peer-device/deviceSurface';
+import {
+  liveSessionInteractionStore,
+  resetLiveSessionInteractionStoreForTest,
+} from '../../services/liveSessionInteractionStore';
 import { usePermissionRequests } from './usePermissionRequests';
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
@@ -108,7 +113,9 @@ async function renderHarness(
 }
 
 function emit(event: PermissionRequestEvent) {
-  act(() => agentApiMock.listener?.(event));
+  act(() => {
+    liveSessionInteractionStore.applyPermissionEvent(getActiveSurfaceId(), event);
+  });
 }
 
 describe('usePermissionRequests', () => {
@@ -135,6 +142,7 @@ describe('usePermissionRequests', () => {
     dispatchApiMock.answerPermission.mockResolvedValue({ resolved: true });
     dispatchApiMock.requestRefresh.mockReset();
     dispatchJobStore.getState().clear();
+    resetLiveSessionInteractionStoreForTest();
   });
 
   afterEach(() => {

--- a/src/web-ui/src/flow_chat/components/modern/usePermissionRequests.ts
+++ b/src/web-ui/src/flow_chat/components/modern/usePermissionRequests.ts
@@ -1,27 +1,24 @@
-import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
+import { useCallback, useEffect, useMemo, useSyncExternalStore } from 'react';
 import {
-  agentAPI,
   type PermissionReplyKind,
-  type PermissionRequestEvent,
   type PermissionRequest,
 } from '@/infrastructure/api/service-api/AgentAPI';
 import {
-  applyPermissionRequestEvent,
-  reconcilePermissionRequestSnapshot,
   selectActivePermissionBatch,
   selectPermissionRequestsForSession,
 } from './permissionRequestRouting';
 import { FlowChatStore } from '../../store/FlowChatStore';
 import { driverForSession } from '../../session-drivers/registry';
+import {
+  ensureActivePermissionMailbox,
+  liveSessionInteractionStore,
+} from '../../services/liveSessionInteractionStore';
 
 const EMPTY_EXTERNAL_REQUESTS: PermissionRequest[] = [];
 const noopSubscribe = () => () => {};
 const emptyExternalSnapshot = () => EMPTY_EXTERNAL_REQUESTS;
 
 export function usePermissionRequests(sessionId?: string) {
-  const [liveRequests, setLiveRequests] = useState<PermissionRequest[]>([]);
-  const resolvedIds = useRef(new Set<string>());
-
   // Driver resolution is per-render: the caller re-renders on any session
   // change, so a projection whose dispatch config binds late is picked up.
   const session = sessionId
@@ -39,53 +36,24 @@ export function usePermissionRequests(sessionId?: string) {
     isLiveSource ? emptyExternalSnapshot : source.getSnapshot,
   ) as unknown as PermissionRequest[];
 
+  const liveMailbox = useSyncExternalStore(
+    liveSessionInteractionStore.subscribe,
+    liveSessionInteractionStore.getActiveSnapshot,
+    liveSessionInteractionStore.getActiveSnapshot,
+  );
+
   useEffect(() => {
-    if (!isLiveSource) {
-      setLiveRequests([]);
-      return undefined;
-    }
-    let disposed = false;
-    const unlisten = agentAPI.onPermissionRequestEvent((event: PermissionRequestEvent) => {
-      if (disposed) return;
-      setLiveRequests((current) => {
-        if (event.event === 'asked') {
-          resolvedIds.current.delete(event.request.requestId);
-        } else {
-          resolvedIds.current.add(event.requestId);
-        }
-        return applyPermissionRequestEvent(current, event);
-      });
-    });
-
-    void (async () => {
-      try {
-        await agentAPI.subscribePermissionRequests();
-        const pending = await agentAPI.listPendingPermissionRequests();
-        if (!disposed) {
-          setLiveRequests((current) =>
-            reconcilePermissionRequestSnapshot(current, pending, resolvedIds.current),
-          );
-        }
-      } catch {
-        if (!disposed) setLiveRequests([]);
-      }
-    })();
-
-    return () => {
-      disposed = true;
-      unlisten();
-    };
-  }, [isLiveSource]);
+    if (isLiveSource) void ensureActivePermissionMailbox();
+  }, [isLiveSource, liveMailbox.surfaceId]);
 
   const respond = useCallback(
     async (requestId: string, reply: PermissionReplyKind, feedback?: string) => {
       await driver.respondPermission(sessionId ?? '', requestId, reply, feedback);
       if (isLiveSource) {
-        resolvedIds.current.add(requestId);
-        setLiveRequests((current) => current.filter((request) => request.requestId !== requestId));
+        liveSessionInteractionStore.markPermissionResolved(liveMailbox.surfaceId, requestId);
       }
     },
-    [driver, sessionId, isLiveSource],
+    [driver, sessionId, isLiveSource, liveMailbox.surfaceId],
   );
 
   const respondBatch = useCallback(
@@ -97,15 +65,18 @@ export function usePermissionRequests(sessionId?: string) {
         feedback,
       );
       if (isLiveSource) {
-        const resolved = new Set(resolvedRequestIds);
-        resolvedRequestIds.forEach((id) => resolvedIds.current.add(id));
-        setLiveRequests((current) => current.filter((request) => !resolved.has(request.requestId)));
+        resolvedRequestIds.forEach((requestId) => {
+          liveSessionInteractionStore.markPermissionResolved(
+            liveMailbox.surfaceId,
+            requestId,
+          );
+        });
       }
     },
-    [driver, sessionId, isLiveSource],
+    [driver, sessionId, isLiveSource, liveMailbox.surfaceId],
   );
 
-  const effectiveRequests = isLiveSource ? liveRequests : externalRequests;
+  const effectiveRequests = isLiveSource ? liveMailbox.requests : externalRequests;
   const sessionRequests = useMemo(
     () => selectPermissionRequestsForSession(effectiveRequests, sessionId),
     [effectiveRequests, sessionId],

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.test.ts
@@ -18,6 +18,10 @@ vi.mock('../../state-machine', () => ({
   stateMachineManager: stateMachineMock,
 }));
 
+vi.mock('../liveSessionInteractionStore', () => ({
+  installLiveSessionInteractionMailbox: vi.fn(),
+}));
+
 import {
   installPeerSessionRefresh,
   PEER_SESSION_REFRESH_INTERVAL_MS,

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.ts
@@ -23,6 +23,7 @@ import {
   SessionExecutionState,
 } from '../../state-machine/types';
 import type { AnyFlowItem, DialogTurn } from '../../types/flow-chat';
+import { installLiveSessionInteractionMailbox } from '../liveSessionInteractionStore';
 import type { FlowChatContext } from './types';
 
 const log = createLogger('PeerSessionRefresh');
@@ -120,6 +121,10 @@ async function alignStateMachineWithSnapshot(
 }
 
 export function installPeerSessionRefresh(context: FlowChatContext): () => void {
+  // Blocking interactions are Runtime mailboxes, so their event projection
+  // must exist for the whole FlowChat lifetime rather than only while a card
+  // component is mounted.
+  installLiveSessionInteractionMailbox();
   let disposed = false;
   let inFlight = false;
   let queued = false;

--- a/src/web-ui/src/flow_chat/services/liveSessionInteractionStore.test.ts
+++ b/src/web-ui/src/flow_chat/services/liveSessionInteractionStore.test.ts
@@ -1,0 +1,212 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  PermissionRequest,
+  PermissionRequestSnapshot,
+} from '@/infrastructure/api/service-api/AgentAPI';
+import {
+  activateSurface,
+  LOCAL_SURFACE_ID,
+} from '@/infrastructure/peer-device/deviceSurface';
+import {
+  PEER_EVENT_SOURCE_KEY,
+  routeSurfaceEvent,
+  setActiveSurfaceDeviceId,
+} from '@/infrastructure/peer-device/deviceSurfaceRouting';
+import {
+  installLiveSessionInteractionMailbox,
+  liveSessionInteractionStore,
+  resetLiveSessionInteractionStoreForTest,
+} from './liveSessionInteractionStore';
+
+vi.mock('@/infrastructure/api/service-api/AgentAPI', () => ({
+  agentAPI: {
+    onPermissionRequestEvent: vi.fn(() => () => {}),
+    subscribePermissionRequests: vi.fn(async () => undefined),
+    listPendingPermissionRequests: vi.fn(async () => []),
+  },
+}));
+
+const PEER_SURFACE_ID = 'peer-device-b';
+
+function request(requestId: string, sessionId = 'session-1'): PermissionRequest {
+  return {
+    requestId,
+    roundId: 'round-1',
+    order: 0,
+    sessionId,
+    toolCallId: `${requestId}-tool`,
+    projectId: 'project-1',
+    agentId: 'agentic',
+    action: 'edit',
+    resources: ['src/main.rs'],
+    source: { kind: 'tool_call', identity: 'Write' },
+  };
+}
+
+function snapshot(
+  revision: number,
+  requests: PermissionRequest[],
+): PermissionRequestSnapshot {
+  return { revision, requests };
+}
+
+function activateTestSurface(surfaceId: string): void {
+  activateSurface(surfaceId);
+  setActiveSurfaceDeviceId(surfaceId === LOCAL_SURFACE_ID ? null : surfaceId);
+}
+
+describe('liveSessionInteractionStore', () => {
+  beforeEach(() => {
+    activateTestSurface(LOCAL_SURFACE_ID);
+    resetLiveSessionInteractionStoreForTest();
+    installLiveSessionInteractionMailbox();
+  });
+
+  it('retains an inactive local-host request while a peer Surface is rendered', () => {
+    activateTestSurface(PEER_SURFACE_ID);
+    const localRequest = request('local-request');
+
+    const route = routeSurfaceEvent('permission://event', {
+      event: 'asked',
+      request: localRequest,
+    });
+
+    expect(route.deliver).toBe(false);
+    expect(liveSessionInteractionStore.getActiveSnapshot().requests).toEqual([]);
+
+    activateTestSurface(LOCAL_SURFACE_ID);
+    expect(liveSessionInteractionStore.getActiveSnapshot().requests).toEqual([
+      localRequest,
+    ]);
+  });
+
+  it('keeps equal session ids isolated by their device Surface', () => {
+    const localRequest = request('local-request', 'shared-session');
+    const peerRequest = request('peer-request', 'shared-session');
+    const localEventVersion = liveSessionInteractionStore.captureEventVersion(
+      LOCAL_SURFACE_ID,
+    );
+    liveSessionInteractionStore.reconcilePermissionSnapshot(
+      LOCAL_SURFACE_ID,
+      'shared-session',
+      snapshot(1, [localRequest]),
+      localEventVersion,
+    );
+
+    routeSurfaceEvent('permission://event', {
+      [PEER_EVENT_SOURCE_KEY]: PEER_SURFACE_ID,
+      event: 'asked',
+      request: peerRequest,
+    });
+
+    expect(liveSessionInteractionStore.getActiveSnapshot().requests).toEqual([
+      localRequest,
+    ]);
+    activateTestSurface(PEER_SURFACE_ID);
+    expect(liveSessionInteractionStore.getActiveSnapshot().requests).toEqual([
+      peerRequest,
+    ]);
+  });
+
+  it('repairs a missed request and removes it from a newer authoritative snapshot', () => {
+    const pending = request('missed-request');
+    const eventVersion = liveSessionInteractionStore.captureEventVersion(
+      LOCAL_SURFACE_ID,
+    );
+
+    liveSessionInteractionStore.reconcilePermissionSnapshot(
+      LOCAL_SURFACE_ID,
+      pending.sessionId,
+      snapshot(4, [pending]),
+      eventVersion,
+    );
+    expect(liveSessionInteractionStore.getActiveSnapshot().requests).toEqual([
+      pending,
+    ]);
+
+    liveSessionInteractionStore.reconcilePermissionSnapshot(
+      LOCAL_SURFACE_ID,
+      pending.sessionId,
+      snapshot(5, []),
+      eventVersion,
+    );
+    expect(liveSessionInteractionStore.getActiveSnapshot().requests).toEqual([]);
+  });
+
+  it('does not let an in-flight stale snapshot erase a newer asked event', () => {
+    const eventVersionBeforeRestore = liveSessionInteractionStore.captureEventVersion(
+      LOCAL_SURFACE_ID,
+    );
+    const arrivedDuringRestore = request('new-request');
+    liveSessionInteractionStore.applyPermissionEvent(LOCAL_SURFACE_ID, {
+      event: 'asked',
+      request: arrivedDuringRestore,
+    });
+
+    liveSessionInteractionStore.reconcilePermissionSnapshot(
+      LOCAL_SURFACE_ID,
+      arrivedDuringRestore.sessionId,
+      snapshot(8, []),
+      eventVersionBeforeRestore,
+    );
+
+    expect(liveSessionInteractionStore.getActiveSnapshot().requests).toEqual([
+      arrivedDuringRestore,
+    ]);
+  });
+
+  it('does not revive a resolved request from an in-flight stale snapshot', () => {
+    const resolved = request('resolved-request');
+    liveSessionInteractionStore.applyPermissionEvent(LOCAL_SURFACE_ID, {
+      event: 'asked',
+      request: resolved,
+    });
+    const eventVersionBeforeRestore = liveSessionInteractionStore.captureEventVersion(
+      LOCAL_SURFACE_ID,
+    );
+    liveSessionInteractionStore.applyPermissionEvent(LOCAL_SURFACE_ID, {
+      event: 'replied',
+      requestId: resolved.requestId,
+      reply: { reply: 'once' },
+      source: 'user',
+    });
+
+    liveSessionInteractionStore.reconcilePermissionSnapshot(
+      LOCAL_SURFACE_ID,
+      resolved.sessionId,
+      snapshot(12, [resolved]),
+      eventVersionBeforeRestore,
+    );
+
+    expect(liveSessionInteractionStore.getActiveSnapshot().requests).toEqual([]);
+  });
+
+  it('rejects a snapshot no newer than the last applied session revision', () => {
+    const pending = request('pending-request');
+    const eventVersion = liveSessionInteractionStore.captureEventVersion(
+      LOCAL_SURFACE_ID,
+    );
+    liveSessionInteractionStore.reconcilePermissionSnapshot(
+      LOCAL_SURFACE_ID,
+      pending.sessionId,
+      snapshot(20, [pending]),
+      eventVersion,
+    );
+    liveSessionInteractionStore.reconcilePermissionSnapshot(
+      LOCAL_SURFACE_ID,
+      pending.sessionId,
+      snapshot(20, []),
+      eventVersion,
+    );
+    liveSessionInteractionStore.reconcilePermissionSnapshot(
+      LOCAL_SURFACE_ID,
+      pending.sessionId,
+      snapshot(19, []),
+      eventVersion,
+    );
+
+    expect(liveSessionInteractionStore.getActiveSnapshot().requests).toEqual([
+      pending,
+    ]);
+  });
+});

--- a/src/web-ui/src/flow_chat/services/liveSessionInteractionStore.ts
+++ b/src/web-ui/src/flow_chat/services/liveSessionInteractionStore.ts
@@ -1,0 +1,329 @@
+import {
+  agentAPI,
+  type PermissionRequest,
+  type PermissionRequestEvent,
+  type PermissionRequestSnapshot,
+} from '@/infrastructure/api/service-api/AgentAPI';
+import {
+  getActiveSurfaceId,
+  getActiveSurfaceScope,
+  isSurfaceChangedError,
+  onSurfaceActivated,
+  surfaceIdForDevice,
+  type DeviceSurfaceId,
+} from '@/infrastructure/peer-device/deviceSurface';
+import { observeSurfaceEvents } from '@/infrastructure/peer-device/deviceSurfaceRouting';
+import { createLogger } from '@/shared/utils/logger';
+
+const log = createLogger('LiveSessionInteractionStore');
+const MAX_RESOLVED_PERMISSION_TOMBSTONES = 4096;
+
+interface SurfacePermissionState {
+  requests: Map<string, PermissionRequest>;
+  resolvedIds: Set<string>;
+  snapshotRevisionBySession: Map<string, number>;
+  eventVersion: number;
+  version: number;
+  cachedVersion: number;
+  cachedRequests: PermissionRequest[];
+}
+
+export interface ActivePermissionMailboxSnapshot {
+  surfaceId: DeviceSurfaceId;
+  requests: PermissionRequest[];
+}
+
+function createSurfaceState(): SurfacePermissionState {
+  return {
+    requests: new Map(),
+    resolvedIds: new Set(),
+    snapshotRevisionBySession: new Map(),
+    eventVersion: 0,
+    version: 0,
+    cachedVersion: -1,
+    cachedRequests: [],
+  };
+}
+
+function requestBelongsToSession(request: PermissionRequest, sessionId: string): boolean {
+  return request.sessionId === sessionId || request.delegation?.parentSessionId === sessionId;
+}
+
+function rememberResolvedRequest(state: SurfacePermissionState, requestId: string): void {
+  // A tombstone prevents an older list/snapshot response from reviving a
+  // request whose reply event won the race. IDs are unique, so retain only a
+  // bounded recent window instead of growing for the lifetime of the app.
+  state.resolvedIds.delete(requestId);
+  state.resolvedIds.add(requestId);
+  while (state.resolvedIds.size > MAX_RESOLVED_PERMISSION_TOMBSTONES) {
+    const oldest = state.resolvedIds.values().next().value;
+    if (typeof oldest !== 'string') break;
+    state.resolvedIds.delete(oldest);
+  }
+}
+
+function parsePermissionEvent(payload: unknown): PermissionRequestEvent | undefined {
+  if (!payload || typeof payload !== 'object') return undefined;
+  const event = payload as PermissionRequestEvent;
+  if (event.event === 'asked') {
+    return event.request?.requestId ? event : undefined;
+  }
+  if (event.event === 'replied' || event.event === 'cancelled') {
+    return event.requestId ? event : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Surface-scoped projection of Runtime-owned blocking interactions.
+ *
+ * The event observer sees inactive devices too, while authoritative snapshots
+ * repair attach-after-event and relay gaps. Components consume one stable
+ * external store instead of each keeping a one-time, device-blind list.
+ */
+class LiveSessionInteractionStore {
+  private readonly surfaces = new Map<DeviceSurfaceId, SurfacePermissionState>();
+  private readonly listeners = new Set<() => void>();
+  private readonly observedPermissionEvents = new WeakSet<object>();
+  private activeSnapshotCache: ActivePermissionMailboxSnapshot | null = null;
+
+  private stateFor(surfaceId: DeviceSurfaceId): SurfacePermissionState {
+    const existing = this.surfaces.get(surfaceId);
+    if (existing) return existing;
+    const created = createSurfaceState();
+    this.surfaces.set(surfaceId, created);
+    return created;
+  }
+
+  private changed(surfaceId: DeviceSurfaceId, state: SurfacePermissionState): void {
+    state.version += 1;
+    state.cachedVersion = -1;
+    if (surfaceId === getActiveSurfaceId()) {
+      this.activeSnapshotCache = null;
+      this.notify();
+    }
+  }
+
+  private notify(): void {
+    for (const listener of Array.from(this.listeners)) {
+      listener();
+    }
+  }
+
+  subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  };
+
+  getActiveSnapshot = (): ActivePermissionMailboxSnapshot => {
+    const surfaceId = getActiveSurfaceId();
+    const state = this.stateFor(surfaceId);
+    if (state.cachedVersion !== state.version) {
+      state.cachedRequests = Array.from(state.requests.values());
+      state.cachedVersion = state.version;
+    }
+    if (
+      this.activeSnapshotCache?.surfaceId === surfaceId &&
+      this.activeSnapshotCache.requests === state.cachedRequests
+    ) {
+      return this.activeSnapshotCache;
+    }
+    this.activeSnapshotCache = {
+      surfaceId,
+      requests: state.cachedRequests,
+    };
+    return this.activeSnapshotCache;
+  };
+
+  captureEventVersion(surfaceId: DeviceSurfaceId): number {
+    return this.stateFor(surfaceId).eventVersion;
+  }
+
+  applyDeliveredPermissionEvent(event: PermissionRequestEvent): void {
+    // Tauri routing invokes Surface observers before the active product
+    // listener, so the exact same object has already been retained below.
+    // WebSocket delivery has no multi-device routing layer and therefore
+    // reaches only this callback; treat it as the local Surface fallback.
+    if (
+      typeof event === 'object'
+      && event !== null
+      && this.observedPermissionEvents.delete(event)
+    ) {
+      return;
+    }
+    this.applyPermissionEvent(getActiveSurfaceId(), event);
+  }
+
+  applyRoutedPermissionEvent(sourceDeviceId: string | null, payload: unknown): void {
+    const event = parsePermissionEvent(payload);
+    if (!event) return;
+    if (typeof payload === 'object' && payload !== null) {
+      this.observedPermissionEvents.add(payload);
+    }
+    this.applyPermissionEvent(surfaceIdForDevice(sourceDeviceId), event);
+  }
+
+  activateSurface(): void {
+    this.activeSnapshotCache = null;
+    this.notify();
+  }
+
+  applyPermissionEvent(surfaceId: DeviceSurfaceId, event: PermissionRequestEvent): void {
+    const state = this.stateFor(surfaceId);
+    state.eventVersion += 1;
+    if (event.event === 'asked') {
+      state.resolvedIds.delete(event.request.requestId);
+      state.requests.set(event.request.requestId, event.request);
+    } else {
+      rememberResolvedRequest(state, event.requestId);
+      state.requests.delete(event.requestId);
+    }
+    this.changed(surfaceId, state);
+  }
+
+  markPermissionResolved(surfaceId: DeviceSurfaceId, requestId: string): void {
+    const state = this.stateFor(surfaceId);
+    rememberResolvedRequest(state, requestId);
+    if (state.requests.delete(requestId)) {
+      this.changed(surfaceId, state);
+    }
+  }
+
+  /** Merge the legacy list command without deleting newer event state. */
+  mergeUnversionedPermissions(
+    surfaceId: DeviceSurfaceId,
+    requests: readonly PermissionRequest[],
+  ): void {
+    const state = this.stateFor(surfaceId);
+    let changed = false;
+    for (const request of requests) {
+      if (state.resolvedIds.has(request.requestId)) continue;
+      const previous = state.requests.get(request.requestId);
+      if (previous !== request) {
+        state.requests.set(request.requestId, request);
+        changed = true;
+      }
+    }
+    if (changed) this.changed(surfaceId, state);
+  }
+
+  /**
+   * Reconcile the filtered Session mailbox returned with restore_session_view.
+   * If an event arrived while the request was in flight, preserve it and only
+   * merge non-resolved entries; the next snapshot can perform replacement.
+   */
+  reconcilePermissionSnapshot(
+    surfaceId: DeviceSurfaceId,
+    sessionId: string,
+    snapshot: PermissionRequestSnapshot,
+    expectedEventVersion: number,
+  ): void {
+    const state = this.stateFor(surfaceId);
+    const previousRevision = state.snapshotRevisionBySession.get(sessionId) ?? -1;
+    if (!Number.isFinite(snapshot.revision) || snapshot.revision <= previousRevision) {
+      return;
+    }
+
+    const eventRace = state.eventVersion !== expectedEventVersion;
+    const pendingIds = new Set(snapshot.requests.map(request => request.requestId));
+    let changed = false;
+    if (!eventRace) {
+      for (const [requestId, request] of state.requests) {
+        if (requestBelongsToSession(request, sessionId) && !pendingIds.has(requestId)) {
+          state.requests.delete(requestId);
+          changed = true;
+        }
+      }
+    }
+
+    for (const request of snapshot.requests) {
+      if (state.resolvedIds.has(request.requestId)) continue;
+      const previous = state.requests.get(request.requestId);
+      if (previous !== request) {
+        state.requests.set(request.requestId, request);
+        changed = true;
+      }
+    }
+
+    if (!eventRace) {
+      state.snapshotRevisionBySession.set(sessionId, snapshot.revision);
+    }
+    if (changed) this.changed(surfaceId, state);
+  }
+
+  resetForTest(): void {
+    this.surfaces.clear();
+    this.activeSnapshotCache = null;
+    this.notify();
+  }
+}
+
+export const liveSessionInteractionStore = new LiveSessionInteractionStore();
+
+let mailboxListenersInstalled = false;
+let mailboxListenerDisposers: Array<() => void> = [];
+const subscribedSurfaces = new Set<DeviceSurfaceId>();
+const subscriptionRequests = new Map<DeviceSurfaceId, Promise<void>>();
+
+/**
+ * Install the process-wide event capture once FlowChat starts. Keeping this
+ * explicit avoids module-import side effects while still retaining requests
+ * when no permission card happens to be mounted.
+ */
+export function installLiveSessionInteractionMailbox(): void {
+  if (mailboxListenersInstalled) return;
+  mailboxListenersInstalled = true;
+  mailboxListenerDisposers = [
+    agentAPI.onPermissionRequestEvent((event) => {
+      liveSessionInteractionStore.applyDeliveredPermissionEvent(event);
+    }),
+    observeSurfaceEvents((eventName, sourceDeviceId, payload) => {
+      if (eventName !== 'permission://event') return;
+      liveSessionInteractionStore.applyRoutedPermissionEvent(sourceDeviceId, payload);
+    }),
+    onSurfaceActivated(() => {
+      liveSessionInteractionStore.activateSurface();
+    }),
+  ];
+}
+
+/** Start one forwarding/list bootstrap per host Surface. */
+export function ensureActivePermissionMailbox(): Promise<void> {
+  installLiveSessionInteractionMailbox();
+  const scope = getActiveSurfaceScope();
+  if (subscribedSurfaces.has(scope.surfaceId)) {
+    return Promise.resolve();
+  }
+  const existing = subscriptionRequests.get(scope.surfaceId);
+  if (existing) return existing;
+
+  const request = (async () => {
+    try {
+      await agentAPI.subscribePermissionRequests();
+      const pending = await agentAPI.listPendingPermissionRequests();
+      scope.assertCurrent('bootstrap permission mailbox');
+      liveSessionInteractionStore.mergeUnversionedPermissions(scope.surfaceId, pending);
+      subscribedSurfaces.add(scope.surfaceId);
+    } catch (error) {
+      if (!isSurfaceChangedError(error)) {
+        log.warn('Failed to bootstrap permission mailbox', {
+          surfaceId: scope.surfaceId,
+          error,
+        });
+      }
+    } finally {
+      subscriptionRequests.delete(scope.surfaceId);
+    }
+  })();
+  subscriptionRequests.set(scope.surfaceId, request);
+  return request;
+}
+
+export function resetLiveSessionInteractionStoreForTest(): void {
+  mailboxListenerDisposers.forEach(dispose => dispose());
+  mailboxListenerDisposers = [];
+  mailboxListenersInstalled = false;
+  subscribedSurfaces.clear();
+  subscriptionRequests.clear();
+  liveSessionInteractionStore.resetForTest();
+}

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
@@ -10,6 +10,7 @@ import type { FlowChatState, Session } from '../types/flow-chat';
 import { startupTrace } from '@/shared/utils/startupTrace';
 import { projectEffectiveToolItem } from '../utils/toolInvocationIdentity';
 import { dispatchJobStore } from '@/features/dispatch/dispatchJobStore';
+import { resetLiveSessionInteractionStoreForTest } from '../services/liveSessionInteractionStore';
 
 const apiMocks = vi.hoisted(() => ({
   listSessions: vi.fn(),
@@ -24,6 +25,9 @@ const apiMocks = vi.hoisted(() => ({
   accountFetchSessionTurns: vi.fn(),
   cancelSession: vi.fn(),
   cancelDispatchJob: vi.fn(),
+  onPermissionRequestEvent: vi.fn(() => () => {}),
+  subscribePermissionRequests: vi.fn(async () => undefined),
+  listPendingPermissionRequests: vi.fn(async () => []),
 }));
 
 const peerModeFlagMock = vi.hoisted(() => ({ active: false }));
@@ -81,6 +85,9 @@ vi.mock('@/infrastructure/api/service-api/AgentAPI', () => ({
     },
     restoreSessionWithTurns: apiMocks.restoreSessionWithTurns,
     loadSessionTurnWindow: apiMocks.loadSessionTurnWindow,
+    onPermissionRequestEvent: apiMocks.onPermissionRequestEvent,
+    subscribePermissionRequests: apiMocks.subscribePermissionRequests,
+    listPendingPermissionRequests: apiMocks.listPendingPermissionRequests,
   },
 }));
 
@@ -151,11 +158,13 @@ const resetStore = () => {
   ((flowChatStore as any).sessionTurnWindowRequests as Map<string, unknown> | undefined)?.clear();
   ((flowChatStore as any).unsupportedRestoreCommands as Set<string> | undefined)?.clear();
   ((flowChatStore as any).pendingRemoveSessionOptions as Map<string, unknown> | undefined)?.clear();
+  ((flowChatStore as any).userQuestionSnapshotRevisions as Map<string, number> | undefined)?.clear();
   flowChatStore.setState((): FlowChatState => ({
     sessions: new Map(),
     activeSessionId: null,
   }));
   dispatchJobStore.getState().clear();
+  resetLiveSessionInteractionStoreForTest();
   flowChatStore.registerPersistUnreadCompletionCallback(() => {});
 };
 
@@ -1646,6 +1655,157 @@ describe('FlowChatStore historical session hydration state', () => {
         dialogTurnId: 'turn-live',
       },
     );
+  });
+
+  it('re-attaches a missed AskUserQuestion mailbox without restarting the running turn', async () => {
+    peerModeFlagMock.active = true;
+    const pendingQuestion = {
+      toolId: 'ask-tool-1',
+      sessionId: 'history-1',
+      dialogTurnId: 'turn-live',
+      modelRoundId: 'round-question',
+      questions: {
+        questions: [{
+          question: 'Which verification should run?',
+          header: 'Verification',
+          options: [
+            { label: 'Focused', description: 'Run the focused checks.' },
+            { label: 'Full', description: 'Run the full suite.' },
+          ],
+        }],
+      },
+      registeredAtMs: 3,
+    };
+    const hostTurn = {
+      turnId: 'turn-live',
+      turnIndex: 0,
+      sessionId: 'history-1',
+      timestamp: 1,
+      userMessage: { id: 'user-live', content: 'ask me first', timestamp: 1 },
+      modelRounds: [],
+      startTime: 1,
+      status: 'inprogress',
+    };
+    const hostSession = {
+      sessionId: 'history-1',
+      sessionName: 'History 1',
+      agentType: 'agentic',
+      state: 'Processing { current_turn_id: "turn-live", phase: ToolExecution }',
+      turnCount: 1,
+      createdAt: 1,
+    };
+    apiMocks.restoreSessionView.mockResolvedValueOnce({
+      session: hostSession,
+      turns: [hostTurn],
+      interactionSnapshot: {
+        sessionId: 'history-1',
+        userQuestions: { revision: 7, questions: [pendingQuestion] },
+        permissions: { revision: 2, requests: [] },
+      },
+      contextRestoreState: 'pending',
+    });
+    flowChatStore.setState(() => ({
+      sessions: new Map([
+        ['history-1', createSession({
+          sessionId: 'history-1',
+          workspacePath: '/Users/host/project',
+          historyState: 'ready',
+        })],
+      ]),
+      activeSessionId: 'history-1',
+    }));
+
+    await flowChatStore.refreshPeerSessionSnapshot(
+      'history-1',
+      '/Users/host/project',
+      { replaceRunningSnapshot: false },
+    );
+
+    const recoveredTurn = flowChatStore
+      .getState()
+      .sessions.get('history-1')
+      ?.dialogTurns[0];
+    expect(recoveredTurn).toMatchObject({
+      id: 'turn-live',
+      status: 'processing',
+      modelRounds: [{
+        id: 'round-question',
+        status: 'streaming',
+        isStreaming: true,
+        items: [{
+          id: 'ask-tool-1',
+          type: 'tool',
+          toolName: 'AskUserQuestion',
+          status: 'waiting',
+          isParamsStreaming: false,
+          toolCall: {
+            id: 'ask-tool-1',
+            input: pendingQuestion.questions,
+          },
+        }],
+      }],
+    });
+
+    // An older Host omits the additive field. Absence means "event-only
+    // compatibility", not an authoritative empty mailbox.
+    apiMocks.restoreSessionView.mockResolvedValueOnce({
+      session: hostSession,
+      turns: [hostTurn],
+      contextRestoreState: 'pending',
+    });
+    await flowChatStore.refreshPeerSessionSnapshot(
+      'history-1',
+      '/Users/host/project',
+      { replaceRunningSnapshot: false },
+    );
+    expect(
+      flowChatStore.getState().sessions.get('history-1')
+        ?.dialogTurns[0].modelRounds[0].items,
+    ).toHaveLength(1);
+
+    // An older snapshot cannot erase a request that a newer Runtime mailbox
+    // already proved is still blocking the turn.
+    apiMocks.restoreSessionView.mockResolvedValueOnce({
+      session: hostSession,
+      turns: [hostTurn],
+      interactionSnapshot: {
+        sessionId: 'history-1',
+        userQuestions: { revision: 6, questions: [] },
+        permissions: { revision: 2, requests: [] },
+      },
+      contextRestoreState: 'pending',
+    });
+    await flowChatStore.refreshPeerSessionSnapshot(
+      'history-1',
+      '/Users/host/project',
+      { replaceRunningSnapshot: false },
+    );
+    expect(
+      flowChatStore.getState().sessions.get('history-1')
+        ?.dialogTurns[0].modelRounds[0].items,
+    ).toHaveLength(1);
+
+    // Once the same Runtime publishes a newer empty mailbox, the recovered
+    // card is removed without cancelling or restarting the Session.
+    apiMocks.restoreSessionView.mockResolvedValueOnce({
+      session: hostSession,
+      turns: [hostTurn],
+      interactionSnapshot: {
+        sessionId: 'history-1',
+        userQuestions: { revision: 8, questions: [] },
+        permissions: { revision: 3, requests: [] },
+      },
+      contextRestoreState: 'pending',
+    });
+    await flowChatStore.refreshPeerSessionSnapshot(
+      'history-1',
+      '/Users/host/project',
+      { replaceRunningSnapshot: false },
+    );
+    expect(
+      flowChatStore.getState().sessions.get('history-1')
+        ?.dialogTurns[0].modelRounds[0].items,
+    ).toEqual([]);
   });
 
   it('reconciles a newly persisted active Peer turn without replacing older history', async () => {
@@ -6314,6 +6474,58 @@ describe('FlowChatStore device surfaces', () => {
     expect(flowChatStore.getState().sessions.get('local-1')).toMatchObject({
       historyState: 'metadata-only',
     });
+  });
+
+  it('never projects a local interaction snapshot into the peer selected mid-refresh', async () => {
+    seedSession('shared-session');
+    const restore = createDeferred<any>();
+    apiMocks.restoreSessionView.mockReturnValueOnce(restore.promise);
+
+    const refresh = flowChatStore.refreshPeerSessionSnapshot(
+      'shared-session',
+      '/repo/BitFun',
+      { requireActiveSession: true },
+    );
+    await flushAsyncWork();
+
+    activateSurface(PEER_SURFACE_ID);
+    seedSession('shared-session');
+    restore.resolve({
+      session: {
+        ...restoredSession('shared-session'),
+        state: 'Processing { current_turn_id: "shared-session-turn-1" }',
+      },
+      turns: [{
+        ...restoredTurn('shared-session'),
+        status: 'inprogress',
+      }],
+      interactionSnapshot: {
+        sessionId: 'shared-session',
+        userQuestions: {
+          revision: 1,
+          questions: [{
+            toolId: 'local-question',
+            sessionId: 'shared-session',
+            dialogTurnId: 'shared-session-turn-1',
+            modelRoundId: 'local-round',
+            questions: { questions: [] },
+            registeredAtMs: 2,
+          }],
+        },
+        permissions: { revision: 1, requests: [] },
+      },
+      contextRestoreState: 'pending',
+    });
+
+    await expect(refresh).rejects.toSatisfy(isSurfaceChangedError);
+    expect(
+      flowChatStore.getState().sessions.get('shared-session')?.dialogTurns,
+    ).toEqual([]);
+
+    activateSurface(LOCAL_SURFACE_ID);
+    expect(
+      flowChatStore.getState().sessions.get('shared-session')?.dialogTurns,
+    ).toEqual([]);
   });
 
   it('does not fall back onto the next device after a typed surface cancellation', async () => {

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.ts
@@ -53,6 +53,7 @@ import type {
 import {
   agentAPI,
   type LoadSessionTurnWindowResponse,
+  type PendingUserQuestionSnapshot,
   type SessionInfo as AgentSessionInfo,
   type SessionViewRestoreTiming,
 } from '@/infrastructure/api/service-api/AgentAPI';
@@ -91,6 +92,7 @@ import { useBackgroundSubagentActivityStore } from './backgroundSubagentActivity
 import { sessionComposerStore } from './sessionComposerStore';
 import { completeSessionMutationReconciliation } from './sessionMutationStore';
 import { recordHistorySessionDiagnosticEvent } from '../services/historySessionDiagnostics';
+import { liveSessionInteractionStore } from '../services/liveSessionInteractionStore';
 import {
   isDispatchJobTerminal,
   isNonLocalDispatchTarget,
@@ -680,6 +682,186 @@ function snapshotDropsProjectedTurnContent(
   }
 
   return false;
+}
+
+interface PendingUserQuestionReconcileResult {
+  turns: DialogTurn[];
+  changed: boolean;
+  revisionApplied: boolean;
+}
+
+/**
+ * Rebuild the user-input card from the Runtime mailbox, independently of the
+ * persisted Turn checkpoint. A running Tool can wait indefinitely, so its
+ * push event is not recoverable by waiting for Turn completion.
+ */
+function reconcilePendingUserQuestionSnapshot(
+  turns: DialogTurn[],
+  snapshot: PendingUserQuestionSnapshot | undefined,
+  previousRevision: number,
+): PendingUserQuestionReconcileResult {
+  if (
+    !snapshot ||
+    !Number.isFinite(snapshot.revision) ||
+    snapshot.revision < previousRevision
+  ) {
+    return { turns, changed: false, revisionApplied: false };
+  }
+
+  const nextTurns = turns.map(turn => ({
+    ...turn,
+    modelRounds: turn.modelRounds.map(round => ({
+      ...round,
+      items: [...round.items],
+    })),
+  }));
+  const pendingIds = new Set(snapshot.questions.map(question => question.toolId));
+  let changed = false;
+  let fullyApplied = true;
+
+  // Remove only cards that this reconciliation path previously marked as
+  // mailbox projections. An existing live/persisted item is marked only while
+  // the Runtime says it is pending; after that, the mailbox is authoritative
+  // for whether the blocking card should remain.
+  for (const turn of nextTurns) {
+    for (const round of turn.modelRounds) {
+      const retained: AnyFlowItem[] = [];
+      for (const item of round.items) {
+        if (item.type !== 'tool') {
+          retained.push(item);
+          continue;
+        }
+        const tool = item as FlowToolItem;
+        if (tool._runtimeInteractionProjection?.kind !== 'user_question') {
+          retained.push(tool);
+          continue;
+        }
+        const toolId = tool.toolCall?.id || tool.id;
+        if (pendingIds.has(toolId)) {
+          retained.push(tool);
+          continue;
+        }
+        if (tool.toolResult || runningStatusRank(tool.status) >= 3) {
+          const { _runtimeInteractionProjection: _projection, ...settledTool } = tool;
+          retained.push(settledTool as FlowToolItem);
+          changed = true;
+          continue;
+        }
+        changed = true;
+      }
+      if (retained.length !== round.items.length) {
+        round.items = retained;
+      } else if (retained.some((item, index) => item !== round.items[index])) {
+        round.items = retained;
+      }
+    }
+  }
+
+  for (const pending of snapshot.questions) {
+    if (!pending || pending.sessionId === '') {
+      continue;
+    }
+    const turn = pending.dialogTurnId
+      ? nextTurns.find(candidate => candidate.id === pending.dialogTurnId)
+      : nextTurns[nextTurns.length - 1];
+    if (!turn || turn.sessionId !== pending.sessionId) {
+      // Tail restore should always contain the active Turn. If it does not,
+      // leave the revision uncommitted so the next reconciliation retries
+      // after that Turn is available instead of losing the mailbox entry.
+      fullyApplied = false;
+      continue;
+    }
+
+    let targetRound = turn.modelRounds.find(round =>
+      round.items.some(item =>
+        item.type === 'tool' &&
+        ((item as FlowToolItem).toolCall?.id === pending.toolId || item.id === pending.toolId)
+      )
+    );
+    if (!targetRound && pending.modelRoundId) {
+      targetRound = turn.modelRounds.find(round => round.id === pending.modelRoundId);
+    }
+    if (!targetRound) {
+      targetRound = turn.modelRounds[turn.modelRounds.length - 1];
+    }
+    if (!targetRound) {
+      targetRound = {
+        id: pending.modelRoundId || `runtime-interaction-${pending.toolId}`,
+        index: 0,
+        items: [],
+        isStreaming: true,
+        isComplete: false,
+        status: 'streaming',
+        startTime: pending.registeredAtMs,
+      };
+      turn.modelRounds.push(targetRound);
+      changed = true;
+    }
+
+    const existingIndex = targetRound.items.findIndex(item =>
+      item.type === 'tool' &&
+      ((item as FlowToolItem).toolCall?.id === pending.toolId || item.id === pending.toolId)
+    );
+    const existing = existingIndex >= 0
+      ? targetRound.items[existingIndex] as FlowToolItem
+      : undefined;
+    const alreadyProjected =
+      existing?._runtimeInteractionProjection?.revision === snapshot.revision &&
+      existing.status === 'waiting';
+    if (!alreadyProjected) {
+      const projected: FlowToolItem = {
+        ...(existing || {
+          id: pending.toolId,
+          type: 'tool',
+          timestamp: pending.registeredAtMs,
+          requiresConfirmation: false,
+        }),
+        id: pending.toolId,
+        type: 'tool',
+        toolName: 'AskUserQuestion',
+        toolCall: {
+          id: pending.toolId,
+          input: pending.questions,
+        },
+        toolResult: undefined,
+        status: 'waiting',
+        isParamsStreaming: false,
+        startTime: existing?.startTime ?? pending.registeredAtMs,
+        endTime: undefined,
+        _runtimeInteractionProjection: {
+          kind: 'user_question',
+          revision: snapshot.revision,
+        },
+      };
+      if (existingIndex >= 0) {
+        targetRound.items[existingIndex] = projected;
+      } else {
+        targetRound.items.push(projected);
+      }
+      changed = true;
+    }
+
+    if (
+      targetRound.status !== 'streaming' ||
+      targetRound.isComplete ||
+      !targetRound.isStreaming
+    ) {
+      targetRound.status = 'streaming';
+      targetRound.isComplete = false;
+      targetRound.isStreaming = true;
+      changed = true;
+    }
+    if (turn.status !== 'processing') {
+      turn.status = 'processing';
+      changed = true;
+    }
+  }
+
+  return {
+    turns: changed ? nextTurns : turns,
+    changed,
+    revisionApplied: fullyApplied,
+  };
 }
 
 function itemMatchesIdentity(item: AnyFlowItem, itemId: string): boolean {
@@ -1544,6 +1726,7 @@ interface SurfaceStateContainer {
   readonly deferredFullHistoryProjections: Map<string, DeferredFullHistoryProjection>;
   readonly fullHistoryProjectionApplyRequests: Set<string>;
   readonly pendingRemoveSessionOptions: Map<string, RemoveSessionOptions>;
+  readonly userQuestionSnapshotRevisions: Map<string, number>;
 }
 
 function createSurfaceStateContainer(surfaceId: DeviceSurfaceId): SurfaceStateContainer {
@@ -1558,6 +1741,7 @@ function createSurfaceStateContainer(surfaceId: DeviceSurfaceId): SurfaceStateCo
     deferredFullHistoryProjections: new Map(),
     fullHistoryProjectionApplyRequests: new Set(),
     pendingRemoveSessionOptions: new Map(),
+    userQuestionSnapshotRevisions: new Map(),
   };
 }
 
@@ -1632,6 +1816,10 @@ export class FlowChatStore {
 
   private get pendingRemoveSessionOptions(): Map<string, RemoveSessionOptions> {
     return this.activeSurface.pendingRemoveSessionOptions;
+  }
+
+  private get userQuestionSnapshotRevisions(): Map<string, number> {
+    return this.activeSurface.userQuestionSnapshotRevisions;
   }
 
   /** Key a store-level cache entry to the surface that asked for it. */
@@ -2588,6 +2776,7 @@ export class FlowChatStore {
       this.fullHistoryProjectionApplyRequests.delete(sessionId);
       this.sessionHistoryViews.delete(sessionId);
       this.sessionHistoryTurnAccessTimes.delete(sessionId);
+      this.userQuestionSnapshotRevisions.delete(sessionId);
     }
 
     const activeSurfaceId = getActiveSurfaceId();
@@ -7079,6 +7268,9 @@ export class FlowChatStore {
     },
   ): Promise<PeerSessionSnapshotRefreshResult> {
     const scope = getActiveSurfaceScope();
+    const interactionEventVersion = liveSessionInteractionStore.captureEventVersion(
+      scope.surfaceId,
+    );
     const initialSession = this.state.sessions.get(sessionId);
     if (!initialSession) {
       return {
@@ -7099,11 +7291,23 @@ export class FlowChatStore {
     // This snapshot describes the device it was read from; reconciling it into
     // the surface that is rendered now would merge two devices' turns.
     scope.assertCurrent('refreshPeerSessionSnapshot');
+    if (restored.interactionSnapshot?.sessionId === sessionId) {
+      liveSessionInteractionStore.reconcilePermissionSnapshot(
+        scope.surfaceId,
+        sessionId,
+        restored.interactionSnapshot.permissions,
+        interactionEventVersion,
+      );
+    }
     const backendActive = isBackendSessionActivelyProcessing(restored.session.state);
     const activeTurnId = backendActive
       ? restored.turns[restored.turns.length - 1]?.turnId
       : undefined;
     const snapshotTurns = this.convertToDialogTurns(restored.turns, { activeTurnId });
+    const pendingUserQuestions =
+      restored.interactionSnapshot?.sessionId === sessionId
+        ? restored.interactionSnapshot.userQuestions
+        : undefined;
     const replaceExistingTurns =
       !backendActive || options?.replaceRunningSnapshot === true;
     let applied = false;
@@ -7126,7 +7330,7 @@ export class FlowChatStore {
         return prev;
       }
 
-      const mergedTurns = [...session.dialogTurns];
+      let mergedTurns = [...session.dialogTurns];
       let turnsChanged = false;
       for (const snapshotTurn of snapshotTurns) {
         const existingIndex = mergedTurns.findIndex(turn => turn.id === snapshotTurn.id);
@@ -7144,6 +7348,22 @@ export class FlowChatStore {
       }
 
       mergedTurns.sort(compareDialogTurnOrder);
+      const previousQuestionRevision = this.userQuestionSnapshotRevisions.get(sessionId) ?? -1;
+      const questionReconciliation = reconcilePendingUserQuestionSnapshot(
+        mergedTurns,
+        pendingUserQuestions,
+        previousQuestionRevision,
+      );
+      if (questionReconciliation.changed) {
+        mergedTurns = questionReconciliation.turns;
+        turnsChanged = true;
+      }
+      if (questionReconciliation.revisionApplied && pendingUserQuestions) {
+        this.userQuestionSnapshotRevisions.set(
+          sessionId,
+          pendingUserQuestions.revision,
+        );
+      }
       const turnCatalog = restored.turnCatalog?.sessionId === sessionId
         ? selectPreferredTurnCatalog(session.turnCatalog, restored.turnCatalog)
         : session.turnCatalog;

--- a/src/web-ui/src/flow_chat/types/flow-chat.ts
+++ b/src/web-ui/src/flow_chat/types/flow-chat.ts
@@ -107,6 +107,17 @@ export interface FlowToolItem extends FlowItem {
   isParamsStreaming?: boolean;  // Params are streaming in.
   partialParams?: Record<string, any>;  // Partial params during streaming.
   _paramsBuffer?: string;  // Internal buffer for accumulated params.
+
+  /**
+   * Runtime re-attachment marker. This item was reconstructed from an
+   * authoritative pending-interaction mailbox rather than a persisted Turn.
+   * It is removed or settled when a newer mailbox revision says the request
+   * no longer exists.
+   */
+  _runtimeInteractionProjection?: {
+    kind: 'user_question';
+    revision: number;
+  };
 }
 
 export interface ToolRejectOptions {

--- a/src/web-ui/src/infrastructure/api/service-api/AgentAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/AgentAPI.ts
@@ -155,6 +155,35 @@ export interface PermissionRequest {
   displayMetadata?: Record<string, unknown>;
 }
 
+export interface PendingUserQuestion {
+  toolId: string;
+  sessionId: string;
+  dialogTurnId?: string;
+  modelRoundId?: string;
+  questions: unknown;
+  registeredAtMs: number;
+}
+
+export interface PendingUserQuestionSnapshot {
+  revision: number;
+  questions: PendingUserQuestion[];
+}
+
+export interface PermissionRequestSnapshot {
+  revision: number;
+  requests: PermissionRequest[];
+}
+
+/**
+ * Runtime-owned blocking interactions required to re-attach a UI Surface to
+ * a Session after push events were missed while another device was rendered.
+ */
+export interface SessionInteractionSnapshot {
+  sessionId: string;
+  userQuestions: PendingUserQuestionSnapshot;
+  permissions: PermissionRequestSnapshot;
+}
+
 export type PermissionRequestEvent =
   | { event: 'asked'; request: PermissionRequest }
   | { event: 'replied'; requestId: string; reply: { reply: PermissionReplyKind }; source: string }
@@ -242,6 +271,8 @@ export interface SessionViewRestoreTiming {
 export interface RestoreSessionViewResponse {
   session: SessionInfo;
   turns: DialogTurnData[];
+  /** Absent when talking to an older Peer Host. */
+  interactionSnapshot?: SessionInteractionSnapshot;
   currentContextUsage?: SessionContextUsage | null;
   turnCatalog?: SessionTurnCatalog;
   contextRestoreState: 'ready' | 'pending';

--- a/src/web-ui/src/infrastructure/peer-device/README.md
+++ b/src/web-ui/src/infrastructure/peer-device/README.md
@@ -134,6 +134,16 @@ Controller-side React/transport layer for Peer Device Mode. Architecture:
     Continuous host output must create a persisted checkpoint within each 2s
     coalescing window, and active snapshots may replace a running projection
     early only when stream/tool content proves forward progress.
+    **Blocking interactions are owner mailboxes, not one-shot UI events.** The
+    Runtime retains native `AskUserQuestion` and interactive permission
+    requests until answer/cancel/drop, and `restore_session_view` returns their
+    additive, revisioned `interactionSnapshot` from both Desktop and CLI Peer
+    Hosts. Keep its frontend projection per Surface, fence it with the captured
+    Surface epoch and newer event state, and use it only to reconstruct UI in
+    the owning Turn/round. Reattachment must never restart or cancel the
+    running Session. Older peers may omit the field; absence is not an empty
+    authoritative mailbox. Any new interaction that can suspend execution is
+    incomplete until its owner exposes equivalent replayable attach state.
 
 13. **Weak links use bounded, idempotency-aware recovery.** Default Peer
     HostInvoke concurrency is four with one slot reserved from normal/low


### PR DESCRIPTION
## Summary

- move native AskUserQuestion and interactive permission recovery onto Runtime-owned, revisioned live mailboxes instead of relying on one-shot UI events
- include an additive interactionSnapshot in Desktop and CLI Peer Host session restore, with CLI Peer Turn ownership filtering and old-host compatibility
- retain permission requests per Device Surface and reconstruct missed AskUserQuestion cards in their exact Turn and model round without restarting the running Session
- fence reconciliation with Surface epochs, event versions, and mailbox revisions so stale snapshots cannot erase or revive requests
- document the blocking-interaction reattachment contract for future interaction owners

## Verification

- cargo test --locked -p bitfun-agent-runtime --no-default-features --features agent-runtime --lib user_questions::tests
- cargo test --locked -p bitfun-agent-runtime --no-default-features --features agent-runtime --lib permission::tests
- focused Agent Runtime wire-compatibility test
- focused bitfun-core AskUserQuestion and Tool context tests
- focused bitfun-cli Peer ownership test
- cargo check --locked -p bitfun-cli
- cargo check --locked -p bitfun-desktop
- cargo test --locked -p bitfun-desktop (311 passed, 4 ignored)
- Web UI focused suites (134 passed), plus old-host compatibility rerun (124 passed)
- pnpm run type-check:web
- pnpm run check:repo-hygiene
- pnpm run check:core-boundaries

## Remote scenarios

- Peer Device Mode: exercised for local-to-peer-to-local switching, inactive-Surface request retention, identical session IDs on two devices, stale in-flight snapshots, and CLI Peer ownership
- Remote workspace: unchanged; not exercised
- Remote control: existing native permission response path preserved; not exercised end to end
- Detached Dispatch: unchanged; dispatch permission driver remains separate
