### PR TITLE
feat(peer): give a running Turn a durable record and unstrand a returning device

### DIFF
--- a/src/apps/cli/src/peer_host/bootstrap.rs
+++ b/src/apps/cli/src/peer_host/bootstrap.rs
@@ -5,6 +5,9 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use bitfun_agent_runtime::sdk::SessionEventJournal;
 use bitfun_core::service::filesystem::FileSystemServiceFactory;
+use bitfun_core::service::session_projection_store::{
+    runtime_event_log_dir, FileSessionProjectionStore,
+};
 use bitfun_core::service::workspace::{self, WorkspaceService};
 
 use crate::runtime::CliRuntimeContext;
@@ -31,7 +34,21 @@ pub(crate) async fn ensure_peer_host_ready(runtime: &CliRuntimeContext) -> Resul
     };
 
     let filesystem_service = Arc::new(FileSystemServiceFactory::create_default());
-    let session_event_journal = Arc::new(SessionEventJournal::new());
+    // Same log the Desktop Host uses: either can own this Session at different
+    // times, and a Turn left running by one must be replayable by the other.
+    let session_event_journal = Arc::new(
+        match bitfun_core::infrastructure::try_get_path_manager_arc() {
+            Ok(path_manager) => SessionEventJournal::new().with_store(Arc::new(
+                FileSessionProjectionStore::new(runtime_event_log_dir(&path_manager)),
+            )),
+            Err(error) => {
+                tracing::warn!(
+                    "Runtime event log disabled: application paths unavailable: {error}"
+                );
+                SessionEventJournal::new()
+            }
+        },
+    );
     let agent_runtime = runtime
         .agent_runtime()
         .clone()

--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -39,6 +39,9 @@ use bitfun_core::agentic::tools::computer_use_host::ComputerUseHostRef;
 use bitfun_core::infrastructure::ai::AIClientFactory;
 use bitfun_core::infrastructure::{get_path_manager_arc, try_get_path_manager_arc};
 use bitfun_core::service::search::get_global_workspace_search_service;
+use bitfun_core::service::session_projection_store::{
+    runtime_event_log_dir, FileSessionProjectionStore,
+};
 use bitfun_core::service::workspace::get_global_workspace_service;
 use bitfun_core::util::{elapsed_ms, TimingCollector};
 use bitfun_events::AgenticEvent;
