### PR TITLE
feat(dsh-acp): offer a per-session model picker

### DIFF
--- a/packages/dsh-acp/README.md
+++ b/packages/dsh-acp/README.md
@@ -28,6 +28,11 @@ the harness's own `dsh-settings-file`, `dsh-credentials-local`, and
 `dsh-agent-default-model` services, so switching models in dsh switches them in
 BitFun too. BitFun writes no DeepSeek credentials of its own.
 
+A session also opens with a model picker of its own: the bridge publishes every
+model your dsh providers advertise as the `model` session config option,
+grouped by provider, starting on the default above. Picking one applies from
+the next message and lasts that session — it does not rewrite your dsh default.
+
 ## How BitFun launches it
 
 BitFun runs `dsh --profile bitfun-acp`. A dsh profile is just a directory under
@@ -71,8 +76,8 @@ reopened conversation loses its history, its context, and the mode it ran under
 
 `session/load` resumes the stored session out of the harness's own persistence
 (`$DSH_HOME/acp-sessions/<project>/<session-id>/`), replays its events to the
-client as `session/update` notifications, and answers with the session's mode.
-Three consequences worth knowing:
+client as `session/update` notifications, and answers with the session's mode
+and model. Four consequences worth knowing:
 
 - **The stored mode wins over the roster default.** Which preset a session ran
   under is read back from its own log, so a conversation started in `minimal`
@@ -80,6 +85,10 @@ Three consequences worth knowing:
 - **A conversation that has started comes back locked.** The mode picker shrinks
   to the one mode in force, because the composition is already baked into the
   transcript — the same rule a live session follows after its first turn.
+- **The model comes back off the log too, and stays switchable.** The picker
+  opens on the provider/model the session's own turns were logged under, not on
+  whatever the dsh default has become. Unlike the mode it is never locked:
+  swapping which model answers the next step leaves every logged turn valid.
 - **A session belongs to the directory it was created in.** Loading it against
   another `cwd` is refused rather than answered with a session whose sandbox
   boundary points somewhere else.

--- a/packages/dsh-acp/cordis.yml
+++ b/packages/dsh-acp/cordis.yml
@@ -19,7 +19,9 @@
 # the harness the user already installed and configured: `$DSH_HOME/settings.yaml`
 # (what dsh's web Models page writes) and `$DSH_HOME/.credentials.yaml`, read
 # through the two provider rows below. Nothing about an account is stored in
-# this repository, and BitFun never asks for a key of its own.
+# this repository, and BitFun never asks for a key of its own. The bridge offers
+# those same routes to the client as the `model` session config option, so an
+# IDE picks per session out of the catalog dsh already holds.
 
 # User-settings document ($DSH_HOME/settings.yaml, hot-reloaded): its
 # `llm-deepseek:` / `llm-pi-ai:` sections override the adapter rows below
@@ -104,9 +106,12 @@
 # keeps its registries (tools, skills, goals, jobs, agents, loop) and hands the
 # model-facing plugins to ./presets. `persona` is likewise absent — each preset
 # carries its own through `@deepseek-ai/dsh-persona`.
-# `provider`/`model` are deliberately absent: each session starts on
+# `provider`/`model` are deliberately absent: each session STARTS on
 # `agent-default-model`'s live selection, so the model chosen in dsh is the
-# model an IDE session runs. Sessions live under the harness home rather than
+# model an IDE session opens on. From there the client picks per session
+# through the `model` config option, over the catalog the rows above register;
+# that pick lasts the session and is not written back as the dsh default.
+# Sessions live under the harness home rather than
 # beside whatever project happens to be open — an ACP client launches this
 # adapter with the USER's workspace as the working directory.
 - id: acp-agent

--- a/packages/dsh-acp/scripts/smoke.mjs
+++ b/packages/dsh-acp/scripts/smoke.mjs
@@ -27,7 +27,8 @@
  * a directory name under `$DSH_HOME/acp-sessions/<project>/` — and `--cwd` must
  * name the workspace it was created in.
  *
- * Usage: `node scripts/smoke.mjs [--mode code] [--load <id>] [--prompt "…"] [--reject] [--cancel-after 3000]`
+ * Usage: `node scripts/smoke.mjs [--mode code] [--model deepseek-official/deepseek-v4]
+ * [--load <id>] [--prompt "…"] [--reject] [--cancel-after 3000]`
  */
 
 import { spawn } from 'node:child_process'
