### PR TITLE
fix(peer): stop a device switch from permanently freezing the chat

### DIFF
--- a/src/web-ui/src/app/layout/AppLayout.tsx
+++ b/src/web-ui/src/app/layout/AppLayout.tsx
@@ -19,6 +19,7 @@ import { useSceneStore } from '../stores/sceneStore';
 import { useShortcut } from '@/infrastructure/hooks/useShortcut';
 import { configManager } from '@/infrastructure/config/services/ConfigManager';
 import { FlowChatManager } from '../../flow_chat/services/FlowChatManager';
+import { isSurfaceChangedError } from '@/infrastructure/peer-device/deviceSurface';
 import WorkspaceBody from './WorkspaceBody';
 import { useToolbarModeContext } from '../../flow_chat/components/toolbar-mode/ToolbarModeContext';
 import { MCPInteractionDialog } from '../components/MCPInteractionDialog/MCPInteractionDialog';
@@ -397,6 +398,14 @@ const AppLayout: React.FC<AppLayoutProps> = ({ className = '' }) => {
         }
       } catch (error) {
         if (cancelled) {
+          return;
+        }
+        // A newer device surface superseded this bootstrap. The activation that
+        // replaced it runs its own, so this is ordinary control flow — not a
+        // failure the user should see, and not a reason to leave the window
+        // without a live subscription.
+        if (isSurfaceChangedError(error)) {
+          void FlowChatManager.getInstance().ensureEventListeners();
           return;
         }
         log.error('FlowChatManager initialization failed', error);

--- a/src/web-ui/src/flow_chat/services/FlowChatManager.test.ts
+++ b/src/web-ui/src/flow_chat/services/FlowChatManager.test.ts
@@ -613,3 +613,59 @@ describe('FlowChatManager initialization', () => {
     expect(storeMocks.store.switchSession).not.toHaveBeenCalled();
   });
 });
