### PR TITLE
fix(peer): preserve runtime turns across device switches

### DIFF
--- a/docs/architecture/agent-runtime-deployment-design.md
+++ b/docs/architecture/agent-runtime-deployment-design.md
@@ -160,6 +160,7 @@ flowchart LR
 - Phase 5 的 Embedded direct adapter 将通过 `AgentRuntime` 提供的 typed event/Permission subscription 直接订阅同一 Runtime owner，再映射为 `TuiRuntimePort` semantic event；它不得创建第二个 Core `EventQueue` owner 或把 Runtime 内部 receiver 暴露给 TUI。
 - Headless CLI、Peer Host、ACP 和 SDK Host 从各自独立 Runtime adapter 订阅，不能直接持有 Core-specific event source。
 - `bitfun-core` 的旧 event-source/builder API 仅保留为 deprecated 源码兼容 facade；它们委托给同一个 Core owner，不形成第二套运行时或第一方调用路径。
+- Desktop Rich Surface 的 Tauri delivery adapter、CLI Peer Host 的 DeviceEvent adapter 与各自窄 `AgentRuntime` facade 共享一个 Runtime-host-owned `SessionEventJournal`。事件在 host 排序/合并边界后写入，按 Session 获得单调 cursor，并通过 `restore_session_view.runtimeEventSnapshot` 提供当前 Turn 的物化 attach state；CLI 仍先执行 Peer-owned-Turn 边界。客户端用 Runtime-process `streamId` + cursor 对 snapshot 与并发 live events 做 fence。该合同只补足同一 Desktop/Peer Host 上 Rich Surface 的重挂载，不把 App Server 或 Shared Runtime IPC 宣称为已有跨连接 replay。
 - 各 adapter 继续拥有自己的失败投影：TUI 标记当前视图不可信，Headless CLI 返回非成功终态，Peer Host 中断其拥有的 turns，ACP 取消 turn 并返回协议错误，SDK Host 终结 Query 并提供 `RestartHost` recovery。
 - 当前 App Server 为每条 connection/stream 发送单调 sequence 和 connection-local cursor；`app/syncEvents` 返回当前连接的 cursor
   与 pending Permission snapshot，`session/sync` 恢复 Session state、transcript、workspace binding 和 pending Permission。它没有跨连接

--- a/docs/architecture/peer-device-mode.md
+++ b/docs/architecture/peer-device-mode.md
@@ -74,9 +74,36 @@ React only subscribes to snapshots. Attachment disposal is the only operation
 that discards a peer's cached surface state.
 
 Because the local surface can now miss its own events while another device is
-rendered, snapshot reconciliation is no longer Peer-only: after this window's
-first surface switch, `isSurfaceReconcileEnabled()` keeps the repair loop
-running for whichever surface is rendered, local included.
+rendered, Session attachment is no longer Peer-only. After this window's first
+surface switch, `isSurfaceReconcileEnabled()` attaches whichever surface is
+rendered, local included.
+
+### Running-Turn attachment
+
+The live WebView/DeviceEvent broadcast is a low-latency delivery path, not the
+owner of a running Turn. Desktop and CLI Peer Runtime Hosts keep a materialized
+projection of each eligible current Turn even when no client is subscribed. Events enter
+that projection after the host's ordering/coalescing boundary and receive a
+per-Session monotonic cursor plus a Runtime-process `streamId`. Text and
+thinking chunks are materialized without collapsing segments across tool
+boundaries; noisy tool progress is compacted.
+
+`restore_session_view` returns this additive `runtimeEventSnapshot`; the CLI
+Peer Host applies its existing Peer-owned-Turn filter before recording or
+returning the projection. During an attach, the frontend fences live events for
+`(DeviceSurfaceId, SessionId)`,
+replays the snapshot into an empty current-Turn projection, and then releases
+only events newer than the snapshot cursor. A different `streamId` is a new
+Runtime process and its cursors are never compared with the old stream. The
+Surface epoch rejects a response from a device that is no longer rendered.
+This makes attach independent of client-written intermediate checkpoints and
+closes the snapshot/live race without restarting, cancelling, or moving the
+Turn. Older Hosts may omit the field and use the persisted-snapshot fallback.
+Controller presence is an admission boundary, not the lifetime owner: after a
+Peer Host accepts a Turn, that Host continues executing and materializing it
+while zero controllers are attached. A later controller attaches to the same
+Runtime projection; controller loss alone must not cancel or interrupt the
+Turn. Actual host event-stream loss remains a fail-closed continuity error.
 
 ### Blocking-interaction reattachment
 
@@ -185,20 +212,19 @@ FS) and must not be mixed with Peer Device Mode.
   controllers; controller re-emits the same event names locally. This includes
   SSH-backed remote PTY Ready / Data / Exit events created on B, not only B's
   local terminal service events.
-- Because DeviceEvent delivery has no ACK/replay contract, the controller also
-  reconciles its active chat session from the Peer Host every 3s, immediately
-  after session/visibility changes, and after detecting a dropped data event.
-  Realtime events remain the primary path; snapshot reconciliation repairs a
-  controller that attached after turn/round lifecycle events or crossed a
-  transient relay gap. The host overlays its authoritative in-memory session
-  state onto the persisted view so an executing turn is not misclassified as
-  interrupted history. Continuous host output is checkpointed at least once
-  per 2s coalescing window. A controller accepts an active snapshot before the
-  stale-stream deadline only when its rounds, streams, and tools provably move
-  forward; an older persisted snapshot cannot overwrite newer DeviceEvents.
-  Native blocking interactions are reconciled from the Runtime-owned
-  `interactionSnapshot` independently of Turn checkpoints, because a Turn can
-  wait indefinitely and never produce a newer persisted snapshot on its own.
+- Relay DeviceEvent delivery itself has no ACK/replay contract. The active chat
+  therefore attaches immediately when the selected Session becomes hydrated,
+  after Surface/visibility changes, and after a detected data gap. The Peer
+  Host's `runtimeEventSnapshot` plus `(streamId, cursor)` is the resumable
+  current-Turn contract: live events are fenced while the snapshot is in
+  flight, the materialized Turn is replayed, and only later cursors are
+  released. The 3s reconciliation remains a liveness retry and an older-Host
+  persisted-snapshot fallback, not the source of Turn continuity. The host
+  still overlays its authoritative in-memory Session state so an executing
+  Turn is not misclassified as interrupted history. Native blocking
+  interactions are reconciled from the Runtime-owned `interactionSnapshot`
+  after event replay, because a Turn can wait indefinitely without emitting
+  another text chunk or producing a newer persisted checkpoint.
 - CLI Peer Host forwards only turns submitted through Peer Host and linked
   child turns. A background-result follow-up inherits ownership only when its
   Core-internal metadata identifies the exact tracked parent and source child

--- a/src/apps/cli/src/peer_host/bootstrap.rs
+++ b/src/apps/cli/src/peer_host/bootstrap.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
+use bitfun_agent_runtime::sdk::SessionEventJournal;
 use bitfun_core::service::filesystem::FileSystemServiceFactory;
 use bitfun_core::service::workspace::{self, WorkspaceService};
 
@@ -30,14 +31,19 @@ pub(crate) async fn ensure_peer_host_ready(runtime: &CliRuntimeContext) -> Resul
     };
 
     let filesystem_service = Arc::new(FileSystemServiceFactory::create_default());
-    let agent_events = runtime
+    let session_event_journal = Arc::new(SessionEventJournal::new());
+    let agent_runtime = runtime
         .agent_runtime()
+        .clone()
+        .with_session_event_journal(session_event_journal.clone());
+    let agent_events = agent_runtime
         .subscribe_events()
         .map_err(|error| anyhow::anyhow!(error.into_message()))
         .context("Peer Host agent event stream is unavailable")?;
 
     let state = PeerHostState {
-        agent_runtime: runtime.agent_runtime().clone(),
+        agent_runtime,
+        session_event_journal,
         local_workspace_snapshot: runtime.local_workspace_snapshot().clone(),
         compatibility: runtime.compatibility().clone(),
         account_runtime: runtime.account_runtime().clone(),

--- a/src/apps/cli/src/peer_host/commands/dialog.rs
+++ b/src/apps/cli/src/peer_host/commands/dialog.rs
@@ -92,7 +92,6 @@ pub(crate) async fn start_dialog_turn(
     if !state
         .turns
         .is_event_stream_generation_current(stream_generation)
-        || !is_controller_lease_current(controller_lease)
     {
         let cancellation = state
             .agent_runtime
@@ -101,7 +100,7 @@ pub(crate) async fn start_dialog_turn(
                 turn_id: Some(turn_id.clone()),
                 source: Some(AgentSubmissionSource::Cli),
                 requester_session_id: None,
-                reason: Some("Peer controller or event stream lost continuity".to_string()),
+                reason: Some("Peer event stream lost continuity".to_string()),
                 wait_timeout_ms: Some(1_500),
                 cancel_descendants: true,
             })
@@ -112,10 +111,7 @@ pub(crate) async fn start_dialog_turn(
                 "Peer continuity was lost after dialog submission and cancellation could not be confirmed: session_id={session_id}, turn_id={turn_id}, error={error}"
             ));
         }
-        return Err(
-            "Peer controller or event stream lost continuity while starting the dialog turn"
-                .to_string(),
-        );
+        return Err("Peer event stream lost continuity while starting the dialog turn".to_string());
     }
 
     Ok(json!({ "success": true, "message": "Dialog turn started" }))

--- a/src/apps/cli/src/peer_host/commands/session.rs
+++ b/src/apps/cli/src/peer_host/commands/session.rs
@@ -8,11 +8,12 @@ use serde_json::{json, Value};
 use bitfun_agent_runtime::sdk::{
     AgentSessionModelSelection, AgentSessionModelSelectionUpdateRequest,
     AgentSessionRestoreRequest, AgentSessionRestoreResult, PortErrorKind, RuntimeError,
-    SessionInteractionSnapshot,
+    SessionEventProjectionSnapshot, SessionInteractionSnapshot,
 };
 use bitfun_core::agentic::core::Session;
 use bitfun_core::agentic::get_agent_registry;
 use bitfun_core::util::errors::BitFunError;
+use bitfun_events::project_agentic_frontend_event;
 use bitfun_runtime_ports::{
     AgentSessionArchiveRequest, AgentSessionCreateRequest, AgentSessionDeleteRequest,
     AgentSessionModeUpdateRequest, AgentSessionRenameRequest, AgentThreadGoalGetRequest,
@@ -35,6 +36,27 @@ fn session_storage_request(request: &Value) -> Result<SessionStoragePathRequest,
         workspace_path: PathBuf::from(workspace_path),
         remote_connection_id: optional_string(request, "remoteConnectionId"),
         remote_ssh_host: optional_string(request, "remoteSshHost"),
+    })
+}
+
+fn runtime_event_snapshot_to_json(snapshot: SessionEventProjectionSnapshot) -> Value {
+    let events = snapshot
+        .events
+        .into_iter()
+        .filter_map(project_agentic_frontend_event)
+        .map(|event| {
+            json!({
+                "eventName": event.event_name,
+                "payload": event.payload,
+            })
+        })
+        .collect::<Vec<_>>();
+    json!({
+        "sessionId": snapshot.session_id,
+        "streamId": snapshot.stream_id,
+        "cursor": snapshot.cursor,
+        "activeTurnId": snapshot.active_turn_id,
+        "events": events,
     })
 }
 