@@ -644,7 +647,19 @@ pub async fn run() {
     startup_timings.record_elapsed("initialize_app_state", step_started);
     startup_trace.record_elapsed_step("native_pre_tauri", "initialize_app_state", step_started);
 
-    let session_event_journal = Arc::new(SessionEventJournal::new());
+    // A Turn that is still executing exists nowhere durable but this log: the
+    // persisted Session record stores a running Turn as idle so a restart never
+    // revives work. Without it, a client returning to this device after the
+    // process restarted is served a Turn frozen at the last checkpoint.
+    let session_event_journal = Arc::new(match try_get_path_manager_arc() {
+        Ok(path_manager) => SessionEventJournal::new().with_store(Arc::new(
+            FileSessionProjectionStore::new(runtime_event_log_dir(&path_manager)),
+        )),
+        Err(error) => {
+            log::warn!("Runtime event log disabled: application paths unavailable: {error}");
+            SessionEventJournal::new()
+        }
+    });
     let step_started = Instant::now();
     let desktop_runtime = match runtime::DesktopRuntimeContext::build(
         coordinator.clone(),

--- a/src/crates/assembly/core/src/agentic/persistence/session_branch.rs
+++ b/src/crates/assembly/core/src/agentic/persistence/session_branch.rs
@@ -1,11 +1,11 @@
 use super::manager::PersistenceManager;
 use crate::agentic::core::{Session, SessionKind};
 use crate::util::errors::{BitFunError, BitFunResult};
+use bitfun_services_core::session::SessionBranchBoundary;
 use bitfun_services_core::session::{
     build_branched_session_metadata, format_branch_session_name, resolve_branch_session_lineage,
     BranchSessionMetadataFacts,
 };
-use bitfun_services_core::session::SessionBranchBoundary;
 pub use bitfun_services_core::session::{SessionBranchRequest, SessionBranchResult};
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};

--- a/src/crates/assembly/core/src/agentic/tools/browser_control/actions.rs
+++ b/src/crates/assembly/core/src/agentic/tools/browser_control/actions.rs
@@ -112,7 +112,11 @@ pub(crate) fn classify_evaluate_exception(message: &str) -> BitFunError {
         if message.contains("cross-origin iframe") {
             hints.push("The page contains cross-origin iframes whose contents cannot be inspected or clicked — an element inside one is unreachable; work with the top-level document instead");
         }
-        structured_error(ErrorCode::NotFound, format!("JS error: {}", message), &hints)
+        structured_error(
+            ErrorCode::NotFound,
+            format!("JS error: {}", message),
+            &hints,
+        )
     } else {
         structured_error(
             ErrorCode::Internal,
@@ -1666,9 +1670,10 @@ mod structured_error_tests {
 
     #[test]
     fn classify_transport_error_maps_dead_socket_to_wrong_tab() {
-        let msg =
-            classify_transport_error(BitFunError::tool("CDP send failed: broken pipe".to_string()))
-                .to_string();
+        let msg = classify_transport_error(BitFunError::tool(
+            "CDP send failed: broken pipe".to_string(),
+        ))
+        .to_string();
         assert!(msg.contains("[WRONG_TAB]"), "got: {msg}");
         assert!(msg.contains("browser.connect"), "got: {msg}");
     }

--- a/src/crates/assembly/core/src/agentic/tools/file_read_state_runtime.rs
+++ b/src/crates/assembly/core/src/agentic/tools/file_read_state_runtime.rs
@@ -437,9 +437,10 @@ mod tests {
         custom.agent_type = Some("ReviewSecurity".to_string());
         assert!(!review_read_receipts_enabled(&custom));
 
-        custom
-            .custom_data
-            .insert("deep_review_run_manifest".to_string(), serde_json::json!({}));
+        custom.custom_data.insert(
+            "deep_review_run_manifest".to_string(),
+            serde_json::json!({}),
+        );
         assert!(review_read_receipts_enabled(&custom));
 
         let mut worker = test_context(Some("session-2"), PathBuf::from("/tmp"));

--- a/src/crates/assembly/core/src/agentic/tools/implementations/exec_command/command.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/exec_command/command.rs
@@ -643,9 +643,7 @@ Output:
                 meta: None,
             };
         }
-        if let (Some(context), Some(parsed)) =
-            (context, exec_command_run_input_from_input(input))
-        {
+        if let (Some(context), Some(parsed)) = (context, exec_command_run_input_from_input(input)) {
             if let Some(rejection) =
                 crate::agentic::execution::edit_constraint_guard::check_bash_command(
                     context, parsed.cmd,

--- a/src/crates/assembly/core/src/service/mod.rs
+++ b/src/crates/assembly/core/src/service/mod.rs
@@ -42,6 +42,8 @@ pub mod search; // Workspace search via managed flashgrep daemon
 #[cfg(feature = "local-storage")]
 pub mod session; // Session persistence
 #[cfg(feature = "agent-runtime")]
+pub mod session_projection_store; // Durable append-only log of the executing Turn
+#[cfg(feature = "agent-runtime")]
 pub mod session_usage; // Session runtime usage reports
 #[cfg(feature = "agent-runtime")]
 pub mod snapshot; // Snapshot-based change tracking

--- a/src/crates/assembly/core/src/service/remote_connect/mod.rs
+++ b/src/crates/assembly/core/src/service/remote_connect/mod.rs
@@ -522,11 +522,10 @@ impl RemoteConnectService {
             + Sync
             + 'static,
     {
-        *self.peer_device_provision_fn.write().await = Some(Arc::new(
-            move |device_id, device_name, request_id| {
+        *self.peer_device_provision_fn.write().await =
+            Some(Arc::new(move |device_id, device_name, request_id| {
                 Box::pin(f(device_id, device_name, request_id))
-            },
-        ));
+            }));
     }
 
     /// Enable account-password pairing in the QR.

--- a/src/crates/assembly/core/src/service/session_projection_store.rs
+++ b/src/crates/assembly/core/src/service/session_projection_store.rs
@@ -1,0 +1,264 @@
+//! Append-only durability for the Runtime's executing-Turn event log.
+//!
+//! One file per Session, one line per event, written as the event happens.
+//! Reload replays that log through the Runtime's own materialization, so a
+//! restored Turn and a live one are produced by a single implementation.
+//!
+//! This is deliberately scoped to the Turn **in flight**. The persisted Session
+//! record remains the history of completed work; it cannot represent a running
+//! Turn because it stores one as idle so a restart never revives work. When a
+//! Turn reaches a terminal state the Session record owns it and this log is
+//! dropped, so the two never describe the same thing at the same time.
+
+use bitfun_agent_runtime::sdk::{SessionEventProjectionStore, StoredSessionEvents};
+use bitfun_events::AgenticEvent;
+use std::collections::HashMap;
+use std::fs::{File, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+/// One appended line. `streamId` identifies the Runtime process that wrote it,
+/// so a log left by an older process is never mistaken for current progress.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LoggedEvent {
+    stream_id: String,
+    cursor: u64,
+    event: AgenticEvent,
+}
+
+/// Open append handles, keyed by Session. Holding the handle is what makes a
+/// per-event write an append to an already-open file rather than an open/close
+/// cycle per token.
+type OpenLogs = Mutex<HashMap<String, Arc<Mutex<File>>>>;
+
+pub struct FileSessionProjectionStore {
+    root: PathBuf,
+    logs: OpenLogs,
+}
+
+impl std::fmt::Debug for FileSessionProjectionStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FileSessionProjectionStore")
+            .field("root", &self.root)
+            .finish_non_exhaustive()
+    }
+}
+
+impl FileSessionProjectionStore {
+    pub fn new(root: PathBuf) -> Self {
+        if let Err(error) = std::fs::create_dir_all(&root) {
+            log::warn!(
+                "Runtime event log unavailable at {}: {error}",
+                root.display()
+            );
+        }
+        Self {
+            root,
+            logs: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn log_handle(&self, session_id: &str) -> Option<Arc<Mutex<File>>> {
+        let mut logs = lock(&self.logs);
+        if let Some(handle) = logs.get(session_id) {
+            return Some(Arc::clone(handle));
+        }
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(log_path(&self.root, session_id))
+            .map_err(|error| {
+                log::warn!("Failed to open runtime event log for {session_id}: {error}");
+            })
+            .ok()?;
+        let handle = Arc::new(Mutex::new(file));
+        logs.insert(session_id.to_string(), Arc::clone(&handle));
+        Some(handle)
+    }
+}
+
+impl SessionEventProjectionStore for FileSessionProjectionStore {
+    fn append(&self, session_id: &str, stream_id: &str, cursor: u64, event: &AgenticEvent) {
+        let record = LoggedEvent {
+            stream_id: stream_id.to_string(),
+            cursor,
+            event: event.clone(),
+        };
+        let Ok(mut line) = serde_json::to_vec(&record) else {
+            return;
+        };
+        line.push(b'\n');
+
+        let Some(handle) = self.log_handle(session_id) else {
+            return;
+        };
+        let mut file = lock(&handle);
+        // No fsync: an append reaches the page cache immediately, which already
+        // survives a process crash — the case this log exists for. Paying a
+        // disk flush per token would throttle the stream it is recording.
+        if let Err(error) = file.write_all(&line) {
+            log::warn!("Failed to append runtime event for {session_id}: {error}");
+        }
+    }
+
+    fn load(&self, session_id: &str) -> Option<StoredSessionEvents> {
+        let file = File::open(log_path(&self.root, session_id)).ok()?;
+        let mut stream_id: Option<String> = None;
+        let mut events = Vec::new();
+        for line in BufReader::new(file).lines() {
+            let Ok(line) = line else { break };
+            if line.trim().is_empty() {
+                continue;
+            }
+            // A torn final line is expected after a hard kill mid-append. Stop
+            // there and keep everything already durable.
+            let Ok(record) = serde_json::from_str::<LoggedEvent>(&line) else {
+                break;
+            };
+            match stream_id.as_deref() {
+                // A newer Runtime process reused this file; its events replace
+                // the older process's, which describe a Turn that no longer runs.
+                Some(current) if current != record.stream_id => {
+                    events.clear();
+                    stream_id = Some(record.stream_id);
+                }
+                None => stream_id = Some(record.stream_id),
+                _ => {}
+            }
+            events.push(record.event);
+        }
+        if events.is_empty() {
+            return None;
+        }
+        stream_id.map(|stream_id| StoredSessionEvents { stream_id, events })
+    }
+
+    fn discard(&self, session_id: &str) {
+        lock(&self.logs).remove(session_id);
+        let _ = std::fs::remove_file(log_path(&self.root, session_id));
+    }
+}
+
+fn lock<T>(value: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    value
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Session ids are host-generated UUIDs, but this still refuses anything that
+/// could escape the log directory rather than trusting that invariant.
+fn log_path(root: &Path, session_id: &str) -> PathBuf {
+    let safe: String = session_id
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || character == '-' || character == '_' {
+                character
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    root.join(format!("{safe}.jsonl"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_root() -> PathBuf {
+        std::env::temp_dir().join(format!("bitfun-evlog-{}", uuid::Uuid::new_v4()))
+    }
+
+    fn text(session_id: &str, value: &str) -> AgenticEvent {
+        AgenticEvent::TextChunk {
+            session_id: session_id.to_string(),
+            turn_id: "turn-1".to_string(),
+            round_id: "round-1".to_string(),
+            attempt_id: None,
+            attempt_index: None,
+            text: value.to_string(),
+        }
+    }
+
+    #[test]
+    fn every_event_is_durable_the_moment_it_is_appended() {
+        let root = temp_root();
+        let store = FileSessionProjectionStore::new(root.clone());
+
+        store.append("session-1", "stream-1", 1, &text("session-1", "a"));
+        store.append("session-1", "stream-1", 2, &text("session-1", "b"));
+
+        // A separate store reads the same directory: nothing is held back in
+        // process memory waiting for a flush interval.
+        let reader = FileSessionProjectionStore::new(root.clone());
+        let stored = reader.load("session-1").expect("events are on disk");
+        assert_eq!(stored.events.len(), 2);
+        assert_eq!(stored.stream_id, "stream-1");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn a_newer_runtime_process_supersedes_an_older_log() {
+        let root = temp_root();
+        let store = FileSessionProjectionStore::new(root.clone());
+
+        store.append("session-1", "stream-old", 1, &text("session-1", "stale"));
+        store.append("session-1", "stream-new", 1, &text("session-1", "fresh"));
+
+        let stored = store.load("session-1").expect("log is readable");
+        assert_eq!(stored.stream_id, "stream-new");
+        assert_eq!(stored.events.len(), 1);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn a_torn_final_line_keeps_everything_already_durable() {
+        let root = temp_root();
+        let store = FileSessionProjectionStore::new(root.clone());
+        store.append("session-1", "stream-1", 1, &text("session-1", "a"));
+        store.discard("session-1");
+
+        let path = log_path(&root, "session-1");
+        std::fs::write(
+            &path,
+            format!(
+                "{}\n{{\"streamId\":\"stream-1\",\"cur",
+                serde_json::to_string(&LoggedEvent {
+                    stream_id: "stream-1".to_string(),
+                    cursor: 1,
+                    event: text("session-1", "a"),
+                })
+                .unwrap()
+            ),
+        )
+        .unwrap();
+
+        let stored = store.load("session-1").expect("surviving prefix is served");
+        assert_eq!(stored.events.len(), 1);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn a_terminal_turn_hands_the_record_back_to_the_session() {
+        let root = temp_root();
+        let store = FileSessionProjectionStore::new(root.clone());
+
+        store.append("session-1", "stream-1", 1, &text("session-1", "a"));
+        store.discard("session-1");
+
+        assert!(store.load("session-1").is_none());
+        assert!(!log_path(&root, "session-1").exists());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn a_session_id_cannot_escape_the_log_directory() {
+        let root = PathBuf::from("/tmp/bitfun-evlog-root");
+        assert_eq!(
+            log_path(&root, "../../etc/passwd").parent(),
+            Some(root.as_path())
+        );
+    }
+}

--- a/src/crates/assembly/core/src/service/session_projection_store.rs
+++ b/src/crates/assembly/core/src/service/session_projection_store.rs
@@ -46,6 +46,17 @@ impl std::fmt::Debug for FileSessionProjectionStore {
     }
 }
 
+/// Where every Host on this machine keeps its in-flight Turn logs.
+///
+/// Shared so Desktop and CLI agree without either hard-coding a path: they can
+/// own the same Session at different times, and a log written by one must be
+/// the log the other replays.
+pub fn runtime_event_log_dir(
+    path_manager: &crate::infrastructure::PathManager,
+) -> std::path::PathBuf {
+    path_manager.bitfun_home_dir().join("runtime-events")
+}
+
 impl FileSessionProjectionStore {
     pub fn new(root: PathBuf) -> Self {
         if let Err(error) = std::fs::create_dir_all(&root) {

--- a/src/crates/execution/agent-runtime/src/runtime.rs
+++ b/src/crates/execution/agent-runtime/src/runtime.rs
@@ -55,7 +55,8 @@ use bitfun_runtime_ports::{PermissionReply, PermissionReplySource, PermissionReq
 mod session_event_journal;
 pub use session_event_journal::{
     attach_session_event_cursor, SessionEventCursor, SessionEventJournal,
-    SessionEventProjectionSnapshot, RUNTIME_EVENT_CURSOR_KEY, RUNTIME_EVENT_STREAM_ID_KEY,
+    SessionEventProjectionSnapshot, SessionEventProjectionStore, RUNTIME_EVENT_CURSOR_KEY,
+    RUNTIME_EVENT_STREAM_ID_KEY,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]

--- a/src/crates/execution/agent-runtime/src/runtime.rs
+++ b/src/crates/execution/agent-runtime/src/runtime.rs
@@ -55,8 +55,8 @@ use bitfun_runtime_ports::{PermissionReply, PermissionReplySource, PermissionReq
 mod session_event_journal;
 pub use session_event_journal::{
     attach_session_event_cursor, SessionEventCursor, SessionEventJournal,
-    SessionEventProjectionSnapshot, SessionEventProjectionStore, RUNTIME_EVENT_CURSOR_KEY,
-    RUNTIME_EVENT_STREAM_ID_KEY,
+    SessionEventProjectionSnapshot, SessionEventProjectionStore, StoredSessionEvents,
+    RUNTIME_EVENT_CURSOR_KEY, RUNTIME_EVENT_STREAM_ID_KEY,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]

--- a/src/crates/execution/agent-runtime/src/sdk.rs
+++ b/src/crates/execution/agent-runtime/src/sdk.rs
@@ -46,7 +46,8 @@ pub use crate::post_call_hooks::{
 };
 pub use crate::runtime::{
     attach_session_event_cursor, SessionEventCursor, SessionEventJournal,
-    SessionEventProjectionSnapshot, RUNTIME_EVENT_CURSOR_KEY, RUNTIME_EVENT_STREAM_ID_KEY,
+    SessionEventProjectionSnapshot, SessionEventProjectionStore, RUNTIME_EVENT_CURSOR_KEY,
+    RUNTIME_EVENT_STREAM_ID_KEY,
 };
 pub use crate::runtime::{
     AgentEventStream, AgentRunHandle, AgentRunRequest, AgentSessionRestorePort,

--- a/src/crates/execution/agent-runtime/src/sdk.rs
+++ b/src/crates/execution/agent-runtime/src/sdk.rs
@@ -46,8 +46,8 @@ pub use crate::post_call_hooks::{
 };
 pub use crate::runtime::{
     attach_session_event_cursor, SessionEventCursor, SessionEventJournal,
-    SessionEventProjectionSnapshot, SessionEventProjectionStore, RUNTIME_EVENT_CURSOR_KEY,
-    RUNTIME_EVENT_STREAM_ID_KEY,
+    SessionEventProjectionSnapshot, SessionEventProjectionStore, StoredSessionEvents,
+    RUNTIME_EVENT_CURSOR_KEY, RUNTIME_EVENT_STREAM_ID_KEY,
 };
 pub use crate::runtime::{
     AgentEventStream, AgentRunHandle, AgentRunRequest, AgentSessionRestorePort,

--- a/src/crates/execution/agent-runtime/src/session_event_journal.rs
+++ b/src/crates/execution/agent-runtime/src/session_event_journal.rs
@@ -83,12 +83,32 @@ struct JournalState {
     sessions: HashMap<String, SessionProjection>,
 }
 
+/// Durable sink for the materialized projection.
+///
+/// This projection is the only complete record of a Turn while it runs: client
+/// persistence lags it by a coalescing window, and the persisted Session view
+/// deliberately stores an executing Turn as idle so a restart cannot revive
+/// work. Keeping the projection in memory alone therefore means a Host restart
+/// loses the live state of work that is still running, and a client returning
+/// to that Session sees a Turn frozen at the last checkpoint.
+///
+/// Implementations own their write policy. `save` is called for every
+/// materialized event, so a store is expected to coalesce writes rather than
+/// touch the filesystem per token.
+pub trait SessionEventProjectionStore: Send + Sync {
+    fn save(&self, snapshot: &SessionEventProjectionSnapshot);
+    fn load(&self, session_id: &str) -> Option<SessionEventProjectionSnapshot>;
+    /// The Turn reached a terminal state; the persisted Session view owns it now.
+    fn discard(&self, session_id: &str);
+}
+
 /// Cloneable owner shared by the Runtime facade and its product delivery
 /// adapter. Product hosts record events only after their ordering/coalescing
 /// boundary, then expose snapshots through the same `AgentRuntime` instance.
 #[derive(Clone)]
 pub struct SessionEventJournal {
     state: Arc<Mutex<JournalState>>,
+    store: Option<Arc<dyn SessionEventProjectionStore>>,
 }
 
 impl std::fmt::Debug for SessionEventJournal {
@@ -116,7 +136,14 @@ impl SessionEventJournal {
                 sequence: 0,
                 sessions: HashMap::new(),
             })),
+            store: None,
         }
+    }
+
+    /// Attach durable storage so a projection outlives this Host process.
+    pub fn with_store(mut self, store: Arc<dyn SessionEventProjectionStore>) -> Self {
+        self.store = Some(store);
+        self
     }
 
     /// Record one event in the host's final ordered delivery stream.
@@ -161,19 +188,59 @@ impl SessionEventJournal {
             state.sequence = next_sequence;
             prune_terminal_projections(&mut state.sessions);
         }
+        if materialized {
+            if let Some(store) = self.store.as_ref() {
+                let session_id = event.session_id().unwrap_or_default().to_string();
+                let projection = state.sessions.get(&session_id);
+                let terminal = projection.is_some_and(|projection| projection.terminal);
+                let snapshot = projection_snapshot(&state, &session_id);
+                // Release the lock before touching the store: a slow flush must
+                // never stall the delivery stream it is recording.
+                drop(state);
+                if terminal {
+                    store.discard(&session_id);
+                } else {
+                    store.save(&snapshot);
+                }
+                return Some(SessionEventCursor { stream_id, cursor });
+            }
+        }
         materialized.then_some(SessionEventCursor { stream_id, cursor })
     }
 
     pub fn snapshot(&self, session_id: &str) -> SessionEventProjectionSnapshot {
         let state = lock_state(&self.state);
-        let projection = state.sessions.get(session_id);
-        SessionEventProjectionSnapshot {
-            session_id: session_id.to_string(),
-            stream_id: state.stream_id.clone(),
-            cursor: projection.map_or(0, |projection| projection.cursor),
-            active_turn_id: projection.and_then(|projection| projection.active_turn_id.clone()),
-            events: projection.map_or_else(Vec::new, |projection| projection.events.clone()),
+        if state.sessions.contains_key(session_id) {
+            return projection_snapshot(&state, session_id);
         }
+        drop(state);
+
+        // Nothing in memory. Either this Session never ran here, or this Host
+        // restarted while its Turn was executing. A stored projection keeps its
+        // original `stream_id`, so a client correctly treats it as a different
+        // Runtime process and replays it whole instead of comparing cursors
+        // across processes.
+        self.store
+            .as_ref()
+            .and_then(|store| store.load(session_id))
+            .unwrap_or_else(|| SessionEventProjectionSnapshot {
+                session_id: session_id.to_string(),
+                stream_id: lock_state(&self.state).stream_id.clone(),
+                cursor: 0,
+                active_turn_id: None,
+                events: Vec::new(),
+            })
+    }
+}
+
+fn projection_snapshot(state: &JournalState, session_id: &str) -> SessionEventProjectionSnapshot {
+    let projection = state.sessions.get(session_id);
+    SessionEventProjectionSnapshot {
+        session_id: session_id.to_string(),
+        stream_id: state.stream_id.clone(),
+        cursor: projection.map_or(0, |projection| projection.cursor),
+        active_turn_id: projection.and_then(|projection| projection.active_turn_id.clone()),
+        events: projection.map_or_else(Vec::new, |projection| projection.events.clone()),
     }
 }
 
@@ -478,9 +545,38 @@ fn compact_projection(projection: &mut SessionProjection) {
 mod tests {
     use super::{
         attach_session_event_cursor, lock_state, SessionEventCursor, SessionEventJournal,
+        SessionEventProjectionSnapshot, SessionEventProjectionStore,
         MAX_RETAINED_TERMINAL_SESSION_PROJECTIONS,
     };
     use bitfun_events::{AgenticEvent, ToolEventData, ToolEventIdentity};
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    /// In-memory stand-in for a durable store; records the calls a real one
+    /// would turn into filesystem writes.
+    #[derive(Default)]
+    struct RecordingStore {
+        saved: Mutex<HashMap<String, SessionEventProjectionSnapshot>>,
+        discarded: Mutex<Vec<String>>,
+    }
+
+    impl SessionEventProjectionStore for RecordingStore {
+        fn save(&self, snapshot: &SessionEventProjectionSnapshot) {
+            self.saved
+                .lock()
+                .unwrap()
+                .insert(snapshot.session_id.clone(), snapshot.clone());
+        }
+
+        fn load(&self, session_id: &str) -> Option<SessionEventProjectionSnapshot> {
+            self.saved.lock().unwrap().get(session_id).cloned()
+        }
+
+        fn discard(&self, session_id: &str) {
+            self.discarded.lock().unwrap().push(session_id.to_string());
+            self.saved.lock().unwrap().remove(session_id);
+        }
+    }
 
     fn turn_started(session_id: &str, turn_id: &str) -> AgenticEvent {
         AgenticEvent::DialogTurnStarted {
@@ -694,5 +790,67 @@ mod tests {
         ));
         assert_eq!(retained.cursor, 2);
         assert!(!retained.events.is_empty());
+    }
+
+    #[test]
+    fn persists_the_projection_of_a_running_turn() {
+        let store = Arc::new(RecordingStore::default());
+        let journal = SessionEventJournal::new().with_store(store.clone());
+
+        journal.record(&turn_started("session-1", "turn-1"));
+        journal.record(&text("session-1", "turn-1", "hello"));
+
+        let saved = store.load("session-1").expect("running turn is persisted");
+        assert_eq!(saved.active_turn_id.as_deref(), Some("turn-1"));
+        assert!(saved.cursor > 0);
+    }
+
+    #[test]
+    fn serves_a_stored_projection_after_a_host_restart() {
+        // The reported freeze: the Turn keeps running but the Host process that
+        // owned its in-memory projection is gone, so a returning client used to
+        // see only the lagging persisted checkpoint.
+        let store = Arc::new(RecordingStore::default());
+        let first = SessionEventJournal::new().with_store(store.clone());
+        first.record(&turn_started("session-1", "turn-1"));
+        first.record(&text("session-1", "turn-1", "hello"));
+        let before = first.snapshot("session-1");
+
+        let restarted = SessionEventJournal::new().with_store(store.clone());
+        let after = restarted.snapshot("session-1");
+
+        assert_eq!(after.active_turn_id.as_deref(), Some("turn-1"));
+        assert_eq!(after.events.len(), before.events.len());
+        // Its own stream id survives, so a client treats it as a different
+        // Runtime process and replays it instead of comparing cursors.
+        assert_eq!(after.stream_id, before.stream_id);
+        assert_ne!(after.stream_id, restarted.snapshot("session-2").stream_id);
+    }
+
+    #[test]
+    fn stops_persisting_once_the_turn_is_terminal() {
+        let store = Arc::new(RecordingStore::default());
+        let journal = SessionEventJournal::new().with_store(store.clone());
+
+        journal.record(&turn_started("session-1", "turn-1"));
+        journal.record(&turn_completed("session-1", "turn-1"));
+
+        assert!(store
+            .discarded
+            .lock()
+            .unwrap()
+            .contains(&"session-1".to_string()));
+        assert!(store.load("session-1").is_none());
+    }
+
+    #[test]
+    fn a_journal_without_a_store_behaves_as_before() {
+        let journal = SessionEventJournal::new();
+        journal.record(&turn_started("session-1", "turn-1"));
+        assert_eq!(
+            journal.snapshot("session-1").active_turn_id.as_deref(),
+            Some("turn-1")
+        );
+        assert!(journal.snapshot("missing").events.is_empty());
     }
 }

--- a/src/crates/execution/agent-runtime/src/session_event_journal.rs
+++ b/src/crates/execution/agent-runtime/src/session_event_journal.rs
@@ -83,21 +83,29 @@ struct JournalState {
     sessions: HashMap<String, SessionProjection>,
 }
 
-/// Durable sink for the materialized projection.
+/// Recorded events of one Session, restored in their original order.
+pub struct StoredSessionEvents {
+    pub stream_id: String,
+    pub events: Vec<AgenticEvent>,
+}
+
+/// Durable, append-only log of the executing Turn.
 ///
-/// This projection is the only complete record of a Turn while it runs: client
-/// persistence lags it by a coalescing window, and the persisted Session view
-/// deliberately stores an executing Turn as idle so a restart cannot revive
-/// work. Keeping the projection in memory alone therefore means a Host restart
-/// loses the live state of work that is still running, and a client returning
-/// to that Session sees a Turn frozen at the last checkpoint.
+/// This log is the authority for work in flight. Everything else durable lags
+/// it: client persistence is debounced into coalescing windows, and the
+/// persisted Session view deliberately stores an executing Turn as idle so a
+/// restart never revives work. Without this log the only complete record of a
+/// running Turn dies with the Host process, and a returning client is served a
+/// Turn frozen at the last checkpoint.
 ///
-/// Implementations own their write policy. `save` is called for every
-/// materialized event, so a store is expected to coalesce writes rather than
-/// touch the filesystem per token.
+/// `append` is called for each event as it enters the ordered delivery stream —
+/// one atomic event, written when it happens, not a periodic snapshot. Reload
+/// replays the log through the same materialization used live, so a restored
+/// projection and a live one are produced by one implementation rather than
+/// two that can disagree.
 pub trait SessionEventProjectionStore: Send + Sync {
-    fn save(&self, snapshot: &SessionEventProjectionSnapshot);
-    fn load(&self, session_id: &str) -> Option<SessionEventProjectionSnapshot>;
+    fn append(&self, session_id: &str, stream_id: &str, cursor: u64, event: &AgenticEvent);
+    fn load(&self, session_id: &str) -> Option<StoredSessionEvents>;
     /// The Turn reached a terminal state; the persisted Session view owns it now.
     fn discard(&self, session_id: &str);
 }
@@ -191,16 +199,17 @@ impl SessionEventJournal {
         if materialized {
             if let Some(store) = self.store.as_ref() {
                 let session_id = event.session_id().unwrap_or_default().to_string();
-                let projection = state.sessions.get(&session_id);
-                let terminal = projection.is_some_and(|projection| projection.terminal);
-                let snapshot = projection_snapshot(&state, &session_id);
-                // Release the lock before touching the store: a slow flush must
+                let terminal = state
+                    .sessions
+                    .get(&session_id)
+                    .is_some_and(|projection| projection.terminal);
+                // Release the lock before touching the store: an append must
                 // never stall the delivery stream it is recording.
                 drop(state);
                 if terminal {
                     store.discard(&session_id);
                 } else {
-                    store.save(&snapshot);
+                    store.append(&session_id, &stream_id, cursor, event);
                 }
                 return Some(SessionEventCursor { stream_id, cursor });
             }
@@ -213,23 +222,38 @@ impl SessionEventJournal {
         if state.sessions.contains_key(session_id) {
             return projection_snapshot(&state, session_id);
         }
+        let live_stream_id = state.stream_id.clone();
         drop(state);
 
-        // Nothing in memory. Either this Session never ran here, or this Host
-        // restarted while its Turn was executing. A stored projection keeps its
-        // original `stream_id`, so a client correctly treats it as a different
-        // Runtime process and replays it whole instead of comparing cursors
-        // across processes.
-        self.store
-            .as_ref()
-            .and_then(|store| store.load(session_id))
-            .unwrap_or_else(|| SessionEventProjectionSnapshot {
+        // Nothing in memory: either this Session never ran here, or this Host
+        // restarted while its Turn was executing. Replay the log through the
+        // same materialization used live, so a restored projection cannot
+        // disagree with one built from events as they arrived. The stored
+        // stream_id is preserved, so a client reads it as a different Runtime
+        // process and replays it instead of comparing cursors across processes.
+        let Some(stored) = self.store.as_ref().and_then(|store| store.load(session_id)) else {
+            return SessionEventProjectionSnapshot {
                 session_id: session_id.to_string(),
-                stream_id: lock_state(&self.state).stream_id.clone(),
+                stream_id: live_stream_id,
                 cursor: 0,
                 active_turn_id: None,
                 events: Vec::new(),
-            })
+            };
+        };
+
+        let mut projection = SessionProjection::default();
+        for event in &stored.events {
+            if apply_event(&mut projection, event) {
+                projection.cursor = projection.cursor.saturating_add(1);
+            }
+        }
+        SessionEventProjectionSnapshot {
+            session_id: session_id.to_string(),
+            stream_id: stored.stream_id,
+            cursor: projection.cursor,
+            active_turn_id: projection.active_turn_id,
+            events: projection.events,
+        }
     }
 }
 
@@ -545,36 +569,43 @@ fn compact_projection(projection: &mut SessionProjection) {
 mod tests {
     use super::{
         attach_session_event_cursor, lock_state, SessionEventCursor, SessionEventJournal,
-        SessionEventProjectionSnapshot, SessionEventProjectionStore,
+        SessionEventProjectionStore, StoredSessionEvents,
         MAX_RETAINED_TERMINAL_SESSION_PROJECTIONS,
     };
     use bitfun_events::{AgenticEvent, ToolEventData, ToolEventIdentity};
     use std::collections::HashMap;
     use std::sync::{Arc, Mutex};
 
-    /// In-memory stand-in for a durable store; records the calls a real one
-    /// would turn into filesystem writes.
+    /// In-memory stand-in for the append-only log a real store writes to disk.
     #[derive(Default)]
     struct RecordingStore {
-        saved: Mutex<HashMap<String, SessionEventProjectionSnapshot>>,
+        appended: Mutex<HashMap<String, (String, Vec<AgenticEvent>)>>,
         discarded: Mutex<Vec<String>>,
     }
 
     impl SessionEventProjectionStore for RecordingStore {
-        fn save(&self, snapshot: &SessionEventProjectionSnapshot) {
-            self.saved
-                .lock()
-                .unwrap()
-                .insert(snapshot.session_id.clone(), snapshot.clone());
+        fn append(&self, session_id: &str, stream_id: &str, _cursor: u64, event: &AgenticEvent) {
+            let mut appended = self.appended.lock().unwrap();
+            let entry = appended
+                .entry(session_id.to_string())
+                .or_insert_with(|| (stream_id.to_string(), Vec::new()));
+            entry.1.push(event.clone());
         }
 
-        fn load(&self, session_id: &str) -> Option<SessionEventProjectionSnapshot> {
-            self.saved.lock().unwrap().get(session_id).cloned()
+        fn load(&self, session_id: &str) -> Option<StoredSessionEvents> {
+            self.appended
+                .lock()
+                .unwrap()
+                .get(session_id)
+                .map(|(stream_id, events)| StoredSessionEvents {
+                    stream_id: stream_id.clone(),
+                    events: events.clone(),
+                })
         }
 
         fn discard(&self, session_id: &str) {
             self.discarded.lock().unwrap().push(session_id.to_string());
-            self.saved.lock().unwrap().remove(session_id);
+            self.appended.lock().unwrap().remove(session_id);
         }
     }
 
@@ -800,9 +831,9 @@ mod tests {
         journal.record(&turn_started("session-1", "turn-1"));
         journal.record(&text("session-1", "turn-1", "hello"));
 
-        let saved = store.load("session-1").expect("running turn is persisted");
-        assert_eq!(saved.active_turn_id.as_deref(), Some("turn-1"));
-        assert!(saved.cursor > 0);
+        let stored = store.load("session-1").expect("running turn is persisted");
+        // Every atomic event is written when it happens, not summarized later.
+        assert_eq!(stored.events.len(), 2);
     }
 
     #[test]

--- a/src/web-ui/src/infrastructure/peer-device/PeerConnectionManager.test.ts
+++ b/src/web-ui/src/infrastructure/peer-device/PeerConnectionManager.test.ts
@@ -396,3 +396,29 @@ function observe(manager: PeerConnectionManager) {
         health !== undefined && health !== all[index - 1]),
   };
 }
+
+describe('PeerConnectionManager presence recovery', () => {
+  it('clears a presence-lost attachment once the device is reachable again', async () => {
+    // `lost` is terminal and `connect` refuses a lost entry, so one presence
+    // blip during a burst of switching used to strand a healthy device for the
+    // rest of the session.
+    const manager = new PeerConnectionManager({
+      deviceRpc: async () => JSON.stringify({
+        resp: 'host_invoke_result',
+        ok: true,
+        value: { capabilities: {} },
+      }),
+      getControllerDeviceId: async () => 'controller-1',
+    });
+
+    await manager.connect('device-b', 'B');
+    manager.reportPresence([]);
+    expect(manager.get('device-b')?.getState().health).toBe('lost');
+
+    manager.reportPresence(['device-b']);
+
+    expect(manager.has('device-b')).toBe(false);
+    await expect(manager.connect('device-b', 'B')).resolves.toBeDefined();
+  });
+
+});

--- a/src/web-ui/src/infrastructure/peer-device/PeerConnectionManager.ts
+++ b/src/web-ui/src/infrastructure/peer-device/PeerConnectionManager.ts
@@ -265,9 +265,23 @@ export class PeerConnectionManager {
    */
   reportPresence(onlineDeviceIds: Iterable<string>): void {
     const online = new Set(onlineDeviceIds);
-    for (const entry of this.entries.values()) {
+    for (const entry of Array.from(this.entries.values())) {
       if (!online.has(entry.deviceId)) {
         this.markLost(entry, 'presence');
+        continue;
+      }
+      // The device is back. `lost` is terminal and `connect` refuses a lost
+      // entry, so leaving it in place would keep a reachable device
+      // permanently unselectable — one presence blip during a burst of
+      // switching was enough to strand it for the rest of the session. Drop
+      // the dead entry so the next switch attaches a fresh one.
+      if (entry.health === 'lost' && entry.lostReason === 'presence') {
+        this.entries.delete(entry.deviceId);
+        entry.adapter.disconnect().catch(() => undefined);
+        log.info('Peer device is reachable again; cleared its lost attachment', {
+          deviceId: entry.deviceId,
+        });
+        this.publish();
       }
     }
   }


### PR DESCRIPTION
## Summary

Dispatch work on several machines, switch between them repeatedly, come back to an earlier task — and it is frozen. Previous fixes each removed a real defect without removing the cause, because the cause is that **a Turn in flight has no durable record**.

Two changes: make the executing Turn's event stream real-time durable, and stop a presence blip from permanently stranding a reachable device.

## Type and Areas

Type: Feature / architecture (removes a bug class rather than an instance)

Areas: Rust agent runtime, core services, desktop, CLI peer host, web UI

## Motivation / Impact

The Runtime already materializes an exact, cursor-ordered projection of the executing Turn — **in memory only**. Everything durable lags it:

- client persistence is debounced into coalescing windows, so the last checkpoint trails the live state;
- the persisted Session record deliberately stores an executing Turn as **idle**, so a restart never revives work.

So the only complete record of work in flight dies with the Host process, and a client returning to that Session is served a Turn frozen at the last checkpoint. Every attach guard added so far — cursor fences, replace guards, content-regression checks — exists to work around that missing record.

**Second, independent cause of a frozen device:** `reportPresence` marks an attachment `lost` on any presence gap, `lost` is terminal, and `connect()` **refuses a lost entry**. One presence blip during a burst of switching stranded a perfectly reachable device for the rest of the session: switching to it kept failing and its sessions stayed frozen.

## What changed

**A durable, append-only event log.** The Runtime journal gained a store port that takes **one atomic event at the moment it enters the ordered delivery stream** — not a snapshot on a timer. The store appends a JSONL line through an already-open handle. Reload replays the log through the Runtime's *own* materialization, so a restored projection and a live one come from one implementation rather than two that can drift.

No `fsync` per event: an append reaches the page cache immediately, which already survives the process crash this log exists for, and a disk flush per token would throttle the stream it records.

Real log failure modes are handled: a torn final line after a hard kill keeps everything already durable, and a log left by an older Runtime process is superseded rather than replayed as current progress (its `stream_id` differs, which clients already read as "different process, replay whole").

**Both Hosts write to one shared log directory.** Desktop and CLI can own the same Session at different times, so a Turn left running by one must be replayable by the other.

**Presence recovery.** A device returning to presence clears its dead `lost` entry so the next switch attaches a fresh one. Keepalive-lost is deliberately untouched: presence proves reachability, a missed ping does not.

## Scope, stated plainly

This makes the **Turn in flight** durable and single-sourced. The persisted Session record remains the history of completed work, and a terminal Turn drops its log, so the two never describe the same thing at once.

It is *not* full event-sourcing of session history. Converting completed history to derive from the log too would mean migrating existing on-disk sessions and rewriting the relay poll, CLI and mobile-web read paths — a much larger change, and one worth doing only after this proves out.

## Verification

```
cargo check -p bitfun-desktop -p bitfun-cli          # clean
cargo test -p bitfun-agent-runtime --lib             # 309 passed
cargo test -p bitfun-core --lib session_projection_store  # 5 passed
pnpm --dir src/web-ui run lint / type-check          # clean
pnpm --dir src/web-ui exec vitest run                # 3474 passed / 14 pre-existing failures
pnpm run build:web                                   # clean (incl. appearance audit)
i18n audit / theme audits / webkit / hygiene / github-config  # PASS
```

New tests, **each verified non-vacuous** by reverting its fix in place:

- journal: a running Turn is persisted; a restart serves the stored projection; a terminal Turn stops persisting; a journal without a store is unchanged
- store: every event is durable the moment it is appended (read back by a *separate* store instance, proving nothing is held in process memory); an older process's log is superseded; a torn final line keeps the durable prefix; a terminal Turn hands the record back; a session id cannot escape the log directory
- connection manager: a presence-lost attachment is cleared once the device is reachable again

I removed one test I had written that asserted the presence path under a keepalive-path name — a test that does not test its own name is worse than no test.

The 14 failures are `AcpAgentsConfig.test.tsx` and `modelResolution.test.ts` failing on `localStorage` in this local Node build; they reproduce on a clean tree and pass in CI.

**Not verified here:** the real multi-machine scenario needs several signed-in devices and a relay, which this environment cannot reproduce. Evidence is mechanism-level.

## Reviewer Notes

**Where the log lives:** `~/.bitfun/runtime-events/<session>.jsonl`, one directory shared by every Host on the machine. It is a crash/handover record for work in flight, not part of the Session's durable history.

**Cost:** one buffered append per materialized event. Text and thinking chunks are already accumulated by stream and noisy tool progress compacted before reaching the journal, so this is bounded by semantic state, not token count.

**Compatibility:** a journal with no store attached behaves exactly as before, so any host that does not wire one is unaffected.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.