@@ -45,6 +46,7 @@ const { values } = parseArgs({
     prompt: { type: 'string' },
     load: { type: 'string' },
     mode: { type: 'string' },
+    model: { type: 'string' },
     profile: { type: 'string' },
     cwd: { type: 'string' },
     reject: { type: 'boolean' },
@@ -99,8 +101,13 @@ function describe(update) {
 function describeOptions(configOptions) {
   if (configOptions === undefined || configOptions.length === 0) return '(none)'
   return configOptions.map(option => {
+    // A select's values are either flat or grouped by provider; a picker
+    // renders both as one list, so this flattens the grouped form too.
     const values = option.type === 'select'
-      ? option.options.map(value => (value.value === option.currentValue ? `[${value.value}]` : value.value)).join(' ')
+      ? option.options
+        .flatMap(entry => (entry.options === undefined ? [entry] : entry.options))
+        .map(value => (value.value === option.currentValue ? `[${value.value}]` : value.value))
+        .join(' ')
       : String(option.currentValue)
     return `${option.id}(${option.category ?? '-'}): ${values}`
   }).join(' | ')
@@ -133,7 +140,7 @@ try {
     : { sessionId: values.load, ...await client.loadSession({ sessionId: values.load, cwd: WORKSPACE, mcpServers: [] }) }
   const sessionId = session.sessionId
   process.stdout.write(`${values.load === undefined ? 'newSession' : 'loadSession'}: ${sessionId}\n`)
-  process.stdout.write(`modes: ${describeOptions(session.configOptions)}\n`)
+  process.stdout.write(`options: ${describeOptions(session.configOptions)}\n`)
 
   if (values.mode !== undefined) {
     const switched = await client.setSessionConfigOption({
@@ -142,6 +149,17 @@ try {
       value: values.mode,
     })
     process.stdout.write(`mode ${values.mode}: ${describeOptions(switched.configOptions)}\n`)
+  }
+
+  // `--model provider/model` is the composer's model dropdown: unlike the mode
+  // it stays live for the whole session, so this can follow a prompt too.
+  if (values.model !== undefined) {
+    const switched = await client.setSessionConfigOption({
+      sessionId,
+      configId: 'model',
+      value: values.model,
+    })
+    process.stdout.write(`model ${values.model}: ${describeOptions(switched.configOptions)}\n`)
   }
 
   if (values.prompt !== undefined) {

--- a/packages/dsh-acp/src/bridge.ts
+++ b/packages/dsh-acp/src/bridge.ts
@@ -40,6 +40,7 @@ import {
   type PromptRequest,
   type PromptResponse,
   type SessionConfigOption,
+  type SessionConfigSelectGroup,
   type SessionConfigSelectOption,
   type SessionNotification,
   type SetSessionConfigOptionRequest,
@@ -48,7 +49,9 @@ import {
   type Stream,
   type ToolCallUpdate,
 } from '@agentclientprotocol/sdk'
-import type { Agent } from '@deepseek-ai/dsh-agent'
+import {
+  installModelSelection, type Agent, type ModelSelection, type ModelSelectionRef,
+} from '@deepseek-ai/dsh-agent'
 // The roster itself is read through `ctx.get`; only the stored-preset resolver
 // is a value here. This import also carries the `agent-preset/selected`
 // session-event declaration the switch below logs and the resolver reads back.
@@ -169,13 +172,26 @@ interface SessionRecord {
    */
   presetId: string | undefined
   /**
-   * Tail of this session's preset switches. Two `session/set_config_option`
-   * requests must not recompose concurrently: the second one's blank-session
-   * check has to see the first one's result, not the state it raced past.
+   * Tail of this session's `session/set_config_option` requests. Two of them
+   * must not run concurrently: a preset switch's blank-session check has to see
+   * the one ahead of it, and every reply carries the WHOLE option set, so an
+   * out-of-order reply would re-render the picker from state that has moved on.
    */
-  presetSwitch: Promise<void> | undefined
+  configSwitch: Promise<void> | undefined
   /** Whether the client has been told the mode is now fixed, so it is said once. */
   presetLockPublished: boolean
+  /**
+   * This session's live model override, installed into its agent's prompt
+   * assembly and request routing. `current` is undefined until the client picks
+   * a model, which leaves the agent on the provider/model it was created with.
+   */
+  modelSelection: ModelSelectionRef
+  /**
+   * The provider/model the agent was created with, captured at creation rather
+   * than re-read: the deployment default is a live setting, and the picker must
+   * report what THIS session runs on, not what the next one would.
+   */
+  modelSeed: { provider?: string; model?: string }
   /** In-flight prompt and its captured turn number for exact settlement. */
   inflight: {
     resolve: (reason: StopReason) => void
@@ -211,6 +227,43 @@ const PRESET_CONFIG_ID = 'agent-preset'
  */
 const PRESET_LOCKED = 'This conversation has already started, so its mode is fixed. '
   + 'Start a new session to pick another mode.'
+
+/**
+ * The session config option the model catalog is offered under.
+ *
+ * ACP 0.25 has no model state of its own — `session/set_model` and
+ * `SessionModelState` do not exist in this schema version — so a model picker
+ * IS a config option, distinguished from the mode picker only by its category.
+ * Clients key off `category: 'model'` first and fall back to matching the id,
+ * which is why the id is the bare word rather than something namespaced.
+ */
+const MODEL_CONFIG_ID = 'model'
+
+/**
+ * Encode one provider/model pair as a config option value.
+ *
+ * A value id is one opaque string, but a model is only identified by its pair,
+ * and the same model id can be served by two providers. Joining them on the
+ * first `/` is also what clients parse to label a value with its provider when
+ * they render an ungrouped list: provider routes carry no `/`, model ids may.
+ * @param provider - the registered provider route.
+ * @param model - the provider-owned model id.
+ * @returns the wire value.
+ */
+function modelValue(provider: string, model: string): string {
+  return `${provider}/${model}`
+}
+
+/**
+ * Split a config option value back into its provider/model pair.
+ * @param value - a value id previously produced by {@link modelValue}.
+ * @returns the pair, or undefined when the value carries no separator.
+ */
+function parseModelValue(value: string): { provider: string; model: string } | undefined {
+  const cut = value.indexOf('/')
+  if (cut <= 0 || cut === value.length - 1) return undefined
+  return { provider: value.slice(0, cut), model: value.slice(cut + 1) }
+}
 
 /**
  * Whether a session may still change its preset.
@@ -251,6 +304,11 @@ export function apply(ctx: Context, config: AcpConfig): void {
   // plugin in its host composition has no modes to offer, and this bridge then
   // behaves exactly as it did before they existed.
   const presets = ctx.get('agentPresets')
+  // Optional for the same reason: a composition whose model routing lives
+  // elsewhere simply offers no model picker, and the bridge behaves as it did
+  // before there was one. The catalog itself is read lazily, so an adapter
+  // registered after this plugin still appears in the list.
+  const llm = ctx.get('llm')
   const logger = ctx.logger
   const sessions = new Map<SessionId, SessionRecord>()
   const publishReasoning = config.reasoning ?? true
@@ -320,6 +378,90 @@ export function apply(ctx: Context, config: AcpConfig): void {
       options: offered.map(presetValue),
     }]
   }
+
+  /**
+   * The provider/model this session is running on right now.
+   *
+   * Three sources in falling order of authority: an explicit pick, the request
+   * header the session's own turns were logged under, and the selection the
+   * agent was created with. A resumed session therefore reports what it
+   * actually ran on rather than what the deployment default has since become.
+   * @param record - the session.
+   * @returns the pair, or undefined when nothing pins one.
+   */
+  const currentModel = (record: SessionRecord): { provider: string; model: string } | undefined => {
+    const picked = record.modelSelection.current
+    if (picked !== undefined) return { provider: picked.provider, model: picked.model }
+    const logged = record.agent.session.requestHeader()?.config
+    if (logged !== undefined) return { provider: logged.provider, model: logged.model }
+    const { provider, model } = record.modelSeed
+    if (provider === undefined || model === undefined) return undefined
+    return { provider, model }
+  }
+
+  /**
+   * The session's model picker: the harness's model catalog as one `select`
+   * config option, grouped by provider.
+   *
+   * Unlike the mode, the model is switchable for the whole life of a session —
+   * a mid-conversation switch changes only which model answers the next step,
+   * and leaves the logged history valid. The catalog is advisory (an adapter
+   * may accept ids it does not advertise), so the model in force is offered
+   * even when it is not listed: a picker whose current value is missing from
+   * its own options renders blank.
+   * @param record - the session.
+   * @returns the one option, or nothing when no model can be named.
+   */
+  const modelOptions = async (record: SessionRecord): Promise<SessionConfigOption[]> => {
+    if (llm === undefined) return []
+    const current = currentModel(record)
+    if (current === undefined) return []
+    const currentValue = modelValue(current.provider, current.model)
+    const groups: SessionConfigSelectGroup[] = []
+    for (const provider of llm.listProviders()) {
+      // One unreachable provider costs its own entries, not the whole picker.
+      const models = await llm.listModels(provider.id).catch((error: unknown) => {
+        logger.warn(`acp: cannot list models for "${provider.id}": ${String(error)}`)
+        return []
+      })
+      const values: SessionConfigSelectOption[] = models.map(model => ({
+        value: modelValue(provider.id, model.id),
+        name: model.name,
+        ...model.description === undefined ? {} : { description: model.description },
+      }))
+      if (provider.id === current.provider && !values.some(value => value.value === currentValue)) {
+        values.push({ value: currentValue, name: current.model })
+      }
+      if (values.length === 0) continue
+      groups.push({ group: provider.id, name: provider.name, options: values })
+    }
+    if (!groups.some(group => group.group === current.provider)) {
+      groups.push({
+        group: current.provider,
+        name: current.provider,
+        options: [{ value: currentValue, name: current.model }],
+      })
+    }
+    return [{ type: 'select', id: MODEL_CONFIG_ID, name: 'Model', category: 'model', currentValue, options: groups }]
+  }
+
+  /**
+   * Everything this session lets the client configure.
+   *
+   * Always published as one set, because that is how a client consumes it: a
+   * `session/new` response, a `set_config_option` reply, and a
+   * `config_option_update` each REPLACE the picker row wholesale, so an answer
+   * that carried only the option that changed would drop the other one.
+   * @param record - the session.
+   * @param locked - whether the mode is already fixed; read off the session by default.
+   * @returns the options, in the order a composer renders them.
+   */
+  const sessionOptions = async (
+    record: SessionRecord, locked?: boolean,
+  ): Promise<SessionConfigOption[]> => [
+    ...await presetOptions(record, locked),
+    ...await modelOptions(record),
+  ]
 
   const settlePrompt = (record: SessionRecord, reason: StopReason): void => {
     const inflight = record.inflight
@@ -450,7 +592,7 @@ export function apply(ctx: Context, config: AcpConfig): void {
         // Locked is asserted rather than read: whether this very event is
         // already in `session.events` is the session's business, not the
         // bridge's, and the answer here is known.
-        void presetOptions(record, true).then(configOptions => {
+        void sessionOptions(record, true).then(configOptions => {
           if (closed || configOptions.length === 0) return
           if (sessions.get(record.agent.session.id) !== record) return
           update(record, { sessionUpdate: 'config_option_update', configOptions })
@@ -623,16 +765,19 @@ export function apply(ctx: Context, config: AcpConfig): void {
         // default is a hot-reloaded setting, and a resumed session must rebuild
         // the composition its turns actually ran under.
         const composed = presets === undefined ? undefined : (await presets.resolve()).id
+        const modelSeed = agentOptions(ctx, config)
+        const modelSelection: ModelSelectionRef = { current: undefined, assembled: undefined }
         const handle = await agents.create({
           sessionId,
           meta: { cwd: params.cwd, ...composed === undefined ? {} : { agentPreset: composed } },
-          agentOptions: agentOptions(ctx, config),
+          agentOptions: modelSeed,
           // Composition belongs in `setup`, which the factory awaits before the
           // agent is published: a preset that fails to mount rolls the whole
           // creation back rather than yielding a session on the empty global
           // tool layer.
-          ...presets === undefined || composed === undefined ? {} : {
-            setup: async (agentCtx: Context) => void await presets.mount(agentCtx, composed),
+          setup: async (agentCtx: Context) => {
+            installModelSelection(agentCtx, modelSelection)
+            if (presets !== undefined && composed !== undefined) await presets.mount(agentCtx, composed)
           },
         })
         /* v8 ignore next 4 -- a real stdio close can race an in-flight create. */
@@ -647,15 +792,17 @@ export function apply(ctx: Context, config: AcpConfig): void {
           streamedReasoning: new Set(),
           published: new Map(),
           presetId: composed,
-          presetSwitch: undefined,
+          configSwitch: undefined,
           presetLockPublished: false,
+          modelSelection,
+          modelSeed,
           inflight: undefined,
         }
         sessions.set(sessionId, record)
         // Carried by the response rather than announced afterwards: a client
         // registers its update handler for a session only once `session/new`
         // has returned, so anything published before that can be dropped.
-        const configOptions = await presetOptions(record, false)
+        const configOptions = await sessionOptions(record, false)
         return { sessionId, ...configOptions.length === 0 ? {} : { configOptions } }
       },
 
@@ -683,7 +830,7 @@ export function apply(ctx: Context, config: AcpConfig): void {
         const live = sessions.get(sessionId)
         if (live !== undefined) {
           replayHistory(live)
-          const configOptions = await presetOptions(live)
+          const configOptions = await sessionOptions(live)
           return configOptions.length === 0 ? {} : { configOptions }
         }
 
@@ -704,11 +851,14 @@ export function apply(ctx: Context, config: AcpConfig): void {
         const composed = presets === undefined
           ? undefined
           : resolveSessionPreset({ header: inspected.meta, events: inspected.events })
+        const modelSeed = agentOptions(ctx, config)
+        const modelSelection: ModelSelectionRef = { current: undefined, assembled: undefined }
         const handle = await agents.resume({
           resumeSessionId: sessionId,
-          agentOptions: agentOptions(ctx, config),
-          ...presets === undefined || composed === undefined ? {} : {
-            setup: async (agentCtx: Context) => void await presets.mount(agentCtx, composed),
+          agentOptions: modelSeed,
+          setup: async (agentCtx: Context) => {
+            installModelSelection(agentCtx, modelSelection)
+            if (presets !== undefined && composed !== undefined) await presets.mount(agentCtx, composed)
           },
         })
         /* v8 ignore next 4 -- a real stdio close can race an in-flight resume. */
@@ -723,33 +873,66 @@ export function apply(ctx: Context, config: AcpConfig): void {
           streamedReasoning: new Set(),
           published: new Map(),
           presetId: composed,
-          presetSwitch: undefined,
+          configSwitch: undefined,
           // A session with turns is already locked, and the response below says
           // so; only a session reopened before its first turn can still be
           // told, by the `turn/start` that starts it.
           presetLockPublished: !sessionBlank(handle.agent.session),
+          modelSelection,
+          modelSeed,
           inflight: undefined,
         }
         sessions.set(sessionId, record)
         replayHistory(record)
-        const configOptions = await presetOptions(record)
+        const configOptions = await sessionOptions(record)
         return configOptions.length === 0 ? {} : { configOptions }
       },
 
       /**
-       * Choose the session's mode.
+       * Choose the session's mode or its model.
        *
-       * Refused once the conversation has started, for the same reason the
-       * picker is down to one entry by then: the turns already logged ran on the
-       * current preset's tools.
+       * A mode switch is refused once the conversation has started, for the same
+       * reason the picker is down to one entry by then: the turns already logged
+       * ran on the current preset's tools. A model switch is not — swapping which
+       * model answers the next step leaves every logged turn valid — so the model
+       * picker stays live for the whole session.
        */
       async setSessionConfigOption(
         params: SetSessionConfigOptionRequest,
       ): Promise<SetSessionConfigOptionResponse> {
         assertOpen()
         const record = requireSession(SessionId(params.sessionId))
-        if (params.configId !== PRESET_CONFIG_ID) {
+        if (params.configId !== PRESET_CONFIG_ID && params.configId !== MODEL_CONFIG_ID) {
           throw invalidParams(`unknown config option: ${params.configId}`)
+        }
+        if (params.configId === MODEL_CONFIG_ID) {
+          if (llm === undefined) throw invalidParams('this deployment offers no models')
+          if (typeof params.value !== 'string') {
+            throw invalidParams(`"${MODEL_CONFIG_ID}" is a select option, not a boolean`)
+          }
+          const value = params.value
+          const pair = parseModelValue(value)
+          if (pair === undefined) throw invalidParams(`unknown model: ${value}`)
+          // Resolved rather than trusted: this both rejects a route the harness
+          // cannot serve — before it becomes a failing turn — and materializes
+          // the adapter's own defaults, so a model whose provider configures a
+          // reasoning effort runs at that effort instead of the previous
+          // model's inherited one.
+          const resolved = await llm.resolveCallConfig(pair).catch((error: unknown) => {
+            throw invalidParams(`cannot use model "${value}": ${errorChain(error)}`)
+          })
+          const selection: ModelSelection = {
+            provider: resolved.provider,
+            model: resolved.model,
+            ...resolved.reasoningEffort === undefined ? {} : { reasoningEffort: resolved.reasoningEffort },
+          }
+          const pick = async (): Promise<SessionConfigOption[]> => {
+            record.modelSelection.current = selection
+            return await sessionOptions(record)
+          }
+          const queuedPick = (record.configSwitch ?? Promise.resolve()).then(pick)
+          record.configSwitch = queuedPick.then(() => undefined, () => undefined)
+          return { configOptions: await queuedPick }
         }
         if (presets === undefined) throw invalidParams('this deployment offers no modes')
         if (typeof params.value !== 'string') {
@@ -764,7 +947,7 @@ export function apply(ctx: Context, config: AcpConfig): void {
           }
           // Asking for the mode already in force is not a switch, so it is
           // answered even on a locked session: it changes nothing either way.
-          if (record.presetId === target.id) return await presetOptions(record)
+          if (record.presetId === target.id) return await sessionOptions(record)
           // Re-read inside the queue: a switch ahead of this one may have run,
           // and a conversation may have started, since this request arrived.
           if (!sessionBlank(record.agent.session)) throw invalidParams(PRESET_LOCKED)
@@ -781,11 +964,11 @@ export function apply(ctx: Context, config: AcpConfig): void {
             // the session stays usable and the user can pick again.
             throw internalError(`failed to switch to "${id}": ${errorChain(error)}`)
           }
-          return await presetOptions(record)
+          return await sessionOptions(record)
         }
-        const queued = record.presetSwitch ?? Promise.resolve()
+        const queued = record.configSwitch ?? Promise.resolve()
         const turn = queued.then(swap)
-        record.presetSwitch = turn.then(() => undefined, () => undefined)
+        record.configSwitch = turn.then(() => undefined, () => undefined)
         return { configOptions: await turn }
       },
 

--- a/packages/dsh-acp/src/bridge.ts
+++ b/packages/dsh-acp/src/bridge.ts
@@ -21,7 +21,9 @@ import { randomUUID } from 'node:crypto'
 import { isAbsolute } from 'node:path'
 import { Readable, Writable } from 'node:stream'
 import Schema from '@deepseek-ai/schemastery'
-import { createUserMessage, errorChain } from '@deepseek-ai/dsh-llm'
+import {
+  createUserMessage, errorChain, type LlmModelInfo, type LlmProviderInfo,
+} from '@deepseek-ai/dsh-llm'
 import {
   AgentSideConnection,
   ndJsonStream,
@@ -401,7 +403,7 @@ export function apply(ctx: Context, config: AcpConfig): void {
 
   /**
    * The session's model picker: the harness's model catalog as one `select`
-   * config option, grouped by provider.
+   * config option, grouped by provider, one row per model.
    *
    * Unlike the mode, the model is switchable for the whole life of a session —
    * a mid-conversation switch changes only which model answers the next step,
@@ -409,6 +411,13 @@ export function apply(ctx: Context, config: AcpConfig): void {
    * may accept ids it does not advertise), so the model in force is offered
    * even when it is not listed: a picker whose current value is missing from
    * its own options renders blank.
+   *
+   * A model reachable through two providers is listed once. The harness's own
+   * DeepSeek adapter and a pi-ai profile pointed at the same account are both
+   * routes to the same models, and a user who configured the second in dsh gets
+   * every model twice — same name, same vendor, nothing to choose between. The
+   * provider carrying the session's current model owns those rows, so the list
+   * stays on the route the session is actually running.
    * @param record - the session.
    * @returns the one option, or nothing when no model can be named.
    */
@@ -417,18 +426,41 @@ export function apply(ctx: Context, config: AcpConfig): void {
     const current = currentModel(record)
     if (current === undefined) return []
     const currentValue = modelValue(current.provider, current.model)
-    const groups: SessionConfigSelectGroup[] = []
+
+    const listed: { provider: LlmProviderInfo; models: LlmModelInfo[] }[] = []
     for (const provider of llm.listProviders()) {
       // One unreachable provider costs its own entries, not the whole picker.
       const models = await llm.listModels(provider.id).catch((error: unknown) => {
         logger.warn(`acp: cannot list models for "${provider.id}": ${String(error)}`)
         return []
       })
-      const values: SessionConfigSelectOption[] = models.map(model => ({
-        value: modelValue(provider.id, model.id),
-        name: model.name,
-        ...model.description === undefined ? {} : { description: model.description },
-      }))
+      listed.push({ provider, models })
+    }
+
+    // Which provider each model id is listed under. Seeded with the session's
+    // own route so the model in force keeps its provider even when that
+    // provider's listing failed, then filled current-provider-first so a
+    // duplicated catalog collapses onto the route already in use.
+    const owner = new Map<string, string>([[current.model, current.provider]])
+    const byCurrentFirst = [
+      ...listed.filter(entry => entry.provider.id === current.provider),
+      ...listed.filter(entry => entry.provider.id !== current.provider),
+    ]
+    for (const { provider, models } of byCurrentFirst) {
+      for (const model of models) {
+        if (!owner.has(model.id)) owner.set(model.id, provider.id)
+      }
+    }
+
+    const groups: SessionConfigSelectGroup[] = []
+    for (const { provider, models } of listed) {
+      const values: SessionConfigSelectOption[] = models
+        .filter(model => owner.get(model.id) === provider.id)
+        .map(model => ({
+          value: modelValue(provider.id, model.id),
+          name: model.name,
+          ...model.description === undefined ? {} : { description: model.description },
+        }))
       if (provider.id === current.provider && !values.some(value => value.value === currentValue)) {
         values.push({ value: currentValue, name: current.model })
       }

--- a/packages/dsh-acp/tests/harness.ts
+++ b/packages/dsh-acp/tests/harness.ts
@@ -20,6 +20,7 @@ import {
   type Client,
   type RequestPermissionRequest,
   type RequestPermissionResponse,
+  type SessionConfigOption,
   type SessionNotification,
   type Stream,
 } from '@agentclientprotocol/sdk'
@@ -30,23 +31,44 @@ import JsonlSessionPersistence from '@deepseek-ai/dsh-session-persistence-jsonl'
 import * as AcpPlugin from '../src/bridge.ts'
 import type { AcpConfig } from '../src/bridge.ts'
 
+/** One provider route the fixture serves, and the models it advertises. */
+export interface CatalogProvider {
+  /** Human-readable provider name — what a grouped model picker labels the group with. */
+  name: string
+  /** Advertised models, in the order a picker lists them. */
+  models: { id: string; name: string; description?: string }[]
+}
+
+/**
+ * The single-provider, single-model catalog every test gets unless it asks for
+ * more, which is what the fixture advertised before it could advertise
+ * anything else.
+ */
+const DEFAULT_CATALOG: Record<string, CatalogProvider> = {
+  mock: { name: 'Mock', models: [{ id: 'mock', name: 'Mock' }] },
+}
+
 /** Scripted adapter for protocol tests. */
 class MockAdapter extends LlmAdapter {
   readonly requests: GenerateOptions[] = []
   private readonly script: (StreamChunk[] | 'hang')[]
+  private readonly catalog: Record<string, CatalogProvider>
 
-  constructor(script: (StreamChunk[] | 'hang')[]) {
+  constructor(script: (StreamChunk[] | 'hang')[], catalog: Record<string, CatalogProvider>) {
     super()
     this.script = script
+    this.catalog = catalog
   }
 
   override providerInfo(provider: string) {
-    if (provider !== 'mock') throw new Error(`MockAdapter: unknown provider ${provider}`)
-    return { id: 'mock', name: 'Mock' }
+    const entry = this.catalog[provider]
+    if (entry === undefined) throw new Error(`MockAdapter: unknown provider ${provider}`)
+    return { id: provider, name: entry.name }
   }
 
   override listModels(provider: string) {
-    return Promise.resolve(provider === 'mock' ? [{ provider: 'mock', id: 'mock', name: 'Mock' }] : [])
+    const entry = this.catalog[provider]
+    return Promise.resolve((entry?.models ?? []).map(model => ({ provider, ...model })))
   }
 
   async * stream(options: GenerateOptions): AsyncIterable<StreamChunk> {
@@ -147,8 +169,16 @@ export async function makeBridgeHarness(options: {
    * persists nothing and the bridge takes its no-archive path.
    */
   persistenceRoot?: string
+  /**
+   * Provider routes and models the one scripted adapter serves, so a test can
+   * exercise a model picker with something to pick. Every route runs the same
+   * script, so a switch still produces a real turn. Defaults to the lone
+   * `mock/mock` route.
+   */
+  catalog?: Record<string, CatalogProvider>
 } = {}): Promise<BridgeHarness> {
-  const adapter = new MockAdapter(options.script ?? [])
+  const catalog = options.catalog ?? DEFAULT_CATALOG
+  const adapter = new MockAdapter(options.script ?? [], catalog)
   const ctx = new Context()
   await mountAgentLoopTestDependencies(ctx, { systemPrompt: { persona: options.persona ?? '' } })
   // Before the loop, as the app composes it: the coordinator captures a
@@ -157,7 +187,7 @@ export async function makeBridgeHarness(options: {
     await ctx.plugin(JsonlSessionPersistence, { root: options.persistenceRoot })
   }
   const loopFiber = await ctx.plugin(AgentLoop, { agents: [] })
-  ctx.llm.registerAdapter(['mock'], adapter)
+  ctx.llm.registerAdapter(Object.keys(catalog), adapter)
   if (options.presets !== undefined) {
     // Before the bridge: it captures the roster during `apply`, exactly as the
     // app's composition orders them.
@@ -264,6 +294,38 @@ export async function waitForUpdates<K extends CapturedUpdate['sessionUpdate']>(
     }
     await new Promise(resolve => setTimeout(resolve, 5))
   }
+}
+
+/**
+ * Every published config option of one semantic category.
+ *
+ * A session publishes several pickers at once and the set is replaced whole on
+ * every publication, so a test reads the one it means by category rather than
+ * by position.
+ * @param configOptions - a published option set, however it arrived.
+ * @param category - the `category` to keep.
+ * @returns the matching options, in publication order.
+ */
+export function optionsOfCategory(
+  configOptions: SessionConfigOption[] | null | undefined, category: string,
+): SessionConfigOption[] {
+  return (configOptions ?? []).filter(option => option.category === category)
+}
+
+/**
+ * The one option of a category, asserted to be a select so its values can be read.
+ * @param configOptions - a published option set.
+ * @param category - the `category` the option is expected under.
+ * @returns that option.
+ */
+export function selectOption(
+  configOptions: SessionConfigOption[] | null | undefined, category: string,
+): Extract<SessionConfigOption, { type: 'select' }> {
+  const [option, ...rest] = optionsOfCategory(configOptions, category)
+  if (rest.length > 0 || option?.type !== 'select') {
+    throw new Error(`expected one ${category} select option, got ${JSON.stringify(configOptions)}`)
+  }
+  return option
 }
 
 /**

--- a/packages/dsh-acp/tests/model-selection.spec.ts
+++ b/packages/dsh-acp/tests/model-selection.spec.ts
@@ -1,0 +1,213 @@
+/**
+ * The model picker: the harness's model catalog offered as a `model` session
+ * config option, and the pick routed to the next model call.
+ *
+ * ACP 0.25 has no model state of its own, so a client's model dropdown IS a
+ * config option — a session that publishes none leaves the IDE with nothing to
+ * pick from, which is the failure these tests exist to keep out. The switch is
+ * driven the way a composer drives it, through `session/set_config_option`, and
+ * read back off the request the scripted adapter actually received rather than
+ * off anything the bridge reports about itself.
+ */
+
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { randomUUID } from 'node:crypto'
+import { afterEach, describe, expect, it } from 'vitest'
+import { PROTOCOL_VERSION } from '@agentclientprotocol/sdk'
+import { createUserMessage } from '@deepseek-ai/dsh-llm'
+import { SessionId } from '@deepseek-ai/dsh-session'
+import {
+  makeBridgeHarness, optionsOfCategory, selectOption, textResponse, updatesOfKind, waitForUpdates,
+  type BridgeHarness, type CatalogProvider,
+} from './harness.ts'
+
+/** Two providers, so grouping and cross-provider switching are both observable. */
+const CATALOG: Record<string, CatalogProvider> = {
+  mock: {
+    name: 'Mock',
+    models: [
+      { id: 'mock', name: 'Mock' },
+      { id: 'mock-pro', name: 'Mock Pro', description: 'the bigger one' },
+    ],
+  },
+  alt: { name: 'Alt Cloud', models: [{ id: 'alt-1', name: 'Alt One' }] },
+}
+
+/** The provider/model each recorded model call was routed to, in order. */
+function routed(harness: BridgeHarness): string[] {
+  return harness.adapter.requests.map(request => `${request.provider}/${request.model}`)
+}
+
+describe('model selection', () => {
+  let harness: BridgeHarness | undefined
+  let root: string | undefined
+
+  afterEach(async () => {
+    await harness?.dispose()
+    harness = undefined
+    if (root !== undefined) await rm(root, { recursive: true, force: true })
+    root = undefined
+  })
+
+  it('offers the catalog grouped by provider, on the model the session runs', async () => {
+    harness = await makeBridgeHarness({ catalog: CATALOG })
+    await harness.client.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} })
+    const session = await harness.client.newSession({ cwd: process.cwd(), mcpServers: [] })
+
+    const option = selectOption(session.configOptions, 'model')
+    expect(option.id).toBe('model')
+    expect(option.currentValue).toBe('mock/mock')
+    // Grouped by provider and keyed by the pair, because the same model id can
+    // be served by two routes and a bare id would not say which one ran.
+    expect(option.options).toEqual([
+      {
+        group: 'mock',
+        name: 'Mock',
+        options: [
+          { value: 'mock/mock', name: 'Mock' },
+          { value: 'mock/mock-pro', name: 'Mock Pro', description: 'the bigger one' },
+        ],
+      },
+      { group: 'alt', name: 'Alt Cloud', options: [{ value: 'alt/alt-1', name: 'Alt One' }] },
+    ])
+  })
+
+  it('routes the next turn to the model the client picked', async () => {
+    harness = await makeBridgeHarness({
+      catalog: CATALOG,
+      script: [textResponse('before'), textResponse('after')],
+    })
+    await harness.client.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} })
+    const { sessionId } = await harness.client.newSession({ cwd: process.cwd(), mcpServers: [] })
+    await harness.client.prompt({ sessionId, prompt: [{ type: 'text', text: 'hello' }] })
+
+    const result = await harness.client.setSessionConfigOption({
+      sessionId, configId: 'model', value: 'alt/alt-1',
+    })
+
+    // Picking a model is a control, not a turn.
+    expect(routed(harness)).toEqual(['mock/mock'])
+    expect(selectOption(result.configOptions, 'model').currentValue).toBe('alt/alt-1')
+
+    await harness.client.prompt({ sessionId, prompt: [{ type: 'text', text: 'again' }] })
+    expect(routed(harness)).toEqual(['mock/mock', 'alt/alt-1'])
+  })
+
+  it('stays switchable after the conversation has started, unlike the mode', async () => {
+    harness = await makeBridgeHarness({
+      catalog: CATALOG,
+      presets: { default: 'alpha' },
+      script: [textResponse('hi')],
+    })
+    await harness.client.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} })
+    const { sessionId } = await harness.client.newSession({ cwd: process.cwd(), mcpServers: [] })
+    await harness.client.prompt({ sessionId, prompt: [{ type: 'text', text: 'hello' }] })
+
+    // The mode is fixed by now; the model is not, because swapping which model
+    // answers the next step leaves every logged turn valid.
+    await expect(harness.client.setSessionConfigOption({
+      sessionId, configId: 'agent-preset', value: 'beta',
+    })).rejects.toThrow(/already started/)
+    const result = await harness.client.setSessionConfigOption({
+      sessionId, configId: 'model', value: 'mock/mock-pro',
+    })
+
+    expect(selectOption(result.configOptions, 'model').currentValue).toBe('mock/mock-pro')
+    // The mode rides along, still locked: every publication replaces the whole
+    // set, so an answer carrying only the model would drop the mode picker.
+    expect(selectOption(result.configOptions, 'mode').description).toMatch(/already started/)
+  })
+
+  it('keeps the picker in the update that locks the mode', async () => {
+    harness = await makeBridgeHarness({
+      catalog: CATALOG, presets: { default: 'alpha' }, script: [textResponse('hi')],
+    })
+    await harness.client.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} })
+    const { sessionId } = await harness.client.newSession({ cwd: process.cwd(), mcpServers: [] })
+    await harness.client.prompt({ sessionId, prompt: [{ type: 'text', text: 'hello' }] })
+
+    await waitForUpdates(harness, 'config_option_update', 1)
+    const [locked] = updatesOfKind(harness, 'config_option_update')
+    expect(selectOption(locked?.configOptions, 'model').currentValue).toBe('mock/mock')
+  })
+
+  it('refuses a model the harness cannot serve', async () => {
+    harness = await makeBridgeHarness({ catalog: CATALOG })
+    await harness.client.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} })
+    const { sessionId } = await harness.client.newSession({ cwd: process.cwd(), mcpServers: [] })
+
+    await expect(harness.client.setSessionConfigOption({
+      sessionId, configId: 'model', value: 'ghost/anything',
+    })).rejects.toThrow(/cannot use model "ghost\/anything"/)
+    // A value with no provider half names nothing: the pair is the identity.
+    await expect(harness.client.setSessionConfigOption({
+      sessionId, configId: 'model', value: 'alt-1',
+    })).rejects.toThrow(/unknown model: alt-1/)
+    await expect(harness.client.setSessionConfigOption({
+      sessionId, configId: 'model', type: 'boolean', value: true,
+    })).rejects.toThrow(/select option, not a boolean/)
+
+    const session = await harness.client.loadSession({ sessionId, cwd: process.cwd(), mcpServers: [] })
+    expect(selectOption(session.configOptions, 'model').currentValue).toBe('mock/mock')
+  })
+
+  it('offers the model in force even when the catalog does not list it', async () => {
+    // The catalog is advisory — an adapter may accept ids it never advertised —
+    // and a picker whose current value is missing from its own options renders
+    // blank, which is the same broken dropdown as having no options at all.
+    harness = await makeBridgeHarness({ catalog: CATALOG, config: { model: 'unlisted' } })
+    await harness.client.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} })
+    const session = await harness.client.newSession({ cwd: process.cwd(), mcpServers: [] })
+
+    const option = selectOption(session.configOptions, 'model')
+    expect(option.currentValue).toBe('mock/unlisted')
+    expect(option.options[0]).toEqual({
+      group: 'mock',
+      name: 'Mock',
+      options: [
+        { value: 'mock/mock', name: 'Mock' },
+        { value: 'mock/mock-pro', name: 'Mock Pro', description: 'the bigger one' },
+        { value: 'mock/unlisted', name: 'unlisted' },
+      ],
+    })
+  })
+
+  it('reopens a cold session on the model its turns ran under', async () => {
+    root = await mkdtemp(join(tmpdir(), 'dsh-acp-model-'))
+    harness = await makeBridgeHarness({
+      catalog: CATALOG, persistenceRoot: root, script: [textResponse('stored answer')],
+    })
+    await harness.client.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} })
+    const cwd = process.cwd()
+    // Seeded outside the bridge and left to go cold: nothing about the session
+    // is in memory when the load arrives, so the picker has only the log.
+    const sessionId = SessionId(randomUUID())
+    const handle = await harness.ctx.agents.create({
+      sessionId, meta: { cwd }, agentOptions: { provider: 'alt', model: 'alt-1' },
+    })
+    handle.agent.followup(createUserMessage({
+      content: [{ type: 'text', text: 'stored question' }], source: { kind: 'user' },
+    }))
+    await handle.agent.whenIdle()
+    await handle.dispose()
+
+    const loaded = await harness.client.loadSession({ sessionId, cwd, mcpServers: [] })
+
+    // `mock/mock` is what a fresh session would open on; the logged header wins.
+    expect(selectOption(loaded.configOptions, 'model').currentValue).toBe('alt/alt-1')
+  })
+
+  it('offers no model when nothing pins one', async () => {
+    harness = await makeBridgeHarness({
+      catalog: CATALOG, config: { provider: undefined, model: undefined },
+    })
+    await harness.client.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} })
+    const session = await harness.client.newSession({ cwd: process.cwd(), mcpServers: [] })
+
+    // Naming a current value the session does not actually run on would be a
+    // lie the client renders as fact, so the picker is withheld instead.
+    expect(optionsOfCategory(session.configOptions, 'model')).toEqual([])
+  })
+})

--- a/packages/dsh-acp/tests/model-selection.spec.ts
+++ b/packages/dsh-acp/tests/model-selection.spec.ts
@@ -74,6 +74,52 @@ describe('model selection', () => {
     ])
   })
 
+  it('lists a model shared by two routes once, under the route in force', async () => {
+    // Two provider ids serving the same catalog is a real deployment, not a
+    // mistake: a second route to the same vendor, mounted under its own id so
+    // it can carry its own key. Listed per provider, every model appeared
+    // twice, with only the value prefix telling the rows apart.
+    harness = await makeBridgeHarness({
+      catalog: {
+        mock: {
+          name: 'Mock',
+          models: [
+            { id: 'mock', name: 'Mock' },
+            { id: 'mock-pro', name: 'Mock Pro', description: 'the bigger one' },
+          ],
+        },
+        mirror: {
+          name: 'Mirror',
+          models: [
+            { id: 'mock', name: 'Mock' },
+            { id: 'mock-pro', name: 'Mock Pro', description: 'the bigger one' },
+            { id: 'mirror-only', name: 'Mirror Only' },
+          ],
+        },
+      },
+      config: { provider: 'mirror', model: 'mock' },
+    })
+    await harness.client.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} })
+    const session = await harness.client.newSession({ cwd: process.cwd(), mcpServers: [] })
+
+    const option = selectOption(session.configOptions, 'model')
+    // The session runs on `mirror`, so `mirror` owns every id it shares — the
+    // checked row keeps the route that actually answers, and `mock` is left
+    // with nothing of its own to list.
+    expect(option.currentValue).toBe('mirror/mock')
+    expect(option.options).toEqual([
+      {
+        group: 'mirror',
+        name: 'Mirror',
+        options: [
+          { value: 'mirror/mock', name: 'Mock' },
+          { value: 'mirror/mock-pro', name: 'Mock Pro', description: 'the bigger one' },
+          { value: 'mirror/mirror-only', name: 'Mirror Only' },
+        ],
+      },
+    ])
+  })
+
   it('routes the next turn to the model the client picked', async () => {
     harness = await makeBridgeHarness({
       catalog: CATALOG,

--- a/packages/dsh-acp/tests/preset-modes.spec.ts
+++ b/packages/dsh-acp/tests/preset-modes.spec.ts
@@ -11,7 +11,8 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { PROTOCOL_VERSION, type SessionConfigOption } from '@agentclientprotocol/sdk'
 import { SessionId } from '@deepseek-ai/dsh-session'
 import {
-  makeBridgeHarness, textResponse, updatesOfKind, waitForUpdates, type BridgeHarness,
+  makeBridgeHarness, optionsOfCategory, selectOption, textResponse, updatesOfKind, waitForUpdates,
+  type BridgeHarness,
 } from './harness.ts'
 
 /** The tools a session's model can call, i.e. what its preset composed. */
@@ -30,14 +31,14 @@ function selections(harness: BridgeHarness, sessionId: string): unknown[] {
     .map(event => (event as { data: { agentPreset: string } }).data.agentPreset)
 }
 
-/** The one mode option, asserted to be a select so its values can be read. */
+/**
+ * The one mode option. A session publishes a model picker alongside it, so the
+ * mode is read by category rather than by being the only thing on the wire.
+ */
 function modeOption(configOptions: SessionConfigOption[] | null | undefined): Extract<
   SessionConfigOption, { type: 'select' }
 > {
-  const [option, ...rest] = configOptions ?? []
-  expect(rest).toEqual([])
-  if (option?.type !== 'select') throw new Error(`expected one select option, got ${JSON.stringify(configOptions)}`)
-  return option
+  return selectOption(configOptions, 'mode')
 }
 
 /** The values a client's picker would list, in roster order. */
@@ -154,12 +155,13 @@ describe('agent-preset modes', () => {
     expect(updatesOfKind(harness, 'config_option_update')).toHaveLength(1)
   })
 
-  it('offers nothing when the deployment has no roster', async () => {
+  it('offers no mode when the deployment has no roster', async () => {
     harness = await makeBridgeHarness({ script: [textResponse('ok')] })
     await harness.client.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} })
     const session = await harness.client.newSession({ cwd: process.cwd(), mcpServers: [] })
 
-    expect(session.configOptions ?? []).toEqual([])
+    // The model picker is orthogonal and still published; only the mode is gone.
+    expect(optionsOfCategory(session.configOptions, 'mode')).toEqual([])
     await expect(harness.client.setSessionConfigOption({
       sessionId: session.sessionId, configId: 'agent-preset', value: 'beta',
     })).rejects.toThrow(/offers no modes/)

--- a/packages/dsh-acp/tests/session-load.spec.ts
+++ b/packages/dsh-acp/tests/session-load.spec.ts
@@ -18,17 +18,17 @@ import { PROTOCOL_VERSION, RequestError, type SessionConfigOption } from '@agent
 import { createUserMessage } from '@deepseek-ai/dsh-llm'
 import { SessionId } from '@deepseek-ai/dsh-session'
 import {
-  makeBridgeHarness, textResponse, updatesOfKind, waitForUpdates, type BridgeHarness,
+  makeBridgeHarness, selectOption, textResponse, updatesOfKind, waitForUpdates, type BridgeHarness,
 } from './harness.ts'
 
-/** The one mode option, asserted to be a select so its values can be read. */
+/**
+ * The one mode option. A reopened session publishes a model picker alongside
+ * it, so the mode is read by category rather than by position.
+ */
 function modeOption(configOptions: SessionConfigOption[] | null | undefined): Extract<
   SessionConfigOption, { type: 'select' }
 > {
-  const [option, ...rest] = configOptions ?? []
-  expect(rest).toEqual([])
-  if (option?.type !== 'select') throw new Error(`expected one select option, got ${JSON.stringify(configOptions)}`)
-  return option
+  return selectOption(configOptions, 'mode')
 }
 
 /** The text of every update of one kind, in arrival order. */

--- a/src/web-ui/src/flow_chat/components/AcpModeSelector.appearance.ts
+++ b/src/web-ui/src/flow_chat/components/AcpModeSelector.appearance.ts
@@ -1,0 +1,17 @@
+import type { AppearanceSurfaceDescriptor } from '@/infrastructure/appearance';
+
+export const acpModeSelectorAppearanceDescriptor: AppearanceSurfaceDescriptor = {
+  id: 'acp-mode-selector',
+  parts: [
+    { id: 'root' },
+    { id: 'trigger' },
+    { id: 'label' },
+    { id: 'menu' },
+    { id: 'header' },
+    { id: 'option' },
+  ],
+  states: [
+    { id: 'open', selector: { kind: 'self', suffix: '[data-bf-state~="open"]' } },
+    { id: 'selected', selector: { kind: 'self', suffix: '[data-bf-state~="selected"]' } },
+  ],
+};

--- a/src/web-ui/src/flow_chat/components/AcpModeSelector.scss
+++ b/src/web-ui/src/flow_chat/components/AcpModeSelector.scss
@@ -1,0 +1,184 @@
+@use '../../component-library/styles/tokens' as *;
+
+.bitfun-acp-mode-selector {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+
+  &__trigger {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    height: 20px;
+    max-width: 132px;
+    padding: 0 8px;
+    border: none;
+    border-radius: 10px;
+    background: transparent;
+    color: var(--bf-appearance-token-color-text-secondary);
+    font-size: var(--bf-appearance-token-flowchat-font-size-2xs);
+    cursor: pointer;
+    opacity: 0.72;
+    outline: none;
+
+    .bitfun-chat-input__box:focus-within &,
+    &:hover,
+    &:focus-visible,
+    &--open {
+      color: var(--bf-appearance-token-color-text-primary);
+      opacity: 1;
+    }
+
+    &:hover,
+    &--open {
+      background: var(--bf-appearance-token-element-bg-medium);
+    }
+
+    &:focus-visible {
+      box-shadow: 0 0 0 2px color-mix(in srgb, var(--bf-appearance-token-color-accent-500) 20%, transparent);
+    }
+
+    &:disabled {
+      cursor: default;
+      opacity: 0.4;
+    }
+  }
+
+  &__label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__menu {
+    --acp-mode-menu-offset: -4px;
+
+    min-width: clamp(0px, 190px, calc(100vw - 16px));
+    max-width: clamp(0px, 240px, calc(100vw - 16px));
+    padding: 4px;
+    overflow: hidden;
+    background: var(--bf-appearance-token-color-bg-elevated);
+    border: 1px solid var(--bf-appearance-token-border-subtle);
+    border-radius: 6px;
+    box-shadow: 0 8px 32px var(--bf-appearance-token-color-overlay-black-50);
+    z-index: $z-popover;
+    transform-origin: center top;
+    transition:
+      opacity 100ms ease,
+      transform 120ms cubic-bezier(0.23, 1, 0.32, 1);
+
+    &[data-open='true']:not([data-keyboard-open='true']) {
+      @starting-style {
+        opacity: 0;
+        transform: translateY(var(--acp-mode-menu-offset)) scale(0.985);
+      }
+    }
+
+    &[data-placement='top'] {
+      --acp-mode-menu-offset: 4px;
+      transform-origin: center bottom;
+    }
+
+    &[data-open='false'] {
+      opacity: 0;
+      transform: translateY(var(--acp-mode-menu-offset)) scale(0.985);
+      pointer-events: none;
+    }
+
+    &[data-keyboard-open='true'] {
+      transition: none;
+    }
+  }
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 5px 7px 7px;
+    color: var(--bf-appearance-token-color-text-muted);
+    font-size: var(--bf-appearance-token-flowchat-font-size-xxs);
+    font-weight: 500;
+  }
+
+  &__header-hint {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-weight: 400;
+    opacity: 0.8;
+  }
+
+  &__option {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    width: 100%;
+    min-height: 30px;
+    padding: 6px 8px;
+    border: 0;
+    border-radius: 4px;
+    background: transparent;
+    color: var(--bf-appearance-token-color-text-secondary);
+    text-align: left;
+    cursor: pointer;
+
+    &:hover,
+    &:focus-visible {
+      background: var(--bf-appearance-token-element-bg-medium);
+      color: var(--bf-appearance-token-color-text-primary);
+      outline: none;
+    }
+
+    &[aria-checked='true'] {
+      background: var(--bf-appearance-token-element-bg-subtle);
+    }
+
+    &:disabled {
+      cursor: default;
+      opacity: 0.55;
+
+      &:hover {
+        background: transparent;
+        color: var(--bf-appearance-token-color-text-secondary);
+      }
+
+      &[aria-checked='true']:hover {
+        background: var(--bf-appearance-token-element-bg-subtle);
+      }
+    }
+
+    > span {
+      display: flex;
+      flex-direction: column;
+      min-width: 0;
+    }
+
+    strong {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      letter-spacing: 0;
+      font-size: var(--bf-appearance-token-flowchat-font-size-xs);
+      font-weight: 500;
+    }
+
+    svg {
+      flex-shrink: 0;
+      color: var(--bf-appearance-token-color-accent-500);
+    }
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bitfun-acp-mode-selector__menu {
+    transition: opacity 100ms linear;
+  }
+}
+
+@media (max-width: 520px) {
+  .bitfun-acp-mode-selector__trigger {
+    max-width: 92px;
+  }
+}

--- a/src/web-ui/src/flow_chat/components/AcpModeSelector.tsx
+++ b/src/web-ui/src/flow_chat/components/AcpModeSelector.tsx
@@ -1,0 +1,280 @@
+/**
+ * The ACP session mode picker.
+ *
+ * ACP's `mode` category is "the picker that is not the model picker": dsh-acp
+ * publishes its agent presets there, claude-code and codex their permission
+ * modes. It used to live as a second section inside the model dropdown, which
+ * made one button stand for two unrelated choices. It is its own trigger now,
+ * sitting beside the model picker and showing the mode in force.
+ */
+
+import React, { useCallback, useEffect, useId, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Check, ChevronDown } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Tooltip } from '@/component-library';
+import { PresenceBoundary } from '@/component-library/components/PresenceBoundary';
+import { getAppearanceOverlayHost } from '@/infrastructure/appearance/runtime/AppearanceOverlayHost';
+import type { AcpModeState } from '../utils/acpSessionConfig';
+import { getModelSelectorDropdownLayout } from './modelSelectorDropdownPosition';
+import './AcpModeSelector.scss';
+
+interface AcpModeSelectorProps {
+  mode: AcpModeState;
+  /** Which agent published the mode; shown as the dropdown's right-hand hint. */
+  clientId?: string;
+  disabled?: boolean;
+  loading?: boolean;
+  dropdownPlacement?: 'top' | 'bottom';
+  /**
+   * Replaces the trigger tooltip. The caller uses this when this picker is the
+   * only one on screen and therefore also carries the context-usage readout.
+   */
+  tooltip?: React.ReactNode;
+  /** Extra trigger content before the chevron — the context-usage badge. */
+  trailing?: React.ReactNode;
+  onSelect: (value: string) => void | Promise<void>;
+}
+
+export const AcpModeSelector: React.FC<AcpModeSelectorProps> = ({
+  mode,
+  clientId,
+  disabled = false,
+  loading = false,
+  dropdownPlacement = 'top',
+  tooltip,
+  trailing,
+  onSelect,
+}) => {
+  const { t } = useTranslation('flow-chat');
+  const [open, setOpen] = useState(false);
+  const [keyboardOpen, setKeyboardOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const menuId = useId();
+  const [menuStyle, setMenuStyle] = useState<React.CSSProperties>({
+    position: 'fixed',
+    visibility: 'hidden',
+  });
+  const [resolvedPlacement, setResolvedPlacement] = useState(dropdownPlacement);
+
+  const candidates = mode.option.options;
+
+  useEffect(() => {
+    if (candidates.length === 0) setOpen(false);
+  }, [candidates.length]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handlePointerDown = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (!rootRef.current?.contains(target) && !menuRef.current?.contains(target)) {
+        setOpen(false);
+        setKeyboardOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handlePointerDown);
+    return () => document.removeEventListener('mousedown', handlePointerDown);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open || !rootRef.current) return;
+    const updatePosition = () => {
+      if (!rootRef.current || !menuRef.current) return;
+      const layout = getModelSelectorDropdownLayout(
+        rootRef.current.getBoundingClientRect(),
+        menuRef.current.getBoundingClientRect(),
+        dropdownPlacement,
+        { width: window.innerWidth, height: window.innerHeight },
+      );
+      setMenuStyle(layout.style);
+      setResolvedPlacement(layout.placement);
+    };
+    updatePosition();
+    const observer = new ResizeObserver(updatePosition);
+    if (menuRef.current) observer.observe(menuRef.current);
+    window.addEventListener('scroll', updatePosition, true);
+    window.addEventListener('resize', updatePosition);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('scroll', updatePosition, true);
+      window.removeEventListener('resize', updatePosition);
+    };
+  }, [dropdownPlacement, open]);
+
+  useEffect(() => {
+    if (!open || !keyboardOpen) return;
+    const frame = window.requestAnimationFrame(() => {
+      const checked = menuRef.current?.querySelector<HTMLButtonElement>(
+        'button[role="menuitemradio"][aria-checked="true"]:not(:disabled)',
+      );
+      const first = menuRef.current?.querySelector<HTMLButtonElement>(
+        'button[role="menuitemradio"]:not(:disabled)',
+      );
+      (checked ?? first)?.focus();
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [keyboardOpen, open]);
+
+  const select = useCallback((value: string) => {
+    if (menuRef.current?.contains(document.activeElement)) {
+      triggerRef.current?.focus();
+    }
+    setOpen(false);
+    void onSelect(value);
+  }, [onSelect]);
+
+  const handleMenuKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      triggerRef.current?.focus();
+      setOpen(false);
+      return;
+    }
+    if (!['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(event.key)) return;
+    const items = Array.from(event.currentTarget.querySelectorAll<HTMLButtonElement>(
+      'button[role="menuitemradio"]:not(:disabled)',
+    ));
+    if (items.length === 0) return;
+    event.preventDefault();
+    const activeIndex = items.indexOf(document.activeElement as HTMLButtonElement);
+    let nextIndex = activeIndex;
+    if (event.key === 'Home') nextIndex = 0;
+    if (event.key === 'End') nextIndex = items.length - 1;
+    if (event.key === 'ArrowDown') nextIndex = activeIndex < 0 ? 0 : (activeIndex + 1) % items.length;
+    if (event.key === 'ArrowUp') nextIndex = activeIndex < 0 ? items.length - 1 : (activeIndex - 1 + items.length) % items.length;
+    items[nextIndex]?.focus();
+  }, []);
+
+  if (candidates.length === 0) return null;
+
+  const currentLabel = candidates.find(candidate => candidate.value === mode.currentValue)?.name
+    ?? mode.currentValue;
+  const triggerTooltip = tooltip
+    ?? mode.option.description
+    ?? `${mode.option.name}: ${currentLabel}`;
+
+  return (
+    <div
+      ref={rootRef}
+      className="bitfun-acp-mode-selector"
+      data-bf-component="acp-mode-selector"
+      data-bf-part="root"
+      data-bf-state={open ? 'open' : undefined}
+    >
+      <Tooltip content={triggerTooltip} disabled={open}>
+        <button
+          ref={triggerRef}
+          type="button"
+          className={`bitfun-acp-mode-selector__trigger${open ? ' bitfun-acp-mode-selector__trigger--open' : ''}`}
+          data-bf-component="acp-mode-selector"
+          data-bf-part="trigger"
+          data-bf-state={open ? 'open' : undefined}
+          data-testid="chat-acp-mode-selector-btn"
+          aria-haspopup="menu"
+          aria-expanded={open}
+          aria-controls={open ? menuId : undefined}
+          disabled={disabled || loading}
+          onClick={(event) => {
+            const nextOpen = !open;
+            if (nextOpen) {
+              setKeyboardOpen(event.detail === 0);
+            } else if (event.detail !== 0) {
+              setKeyboardOpen(false);
+            }
+            setOpen(nextOpen);
+          }}
+          onKeyDown={(event) => {
+            if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+              event.preventDefault();
+              setKeyboardOpen(true);
+              setOpen(true);
+            } else if (event.key === 'Escape' && open) {
+              event.preventDefault();
+              setOpen(false);
+            }
+          }}
+        >
+          <span
+            className="bitfun-acp-mode-selector__label"
+            data-bf-component="acp-mode-selector"
+            data-bf-part="label"
+          >
+            {currentLabel}
+          </span>
+          {trailing}
+          <ChevronDown size={10} aria-hidden="true" />
+        </button>
+      </Tooltip>
+
+      <PresenceBoundary active={open}>
+        {createPortal(
+          <div
+            id={menuId}
+            ref={menuRef}
+            className="bitfun-acp-mode-selector__menu"
+            data-bf-component="acp-mode-selector"
+            data-bf-part="menu"
+            data-placement={resolvedPlacement}
+            data-open={open ? 'true' : 'false'}
+            data-keyboard-open={keyboardOpen ? 'true' : 'false'}
+            style={menuStyle}
+            role="menu"
+            aria-hidden={!open}
+            {...(!open ? { inert: '' } : {})}
+            aria-label={t('modelSelector.acpMode')}
+            data-testid="chat-acp-mode-selector-menu"
+            onKeyDown={handleMenuKeyDown}
+          >
+            <div
+              className="bitfun-acp-mode-selector__header"
+              data-bf-component="acp-mode-selector"
+              data-bf-part="header"
+            >
+              <span>{t('modelSelector.acpMode')}</span>
+              {clientId && (
+                <span className="bitfun-acp-mode-selector__header-hint">{clientId}</span>
+              )}
+            </div>
+            {candidates.map((candidate) => {
+              const isSelected = mode.currentValue === candidate.value;
+              // The row stays one line; what a mode does — or why it can no
+              // longer change — is hover-only.
+              const hint = mode.locked
+                ? (mode.option.description ?? t('modelSelector.acpModeLocked'))
+                : (candidate.description ?? candidate.name);
+
+              return (
+                <Tooltip key={candidate.value} content={hint} placement="right">
+                  <button
+                    type="button"
+                    role="menuitemradio"
+                    aria-checked={isSelected}
+                    data-testid="chat-acp-mode-option"
+                    data-mode-value={candidate.value}
+                    data-selected={isSelected ? 'true' : 'false'}
+                    disabled={mode.locked || loading}
+                    className="bitfun-acp-mode-selector__option"
+                    data-bf-component="acp-mode-selector"
+                    data-bf-part="option"
+                    data-bf-state={isSelected ? 'selected' : undefined}
+                    onClick={() => select(candidate.value)}
+                  >
+                    <span>
+                      <strong>{candidate.name}</strong>
+                    </span>
+                    {isSelected && <Check size={14} aria-hidden="true" />}
+                  </button>
+                </Tooltip>
+              );
+            })}
+          </div>,
+          getAppearanceOverlayHost(),
+        )}
+      </PresenceBoundary>
+    </div>
+  );
+};
+
+export default AcpModeSelector;

--- a/src/web-ui/src/flow_chat/components/ModelSelector.tsx
+++ b/src/web-ui/src/flow_chat/components/ModelSelector.tsx
@@ -44,6 +44,7 @@ import {
 } from '../utils/tokenUsageDisplay';
 import { createLogger } from '@/shared/utils/logger';
 import { getModelSelectorDropdownLayout } from './modelSelectorDropdownPosition';
+import { AcpModeSelector } from './AcpModeSelector';
 import { ReasoningPresetSelector } from './ReasoningPresetSelector';
 import {
   getRecentReasoningPreset,
@@ -1223,10 +1224,21 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
       ? (acpMode.option.options.find(candidate => candidate.value === acpMode.currentValue)?.name
         ?? acpMode.currentValue)
       : '';
-    const acpModeOnly = acpAvailableModels.length === 0 && acpMode !== null;
-    const acpBaseTooltip = acpModeOnly
-      ? (acpMode?.option.description ?? `${acpMode?.option.name ?? ''}: ${acpModeLabel}`)
-      : getModelTooltipText(acpCurrentModel, acpClientId ? `${acpClientId} ACP` : 'ACP');
+    // The mode has a trigger of its own now. What is left here is the model
+    // list and the fast-mode switch, so this picker only appears when the agent
+    // published one of them — a mode-only agent shows the mode picker alone.
+    const showModelTrigger = acpAvailableModels.length > 0 || acpFastMode !== null;
+    let acpBaseTooltip: string;
+    if (acpAvailableModels.length > 0) {
+      acpBaseTooltip = getModelTooltipText(acpCurrentModel, acpClientId ? `${acpClientId} ACP` : 'ACP');
+    } else if (showModelTrigger) {
+      acpBaseTooltip = t('modelSelector.fastMode');
+    } else {
+      acpBaseTooltip = acpMode?.option.description ?? `${acpMode?.option.name ?? ''}: ${acpModeLabel}`;
+    }
+    const acpDropdownTitle = acpAvailableModels.length > 0
+      ? 'ACP model'
+      : t('modelSelector.fastMode');
     const acpTooltip = buildContextUsageTooltip({
       baseTooltip: acpBaseTooltip,
       usage: {
@@ -1236,12 +1248,24 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
       },
       t,
     });
+    // Whichever trigger is on screen carries the context readout; with no model
+    // trigger it rides along on the mode one instead of disappearing.
+    const contextUsageBadge = tokenPercentage > 0 ? (
+      <span
+        className={`bitfun-model-selector__ctx-usage${tokenStatusClass ? ` bitfun-model-selector__ctx-usage--${tokenStatusClass}` : ''}`}
+        data-bf-component="model-selector"
+        data-bf-part="contextUsage"
+      >
+        · {tokenPercentage}%
+      </span>
+    ) : null;
 
     return (
       <div data-bf-component="model-selector" data-bf-part="root" data-bf-state={dropdownOpen ? 'open' : undefined}
         ref={dropdownRef}
         className={`bitfun-model-selector ${className}`}
       >
+        {showModelTrigger && (
         <Tooltip content={acpTooltip} disabled={dropdownOpen}>
           <button
             ref={triggerRef}
@@ -1267,19 +1291,30 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
             disabled={disabled || loading}
            data-bf-component="model-selector" data-bf-part="trigger" data-bf-state={dropdownOpen ? 'open' : undefined}>
             <span className="bitfun-model-selector__name" data-bf-component="model-selector" data-bf-part="name">
-              {acpModeOnly ? acpModeLabel : getModelDisplayLabel(acpCurrentModel, currentAcpModelId)}
+              {acpAvailableModels.length > 0
+                ? getModelDisplayLabel(acpCurrentModel, currentAcpModelId)
+                : t('modelSelector.fastMode')}
             </span>
             {acpFastMode?.enabled && (
               <Zap size={9} className="bitfun-model-selector__fast-icon" />
             )}
-            {tokenPercentage > 0 && (
-              <span className={`bitfun-model-selector__ctx-usage${tokenStatusClass ? ` bitfun-model-selector__ctx-usage--${tokenStatusClass}` : ''}`} data-bf-component="model-selector" data-bf-part="contextUsage">
-                · {tokenPercentage}%
-              </span>
-            )}
+            {contextUsageBadge}
             <ChevronDown size={10} className="bitfun-model-selector__chevron" />
           </button>
         </Tooltip>
+        )}
+
+        {acpMode && (
+          <AcpModeSelector
+            mode={acpMode}
+            clientId={acpClientId ?? undefined}
+            disabled={disabled}
+            loading={loading}
+            dropdownPlacement={dropdownPlacement}
+            onSelect={handleSelectAcpMode}
+            {...(showModelTrigger ? {} : { tooltip: acpTooltip, trailing: contextUsageBadge })}
+          />
+        )}
 
         {acpReasoning && (
           <ReasoningPresetSelector
@@ -1292,6 +1327,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
           />
         )}
 
+        {showModelTrigger && (
         <PresenceBoundary active={dropdownOpen}>
           {createPortal(
             <div
@@ -1308,11 +1344,11 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
             aria-hidden={!dropdownOpen}
             {...(!dropdownOpen ? { inert: '' } : {})}
             role="menu"
-            aria-label={acpModeOnly ? t('modelSelector.acpMode') : 'ACP model'}
+            aria-label={acpDropdownTitle}
             onKeyDown={handleDropdownKeyDown}
           >
             <div className="bitfun-model-selector__dropdown-header" data-bf-component="model-selector" data-bf-part="dropdownHeader">
-              <span>{acpModeOnly ? t('modelSelector.acpMode') : 'ACP model'}</span>
+              <span>{acpDropdownTitle}</span>
               <span className="bitfun-model-selector__dropdown-hint">
                 {acpClientId}
               </span>
@@ -1357,64 +1393,11 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
             </div>
             )}
 
-            {acpMode && (
-              <>
-                {acpAvailableModels.length > 0 && (
-                  <>
-                    <div className="bitfun-model-selector__divider" />
-                    <div className="bitfun-model-selector__dropdown-header" data-bf-component="model-selector" data-bf-part="dropdownHeader">
-                      <span>{t('modelSelector.acpMode')}</span>
-                    </div>
-                  </>
-                )}
-                <div className="bitfun-model-selector__list" data-bf-component="model-selector" data-bf-part="list">
-                  {acpMode.option.options.map(candidate => {
-                    const isSelected = acpMode.currentValue === candidate.value;
-                    // The row stays one line; what a mode does — or why it can no
-                    // longer change — is hover-only.
-                    const hint = acpMode.locked
-                      ? (acpMode.option.description ?? t('modelSelector.acpModeLocked'))
-                      : (candidate.description ?? candidate.name);
-
-                    return (
-                      <Tooltip
-                        key={candidate.value}
-                        content={hint}
-                        placement="right"
-                      >
-                        <button
-                          type="button"
-                          role="menuitemradio"
-                          aria-checked={isSelected}
-                          data-testid="chat-acp-mode-option"
-                          data-mode-value={candidate.value}
-                          data-selected={isSelected ? 'true' : 'false'}
-                          disabled={acpMode.locked || loading}
-                          className={`bitfun-model-selector__option ${isSelected ? 'bitfun-model-selector__option--selected' : ''}`}
-                          data-bf-component="model-selector"
-                          data-bf-part="option"
-                          data-bf-state={isSelected ? 'selected' : undefined}
-                          onClick={() => { void handleSelectAcpMode(candidate.value); }}
-                        >
-                          <div className="bitfun-model-selector__option-main" data-bf-component="model-selector" data-bf-part="optionMain">
-                            <span className="bitfun-model-selector__option-name">
-                              {candidate.name}
-                            </span>
-                          </div>
-                          {isSelected && (
-                            <Check size={14} className="bitfun-model-selector__option-check" />
-                          )}
-                        </button>
-                      </Tooltip>
-                    );
-                  })}
-                </div>
-              </>
-            )}
-
             {acpFastMode && (
               <>
-                <div className="bitfun-model-selector__divider" />
+                {acpAvailableModels.length > 0 && (
+                  <div className="bitfun-model-selector__divider" />
+                )}
                 <div className="bitfun-model-selector__config-row" data-bf-component="model-selector" data-bf-part="configRow">
                   <div className="bitfun-model-selector__config-copy">
                     <span className="bitfun-model-selector__config-name">
@@ -1438,6 +1421,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
             getAppearanceOverlayHost()
           )}
         </PresenceBoundary>
+        )}
       </div>
     );
   }

--- a/src/web-ui/src/flow_chat/components/ModelSelectorAcpMode.test.tsx
+++ b/src/web-ui/src/flow_chat/components/ModelSelectorAcpMode.test.tsx
@@ -2,9 +2,10 @@
  * @vitest-environment jsdom
  *
  * The composer's mode picker for ACP sessions. An agent publishes its modes as
- * a `mode`-category config option, and dsh-acp publishes ONLY that — no models —
- * so this covers the case where the mode is the whole picker, and the case where
- * the agent has fixed it and left exactly one choice.
+ * a `mode`-category config option, and it gets a trigger of its own beside the
+ * model picker — the two are unrelated choices and used to share one dropdown.
+ * This covers the agent that publishes only a mode, the agent that publishes
+ * both, and the agent that has fixed the mode and left exactly one choice.
  */
 
 import { act } from 'react';
@@ -136,9 +137,13 @@ describe('ModelSelector ACP mode picker', () => {
   });
 
   /** Render the selector against one set of ACP session options. */
-  const renderWithOptions = async (configOptions: unknown[]) => {
+  const renderWithOptions = async (
+    configOptions: unknown[],
+    session: { availableModels?: unknown[]; currentModelId?: string } = {},
+  ) => {
     vi.mocked(ACPClientAPI.getSessionOptions).mockResolvedValue({
-      availableModels: [],
+      availableModels: session.availableModels ?? [],
+      ...(session.currentModelId ? { currentModelId: session.currentModelId } : {}),
       configOptions,
     } as never);
     await act(async () => {
@@ -151,16 +156,44 @@ describe('ModelSelector ACP mode picker', () => {
   it('renders the mode as the whole picker when the agent offers no models', async () => {
     await renderWithOptions([MODE_OPTION]);
 
-    const trigger = container.querySelector<HTMLButtonElement>('[data-testid="chat-model-selector-btn"]');
+    const trigger = container.querySelector<HTMLButtonElement>('[data-testid="chat-acp-mode-selector-btn"]');
     // Without this the ACP branch used to return null on an empty model list,
     // leaving a dsh session with no picker at all.
     expect(trigger, 'the mode picker must render without models').not.toBeNull();
     expect(trigger?.textContent).toContain('Standard');
+    // Nothing left for the model picker to show, so it stays away entirely.
+    expect(container.querySelector('[data-testid="chat-model-selector-btn"]')).toBeNull();
 
     await act(async () => { trigger?.click(); });
     const options = document.body.querySelectorAll('[data-testid="chat-acp-mode-option"]');
     expect([...options].map(option => option.getAttribute('data-mode-value')))
       .toEqual(['standard', 'minimal']);
+  });
+
+  it('keeps the mode out of the model dropdown when the agent offers both', async () => {
+    await renderWithOptions([MODE_OPTION], {
+      availableModels: [
+        { id: 'deepseek-official/deepseek-v4-flash', name: 'DeepSeek V4 Flash' },
+        { id: 'deepseek-official/deepseek-v4-pro', name: 'DeepSeek V4 Pro' },
+      ],
+      currentModelId: 'deepseek-official/deepseek-v4-flash',
+    });
+
+    const modelTrigger = container.querySelector<HTMLButtonElement>('[data-testid="chat-model-selector-btn"]');
+    const modeTrigger = container.querySelector<HTMLButtonElement>('[data-testid="chat-acp-mode-selector-btn"]');
+    expect(modelTrigger, 'the model picker keeps its own trigger').not.toBeNull();
+    expect(modeTrigger?.textContent).toContain('Standard');
+
+    // The whole point of the split: one button, one kind of choice.
+    await act(async () => { modelTrigger?.click(); });
+    const modelMenu = document.body.querySelector('[data-testid="chat-model-selector-menu"]');
+    expect(modelMenu?.querySelectorAll('[data-testid="chat-model-selector-option"]')).toHaveLength(2);
+    expect(modelMenu?.querySelectorAll('[data-testid="chat-acp-mode-option"]')).toHaveLength(0);
+
+    await act(async () => { modeTrigger?.click(); });
+    expect(
+      document.body.querySelectorAll('[data-testid="chat-acp-mode-selector-menu"] [data-testid="chat-acp-mode-option"]'),
+    ).toHaveLength(2);
   });
 
   it('sends the chosen mode to the agent', async () => {
@@ -171,7 +204,7 @@ describe('ModelSelector ACP mode picker', () => {
     } as never);
 
     await act(async () => {
-      container.querySelector<HTMLButtonElement>('[data-testid="chat-model-selector-btn"]')?.click();
+      container.querySelector<HTMLButtonElement>('[data-testid="chat-acp-mode-selector-btn"]')?.click();
     });
     await act(async () => {
       document.body.querySelector<HTMLButtonElement>(
@@ -187,7 +220,7 @@ describe('ModelSelector ACP mode picker', () => {
       value: { type: 'select', value: 'minimal' },
     }));
     expect(
-      container.querySelector('[data-testid="chat-model-selector-btn"]')?.textContent,
+      container.querySelector('[data-testid="chat-acp-mode-selector-btn"]')?.textContent,
     ).toContain('Minimal');
   });
 
@@ -201,7 +234,7 @@ describe('ModelSelector ACP mode picker', () => {
     }]);
 
     await act(async () => {
-      container.querySelector<HTMLButtonElement>('[data-testid="chat-model-selector-btn"]')?.click();
+      container.querySelector<HTMLButtonElement>('[data-testid="chat-acp-mode-selector-btn"]')?.click();
     });
     const options = document.body.querySelectorAll<HTMLButtonElement>(
       '[data-testid="chat-acp-mode-option"]',

--- a/src/web-ui/src/infrastructure/appearance/registry/defaultAppearanceRegistry.ts
+++ b/src/web-ui/src/infrastructure/appearance/registry/defaultAppearanceRegistry.ts
@@ -40,6 +40,7 @@ import { modelRoundItemAppearanceDescriptor } from '@/flow_chat/components/moder
 import { deepReviewActionBarAppearanceDescriptor } from '@/flow_chat/deep-review/action-bar/appearance';
 import { modelSelectorAppearanceDescriptor } from '@/flow_chat/components/ModelSelector.appearance';
 import { reasoningPresetSelectorAppearanceDescriptor } from '@/flow_chat/components/ReasoningPresetSelector.appearance';
+import { acpModeSelectorAppearanceDescriptor } from '@/flow_chat/components/AcpModeSelector.appearance';
 import { flowChatHeaderAppearanceDescriptor } from '@/flow_chat/components/modern/FlowChatHeader.appearance';
 import { flowChatTurnRailAppearanceDescriptor } from '@/flow_chat/components/modern/FlowChatTurnRail.appearance';
 import { sessionFilesBadgeAppearanceDescriptor } from '@/flow_chat/components/modern/SessionFilesBadge.appearance';
@@ -322,6 +323,7 @@ export function createDefaultAppearanceRegistry(): AppearanceRegistry {
     .registerComponent(deepReviewActionBarAppearanceDescriptor)
     .registerComponent(modelSelectorAppearanceDescriptor)
     .registerComponent(reasoningPresetSelectorAppearanceDescriptor)
+    .registerComponent(acpModeSelectorAppearanceDescriptor)
     .registerComponent(flowChatHeaderAppearanceDescriptor)
     .registerComponent(flowChatTurnRailAppearanceDescriptor)
     .registerComponent(sessionFilesBadgeAppearanceDescriptor)


### PR DESCRIPTION
## The problem

A dsh ACP session cannot select a model. ACP 0.25 carries no model state of its own — there is no `session/set_model` — so a client's model dropdown IS a session config option with `category: "model"`. This bridge only ever published the mode option, so the dropdown had nothing to render and every session ran whatever `agent-default-model` resolved at creation time, for its whole life.

The rest of the stack was already ready: `session_options.rs` flattens grouped select options on the Rust side, and `ModelSelector.tsx` builds its list off `acpOptions.availableModels`. What was missing was the agent-side publication. `cordis.yml` even documented the old behaviour as deliberate, so this is a feature addition rather than a regression repair.

## What changed

- The bridge publishes a `model` select alongside the mode, built from `ctx.llm`'s catalog and grouped by provider. The value is the `provider/model` pair, because the same model id can be served by two routes and a bare id would not say which one ran.
- A pick is validated through `llm.resolveCallConfig` (which also materializes adapter defaults such as `reasoningEffort`) and applied to a per-session `ModelSelectionRef`, installed via `installModelSelection` on both the create and the resume path. With `ref.current === undefined` that hook is a pure passthrough, which is why an uninitialized ref left the agent pinned to its creation-time route.
- The pick is **session-scoped on purpose**: unlike `dsh-host-apiproxy`, this never writes back `agent-default-model`, so an IDE session does not mutate the model you chose in dsh.
- Unlike the mode, the model is never locked — swapping which model answers the next step leaves every logged turn valid. A reopened session comes back on the provider/model its own turns were logged under (`session.requestHeader()`), not on whatever the default has moved to since.
- The catalog is advisory: an adapter may accept ids it never advertised, so the model in force is offered even when unlisted. A picker whose `currentValue` is absent from its own options renders blank, which is the same broken dropdown as having no options at all. Conversely, when nothing can name a current model the picker is withheld rather than naming one the session does not actually run.
- `presetSwitch` is renamed to `configSwitch` and shared with model switches, because every publication replaces the whole option set: an unordered reply would drop the other picker or carry a stale one.

## One row per model

Two provider ids serving the same models is a real deployment, not a mistake: a second route to the same vendor, mounted under its own id so it can carry its own key. Listed per provider, that made every model appear twice — same name, same vendor, nothing to choose between, and only the `provider/model` prefix telling the rows apart.

`modelOptions` now publishes one row per model id. The provider carrying the session's current model owns the shared ids, so the list stays on the route that actually answers, and the checked row keeps its provider even when that provider's listing failed. A provider left with no models of its own drops out of the picker; one that serves models nobody else does keeps its group. The unlisted-model fallback above is unchanged.

## The mode gets a picker of its own

With the model list added, the ACP dropdown held three unrelated things: the models, the agent's `mode` option (dsh's agent presets; claude-code and codex publish permission modes in the same category), and the fast-mode switch. One trigger, and it named the model — so nothing on the composer said which mode was in force, and opening the model list to change a permission mode read as the wrong menu.

- New `AcpModeSelector`, built on the same dropdown, keyboard, and positioning code as `ReasoningPresetSelector`, rendered beside the model trigger. The composer now reads model, mode, reasoning, and the mode trigger shows the mode name.
- Protocol behaviour is untouched: the same `session/set_config_option` call, the same lock semantics once a conversation has started, the same option ids and test hooks. `handleSelectAcpMode` did not move.
- An agent that publishes a mode and no models keeps a full picker. The mode trigger takes over the context-usage badge and the tooltip the model trigger would have carried, so nothing is lost when there is no model button to render.
- No new i18n keys — the existing `modelSelector.acpMode` / `acpModeLocked` / `acpModeFailed` cover it.

## Verification

From `packages/dsh-acp/`:

- `npx vitest run` — 7 files / 39 tests pass, including `tests/model-selection.spec.ts` (9 cases: the grouped catalog; a model shared by two routes listed once under the route in force; a switch actually routing the next turn, asserted off the requests the mock adapter received; still switchable after the mode locks; the locking `config_option_update` still carrying the picker; refusing an unknown pair, a separator-less value, and a boolean; a cold session reopening on its logged model; and no picker when nothing pins a model).
- `npx tsc -p tsconfig.json --noEmit` and `npx tsc -p tsconfig.build.json --noEmit` — clean.
- `npm run build` and `node scripts/prepare-dsh-profile.mjs` — both succeed; the latter is the only CI job that touches this package.
- `scripts/smoke.mjs` gained `--model provider/model`, and `describeOptions` now flattens grouped selects, so the path can be driven by hand against a real installation.

From the repository root:

- `pnpm --dir src/web-ui run test:run src/flow_chat/components/ModelSelectorAcpMode.test.tsx` — 4 pass, including a new case asserting the model dropdown no longer contains any mode row while both triggers render.
- `pnpm --dir src/web-ui run test:run` over `ModelSelectorExternal.test.tsx`, `ModelSelectorPortalLayer.test.ts`, `ReasoningPresetSelector.test.tsx`, `acpSessionConfig.test.ts` — 27 pass.
- `pnpm run lint:web` and `pnpm run theme:color-audit:all` — clean.
- `pnpm run type-check:web` — clean apart from a pre-existing `GitTrustReport` error from a stale local `src/web-ui/src/generated/api/` (gitignored, unrelated to this branch).
- Manually against a dsh ACP session in `pnpm run desktop:dev`: three separate triggers on the composer, the duplicated provider gone from the model list, and the mode picker locking after the first turn.