@@ -292,6 +314,16 @@ pub(crate) async fn restore_session_view(
     // the same boundary as permission event fan-out/listing; otherwise a
     // controller could answer a same-session turn started by another surface.
     retain_peer_owned_interactions(&state.turns, &mut interaction_snapshot);
+    let runtime_event_snapshot = state
+        .agent_runtime
+        .session_event_projection_snapshot(&session_id)
+        .filter(|snapshot| {
+            snapshot
+                .active_turn_id
+                .as_ref()
+                .is_none_or(|turn_id| state.turns.owns(&session_id, Some(turn_id.as_str())))
+        })
+        .map(runtime_event_snapshot_to_json);
 
     let loaded_turn_count = turns.len();
     let is_partial = loaded_turn_count < total_turn_count;
@@ -299,6 +331,7 @@ pub(crate) async fn restore_session_view(
         "session": session_to_json(session, total_turn_count),
         "turns": turns,
         "interactionSnapshot": interaction_snapshot,
+        "runtimeEventSnapshot": runtime_event_snapshot,
         "turnCatalog": turn_catalog,
         "contextRestoreState": "pending",
         "isPartial": is_partial,
@@ -732,18 +765,20 @@ pub(crate) async fn save_session_turn(
 mod tests {
     use super::{
         overlay_live_session_state, peer_core_session_error, peer_runtime_session_error,
-        restored_session_to_json, retain_peer_owned_interactions, session_stats_validation_error,
+        restored_session_to_json, retain_peer_owned_interactions, runtime_event_snapshot_to_json,
+        session_stats_validation_error,
     };
     use crate::peer_host::state::{PeerTurnKey, PeerTurnTracker};
     use bitfun_agent_runtime::sdk::{
         AgentSessionRestoreResult, AgentSessionSummary, PendingUserQuestion,
         PendingUserQuestionSnapshot, PortError, PortErrorKind, RuntimeError,
-        SessionInteractionSnapshot, SessionState,
+        SessionEventProjectionSnapshot, SessionInteractionSnapshot, SessionState,
     };
     use bitfun_core::agentic::core::{
         ProcessingPhase, Session as CoreSession, SessionConfig, SessionState as CoreSessionState,
     };
     use bitfun_core::util::errors::BitFunError;
+    use bitfun_events::AgenticEvent;
 
     #[test]
     fn peer_writer_conflicts_keep_the_stable_transport_code() {
@@ -766,6 +801,31 @@ mod tests {
             "session_in_use: Session is already open for writing: session-1"
         );
         assert_eq!(runtime_error, core_error);
+    }
+
+    #[test]
+    fn peer_restore_projects_runtime_events_with_the_cursor_fence() {
+        let value = runtime_event_snapshot_to_json(SessionEventProjectionSnapshot {
+            session_id: "session-1".to_string(),
+            stream_id: "runtime-a".to_string(),
+            cursor: 7,
+            active_turn_id: Some("turn-1".to_string()),
+            events: vec![AgenticEvent::TextChunk {
+                session_id: "session-1".to_string(),
+                turn_id: "turn-1".to_string(),
+                round_id: "round-1".to_string(),
+                attempt_id: None,
+                attempt_index: None,
+                text: "hello".to_string(),
+            }],
+        });
+
+        assert_eq!(value["sessionId"], "session-1");
+        assert_eq!(value["streamId"], "runtime-a");
+        assert_eq!(value["cursor"], 7);
+        assert_eq!(value["activeTurnId"], "turn-1");
+        assert_eq!(value["events"][0]["eventName"], "agentic://text-chunk");
+        assert_eq!(value["events"][0]["payload"]["text"], "hello");
     }
 
     #[test]

--- a/src/apps/cli/src/peer_host/dispatch.rs
+++ b/src/apps/cli/src/peer_host/dispatch.rs
@@ -9,7 +9,7 @@ use super::control::{
     attach_controller, detach_controller, parse_controller_device_id, peer_mode_ping_value,
 };
 use super::deny::{is_cli_unsupported_command, is_local_only_command};
-use super::state::{peer_host_state, try_peer_host_state};
+use super::state::peer_host_state;
 
 #[derive(Debug, Clone)]
 struct HostInvokeBridgeResult {
@@ -79,18 +79,7 @@ async fn handle_host_invoke_inner(command: &str, args: Value) -> HostInvokeBridg
     }
     if command == "peer_control_detach" {
         let controller_id = parse_controller_device_id(&args);
-        if detach_controller(&controller_id).await {
-            if let Some(state) = try_peer_host_state() {
-                if let Err(error) = state
-                    .cancel_and_drain_peer_turns("last Peer controller detached")
-                    .await
-                {
-                    return HostInvokeBridgeResult::err(format!(
-                        "Peer controller detached, but active work was not fully cancelled: {error}"
-                    ));
-                }
-            }
-        }
+        detach_controller(&controller_id).await;
         return HostInvokeBridgeResult::ok_value(json!({ "detached": true }));
     }
     if command == "peer_mode_ping" {

--- a/src/apps/cli/src/peer_host/fanout.rs
+++ b/src/apps/cli/src/peer_host/fanout.rs
@@ -3,7 +3,9 @@
 use std::collections::HashSet;
 use std::sync::OnceLock;
 
-use bitfun_agent_runtime::sdk::{AgentEventReceiver, PermissionRequestEvent};
+use bitfun_agent_runtime::sdk::{
+    attach_session_event_cursor, AgentEventReceiver, PermissionRequestEvent,
+};
 use bitfun_agent_tools::effective_tool_invocation;
 use bitfun_core::service::remote_connect::encryption::encrypt_to_base64;
 use bitfun_core::service::remote_connect::remote_server::RemoteCommand;
@@ -68,6 +70,12 @@ fn continuity_is_current(continuity: &Option<(super::state::PeerTurnTracker, u64
     continuity
         .as_ref()
         .is_none_or(|(turns, generation)| turns.is_event_stream_generation_current(*generation))
+}
+
+fn settle_record_only_event(turns: &super::state::PeerTurnTracker, terminal: Option<&PeerTurnKey>) {
+    if let Some(turn) = terminal {
+        turns.finish_turn(turn);
+    }
 }
 
 static PEER_EVENT_FANOUT_TX: OnceLock<mpsc::Sender<QueuedPeerDeviceEvent>> = OnceLock::new();
@@ -397,15 +405,23 @@ async fn handle_agentic_event(state: &PeerHostState, event: AgenticEvent) -> Res
         }
     }
 
-    let Some(projected) = project_agentic_frontend_event(event) else {
+    let cursor = state.session_event_journal.record(&event);
+    let Some(mut projected) = project_agentic_frontend_event(event) else {
         if let Some(turn) = terminal_turn {
             state.turns.finish_turn(&turn);
         }
         return Ok(());
     };
+    if let Some(cursor) = cursor {
+        attach_session_event_cursor(&mut projected.payload, cursor);
+    }
     let targets = attached_controllers();
     if targets.is_empty() {
-        return Err("no attached Peer controller can receive Agent events".to_string());
+        // Controller presence is not Runtime ownership. Keep recording the
+        // materialized Turn while every controller is between devices, and
+        // release Peer ownership normally if this was the terminal event.
+        settle_record_only_event(&state.turns, terminal_turn.as_ref());
+        return Ok(());
     }
     let generation = state.turns.current_event_stream_generation()?;
     let owner = state
@@ -729,7 +745,8 @@ mod tests {
     use super::{
         continuity_is_current, drain_broadcast_receiver, enqueue_inherited_peer_device_event,
         enqueue_peer_device_event, event_turn_key, interrupted_turn_failure_projection,
-        retained_delivery_targets, QueuedPeerDeviceEvent, TerminalDeliveryGuard,
+        retained_delivery_targets, settle_record_only_event, QueuedPeerDeviceEvent,
+        TerminalDeliveryGuard,
     };
     use crate::peer_host::state::{PeerTurnKey, PeerTurnTracker};
 
@@ -762,6 +779,35 @@ mod tests {
             vec!["controller-2"]
         );
         assert!(retained_delivery_targets(&queued_targets, &[]).is_empty());
+    }
+
+    #[test]
+    fn record_only_gap_keeps_running_turn_owned_until_reattach() {
+        let tracker = PeerTurnTracker::new();
+        tracker.mark_event_stream_ready();
+        let turn = PeerTurnKey::new("session-1", "turn-1");
+        tracker.register_root(turn.clone()).expect("register root");
+        assert!(tracker.mark_started(&turn));
+
+        settle_record_only_event(&tracker, None);
+
+        assert!(tracker.owns("session-1", Some("turn-1")));
+    }
+
+    #[test]
+    fn record_only_terminal_releases_peer_turn_ownership() {
+        let tracker = PeerTurnTracker::new();
+        tracker.mark_event_stream_ready();
+        let turn = PeerTurnKey::new("session-1", "turn-1");
+        tracker.register_root(turn.clone()).expect("register root");
+        assert!(tracker.mark_started(&turn));
+        assert!(tracker
+            .claim_terminal_delivery(&turn)
+            .expect("claim terminal"));
+
+        settle_record_only_event(&tracker, Some(&turn));
+
+        assert!(!tracker.owns("session-1", Some("turn-1")));
     }
 
     #[test]

--- a/src/apps/cli/src/peer_host/mod.rs
+++ b/src/apps/cli/src/peer_host/mod.rs
@@ -31,17 +31,5 @@ pub(crate) fn notify_controllers_settings_changed() {
 }
 
 pub(crate) async fn update_controller_presence(online_device_ids: Vec<String>) {
-    let lost_last_controller =
-        control::retain_online_controllers(online_device_ids.iter().map(String::as_str)).await;
-    if !lost_last_controller {
-        return;
-    }
-    if let Some(state) = state::try_peer_host_state() {
-        if let Err(error) = state
-            .cancel_and_drain_peer_turns("last Peer controller went offline")
-            .await
-        {
-            tracing::warn!("Peer work was not fully cancelled after controller loss: {error}");
-        }
-    }
+    control::retain_online_controllers(online_device_ids.iter().map(String::as_str)).await;
 }

--- a/src/apps/cli/src/peer_host/state.rs
+++ b/src/apps/cli/src/peer_host/state.rs
@@ -3,8 +3,8 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex, OnceLock};
 
-use bitfun_agent_runtime::sdk::AgentRuntime;
 use bitfun_agent_runtime::sdk::PermissionRequest;
+use bitfun_agent_runtime::sdk::{AgentRuntime, SessionEventJournal};
 use bitfun_core::product_runtime::CoreAgentRuntimeCompatibility;
 use bitfun_core::service::filesystem::FileSystemService;
 use bitfun_core::service::workspace::WorkspaceService;
@@ -887,6 +887,7 @@ fn prune_idle_tree(inner: &mut PeerTurnTrackerInner, key: &PeerTurnKey) {
 #[derive(Clone)]
 pub(crate) struct PeerHostState {
     pub(crate) agent_runtime: AgentRuntime,
+    pub(crate) session_event_journal: Arc<SessionEventJournal>,
     pub(crate) local_workspace_snapshot: Arc<dyn bitfun_runtime_ports::LocalWorkspaceSnapshotPort>,
     pub(crate) compatibility: CoreAgentRuntimeCompatibility,
     pub(crate) account_runtime:

--- a/src/apps/desktop/src/api/agentic_api.rs
+++ b/src/apps/desktop/src/api/agentic_api.rs
@@ -22,7 +22,7 @@ use bitfun_agent_runtime::sdk::{
     AgentSessionModelSelectionUpdateRequest, AgentSessionModelUpdateRequest, AgentSubmissionSource,
     AgentTurnCancellationRequest, AgentTurnInterruptionRequest, DialogSteerOutcome,
     PermissionAuditRecord, PermissionGrant, PermissionGrantKey, PermissionReply, PermissionRequest,
-    RuntimeError, SessionInteractionSnapshot,
+    RuntimeError, SessionEventProjectionSnapshot, SessionInteractionSnapshot,
 };
 use bitfun_core::agentic::agents::AgentSource;
 use bitfun_core::agentic::coordination::{
@@ -553,6 +553,11 @@ pub struct RestoreSessionViewResponse {
     pub session: SessionResponse,
     pub turns: Vec<DialogTurnData>,
     pub interaction_snapshot: SessionInteractionSnapshot,
+    /// Runtime-owned projection of the current Turn. New clients use this to
+    /// reattach without relying on UI-written intermediate checkpoints; older
+    /// hosts omit it and remain compatible with the persisted-turn fallback.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_event_snapshot: Option<FrontendSessionEventProjectionSnapshot>,
     pub current_context_usage: Option<SessionContextUsage>,
     pub turn_catalog: SessionTurnCatalog,
     pub context_restore_state: String,
@@ -560,6 +565,43 @@ pub struct RestoreSessionViewResponse {
     pub loaded_turn_count: usize,
     pub total_turn_count: usize,
     pub timings: SessionViewRestoreTiming,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrontendSessionEventProjectionSnapshot {
+    pub session_id: String,
+    pub stream_id: String,
+    pub cursor: u64,
+    pub active_turn_id: Option<String>,
+    pub events: Vec<FrontendProjectedAgenticEvent>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrontendProjectedAgenticEvent {
+    pub event_name: String,
+    pub payload: serde_json::Value,
+}
+
+fn frontend_event_projection_snapshot(
+    snapshot: SessionEventProjectionSnapshot,
+) -> FrontendSessionEventProjectionSnapshot {
+    FrontendSessionEventProjectionSnapshot {
+        session_id: snapshot.session_id,
+        stream_id: snapshot.stream_id,
+        cursor: snapshot.cursor,
+        active_turn_id: snapshot.active_turn_id,
+        events: snapshot
+            .events
+            .into_iter()
+            .filter_map(bitfun_events::project_agentic_frontend_event)
+            .map(|event| FrontendProjectedAgenticEvent {
+                event_name: event.event_name,
+                payload: event.payload,
+            })
+            .collect(),
+    }
 }
 
 #[derive(Debug, Default)]
@@ -3438,6 +3480,9 @@ pub async fn restore_session_view(
         let session = restored.session;
         let mut turns = restored.turns;
         let interaction_snapshot = restored.interaction_snapshot;
+        let runtime_event_snapshot = restored
+            .runtime_event_snapshot
+            .map(frontend_event_projection_snapshot);
         let current_context_usage = restored.current_context_usage;
         let total_turn_count = restored.total_turn_count;
         let turn_catalog = restored.turn_catalog;
@@ -3492,6 +3537,7 @@ pub async fn restore_session_view(
             session: session_to_response_with_turn_count(session, total_turn_count),
             turns,
             interaction_snapshot,
+            runtime_event_snapshot,
             current_context_usage,
             turn_catalog,
             context_restore_state: "pending".to_string(),
@@ -3909,6 +3955,7 @@ mod tests {
     use bitfun_core::service::session::{
         ModelRoundData, ToolCallData, ToolItemData, ToolResultData, TurnStatus, UserMessageData,
     };
+    use bitfun_events::AgenticEvent;
     use bitfun_product_domains::tool_permissions::{PermissionEffect, PermissionRule};
     use serde_json::json;
 
@@ -3923,6 +3970,31 @@ mod tests {
         };
 
         assert!(!mode_catalog_supports_external_sources(&request, Some(&desktop_host_path)).await);
+    }
+
+    #[test]
+    fn desktop_restore_projects_runtime_events_with_the_cursor_fence() {
+        let snapshot = frontend_event_projection_snapshot(SessionEventProjectionSnapshot {
+            session_id: "session-1".to_string(),
+            stream_id: "runtime-a".to_string(),
+            cursor: 9,
+            active_turn_id: Some("turn-1".to_string()),
+            events: vec![AgenticEvent::TextChunk {
+                session_id: "session-1".to_string(),
+                turn_id: "turn-1".to_string(),
+                round_id: "round-1".to_string(),
+                attempt_id: None,
+                attempt_index: None,
+                text: "hello".to_string(),
+            }],
+        });
+
+        assert_eq!(snapshot.session_id, "session-1");
+        assert_eq!(snapshot.stream_id, "runtime-a");
+        assert_eq!(snapshot.cursor, 9);
+        assert_eq!(snapshot.active_turn_id.as_deref(), Some("turn-1"));
+        assert_eq!(snapshot.events[0].event_name, "agentic://text-chunk");
+        assert_eq!(snapshot.events[0].payload["text"], "hello");
     }
 
     #[test]

--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -33,6 +33,7 @@ pub mod startup_trace;
 pub mod tray;
 mod webview_recovery;
 
+use bitfun_agent_runtime::sdk::{attach_session_event_cursor, SessionEventJournal};
 use bitfun_core::agentic::tools::computer_use_capability::set_computer_use_desktop_available;
 use bitfun_core::agentic::tools::computer_use_host::ComputerUseHostRef;
 use bitfun_core::infrastructure::ai::AIClientFactory;
@@ -643,6 +644,7 @@ pub async fn run() {
     startup_timings.record_elapsed("initialize_app_state", step_started);
     startup_trace.record_elapsed_step("native_pre_tauri", "initialize_app_state", step_started);
 
+    let session_event_journal = Arc::new(SessionEventJournal::new());
     let step_started = Instant::now();
     let desktop_runtime = match runtime::DesktopRuntimeContext::build(
         coordinator.clone(),
@@ -651,6 +653,7 @@ pub async fn run() {
         app_state.workspace_service.clone(),
         app_state.ssh_manager.clone(),
         app_state.acp_client_service.clone(),
+        session_event_journal.clone(),
     ) {
         Ok(runtime) => runtime,
         Err(error) => {
@@ -1051,7 +1054,12 @@ pub async fn run() {
             let transport = Arc::new(TauriTransportAdapter::new(app_handle.clone()));
 
             let step_started = Instant::now();
-            start_event_loop_with_transport(event_queue, event_router, transport);
+            start_event_loop_with_transport(
+                event_queue,
+                event_router,
+                transport,
+                session_event_journal.clone(),
+            );
             startup_trace.record_elapsed_step(
                 "native_setup",
                 "start_event_loop_with_transport",
@@ -2225,18 +2233,29 @@ fn configure_workspace_search_daemon_env() -> Option<std::path::PathBuf> {
 /// Deliver one event to the WebView and, when peer controllers are attached,
 /// fan it out to paired devices. Text chunks arrive here already coalesced by
 /// `TextChunkCoalescer`.
-async fn deliver_event_to_webview(transport: &TauriTransportAdapter, event: AgenticEvent) {
-    if let Err(e) = transport.emit_event(event.clone()).await {
+async fn deliver_event_to_webview(
+    transport: &TauriTransportAdapter,
+    event: AgenticEvent,
+    session_event_journal: &SessionEventJournal,
+) {
+    let cursor = session_event_journal.record(&event);
+    let Some(mut projected) = bitfun_events::project_agentic_frontend_event(event) else {
+        log::warn!("Unhandled AgenticEvent type in desktop delivery");
+        return;
+    };
+    if let Some(cursor) = cursor {
+        attach_session_event_cursor(&mut projected.payload, cursor);
+    }
+
+    if let Err(e) = transport
+        .emit_generic(&projected.event_name, projected.payload.clone())
+        .await
+    {
         log::error!("Failed to emit event: {:?}", e);
     }
 
     if !api::peer_host_invoke::attached_controllers().is_empty() {
-        if let Some(projected) = bitfun_events::project_agentic_frontend_event(event) {
-            api::remote_connect_api::fanout_peer_device_event(
-                projected.event_name,
-                projected.payload,
-            );
-        }
+        api::remote_connect_api::fanout_peer_device_event(projected.event_name, projected.payload);
     }
 }
 
@@ -2435,12 +2454,14 @@ fn start_event_loop_with_transport(
     event_queue: Arc<bitfun_core::agentic::events::EventQueue>,
     event_router: Arc<bitfun_core::agentic::events::EventRouter>,
     transport: Arc<TauriTransportAdapter>,
+    session_event_journal: Arc<SessionEventJournal>,
 ) {
     tokio::spawn(async move {
         event_loop_driver(event_queue, event_router, |event| {
             let transport = transport.clone();
+            let session_event_journal = session_event_journal.clone();
             async move {
-                deliver_event_to_webview(&transport, event).await;
+                deliver_event_to_webview(&transport, event, &session_event_journal).await;
             }
         })
         .await;

--- a/src/apps/desktop/src/runtime/mod.rs
+++ b/src/apps/desktop/src/runtime/mod.rs
@@ -1,6 +1,7 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
+use bitfun_agent_runtime::sdk::SessionEventJournal;
 use bitfun_agent_runtime::sdk::{AgentRuntime, PermissionRequestEvent};
 use bitfun_core::agentic::coordination::{ConversationCoordinator, DialogScheduler};
 use bitfun_core::service::remote_ssh::SSHConnectionManager;
@@ -37,6 +38,7 @@ impl DesktopRuntimeContext {
         workspace_service: Arc<WorkspaceService>,
         ssh_manager: Arc<RwLock<Option<SSHConnectionManager>>>,
         acp_client_service: Option<Arc<bitfun_acp::AcpClientService>>,
+        session_event_journal: Arc<SessionEventJournal>,
     ) -> Result<Self, String> {
         let host_effects = Arc::new(ProductionDesktopSessionHostEffects::new(acp_client_service));
         let session_application = DesktopSessionApplication::build(
@@ -46,6 +48,7 @@ impl DesktopRuntimeContext {
             workspace_service,
             ssh_manager,
             host_effects,
+            session_event_journal,
         )?;
         Ok(Self {
             session_application,

--- a/src/apps/desktop/src/runtime/session_application.rs
+++ b/src/apps/desktop/src/runtime/session_application.rs
@@ -13,7 +13,8 @@ use bitfun_agent_runtime::sdk::{
     AgentLocalCommandTurnRecordRequest, AgentRuntime, AgentSessionArchiveStateRequest,
     AgentSessionDeleteRequest, AgentSessionForkAtTurnRequest, AgentSessionLineageRequest,
     AgentSessionLineageSnapshot, AgentSessionRenameRequest, AgentSessionUsageRequest,
-    PortErrorKind, RuntimeError, SessionInteractionSnapshot,
+    PortErrorKind, RuntimeError, SessionEventJournal, SessionEventProjectionSnapshot,
+    SessionInteractionSnapshot,
 };
 use bitfun_core::agentic::coordination::{ConversationCoordinator, DialogScheduler};
 use bitfun_core::agentic::core::Session;
@@ -126,6 +127,7 @@ pub(crate) struct DesktopSessionViewRestore {
     pub session: Session,
     pub turns: Vec<DialogTurnData>,
     pub interaction_snapshot: SessionInteractionSnapshot,
+    pub runtime_event_snapshot: Option<SessionEventProjectionSnapshot>,
     pub current_context_usage: Option<SessionContextUsage>,
     pub total_turn_count: usize,
     pub turn_catalog: SessionTurnCatalog,
@@ -289,11 +291,13 @@ impl DesktopSessionApplication {
         workspace_service: Arc<WorkspaceService>,
         ssh_manager: Arc<RwLock<Option<SSHConnectionManager>>>,
         host_effects: Arc<dyn DesktopSessionHostEffects>,
+        session_event_journal: Arc<SessionEventJournal>,
     ) -> Result<Self, String> {
-        let agent_runtime = CoreProductAgentRuntime::build_session_surface(
+        let agent_runtime = CoreProductAgentRuntime::build_session_surface_with_event_journal(
             coordinator.clone(),
             scheduler.clone(),
             token_usage_service,
+            session_event_journal,
         )?;
         let compatibility = CoreAgentRuntimeCompatibility::build(coordinator.clone(), scheduler);
 
@@ -789,6 +793,9 @@ impl DesktopSessionApplication {
             .map_err(|error| DesktopSessionApplicationError::Core(error.to_string()))?;
         overlay_live_session_state(&mut session, live_session);
         let interaction_snapshot = self.agent_runtime.session_interaction_snapshot(session_id);
+        let runtime_event_snapshot = self
+            .agent_runtime
+            .session_event_projection_snapshot(session_id);
         let current_context_usage = self
             .compatibility
             .load_persisted_session_metadata(&storage_path, session_id)
@@ -800,6 +807,7 @@ impl DesktopSessionApplication {
             session,
             turns,
             interaction_snapshot,
+            runtime_event_snapshot,
             current_context_usage,
             total_turn_count,
             turn_catalog,

--- a/src/crates/assembly/core/src/product_runtime.rs
+++ b/src/crates/assembly/core/src/product_runtime.rs
@@ -588,6 +588,18 @@ impl CoreProductAgentRuntime {
         )
     }
 
+    /// Build the Desktop/Rich-client Session facade with the Runtime-owned
+    /// materialized event projection used for client reattachment.
+    pub fn build_session_surface_with_event_journal(
+        coordinator: Arc<ConversationCoordinator>,
+        scheduler: Arc<DialogScheduler>,
+        token_usage_service: Arc<TokenUsageService>,
+        event_journal: Arc<bitfun_agent_runtime::sdk::SessionEventJournal>,
+    ) -> Result<AgentRuntime, String> {
+        Self::build_session_surface(coordinator, scheduler, token_usage_service)
+            .map(|runtime| runtime.with_session_event_journal(event_journal))
+    }
+
     #[deprecated(note = "use build_with_event_source for first-party product runtimes")]
     pub fn build(
         coordinator: Arc<ConversationCoordinator>,

--- a/src/crates/execution/agent-runtime/src/runtime.rs
+++ b/src/crates/execution/agent-runtime/src/runtime.rs
@@ -51,6 +51,13 @@ use crate::post_call_hooks::RuntimeHookRegistry;
 use crate::user_questions::{get_user_input_manager, PendingUserQuestionSnapshot};
 use bitfun_runtime_ports::{PermissionReply, PermissionReplySource, PermissionRequest};
 
+#[path = "session_event_journal.rs"]
+mod session_event_journal;
+pub use session_event_journal::{
+    attach_session_event_cursor, SessionEventCursor, SessionEventJournal,
+    SessionEventProjectionSnapshot, RUNTIME_EVENT_CURSOR_KEY, RUNTIME_EVENT_STREAM_ID_KEY,
+};
+
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum RuntimeBuildError {
     #[error("agent submission port is required")]
@@ -222,6 +229,7 @@ pub struct AgentRuntime {
     services: Option<RuntimeServices>,
     event_stream: Option<AgentEventStream>,
     event_source: Option<AgentEventSource>,
+    session_event_journal: Option<Arc<SessionEventJournal>>,
     tool_registry: Option<Arc<dyn RuntimeToolRegistry>>,
     harness_registry: Option<Arc<HarnessRegistry>>,
     hook_registry: RuntimeHookRegistry,
@@ -386,6 +394,13 @@ impl std::fmt::Debug for AgentRuntime {
                 &self.event_source.as_ref().map(|_| "<AgentEventSource>"),
             )
             .field(
+                "session_event_journal",
+                &self
+                    .session_event_journal
+                    .as_ref()
+                    .map(|_| "<SessionEventJournal>"),
+            )
+            .field(
                 "tool_registry",
                 &self.tool_registry.as_ref().map(|_| "<RuntimeToolRegistry>"),
             )
@@ -446,6 +461,7 @@ pub struct AgentRuntimeBuilder {
     services: Option<RuntimeServices>,
     event_stream: Option<AgentEventStream>,
     event_source: Option<AgentEventSource>,
+    session_event_journal: Option<Arc<SessionEventJournal>>,
     tool_registry: Option<Arc<dyn RuntimeToolRegistry>>,
     harness_registry: Option<Arc<HarnessRegistry>>,
     hook_registry: RuntimeHookRegistry,
@@ -613,6 +629,11 @@ impl AgentRuntimeBuilder {
         self
     }
 
+    pub fn with_session_event_journal(mut self, journal: Arc<SessionEventJournal>) -> Self {
+        self.session_event_journal = Some(journal);
+        self
+    }
+
     pub fn with_tool_registry(mut self, registry: Arc<dyn RuntimeToolRegistry>) -> Self {
         self.tool_registry = Some(registry);
         self
@@ -665,6 +686,7 @@ impl AgentRuntimeBuilder {
             services,
             event_stream,
             event_source,
+            session_event_journal,
             tool_registry,
             harness_registry,
             hook_registry,
@@ -702,6 +724,7 @@ impl AgentRuntimeBuilder {
             services,
             event_stream,
             event_source,
+            session_event_journal,
             tool_registry,
             harness_registry,
             hook_registry,
@@ -808,6 +831,13 @@ pub struct AgentRunHandle {
 }
 
 impl AgentRuntime {
+    /// Attach the host-owned Session event projection after a narrow Runtime
+    /// facade has been assembled from existing product ports.
+    pub fn with_session_event_journal(mut self, journal: Arc<SessionEventJournal>) -> Self {
+        self.session_event_journal = Some(journal);
+        self
+    }
+
     pub fn subscribe_events(&self) -> Result<AgentEventReceiver, RuntimeError> {
         self.event_source
             .as_ref()
@@ -856,6 +886,19 @@ impl AgentRuntime {
             user_questions,
             permissions,
         }
+    }
+
+    /// Materialized current-Turn projection owned by the Runtime Host.
+    ///
+    /// Unlike a live receiver, this remains available while no client is
+    /// subscribed and is therefore safe for GUI/TUI/Peer reattachment.
+    pub fn session_event_projection_snapshot(
+        &self,
+        session_id: &str,
+    ) -> Option<SessionEventProjectionSnapshot> {
+        self.session_event_journal
+            .as_ref()
+            .map(|journal| journal.snapshot(session_id))
     }
 
     pub fn permission_request_dialog_turn_id(

--- a/src/crates/execution/agent-runtime/src/sdk.rs
+++ b/src/crates/execution/agent-runtime/src/sdk.rs
@@ -45,6 +45,10 @@ pub use crate::post_call_hooks::{
     RuntimeHookRegistryBuildError,
 };
 pub use crate::runtime::{
+    attach_session_event_cursor, SessionEventCursor, SessionEventJournal,
+    SessionEventProjectionSnapshot, RUNTIME_EVENT_CURSOR_KEY, RUNTIME_EVENT_STREAM_ID_KEY,
+};
+pub use crate::runtime::{
     AgentEventStream, AgentRunHandle, AgentRunRequest, AgentSessionRestorePort,
     AgentSessionRestoreRequest, AgentSessionRestoreResult, RuntimeAgentRegistry,
     RuntimeAgentRegistryQuery, RuntimeBuildError, RuntimeError, RuntimeToolRegistry,
@@ -291,6 +295,11 @@ impl AgentRuntimeBuilder {
         self
     }
 
+    pub fn with_session_event_journal(mut self, journal: Arc<SessionEventJournal>) -> Self {
+        self.inner = self.inner.with_session_event_journal(journal);
+        self
+    }
+
     pub fn with_tool_registry(mut self, registry: Arc<dyn RuntimeToolRegistry>) -> Self {
         self.inner = self.inner.with_tool_registry(registry);
         self
@@ -317,6 +326,11 @@ impl AgentRuntimeBuilder {
 }
 
 impl AgentRuntime {
+    pub fn with_session_event_journal(mut self, journal: Arc<SessionEventJournal>) -> Self {
+        self.inner = self.inner.with_session_event_journal(journal);
+        self
+    }
+
     pub fn subscribe_events(&self) -> Result<AgentEventReceiver, RuntimeError> {
         self.inner.subscribe_events()
     }
@@ -747,6 +761,13 @@ impl AgentRuntime {
 
     pub fn session_interaction_snapshot(&self, session_id: &str) -> SessionInteractionSnapshot {
         self.inner.session_interaction_snapshot(session_id)
+    }
+
+    pub fn session_event_projection_snapshot(
+        &self,
+        session_id: &str,
+    ) -> Option<SessionEventProjectionSnapshot> {
+        self.inner.session_event_projection_snapshot(session_id)
     }
 
     pub async fn publish_event(&self, event: RuntimeEventEnvelope) -> Result<(), RuntimeError> {

--- a/src/crates/execution/agent-runtime/src/session_event_journal.rs
+++ b/src/crates/execution/agent-runtime/src/session_event_journal.rs
@@ -1,0 +1,698 @@
+//! Runtime-owned, materialized event projection for reconnecting Session clients.
+//!
+//! Live broadcasts are intentionally bounded and ephemeral. A GUI, TUI, or
+//! remote controller can therefore miss events while it is detached without
+//! affecting the Dialog Turn that continues to run. This journal keeps the
+//! smallest reconstructable projection of the current Turn, independently of
+//! any client subscription or client-written persistence checkpoint.
+
+use bitfun_events::{AgenticEvent, ToolEventData};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, MutexGuard};
+
+const MAX_PROJECTED_EVENTS_PER_SESSION: usize = 2048;
+const MAX_RETAINED_TERMINAL_SESSION_PROJECTIONS: usize = 64;
+
+/// Reserved metadata carried only by the product delivery envelope. Existing
+/// frontend event payload fields remain unchanged for older clients.
+pub const RUNTIME_EVENT_STREAM_ID_KEY: &str = "__bitfunRuntimeStreamId";
+pub const RUNTIME_EVENT_CURSOR_KEY: &str = "__bitfunRuntimeEventCursor";
+
+/// Add the cursor to an existing frontend event payload without changing its
+/// stable product fields. Non-object payloads cannot identify a Session and
+/// are left untouched.
+pub fn attach_session_event_cursor(
+    payload: &mut serde_json::Value,
+    cursor: SessionEventCursor,
+) -> bool {
+    let Some(payload) = payload.as_object_mut() else {
+        return false;
+    };
+    payload.insert(
+        RUNTIME_EVENT_STREAM_ID_KEY.to_string(),
+        serde_json::Value::String(cursor.stream_id),
+    );
+    payload.insert(
+        RUNTIME_EVENT_CURSOR_KEY.to_string(),
+        serde_json::Value::Number(cursor.cursor.into()),
+    );
+    true
+}
+
+/// Cursor attached to one event after it enters the host's ordered delivery
+/// stream. `stream_id` changes when the Runtime Host process restarts, so a
+/// cursor from an older process can never be mistaken for current progress.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionEventCursor {
+    pub stream_id: String,
+    pub cursor: u64,
+}
+
+/// Coherent materialized projection of the currently executing Turn.
+///
+/// `events` are deliberately the existing authoritative `AgenticEvent`
+/// contract. Text/thinking chunks are accumulated by stream and noisy tool
+/// progress facts are compacted, so attachment cost is bounded by semantic
+/// state rather than by how long a client was disconnected.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionEventProjectionSnapshot {
+    pub session_id: String,
+    pub stream_id: String,
+    pub cursor: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_turn_id: Option<String>,
+    #[serde(default)]
+    pub events: Vec<AgenticEvent>,
+}
+
+#[derive(Default)]
+struct SessionProjection {
+    cursor: u64,
+    active_turn_id: Option<String>,
+    events: Vec<AgenticEvent>,
+    terminal: bool,
+    last_touched: u64,
+}
+
+struct JournalState {
+    stream_id: String,
+    sequence: u64,
+    sessions: HashMap<String, SessionProjection>,
+}
+
+/// Cloneable owner shared by the Runtime facade and its product delivery
+/// adapter. Product hosts record events only after their ordering/coalescing
+/// boundary, then expose snapshots through the same `AgentRuntime` instance.
+#[derive(Clone)]
+pub struct SessionEventJournal {
+    state: Arc<Mutex<JournalState>>,
+}
+
+impl std::fmt::Debug for SessionEventJournal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SessionEventJournal")
+            .finish_non_exhaustive()
+    }
+}
+
+impl Default for SessionEventJournal {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SessionEventJournal {
+    pub fn new() -> Self {
+        Self::with_stream_id(uuid::Uuid::new_v4().to_string())
+    }
+
+    fn with_stream_id(stream_id: String) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(JournalState {
+                stream_id,
+                sequence: 0,
+                sessions: HashMap::new(),
+            })),
+        }
+    }
+
+    /// Record one event in the host's final ordered delivery stream.
+    ///
+    /// A returned cursor must travel with that same live event. `None` means
+    /// the event is not represented by this projection; attachment must always
+    /// release that live event instead of letting a snapshot cursor cover it.
+    pub fn record(&self, event: &AgenticEvent) -> Option<SessionEventCursor> {
+        let session_id = event.session_id()?.to_string();
+        let mut state = lock_state(&self.state);
+        if matches!(event, AgenticEvent::SessionDeleted { .. }) {
+            if let Some(projection) = state.sessions.get_mut(&session_id) {
+                projection.events.clear();
+                projection.active_turn_id = None;
+                projection.terminal = true;
+            }
+            return None;
+        }
+        if event_turn_id(event).is_none()
+            || matches!(
+                event,
+                AgenticEvent::ToolEvent {
+                    tool_event: ToolEventData::StreamChunk { .. },
+                    ..
+                }
+            )
+        {
+            return None;
+        }
+        let stream_id = state.stream_id.clone();
+        let next_sequence = state.sequence.saturating_add(1);
+        let (cursor, materialized) = {
+            let projection = state.sessions.entry(session_id).or_default();
+            let materialized = apply_event(projection, event);
+            if materialized {
+                projection.cursor = projection.cursor.saturating_add(1);
+                projection.last_touched = next_sequence;
+            }
+            (projection.cursor, materialized)
+        };
+        if materialized {
+            state.sequence = next_sequence;
+            prune_terminal_projections(&mut state.sessions);
+        }
+        materialized.then_some(SessionEventCursor { stream_id, cursor })
+    }
+
+    pub fn snapshot(&self, session_id: &str) -> SessionEventProjectionSnapshot {
+        let state = lock_state(&self.state);
+        let projection = state.sessions.get(session_id);
+        SessionEventProjectionSnapshot {
+            session_id: session_id.to_string(),
+            stream_id: state.stream_id.clone(),
+            cursor: projection.map_or(0, |projection| projection.cursor),
+            active_turn_id: projection.and_then(|projection| projection.active_turn_id.clone()),
+            events: projection.map_or_else(Vec::new, |projection| projection.events.clone()),
+        }
+    }
+}
+
+fn lock_state(state: &Mutex<JournalState>) -> MutexGuard<'_, JournalState> {
+    state
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn event_turn_id(event: &AgenticEvent) -> Option<&str> {
+    match event {
+        AgenticEvent::DialogTurnStarted { turn_id, .. }
+        | AgenticEvent::DialogTurnCompleted { turn_id, .. }
+        | AgenticEvent::DialogTurnCancelled { turn_id, .. }
+        | AgenticEvent::DialogTurnInterrupted { turn_id, .. }
+        | AgenticEvent::DialogTurnRecovered { turn_id, .. }
+        | AgenticEvent::DialogTurnFailed { turn_id, .. }
+        | AgenticEvent::TokenUsageUpdated { turn_id, .. }
+        | AgenticEvent::ContextCompressionStarted { turn_id, .. }
+        | AgenticEvent::ContextCompressionCompleted { turn_id, .. }
+        | AgenticEvent::ContextCompressionFailed { turn_id, .. }
+        | AgenticEvent::ModelRoundStarted { turn_id, .. }
+        | AgenticEvent::ModelRoundAttemptSuperseded { turn_id, .. }
+        | AgenticEvent::ModelRoundCompleted { turn_id, .. }
+        | AgenticEvent::TextChunk { turn_id, .. }
+        | AgenticEvent::ThinkingChunk { turn_id, .. }
+        | AgenticEvent::ToolEvent { turn_id, .. }
+        | AgenticEvent::DeepReviewQueueStateChanged { turn_id, .. }
+        | AgenticEvent::UserSteeringInjected { turn_id, .. } => Some(turn_id),
+        AgenticEvent::SubagentSessionLinked {
+            subagent_dialog_turn_id,
+            ..
+        } => Some(subagent_dialog_turn_id),
+        _ => None,
+    }
+}
+
+fn apply_event(projection: &mut SessionProjection, event: &AgenticEvent) -> bool {
+    if let AgenticEvent::DialogTurnStarted { turn_id, .. } = event {
+        if projection.active_turn_id.as_deref() != Some(turn_id) {
+            projection.events.clear();
+            projection.active_turn_id = Some(turn_id.clone());
+        }
+        projection.terminal = false;
+        replace_unique(
+            &mut projection.events,
+            event.clone(),
+            |candidate| matches!(candidate, AgenticEvent::DialogTurnStarted { turn_id: candidate_turn, .. } if candidate_turn == turn_id),
+        );
+        return true;
+    }
+
+    let Some(turn_id) = event_turn_id(event) else {
+        return false;
+    };
+    if projection.active_turn_id.as_deref() != Some(turn_id) {
+        // A Turn may begin before a particular product delivery adapter is
+        // installed. Start a scoped projection on the first concrete Turn
+        // event instead of mixing it with an older Turn.
+        projection.events.clear();
+        projection.active_turn_id = Some(turn_id.to_string());
+        projection.terminal = false;
+    }
+
+    match event {
+        AgenticEvent::TextChunk {
+            turn_id,
+            round_id,
+            attempt_id,
+            attempt_index,
+            text,
+            ..
+        } => {
+            if let Some(AgenticEvent::TextChunk {
+                text: accumulated, ..
+            }) = projection.events.last_mut().filter(|candidate| {
+                matches!(candidate, AgenticEvent::TextChunk {
+                    turn_id: candidate_turn,
+                    round_id: candidate_round,
+                    attempt_id: candidate_attempt,
+                    attempt_index: candidate_attempt_index,
+                    ..
+                } if candidate_turn == turn_id
+                    && candidate_round == round_id
+                    && candidate_attempt == attempt_id
+                    && candidate_attempt_index == attempt_index)
+            }) {
+                accumulated.push_str(text);
+            } else {
+                projection.events.push(event.clone());
+            }
+        }
+        AgenticEvent::ThinkingChunk {
+            turn_id,
+            round_id,
+            attempt_id,
+            attempt_index,
+            content,
+            is_end,
+            ..
+        } => {
+            if let Some(AgenticEvent::ThinkingChunk {
+                content: accumulated,
+                is_end: accumulated_end,
+                ..
+            }) = projection.events.last_mut().filter(|candidate| {
+                matches!(candidate, AgenticEvent::ThinkingChunk {
+                    turn_id: candidate_turn,
+                    round_id: candidate_round,
+                    attempt_id: candidate_attempt,
+                    attempt_index: candidate_attempt_index,
+                    ..
+                } if candidate_turn == turn_id
+                    && candidate_round == round_id
+                    && candidate_attempt == attempt_id
+                    && candidate_attempt_index == attempt_index)
+            }) {
+                accumulated.push_str(content);
+                *accumulated_end |= *is_end;
+            } else {
+                projection.events.push(event.clone());
+            }
+        }
+        AgenticEvent::ModelRoundStarted { round_id, .. } => {
+            replace_unique(
+                &mut projection.events,
+                event.clone(),
+                |candidate| matches!(candidate, AgenticEvent::ModelRoundStarted { round_id: candidate_round, .. } if candidate_round == round_id),
+            );
+        }
+        AgenticEvent::ModelRoundCompleted { round_id, .. } => {
+            replace_unique(
+                &mut projection.events,
+                event.clone(),
+                |candidate| matches!(candidate, AgenticEvent::ModelRoundCompleted { round_id: candidate_round, .. } if candidate_round == round_id),
+            );
+        }
+        AgenticEvent::TokenUsageUpdated { .. } => {
+            replace_unique(&mut projection.events, event.clone(), |candidate| {
+                matches!(candidate, AgenticEvent::TokenUsageUpdated { .. })
+            });
+        }
+        AgenticEvent::ToolEvent {
+            tool_event: ToolEventData::ParamsPartial { identity, params },
+            ..
+        } => {
+            if let Some(AgenticEvent::ToolEvent {
+                tool_event:
+                    ToolEventData::ParamsPartial {
+                        params: accumulated,
+                        ..
+                    },
+                ..
+            }) = projection.events.iter_mut().find(|candidate| {
+                matches!(candidate, AgenticEvent::ToolEvent {
+                    tool_event: ToolEventData::ParamsPartial { identity: candidate_identity, .. },
+                    ..
+                } if candidate_identity.tool_id == identity.tool_id)
+            }) {
+                accumulated.push_str(params);
+            } else {
+                projection.events.push(event.clone());
+            }
+        }
+        AgenticEvent::ToolEvent { tool_event, .. } if compactable_tool_event(tool_event) => {
+            let tool_id = tool_event_identity(tool_event);
+            replace_unique(&mut projection.events, event.clone(), |candidate| {
+                matches!(candidate, AgenticEvent::ToolEvent { tool_event: candidate_event, .. }
+                    if compactable_tool_event(candidate_event)
+                        && tool_event_identity(candidate_event) == tool_id
+                        && std::mem::discriminant(candidate_event) == std::mem::discriminant(tool_event))
+            });
+        }
+        AgenticEvent::ToolEvent { tool_event, .. } => {
+            let tool_id = tool_event_identity(tool_event);
+            replace_unique(&mut projection.events, event.clone(), |candidate| {
+                matches!(candidate, AgenticEvent::ToolEvent { tool_event: candidate_event, .. }
+                    if tool_event_identity(candidate_event) == tool_id
+                        && std::mem::discriminant(candidate_event) == std::mem::discriminant(tool_event))
+            });
+        }
+        _ => projection.events.push(event.clone()),
+    }
+
+    compact_projection(projection);
+    if matches!(
+        event,
+        AgenticEvent::DialogTurnCompleted { .. }
+            | AgenticEvent::DialogTurnCancelled { .. }
+            | AgenticEvent::DialogTurnFailed { .. }
+    ) {
+        projection.terminal = true;
+    }
+    true
+}
+
+fn prune_terminal_projections(sessions: &mut HashMap<String, SessionProjection>) {
+    let mut retained = sessions
+        .iter()
+        .filter_map(|(session_id, projection)| {
+            (projection.terminal && !projection.events.is_empty())
+                .then_some((session_id.clone(), projection.last_touched))
+        })
+        .collect::<Vec<_>>();
+    if retained.len() <= MAX_RETAINED_TERMINAL_SESSION_PROJECTIONS {
+        return;
+    }
+    retained.sort_unstable_by(|left, right| right.1.cmp(&left.1));
+    for (session_id, _) in retained
+        .into_iter()
+        .skip(MAX_RETAINED_TERMINAL_SESSION_PROJECTIONS)
+    {
+        if let Some(projection) = sessions.get_mut(&session_id) {
+            // Keep the per-Session cursor tombstone monotonic while releasing
+            // replay content that persisted idle history can reconstruct.
+            projection.events.clear();
+            projection.active_turn_id = None;
+        }
+    }
+}
+
+fn replace_unique(
+    events: &mut Vec<AgenticEvent>,
+    replacement: AgenticEvent,
+    matches: impl Fn(&AgenticEvent) -> bool,
+) {
+    if let Some(index) = events.iter().position(matches) {
+        events[index] = replacement;
+    } else {
+        events.push(replacement);
+    }
+}
+
+fn compactable_tool_event(event: &ToolEventData) -> bool {
+    matches!(
+        event,
+        ToolEventData::EarlyDetected { .. }
+            | ToolEventData::Queued { .. }
+            | ToolEventData::Waiting { .. }
+            | ToolEventData::Progress { .. }
+            | ToolEventData::Streaming { .. }
+    )
+}
+
+fn tool_event_identity(event: &ToolEventData) -> &str {
+    match event {
+        ToolEventData::EarlyDetected { identity }
+        | ToolEventData::ParamsPartial { identity, .. }
+        | ToolEventData::Queued { identity, .. }
+        | ToolEventData::Waiting { identity, .. }
+        | ToolEventData::Started { identity, .. }
+        | ToolEventData::Progress { identity, .. }
+        | ToolEventData::Streaming { identity, .. }
+        | ToolEventData::StreamChunk { identity, .. }
+        | ToolEventData::ConfirmationNeeded { identity, .. }
+        | ToolEventData::Confirmed { identity }
+        | ToolEventData::Rejected { identity }
+        | ToolEventData::Completed { identity, .. }
+        | ToolEventData::Failed { identity, .. }
+        | ToolEventData::Cancelled { identity, .. } => &identity.tool_id,
+    }
+}
+
+fn compact_projection(projection: &mut SessionProjection) {
+    if projection.events.len() <= MAX_PROJECTED_EVENTS_PER_SESSION {
+        return;
+    }
+    let excess = projection.events.len() - MAX_PROJECTED_EVENTS_PER_SESSION;
+    let mut removable = projection
+        .events
+        .iter()
+        .enumerate()
+        .filter_map(|(index, event)| {
+            (index > 0
+                && matches!(
+                    event,
+                    AgenticEvent::ToolEvent {
+                        tool_event: ToolEventData::Progress { .. }
+                            | ToolEventData::Streaming { .. }
+                            | ToolEventData::StreamChunk { .. },
+                        ..
+                    }
+                ))
+            .then_some(index)
+        })
+        .take(excess)
+        .collect::<Vec<_>>();
+    if removable.len() < excess {
+        let fallback = (1..projection.events.len())
+            .filter(|index| !removable.contains(index))
+            .take(excess - removable.len())
+            .collect::<Vec<_>>();
+        removable.extend(fallback);
+    }
+    removable.sort_unstable_by(|left, right| right.cmp(left));
+    for index in removable {
+        projection.events.remove(index);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        attach_session_event_cursor, lock_state, SessionEventCursor, SessionEventJournal,
+        MAX_RETAINED_TERMINAL_SESSION_PROJECTIONS,
+    };
+    use bitfun_events::{AgenticEvent, ToolEventData, ToolEventIdentity};
+
+    fn turn_started(session_id: &str, turn_id: &str) -> AgenticEvent {
+        AgenticEvent::DialogTurnStarted {
+            session_id: session_id.to_string(),
+            turn_id: turn_id.to_string(),
+            turn_index: 0,
+            user_input: "prompt".to_string(),
+            original_user_input: None,
+            user_message_metadata: None,
+        }
+    }
+
+    fn text(session_id: &str, turn_id: &str, value: &str) -> AgenticEvent {
+        AgenticEvent::TextChunk {
+            session_id: session_id.to_string(),
+            turn_id: turn_id.to_string(),
+            round_id: "round".to_string(),
+            attempt_id: None,
+            attempt_index: None,
+            text: value.to_string(),
+        }
+    }
+
+    fn turn_completed(session_id: &str, turn_id: &str) -> AgenticEvent {
+        AgenticEvent::DialogTurnCompleted {
+            session_id: session_id.to_string(),
+            turn_id: turn_id.to_string(),
+            total_rounds: 1,
+            total_tools: 0,
+            duration_ms: 1,
+            partial_recovery_reason: None,
+            success: Some(true),
+            finish_reason: Some("stop".to_string()),
+            has_final_response: Some(true),
+        }
+    }
+
+    fn tool(session_id: &str, turn_id: &str, tool_event: ToolEventData) -> AgenticEvent {
+        AgenticEvent::ToolEvent {
+            session_id: session_id.to_string(),
+            turn_id: turn_id.to_string(),
+            round_id: "round".to_string(),
+            attempt_id: None,
+            attempt_index: None,
+            tool_event,
+        }
+    }
+
+    #[test]
+    fn materializes_stream_content_without_a_subscriber() {
+        let journal = SessionEventJournal::with_stream_id("runtime-a".to_string());
+        let first = journal.record(&turn_started("session", "turn")).unwrap();
+        let second = journal.record(&text("session", "turn", "hel")).unwrap();
+        let third = journal.record(&text("session", "turn", "lo")).unwrap();
+
+        assert_eq!(first.cursor, 1);
+        assert_eq!(second.cursor, 2);
+        assert_eq!(third.cursor, 3);
+        assert_eq!(third.stream_id, "runtime-a");
+
+        let snapshot = journal.snapshot("session");
+        assert_eq!(snapshot.active_turn_id.as_deref(), Some("turn"));
+        assert_eq!(snapshot.cursor, 3);
+        assert_eq!(snapshot.events.len(), 2);
+        assert!(matches!(
+            &snapshot.events[1],
+            AgenticEvent::TextChunk { text, .. } if text == "hello"
+        ));
+    }
+
+    #[test]
+    fn a_new_turn_replaces_the_previous_turn_projection() {
+        let journal = SessionEventJournal::with_stream_id("runtime-a".to_string());
+        journal.record(&turn_started("session", "turn-1"));
+        journal.record(&text("session", "turn-1", "old"));
+        journal.record(&turn_started("session", "turn-2"));
+
+        let snapshot = journal.snapshot("session");
+        assert_eq!(snapshot.cursor, 3);
+        assert_eq!(snapshot.active_turn_id.as_deref(), Some("turn-2"));
+        assert_eq!(snapshot.events.len(), 1);
+        assert!(matches!(
+            &snapshot.events[0],
+            AgenticEvent::DialogTurnStarted { turn_id, .. } if turn_id == "turn-2"
+        ));
+    }
+
+    #[test]
+    fn session_projections_and_cursors_are_isolated() {
+        let journal = SessionEventJournal::with_stream_id("runtime-a".to_string());
+        journal.record(&turn_started("session-a", "turn-a"));
+        journal.record(&turn_started("session-b", "turn-b"));
+        journal.record(&text("session-a", "turn-a", "a"));
+
+        assert_eq!(journal.snapshot("session-a").cursor, 2);
+        assert_eq!(journal.snapshot("session-b").cursor, 1);
+        assert_eq!(journal.snapshot("missing").cursor, 0);
+    }
+
+    #[test]
+    fn preserves_text_segments_separated_by_a_tool() {
+        let journal = SessionEventJournal::with_stream_id("runtime-a".to_string());
+        journal.record(&turn_started("session", "turn"));
+        journal.record(&text("session", "turn", "before"));
+        journal.record(&tool(
+            "session",
+            "turn",
+            ToolEventData::EarlyDetected {
+                identity: ToolEventIdentity::direct("tool", "Read"),
+            },
+        ));
+        journal.record(&text("session", "turn", "after"));
+
+        let snapshot = journal.snapshot("session");
+        assert_eq!(snapshot.events.len(), 4);
+        assert!(matches!(
+            &snapshot.events[1],
+            AgenticEvent::TextChunk { text, .. } if text == "before"
+        ));
+        assert!(matches!(
+            &snapshot.events[3],
+            AgenticEvent::TextChunk { text, .. } if text == "after"
+        ));
+    }
+
+    #[test]
+    fn materializes_partial_tool_params_and_discards_noop_stream_chunks() {
+        let journal = SessionEventJournal::with_stream_id("runtime-a".to_string());
+        journal.record(&turn_started("session", "turn"));
+        for params in ["{\"path\":\"", "file.rs\"}"] {
+            journal.record(&tool(
+                "session",
+                "turn",
+                ToolEventData::ParamsPartial {
+                    identity: ToolEventIdentity::direct("tool", "Read"),
+                    params: params.to_string(),
+                },
+            ));
+        }
+        journal.record(&tool(
+            "session",
+            "turn",
+            ToolEventData::StreamChunk {
+                identity: ToolEventIdentity::direct("tool", "Read"),
+                data: serde_json::json!({ "ignored": true }),
+            },
+        ));
+
+        let snapshot = journal.snapshot("session");
+        assert_eq!(snapshot.cursor, 3);
+        assert_eq!(snapshot.events.len(), 2);
+        assert!(matches!(
+            &snapshot.events[1],
+            AgenticEvent::ToolEvent {
+                tool_event: ToolEventData::ParamsPartial { params, .. },
+                ..
+            } if params == "{\"path\":\"file.rs\"}"
+        ));
+    }
+
+    #[test]
+    fn cursor_metadata_is_additive_to_product_payloads() {
+        let mut payload = serde_json::json!({ "sessionId": "session", "text": "hello" });
+        assert!(attach_session_event_cursor(
+            &mut payload,
+            SessionEventCursor {
+                stream_id: "runtime-a".to_string(),
+                cursor: 42,
+            },
+        ));
+        assert_eq!(payload["sessionId"], "session");
+        assert_eq!(payload["text"], "hello");
+        assert_eq!(payload["__bitfunRuntimeStreamId"], "runtime-a");
+        assert_eq!(payload["__bitfunRuntimeEventCursor"], 42);
+    }
+
+    #[test]
+    fn non_materialized_session_events_are_not_cursor_fenced() {
+        let journal = SessionEventJournal::with_stream_id("runtime-a".to_string());
+        let cursor = journal.record(&AgenticEvent::SessionTitleGenerated {
+            session_id: "session".to_string(),
+            title: "A title that must stay live".to_string(),
+            method: "model".to_string(),
+        });
+
+        assert!(cursor.is_none());
+        let snapshot = journal.snapshot("session");
+        assert_eq!(snapshot.cursor, 0);
+        assert!(snapshot.events.is_empty());
+        assert!(lock_state(&journal.state).sessions.is_empty());
+    }
+
+    #[test]
+    fn terminal_projection_retention_is_bounded_without_resetting_cursors() {
+        let journal = SessionEventJournal::with_stream_id("runtime-a".to_string());
+        for index in 0..=MAX_RETAINED_TERMINAL_SESSION_PROJECTIONS {
+            let session_id = format!("session-{index}");
+            let turn_id = format!("turn-{index}");
+            journal.record(&turn_started(&session_id, &turn_id));
+            journal.record(&turn_completed(&session_id, &turn_id));
+        }
+
+        let evicted = journal.snapshot("session-0");
+        assert_eq!(evicted.cursor, 2);
+        assert!(evicted.active_turn_id.is_none());
+        assert!(evicted.events.is_empty());
+
+        let retained = journal.snapshot(&format!(
+            "session-{}",
+            MAX_RETAINED_TERMINAL_SESSION_PROJECTIONS
+        ));
+        assert_eq!(retained.cursor, 2);
+        assert!(!retained.events.is_empty());
+    }
+}

--- a/src/web-ui/src/flow_chat/hooks/useSessionStateMachine.ts
+++ b/src/web-ui/src/flow_chat/hooks/useSessionStateMachine.ts
@@ -2,7 +2,11 @@
  * Session state machine hook.
  */
 
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useSyncExternalStore } from 'react';
+import {
+  getActiveSurfaceScope,
+  onSurfaceActivated,
+} from '@/infrastructure/peer-device/deviceSurface';
 import { stateMachineManager } from '../state-machine';
 import {
   SessionStateMachine,
@@ -11,32 +15,49 @@ import {
 } from '../state-machine/types';
 import { deriveSessionState } from '../state-machine/derivedState';
 
+const subscribeToSurfaceActivation = (listener: () => void): (() => void) =>
+  onSurfaceActivated(() => listener());
+
+const currentSurfaceEpoch = (): number => getActiveSurfaceScope().epoch;
+
 /**
  * Access the session state machine.
  */
 export function useSessionStateMachine(sessionId: string | null) {
-  const [snapshot, setSnapshot] = useState<SessionStateMachine | null>(null);
+  const surfaceEpoch = useSyncExternalStore(
+    subscribeToSurfaceActivation,
+    currentSurfaceEpoch,
+    currentSurfaceEpoch,
+  );
+  const identity = `${surfaceEpoch}:${sessionId ?? ''}`;
+  const [snapshotState, setSnapshotState] = useState<{
+    identity: string;
+    snapshot: SessionStateMachine | null;
+  }>({ identity, snapshot: null });
 
   useEffect(() => {
     if (!sessionId) {
-      setSnapshot(null);
+      setSnapshotState({ identity, snapshot: null });
       return;
     }
 
     const machine = stateMachineManager.getOrCreate(sessionId);
-    
-    setSnapshot(machine.getSnapshot());
+
+    setSnapshotState({ identity, snapshot: machine.getSnapshot() });
 
     const unsubscribe = machine.subscribe((newSnapshot) => {
-      setSnapshot(newSnapshot);
+      setSnapshotState({ identity, snapshot: newSnapshot });
     });
 
     return () => {
       unsubscribe();
     };
-  }, [sessionId]);
+  }, [identity, sessionId]);
 
-  return snapshot;
+  // React retains hook state for one render when either the Session or Surface
+  // identity changes. Never pair that previous machine snapshot with the new
+  // Session id while the effect re-subscribes.
+  return snapshotState.identity === identity ? snapshotState.snapshot : null;
 }
 
 /**
@@ -92,4 +113,3 @@ export function useSessionStateMachineActions(sessionId: string | null) {
     updatePlanner,
   };
 }
-

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.test.ts
@@ -9,6 +9,10 @@ const stateMachineMock = vi.hoisted(() => ({
   reset: vi.fn(),
   transition: vi.fn(async () => true),
 }));
+const agenticListenerMock = vi.hoisted(() => ({
+  getIsListening: vi.fn(() => true),
+  dispatchExternal: vi.fn(() => true),
+}));
 
 vi.mock('@/infrastructure/peer-device/peerModeFlag', () => ({
   isPeerDeviceModeActive: () => peerModeMock.active,
@@ -22,11 +26,16 @@ vi.mock('../liveSessionInteractionStore', () => ({
   installLiveSessionInteractionMailbox: vi.fn(),
 }));
 
+vi.mock('../AgenticEventListener', () => ({
+  agenticEventListener: agenticListenerMock,
+}));
+
 import {
   installPeerSessionRefresh,
   PEER_SESSION_REFRESH_INTERVAL_MS,
   requestPeerSessionRefresh,
 } from './PeerSessionRefreshModule';
+import { resetRuntimeSessionEventGateForTest } from '@/infrastructure/peer-device/runtimeSessionEventGate';
 
 describe('PeerSessionRefreshModule', () => {
   beforeEach(() => {
@@ -44,6 +53,7 @@ describe('PeerSessionRefreshModule', () => {
   });
 
   afterEach(() => {
+    resetRuntimeSessionEventGateForTest();
     vi.clearAllMocks();
     vi.unstubAllGlobals();
     vi.useRealTimers();
@@ -76,6 +86,7 @@ describe('PeerSessionRefreshModule', () => {
       },
       eventBatcher: {
         flushNow: vi.fn(),
+        clear: vi.fn(),
       },
       contentBuffers: new Map(),
       activeTextItems: new Map(),
@@ -110,6 +121,7 @@ describe('PeerSessionRefreshModule', () => {
       },
       eventBatcher: {
         flushNow: vi.fn(),
+        clear: vi.fn(),
       },
       contentBuffers: new Map(),
       activeTextItems: new Map(),
@@ -166,8 +178,9 @@ describe('PeerSessionRefreshModule re-attach after a surface switch', () => {
         getState: () => state,
         subscribeSelector: vi.fn(() => () => {}),
         refreshPeerSessionSnapshot,
+        reconcilePendingUserQuestions: vi.fn(),
       },
-      eventBatcher: { flushNow: vi.fn() },
+      eventBatcher: { flushNow: vi.fn(), clear: vi.fn() },
       contentBuffers: new Map(),
       activeTextItems: new Map(),
     } as any;
@@ -196,7 +209,7 @@ describe('PeerSessionRefreshModule re-attach after a surface switch', () => {
     cleanup();
   });
 
-  it('does not churn the state machine while a turn is already streaming', async () => {
+  it('does not poll or churn while a turn is already streaming fresh events', async () => {
     stateMachineMock.get.mockReturnValue({
       getCurrentState: () => 'processing',
       getContext: () => ({ lastUpdateTime: Date.now(), version: 0 }),
@@ -212,7 +225,102 @@ describe('PeerSessionRefreshModule re-attach after a surface switch', () => {
     await vi.advanceTimersByTimeAsync(1);
     await vi.advanceTimersByTimeAsync(PEER_SESSION_REFRESH_INTERVAL_MS);
 
-    expect(refresh).toHaveBeenCalled();
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(stateMachineMock.reset).not.toHaveBeenCalled();
+    cleanup();
+  });
+
+  it('replays the Runtime projection before reconciling the blocking mailbox', async () => {
+    stateMachineMock.get.mockReturnValue({
+      getCurrentState: () => 'idle',
+      getContext: () => ({ lastUpdateTime: 0, version: 0 }),
+    });
+    const runtimeEventSnapshot = {
+      sessionId: 'session-1',
+      streamId: 'runtime-a',
+      cursor: 8,
+      activeTurnId: 'turn-live',
+      events: [
+        {
+          eventName: 'agentic://dialog-turn-started',
+          payload: { sessionId: 'session-1', turnId: 'turn-live' },
+        },
+        {
+          eventName: 'agentic://text-chunk',
+          payload: {
+            sessionId: 'session-1',
+            turnId: 'turn-live',
+            roundId: 'round-0',
+            text: 'materialized output',
+          },
+        },
+      ],
+    };
+    const refresh = vi.fn(async () => ({
+      applied: true,
+      backendState: 'Processing { current_turn_id: "turn-live", phase: Streaming }',
+      latestTurnId: 'turn-live',
+      latestTurnStatus: 'processing',
+      runtimeEventSnapshot,
+      pendingUserQuestions: { revision: 2, questions: [] },
+    }));
+    const context = contextWithSnapshot(refresh);
+
+    const cleanup = installPeerSessionRefresh(context);
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(agenticListenerMock.dispatchExternal).toHaveBeenNthCalledWith(
+      1,
+      'agentic://dialog-turn-started',
+      runtimeEventSnapshot.events[0].payload,
+    );
+    expect(agenticListenerMock.dispatchExternal).toHaveBeenNthCalledWith(
+      2,
+      'agentic://text-chunk',
+      runtimeEventSnapshot.events[1].payload,
+    );
+    expect(context.eventBatcher.clear).toHaveBeenCalled();
+    expect(context.flowChatStore.reconcilePendingUserQuestions).toHaveBeenCalledWith(
+      'session-1',
+      { revision: 2, questions: [] },
+    );
+    cleanup();
+  });
+
+  it('advances a healthy Runtime fence without resetting and replaying it', async () => {
+    stateMachineMock.get.mockReturnValue({
+      getCurrentState: () => 'processing',
+      getContext: () => ({ lastUpdateTime: Date.now(), version: 0 }),
+    });
+    const refresh = vi.fn(async () => ({
+      applied: false,
+      backendState: 'Processing { current_turn_id: "turn-live", phase: Streaming }',
+      latestTurnId: 'turn-live',
+      latestTurnStatus: 'processing',
+      runtimeEventReplayRequired: false,
+      runtimeEventSnapshot: {
+        sessionId: 'session-1',
+        streamId: 'runtime-a',
+        cursor: 8,
+        activeTurnId: 'turn-live',
+        events: [{
+          eventName: 'agentic://text-chunk',
+          payload: {
+            sessionId: 'session-1',
+            turnId: 'turn-live',
+            roundId: 'round-0',
+            text: 'already rendered',
+          },
+        }],
+      },
+    }));
+    const context = contextWithSnapshot(refresh);
+
+    const cleanup = installPeerSessionRefresh(context);
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(agenticListenerMock.dispatchExternal).not.toHaveBeenCalled();
+    expect(context.eventBatcher.clear).not.toHaveBeenCalled();
     expect(stateMachineMock.reset).not.toHaveBeenCalled();
     cleanup();
   });

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.ts
@@ -11,8 +11,15 @@
  * requests when an event gap is detected.
  */
 
-import { isSurfaceChangedError } from '@/infrastructure/peer-device/deviceSurface';
+import {
+  getActiveSurfaceScope,
+  isSurfaceChangedError,
+} from '@/infrastructure/peer-device/deviceSurface';
 import { isSurfaceReconcileEnabled } from '@/infrastructure/peer-device/deviceSurfaceReconcile';
+import {
+  beginRuntimeSessionAttachment,
+  subscribeRuntimeSessionEventGaps,
+} from '@/infrastructure/peer-device/runtimeSessionEventGate';
 import { createLogger } from '@/shared/utils/logger';
 import {
   isBackendSessionActivelyProcessing,
@@ -24,6 +31,7 @@ import {
 } from '../../state-machine/types';
 import type { AnyFlowItem, DialogTurn } from '../../types/flow-chat';
 import { installLiveSessionInteractionMailbox } from '../liveSessionInteractionStore';
+import { agenticEventListener } from '../AgenticEventListener';
 import type { FlowChatContext } from './types';
 
 const log = createLogger('PeerSessionRefresh');
@@ -130,7 +138,10 @@ export function installPeerSessionRefresh(context: FlowChatContext): () => void 
   let queued = false;
   let immediateTimer: ReturnType<typeof setTimeout> | null = null;
 
-  async function runRefresh(requestedSessionId?: string): Promise<void> {
+  async function runRefresh(
+    requestedSessionId?: string,
+    staleOnly = false,
+  ): Promise<void> {
     if (disposed || inFlight || !isSurfaceReconcileEnabled()) {
       if (inFlight) {
         queued = true;
@@ -138,6 +149,9 @@ export function installPeerSessionRefresh(context: FlowChatContext): () => void 
       return;
     }
     if (typeof document !== 'undefined' && document.visibilityState === 'hidden') {
+      return;
+    }
+    if (!agenticEventListener.getIsListening()) {
       return;
     }
 
@@ -164,12 +178,20 @@ export function installPeerSessionRefresh(context: FlowChatContext): () => void 
       return;
     }
     const lastUpdateTime = machine?.getContext().lastUpdateTime ?? 0;
-    const replaceRunningSnapshot =
+    const forceRuntimeReplay =
       machineState === SessionExecutionState.IDLE ||
-      machineState === SessionExecutionState.ERROR ||
-      Date.now() - lastUpdateTime >= PEER_SESSION_STREAM_STALE_MS;
+      machineState === SessionExecutionState.ERROR;
+    const streamIsStale = Date.now() - lastUpdateTime >= PEER_SESSION_STREAM_STALE_MS;
+    if (staleOnly && !forceRuntimeReplay && !streamIsStale) {
+      return;
+    }
+    const replaceRunningSnapshot =
+      forceRuntimeReplay || streamIsStale;
     context.eventBatcher.flushNow();
     const machineVersion = machine?.getContext().version ?? 0;
+    const surfaceScope = getActiveSurfaceScope();
+    const attachment = beginRuntimeSessionAttachment(surfaceScope.surfaceId, sessionId);
+    let attachmentFinished = false;
 
     inFlight = true;
     try {
@@ -186,8 +208,79 @@ export function installPeerSessionRefresh(context: FlowChatContext): () => void 
             const currentMachine = stateMachineManager.get(sessionId);
             return (currentMachine?.getContext().version ?? 0) === machineVersion;
           },
+          shouldReplayRuntimeSnapshot: snapshot =>
+            forceRuntimeReplay || attachment.requiresReplay(snapshot),
         },
       );
+      surfaceScope.assertCurrent('attachRuntimeSession');
+
+      if (result.runtimeEventSnapshot) {
+        if (result.runtimeEventReplayRequired === false) {
+          // The rendered projection already includes this exact Runtime
+          // cursor. Advance the in-flight fence without resetting a healthy
+          // state machine every time the liveness timer runs.
+          attachment.finish({
+            streamId: result.runtimeEventSnapshot.streamId,
+            cursor: result.runtimeEventSnapshot.cursor,
+          });
+          attachmentFinished = true;
+          log.debug('Runtime session projection already current', {
+            sessionId,
+            cursor: result.runtimeEventSnapshot.cursor,
+          });
+          return;
+        }
+
+        // Establish an empty current-Turn base before replay. The journal is
+        // authoritative for everything after DialogTurnStarted, so no
+        // UI-written partial checkpoint is allowed to overlap it.
+        context.eventBatcher.clear();
+        context.contentBuffers.delete(sessionId);
+        context.activeTextItems.delete(sessionId);
+        stateMachineManager.reset(sessionId);
+        await alignStateMachineWithSnapshot(
+          context,
+          sessionId,
+          result.backendState,
+          result.runtimeEventSnapshot.activeTurnId ?? result.latestTurnId,
+        );
+
+        for (const event of result.runtimeEventSnapshot.events) {
+          surfaceScope.assertCurrent('replayRuntimeSessionProjection');
+          if (!agenticEventListener.dispatchExternal(event.eventName, event.payload)) {
+            throw new Error('Agentic event listener is unavailable during Runtime replay');
+          }
+        }
+        context.eventBatcher.flushNow();
+        context.flowChatStore.reconcilePendingUserQuestions(
+          sessionId,
+          result.pendingUserQuestions,
+        );
+        await alignStateMachineWithSnapshot(
+          context,
+          sessionId,
+          result.backendState,
+          result.runtimeEventSnapshot.activeTurnId ?? result.latestTurnId,
+        );
+        surfaceScope.assertCurrent('finishRuntimeSessionAttachment');
+        attachment.finish({
+          streamId: result.runtimeEventSnapshot.streamId,
+          cursor: result.runtimeEventSnapshot.cursor,
+        });
+        attachmentFinished = true;
+        log.debug('Runtime session projection attached', {
+          sessionId,
+          backendState: result.backendState,
+          cursor: result.runtimeEventSnapshot.cursor,
+          eventCount: result.runtimeEventSnapshot.events.length,
+        });
+        return;
+      }
+
+      // Older hosts have no cursor contract. Release their queued live events
+      // and retain the existing persisted-snapshot reconciliation fallback.
+      attachment.abort();
+      attachmentFinished = true;
       if (!result.applied) {
         // A snapshot that changed nothing — or that was refused because it
         // would have dropped projected content — still reports whether the
@@ -226,6 +319,10 @@ export function installPeerSessionRefresh(context: FlowChatContext): () => void 
         latestTurnId: result.latestTurnId,
       });
     } catch (error) {
+      if (!attachmentFinished) {
+        attachment.abort({ discard: !surfaceScope.isCurrent() });
+        attachmentFinished = true;
+      }
       if (isSurfaceChangedError(error)) {
         // The snapshot belongs to a device this window stopped rendering. Its
         // own container keeps the projection; the surface now on screen
@@ -238,6 +335,9 @@ export function installPeerSessionRefresh(context: FlowChatContext): () => void 
       // auto-exit from Peer Mode.
       log.warn('Peer session snapshot refresh failed', { sessionId, error });
     } finally {
+      if (!attachmentFinished) {
+        attachment.abort({ discard: !surfaceScope.isCurrent() });
+      }
       inFlight = false;
       if (queued && !disposed) {
         queued = false;
@@ -262,12 +362,29 @@ export function installPeerSessionRefresh(context: FlowChatContext): () => void 
   installedRefreshRequester = scheduleRefresh;
 
   const unsubscribeActiveSession = context.flowChatStore.subscribeSelector(
-    state => state.activeSessionId,
-    sessionId => scheduleRefresh(sessionId ?? undefined),
+    state => {
+      const sessionId = state.activeSessionId;
+      const session = sessionId ? state.sessions.get(sessionId) : undefined;
+      return JSON.stringify([
+        sessionId ?? '',
+        session?.historyState ?? '',
+        session?.workspacePath ?? '',
+        session?.isTransient === true,
+        session?.isHistorical === true,
+      ]);
+    },
+    () => scheduleRefresh(),
   );
   const interval = setInterval(() => {
-    void runRefresh();
+    void runRefresh(undefined, true);
   }, PEER_SESSION_REFRESH_INTERVAL_MS);
+  const unsubscribeRuntimeGaps = subscribeRuntimeSessionEventGaps(
+    (surfaceId, sessionId) => {
+      if (getActiveSurfaceScope().surfaceId === surfaceId) {
+        scheduleRefresh(sessionId);
+      }
+    },
+  );
 
   const handlePeerModeChanged = (): void => scheduleRefresh();
   const handleVisibilityChanged = (): void => {
@@ -294,6 +411,7 @@ export function installPeerSessionRefresh(context: FlowChatContext): () => void 
     }
     clearInterval(interval);
     unsubscribeActiveSession();
+    unsubscribeRuntimeGaps();
     if (typeof window !== 'undefined') {
       window.removeEventListener('peer-mode:changed', handlePeerModeChanged);
     }

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
@@ -1808,6 +1808,112 @@ describe('FlowChatStore historical session hydration state', () => {
     ).toEqual([]);
   });
 
+  it('acquires an empty current-Turn base for Runtime event replay before applying interactions', async () => {
+    peerModeFlagMock.active = true;
+    const pendingQuestion = {
+      toolId: 'ask-tool-1',
+      sessionId: 'history-1',
+      dialogTurnId: 'turn-live',
+      modelRoundId: 'round-live',
+      questions: { questions: [{ question: 'Continue?', header: 'Choice', options: [] }] },
+      registeredAtMs: 4,
+    };
+    apiMocks.restoreSessionView.mockResolvedValueOnce({
+      session: {
+        sessionId: 'history-1',
+        sessionName: 'History 1',
+        agentType: 'agentic',
+        state: 'Processing { current_turn_id: "turn-live", phase: ToolExecution }',
+        turnCount: 1,
+        createdAt: 1,
+      },
+      turns: [{
+        turnId: 'turn-live',
+        turnIndex: 0,
+        sessionId: 'history-1',
+        timestamp: 1,
+        userMessage: { id: 'user-live', content: 'ask me', timestamp: 1 },
+        modelRounds: [],
+        startTime: 1,
+        status: 'inprogress',
+      }],
+      interactionSnapshot: {
+        sessionId: 'history-1',
+        userQuestions: { revision: 3, questions: [pendingQuestion] },
+        permissions: { revision: 0, requests: [] },
+      },
+      runtimeEventSnapshot: {
+        sessionId: 'history-1',
+        streamId: 'runtime-a',
+        cursor: 12,
+        activeTurnId: 'turn-live',
+        events: [{
+          eventName: 'agentic://dialog-turn-started',
+          payload: { sessionId: 'history-1', turnId: 'turn-live' },
+        }],
+      },
+      contextRestoreState: 'pending',
+    });
+    const staleProjectedTurn = {
+      id: 'turn-live',
+      sessionId: 'history-1',
+      userMessage: { id: 'user-live', content: 'ask me', timestamp: 1 },
+      modelRounds: [{
+        id: 'round-live',
+        index: 0,
+        items: [{
+          id: 'stale-text',
+          type: 'text' as const,
+          content: 'stale partial projection',
+          timestamp: 2,
+          status: 'streaming' as const,
+        }],
+        isStreaming: true,
+        isComplete: false,
+        status: 'streaming' as const,
+        startTime: 2,
+      }],
+      status: 'processing' as const,
+      startTime: 1,
+    };
+    flowChatStore.setState(() => ({
+      sessions: new Map([
+        ['history-1', createSession({
+          sessionId: 'history-1',
+          workspacePath: '/Users/host/project',
+          historyState: 'ready',
+          dialogTurns: [staleProjectedTurn],
+        })],
+      ]),
+      activeSessionId: 'history-1',
+    }));
+
+    const result = await flowChatStore.refreshPeerSessionSnapshot(
+      'history-1',
+      '/Users/host/project',
+    );
+
+    expect(result.runtimeEventSnapshot).toMatchObject({
+      streamId: 'runtime-a',
+      cursor: 12,
+      activeTurnId: 'turn-live',
+    });
+    expect(result.pendingUserQuestions).toEqual({ revision: 3, questions: [pendingQuestion] });
+    expect(
+      flowChatStore.getState().sessions.get('history-1')?.dialogTurns[0].modelRounds,
+    ).toEqual([]);
+
+    flowChatStore.reconcilePendingUserQuestions('history-1', result.pendingUserQuestions);
+    expect(
+      flowChatStore.getState().sessions.get('history-1')
+        ?.dialogTurns[0].modelRounds[0].items[0],
+    ).toMatchObject({
+      id: 'ask-tool-1',
+      toolName: 'AskUserQuestion',
+      status: 'waiting',
+    });
+  });
+
   it('reconciles a newly persisted active Peer turn without replacing older history', async () => {
     peerModeFlagMock.active = true;
     apiMocks.restoreSessionView.mockResolvedValueOnce({
@@ -1868,6 +1974,83 @@ describe('FlowChatStore historical session hydration state', () => {
     expect(
       flowChatStore.getState().sessions.get('history-1')?.dialogTurns.map(turn => turn.id),
     ).toEqual(['turn-old', 'turn-live']);
+  });
+
+  it('keeps a healthy live projection when it already includes the Runtime cursor', async () => {
+    peerModeFlagMock.active = true;
+    apiMocks.restoreSessionView.mockResolvedValueOnce({
+      session: {
+        sessionId: 'history-1',
+        sessionName: 'History 1',
+        agentType: 'agentic',
+        state: 'Processing { current_turn_id: "turn-live", phase: Streaming }',
+        turnCount: 1,
+        createdAt: 1,
+      },
+      turns: [{
+        turnId: 'turn-live',
+        turnIndex: 0,
+        sessionId: 'history-1',
+        timestamp: 1,
+        userMessage: { id: 'user-live', content: 'keep streaming', timestamp: 1 },
+        modelRounds: [],
+        startTime: 1,
+        status: 'inprogress',
+      }],
+      runtimeEventSnapshot: {
+        sessionId: 'history-1',
+        streamId: 'runtime-a',
+        cursor: 12,
+        activeTurnId: 'turn-live',
+        events: [],
+      },
+      contextRestoreState: 'pending',
+    });
+    const liveTurn = {
+      id: 'turn-live',
+      sessionId: 'history-1',
+      userMessage: { id: 'user-live', content: 'keep streaming', timestamp: 1 },
+      modelRounds: [{
+        id: 'round-live',
+        index: 0,
+        items: [{
+          id: 'live-text',
+          type: 'text' as const,
+          content: 'already rendered',
+          timestamp: 2,
+          status: 'streaming' as const,
+        }],
+        isStreaming: true,
+        isComplete: false,
+        status: 'streaming' as const,
+        startTime: 2,
+      }],
+      status: 'processing' as const,
+      startTime: 1,
+    };
+    flowChatStore.setState(() => ({
+      sessions: new Map([
+        ['history-1', createSession({
+          sessionId: 'history-1',
+          workspacePath: '/Users/host/project',
+          historyState: 'ready',
+          dialogTurns: [liveTurn],
+        })],
+      ]),
+      activeSessionId: 'history-1',
+    }));
+
+    const result = await flowChatStore.refreshPeerSessionSnapshot(
+      'history-1',
+      '/Users/host/project',
+      { shouldReplayRuntimeSnapshot: () => false },
+    );
+
+    expect(result.runtimeEventReplayRequired).toBe(false);
+    expect(
+      flowChatStore.getState().sessions.get('history-1')
+        ?.dialogTurns[0].modelRounds[0].items[0],
+    ).toMatchObject({ id: 'live-text', content: 'already rendered' });
   });
 
   it('advances a running Peer turn from a newer persisted checkpoint', async () => {

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.ts
@@ -54,6 +54,7 @@ import {
   agentAPI,
   type LoadSessionTurnWindowResponse,
   type PendingUserQuestionSnapshot,
+  type SessionRuntimeEventSnapshot,
   type SessionInfo as AgentSessionInfo,
   type SessionViewRestoreTiming,
 } from '@/infrastructure/api/service-api/AgentAPI';
@@ -343,6 +344,12 @@ export interface PeerSessionSnapshotRefreshResult {
   backendState: string;
   latestTurnId?: string;
   latestTurnStatus?: DialogTurn['status'];
+  /** Present only when this refresh acquired a coherent running-Turn base. */
+  runtimeEventSnapshot?: SessionRuntimeEventSnapshot;
+  /** False when the rendered projection already includes this cursor. */
+  runtimeEventReplayRequired?: boolean;
+  /** Applied after Runtime event replay so the blocking card binds to its tool. */
+  pendingUserQuestions?: PendingUserQuestionSnapshot;
 }
 
 export interface DispatchSnapshotApplyResult {
@@ -7265,6 +7272,7 @@ export class FlowChatStore {
       replaceRunningSnapshot?: boolean;
       requireActiveSession?: boolean;
       shouldApply?: () => boolean;
+      shouldReplayRuntimeSnapshot?: (snapshot: SessionRuntimeEventSnapshot) => boolean;
     },
   ): Promise<PeerSessionSnapshotRefreshResult> {
     const scope = getActiveSurfaceScope();
@@ -7300,10 +7308,47 @@ export class FlowChatStore {
       );
     }
     const backendActive = isBackendSessionActivelyProcessing(restored.session.state);
+    const runtimeSnapshotCandidate =
+      restored.runtimeEventSnapshot?.sessionId === sessionId
+        ? restored.runtimeEventSnapshot
+        : undefined;
     const activeTurnId = backendActive
-      ? restored.turns[restored.turns.length - 1]?.turnId
+      ? runtimeSnapshotCandidate?.activeTurnId ?? restored.turns[restored.turns.length - 1]?.turnId
       : undefined;
-    const snapshotTurns = this.convertToDialogTurns(restored.turns, { activeTurnId });
+    const runtimeEventSnapshot =
+      backendActive &&
+      runtimeSnapshotCandidate !== undefined &&
+      runtimeSnapshotCandidate.activeTurnId === activeTurnId &&
+      typeof runtimeSnapshotCandidate.streamId === 'string' &&
+      Number.isSafeInteger(runtimeSnapshotCandidate.cursor) &&
+      Array.isArray(runtimeSnapshotCandidate.events)
+        ? runtimeSnapshotCandidate
+        : undefined;
+    const runtimeEventReplayRequired = runtimeEventSnapshot
+      ? options?.shouldReplayRuntimeSnapshot?.(runtimeEventSnapshot) ?? true
+      : false;
+    const runtimeReplaySnapshot = runtimeEventReplayRequired
+      ? runtimeEventSnapshot
+      : undefined;
+    const snapshotTurns = this.convertToDialogTurns(restored.turns, { activeTurnId }).map(turn =>
+      runtimeReplaySnapshot && turn.id === runtimeReplaySnapshot.activeTurnId
+        ? {
+            ...turn,
+            // Runtime event replay is authoritative for the current Turn.
+            // Start from the persisted identity/user message, never from a
+            // UI-written partial projection that may overlap the replay.
+            modelRounds: [],
+            status: 'pending' as const,
+            endTime: undefined,
+            error: undefined,
+            errorDetail: undefined,
+            success: undefined,
+            finishReason: undefined,
+            hasFinalResponse: undefined,
+            recovery: undefined,
+          }
+        : turn
+    );
     const pendingUserQuestions =
       restored.interactionSnapshot?.sessionId === sessionId
         ? restored.interactionSnapshot.userQuestions
@@ -7311,6 +7356,7 @@ export class FlowChatStore {
     const replaceExistingTurns =
       !backendActive || options?.replaceRunningSnapshot === true;
     let applied = false;
+    let snapshotAccepted = false;
 
     this.setState(prev => {
       if (
@@ -7329,6 +7375,7 @@ export class FlowChatStore {
       if (!session || session !== initialSession) {
         return prev;
       }
+      snapshotAccepted = true;
 
       let mergedTurns = [...session.dialogTurns];
       let turnsChanged = false;
@@ -7338,7 +7385,9 @@ export class FlowChatStore {
           mergedTurns.push(snapshotTurn);
           turnsChanged = true;
         } else if (
-          replaceExistingTurns
+          (runtimeReplaySnapshot && snapshotTurn.id === runtimeReplaySnapshot.activeTurnId)
+            ? true
+            : replaceExistingTurns
             ? !snapshotDropsProjectedTurnContent(mergedTurns[existingIndex], snapshotTurn)
             : isRunningSnapshotForwardProgress(mergedTurns[existingIndex], snapshotTurn)
         ) {
@@ -7348,21 +7397,23 @@ export class FlowChatStore {
       }
 
       mergedTurns.sort(compareDialogTurnOrder);
-      const previousQuestionRevision = this.userQuestionSnapshotRevisions.get(sessionId) ?? -1;
-      const questionReconciliation = reconcilePendingUserQuestionSnapshot(
-        mergedTurns,
-        pendingUserQuestions,
-        previousQuestionRevision,
-      );
-      if (questionReconciliation.changed) {
-        mergedTurns = questionReconciliation.turns;
-        turnsChanged = true;
-      }
-      if (questionReconciliation.revisionApplied && pendingUserQuestions) {
-        this.userQuestionSnapshotRevisions.set(
-          sessionId,
-          pendingUserQuestions.revision,
+      if (!runtimeReplaySnapshot) {
+        const previousQuestionRevision = this.userQuestionSnapshotRevisions.get(sessionId) ?? -1;
+        const questionReconciliation = reconcilePendingUserQuestionSnapshot(
+          mergedTurns,
+          pendingUserQuestions,
+          previousQuestionRevision,
         );
+        if (questionReconciliation.changed) {
+          mergedTurns = questionReconciliation.turns;
+          turnsChanged = true;
+        }
+        if (questionReconciliation.revisionApplied && pendingUserQuestions) {
+          this.userQuestionSnapshotRevisions.set(
+            sessionId,
+            pendingUserQuestions.revision,
+          );
+        }
       }
       const turnCatalog = restored.turnCatalog?.sessionId === sessionId
         ? selectPreferredTurnCatalog(session.turnCatalog, restored.turnCatalog)
@@ -7437,7 +7488,49 @@ export class FlowChatStore {
       backendState: restored.session.state,
       latestTurnId: latestTurn?.id,
       latestTurnStatus: latestTurn?.status,
+      ...(snapshotAccepted && runtimeEventSnapshot
+        ? {
+            runtimeEventSnapshot,
+            runtimeEventReplayRequired,
+            pendingUserQuestions,
+          }
+        : {}),
     };
+  }
+
+  /** Reconcile blocking user questions after Runtime event replay. */
+  public reconcilePendingUserQuestions(
+    sessionId: string,
+    pendingUserQuestions: PendingUserQuestionSnapshot | undefined,
+  ): boolean {
+    let applied = false;
+    this.setState(prev => {
+      const session = prev.sessions.get(sessionId);
+      if (!session) {
+        return prev;
+      }
+      const previousRevision = this.userQuestionSnapshotRevisions.get(sessionId) ?? -1;
+      const reconciliation = reconcilePendingUserQuestionSnapshot(
+        session.dialogTurns,
+        pendingUserQuestions,
+        previousRevision,
+      );
+      if (reconciliation.revisionApplied && pendingUserQuestions) {
+        this.userQuestionSnapshotRevisions.set(sessionId, pendingUserQuestions.revision);
+      }
+      if (!reconciliation.changed) {
+        applied = reconciliation.revisionApplied;
+        return prev;
+      }
+      const sessions = new Map(prev.sessions);
+      sessions.set(sessionId, {
+        ...session,
+        dialogTurns: reconciliation.turns,
+      });
+      applied = true;
+      return { ...prev, sessions };
+    });
+    return applied;
   }
 
   /**

--- a/src/web-ui/src/infrastructure/api/adapters/tauri-adapter.ts
+++ b/src/web-ui/src/infrastructure/api/adapters/tauri-adapter.ts
@@ -5,6 +5,8 @@ import { elapsedMs, nowMs } from '@/shared/utils/timing';
 import { ITransportAdapter, type TransportRequestTiming } from './base';
 import { createLogger } from '@/shared/utils/logger';
 import { routeSurfaceEvent } from '@/infrastructure/peer-device/deviceSurfaceRouting';
+import { surfaceIdForDevice } from '@/infrastructure/peer-device/deviceSurface';
+import { routeRuntimeSessionEvent } from '@/infrastructure/peer-device/runtimeSessionEventGate';
 import { sanitizeErrorForLog } from '../logSanitizer';
 
 const log = createLogger('TauriAdapter');
@@ -135,11 +137,21 @@ export class TauriTransportAdapter implements ITransportAdapter {
         if (!route.deliver) {
           return;
         }
-        try {
-          callback(route.payload);
-        } catch (error) {
-      log.error('Error in event listener callback', { event, error: sanitizeErrorForLog(error) });
-        }
+        routeRuntimeSessionEvent(
+          surfaceIdForDevice(route.sourceDeviceId),
+          event,
+          route.payload,
+          payload => {
+            try {
+              callback(payload);
+            } catch (error) {
+              log.error('Error in event listener callback', {
+                event,
+                error: sanitizeErrorForLog(error),
+              });
+            }
+          },
+        );
       }
     }).then(fn => {
       if (isUnlistened) {

--- a/src/web-ui/src/infrastructure/api/service-api/AgentAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/AgentAPI.ts
@@ -184,6 +184,23 @@ export interface SessionInteractionSnapshot {
   permissions: PermissionRequestSnapshot;
 }
 
+export interface RuntimeProjectedAgenticEvent {
+  eventName: string;
+  payload: Record<string, unknown>;
+}
+
+/**
+ * Runtime-owned materialized projection of the current Turn. `streamId` and
+ * `cursor` fence this snapshot against concurrent live events.
+ */
+export interface SessionRuntimeEventSnapshot {
+  sessionId: string;
+  streamId: string;
+  cursor: number;
+  activeTurnId?: string | null;
+  events: RuntimeProjectedAgenticEvent[];
+}
+
 export type PermissionRequestEvent =
   | { event: 'asked'; request: PermissionRequest }
   | { event: 'replied'; requestId: string; reply: { reply: PermissionReplyKind }; source: string }
@@ -273,6 +290,8 @@ export interface RestoreSessionViewResponse {
   turns: DialogTurnData[];
   /** Absent when talking to an older Peer Host. */
   interactionSnapshot?: SessionInteractionSnapshot;
+  /** Absent when talking to a host without resumable Session attachment. */
+  runtimeEventSnapshot?: SessionRuntimeEventSnapshot | null;
   currentContextUsage?: SessionContextUsage | null;
   turnCatalog?: SessionTurnCatalog;
   contextRestoreState: 'ready' | 'pending';

--- a/src/web-ui/src/infrastructure/peer-device/README.md
+++ b/src/web-ui/src/infrastructure/peer-device/README.md
@@ -59,6 +59,11 @@ Controller-side React/transport layer for Peer Device Mode. Architecture:
      it to `SURFACE_SCOPED_EVENTS`/prefixes too, or local and peer streams will
      interleave in one store. Never route control-plane events (`account://…`)
      — they must always pass.
+   - **React subscriptions include the Surface activation.** A Session id is
+     not a complete subscription identity. Hooks that read per-Surface state
+     machines subscribe to the Surface epoch and return no snapshot during the
+     rebind render; otherwise React can pair A's old `turnId` with B's Session
+     for one render, including when both devices use the same Session id.
 
 1. **Cloud session/turn APIs stay on the controller** (`LOCAL_ONLY` in
    `peer-device-adapter.ts`). Peer history comes from HostInvoke
@@ -120,27 +125,42 @@ Controller-side React/transport layer for Peer Device Mode. Architecture:
     Remote `SIGINT` / `SIGTSTP` map to PTY control bytes instead of silently
     succeeding without affecting the process.
 
-12. **Active chat has snapshot self-healing.** DeviceEvent has no ACK/replay, so
-    FlowChat reconciles the active session from `restore_session_view`
-    every 3s and immediately after a detected event gap. This is gated on
+12. **Active chat attaches to a Runtime-owned Turn projection.** DeviceEvent is
+    the low-latency path, not the owner of current-Turn state. Desktop and CLI
+    Peer Hosts materialize eligible current Turns after their ordered delivery
+    boundary and expose them
+    from `restore_session_view` as `runtimeEventSnapshot` with a per-Session
+    cursor and Runtime-process `streamId`. While restore is in flight,
+    `runtimeSessionEventGate` queues live events by
+    `(DeviceSurfaceId, SessionId)`; replay starts from an empty active-Turn base,
+    then the gate drops cursor-covered events and releases newer events in
+    order. Never compare cursors across different `streamId` values. This is
+    gated on
     `isSurfaceReconcileEnabled()`, **not** on Peer Mode: once a window has
     switched surface, a turn left running on the local device also needs the
-    repair, because its events were dropped by surface routing while another
-    device was rendered. The Peer Host must
+    same attach, because its live events were dropped by surface routing while
+    another device was rendered. Attach is requested as soon as active Session
+    hydration becomes ready; the 3s loop is only a liveness retry and an
+    older-Host fallback. The Peer Host must
     overlay its live in-memory session state on the persisted view; otherwise
     an in-progress turn is normalized as interrupted history and later chunks
-    are dropped by the controller state machine. Reconciliation must not
-    overwrite a local projection that changed while HostInvoke was in flight.
-    Continuous host output must create a persisted checkpoint within each 2s
-    coalescing window, and active snapshots may replace a running projection
-    early only when stream/tool content proves forward progress.
+    are dropped by the controller state machine. Surface epoch checks reject a
+    restore from a device no longer rendered. Older hosts may omit the Runtime
+    projection; their persisted snapshot must still never overwrite newer live
+    content.
+    **Controller presence is not Turn ownership.** A controller lease gates
+    submission and interaction responses, but once a Peer Host accepts a Turn,
+    the Host keeps executing and materializing it through a zero-controller
+    device-switch interval. Detach/presence loss must not cancel that Turn;
+    only an actual host event-stream continuity failure may fail it closed.
     **Blocking interactions are owner mailboxes, not one-shot UI events.** The
     Runtime retains native `AskUserQuestion` and interactive permission
     requests until answer/cancel/drop, and `restore_session_view` returns their
     additive, revisioned `interactionSnapshot` from both Desktop and CLI Peer
     Hosts. Keep its frontend projection per Surface, fence it with the captured
-    Surface epoch and newer event state, and use it only to reconstruct UI in
-    the owning Turn/round. Reattachment must never restart or cancel the
+    Surface epoch and newer event state, replay it after the Turn projection,
+    and use it only to reconstruct UI in the owning Turn/round. Reattachment
+    must never restart or cancel the
     running Session. Older peers may omit the field; absence is not an empty
     authoritative mailbox. Any new interaction that can suspend execution is
     incomplete until its owner exposes equivalent replayable attach state.

--- a/src/web-ui/src/infrastructure/peer-device/deviceSurfaceRouting.test.ts
+++ b/src/web-ui/src/infrastructure/peer-device/deviceSurfaceRouting.test.ts
@@ -22,6 +22,7 @@ describe('isSurfaceScopedEvent', () => {
     expect(isSurfaceScopedEvent('backend-event-toolexecutionstarted')).toBe(true);
     expect(isSurfaceScopedEvent('terminal_event')).toBe(true);
     expect(isSurfaceScopedEvent('permission://event')).toBe(true);
+    expect(isSurfaceScopedEvent('session_title_generated')).toBe(true);
   });
 
   it('leaves control-plane events unscoped so they always pass', () => {

--- a/src/web-ui/src/infrastructure/peer-device/deviceSurfaceRouting.ts
+++ b/src/web-ui/src/infrastructure/peer-device/deviceSurfaceRouting.ts
@@ -34,6 +34,7 @@ const SURFACE_SCOPED_EVENTS = new Set<string>([
   'permission://event',
   'account://settings-applied',
   'ai://model-catalog-updated',
+  'session_title_generated',
 ]);
 
 const SURFACE_SCOPED_PREFIXES = ['agentic://', 'backend-event-'];
@@ -111,6 +112,8 @@ export interface SurfaceEventRoute<T> {
   deliver: boolean;
   /** Payload with the routing tag removed. */
   payload: T;
+  /** `null` identifies events produced by this local Runtime Host. */
+  sourceDeviceId: string | null;
 }
 
 /**
@@ -123,7 +126,11 @@ export function routeSurfaceEvent<T>(event: string, payload: T): SurfaceEventRou
   const sourceDeviceId = readSourceDeviceId(payload);
 
   if (!isSurfaceScopedEvent(event)) {
-    return { deliver: true, payload: unwrapSurfacePayload(payload) };
+    return {
+      deliver: true,
+      payload: unwrapSurfacePayload(payload),
+      sourceDeviceId,
+    };
   }
 
   const unwrapped = unwrapSurfacePayload(payload);
@@ -138,5 +145,9 @@ export function routeSurfaceEvent<T>(event: string, payload: T): SurfaceEventRou
     }
   }
 
-  return { deliver: activeSurfaceDeviceId === sourceDeviceId, payload: unwrapped };
+  return {
+    deliver: activeSurfaceDeviceId === sourceDeviceId,
+    payload: unwrapped,
+    sourceDeviceId,
+  };
 }

--- a/src/web-ui/src/infrastructure/peer-device/runtimeSessionEventGate.test.ts
+++ b/src/web-ui/src/infrastructure/peer-device/runtimeSessionEventGate.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  beginRuntimeSessionAttachment,
+  resetRuntimeSessionEventGateForTest,
+  routeRuntimeSessionEvent,
+  RUNTIME_EVENT_CURSOR_KEY,
+  RUNTIME_EVENT_STREAM_ID_KEY,
+  subscribeRuntimeSessionEventGaps,
+} from './runtimeSessionEventGate';
+
+function payload(sessionId: string, streamId: string, cursor: number, text: string) {
+  return {
+    sessionId,
+    text,
+    [RUNTIME_EVENT_STREAM_ID_KEY]: streamId,
+    [RUNTIME_EVENT_CURSOR_KEY]: cursor,
+  };
+}
+
+afterEach(() => {
+  resetRuntimeSessionEventGateForTest();
+});
+
+describe('runtimeSessionEventGate', () => {
+  it('strips cursor metadata on the ordinary live path', () => {
+    const delivered = vi.fn();
+    routeRuntimeSessionEvent(
+      'local',
+      'agentic://text-chunk',
+      payload('session', 'runtime-a', 1, 'a'),
+      delivered,
+    );
+
+    expect(delivered).toHaveBeenCalledWith({ sessionId: 'session', text: 'a' });
+  });
+
+  it('fences snapshot-covered events and releases only newer cursors in order', () => {
+    const delivered: string[] = [];
+    const attachment = beginRuntimeSessionAttachment('local', 'session');
+
+    for (const [cursor, text] of [[4, 'covered'], [6, 'newer-1'], [7, 'newer-2']] as const) {
+      routeRuntimeSessionEvent(
+        'local',
+        'agentic://text-chunk',
+        payload('session', 'runtime-a', cursor, text),
+        event => delivered.push(event.text),
+      );
+    }
+    expect(delivered).toEqual([]);
+
+    attachment.finish({ streamId: 'runtime-a', cursor: 5 });
+    expect(delivered).toEqual(['newer-1', 'newer-2']);
+
+    const nextAttachment = beginRuntimeSessionAttachment('local', 'session');
+    expect(nextAttachment.requiresReplay({ streamId: 'runtime-a', cursor: 7 })).toBe(false);
+    expect(nextAttachment.requiresReplay({ streamId: 'runtime-a', cursor: 8 })).toBe(true);
+    nextAttachment.abort({ discard: true });
+  });
+
+  it('never compares cursors across Runtime process streams', () => {
+    const delivered: string[] = [];
+    const attachment = beginRuntimeSessionAttachment('local', 'session');
+    routeRuntimeSessionEvent(
+      'local',
+      'agentic://text-chunk',
+      payload('session', 'runtime-b', 1, 'after-restart'),
+      event => delivered.push(event.text),
+    );
+
+    attachment.finish({ streamId: 'runtime-a', cursor: 99 });
+    expect(delivered).toEqual(['after-restart']);
+  });
+
+  it('tracks ordinary live progress so healthy periodic refreshes do not replay', () => {
+    for (const cursor of [1, 2, 3, 4]) {
+      routeRuntimeSessionEvent(
+        'local',
+        'agentic://text-chunk',
+        payload('session', 'runtime-a', cursor, 'live'),
+        vi.fn(),
+      );
+    }
+
+    const attachment = beginRuntimeSessionAttachment('local', 'session');
+    expect(attachment.requiresReplay({ streamId: 'runtime-a', cursor: 4 })).toBe(false);
+    expect(attachment.requiresReplay({ streamId: 'runtime-a', cursor: 5 })).toBe(true);
+    expect(attachment.requiresReplay({ streamId: 'runtime-b', cursor: 1 })).toBe(true);
+    attachment.abort({ discard: true });
+  });
+
+  it('requires replay after detecting a missing live cursor', () => {
+    const gapListener = vi.fn();
+    subscribeRuntimeSessionEventGaps(gapListener);
+    for (const cursor of [1, 3]) {
+      routeRuntimeSessionEvent(
+        'local',
+        'agentic://text-chunk',
+        payload('session', 'runtime-a', cursor, 'live'),
+        vi.fn(),
+      );
+    }
+
+    const attachment = beginRuntimeSessionAttachment('local', 'session');
+    expect(gapListener).toHaveBeenCalledWith('local', 'session');
+    expect(attachment.requiresReplay({ streamId: 'runtime-a', cursor: 3 })).toBe(true);
+    attachment.finish({ streamId: 'runtime-a', cursor: 3 });
+
+    const nextAttachment = beginRuntimeSessionAttachment('local', 'session');
+    expect(nextAttachment.requiresReplay({ streamId: 'runtime-a', cursor: 3 })).toBe(false);
+    nextAttachment.abort({ discard: true });
+  });
+
+  it('releases events that the Runtime snapshot does not materialize', () => {
+    const delivered = vi.fn();
+    const attachment = beginRuntimeSessionAttachment('local', 'session');
+    routeRuntimeSessionEvent(
+      'local',
+      'session_title_generated',
+      { sessionId: 'session', title: 'Keep me live' },
+      delivered,
+    );
+
+    attachment.finish({ streamId: 'runtime-a', cursor: 100 });
+    expect(delivered).toHaveBeenCalledWith({
+      sessionId: 'session',
+      title: 'Keep me live',
+    });
+  });
+
+  it('isolates identical Session ids on different device Surfaces', () => {
+    const localDelivered = vi.fn();
+    const peerDelivered = vi.fn();
+    const attachment = beginRuntimeSessionAttachment('local', 'same-session');
+
+    routeRuntimeSessionEvent(
+      'local',
+      'agentic://text-chunk',
+      payload('same-session', 'local-runtime', 2, 'local'),
+      localDelivered,
+    );
+    routeRuntimeSessionEvent(
+      'peer-a',
+      'agentic://text-chunk',
+      payload('same-session', 'peer-runtime', 2, 'peer'),
+      peerDelivered,
+    );
+
+    expect(localDelivered).not.toHaveBeenCalled();
+    expect(peerDelivered).toHaveBeenCalledTimes(1);
+    attachment.abort({ discard: true });
+  });
+});

--- a/src/web-ui/src/infrastructure/peer-device/runtimeSessionEventGate.ts
+++ b/src/web-ui/src/infrastructure/peer-device/runtimeSessionEventGate.ts
@@ -1,0 +1,248 @@
+/**
+ * Cursor fence for attaching a UI Surface to a running Runtime Session.
+ *
+ * A restore request and the live event stream race by definition. While the
+ * Runtime snapshot is in flight, live events for that Surface/Session are held
+ * here. Snapshot replay establishes the state at `cursor`; finishing the
+ * attachment drops already-covered events and releases only newer ones.
+ */
+
+import {
+  surfaceScopedKey,
+  type DeviceSurfaceId,
+} from './deviceSurface';
+
+/** Keep in sync with the Rust `SessionEventJournal` delivery-envelope keys. */
+export const RUNTIME_EVENT_STREAM_ID_KEY = '__bitfunRuntimeStreamId';
+export const RUNTIME_EVENT_CURSOR_KEY = '__bitfunRuntimeEventCursor';
+
+interface QueuedRuntimeEvent {
+  sequence: number;
+  streamId?: string;
+  cursor?: number;
+  deliver: () => void;
+}
+
+interface RuntimeSessionAttachment {
+  generation: number;
+  queued: QueuedRuntimeEvent[];
+}
+
+interface RuntimeSessionProgress {
+  streamId: string;
+  cursor: number;
+  hasGap: boolean;
+}
+
+const attachments = new Map<string, RuntimeSessionAttachment>();
+const progress = new Map<string, RuntimeSessionProgress>();
+const gapListeners = new Set<(surfaceId: DeviceSurfaceId, sessionId: string) => void>();
+let nextGeneration = 0;
+let nextSequence = 0;
+
+function attachmentKey(surfaceId: DeviceSurfaceId, sessionId: string): string {
+  return surfaceScopedKey(surfaceId, 'runtime-session-attachment', sessionId);
+}
+
+function readEventMetadata(payload: unknown): {
+  streamId?: string;
+  cursor?: number;
+} {
+  if (!payload || typeof payload !== 'object') {
+    return {};
+  }
+  const record = payload as Record<string, unknown>;
+  const streamId = record[RUNTIME_EVENT_STREAM_ID_KEY];
+  const cursor = record[RUNTIME_EVENT_CURSOR_KEY];
+  return {
+    ...(typeof streamId === 'string' && streamId ? { streamId } : {}),
+    ...(typeof cursor === 'number' && Number.isSafeInteger(cursor) && cursor >= 0
+      ? { cursor }
+      : {}),
+  };
+}
+
+function stripEventMetadata<T>(payload: T): T {
+  if (!payload || typeof payload !== 'object') {
+    return payload;
+  }
+  const record = payload as Record<string, unknown>;
+  if (
+    !(RUNTIME_EVENT_STREAM_ID_KEY in record) &&
+    !(RUNTIME_EVENT_CURSOR_KEY in record)
+  ) {
+    return payload;
+  }
+  const {
+    [RUNTIME_EVENT_STREAM_ID_KEY]: _streamId,
+    [RUNTIME_EVENT_CURSOR_KEY]: _cursor,
+    ...productPayload
+  } = record;
+  return productPayload as T;
+}
+
+function advanceProgress(
+  key: string,
+  metadata: { streamId?: string; cursor?: number },
+): boolean {
+  if (metadata.streamId === undefined || metadata.cursor === undefined) {
+    return false;
+  }
+  const current = progress.get(key);
+  if (!current || current.streamId !== metadata.streamId) {
+    const hasGap = metadata.cursor > 1;
+    progress.set(key, {
+      streamId: metadata.streamId,
+      cursor: metadata.cursor,
+      hasGap,
+    });
+    return hasGap;
+  }
+  if (metadata.cursor > current.cursor) {
+    const detectedGap = !current.hasGap && metadata.cursor > current.cursor + 1;
+    progress.set(key, {
+      streamId: current.streamId,
+      cursor: metadata.cursor,
+      hasGap: current.hasGap || detectedGap,
+    });
+    return detectedGap;
+  }
+  return false;
+}
+
+function drain(events: QueuedRuntimeEvent[], shouldDeliver: (event: QueuedRuntimeEvent) => boolean) {
+  events.sort((left, right) => left.sequence - right.sequence);
+  for (const event of events) {
+    if (shouldDeliver(event)) {
+      event.deliver();
+    }
+  }
+}
+
+export interface RuntimeSessionAttachmentHandle {
+  requiresReplay(snapshot: { streamId: string; cursor: number }): boolean;
+  finish(snapshot: { streamId: string; cursor: number }): void;
+  abort(options?: { discard?: boolean }): void;
+}
+
+export function subscribeRuntimeSessionEventGaps(
+  listener: (surfaceId: DeviceSurfaceId, sessionId: string) => void,
+): () => void {
+  gapListeners.add(listener);
+  return () => gapListeners.delete(listener);
+}
+
+export function beginRuntimeSessionAttachment(
+  surfaceId: DeviceSurfaceId,
+  sessionId: string,
+): RuntimeSessionAttachmentHandle {
+  const key = attachmentKey(surfaceId, sessionId);
+  const previous = attachments.get(key);
+  if (previous) {
+    attachments.delete(key);
+    // Overlapping attachment is not expected, but live events must never be
+    // silently lost if a newer reconciliation supersedes an older one.
+    drain(previous.queued, () => true);
+  }
+
+  const generation = ++nextGeneration;
+  const attachment: RuntimeSessionAttachment = { generation, queued: [] };
+  attachments.set(key, attachment);
+
+  const takeOwnedQueue = (): QueuedRuntimeEvent[] | null => {
+    const current = attachments.get(key);
+    if (!current || current.generation !== generation) {
+      return null;
+    }
+    attachments.delete(key);
+    return current.queued;
+  };
+
+  return {
+    requiresReplay(snapshot) {
+      const current = progress.get(key);
+      return (
+        !current ||
+        current.streamId !== snapshot.streamId ||
+        current.hasGap ||
+        current.cursor < snapshot.cursor
+      );
+    },
+    finish(snapshot) {
+      const queued = takeOwnedQueue();
+      if (!queued) {
+        return;
+      }
+      progress.set(key, { ...snapshot, hasGap: false });
+      drain(queued, event => (
+        event.streamId !== snapshot.streamId ||
+        event.cursor === undefined ||
+        event.cursor > snapshot.cursor
+      ));
+    },
+    abort(options) {
+      const queued = takeOwnedQueue();
+      if (!queued || options?.discard === true) {
+        return;
+      }
+      drain(queued, () => true);
+    },
+  };
+}
+
+/**
+ * Route one already surface-selected transport event through an in-flight
+ * Session attachment. Product listeners never see the reserved cursor keys.
+ */
+export function routeRuntimeSessionEvent<T>(
+  surfaceId: DeviceSurfaceId,
+  eventName: string,
+  payload: T,
+  deliver: (payload: T) => void,
+): void {
+  const productPayload = stripEventMetadata(payload);
+  if (!eventName.startsWith('agentic://') && eventName !== 'session_title_generated') {
+    deliver(productPayload);
+    return;
+  }
+  if (!payload || typeof payload !== 'object') {
+    deliver(productPayload);
+    return;
+  }
+  const sessionId = (payload as Record<string, unknown>).sessionId;
+  if (typeof sessionId !== 'string' || !sessionId) {
+    deliver(productPayload);
+    return;
+  }
+
+  const attachment = attachments.get(attachmentKey(surfaceId, sessionId));
+  const key = attachmentKey(surfaceId, sessionId);
+  const metadata = readEventMetadata(payload);
+  const deliverWithProgress = (): void => {
+    const gapDetected = advanceProgress(key, metadata);
+    deliver(productPayload);
+    if (gapDetected) {
+      for (const listener of gapListeners) {
+        listener(surfaceId, sessionId);
+      }
+    }
+  };
+  if (!attachment) {
+    deliverWithProgress();
+    return;
+  }
+
+  attachment.queued.push({
+    sequence: ++nextSequence,
+    ...metadata,
+    deliver: deliverWithProgress,
+  });
+}
+
+export function resetRuntimeSessionEventGateForTest(): void {
+  attachments.clear();
+  progress.clear();
+  gapListeners.clear();
+  nextGeneration = 0;
+  nextSequence = 0;
+}


### PR DESCRIPTION
## Root cause

A running Agent Turn was owned by the host Runtime, but Rich Surface recovery still depended on ephemeral WebView/DeviceEvent broadcasts and UI-written partial checkpoints. Surface routing correctly drops events for the inactive device, so switching back could leave the UI in `Processing` after it had missed text, tool, or terminal events. The restore request also raced concurrent live delivery, and one React render could retain the previous Surface state-machine identity.

The CLI Peer Host had a second ownership violation: losing the final controller cancelled accepted Peer Turns and post-submit continuity still depended on the controller lease.

## Architecture

- Add a Runtime-host-owned `SessionEventJournal` that materializes the current Turn after each host ordering/coalescing boundary. It assigns a per-Session cursor and Runtime-process `streamId`, aggregates contiguous text/thinking chunks, and compacts tool progress.
- Extend `restore_session_view` additively with `runtimeEventSnapshot` on Desktop and CLI Peer Hosts. Older hosts continue through the persisted-snapshot fallback.
- Fence attach by `(DeviceSurfaceId, SessionId)`: queue concurrent live events, replay the coherent Runtime projection, drop cursor-covered events, then release newer events in order. Cursor gaps and Runtime restarts trigger replay without resetting a healthy stream every polling interval.
- Make controller presence an admission/interaction boundary, not a Turn lifetime owner. An accepted CLI Peer Turn continues and remains materialized with zero attached controllers; actual host event-stream loss still fails closed.
- Replay the Turn before reconciling blocking interaction mailboxes and bind React session state to the Surface activation epoch.
- Document the Runtime/Surface ownership and compatibility contracts.

## Verification

- `cargo test -p bitfun-agent-runtime --no-default-features --features agent-runtime --lib --quiet` — 305 passed
- `cargo test -p bitfun-desktop --quiet` — 312 passed, 4 ignored system-permission tests
- `cargo test -p bitfun-cli --quiet` — all unit and contract targets passed
- Web Vitest suite — 483 files / 3481 tests passed
- `pnpm --dir src/web-ui run build`
- `pnpm run type-check:web`
- `pnpm run lint:web`
- `pnpm run check:core-boundaries`
- `pnpm run check:repo-hygiene`
- `git diff --check`

Peer Device Mode was exercised through both Desktop-host and CLI-host suites, including cursor gaps, Runtime restarts, identical Session ids on different Surfaces, zero-controller continuation, and terminal ownership release. The local Desktop return path uses the same Surface-scoped attach contract. Remote workspace, Remote Control product surfaces, and Detached Dispatch behavior were not changed.