+
+describe('FlowChatManager live subscription self-healing', () => {
+  beforeEach(() => {
+    resetDeviceSurfaceForTest();
+    (FlowChatManager as any).instance = undefined;
+    vi.clearAllMocks();
+    storeMocks.eventBatchers.length = 0;
+    storeMocks.store = {};
+    storeMocks.initializeEventListeners.mockResolvedValue(() => {});
+  });
+
+  it('re-arms the subscription on every surface activation', async () => {
+    // A switch tears the subscription down and the workspace bootstrap that
+    // used to rebuild it may legitimately be superseded. Activation itself must
+    // therefore restore the only live view of a running Turn.
+    const manager = FlowChatManager.getInstance();
+    await (manager as any).ensureEventListeners();
+    expect(storeMocks.initializeEventListeners).toHaveBeenCalledTimes(1);
+
+    manager.cleanupEventListeners();
+    activateSurface('device-b');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(storeMocks.initializeEventListeners).toHaveBeenCalledTimes(2);
+    manager.destroy();
+  });
+
+  it('retries a subscription that failed to start', async () => {
+    vi.useFakeTimers();
+    try {
+      storeMocks.initializeEventListeners.mockRejectedValueOnce(new Error('bridge not ready'));
+      const manager = FlowChatManager.getInstance();
+
+      await (manager as any).ensureEventListeners();
+      expect(storeMocks.initializeEventListeners).toHaveBeenCalledTimes(1);
+
+      storeMocks.initializeEventListeners.mockResolvedValue(() => {});
+      await vi.advanceTimersByTimeAsync(2500);
+
+      expect(storeMocks.initializeEventListeners).toHaveBeenCalledTimes(2);
+      manager.destroy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('leaves a healthy subscription alone', async () => {
+    const manager = FlowChatManager.getInstance();
+    await (manager as any).ensureEventListeners();
+    await (manager as any).ensureEventListeners();
+
+    expect(storeMocks.initializeEventListeners).toHaveBeenCalledTimes(1);
+    manager.destroy();
+  });
+});

--- a/src/web-ui/src/flow_chat/services/FlowChatManager.ts
+++ b/src/web-ui/src/flow_chat/services/FlowChatManager.ts
@@ -19,6 +19,7 @@ import {
   getActiveSurfaceId,
   getActiveSurfaceScope,
   isSurfaceChangedError,
+  onSurfaceActivated,
   type DeviceSurfaceId,
 } from '@/infrastructure/peer-device/deviceSurface';
 import type { WorkspaceInfo } from '@/shared/types';
@@ -72,6 +73,9 @@ import { registerDriverSessionLookup } from '../session-drivers/resolve';
 
 const log = createLogger('FlowChatManager');
 
+/** Backstop cadence for re-establishing a subscription that failed to start. */
+const EVENT_LISTENER_RETRY_MS = 2000;
+
 export class FlowChatManager {
   private static instance: FlowChatManager | null = null;
   private context: FlowChatContext;
@@ -83,6 +87,8 @@ export class FlowChatManager {
   private latestInitializationRequestKey: string | null = null;
   private peerSessionRefreshCleanup: (() => void) | null = null;
   private dispatchJobObserverCleanup: (() => void) | null = null;
+  private surfaceActivationCleanup: (() => void) | null = null;
+  private eventListenerRetryTimer: ReturnType<typeof setTimeout> | null = null;
   private disposed = false;
 
   private constructor() {
@@ -107,7 +113,8 @@ export class FlowChatManager {
       runtimeStatusTimers: new Map(),
       userCancelledSessionIds: new Set(),
       handledTerminalTurnEvents: new Set(),
-      currentWorkspacePath: null
+      currentWorkspacePath: null,
+      ensureLiveSubscription: () => this.ensureEventListeners(),
     };
     
     this.agentService = AgentService.getInstance();
@@ -117,6 +124,12 @@ export class FlowChatManager {
     installPendingQueueDrainListener(this.context);
     this.peerSessionRefreshCleanup = installPeerSessionRefresh(this.context);
     this.dispatchJobObserverCleanup = installDispatchJobObserver(this.context);
+    // The agentic subscription is this window's only live view of a running
+    // Turn, so its lifetime must not depend on a workspace bootstrap that a
+    // rapid switch is allowed to abandon. Re-arm on every activation instead.
+    this.surfaceActivationCleanup = onSurfaceActivated(() => {
+      void this.ensureEventListeners();
+    });
   }
 
   /** Public hook used by the queue panel "send now" fallback to drain head item. */
@@ -417,6 +430,45 @@ export class FlowChatManager {
     }
   }
 
+  /**
+   * Guarantee this window has a live agentic subscription.
+   *
+   * Idempotent and safe to call from anywhere. It exists because the
+   * subscription used to be re-established only as a side effect of a
+   * successful workspace bootstrap: a switch tore it down, and a bootstrap that
+   * a newer switch legitimately superseded left the window with no live Turn
+   * events and nothing to retry — a permanently frozen chat.
+   */
+  public async ensureEventListeners(): Promise<void> {
+    try {
+      await this.initializeEventListeners();
+    } catch (error) {
+      if (isSurfaceChangedError(error)) {
+        return;
+      }
+      log.warn('Failed to establish the agentic subscription; retrying', { error });
+      this.scheduleEventListenerRetry();
+    }
+  }
+
+  /**
+   * A failed subscription cannot repair itself from the event path, so recovery
+   * is time-based. The reconcile loop also calls `ensureEventListeners` when it
+   * observes a dead subscription, so this is the backstop, not the only path.
+   */
+  private scheduleEventListenerRetry(): void {
+    if (this.disposed || this.eventListenerRetryTimer !== null) {
+      return;
+    }
+    this.eventListenerRetryTimer = setTimeout(() => {
+      this.eventListenerRetryTimer = null;
+      if (this.disposed || this.eventListenerInitialized) {
+        return;
+      }
+      void this.ensureEventListeners();
+    }, EVENT_LISTENER_RETRY_MS);
+  }
+
   private async initializeEventListeners(): Promise<void> {
     if (this.disposed) {
       return;
@@ -536,6 +588,12 @@ export class FlowChatManager {
     this.initializationRequests.clear();
     this.latestInitializationRequestKey = null;
     this.cleanupEventListeners();
+    if (this.eventListenerRetryTimer !== null) {
+      clearTimeout(this.eventListenerRetryTimer);
+      this.eventListenerRetryTimer = null;
+    }
+    this.surfaceActivationCleanup?.();
+    this.surfaceActivationCleanup = null;
     this.peerSessionRefreshCleanup?.();
     this.peerSessionRefreshCleanup = null;
     this.dispatchJobObserverCleanup?.();

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.test.ts
@@ -325,3 +325,108 @@ describe('PeerSessionRefreshModule re-attach after a surface switch', () => {
     cleanup();
   });
 });
+
+describe('PeerSessionRefreshModule dead subscription recovery', () => {
+  /**
+   * The reported freeze: repeated device switching tore the agentic
+   * subscription down, and the reconcile loop refused to run while it was
+   * down — so the only path that could repair the session view was disabled by
+   * the very condition it existed to repair.
+   */
+  function contextWithDeadSubscription() {
+    const refreshPeerSessionSnapshot = vi.fn(async () => ({
+      applied: false,
+      backendState: 'Processing { current_turn_id: "turn-live", phase: Streaming }',
+      latestTurnId: 'turn-live',
+      latestTurnStatus: 'processing',
+    }));
+    const ensureLiveSubscription = vi.fn(async () => {});
+    const state = {
+      activeSessionId: 'session-1',
+      sessions: new Map([
+        ['session-1', {
+          sessionId: 'session-1',
+          workspacePath: '/repo/BitFun',
+          historyState: 'ready',
+          isHistorical: false,
+          isTransient: false,
+          dialogTurns: [{ id: 'turn-live', status: 'processing', modelRounds: [] }],
+        }],
+      ]),
+    };
+    return {
+      refreshPeerSessionSnapshot,
+      ensureLiveSubscription,
+      context: {
+        flowChatStore: {
+          getState: () => state,
+          subscribeSelector: vi.fn(() => () => {}),
+          refreshPeerSessionSnapshot,
+        },
+        eventBatcher: { flushNow: vi.fn() },
+        contentBuffers: new Map(),
+        activeTextItems: new Map(),
+        ensureLiveSubscription,
+      } as any,
+    };
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    peerModeMock.active = true;
+    resetRuntimeSessionEventGateForTest();
+    stateMachineMock.get.mockReturnValue({
+      getCurrentState: () => 'idle',
+      getContext: () => ({ lastUpdateTime: 0, version: 0 }),
+    });
+    vi.stubGlobal('document', {
+      visibilityState: 'visible',
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+    vi.stubGlobal('window', { addEventListener: vi.fn(), removeEventListener: vi.fn() });
+  });
+
+  afterEach(() => {
+    agenticListenerMock.getIsListening.mockReturnValue(true);
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('still reconciles when the subscription is down', async () => {
+    agenticListenerMock.getIsListening.mockReturnValue(false);
+    const { context, refreshPeerSessionSnapshot } = contextWithDeadSubscription();
+
+    const cleanup = installPeerSessionRefresh(context);
+    await vi.advanceTimersByTimeAsync(1);
+    await vi.advanceTimersByTimeAsync(PEER_SESSION_REFRESH_INTERVAL_MS);
+
+    expect(refreshPeerSessionSnapshot).toHaveBeenCalled();
+    cleanup();
+  });
+
+  it('re-arms the subscription it found dead', async () => {
+    agenticListenerMock.getIsListening.mockReturnValue(false);
+    const { context, ensureLiveSubscription } = contextWithDeadSubscription();
+
+    const cleanup = installPeerSessionRefresh(context);
+    await vi.advanceTimersByTimeAsync(1);
+    await vi.advanceTimersByTimeAsync(PEER_SESSION_REFRESH_INTERVAL_MS);
+
+    expect(ensureLiveSubscription).toHaveBeenCalled();
+    cleanup();
+  });
+
+  it('does not re-arm a subscription that is already live', async () => {
+    agenticListenerMock.getIsListening.mockReturnValue(true);
+    const { context, ensureLiveSubscription } = contextWithDeadSubscription();
+
+    const cleanup = installPeerSessionRefresh(context);
+    await vi.advanceTimersByTimeAsync(1);
+    await vi.advanceTimersByTimeAsync(PEER_SESSION_REFRESH_INTERVAL_MS);
+
+    expect(ensureLiveSubscription).not.toHaveBeenCalled();
+    cleanup();
+  });
+});

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.ts
@@ -151,8 +151,13 @@ export function installPeerSessionRefresh(context: FlowChatContext): () => void 
     if (typeof document !== 'undefined' && document.visibilityState === 'hidden') {
       return;
     }
+    // A dead subscription is the strongest reason to reconcile, not a reason to
+    // skip: bailing here meant a switch that tore the listener down disabled
+    // the only path that could repair it, and the chat froze for good. Re-arm
+    // and continue — the runtime cursor fence already covers the snapshot/live
+    // race while the subscription is coming back up.
     if (!agenticEventListener.getIsListening()) {
-      return;
+      void context.ensureLiveSubscription?.();
     }
 
     const state = context.flowChatStore.getState();

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/types.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/types.ts
@@ -61,6 +61,12 @@ export interface FlowChatContext {
    */
   handledTerminalTurnEvents: Set<string>;
   currentWorkspacePath: string | null;
+  /**
+   * Re-arm this window's live agentic subscription. The reconcile loop calls it
+   * when it observes a dead subscription, so recovery does not depend on a
+   * workspace bootstrap that a newer surface switch may have superseded.
+   */
+  ensureLiveSubscription?: () => Promise<void>;
 }
 
 /** Current owner scope used only when a restored child lacks saved location metadata. */

--- a/src/web-ui/src/infrastructure/peer-device/README.md
+++ b/src/web-ui/src/infrastructure/peer-device/README.md
@@ -148,6 +148,21 @@ Controller-side React/transport layer for Peer Device Mode. Architecture:
     restore from a device no longer rendered. Older hosts may omit the Runtime
     projection; their persisted snapshot must still never overwrite newer live
     content.
+
+    **The subscription and the attach loop must never be able to disable each
+    other.** The agentic subscription is this window's only live view of a
+    running Turn, and a surface switch tears it down. Rebuilding it used to be
+    a side effect of `FlowChatManager.initialize()`, which a newer switch is
+    allowed to supersede — so a rapid switch could leave the window with no
+    subscription and nothing to retry. The attach loop then *refused to run
+    while the subscription was down*, disabling the only path that could repair
+    it, and the chat froze permanently with no live output and no snapshot
+    repair (regression: 2026-08-16). `FlowChatManager` therefore re-arms on
+    `onSurfaceActivated` and retries a failed start on its own, the attach loop
+    treats a dead subscription as a reason to reconcile **and** re-arm rather
+    than to bail, and callers of `initialize()` must not report a superseded
+    bootstrap as a product failure. Any new gate on subscription readiness has
+    to keep both halves independently recoverable.
     **Controller presence is not Turn ownership.** A controller lease gates
     submission and interaction responses, but once a Peer Host accepts a Turn,
     the Host keeps executing and materializing it through a zero-controller


### PR DESCRIPTION
## Summary

Switching devices repeatedly left a session showing no live output and no way back — no streaming, no result, and no recovery until restart. The reporter's diagnosis was right: the display is driven by the live stream, repeated switching stops that stream, and the recovery path existed but never took effect.

It is one deadlock, not a display bug.

## Type and Areas

Type: Bug fix (a deadlock between two recovery mechanisms)

Areas: web UI — FlowChat lifecycle, device-surface attach loop

## Motivation / Impact

The agentic subscription is this window's **only live view of a running Turn**, but its lifetime was tied to workspace bootstrap:

1. A surface switch calls `resetForPeerModeSwitch()` → `cleanupEventListeners()` → the subscription stops.
2. It is rebuilt only as a side effect of `FlowChatManager.initialize()`, reached through `AppLayout`'s workspace effect.
3. That bootstrap can legitimately abandon with `SurfaceChangedError` when a newer switch supersedes it — guaranteed under rapid switching — and the effect does not re-run at all when both devices share a workspace path, which is the normal case for one person's own machines.
4. Nothing retried. There was no supervisor.

Then the deadlock. The attach/reconcile loop — the mechanism whose entire purpose is repairing a session view that missed events — was gated on the same subscription:

```ts
// PeerSessionRefreshModule.ts
if (!agenticEventListener.getIsListening()) {
  return;
}
```

So the moment the subscription died, the only path that could repair it refused to run. No live events, no snapshot repair, frozen permanently.

`AppLayout` compounded it by reporting the superseded bootstrap through the generic `flowChatInitFailed` toast, so the visible symptom pointed away from the cause.

The gate came from #2325 with no test covering its `false` branch and no documented rationale; it reads as defensive, and it inverted the intended relationship.

## The fix

Make the two halves independently recoverable — neither may disable the other.

- **The subscription self-heals.** `FlowChatManager` re-arms on `onSurfaceActivated` and retries a failed start on a backstop timer, so it no longer depends on a bootstrap that is allowed to be abandoned. `ensureEventListeners()` is idempotent and safe to call from anywhere.
- **A dead subscription now triggers repair instead of blocking it.** The attach loop reconciles *and* re-arms. This is safe because `runtimeSessionEventGate` already fences the snapshot/live race by `(streamId, cursor)` while the subscription comes back up.
- **A superseded bootstrap is control flow, not a failure.** No toast, and it ensures the subscription rather than leaving the window dark.

## Verification

```
pnpm --dir src/web-ui run lint                      # clean
pnpm --dir src/web-ui run type-check                # clean
pnpm --dir src/web-ui exec vitest run               # 3473 passed (+6 new) / 14 pre-existing failures
pnpm run build:web                                  # clean (incl. appearance contract audit)
node scripts/i18n-audit.mjs                         # 0 warnings
theme:color-audit:all / theme:visual-contract       # PASS
verify:webkit-compatibility:test                    # PASS
check:repo-hygiene / check:github-config            # PASS
```

Six new tests, **each verified non-vacuous** by reverting its fix in place:

| Reverted | Failing test |
|---|---|
| the inverted gate (back to `return`) | `still reconciles when the subscription is down`, `re-arms the subscription it found dead` |
| the activation re-arm | `re-arms the subscription on every surface activation` |

Plus: the retry path for a subscription that fails to start, and negative cases asserting a healthy subscription is neither re-armed nor re-initialized (so this cannot churn on every tick).

The 14 failures are `AcpAgentsConfig.test.tsx` and `modelResolution.test.ts` failing on `localStorage` being unavailable in this local Node build; they reproduce on a clean tree and pass in CI.

**Not verified here:** the real two-device scenario needs the desktop app, an account, a relay and a second machine, which this environment cannot reproduce. Evidence is the deadlock reproduced at the unit level, not a click-through.

## Reviewer Notes

**Why the gate was wrong rather than just unlucky.** A subscription that is down is the strongest signal that the projection is stale — it is exactly when reconciliation is needed. Gating recovery on the health of the thing being recovered makes the failure absorbing: once entered, no path leaves it.

**Scope.** This fixes the desktop client's device-switch path, which is where it was reported. The broader split — desktop uses a live stream plus runtime snapshot/cursor attach while mobile-web polls `poll_session` with a version tracker and persisted messages — is real and unaddressed here. Unifying all clients on the `(streamId, cursor)` attach contract is the follow-up; this change does not block it and moves in its direction by making the subscription an explicit, supervised resource.

**Invariant recorded** in `src/web-ui/src/infrastructure/peer-device/README.md` under invariant 12, including the property that will re-break it: any new gate on subscription readiness must keep both halves independently recoverable.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.
