### PR TITLE
refactor(peer): give a Session's projection one owner, and make a delivery gap answerable

### DIFF
--- a/docs/architecture/peer-device-mode.md
+++ b/docs/architecture/peer-device-mode.md
@@ -90,7 +90,19 @@ boundaries; noisy tool progress is compacted.
 
 `restore_session_view` returns this additive `runtimeEventSnapshot`; the CLI
 Peer Host applies its existing Peer-owned-Turn filter before recording or
-returning the projection. During an attach, the frontend fences live events for
+returning the projection. The persisted Session record of an executing Turn is
+a lagging checkpoint, not the live projection: `loadSessionHistory` and
+`refreshPeerSessionSnapshot` must not paint that checkpoint's in-progress
+tool rows. A restore that races a live store update must still return the
+journal so attach can replay. Delivery of a live event to a product listener
+is not acceptance — a dropped ToolEvent / TextChunk marks the projection
+stale so the next attach replays instead of treating the cursor as current.
+`finish()` covers those cursors only after the painted projection has caught
+up with journal terminal tools; a matching cursor alone is not enough.
+Overlapping attach transfers the in-flight fence rather than delivering it
+onto a state machine that is about to reset. Hidden-document and
+fresh-TextChunk liveness skips apply only to the 3s poll, not to a dirty
+projection. During an attach, the frontend fences live events for
 `(DeviceSurfaceId, SessionId)`,
 replays the snapshot into an empty current-Turn projection, and then releases
 only events newer than the snapshot cursor. A different `streamId` is a new

--- a/docs/architecture/session-projection.md
+++ b/docs/architecture/session-projection.md
@@ -1,0 +1,153 @@
+# Session Projection
+
+What a client shows for a Session is a **projection of an ordered stream**. This
+document is the contract that projection obeys, and the migration that brings
+the existing writers under it.
+
+Read [`peer-device-mode.md`](peer-device-mode.md) for how a controller reaches
+another device. This document is about what happens to the data once it
+arrives, and applies identically on the local surface.
+
+## The problem this replaces
+
+Seven independent writers currently produce a Session's on-screen state:
+
+| # | Writer | Entry point |
+|---|---|---|
+| 1 | Live agentic events | `AgenticEventListener` → `eventBatcher` |
+| 2 | Disk hydrate | `loadSessionHistory` → `restore_session_view` |
+| 3 | Windowed history | `load_session_turn_window` |
+| 4 | Snapshot reconcile | `refreshPeerSessionSnapshot`, `replaceRunningSnapshot` |
+| 5 | Journal snapshot replay | `dispatchExternal(snapshot.events)` |
+| 6 | Interaction mailbox | `reconcilePendingUserQuestions` |
+| 7 | Backfill delta | `load_session_event_backfill` |
+
+None of them carries a position that the others can compare against, so every
+pair needs its own conflict rule. Those rules are the fourteen invariants in
+[`peer-device/README.md`](../../src/web-ui/src/infrastructure/peer-device/README.md),
+and they are written in terms of painted content rather than ordering:
+`snapshotDropsProjectedTurnContent` decides whether a write is safe by counting
+rounds and progress entries; `runtimeProjectionCaughtUp` decides whether a
+cursor may be trusted by looking for tool cards on screen.
+
+Counting pixels to decide whether a write is safe is what a missing position
+looks like. The rule table also grows quadratically: adding writer 7 required
+two new pairwise rules (7↔1, 7↔6), and shipping without them produced exactly
+two defects — the live stream stalled behind writer 7's fence, and a blocking
+interaction came back unanswerable because writer 6 never ran.
+
+## Contract
+
+### 1. Every write carries a position, and the projection never regresses
+
+A write whose position is not ahead of what has been applied is **dropped, not
+merged**. There is no operation that replaces projected content, so no writer
+needs to prove it is not about to lose any.
+
+Positions are per `(surface, session)`:
+
+- **Runtime positions** — `(streamId, cursor)`, minted by the Host journal as
+  each event enters its ordered delivery stream. `streamId` identifies the
+  Runtime process; cursors from different `streamId`s are never comparable.
+- **History positions** — turn ordinal within the persisted record. Immutable
+  and totally ordered.
+
+The two are not compared with each other. They cannot conflict, because of
+invariant 2.
+
+### 2. A Turn has exactly one writer, decided by whether it is executing
+
+- An **executing** Turn is owned by the runtime stream. No persisted record,
+  checkpoint, or snapshot of that Turn may write it.
+- A **settled** Turn is owned by the persisted record. No live event may
+  write it.
+- Ownership transfers **once**, on the Turn's terminal event, driven by
+  position — never by inspecting what is on screen.
+
+This is why history and live events cannot race: they are never both
+authoritative for the same Turn. The persisted checkpoint of an executing Turn
+is identity only; it names the Turn and carries none of its content.
+
+### 3. Identity is `(surface, session)` by construction
+
+One `SessionStream` object owns the position, the pending queue, and the
+projection for one `(DeviceSurfaceId, SessionId)`. Workspace paths and session
+ids repeat across machines, so surface is part of identity, not an extra
+argument each feature remembers to thread through.
+
+Any state that is per-Session is reached through its stream. A feature cannot
+hold Session state that is not surface-scoped, because there is nowhere to
+put it.
+
+## Sources are not writers
+
+Every source above becomes a way of **obtaining positioned events**, applied
+through one path:
+
+| Source | Produces |
+|---|---|
+| Live DeviceEvent / local emit | events at `(streamId, cursor)` |
+| `load_session_event_backfill` | events after a position, or `snapshotRequired` |
+| `restore_session_view` runtime snapshot | a compacted prefix ending at a position |
+| `restore_session_view` turns / `load_session_turn_window` | settled Turns at history positions |
+| Interaction mailbox | revisioned state of an executing Turn, applied at its position |
+
+A snapshot is a prefix. A delta is a suffix. History is the older part of the
+same order. None of them is a distinct kind of write.
+
+## What this deletes
+
+Each item disappears when its writer migrates. This list is the acceptance
+criteria — a migration step that does not remove its entry has not finished.
+
+| Removed | Replaced by |
+|---|---|
+| `snapshotDropsProjectedTurnContent` | positions cannot regress (contract 1) |
+| `replaceRunningSnapshot` | there is no replace operation (contract 1) |
+| `runtimeProjectionCaughtUp` | the applied position is the answer (contract 1) |
+| `prepareRuntimeTurnReplay` / `asRuntimeReplayTurn` | an executing Turn has one writer (contract 2) |
+| `hasGap` / `projectionStale` / `markRuntimeSessionProjectionStale` | a position discontinuity is the gap |
+| `beginRuntimeSessionAttachment` fence | the stream's own queue (contract 3) |
+| manual `(DeviceSurfaceId, …)` threading | stream identity (contract 3) |
+
+The 3s poll is **not** on this list. Events that never arrive advance no
+cursor, so no discontinuity is observable; the poll remains the liveness probe
+that notices a stream has gone quiet. It stops being a repair mechanism.
+
+## Migration
+
+Ordered so that each step is separately verifiable and deletes its own rules.
+
+1. **Position algebra + `SessionStream`** — the contract as a tested module,
+   with no writer on it yet.
+2. **Runtime-stream writers (1, 5, 7)** — live events, snapshot replay, and
+   backfill are already positioned; move them onto the stream and delete the
+   fence, `hasGap`, and `runtimeProjectionCaughtUp`.
+3. **Snapshot reconcile (4)** — becomes "apply a prefix"; deletes
+   `replaceRunningSnapshot` and `snapshotDropsProjectedTurnContent`.
+4. **Interaction mailbox (6)** — applied at the executing Turn's position
+   rather than as a separate reconcile pass.
+5. **History (2, 3)** — settled Turns at history positions; deletes the
+   executing/settled overlap rules and `prepareRuntimeTurnReplay`.
+
+Steps 2–5 each remove entries from the peer-device README's invariant list.
+That list shrinking is the measure of progress; if it is not shrinking, the
+step reintroduced a pairwise rule instead of removing one.
+
+## Host contract
+
+Hosts expose exactly two reads over a Session's stream, both already present:
+
+- `restore_session_view` — a prefix (compacted projection + settled Turns +
+  mailbox), ending at a position.
+- `load_session_event_backfill` — the suffix after a position, or
+  `snapshotRequired` when contiguity cannot be proven.
+
+`SessionEventJournal` owns both. The compacted projection answers "what does
+this Turn look like now"; the append-only tail answers "what came after
+position N". Neither is allowed to answer the other's question — that
+conflation is what made a gap something to infer.
+
+Peer ownership is a cancellation and bookkeeping boundary and never filters
+either read. A Turn started in a Host's own TUI is part of the Session every
+attached surface projects.

--- a/docs/architecture/session-projection.md
+++ b/docs/architecture/session-projection.md
@@ -102,7 +102,6 @@ criteria — a migration step that does not remove its entry has not finished.
 
 | Removed | Replaced by |
 |---|---|
-| `snapshotDropsProjectedTurnContent` | positions cannot regress (contract 1) |
 | `replaceRunningSnapshot` | there is no replace operation (contract 1) |
 | `runtimeProjectionCaughtUp` | the applied position is the answer (contract 1) |
 | `prepareRuntimeTurnReplay` / `asRuntimeReplayTurn` | an executing Turn has one writer (contract 2) |
@@ -113,6 +112,27 @@ criteria — a migration step that does not remove its entry has not finished.
 The 3s poll is **not** on this list. Events that never arrive advance no
 cursor, so no discontinuity is observable; the poll remains the liveness probe
 that notices a stream has gone quiet. It stops being a repair mechanism.
+
+### Two gaps the contract does not yet close
+
+Both were found by deleting a heuristic and watching a behavioural test fail.
+They are why `snapshotDropsProjectedTurnContent` and
+`isRunningSnapshotForwardProgress` survive, inside
+`persistedReadMayReplaceTurn`, as the last content comparison in the merge:
+
+- **A Host that serves no runtime projection.** Contract 2 hands an executing
+  Turn to the runtime stream, but an older Host has no such stream. Its
+  persisted checkpoint is the only progress that exists, so forward progress
+  from it is still admitted when `runtimeEventSnapshot` is absent.
+- **A partial history read.** History positions are turn ordinals, and a
+  windowed or not-yet-checkpointed read can name a Turn while carrying none of
+  its work. Such a read holds no position for the content it omitted, so
+  writing the Turn from it is lossy rather than advancing. Closing this needs
+  the read to report its own completeness; until then "would this write lose
+  content" is the only question available.
+
+Deleting either guard without first closing its gap reintroduces a real defect,
+not just a test failure.
 
 ## Migration
 

--- a/src/apps/cli/src/peer_host/commands/dialog.rs
+++ b/src/apps/cli/src/peer_host/commands/dialog.rs
@@ -1,6 +1,11 @@
 //! Dialog HostInvoke handlers.
 
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
 use serde_json::{json, Value};
+use tokio::sync::Mutex as AsyncMutex;
 
 use bitfun_runtime_ports::{
     AgentDialogTurnRequest, AgentSubmissionSource, AgentTurnCancellationRequest,
@@ -8,8 +13,63 @@ use bitfun_runtime_ports::{
 };
 
 use crate::peer_host::args::{get_string, optional_string, request_value};
-use crate::peer_host::control::{attached_controller_lease, is_controller_lease_current};
 use crate::peer_host::state::{PeerHostState, PeerTurnKey};
+
+/// How long a settled submission stays replayable. The controller's own
+/// bounded retry window is far shorter; this only has to outlive it.
+const DIALOG_SUBMISSION_TTL: Duration = Duration::from_secs(120);
+const MAX_CACHED_DIALOG_SUBMISSIONS: usize = 128;
+
+type DialogSubmissionOutcome = Arc<AsyncMutex<Option<Result<Value, String>>>>;
+
+struct CachedDialogSubmission {
+    expires_at: Instant,
+    outcome: DialogSubmissionOutcome,
+}
+
+fn dialog_submissions() -> &'static Mutex<HashMap<String, CachedDialogSubmission>> {
+    static DIALOG_SUBMISSIONS: OnceLock<Mutex<HashMap<String, CachedDialogSubmission>>> =
+        OnceLock::new();
+    DIALOG_SUBMISSIONS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Reserve the slot that records the outcome of one `(sessionId, turnId)`
+/// submission.
+///
+/// A Relay timeout leaves the controller unable to tell "never arrived" from
+/// "already running". Holding the outcome behind a per-identity async lock
+/// makes a replay wait for the original attempt and then observe its result,
+/// instead of starting the prompt a second time. Desktop Peer Hosts get this
+/// from the webview bridge's idempotency cache; a CLI Host has no webview, so
+/// it owns the same contract here.
+fn dialog_submission_slot(
+    session_id: &str,
+    turn_id: &str,
+) -> Result<DialogSubmissionOutcome, String> {
+    let mut submissions = dialog_submissions()
+        .lock()
+        .map_err(|_| "Peer dialog submission cache is unavailable".to_string())?;
+    let now = Instant::now();
+    submissions.retain(|_, entry| entry.expires_at > now);
+    while submissions.len() >= MAX_CACHED_DIALOG_SUBMISSIONS {
+        let Some(oldest) = submissions
+            .iter()
+            .min_by_key(|(_, entry)| entry.expires_at)
+            .map(|(key, _)| key.clone())
+        else {
+            break;
+        };
+        submissions.remove(&oldest);
+    }
+    Ok(submissions
+        .entry(format!("{session_id}:{turn_id}"))
+        .or_insert_with(|| CachedDialogSubmission {
+            expires_at: now + DIALOG_SUBMISSION_TTL,
+            outcome: Arc::new(AsyncMutex::new(None)),
+        })
+        .outcome
+        .clone())
+}
 
 fn peer_dialog_metadata(request: &Value) -> Result<serde_json::Map<String, Value>, String> {
     let mut metadata = match request.get("userMessageMetadata") {
@@ -37,6 +97,25 @@ pub(crate) async fn start_dialog_turn(
 ) -> Result<Value, String> {
     let request = request_value(args);
     let session_id = get_string(request, "sessionId")?;
+    // Only a client-supplied turn id gives the submission a stable identity.
+    // Without one there is nothing to deduplicate against — and the controller
+    // stays single-shot for exactly that reason.
+    let Some(turn_id) = optional_string(request, "turnId") else {
+        return submit_dialog_turn(state, args).await;
+    };
+    let outcome_slot = dialog_submission_slot(&session_id, &turn_id)?;
+    let mut outcome = outcome_slot.lock().await;
+    if let Some(settled) = outcome.as_ref() {
+        return settled.clone();
+    }
+    let result = submit_dialog_turn(state, args).await;
+    *outcome = Some(result.clone());
+    result
+}
+
+async fn submit_dialog_turn(state: &PeerHostState, args: &Value) -> Result<Value, String> {
+    let request = request_value(args);
+    let session_id = get_string(request, "sessionId")?;
     let user_input = get_string(request, "userInput")?;
     let original_user_input = optional_string(request, "originalUserInput");
     let agent_type = get_string(request, "agentType")?;
@@ -44,22 +123,23 @@ pub(crate) async fn start_dialog_turn(
         .or_else(|| optional_string(request, "workspacePath"));
     let remote_connection_id = optional_string(request, "remoteConnectionId");
     let remote_ssh_host = optional_string(request, "remoteSshHost");
-    let controller_lease = attached_controller_lease()?;
     let turn_id =
         optional_string(request, "turnId").unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
     let metadata = peer_dialog_metadata(request)?;
     let turn = PeerTurnKey::new(session_id.clone(), turn_id.clone());
     let stream_generation = state.turns.register_root(turn.clone())?;
+    // Controller presence is not an admission requirement. This host owns and
+    // keeps executing the Turn whether or not a controller is watching, exactly
+    // like a Turn submitted in its own TUI; a controller that leaves and comes
+    // back re-attaches to the same Runtime projection. Only this host's own
+    // event-stream continuity still gates submission, because a Turn nobody can
+    // observe is a Turn nobody can attach to.
     if !state
         .turns
         .is_event_stream_generation_current(stream_generation)
-        || !is_controller_lease_current(controller_lease)
     {
         state.turns.finish_turn(&turn);
-        return Err(
-            "Peer controller or event stream continuity was lost before dialog submission"
-                .to_string(),
-        );
+        return Err("Peer event stream continuity was lost before dialog submission".to_string());
     }
 
     let policy = DialogSubmissionPolicy::for_source(DialogTriggerSource::DesktopUi);
@@ -124,9 +204,10 @@ pub(crate) async fn cancel_dialog_turn(
     let request = request_value(args);
     let session_id = get_string(request, "sessionId")?;
     let dialog_turn_id = get_string(request, "dialogTurnId")?;
-    if !state.turns.owns(&session_id, Some(&dialog_turn_id)) {
-        return Err("The dialog turn is not owned by the Peer controller".to_string());
-    }
+    // Cancellation follows visibility: a controller renders every Turn in the
+    // Session, including ones this host started, so it must be able to stop
+    // them. A Desktop Peer Host reaches the same handler the local UI does and
+    // has never had an ownership gate here.
     state
         .agent_runtime
         .cancel_turn(AgentTurnCancellationRequest {
@@ -147,7 +228,7 @@ pub(crate) async fn cancel_dialog_turn(
 mod tests {
     use serde_json::json;
 
-    use super::peer_dialog_metadata;
+    use super::{dialog_submission_slot, peer_dialog_metadata};
 
     #[test]
     fn peer_metadata_removes_reserved_runtime_fields() {
@@ -195,5 +276,31 @@ mod tests {
 
         assert_eq!(metadata.get("kind"), Some(&json!("manual_compaction")));
         assert_eq!(metadata.get("sourceKind"), Some(&json!("user")));
+    }
+
+    #[tokio::test]
+    async fn a_replayed_submission_observes_the_first_attempt_instead_of_running_twice() {
+        let first = dialog_submission_slot("session-1", "turn-1").expect("first slot");
+        let mut outcome = first.lock().await;
+        assert!(outcome.is_none(), "a fresh identity has nothing to replay");
+        *outcome = Some(Ok(json!({ "success": true })));
+        drop(outcome);
+
+        // The Relay timed out, so the controller replays the exact payload. It
+        // must observe the recorded outcome, not submit the prompt again.
+        let replay = dialog_submission_slot("session-1", "turn-1").expect("replay slot");
+        assert_eq!(
+            replay.lock().await.clone(),
+            Some(Ok(json!({ "success": true }))),
+        );
+
+        // A different turn in the same Session is a different submission.
+        let other_turn = dialog_submission_slot("session-1", "turn-2").expect("other turn slot");
+        assert!(other_turn.lock().await.is_none());
+
+        // As is the same turn id under a different Session.
+        let other_session =
+            dialog_submission_slot("session-2", "turn-1").expect("other session slot");
+        assert!(other_session.lock().await.is_none());
     }
 }

--- a/src/apps/cli/src/peer_host/commands/mod.rs
+++ b/src/apps/cli/src/peer_host/commands/mod.rs
@@ -77,6 +77,7 @@ pub(crate) async fn dispatch(
         }
         "load_session_turn_window" => session::load_session_turn_window(state, args).await,
         "load_session_turns" => session::load_session_turns(state, args).await,
+        "load_session_event_backfill" => session::load_session_event_backfill(state, args),
         "restore_session_view" => session::restore_session_view(state, args).await,
         "restore_session_with_turns" => session::restore_session_with_turns(state, args).await,
         "restore_session" => session::restore_session(state, args).await,

--- a/src/apps/cli/src/peer_host/commands/permission.rs
+++ b/src/apps/cli/src/peer_host/commands/permission.rs
@@ -7,7 +7,6 @@ use bitfun_core::service::remote_ssh::workspace_state::resolve_workspace_session
 use bitfun_core::service::workspace::WorkspaceKind;
 
 use crate::peer_host::args::{get_string, request_value};
-use crate::peer_host::control::attached_controller_lease;
 use crate::peer_host::state::PeerHostState;
 
 fn permission_reply(request: &Value) -> Result<PermissionReply, String> {
@@ -64,16 +63,12 @@ pub(crate) fn list_pending_permission_requests(state: &PeerHostState) -> Result<
     let requests = state
         .agent_runtime
         .pending_permission_requests()
-        .map_err(|error| error.into_message())?
-        .into_iter()
-        .filter(|request| state.turns.owns_permission_request(request))
-        .collect::<Vec<_>>();
+        .map_err(|error| error.into_message())?;
     serde_json::to_value(requests)
         .map_err(|error| format!("Failed to serialize permission requests: {error}"))
 }
 
 pub(crate) fn subscribe_permission_requests() -> Result<Value, String> {
-    attached_controller_lease()?;
     Ok(Value::Null)
 }
 
@@ -81,22 +76,12 @@ pub(crate) async fn respond_permission(
     state: &PeerHostState,
     args: &Value,
 ) -> Result<Value, String> {
-    let lease = attached_controller_lease()?;
     let request = request_value(args);
     let request_id = get_string(request, "requestId")?;
-    let pending = state
-        .agent_runtime
-        .pending_permission_requests()
-        .map_err(|error| error.into_message())?
-        .into_iter()
-        .find(|pending| pending.request_id == request_id)
-        .ok_or_else(|| format!("Permission request not found: {request_id}"))?;
-    if !state.turns.owns_permission_request(&pending) {
-        return Err("The permission request is not owned by the Peer controller".to_string());
-    }
-    if !crate::peer_host::control::is_controller_lease_current(lease) {
-        return Err("Peer controller continuity was lost before permission response".to_string());
-    }
+    // Any attached surface of the account may answer any pending request on
+    // this host. The Runtime mailbox is the arbiter: it resolves exactly once,
+    // so a request answered in this host's TUI is simply gone by the time a
+    // second answer arrives, and `respond_permission` reports that itself.
     let reply = permission_reply(request)?;
     state
         .agent_runtime
@@ -110,22 +95,8 @@ pub(crate) async fn respond_permission_batch(
     state: &PeerHostState,
     args: &Value,
 ) -> Result<Value, String> {
-    let lease = attached_controller_lease()?;
     let request = request_value(args);
     let request_id = get_string(request, "requestId")?;
-    let pending = state
-        .agent_runtime
-        .pending_permission_requests()
-        .map_err(|error| error.into_message())?
-        .into_iter()
-        .find(|pending| pending.request_id == request_id)
-        .ok_or_else(|| format!("Permission request not found: {request_id}"))?;
-    if !state.turns.owns_permission_request(&pending) {
-        return Err("The permission request is not owned by the Peer controller".to_string());
-    }
-    if !crate::peer_host::control::is_controller_lease_current(lease) {
-        return Err("Peer controller continuity was lost before permission response".to_string());
-    }
     let reply = permission_reply(request)?;
     let resolved_request_ids = state
         .agent_runtime
@@ -155,7 +126,6 @@ pub(crate) async fn remove_project_permission_grant(
     state: &PeerHostState,
     args: &Value,
 ) -> Result<Value, String> {
-    attached_controller_lease()?;
     let request = request_value(args);
     let workspace_id = get_string(request, "workspaceId")?;
     let project_id = permission_project_id_for_workspace(state, &workspace_id).await?;
@@ -175,7 +145,6 @@ pub(crate) async fn clear_project_permission_grants(
     state: &PeerHostState,
     args: &Value,
 ) -> Result<Value, String> {
-    attached_controller_lease()?;
     let request = request_value(args);
     let workspace_id = get_string(request, "workspaceId")?;
     let project_id = permission_project_id_for_workspace(state, &workspace_id).await?;

--- a/src/apps/cli/src/peer_host/commands/session.rs
+++ b/src/apps/cli/src/peer_host/commands/session.rs
@@ -8,12 +8,12 @@ use serde_json::{json, Value};
 use bitfun_agent_runtime::sdk::{
     AgentSessionModelSelection, AgentSessionModelSelectionUpdateRequest,
     AgentSessionRestoreRequest, AgentSessionRestoreResult, PortErrorKind, RuntimeError,
-    SessionEventProjectionSnapshot,
+    SessionEventBackfill, SessionEventProjectionSnapshot,
 };
 use bitfun_core::agentic::core::Session;
 use bitfun_core::agentic::get_agent_registry;
 use bitfun_core::util::errors::BitFunError;
-use bitfun_events::project_agentic_frontend_event;
+use bitfun_events::{project_agentic_frontend_event, AgenticEvent};
 use bitfun_runtime_ports::{
     AgentSessionArchiveRequest, AgentSessionCreateRequest, AgentSessionDeleteRequest,
     AgentSessionModeUpdateRequest, AgentSessionRenameRequest, AgentThreadGoalGetRequest,
@@ -39,9 +39,8 @@ fn session_storage_request(request: &Value) -> Result<SessionStoragePathRequest,
     })
 }
 
-fn runtime_event_snapshot_to_json(snapshot: SessionEventProjectionSnapshot) -> Value {
-    let events = snapshot
-        .events
+fn frontend_events(events: Vec<AgenticEvent>) -> Vec<Value> {
+    events
         .into_iter()
         .filter_map(project_agentic_frontend_event)
         .map(|event| {
@@ -50,14 +49,56 @@ fn runtime_event_snapshot_to_json(snapshot: SessionEventProjectionSnapshot) -> V
                 "payload": event.payload,
             })
         })
-        .collect::<Vec<_>>();
+        .collect()
+}
+
+fn runtime_event_snapshot_to_json(snapshot: SessionEventProjectionSnapshot) -> Value {
     json!({
         "sessionId": snapshot.session_id,
         "streamId": snapshot.stream_id,
         "cursor": snapshot.cursor,
         "activeTurnId": snapshot.active_turn_id,
-        "events": events,
+        "events": frontend_events(snapshot.events),
     })
+}
+
+/// Project the incremental catch-up answer in the same event shape the
+/// snapshot uses, so a controller applies both through one path.
+///
+/// A Host with no journal cannot prove contiguity either, so it answers the
+/// same way an aged-out cursor does: take a snapshot.
+fn session_event_backfill_to_json(backfill: Option<SessionEventBackfill>) -> Value {
+    match backfill {
+        Some(SessionEventBackfill::Delta {
+            stream_id,
+            cursor,
+            events,
+        }) => json!({
+            "kind": "delta",
+            "streamId": stream_id,
+            "cursor": cursor,
+            "events": frontend_events(events),
+        }),
+        Some(SessionEventBackfill::SnapshotRequired) | None => json!({
+            "kind": "snapshotRequired",
+        }),
+    }
+}
+
+/// Serve everything a controller missed after the cursor it already applied.
+pub(crate) fn load_session_event_backfill(
+    state: &PeerHostState,
+    args: &Value,
+) -> Result<Value, String> {
+    let request = request_value(args);
+    let session_id = validated_session_id(request)?;
+    let stream_id = get_string(request, "streamId")?;
+    let cursor = request.get("cursor").and_then(Value::as_u64).unwrap_or(0);
+    Ok(session_event_backfill_to_json(
+        state
+            .agent_runtime
+            .session_events_since(&session_id, &stream_id, cursor),
+    ))
 }
 
 pub(super) fn ensure_session_workspace_runtime_ownership(

--- a/src/apps/cli/src/peer_host/commands/session.rs
+++ b/src/apps/cli/src/peer_host/commands/session.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use bitfun_agent_runtime::sdk::{
     AgentSessionModelSelection, AgentSessionModelSelectionUpdateRequest,
     AgentSessionRestoreRequest, AgentSessionRestoreResult, PortErrorKind, RuntimeError,
-    SessionEventProjectionSnapshot, SessionInteractionSnapshot,
+    SessionEventProjectionSnapshot,
 };
 use bitfun_core::agentic::core::Session;
 use bitfun_core::agentic::get_agent_registry;
@@ -22,7 +22,7 @@ use bitfun_runtime_ports::{
 
 use crate::diagnostics::{OUTCOME_UNKNOWN_ERROR_CODE, SESSION_IN_USE_ERROR_CODE};
 use crate::peer_host::args::{get_string, optional_bool, optional_string, request_value};
-use crate::peer_host::state::{PeerHostState, PeerTurnTracker};
+use crate::peer_host::state::PeerHostState;
 
 use super::snapshot::{local_snapshot_session_stats, require_local_snapshot_workspace};
 
@@ -94,22 +94,6 @@ fn validated_session_id(request: &Value) -> Result<String, String> {
     let session_id = get_string(request, "sessionId")?;
     bitfun_agent_runtime::session_control::validate_session_id(&session_id)?;
     Ok(session_id)
-}
-
-fn retain_peer_owned_interactions(
-    turns: &PeerTurnTracker,
-    snapshot: &mut SessionInteractionSnapshot,
-) {
-    snapshot.user_questions.questions.retain(|question| {
-        question
-            .dialog_turn_id
-            .as_deref()
-            .is_some_and(|turn_id| turns.owns(&question.session_id, Some(turn_id)))
-    });
-    snapshot
-        .permissions
-        .requests
-        .retain(|request| turns.owns_permission_request(request));
 }
 
 fn system_time_to_unix_secs(time: SystemTime) -> u64 {
@@ -306,23 +290,17 @@ pub(crate) async fn restore_session_view(
         .loaded_session_snapshot(&session_id)
         .map_err(|e| format!("Failed to read live session state: {e}"))?;
     overlay_live_session_state(&mut session, live_session);
-    let mut interaction_snapshot = state
+    // The Session is the account's, not one controller's. Every attached
+    // surface of the same account resumes the same blocking interactions and
+    // the same live Turn projection, including work this host started in its
+    // own TUI — otherwise a controller renders a Turn it can watch but never
+    // answer. The Runtime mailbox remains the arbiter for double answers.
+    let interaction_snapshot = state
         .agent_runtime
         .session_interaction_snapshot(&session_id);
-    // A CLI Peer controller may only resume interactions owned by turns it
-    // submitted (or their tracked descendants). Keep snapshot recovery inside
-    // the same boundary as permission event fan-out/listing; otherwise a
-    // controller could answer a same-session turn started by another surface.
-    retain_peer_owned_interactions(&state.turns, &mut interaction_snapshot);
     let runtime_event_snapshot = state
         .agent_runtime
         .session_event_projection_snapshot(&session_id)
-        .filter(|snapshot| {
-            snapshot
-                .active_turn_id
-                .as_ref()
-                .is_none_or(|turn_id| state.turns.owns(&session_id, Some(turn_id.as_str())))
-        })
         .map(runtime_event_snapshot_to_json);
 
     let loaded_turn_count = turns.len();
@@ -765,14 +743,11 @@ pub(crate) async fn save_session_turn(
 mod tests {
     use super::{
         overlay_live_session_state, peer_core_session_error, peer_runtime_session_error,
-        restored_session_to_json, retain_peer_owned_interactions, runtime_event_snapshot_to_json,
-        session_stats_validation_error,
+        restored_session_to_json, runtime_event_snapshot_to_json, session_stats_validation_error,
     };
-    use crate::peer_host::state::{PeerTurnKey, PeerTurnTracker};
     use bitfun_agent_runtime::sdk::{
-        AgentSessionRestoreResult, AgentSessionSummary, PendingUserQuestion,
-        PendingUserQuestionSnapshot, PortError, PortErrorKind, RuntimeError,
-        SessionEventProjectionSnapshot, SessionInteractionSnapshot, SessionState,
+        AgentSessionRestoreResult, AgentSessionSummary, PortError, PortErrorKind, RuntimeError,
+        SessionEventProjectionSnapshot, SessionState,
     };
     use bitfun_core::agentic::core::{
         ProcessingPhase, Session as CoreSession, SessionConfig, SessionState as CoreSessionState,
@@ -955,48 +930,5 @@ mod tests {
                 ..
             } if current_turn_id == "turn_1"
         ));
-    }
-
-    #[test]
-    fn view_restore_exposes_only_peer_owned_user_questions() {
-        let tracker = PeerTurnTracker::new();
-        tracker.mark_event_stream_ready();
-        let owned_turn = PeerTurnKey::new("session-1", "peer-turn");
-        tracker
-            .register_root(owned_turn)
-            .expect("register Peer-owned turn");
-        let question = |tool_id: &str, turn_id: Option<&str>| {
-            PendingUserQuestion::new(
-                tool_id,
-                "session-1",
-                turn_id.map(str::to_string),
-                Some("round-1".to_string()),
-                serde_json::json!({"questions": []}),
-            )
-        };
-        let mut snapshot = SessionInteractionSnapshot {
-            session_id: "session-1".to_string(),
-            user_questions: PendingUserQuestionSnapshot {
-                revision: 3,
-                questions: vec![
-                    question("owned", Some("peer-turn")),
-                    question("local", Some("local-turn")),
-                    question("unscoped", None),
-                ],
-            },
-            permissions: Default::default(),
-        };
-
-        retain_peer_owned_interactions(&tracker, &mut snapshot);
-
-        assert_eq!(
-            snapshot
-                .user_questions
-                .questions
-                .iter()
-                .map(|question| question.tool_id.as_str())
-                .collect::<Vec<_>>(),
-            vec!["owned"]
-        );
     }
 }

--- a/src/apps/cli/src/peer_host/commands/session.rs
+++ b/src/apps/cli/src/peer_host/commands/session.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use bitfun_agent_runtime::sdk::{
     AgentSessionModelSelection, AgentSessionModelSelectionUpdateRequest,
     AgentSessionRestoreRequest, AgentSessionRestoreResult, PortErrorKind, RuntimeError,
-    SessionEventBackfill, SessionEventProjectionSnapshot,
+    SessionEventBackfill, SessionEventProjectionSnapshot, SessionInteractionSnapshot,
 };
 use bitfun_core::agentic::core::Session;
 use bitfun_core::agentic::get_agent_registry;
@@ -67,7 +67,10 @@ fn runtime_event_snapshot_to_json(snapshot: SessionEventProjectionSnapshot) -> V
 ///
 /// A Host with no journal cannot prove contiguity either, so it answers the
 /// same way an aged-out cursor does: take a snapshot.
-fn session_event_backfill_to_json(backfill: Option<SessionEventBackfill>) -> Value {
+fn session_event_backfill_to_json(
+    backfill: Option<SessionEventBackfill>,
+    interaction_snapshot: SessionInteractionSnapshot,
+) -> Value {
     match backfill {
         Some(SessionEventBackfill::Delta {
             stream_id,
@@ -78,6 +81,10 @@ fn session_event_backfill_to_json(backfill: Option<SessionEventBackfill>) -> Val
             "streamId": stream_id,
             "cursor": cursor,
             "events": frontend_events(events),
+            // Replaying events rebuilds the card; only the mailbox makes it
+            // answerable. A catch-up that skipped this left a blocking
+            // interaction on screen that no surface could resolve.
+            "interactionSnapshot": interaction_snapshot,
         }),
         Some(SessionEventBackfill::SnapshotRequired) | None => json!({
             "kind": "snapshotRequired",
@@ -98,6 +105,9 @@ pub(crate) fn load_session_event_backfill(
         state
             .agent_runtime
             .session_events_since(&session_id, &stream_id, cursor),
+        state
+            .agent_runtime
+            .session_interaction_snapshot(&session_id),
     ))
 }
 

--- a/src/apps/cli/src/peer_host/control.rs
+++ b/src/apps/cli/src/peer_host/control.rs
@@ -11,12 +11,6 @@ use bitfun_core::service::remote_connect::DeviceIdentity;
 #[derive(Default)]
 struct ControllerRegistry {
     ids: HashSet<String>,
-    generation: u64,
-}
-
-#[derive(Clone, Copy)]
-pub(crate) struct ControllerLease {
-    generation: u64,
 }
 
 static CONTROL_SUBSCRIBERS: OnceLock<Mutex<ControllerRegistry>> = OnceLock::new();
@@ -78,11 +72,7 @@ pub(crate) async fn controller_delivery_lease(
 
 fn detach_from_registry(registry: &mut ControllerRegistry, device_id: &str) -> bool {
     let was_attached = registry.ids.remove(device_id);
-    let lost_all = was_attached && registry.ids.is_empty();
-    if lost_all {
-        registry.generation = registry.generation.wrapping_add(1);
-    }
-    lost_all
+    was_attached && registry.ids.is_empty()
 }
 
 fn retain_online_in_registry(registry: &mut ControllerRegistry, online: &HashSet<&str>) -> bool {
@@ -90,30 +80,7 @@ fn retain_online_in_registry(registry: &mut ControllerRegistry, online: &HashSet
     registry
         .ids
         .retain(|device_id| online.contains(device_id.as_str()));
-    let lost_all = had_controllers && registry.ids.is_empty();
-    if lost_all {
-        registry.generation = registry.generation.wrapping_add(1);
-    }
-    lost_all
-}
-
-pub(crate) fn attached_controller_lease() -> Result<ControllerLease, String> {
-    let registry = control_subscribers()
-        .lock()
-        .map_err(|_| "Peer controller registry is unavailable".to_string())?;
-    if registry.ids.is_empty() {
-        return Err("A Peer controller must attach before starting a dialog turn".to_string());
-    }
-    Ok(ControllerLease {
-        generation: registry.generation,
-    })
-}
-
-pub(crate) fn is_controller_lease_current(lease: ControllerLease) -> bool {
-    control_subscribers()
-        .lock()
-        .map(|registry| !registry.ids.is_empty() && registry.generation == lease.generation)
-        .unwrap_or(false)
+    had_controllers && registry.ids.is_empty()
 }
 
 pub(crate) fn attached_controllers() -> Vec<String> {
@@ -134,6 +101,7 @@ pub(crate) fn peer_mode_ping_value() -> Value {
         "peer": true,
         "device_id": device_id,
         "capabilities": {
+            "idempotent_dialog_submit": true,
             "targeted_session_rollback": true,
         },
     })
@@ -160,25 +128,16 @@ mod tests {
 
     use super::{
         attach_controller, controller_delivery_lease, detach_controller, detach_from_registry,
-        retain_online_in_registry, ControllerLease, ControllerRegistry,
+        retain_online_in_registry, ControllerRegistry,
     };
-
-    fn lease_is_current(registry: &ControllerRegistry, lease: ControllerLease) -> bool {
-        !registry.ids.is_empty() && registry.generation == lease.generation
-    }
 
     #[test]
     fn only_the_last_detach_reports_loss_of_all_controllers() {
         let mut registry = ControllerRegistry {
             ids: HashSet::from(["controller-1".to_string(), "controller-2".to_string()]),
-            generation: 0,
         };
-        let lease = ControllerLease { generation: 0 };
-
         assert!(!detach_from_registry(&mut registry, "controller-1"));
-        assert!(lease_is_current(&registry, lease));
         assert!(detach_from_registry(&mut registry, "controller-2"));
-        assert!(!lease_is_current(&registry, lease));
         assert!(!detach_from_registry(&mut registry, "controller-2"));
     }
 
@@ -186,32 +145,11 @@ mod tests {
     fn presence_removal_reports_when_the_last_controller_goes_offline() {
         let mut registry = ControllerRegistry {
             ids: HashSet::from(["controller-1".to_string(), "controller-2".to_string()]),
-            generation: 0,
         };
         let first_online = HashSet::from(["controller-1"]);
         assert!(!retain_online_in_registry(&mut registry, &first_online));
 
         assert!(retain_online_in_registry(&mut registry, &HashSet::new()));
-    }
-
-    #[test]
-    fn reattach_does_not_revalidate_a_lease_from_before_the_last_detach() {
-        let mut registry = ControllerRegistry {
-            ids: HashSet::from(["controller-1".to_string()]),
-            generation: 7,
-        };
-        let old_lease = ControllerLease { generation: 7 };
-
-        assert!(detach_from_registry(&mut registry, "controller-1"));
-        registry.ids.insert("controller-2".to_string());
-
-        assert!(!lease_is_current(&registry, old_lease));
-        assert!(lease_is_current(
-            &registry,
-            ControllerLease {
-                generation: registry.generation,
-            }
-        ));
     }
 
     #[tokio::test]

--- a/src/apps/cli/src/peer_host/fanout.rs
+++ b/src/apps/cli/src/peer_host/fanout.rs
@@ -1,4 +1,8 @@
 //! DeviceEvent fan-out to attached Peer Mode controllers.
+//!
+//! Every agentic event this host produces is journaled and forwarded, not
+//! only the Turns a controller submitted. Peer ownership is a cancellation
+//! and bookkeeping boundary; it is not a visibility boundary.
 
 use std::collections::HashSet;
 use std::sync::OnceLock;
@@ -72,6 +76,26 @@ fn continuity_is_current(continuity: &Option<(super::state::PeerTurnTracker, u64
         .is_none_or(|(turns, generation)| turns.is_event_stream_generation_current(*generation))
 }
 
+/// Resolve the ownership bookkeeping an event carries, after visibility has
+/// already been decided without it.
+///
+/// Peer ownership answers "may this host release Peer tracking for the Turn and
+/// dedup its terminal delivery", never "may a controller see this". This host is
+/// a Peer of the account, not a remote-execution proxy for one controller: a
+/// Turn started in its own TUI belongs to the same Session an attached
+/// controller renders, so it is journaled and forwarded like any other. Note
+/// the return type — an unowned Turn yields no bookkeeping, and "suppress the
+/// event" is deliberately not expressible through this seam.
+fn owned_terminal_turn(
+    turns: &super::state::PeerTurnTracker,
+    session_id: &str,
+    event_turn: Option<&PeerTurnKey>,
+    terminal_turn: Option<PeerTurnKey>,
+) -> Option<PeerTurnKey> {
+    let peer_owned = turns.owns(session_id, event_turn.map(|turn| turn.turn_id.as_str()));
+    terminal_turn.filter(|_| peer_owned)
+}
+
 fn settle_record_only_event(turns: &super::state::PeerTurnTracker, terminal: Option<&PeerTurnKey>) {
     if let Some(turn) = terminal {
         turns.finish_turn(turn);
@@ -92,7 +116,7 @@ fn peer_event_sender() -> &'static mpsc::Sender<QueuedPeerDeviceEvent> {
     })
 }
 
-/// Subscribe to the invocation-scoped event source and forward only Peer-owned turns.
+/// Subscribe to the invocation-scoped event source and forward this host's turns.
 pub(crate) fn start_peer_event_fanout(state: PeerHostState, mut rx: AgentEventReceiver) {
     start_peer_permission_event_fanout(state.clone());
     state.turns.mark_event_stream_ready();
@@ -139,20 +163,22 @@ fn start_peer_permission_event_fanout(state: PeerHostState) {
         return;
     };
     tokio::spawn(async move {
-        let mut owned_request_ids = HashSet::new();
+        // Every pending request on this host is forwarded, not only the ones a
+        // controller's own Turn raised. A controller rendering a Turn this host
+        // started locally would otherwise watch it block forever with nothing
+        // on screen to answer. The Runtime mailbox stays the single arbiter, so
+        // whichever surface answers first settles the request.
+        let mut forwarded_request_ids = HashSet::new();
         loop {
             match receiver.recv().await {
                 Ok(event) => match &event {
                     PermissionRequestEvent::Asked { request } => {
-                        if !state.turns.owns_permission_request(request) {
-                            continue;
-                        }
-                        owned_request_ids.insert(request.request_id.clone());
+                        forwarded_request_ids.insert(request.request_id.clone());
                         fanout_permission_event(event).await;
                     }
                     PermissionRequestEvent::Replied { request_id, .. }
                     | PermissionRequestEvent::Cancelled { request_id, .. } => {
-                        if owned_request_ids.remove(request_id) {
+                        if forwarded_request_ids.remove(request_id) {
                             fanout_permission_event(event).await;
                         }
                     }
@@ -162,15 +188,12 @@ fn start_peer_permission_event_fanout(state: PeerHostState) {
                     let pending = state
                         .agent_runtime
                         .pending_permission_requests()
-                        .unwrap_or_default()
-                        .into_iter()
-                        .filter(|request| state.turns.owns_permission_request(request))
-                        .collect::<Vec<_>>();
+                        .unwrap_or_default();
                     let pending_ids = pending
                         .iter()
                         .map(|request| request.request_id.clone())
                         .collect::<HashSet<_>>();
-                    let stale_request_ids = owned_request_ids
+                    let stale_request_ids = forwarded_request_ids
                         .difference(&pending_ids)
                         .cloned()
                         .collect::<Vec<_>>();
@@ -181,7 +204,7 @@ fn start_peer_permission_event_fanout(state: PeerHostState) {
                         })
                         .await;
                     }
-                    owned_request_ids = pending_ids;
+                    forwarded_request_ids = pending_ids;
                     for request in pending {
                         fanout_permission_event(PermissionRequestEvent::Asked { request }).await;
                     }
@@ -297,23 +320,20 @@ async fn handle_agentic_event(state: &PeerHostState, event: AgenticEvent) -> Res
     }
 
     if matches!(&event, AgenticEvent::DialogTurnStarted { .. }) {
-        let Some(turn) = event_turn.as_ref() else {
-            return Ok(());
-        };
-        if !state.turns.mark_started(turn) {
-            return Ok(());
+        if let Some(turn) = event_turn.as_ref() {
+            // Only a Peer-registered root enters `started`. A Turn this host
+            // started on its own has no Peer ownership to record, and that is
+            // not a reason to hide it.
+            state.turns.mark_started(turn);
         }
     }
 
     let Some(session_id) = event.session_id() else {
         return Ok(());
     };
-    if !state.turns.owns(
-        session_id,
-        event_turn.as_ref().map(|turn| turn.turn_id.as_str()),
-    ) {
-        return Ok(());
-    }
+
+    let terminal_turn =
+        owned_terminal_turn(&state.turns, session_id, event_turn.as_ref(), terminal_turn);
     if let Some(turn) = terminal_turn.as_ref() {
         if !state.turns.claim_terminal_delivery(turn)? {
             return Ok(());
@@ -745,8 +765,8 @@ mod tests {
     use super::{
         continuity_is_current, drain_broadcast_receiver, enqueue_inherited_peer_device_event,
         enqueue_peer_device_event, event_turn_key, interrupted_turn_failure_projection,
-        retained_delivery_targets, settle_record_only_event, QueuedPeerDeviceEvent,
-        TerminalDeliveryGuard,
+        owned_terminal_turn, retained_delivery_targets, settle_record_only_event,
+        QueuedPeerDeviceEvent, TerminalDeliveryGuard,
     };
     use crate::peer_host::state::{PeerTurnKey, PeerTurnTracker};
 
@@ -981,5 +1001,42 @@ mod tests {
 
         assert!(!drain_broadcast_receiver(&mut rx));
         assert!(turns.register_root(turn).is_err());
+    }
+
+    #[test]
+    fn a_locally_started_turn_carries_no_peer_bookkeeping_and_is_still_forwarded() {
+        let tracker = PeerTurnTracker::new();
+        tracker.mark_event_stream_ready();
+        let peer_turn = PeerTurnKey::new("session-1", "peer-turn");
+        tracker
+            .register_root(peer_turn.clone())
+            .expect("register Peer-owned turn");
+        let local_turn = PeerTurnKey::new("session-1", "local-turn");
+
+        // A Turn the controller submitted still settles Peer tracking on its
+        // terminal event.
+        assert_eq!(
+            owned_terminal_turn(
+                &tracker,
+                "session-1",
+                Some(&peer_turn),
+                Some(peer_turn.clone()),
+            ),
+            Some(peer_turn),
+        );
+
+        // A Turn this host started on its own has no Peer tracking to settle.
+        // The caller keeps journaling and forwarding it regardless: there is no
+        // value of this function that means "drop the event".
+        assert_eq!(
+            owned_terminal_turn(
+                &tracker,
+                "session-1",
+                Some(&local_turn),
+                Some(local_turn.clone()),
+            ),
+            None,
+        );
+        assert!(!tracker.owns("session-1", Some("local-turn")));
     }
 }

--- a/src/apps/cli/src/peer_host/state.rs
+++ b/src/apps/cli/src/peer_host/state.rs
@@ -3,7 +3,6 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex, OnceLock};
 
-use bitfun_agent_runtime::sdk::PermissionRequest;
 use bitfun_agent_runtime::sdk::{AgentRuntime, SessionEventJournal};
 use bitfun_core::product_runtime::CoreAgentRuntimeCompatibility;
 use bitfun_core::service::filesystem::FileSystemService;
@@ -402,14 +401,6 @@ impl PeerTurnTracker {
                 None => inner.started.iter().any(|key| key.session_id == session_id),
             })
             .unwrap_or(false)
-    }
-
-    pub(crate) fn owns_permission_request(&self, request: &PermissionRequest) -> bool {
-        self.owns(&request.session_id, None)
-            || request
-                .delegation
-                .as_ref()
-                .is_some_and(|delegation| self.owns(&delegation.parent_session_id, None))
     }
 
     pub(crate) fn mark_started(&self, key: &PeerTurnKey) -> bool {
@@ -1080,11 +1071,6 @@ pub(crate) fn peer_host_state() -> Result<&'static PeerHostState, String> {
 mod tests {
     use std::collections::HashSet;
 
-    use bitfun_agent_runtime::sdk::{
-        PermissionDelegationContext, PermissionRequest, PermissionRequestSource,
-        PermissionRequestSourceKind,
-    };
-
     use super::{aggregate_cancellation_results, PeerTurnKey, PeerTurnTracker};
 
     fn register_background_child(
@@ -1099,33 +1085,6 @@ mod tests {
         assert!(tracker
             .register_linked_child(parent, child, &tool_call_id)
             .expect("register background child"));
-    }
-
-    fn permission_request(session_id: &str, parent_session_id: Option<&str>) -> PermissionRequest {
-        PermissionRequest {
-            request_id: format!("request-{session_id}"),
-            round_id: format!("synthetic:request-{session_id}"),
-            order: 0,
-            tool_call_id: Some("tool-call".to_string()),
-            project_path: None,
-            project_id: "project".to_string(),
-            session_id: session_id.to_string(),
-            agent_id: "Explore".to_string(),
-            action: "read".to_string(),
-            resources: vec!["README.md".to_string()],
-            save_resources: Vec::new(),
-            source: PermissionRequestSource {
-                kind: PermissionRequestSourceKind::ToolCall,
-                identity: "Read".to_string(),
-            },
-            delegation: parent_session_id.map(|parent_session_id| PermissionDelegationContext {
-                parent_session_id: parent_session_id.to_string(),
-                parent_dialog_turn_id: Some("parent-turn".to_string()),
-                parent_tool_call_id: "parent-task".to_string(),
-                subagent_type: "Explore".to_string(),
-            }),
-            display_metadata: serde_json::Map::new(),
-        }
     }
 
     #[test]
@@ -1156,23 +1115,6 @@ mod tests {
             vec![turn.clone()]
         );
         assert!(tracker.register_root(turn).is_err());
-    }
-
-    #[test]
-    fn permission_ownership_includes_delegated_child_requests_without_leaking_unrelated_sessions() {
-        let tracker = PeerTurnTracker::new();
-        tracker.mark_event_stream_ready();
-        let root = PeerTurnKey::new("parent-session", "parent-turn");
-        tracker.register_root(root.clone()).expect("register root");
-        assert!(tracker.mark_started(&root));
-
-        assert!(tracker.owns_permission_request(&permission_request("parent-session", None)));
-        assert!(tracker
-            .owns_permission_request(
-                &permission_request("child-session", Some("parent-session"),)
-            ));
-        assert!(!tracker
-            .owns_permission_request(&permission_request("other-child", Some("other-parent"),)));
     }
 
     #[test]

--- a/src/apps/desktop/src/api/agentic_api.rs
+++ b/src/apps/desktop/src/api/agentic_api.rs
@@ -613,11 +613,18 @@ pub enum FrontendSessionEventBackfill {
         stream_id: String,
         cursor: u64,
         events: Vec<FrontendProjectedAgenticEvent>,
+        /// Replaying events rebuilds a blocking interaction's card; only the
+        /// mailbox makes it answerable. A catch-up that skipped this left the
+        /// card on screen with no surface able to resolve it.
+        interaction_snapshot: SessionInteractionSnapshot,
     },
     SnapshotRequired,
 }
 
-fn session_event_backfill_to_response(backfill: Option<SessionEventBackfill>) -> serde_json::Value {
+fn session_event_backfill_to_response(
+    backfill: Option<SessionEventBackfill>,
+    interaction_snapshot: SessionInteractionSnapshot,
+) -> serde_json::Value {
     let projected = match backfill {
         Some(SessionEventBackfill::Delta {
             stream_id,
@@ -626,6 +633,7 @@ fn session_event_backfill_to_response(backfill: Option<SessionEventBackfill>) ->
         }) => FrontendSessionEventBackfill::Delta {
             stream_id,
             cursor,
+            interaction_snapshot,
             events: events
                 .into_iter()
                 .filter_map(bitfun_events::project_agentic_frontend_event)
@@ -3619,6 +3627,9 @@ pub async fn load_session_event_backfill(
             &request.stream_id,
             request.cursor,
         ),
+        runtime
+            .session_application()
+            .session_interaction_snapshot(&request.session_id),
     ))
 }
 

--- a/src/apps/desktop/src/api/agentic_api.rs
+++ b/src/apps/desktop/src/api/agentic_api.rs
@@ -22,7 +22,7 @@ use bitfun_agent_runtime::sdk::{
     AgentSessionModelSelectionUpdateRequest, AgentSessionModelUpdateRequest, AgentSubmissionSource,
     AgentTurnCancellationRequest, AgentTurnInterruptionRequest, DialogSteerOutcome,
     PermissionAuditRecord, PermissionGrant, PermissionGrantKey, PermissionReply, PermissionRequest,
-    RuntimeError, SessionEventProjectionSnapshot, SessionInteractionSnapshot,
+    RuntimeError, SessionEventBackfill, SessionEventProjectionSnapshot, SessionInteractionSnapshot,
 };
 use bitfun_core::agentic::agents::AgentSource;
 use bitfun_core::agentic::coordination::{
@@ -602,6 +602,48 @@ fn frontend_event_projection_snapshot(
             })
             .collect(),
     }
+}
+
+/// Incremental catch-up answer, in the same event shape the snapshot uses so a
+/// client applies both through one path.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+pub enum FrontendSessionEventBackfill {
+    Delta {
+        stream_id: String,
+        cursor: u64,
+        events: Vec<FrontendProjectedAgenticEvent>,
+    },
+    SnapshotRequired,
+}
+
+fn session_event_backfill_to_response(backfill: Option<SessionEventBackfill>) -> serde_json::Value {
+    let projected = match backfill {
+        Some(SessionEventBackfill::Delta {
+            stream_id,
+            cursor,
+            events,
+        }) => FrontendSessionEventBackfill::Delta {
+            stream_id,
+            cursor,
+            events: events
+                .into_iter()
+                .filter_map(bitfun_events::project_agentic_frontend_event)
+                .map(|event| FrontendProjectedAgenticEvent {
+                    event_name: event.event_name,
+                    payload: event.payload,
+                })
+                .collect(),
+        },
+        Some(SessionEventBackfill::SnapshotRequired) | None => {
+            FrontendSessionEventBackfill::SnapshotRequired
+        }
+    };
+    serde_json::to_value(projected).unwrap_or_else(|_| {
+        serde_json::json!({
+            "kind": "snapshotRequired",
+        })
+    })
 }
 
 #[derive(Debug, Default)]
@@ -3550,6 +3592,34 @@ pub async fn restore_session_view(
     .await;
     startup_trace.record_tauri_command_elapsed("restore_session_view", None, started_at);
     result
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LoadSessionEventBackfillRequest {
+    pub session_id: String,
+    pub stream_id: String,
+    #[serde(default)]
+    pub cursor: u64,
+}
+
+/// Serve everything a client missed after the cursor it already applied.
+///
+/// The journal answers either with a contiguous delta or with
+/// `snapshotRequired`; a Host with no journal cannot prove contiguity and
+/// answers the same way an aged-out cursor does.
+#[tauri::command]
+pub async fn load_session_event_backfill(
+    runtime: State<'_, DesktopRuntimeContext>,
+    request: LoadSessionEventBackfillRequest,
+) -> Result<serde_json::Value, String> {
+    Ok(session_event_backfill_to_response(
+        runtime.session_application().session_events_since(
+            &request.session_id,
+            &request.stream_id,
+            request.cursor,
+        ),
+    ))
 }
 
 #[tauri::command]

--- a/src/apps/desktop/src/api/remote_workspace_policy.rs
+++ b/src/apps/desktop/src/api/remote_workspace_policy.rs
@@ -975,6 +975,10 @@ pub const REMOTE_WORKSPACE_COMMAND_POLICIES: &[(&str, RemoteWorkspacePolicy)] = 
         RemoteWorkspacePolicy::LegacyUnaudited,
     ),
     (
+        "load_session_event_backfill",
+        RemoteWorkspacePolicy::WorkspaceAgnostic,
+    ),
+    (
         "load_session_turn_window",
         RemoteWorkspacePolicy::RemoteRouted,
     ),

--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -1255,6 +1255,7 @@ pub async fn run() {
             api::agentic_api::delete_session,
             api::agentic_api::restore_session,
             api::agentic_api::restore_session_view,
+            api::agentic_api::load_session_event_backfill,
             api::agentic_api::load_session_turn_window,
             api::agentic_api::restore_session_with_turns,
             api::agentic_api::reset_memory,

--- a/src/apps/desktop/src/runtime/session_application.rs
+++ b/src/apps/desktop/src/runtime/session_application.rs
@@ -13,8 +13,8 @@ use bitfun_agent_runtime::sdk::{
     AgentLocalCommandTurnRecordRequest, AgentRuntime, AgentSessionArchiveStateRequest,
     AgentSessionDeleteRequest, AgentSessionForkAtTurnRequest, AgentSessionLineageRequest,
     AgentSessionLineageSnapshot, AgentSessionRenameRequest, AgentSessionUsageRequest,
-    PortErrorKind, RuntimeError, SessionEventJournal, SessionEventProjectionSnapshot,
-    SessionInteractionSnapshot,
+    PortErrorKind, RuntimeError, SessionEventBackfill, SessionEventJournal,
+    SessionEventProjectionSnapshot, SessionInteractionSnapshot,
 };
 use bitfun_core::agentic::coordination::{ConversationCoordinator, DialogScheduler};
 use bitfun_core::agentic::core::Session;
@@ -758,6 +758,20 @@ impl DesktopSessionApplication {
             .restore_session_from_storage_path(&storage_path, session_id, include_internal)
             .await
             .map_err(desktop_core_session_error)
+    }
+
+    /// Incremental catch-up for a client that already applied up to `cursor`.
+    ///
+    /// Workspace-agnostic: the journal belongs to this Runtime Host, not to any
+    /// workspace filesystem, so no session scope is resolved here.
+    pub(crate) fn session_events_since(
+        &self,
+        session_id: &str,
+        stream_id: &str,
+        cursor: u64,
+    ) -> Option<SessionEventBackfill> {
+        self.agent_runtime
+            .session_events_since(session_id, stream_id, cursor)
     }
 
     pub(crate) async fn restore_session_view<F>(

--- a/src/apps/desktop/src/runtime/session_application.rs
+++ b/src/apps/desktop/src/runtime/session_application.rs
@@ -760,6 +760,13 @@ impl DesktopSessionApplication {
             .map_err(desktop_core_session_error)
     }
 
+    pub(crate) fn session_interaction_snapshot(
+        &self,
+        session_id: &str,
+    ) -> SessionInteractionSnapshot {
+        self.agent_runtime.session_interaction_snapshot(session_id)
+    }
+
     /// Incremental catch-up for a client that already applied up to `cursor`.
     ///
     /// Workspace-agnostic: the journal belongs to this Runtime Host, not to any

--- a/src/crates/execution/agent-runtime/src/runtime.rs
+++ b/src/crates/execution/agent-runtime/src/runtime.rs
@@ -55,7 +55,7 @@ use bitfun_runtime_ports::{PermissionReply, PermissionReplySource, PermissionReq
 #[path = "session_event_journal.rs"]
 mod session_event_journal;
 pub use session_event_journal::{
-    attach_session_event_cursor, SessionEventCursor, SessionEventJournal,
+    attach_session_event_cursor, SessionEventBackfill, SessionEventCursor, SessionEventJournal,
     SessionEventProjectionSnapshot, SessionEventProjectionStore, StoredSessionEvents,
     RUNTIME_EVENT_CURSOR_KEY, RUNTIME_EVENT_STREAM_ID_KEY,
 };
@@ -910,6 +910,22 @@ impl AgentRuntime {
         self.session_event_journal
             .as_ref()
             .map(|journal| journal.snapshot(session_id))
+    }
+
+    /// Incremental catch-up for a client that already applied up to `cursor`.
+    ///
+    /// Prefer this over a snapshot when a client detects a delivery gap: it
+    /// returns only what was missed, so a live projection is repaired instead
+    /// of rebuilt.
+    pub fn session_events_since(
+        &self,
+        session_id: &str,
+        stream_id: &str,
+        cursor: u64,
+    ) -> Option<SessionEventBackfill> {
+        self.session_event_journal
+            .as_ref()
+            .map(|journal| journal.events_since(session_id, stream_id, cursor))
     }
 
     pub fn permission_request_dialog_turn_id(

--- a/src/crates/execution/agent-runtime/src/sdk.rs
+++ b/src/crates/execution/agent-runtime/src/sdk.rs
@@ -45,7 +45,7 @@ pub use crate::post_call_hooks::{
     RuntimeHookRegistryBuildError,
 };
 pub use crate::runtime::{
-    attach_session_event_cursor, SessionEventCursor, SessionEventJournal,
+    attach_session_event_cursor, SessionEventBackfill, SessionEventCursor, SessionEventJournal,
     SessionEventProjectionSnapshot, SessionEventProjectionStore, StoredSessionEvents,
     RUNTIME_EVENT_CURSOR_KEY, RUNTIME_EVENT_STREAM_ID_KEY,
 };
@@ -782,6 +782,16 @@ impl AgentRuntime {
         session_id: &str,
     ) -> Option<SessionEventProjectionSnapshot> {
         self.inner.session_event_projection_snapshot(session_id)
+    }
+
+    pub fn session_events_since(
+        &self,
+        session_id: &str,
+        stream_id: &str,
+        cursor: u64,
+    ) -> Option<SessionEventBackfill> {
+        self.inner
+            .session_events_since(session_id, stream_id, cursor)
     }
 
     pub async fn publish_event(&self, event: RuntimeEventEnvelope) -> Result<(), RuntimeError> {

--- a/src/crates/execution/agent-runtime/src/session_event_journal.rs
+++ b/src/crates/execution/agent-runtime/src/session_event_journal.rs
@@ -8,11 +8,19 @@
 
 use bitfun_events::{AgenticEvent, ToolEventData};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex, MutexGuard};
 
 const MAX_PROJECTED_EVENTS_PER_SESSION: usize = 2048;
 const MAX_RETAINED_TERMINAL_SESSION_PROJECTIONS: usize = 64;
+
+/// How many raw materialized events stay individually replayable per Session.
+///
+/// This is the incremental catch-up window, deliberately separate from the
+/// compacted projection above it. It only has to cover an ordinary delivery
+/// gap — a network blip, a device switch, a backgrounded window — not an
+/// arbitrarily long detachment; anything older is answered with a snapshot.
+const MAX_REPLAYABLE_TAIL_EVENTS: usize = 1024;
 
 /// Reserved metadata carried only by the product delivery envelope. Existing
 /// frontend event payload fields remain unchanged for older clients.
@@ -68,13 +76,87 @@ pub struct SessionEventProjectionSnapshot {
     pub events: Vec<AgenticEvent>,
 }
 
+/// One materialized event, kept verbatim next to the cursor it was assigned.
+struct JournaledEvent {
+    cursor: u64,
+    event: AgenticEvent,
+}
+
 #[derive(Default)]
 struct SessionProjection {
     cursor: u64,
     active_turn_id: Option<String>,
     events: Vec<AgenticEvent>,
+    /// Append-only, uncompacted view of the same events `events` compacts.
+    ///
+    /// The compacted projection answers "what does this Turn look like now";
+    /// it cannot answer "what did I miss after cursor N", because accumulating
+    /// a text chunk mutates an entry written at an older cursor and a new Turn
+    /// clears the whole vector. Entries here are never merged or rewritten, so
+    /// a suffix of this queue is exactly what a client behind by a few events
+    /// needs — and nothing else has to be inferred.
+    tail: VecDeque<JournaledEvent>,
     terminal: bool,
     last_touched: u64,
+}
+
+impl SessionProjection {
+    fn push_tail(&mut self, cursor: u64, event: &AgenticEvent) {
+        self.tail.push_back(JournaledEvent {
+            cursor,
+            event: event.clone(),
+        });
+        while self.tail.len() > MAX_REPLAYABLE_TAIL_EVENTS {
+            self.tail.pop_front();
+        }
+    }
+
+    /// Events after `cursor`, or `None` when the retained tail cannot prove it
+    /// is contiguous with what the client already applied.
+    fn tail_since(&self, cursor: u64) -> Option<Vec<AgenticEvent>> {
+        if cursor > self.cursor {
+            // A cursor ahead of this stream's own progress is not a gap this
+            // journal can reason about.
+            return None;
+        }
+        if cursor == self.cursor {
+            return Some(Vec::new());
+        }
+        // The client's next expected event must still be retained; if the
+        // oldest entry is newer than that, the events between were dropped.
+        match self.tail.front() {
+            Some(oldest) if oldest.cursor <= cursor.saturating_add(1) => Some(
+                self.tail
+                    .iter()
+                    .filter(|entry| entry.cursor > cursor)
+                    .map(|entry| entry.event.clone())
+                    .collect(),
+            ),
+            _ => None,
+        }
+    }
+
+    fn clear_replay_content(&mut self) {
+        self.events.clear();
+        self.tail.clear();
+        self.active_turn_id = None;
+    }
+}
+
+/// Everything a client missed after a cursor it already applied.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+pub enum SessionEventBackfill {
+    /// Contiguous with the client's cursor: apply these in order and it is
+    /// caught up, with no snapshot and no projection rebuild.
+    Delta {
+        stream_id: String,
+        cursor: u64,
+        events: Vec<AgenticEvent>,
+    },
+    /// The client's cursor predates the retained tail, or belongs to an older
+    /// Runtime process. Only a full snapshot can restore it.
+    SnapshotRequired,
 }
 
 struct JournalState {
@@ -164,8 +246,7 @@ impl SessionEventJournal {
         let mut state = lock_state(&self.state);
         if matches!(event, AgenticEvent::SessionDeleted { .. }) {
             if let Some(projection) = state.sessions.get_mut(&session_id) {
-                projection.events.clear();
-                projection.active_turn_id = None;
+                projection.clear_replay_content();
                 projection.terminal = true;
             }
             return None;
@@ -189,6 +270,7 @@ impl SessionEventJournal {
             if materialized {
                 projection.cursor = projection.cursor.saturating_add(1);
                 projection.last_touched = next_sequence;
+                projection.push_tail(projection.cursor, event);
             }
             (projection.cursor, materialized)
         };
@@ -215,6 +297,37 @@ impl SessionEventJournal {
             }
         }
         materialized.then_some(SessionEventCursor { stream_id, cursor })
+    }
+
+    /// Serve everything recorded after `cursor` on `stream_id`.
+    ///
+    /// This is the ordinary path back to live: a client that missed events
+    /// asks what it missed and applies the answer in order. It replaces
+    /// inferring a gap from painted content, because a gap is now either
+    /// contiguous with the retained tail or explicitly `SnapshotRequired` —
+    /// never a guess. A cursor from another Runtime process is never compared
+    /// with this one's.
+    pub fn events_since(
+        &self,
+        session_id: &str,
+        stream_id: &str,
+        cursor: u64,
+    ) -> SessionEventBackfill {
+        let state = lock_state(&self.state);
+        if state.stream_id != stream_id {
+            return SessionEventBackfill::SnapshotRequired;
+        }
+        let Some(projection) = state.sessions.get(session_id) else {
+            return SessionEventBackfill::SnapshotRequired;
+        };
+        match projection.tail_since(cursor) {
+            Some(events) => SessionEventBackfill::Delta {
+                stream_id: state.stream_id.clone(),
+                cursor: projection.cursor,
+                events,
+            },
+            None => SessionEventBackfill::SnapshotRequired,
+        }
     }
 
     pub fn snapshot(&self, session_id: &str) -> SessionEventProjectionSnapshot {
@@ -480,8 +593,7 @@ fn prune_terminal_projections(sessions: &mut HashMap<String, SessionProjection>)
         if let Some(projection) = sessions.get_mut(&session_id) {
             // Keep the per-Session cursor tombstone monotonic while releasing
             // replay content that persisted idle history can reconstruct.
-            projection.events.clear();
-            projection.active_turn_id = None;
+            projection.clear_replay_content();
         }
     }
 }
@@ -568,9 +680,9 @@ fn compact_projection(projection: &mut SessionProjection) {
 #[cfg(test)]
 mod tests {
     use super::{
-        attach_session_event_cursor, lock_state, SessionEventCursor, SessionEventJournal,
-        SessionEventProjectionStore, StoredSessionEvents,
-        MAX_RETAINED_TERMINAL_SESSION_PROJECTIONS,
+        attach_session_event_cursor, lock_state, SessionEventBackfill, SessionEventCursor,
+        SessionEventJournal, SessionEventProjectionStore, StoredSessionEvents,
+        MAX_REPLAYABLE_TAIL_EVENTS, MAX_RETAINED_TERMINAL_SESSION_PROJECTIONS,
     };
     use bitfun_events::{AgenticEvent, ToolEventData, ToolEventIdentity};
     use std::collections::HashMap;
@@ -883,5 +995,116 @@ mod tests {
             Some("turn-1")
         );
         assert!(journal.snapshot("missing").events.is_empty());
+    }
+
+    fn delta(backfill: SessionEventBackfill) -> Vec<AgenticEvent> {
+        match backfill {
+            SessionEventBackfill::Delta { events, .. } => events,
+            SessionEventBackfill::SnapshotRequired => {
+                panic!("expected a contiguous delta, got SnapshotRequired")
+            }
+        }
+    }
+
+    #[test]
+    fn a_delta_replays_each_chunk_the_projection_merged_away() {
+        // The compacted projection accumulates both chunks into one entry, so
+        // it cannot express "you only missed the second half". The tail can.
+        let journal = SessionEventJournal::with_stream_id("runtime-a".to_string());
+        journal.record(&turn_started("session", "turn"));
+        journal.record(&text("session", "turn", "hel"));
+        journal.record(&text("session", "turn", "lo"));
+
+        assert_eq!(journal.snapshot("session").events.len(), 2);
+
+        let missed = delta(journal.events_since("session", "runtime-a", 2));
+        assert_eq!(missed.len(), 1);
+        assert!(matches!(
+            &missed[0],
+            AgenticEvent::TextChunk { text, .. } if text == "lo"
+        ));
+    }
+
+    #[test]
+    fn a_caught_up_client_is_told_it_missed_nothing() {
+        let journal = SessionEventJournal::with_stream_id("runtime-a".to_string());
+        journal.record(&turn_started("session", "turn"));
+        journal.record(&text("session", "turn", "hello"));
+
+        match journal.events_since("session", "runtime-a", 2) {
+            SessionEventBackfill::Delta { cursor, events, .. } => {
+                assert_eq!(cursor, 2);
+                assert!(events.is_empty());
+            }
+            SessionEventBackfill::SnapshotRequired => panic!("no gap should need a snapshot"),
+        }
+    }
+
+    #[test]
+    fn a_turn_boundary_stays_contiguous_for_a_detached_client() {
+        // The exact shape of a controller that was away while its Turn ended:
+        // the projection cleared for the next Turn, but the events that settled
+        // the old one are still individually replayable.
+        let journal = SessionEventJournal::with_stream_id("runtime-a".to_string());
+        journal.record(&turn_started("session", "turn-1"));
+        journal.record(&text("session", "turn-1", "answer"));
+        journal.record(&turn_completed("session", "turn-1"));
+        journal.record(&turn_started("session", "turn-2"));
+
+        assert_eq!(
+            journal.snapshot("session").active_turn_id.as_deref(),
+            Some("turn-2"),
+        );
+
+        let missed = delta(journal.events_since("session", "runtime-a", 2));
+        assert!(matches!(
+            missed.as_slice(),
+            [
+                AgenticEvent::DialogTurnCompleted { turn_id: completed, .. },
+                AgenticEvent::DialogTurnStarted { turn_id: started, .. },
+            ] if completed == "turn-1" && started == "turn-2"
+        ));
+    }
+
+    #[test]
+    fn a_client_behind_the_retained_tail_is_told_to_take_a_snapshot() {
+        let journal = SessionEventJournal::with_stream_id("runtime-a".to_string());
+        journal.record(&turn_started("session", "turn"));
+        // One event more than the tail retains, so the event this client is
+        // waiting for has already been dropped from the front.
+        for index in 0..=MAX_REPLAYABLE_TAIL_EVENTS {
+            journal.record(&text("session", "turn", &format!("chunk-{index} ")));
+        }
+        let latest = journal.snapshot("session").cursor;
+
+        assert!(matches!(
+            journal.events_since("session", "runtime-a", 1),
+            SessionEventBackfill::SnapshotRequired,
+        ));
+        // A client only slightly behind is still served incrementally.
+        assert_eq!(
+            delta(journal.events_since("session", "runtime-a", latest - 2)).len(),
+            2,
+        );
+    }
+
+    #[test]
+    fn cursors_are_never_compared_across_runtime_processes_or_unknown_sessions() {
+        let journal = SessionEventJournal::with_stream_id("runtime-b".to_string());
+        journal.record(&turn_started("session", "turn"));
+
+        assert!(matches!(
+            journal.events_since("session", "runtime-a", 1),
+            SessionEventBackfill::SnapshotRequired,
+        ));
+        assert!(matches!(
+            journal.events_since("other-session", "runtime-b", 0),
+            SessionEventBackfill::SnapshotRequired,
+        ));
+        // A cursor ahead of this stream's own progress is not a gap either.
+        assert!(matches!(
+            journal.events_since("session", "runtime-b", 9),
+            SessionEventBackfill::SnapshotRequired,
+        ));
     }
 }

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.test.ts
@@ -851,6 +851,45 @@ describe('shouldProcessEvent', () => {
     expect(stateMachineManager.get(mockSessionId)?.getContext().currentDialogTurnId).toBe(mockTurnId);
   });
 
+  it('keeps accepting latest-turn data while idle recovery is still in flight', () => {
+    FlowChatStore.getInstance().setState(() => ({
+      sessions: new Map([[
+        mockSessionId,
+        {
+          sessionId: mockSessionId,
+          title: 'Test Session',
+          dialogTurns: [{
+            id: mockTurnId,
+            sessionId: mockSessionId,
+            userMessage: {
+              id: 'user-1',
+              content: 'Continue review',
+              timestamp: 1000,
+            },
+            modelRounds: [],
+            status: 'processing',
+            startTime: 1000,
+          }],
+          status: 'idle',
+          config: { agentType: 'agentic' },
+          createdAt: 1000,
+          lastActiveAt: 1000,
+          error: null,
+          sessionKind: 'normal',
+        } as Session,
+      ]]),
+      activeSessionId: mockSessionId,
+    }));
+    vi.spyOn(stateMachineManager, 'get').mockReturnValue({
+      getCurrentState: () => SessionExecutionState.IDLE,
+      getContext: () => ({ currentDialogTurnId: mockTurnId }),
+    } as any);
+
+    expect(
+      shouldProcessEvent(mockSessionId, mockTurnId, 'data', 'ToolEvent'),
+    ).toBe(true);
+  });
+
   it('does not recover idle data for an old non-latest turn', () => {
     FlowChatStore.getInstance().setState(() => ({
       sessions: new Map([[

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
@@ -82,7 +82,7 @@ import {
   clearRuntimeStatus,
   scheduleModelResponseStatus,
 } from './RuntimeStatusModule';
-import { requestPeerSessionRefresh } from './PeerSessionRefreshModule';
+import { requestRuntimeProjectionRepair } from './PeerSessionRefreshModule';
 import { isPeerDeviceModeActive } from '@/infrastructure/peer-device/peerModeFlag';
 import {
   optimisticTurnAdoptionKey,
@@ -196,7 +196,7 @@ function logDroppedDataEvent(
   turnId: string | null,
   details: Record<string, unknown>
 ): void {
-  requestPeerSessionRefresh(sessionId);
+  requestRuntimeProjectionRepair(sessionId);
   log.debug('Dropped agentic data event', {
     eventName,
     sessionId,
@@ -256,6 +256,29 @@ function recoverIdleLatestTurnDataEvent(
     eventName,
   });
   return true;
+}
+
+function isRecoveringIdleTurn(
+  sessionId: string,
+  turnId: string | null,
+  currentState: SessionExecutionState,
+  currentDialogTurnId: string | null,
+): boolean {
+  if (
+    currentState !== SessionExecutionState.IDLE ||
+    !turnId ||
+    currentDialogTurnId !== turnId
+  ) {
+    return false;
+  }
+
+  const session = FlowChatStore.getInstance().getState().sessions.get(sessionId);
+  const latestTurn = session?.dialogTurns[session.dialogTurns.length - 1];
+  return Boolean(
+    latestTurn &&
+    latestTurn.id === turnId &&
+    RECOVERABLE_IDLE_TURN_STATUSES.has(latestTurn.status)
+  );
 }
 
 function handleDeepReviewQueueStateChanged(event: DeepReviewQueueStateChangedEvent): void {
@@ -678,6 +701,10 @@ export function shouldProcessEvent(
       currentState,
       context.currentDialogTurnId,
     )) {
+      return true;
+    }
+
+    if (isRecoveringIdleTurn(sessionId, turnId, currentState, context.currentDialogTurnId)) {
       return true;
     }
 
@@ -1827,7 +1854,7 @@ function handleTextChunk(context: FlowChatContext, event: any): void {
 
   const dialogTurn = session.dialogTurns.find((turn: DialogTurn) => turn.id === turnId);
   if (!dialogTurn) {
-    requestPeerSessionRefresh(sessionId);
+    requestRuntimeProjectionRepair(sessionId);
     log.debug('Dialog turn not found', { turnId });
     return;
   }
@@ -2005,7 +2032,7 @@ function handleModelRoundStart(context: FlowChatContext, event: ModelRoundStarte
 
   const dialogTurn = session.dialogTurns.find((turn: DialogTurn) => turn.id === turnId);
   if (!dialogTurn) {
-    requestPeerSessionRefresh(sessionId);
+    requestRuntimeProjectionRepair(sessionId);
     log.debug('Dialog turn not found (model round start)', { turnId });
     return;
   }

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.test.ts
@@ -30,13 +30,19 @@ vi.mock('../AgenticEventListener', () => ({
   agenticEventListener: agenticListenerMock,
 }));
 
+import { FlowChatStore } from '../../store/FlowChatStore';
 import {
   installPeerSessionRefresh,
   isSessionProjectionAttachable,
   PEER_SESSION_REFRESH_INTERVAL_MS,
   requestPeerSessionRefresh,
+  runtimeProjectionCaughtUp,
 } from './PeerSessionRefreshModule';
-import { resetRuntimeSessionEventGateForTest } from '@/infrastructure/peer-device/runtimeSessionEventGate';
+import { processToolEvent } from './ToolEventModule';
+import {
+  markRuntimeSessionProjectionStale,
+  resetRuntimeSessionEventGateForTest,
+} from '@/infrastructure/peer-device/runtimeSessionEventGate';
 
 describe('PeerSessionRefreshModule', () => {
   beforeEach(() => {
@@ -140,6 +146,7 @@ describe('PeerSessionRefreshModule re-attach after a surface switch', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     peerModeMock.active = true;
+    resetRuntimeSessionEventGateForTest();
     vi.stubGlobal('document', {
       visibilityState: 'visible',
       addEventListener: vi.fn(),
@@ -149,6 +156,7 @@ describe('PeerSessionRefreshModule re-attach after a surface switch', () => {
   });
 
   afterEach(() => {
+    resetRuntimeSessionEventGateForTest();
     vi.clearAllMocks();
     vi.unstubAllGlobals();
     vi.useRealTimers();
@@ -180,6 +188,7 @@ describe('PeerSessionRefreshModule re-attach after a surface switch', () => {
         subscribeSelector: vi.fn(() => () => {}),
         refreshPeerSessionSnapshot,
         reconcilePendingUserQuestions: vi.fn(),
+        prepareRuntimeTurnReplay: vi.fn(),
       },
       eventBatcher: { flushNow: vi.fn(), clear: vi.fn() },
       contentBuffers: new Map(),
@@ -228,6 +237,141 @@ describe('PeerSessionRefreshModule re-attach after a surface switch', () => {
 
     expect(refresh).toHaveBeenCalledTimes(1);
     expect(stateMachineMock.reset).not.toHaveBeenCalled();
+    cleanup();
+  });
+
+  it('still attaches a fresh streaming turn when the projection is stale', async () => {
+    stateMachineMock.get.mockReturnValue({
+      getCurrentState: () => 'processing',
+      getContext: () => ({ lastUpdateTime: Date.now(), version: 0 }),
+    });
+    const refresh = vi.fn(async () => ({
+      applied: false,
+      backendState: 'Processing { current_turn_id: "turn-live", phase: Streaming }',
+      latestTurnId: 'turn-live',
+      latestTurnStatus: 'processing',
+    }));
+
+    const cleanup = installPeerSessionRefresh(contextWithSnapshot(refresh));
+    await vi.advanceTimersByTimeAsync(1);
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    markRuntimeSessionProjectionStale('local', 'session-1');
+    await vi.advanceTimersByTimeAsync(1);
+    expect(refresh).toHaveBeenCalledTimes(2);
+    cleanup();
+  });
+
+  it('repairs a named session while the document is hidden', async () => {
+    const documentStub = {
+      visibilityState: 'visible' as Document['visibilityState'],
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+    vi.stubGlobal('document', documentStub);
+    stateMachineMock.get.mockReturnValue({
+      getCurrentState: () => 'processing',
+      getContext: () => ({ lastUpdateTime: Date.now(), version: 0 }),
+    });
+    const refresh = vi.fn(async () => ({
+      applied: false,
+      backendState: 'Processing { current_turn_id: "turn-live", phase: Streaming }',
+      latestTurnId: 'turn-live',
+      latestTurnStatus: 'processing',
+    }));
+
+    const cleanup = installPeerSessionRefresh(contextWithSnapshot(refresh));
+    await vi.advanceTimersByTimeAsync(1);
+    refresh.mockClear();
+
+    documentStub.visibilityState = 'hidden';
+    await vi.advanceTimersByTimeAsync(PEER_SESSION_REFRESH_INTERVAL_MS);
+    expect(refresh).not.toHaveBeenCalled();
+
+    requestPeerSessionRefresh('session-1');
+    await vi.advanceTimersByTimeAsync(1);
+    expect(refresh).toHaveBeenCalledTimes(1);
+    cleanup();
+  });
+
+  it('attaches during FINISHING when the projection is stale', async () => {
+    stateMachineMock.get.mockReturnValue({
+      getCurrentState: () => 'finishing',
+      getContext: () => ({ lastUpdateTime: Date.now(), version: 0 }),
+    });
+    const refresh = vi.fn(async () => ({
+      applied: false,
+      backendState: 'Processing { current_turn_id: "turn-live", phase: Streaming }',
+      latestTurnId: 'turn-live',
+      latestTurnStatus: 'processing',
+    }));
+
+    const cleanup = installPeerSessionRefresh(contextWithSnapshot(refresh));
+    await vi.advanceTimersByTimeAsync(1);
+    expect(refresh).not.toHaveBeenCalled();
+
+    markRuntimeSessionProjectionStale('local', 'session-1');
+    await vi.advanceTimersByTimeAsync(1);
+    expect(refresh).toHaveBeenCalledTimes(1);
+    cleanup();
+  });
+
+  it('replays when the cursor matches but a journal ToolEnd is still running in the UI', async () => {
+    stateMachineMock.get.mockReturnValue({
+      getCurrentState: () => 'processing',
+      getContext: () => ({ lastUpdateTime: Date.now(), version: 0 }),
+    });
+    const runtimeEventSnapshot = {
+      sessionId: 'session-1',
+      streamId: 'runtime-a',
+      cursor: 8,
+      activeTurnId: 'turn-live',
+      events: [{
+        eventName: 'agentic://tool-event',
+        payload: {
+          sessionId: 'session-1',
+          turnId: 'turn-live',
+          roundId: 'round-0',
+          toolEvent: {
+            event_type: 'Completed',
+            tool_id: 'read-1',
+            tool_name: 'Read',
+          },
+        },
+      }],
+    };
+    const refresh = vi.fn(async () => ({
+      applied: false,
+      backendState: 'Processing { current_turn_id: "turn-live", phase: ToolExecution }',
+      latestTurnId: 'turn-live',
+      latestTurnStatus: 'processing',
+      runtimeEventReplayRequired: false,
+      runtimeEventSnapshot,
+    }));
+    const context = contextWithSnapshot(refresh);
+    const session = context.flowChatStore.getState().sessions.get('session-1');
+    session.dialogTurns[0].modelRounds[0].items = [{
+      id: 'read-1',
+      type: 'tool',
+      toolName: 'Read',
+      status: 'running',
+      timestamp: 1,
+      toolCall: { id: 'read-1', input: { file_path: 'README.md' } },
+    }];
+
+    expect(runtimeProjectionCaughtUp(session, runtimeEventSnapshot)).toBe(false);
+
+    const cleanup = installPeerSessionRefresh(context);
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(agenticListenerMock.dispatchExternal).toHaveBeenCalledWith(
+      'agentic://tool-event',
+      runtimeEventSnapshot.events[0].payload,
+    );
+    expect(context.flowChatStore.prepareRuntimeTurnReplay).toHaveBeenCalledWith(
+      'session-1',
+      'turn-live',
+    );
     cleanup();
   });
 
@@ -281,6 +425,10 @@ describe('PeerSessionRefreshModule re-attach after a surface switch', () => {
       runtimeEventSnapshot.events[1].payload,
     );
     expect(context.eventBatcher.clear).toHaveBeenCalled();
+    expect(context.flowChatStore.prepareRuntimeTurnReplay).toHaveBeenCalledWith(
+      'session-1',
+      'turn-live',
+    );
     expect(context.flowChatStore.reconcilePendingUserQuestions).toHaveBeenCalledWith(
       'session-1',
       { revision: 2, questions: [] },
@@ -323,6 +471,41 @@ describe('PeerSessionRefreshModule re-attach after a surface switch', () => {
     expect(agenticListenerMock.dispatchExternal).not.toHaveBeenCalled();
     expect(context.eventBatcher.clear).not.toHaveBeenCalled();
     expect(stateMachineMock.reset).not.toHaveBeenCalled();
+    cleanup();
+  });
+
+  it('replays the Runtime journal even when persist merge was skipped', async () => {
+    stateMachineMock.get.mockReturnValue({
+      getCurrentState: () => 'processing',
+      getContext: () => ({ lastUpdateTime: Date.now(), version: 0 }),
+    });
+    const runtimeEventSnapshot = {
+      sessionId: 'session-1',
+      streamId: 'runtime-a',
+      cursor: 20,
+      activeTurnId: 'turn-live',
+      events: [{
+        eventName: 'agentic://tool-event',
+        payload: { sessionId: 'session-1', turnId: 'turn-live', toolId: 'read-1' },
+      }],
+    };
+    const refresh = vi.fn(async () => ({
+      applied: false,
+      backendState: 'Processing { current_turn_id: "turn-live", phase: ToolExecution }',
+      latestTurnId: 'turn-live',
+      latestTurnStatus: 'processing',
+      runtimeEventReplayRequired: true,
+      runtimeEventSnapshot,
+    }));
+    const context = contextWithSnapshot(refresh);
+
+    const cleanup = installPeerSessionRefresh(context);
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(agenticListenerMock.dispatchExternal).toHaveBeenCalledWith(
+      'agentic://tool-event',
+      runtimeEventSnapshot.events[0].payload,
+    );
     cleanup();
   });
 });
@@ -679,6 +862,174 @@ describe('PeerSessionRefreshModule attach eligibility after a surface switch', (
       '/repo/BitFun',
       expect.objectContaining({ requireActiveSession: false }),
     );
+    cleanup();
+  });
+});
+
+describe('PeerSessionRefreshModule journal apply', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    peerModeMock.active = true;
+    resetRuntimeSessionEventGateForTest();
+    stateMachineMock.get.mockReturnValue({
+      getCurrentState: () => 'processing',
+      getContext: () => ({ lastUpdateTime: Date.now(), version: 0 }),
+    });
+    vi.stubGlobal('document', {
+      visibilityState: 'visible',
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+    vi.stubGlobal('window', { addEventListener: vi.fn(), removeEventListener: vi.fn() });
+    FlowChatStore.getInstance().setState(prev => ({
+      ...prev,
+      sessions: new Map(),
+      activeSessionId: null,
+    }));
+  });
+
+  afterEach(() => {
+    resetRuntimeSessionEventGateForTest();
+    agenticListenerMock.dispatchExternal.mockReset();
+    agenticListenerMock.dispatchExternal.mockReturnValue(true);
+    FlowChatStore.getInstance().setState(prev => ({
+      ...prev,
+      sessions: new Map(),
+      activeSessionId: null,
+    }));
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('replays a cursor-covered ToolEnd until the card is completed', async () => {
+    const store = FlowChatStore.getInstance();
+    store.setState(prev => ({
+      ...prev,
+      activeSessionId: 'session-1',
+      sessions: new Map([[
+        'session-1',
+        {
+          sessionId: 'session-1',
+          title: 'Live',
+          workspacePath: '/repo/BitFun',
+          historyState: 'ready',
+          isHistorical: false,
+          isTransient: false,
+          dialogTurns: [{
+            id: 'turn-live',
+            sessionId: 'session-1',
+            userMessage: { id: 'user-1', content: 'Read it', timestamp: 1 },
+            modelRounds: [{
+              id: 'round-0',
+              index: 0,
+              items: [{
+                id: 'read-1',
+                type: 'tool',
+                toolName: 'Read',
+                status: 'running',
+                timestamp: 2,
+                toolCall: { id: 'read-1', input: { file_path: 'README.md' } },
+              }],
+              isStreaming: true,
+              isComplete: false,
+              status: 'streaming',
+              startTime: 2,
+            }],
+            status: 'processing',
+            startTime: 1,
+          }],
+          status: 'active',
+          config: { agentType: 'agentic' },
+          createdAt: 1,
+          lastActiveAt: 2,
+          error: null,
+          sessionKind: 'normal',
+        } as any,
+      ]]),
+    }));
+
+    const runtimeEventSnapshot = {
+      sessionId: 'session-1',
+      streamId: 'runtime-a',
+      cursor: 4,
+      activeTurnId: 'turn-live',
+      events: [
+        {
+          eventName: 'agentic://tool-event',
+          payload: {
+            sessionId: 'session-1',
+            turnId: 'turn-live',
+            roundId: 'round-0',
+            toolEvent: {
+              event_type: 'Started',
+              tool_id: 'read-1',
+              tool_name: 'Read',
+              params: { file_path: 'README.md' },
+            },
+          },
+        },
+        {
+          eventName: 'agentic://tool-event',
+          payload: {
+            sessionId: 'session-1',
+            turnId: 'turn-live',
+            roundId: 'round-0',
+            toolEvent: {
+              event_type: 'Completed',
+              tool_id: 'read-1',
+              tool_name: 'Read',
+              result: 'ok',
+            },
+          },
+        },
+      ],
+    };
+
+    agenticListenerMock.dispatchExternal.mockImplementation((eventName: string, payload: any) => {
+      if (eventName === 'agentic://tool-event') {
+        processToolEvent(
+          {
+            flowChatStore: store,
+            eventBatcher: { getBufferSize: () => 0, flushNow: () => {} },
+            saveDebouncers: new Map(),
+            lastSaveTimestamps: new Map(),
+            lastSaveHashes: new Map(),
+            turnSaveInFlight: new Map(),
+            turnSavePending: new Set(),
+          } as any,
+          payload.sessionId,
+          payload.turnId,
+          payload.roundId,
+          payload.toolEvent,
+        );
+      }
+      return true;
+    });
+
+    vi.spyOn(store, 'refreshPeerSessionSnapshot').mockResolvedValue({
+      applied: false,
+      backendState: 'Processing { current_turn_id: "turn-live", phase: ToolExecution }',
+      latestTurnId: 'turn-live',
+      latestTurnStatus: 'processing',
+      runtimeEventReplayRequired: false,
+      runtimeEventSnapshot,
+    });
+
+    const cleanup = installPeerSessionRefresh({
+      flowChatStore: store,
+      eventBatcher: { flushNow: vi.fn(), clear: vi.fn() },
+      contentBuffers: new Map(),
+      activeTextItems: new Map(),
+    } as any);
+
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(store.findToolItem('session-1', 'turn-live', 'read-1')?.status).toBe('completed');
+    expect(runtimeProjectionCaughtUp(
+      store.getState().sessions.get('session-1'),
+      runtimeEventSnapshot,
+    )).toBe(true);
     cleanup();
   });
 });

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.ts
@@ -297,6 +297,17 @@ async function tryIncrementalCatchUp(
     }
     context.eventBatcher.flushNow();
 
+    // Replaying events rebuilds a blocking interaction's card, but only the
+    // Runtime mailbox rebinds it to something that can answer. Skipping this
+    // left an AskUserQuestion on screen that no click could resolve after a
+    // device switch.
+    context.flowChatStore.reconcilePendingUserQuestions(
+      sessionId,
+      backfill.interactionSnapshot?.sessionId === sessionId
+        ? backfill.interactionSnapshot.userQuestions
+        : undefined,
+    );
+
     // Delivery is still not acceptance. If the state machine dropped one of
     // these, escalate to the snapshot path in this same tick instead of
     // recording a cursor the screen does not actually reflect.
@@ -459,22 +470,35 @@ export function installPeerSessionRefresh(context: FlowChatContext): () => void 
     if (staleOnly && !forceRuntimeReplay && !streamIsStale && !projectionStale) {
       return;
     }
-    inFlight = true;
-    try {
-      // Ask what was missed before rebuilding anything. A repair that applies
-      // the exact events after our cursor cannot drop content, so the snapshot
-      // path below is now the fallback for a cursor the Host can no longer
-      // serve — not the normal way back to live.
-      if (await tryIncrementalCatchUp(context, surfaceScope, sessionId)) {
-        return;
+    // Repair only what is actually broken. This path installs an event fence
+    // and makes a Host round trip, so running it on an ordinary lifecycle
+    // refresh held the live stream behind a relay RPC — the model's reply sat
+    // in the fence queue waiting for a request that had nothing to repair
+    // (regression: send-to-first-token latency, and the fence churn that left
+    // an interactive card unanswerable after a device switch).
+    //
+    // `forceRuntimeReplay` is deliberately excluded: an idle or errored
+    // machine has no live projection to continue, and wants the snapshot.
+    const canRepairIncrementally =
+      !forceRuntimeReplay && (projectionStale || streamIsStale);
+    if (canRepairIncrementally) {
+      inFlight = true;
+      try {
+        // Ask what was missed before rebuilding anything. A repair that
+        // applies the exact events after our cursor cannot drop content, so
+        // the snapshot path below is the fallback for a cursor the Host can no
+        // longer serve — not the normal way back to live.
+        if (await tryIncrementalCatchUp(context, surfaceScope, sessionId)) {
+          return;
+        }
+      } catch (error) {
+        if (isSurfaceChangedError(error)) {
+          return;
+        }
+        throw error;
+      } finally {
+        inFlight = false;
       }
-    } catch (error) {
-      if (isSurfaceChangedError(error)) {
-        return;
-      }
-      throw error;
-    } finally {
-      inFlight = false;
     }
 
     const replaceRunningSnapshot =

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.ts
@@ -272,6 +272,17 @@ async function tryIncrementalCatchUp(
   }
 
   const attachment = beginRuntimeSessionAttachment(surfaceScope.surfaceId, sessionId);
+  // A fence that is neither settled nor handed off holds this Session's live
+  // events forever, which reads as the chat freezing and then flooding when
+  // something else finally opens a read. Every exit below either settles it or
+  // states which read inherits it, and the `finally` covers the rest.
+  let fenceResolved = false;
+  const handOffToSnapshotPath = (): boolean => {
+    // The caller runs the snapshot path immediately when we return false, and
+    // its own `beginRead` inherits the held events rather than racing them.
+    fenceResolved = true;
+    return false;
+  };
   try {
     const backfill = await agentAPI.loadSessionEventBackfill(
       sessionId,
@@ -280,13 +291,12 @@ async function tryIncrementalCatchUp(
     );
     surfaceScope.assertCurrent('runtimeSessionBackfill');
     if (!attachment.isCurrent()) {
-      // A newer attach owns the fence and carries our queue with it.
+      // A newer read owns the fence and carries our queue with it.
+      fenceResolved = true;
       return true;
     }
     if (backfill.kind !== 'delta') {
-      // Leave the fence in place: the snapshot path begins its own attachment
-      // and inherits the queued events rather than racing them.
-      return false;
+      return handOffToSnapshotPath();
     }
 
     for (const event of backfill.events) {
@@ -321,13 +331,14 @@ async function tryIncrementalCatchUp(
     });
     if (!caughtUp) {
       markRuntimeSessionProjectionStale(surfaceScope.surfaceId, sessionId);
-      return false;
+      return handOffToSnapshotPath();
     }
 
     attachment.finish(
       { streamId: backfill.streamId, cursor: backfill.cursor },
       { projectionCaughtUp: true },
     );
+    fenceResolved = true;
     log.debug('Runtime session projection caught up incrementally', {
       sessionId,
       from: applied.cursor,
@@ -339,13 +350,17 @@ async function tryIncrementalCatchUp(
     if (isSurfaceChangedError(error)) {
       throw error;
     }
-    // Never strand the queued live events on a failed repair.
-    attachment.abort();
     log.debug('Incremental catch-up failed; falling back to a snapshot', {
       sessionId,
       error,
     });
     return false;
+  } finally {
+    if (!fenceResolved) {
+      // Release the held events rather than stranding them. On a superseded
+      // read this is a no-op, which is why it is safe unconditionally.
+      attachment.abort();
+    }
   }
 }
 
@@ -501,8 +516,6 @@ export function installPeerSessionRefresh(context: FlowChatContext): () => void 
       }
     }
 
-    const replaceRunningSnapshot =
-      forceRuntimeReplay || streamIsStale;
     context.eventBatcher.flushNow();
     const machineVersion = machine?.getContext().version ?? 0;
     const attachment = beginRuntimeSessionAttachment(surfaceScope.surfaceId, sessionId);
@@ -514,7 +527,6 @@ export function installPeerSessionRefresh(context: FlowChatContext): () => void 
         sessionId,
         workspacePath,
         {
-          replaceRunningSnapshot,
           // A background session on this surface still owns its projection.
           // Requiring the focused tab aborted the dropped-event repair for
           // every non-active running chat after a multi-session switch.

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.ts
@@ -16,11 +16,16 @@ import {
   isSurfaceChangedError,
 } from '@/infrastructure/peer-device/deviceSurface';
 import { isSurfaceReconcileEnabled } from '@/infrastructure/peer-device/deviceSurfaceReconcile';
-import type { SessionRuntimeEventSnapshot } from '@/infrastructure/api/service-api/AgentAPI';
+import { agentAPI } from '@/infrastructure/api/service-api/AgentAPI';
+import type {
+  RuntimeProjectedAgenticEvent,
+  SessionRuntimeEventSnapshot,
+} from '@/infrastructure/api/service-api/AgentAPI';
 import {
   beginRuntimeSessionAttachment,
   isRuntimeSessionProjectionStale,
   markRuntimeSessionProjectionStale,
+  readRuntimeSessionProgress,
   subscribeRuntimeSessionEventGaps,
 } from '@/infrastructure/peer-device/runtimeSessionEventGate';
 import { createLogger } from '@/shared/utils/logger';
@@ -226,6 +231,113 @@ export function runtimeProjectionCaughtUp(
   return true;
 }
 
+/**
+ * The Turn a delta ends in, read from the events themselves.
+ *
+ * A delta names no active Turn — it is a stream position, not a projection —
+ * but the caught-up check is per Turn, so take the last one the events mention.
+ */
+function deltaActiveTurnId(events: RuntimeProjectedAgenticEvent[]): string | undefined {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const turnId = events[index]?.payload?.turnId;
+    if (typeof turnId === 'string' && turnId) {
+      return turnId;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Repair the projection by applying exactly what was missed.
+ *
+ * This is the ordinary way back to live. The Host knows what it sent after our
+ * cursor, so a gap is answered rather than guessed at: nothing is cleared, no
+ * state machine is reset, and no snapshot has to be judged against painted
+ * content. Returns false when the caller must fall back to the snapshot path —
+ * we have no cursor to be contiguous with, the Host cannot serve one, or the
+ * delta applied but did not land.
+ *
+ * The attachment fence is what makes this safe against the live stream: events
+ * arriving while the request is in flight are queued, then released in order
+ * with the ones the delta already covered dropped by cursor.
+ */
+async function tryIncrementalCatchUp(
+  context: FlowChatContext,
+  surfaceScope: ReturnType<typeof getActiveSurfaceScope>,
+  sessionId: string,
+): Promise<boolean> {
+  const applied = readRuntimeSessionProgress(surfaceScope.surfaceId, sessionId);
+  if (!applied) {
+    return false;
+  }
+
+  const attachment = beginRuntimeSessionAttachment(surfaceScope.surfaceId, sessionId);
+  try {
+    const backfill = await agentAPI.loadSessionEventBackfill(
+      sessionId,
+      applied.streamId,
+      applied.cursor,
+    );
+    surfaceScope.assertCurrent('runtimeSessionBackfill');
+    if (!attachment.isCurrent()) {
+      // A newer attach owns the fence and carries our queue with it.
+      return true;
+    }
+    if (backfill.kind !== 'delta') {
+      // Leave the fence in place: the snapshot path begins its own attachment
+      // and inherits the queued events rather than racing them.
+      return false;
+    }
+
+    for (const event of backfill.events) {
+      surfaceScope.assertCurrent('applyRuntimeSessionBackfill');
+      if (!agenticEventListener.dispatchExternal(event.eventName, event.payload)) {
+        throw new Error('Agentic event listener is unavailable during Runtime catch-up');
+      }
+    }
+    context.eventBatcher.flushNow();
+
+    // Delivery is still not acceptance. If the state machine dropped one of
+    // these, escalate to the snapshot path in this same tick instead of
+    // recording a cursor the screen does not actually reflect.
+    const projectedSession = context.flowChatStore.getState().sessions.get(sessionId);
+    const caughtUp = runtimeProjectionCaughtUp(projectedSession, {
+      sessionId,
+      streamId: backfill.streamId,
+      cursor: backfill.cursor,
+      activeTurnId: deltaActiveTurnId(backfill.events),
+      events: backfill.events,
+    });
+    if (!caughtUp) {
+      markRuntimeSessionProjectionStale(surfaceScope.surfaceId, sessionId);
+      return false;
+    }
+
+    attachment.finish(
+      { streamId: backfill.streamId, cursor: backfill.cursor },
+      { projectionCaughtUp: true },
+    );
+    log.debug('Runtime session projection caught up incrementally', {
+      sessionId,
+      from: applied.cursor,
+      to: backfill.cursor,
+      eventCount: backfill.events.length,
+    });
+    return true;
+  } catch (error) {
+    if (isSurfaceChangedError(error)) {
+      throw error;
+    }
+    // Never strand the queued live events on a failed repair.
+    attachment.abort();
+    log.debug('Incremental catch-up failed; falling back to a snapshot', {
+      sessionId,
+      error,
+    });
+    return false;
+  }
+}
+
 async function alignStateMachineWithSnapshot(
   context: FlowChatContext,
   sessionId: string,
@@ -347,6 +459,24 @@ export function installPeerSessionRefresh(context: FlowChatContext): () => void 
     if (staleOnly && !forceRuntimeReplay && !streamIsStale && !projectionStale) {
       return;
     }
+    inFlight = true;
+    try {
+      // Ask what was missed before rebuilding anything. A repair that applies
+      // the exact events after our cursor cannot drop content, so the snapshot
+      // path below is now the fallback for a cursor the Host can no longer
+      // serve — not the normal way back to live.
+      if (await tryIncrementalCatchUp(context, surfaceScope, sessionId)) {
+        return;
+      }
+    } catch (error) {
+      if (isSurfaceChangedError(error)) {
+        return;
+      }
+      throw error;
+    } finally {
+      inFlight = false;
+    }
+
     const replaceRunningSnapshot =
       forceRuntimeReplay || streamIsStale;
     context.eventBatcher.flushNow();

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.ts
@@ -16,8 +16,11 @@ import {
   isSurfaceChangedError,
 } from '@/infrastructure/peer-device/deviceSurface';
 import { isSurfaceReconcileEnabled } from '@/infrastructure/peer-device/deviceSurfaceReconcile';
+import type { SessionRuntimeEventSnapshot } from '@/infrastructure/api/service-api/AgentAPI';
 import {
   beginRuntimeSessionAttachment,
+  isRuntimeSessionProjectionStale,
+  markRuntimeSessionProjectionStale,
   subscribeRuntimeSessionEventGaps,
 } from '@/infrastructure/peer-device/runtimeSessionEventGate';
 import { createLogger } from '@/shared/utils/logger';
@@ -29,7 +32,7 @@ import {
   SessionExecutionEvent,
   SessionExecutionState,
 } from '../../state-machine/types';
-import type { AnyFlowItem, DialogTurn, Session } from '../../types/flow-chat';
+import type { AnyFlowItem, DialogTurn, FlowToolItem, Session } from '../../types/flow-chat';
 import { installLiveSessionInteractionMailbox } from '../liveSessionInteractionStore';
 import { agenticEventListener } from '../AgenticEventListener';
 import { pendingQueueManager } from './PendingQueueModule';
@@ -83,6 +86,12 @@ export function requestPeerSessionRefresh(sessionId?: string): void {
   installedRefreshRequester?.(sessionId);
 }
 
+/** Cursor delivery is not acceptance — force the next attach to replay. */
+export function requestRuntimeProjectionRepair(sessionId: string): void {
+  markRuntimeSessionProjectionStale(getActiveSurfaceScope().surfaceId, sessionId);
+  requestPeerSessionRefresh(sessionId);
+}
+
 function streamKey(
   roundId: string,
   item: Pick<AnyFlowItem, 'attemptId' | 'attemptIndex'>,
@@ -124,6 +133,97 @@ function isTerminalTurn(turn: DialogTurn | undefined): boolean {
   return turn?.status === 'completed' ||
     turn?.status === 'cancelled' ||
     turn?.status === 'error';
+}
+
+const JOURNAL_TERMINAL_TOOL_EVENTS = new Set([
+  'Completed',
+  'Failed',
+  'Cancelled',
+  'Rejected',
+]);
+
+function readJournalToolEvent(payload: Record<string, unknown>): {
+  eventType: string;
+  toolId: string;
+} | null {
+  const raw = payload.toolEvent ?? payload.tool_event;
+  if (!raw || typeof raw !== 'object') {
+    return null;
+  }
+  const record = raw as Record<string, unknown>;
+  const eventType = record.event_type ?? record.eventType;
+  const toolId = record.tool_id ?? record.toolId;
+  if (typeof eventType !== 'string' || !eventType || typeof toolId !== 'string' || !toolId) {
+    return null;
+  }
+  return { eventType, toolId };
+}
+
+function collectTurnTools(turn: DialogTurn): FlowToolItem[] {
+  const tools: FlowToolItem[] = [];
+  const pushTool = (item: AnyFlowItem): void => {
+    if (item.type === 'tool') {
+      tools.push(item as FlowToolItem);
+    }
+  };
+  for (const round of turn.modelRounds) {
+    for (const item of round.items) {
+      pushTool(item);
+    }
+    for (const attempt of round.attempts ?? []) {
+      for (const item of attempt.items) {
+        pushTool(item);
+      }
+    }
+  }
+  return tools;
+}
+
+function toolStatusMatchesJournal(status: FlowToolItem['status'], eventType: string): boolean {
+  switch (eventType) {
+    case 'Completed':
+      return status === 'completed';
+    case 'Failed':
+      return status === 'error';
+    case 'Cancelled':
+      return status === 'cancelled' || status === 'confirmed';
+    case 'Rejected':
+      return status === 'rejected';
+    default:
+      return false;
+  }
+}
+
+/** Host journal terminal tools must already be painted before we cover their cursors. */
+export function runtimeProjectionCaughtUp(
+  session: Session | undefined,
+  snapshot: SessionRuntimeEventSnapshot,
+): boolean {
+  const turnId = snapshot.activeTurnId;
+  if (!session || !turnId) {
+    return false;
+  }
+  const turn = session.dialogTurns.find(candidate => candidate.id === turnId);
+  if (!turn) {
+    return false;
+  }
+  const tools = collectTurnTools(turn);
+  for (const event of snapshot.events) {
+    if (event.eventName !== 'agentic://tool-event') {
+      continue;
+    }
+    const toolEvent = readJournalToolEvent(event.payload);
+    if (!toolEvent || !JOURNAL_TERMINAL_TOOL_EVENTS.has(toolEvent.eventType)) {
+      continue;
+    }
+    const item = tools.find(tool => (
+      tool.id === toolEvent.toolId || tool.toolCall?.id === toolEvent.toolId
+    ));
+    if (!item || !toolStatusMatchesJournal(item.status, toolEvent.eventType)) {
+      return false;
+    }
+  }
+  return true;
 }
 
 async function alignStateMachineWithSnapshot(
@@ -195,7 +295,13 @@ export function installPeerSessionRefresh(context: FlowChatContext): () => void 
       }
       return;
     }
-    if (typeof document !== 'undefined' && document.visibilityState === 'hidden') {
+    // Hidden only skips the 3s liveness poll. A named repair or first attach
+    // must still run — otherwise a dropped ToolEnd stays frozen in the background.
+    if (
+      staleOnly &&
+      typeof document !== 'undefined' &&
+      document.visibilityState === 'hidden'
+    ) {
       return;
     }
     // A dead subscription is the strongest reason to reconcile, not a reason to
@@ -226,9 +332,11 @@ export function installPeerSessionRefresh(context: FlowChatContext): () => void 
       state.sessions.get(sessionId)?.dialogTurns ?? [],
     );
 
+    const surfaceScope = getActiveSurfaceScope();
+    const projectionStale = isRuntimeSessionProjectionStale(surfaceScope.surfaceId, sessionId);
     const machine = stateMachineManager.get(sessionId);
     const machineState = machine?.getCurrentState() ?? SessionExecutionState.IDLE;
-    if (machineState === SessionExecutionState.FINISHING) {
+    if (machineState === SessionExecutionState.FINISHING && !projectionStale) {
       return;
     }
     const lastUpdateTime = machine?.getContext().lastUpdateTime ?? 0;
@@ -236,14 +344,13 @@ export function installPeerSessionRefresh(context: FlowChatContext): () => void 
       machineState === SessionExecutionState.IDLE ||
       machineState === SessionExecutionState.ERROR;
     const streamIsStale = Date.now() - lastUpdateTime >= PEER_SESSION_STREAM_STALE_MS;
-    if (staleOnly && !forceRuntimeReplay && !streamIsStale) {
+    if (staleOnly && !forceRuntimeReplay && !streamIsStale && !projectionStale) {
       return;
     }
     const replaceRunningSnapshot =
       forceRuntimeReplay || streamIsStale;
     context.eventBatcher.flushNow();
     const machineVersion = machine?.getContext().version ?? 0;
-    const surfaceScope = getActiveSurfaceScope();
     const attachment = beginRuntimeSessionAttachment(surfaceScope.surfaceId, sessionId);
     let attachmentFinished = false;
 
@@ -270,6 +377,10 @@ export function installPeerSessionRefresh(context: FlowChatContext): () => void 
         },
       );
       surfaceScope.assertCurrent('attachRuntimeSession');
+      if (!attachment.isCurrent()) {
+        attachmentFinished = true;
+        return;
+      }
       const restoredSession = context.flowChatStore.getState().sessions.get(sessionId);
       if (restoredSession) {
         pendingQueueManager.reconcileAgainstLiveTurns(
@@ -279,18 +390,20 @@ export function installPeerSessionRefresh(context: FlowChatContext): () => void 
       }
 
       if (result.runtimeEventSnapshot) {
-        if (result.runtimeEventReplayRequired === false) {
-          // The rendered projection already includes this exact Runtime
-          // cursor. Advance the in-flight fence without resetting a healthy
-          // state machine every time the liveness timer runs.
+        const snapshot = result.runtimeEventSnapshot;
+        const alreadyCurrent = result.runtimeEventReplayRequired === false
+          && runtimeProjectionCaughtUp(restoredSession, snapshot);
+        if (alreadyCurrent) {
+          // Cursor match is not enough: the UI must already show journal
+          // terminal tools before we cover those events.
           attachment.finish({
-            streamId: result.runtimeEventSnapshot.streamId,
-            cursor: result.runtimeEventSnapshot.cursor,
-          });
+            streamId: snapshot.streamId,
+            cursor: snapshot.cursor,
+          }, { projectionCaughtUp: true });
           attachmentFinished = true;
           log.debug('Runtime session projection already current', {
             sessionId,
-            cursor: result.runtimeEventSnapshot.cursor,
+            cursor: snapshot.cursor,
           });
           return;
         }
@@ -301,15 +414,23 @@ export function installPeerSessionRefresh(context: FlowChatContext): () => void 
         context.eventBatcher.clear();
         context.contentBuffers.delete(sessionId);
         context.activeTextItems.delete(sessionId);
+        const replayTurnId = snapshot.activeTurnId ?? result.latestTurnId;
+        if (replayTurnId) {
+          context.flowChatStore.prepareRuntimeTurnReplay?.(sessionId, replayTurnId);
+        }
         stateMachineManager.reset(sessionId);
         await alignStateMachineWithSnapshot(
           context,
           sessionId,
           result.backendState,
-          result.runtimeEventSnapshot.activeTurnId ?? result.latestTurnId,
+          snapshot.activeTurnId ?? result.latestTurnId,
         );
+        if (!attachment.isCurrent()) {
+          attachmentFinished = true;
+          return;
+        }
 
-        for (const event of result.runtimeEventSnapshot.events) {
+        for (const event of snapshot.events) {
           surfaceScope.assertCurrent('replayRuntimeSessionProjection');
           if (!agenticEventListener.dispatchExternal(event.eventName, event.payload)) {
             throw new Error('Agentic event listener is unavailable during Runtime replay');
@@ -324,19 +445,29 @@ export function installPeerSessionRefresh(context: FlowChatContext): () => void 
           context,
           sessionId,
           result.backendState,
-          result.runtimeEventSnapshot.activeTurnId ?? result.latestTurnId,
+          snapshot.activeTurnId ?? result.latestTurnId,
         );
         surfaceScope.assertCurrent('finishRuntimeSessionAttachment');
+        if (!attachment.isCurrent()) {
+          attachmentFinished = true;
+          return;
+        }
+        const projectedSession = context.flowChatStore.getState().sessions.get(sessionId);
+        const projectionCaughtUp = runtimeProjectionCaughtUp(projectedSession, snapshot);
         attachment.finish({
-          streamId: result.runtimeEventSnapshot.streamId,
-          cursor: result.runtimeEventSnapshot.cursor,
-        });
+          streamId: snapshot.streamId,
+          cursor: snapshot.cursor,
+        }, { projectionCaughtUp });
         attachmentFinished = true;
+        if (!projectionCaughtUp) {
+          markRuntimeSessionProjectionStale(surfaceScope.surfaceId, sessionId);
+        }
         log.debug('Runtime session projection attached', {
           sessionId,
           backendState: result.backendState,
-          cursor: result.runtimeEventSnapshot.cursor,
-          eventCount: result.runtimeEventSnapshot.events.length,
+          cursor: snapshot.cursor,
+          eventCount: snapshot.events.length,
+          projectionCaughtUp,
         });
         return;
       }
@@ -383,8 +514,11 @@ export function installPeerSessionRefresh(context: FlowChatContext): () => void 
         latestTurnId: result.latestTurnId,
       });
     } catch (error) {
-      if (!attachmentFinished) {
+      if (!attachmentFinished && attachment.isCurrent()) {
         attachment.abort({ discard: !surfaceScope.isCurrent() });
+        if (surfaceScope.isCurrent()) {
+          markRuntimeSessionProjectionStale(surfaceScope.surfaceId, sessionId);
+        }
         attachmentFinished = true;
       }
       if (isSurfaceChangedError(error)) {
@@ -399,8 +533,11 @@ export function installPeerSessionRefresh(context: FlowChatContext): () => void 
       // auto-exit from Peer Mode.
       log.warn('Peer session snapshot refresh failed', { sessionId, error });
     } finally {
-      if (!attachmentFinished) {
+      if (!attachmentFinished && attachment.isCurrent()) {
         attachment.abort({ discard: !surfaceScope.isCurrent() });
+        if (surfaceScope.isCurrent()) {
+          markRuntimeSessionProjectionStale(surfaceScope.surfaceId, sessionId);
+        }
       }
       inFlight = false;
       drainFollowUpRefresh();

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/ToolEventModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/ToolEventModule.test.ts
@@ -304,7 +304,42 @@ describe('processToolEvent late Started event behavior', () => {
     expect(updatedRound2?.items.some(item => item.id === 'tool-late-1')).toBe(false);
   });
 
-  it('drops a Started event when the referenced round does not exist', () => {
+  it('does not downgrade a completed tool when a late Started event arrives', () => {
+    const session = createSessionWithTool({
+      id: 'tool-1',
+      type: 'tool',
+      toolName: 'Read',
+      timestamp: 1000,
+      status: 'completed',
+      toolCall: { id: 'tool-1', input: { file_path: 'README.md' } },
+      toolResult: { result: 'ok', success: true },
+    });
+    FlowChatStore.getInstance().setState(prev => ({
+      ...prev,
+      sessions: new Map([['session-1', session]]),
+      activeSessionId: 'session-1',
+    }));
+
+    processToolEvent(
+      makeToolContext(),
+      'session-1',
+      'turn-1',
+      'round-1',
+      {
+        event_type: 'Started',
+        tool_id: 'tool-1',
+        tool_name: 'Read',
+        params: { file_path: 'README.md' },
+      },
+    );
+
+    const tool = FlowChatStore.getInstance()
+      .findToolItem('session-1', 'turn-1', 'tool-1') as FlowToolItem;
+    expect(tool.status).toBe('completed');
+    expect(tool.toolResult).toMatchObject({ success: true });
+  });
+
+  it('creates the journal round when a Started event references a missing round', () => {
     const turn: DialogTurn = {
       id: 'turn-1',
       sessionId: 'session-1',
@@ -357,7 +392,51 @@ describe('processToolEvent late Started event behavior', () => {
     );
 
     const updatedTurn = FlowChatStore.getInstance().getState().sessions.get('session-1')?.dialogTurns[0];
-    expect(updatedTurn?.modelRounds[0]?.items.some(item => item.id === 'tool-late-1')).toBe(false);
+    expect(updatedTurn?.modelRounds.some(round => round.id === 'round-missing')).toBe(true);
+    expect(
+      updatedTurn?.modelRounds
+        .find(round => round.id === 'round-missing')
+        ?.items.some(item => item.id === 'tool-late-1'),
+    ).toBe(true);
+  });
+
+  it('upserts a Completed card when Started never created one', () => {
+    const session = createSessionWithTool({
+      id: 'placeholder',
+      type: 'tool',
+      toolName: 'Read',
+      timestamp: 1000,
+      status: 'running',
+      toolCall: { id: 'placeholder', input: {} },
+    });
+    session.dialogTurns[0].modelRounds[0].items = [];
+    FlowChatStore.getInstance().setState(prev => ({
+      ...prev,
+      sessions: new Map([['session-1', session]]),
+      activeSessionId: 'session-1',
+    }));
+
+    processToolEvent(
+      makeToolContext(),
+      'session-1',
+      'turn-1',
+      'round-1',
+      {
+        event_type: 'Completed',
+        tool_id: 'read-1',
+        tool_name: 'Read',
+        result: 'file contents',
+        result_for_assistant: 'file contents',
+      } as any,
+    );
+
+    const tool = FlowChatStore.getInstance()
+      .findToolItem('session-1', 'turn-1', 'read-1') as FlowToolItem;
+    expect(tool).toMatchObject({
+      id: 'read-1',
+      status: 'completed',
+      toolName: 'Read',
+    });
   });
 });
 

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/ToolEventModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/ToolEventModule.ts
@@ -6,11 +6,12 @@
 import { FlowChatStore } from '../../store/FlowChatStore';
 import { extractFilePathFromJsonBuffer, parsePartialJson, splitFilePathAndContent } from '../../../shared/utils/partialJsonParser';
 import { createLogger } from '@/shared/utils/logger';
-import type { FlowChatContext, FlowToolItem, ToolEventOptions, DialogTurn } from './types';
+import type { FlowChatContext, FlowToolItem, ToolEventOptions, DialogTurn, ModelRound } from './types';
 import { immediateSaveDialogTurn } from './PersistenceModule';
 import { applyPendingAcpPermissionForTool } from './AcpPermissionToolCardModule';
 import { normalizeParamsPartialFragment } from '../EventBatcher';
 import { effectiveToolInvocation } from '../../utils/toolInvocationIdentity';
+import { requestRuntimeProjectionRepair } from './PeerSessionRefreshModule';
 import type {
   CancelledToolEvent,
   CompletedToolEvent,
@@ -28,6 +29,73 @@ import type {
 
 const log = createLogger('ToolEventModule');
 const pendingTerminalSessionIds = new Map<string, string>();
+const TERMINAL_TOOL_STATUSES = new Set<FlowToolItem['status']>([
+  'completed',
+  'error',
+  'cancelled',
+  'rejected',
+]);
+
+function isTerminalToolStatus(status: FlowToolItem['status'] | undefined): boolean {
+  return status !== undefined && TERMINAL_TOOL_STATUSES.has(status);
+}
+
+function resolveToolRoundId(dialogTurn: DialogTurn, roundId: string): string | undefined {
+  if (dialogTurn.modelRounds.some(round => round.id === roundId)) {
+    return roundId;
+  }
+  return dialogTurn.modelRounds.at(-1)?.id;
+}
+
+function ensureToolRoundId(
+  store: FlowChatStore,
+  sessionId: string,
+  turnId: string,
+  dialogTurn: DialogTurn,
+  roundId: string,
+): string | undefined {
+  if (dialogTurn.modelRounds.some(round => round.id === roundId)) {
+    return roundId;
+  }
+  if (roundId) {
+    const created: ModelRound = {
+      id: roundId,
+      index: dialogTurn.modelRounds.length,
+      items: [],
+      isStreaming: true,
+      isComplete: false,
+      status: 'streaming',
+      startTime: Date.now(),
+    };
+    store.addModelRound(sessionId, turnId, created);
+    return roundId;
+  }
+  return resolveToolRoundId(dialogTurn, roundId);
+}
+
+function applyToolItemUpdateOrInsert(
+  store: FlowChatStore,
+  sessionId: string,
+  turnId: string,
+  dialogTurn: DialogTurn,
+  roundId: string,
+  toolId: string,
+  updates: Record<string, unknown>,
+  createItem: () => FlowToolItem,
+): void {
+  if (store.findToolItem(sessionId, turnId, toolId)) {
+    if (!store.updateModelRoundItem(sessionId, turnId, toolId, updates as any)) {
+      requestRuntimeProjectionRepair(sessionId);
+    }
+    return;
+  }
+  const targetRoundId = ensureToolRoundId(store, sessionId, turnId, dialogTurn, roundId);
+  if (!targetRoundId) {
+    requestRuntimeProjectionRepair(sessionId);
+    return;
+  }
+  store.addModelRoundItem(sessionId, turnId, createItem(), targetRoundId);
+}
 
 interface ToolTerminalReadyEvent {
   tool_use_id: string;
@@ -54,12 +122,14 @@ export function processToolEvent(
   const session = state.sessions.get(sessionId);
   
   if (!session) {
+    requestRuntimeProjectionRepair(sessionId);
     log.debug('Session not found (processToolEvent)', { sessionId });
     return;
   }
 
   const dialogTurn = session.dialogTurns.find((turn: DialogTurn) => turn.id === turnId);
   if (!dialogTurn) {
+    requestRuntimeProjectionRepair(sessionId);
     log.debug('Dialog turn not found (processToolEvent)', { turnId });
     return;
   }
@@ -95,25 +165,25 @@ export function processToolEvent(
     
     case 'Completed': {
       flushPendingBatchedEvents(context);
-      handleCompleted(context, store, sessionId, turnId, toolEvent, options, onTodoWriteResult);
+      handleCompleted(context, store, sessionId, turnId, roundId, dialogTurn, toolEvent, options, onTodoWriteResult);
       break;
     }
     
     case 'Failed': {
       flushPendingBatchedEvents(context);
-      handleFailed(context, store, sessionId, turnId, toolEvent);
+      handleFailed(context, store, sessionId, turnId, roundId, dialogTurn, toolEvent);
       break;
     }
     
     case 'Cancelled': {
       flushPendingBatchedEvents(context);
-      handleCancelled(context, store, sessionId, turnId, toolEvent);
+      handleCancelled(context, store, sessionId, turnId, roundId, dialogTurn, toolEvent);
       break;
     }
 
     case 'Rejected': {
       flushPendingBatchedEvents(context);
-      handleRejected(context, store, sessionId, turnId, toolEvent);
+      handleRejected(context, store, sessionId, turnId, roundId, dialogTurn, toolEvent);
       break;
     }
     
@@ -129,6 +199,10 @@ export function processToolEvent(
     }
 
     case 'Streaming': {
+      const existing = store.findToolItem(sessionId, turnId, toolEvent.tool_id);
+      if (isTerminalToolStatus(existing?.status)) {
+        break;
+      }
       updateToolItem(store, sessionId, turnId, toolEvent.tool_id, {
         status: 'streaming',
         isParamsStreaming: false,
@@ -387,8 +461,9 @@ function handleEarlyDetected(
     attemptIndex,
   };
 
-  const targetRound = dialogTurn.modelRounds.find(round => round.id === roundId);
-  if (!targetRound) {
+  const targetRoundId = ensureToolRoundId(store, sessionId, turnId, dialogTurn, roundId);
+  if (!targetRoundId) {
+    requestRuntimeProjectionRepair(sessionId);
     log.error('Tool EarlyDetected event references missing round (backend bug)', {
       sessionId,
       turnId,
@@ -399,7 +474,7 @@ function handleEarlyDetected(
     return;
   }
 
-  store.addModelRoundItem(sessionId, turnId, preparingToolItem, roundId);
+  store.addModelRoundItem(sessionId, turnId, preparingToolItem, targetRoundId);
   applyPendingAcpPermissionForTool(store, toolEvent.tool_id);
 }
 
@@ -425,7 +500,7 @@ function handleQueued(
   toolEvent: QueuedToolEvent
 ): void {
   const existingItem = store.findToolItem(sessionId, turnId, toolEvent.tool_id);
-  if (existingItem && existingItem.type === 'tool') {
+  if (existingItem && existingItem.type === 'tool' && !isTerminalToolStatus(existingItem.status)) {
     updateToolItem(store, sessionId, turnId, toolEvent.tool_id, {
       status: 'queued',
     });
@@ -442,7 +517,7 @@ function handleWaiting(
   toolEvent: WaitingToolEvent
 ): void {
   const existingItem = store.findToolItem(sessionId, turnId, toolEvent.tool_id);
-  if (existingItem && existingItem.type === 'tool') {
+  if (existingItem && existingItem.type === 'tool' && !isTerminalToolStatus(existingItem.status)) {
     updateToolItem(store, sessionId, turnId, toolEvent.tool_id, {
       status: 'waiting',
     });
@@ -474,12 +549,17 @@ function handleStarted(
   };
 
   if (existingItem) {
+    const keepTerminalStatus = isTerminalToolStatus(existingItem.status);
     store.updateModelRoundItem(sessionId, turnId, toolEvent.tool_id, {
       toolName: toolEvent.tool_name,
       toolCall: toolCallData,
-      status: 'running',
-      isParamsStreaming: false,
-      partialParams: undefined,
+      ...(keepTerminalStatus
+        ? {}
+        : {
+            status: 'running',
+            isParamsStreaming: false,
+            partialParams: undefined,
+          }),
       attemptId,
       attemptIndex,
     } as any);
@@ -500,12 +580,13 @@ function handleStarted(
       attemptIndex,
     };
 
-    const targetRound = dialogTurn.modelRounds.find(round => round.id === roundId);
-    if (targetRound) {
-      store.addModelRoundItem(sessionId, turnId, toolItem, roundId);
+    const targetRoundId = ensureToolRoundId(store, sessionId, turnId, dialogTurn, roundId);
+    if (targetRoundId) {
+      store.addModelRoundItem(sessionId, turnId, toolItem, targetRoundId);
       pendingTerminalSessionIds.delete(toolEvent.tool_id);
       applyPendingAcpPermissionForTool(store, toolEvent.tool_id);
     } else {
+      requestRuntimeProjectionRepair(sessionId);
       log.error('Tool Started event references missing round (backend bug)', {
         sessionId,
         turnId,
@@ -525,6 +606,8 @@ function handleCompleted(
   store: FlowChatStore,
   sessionId: string,
   turnId: string,
+  roundId: string,
+  dialogTurn: DialogTurn,
   toolEvent: CompletedToolEvent,
   options?: ToolEventOptions,
   onTodoWriteResult?: (sessionId: string, turnId: string, result: any) => void
@@ -554,7 +637,26 @@ function handleCompleted(
     executionMs: toolEvent.execution_ms
   };
 
-  store.updateModelRoundItem(sessionId, turnId, toolEvent.tool_id, updates as any);
+  applyToolItemUpdateOrInsert(
+    store,
+    sessionId,
+    turnId,
+    dialogTurn,
+    roundId,
+    toolEvent.tool_id,
+    updates,
+    () => ({
+      id: toolEvent.tool_id,
+      type: 'tool',
+      toolName: toolEvent.tool_name,
+      toolCall: {
+        input: {},
+        id: toolEvent.tool_id,
+      },
+      timestamp: Date.now(),
+      ...updates,
+    }),
+  );
 
   store.clearSessionNeedsAttention(sessionId);
 
@@ -569,16 +671,18 @@ function handleFailed(
   store: FlowChatStore,
   sessionId: string,
   turnId: string,
+  roundId: string,
+  dialogTurn: DialogTurn,
   toolEvent: FailedToolEvent
 ): void {
-  store.updateModelRoundItem(sessionId, turnId, toolEvent.tool_id, {
+  const updates = {
     toolResult: {
       result: null,
       success: false,
       error: toolEvent.error,
       duration_ms: toolEvent.duration_ms
     },
-    status: 'error',
+    status: 'error' as const,
     requiresConfirmation: false,
     acpPermission: undefined,
     endTime: Date.now(),
@@ -587,7 +691,28 @@ function handleFailed(
     preflightMs: toolEvent.preflight_ms,
     confirmationWaitMs: toolEvent.confirmation_wait_ms,
     executionMs: toolEvent.execution_ms
-  } as any);
+  };
+
+  applyToolItemUpdateOrInsert(
+    store,
+    sessionId,
+    turnId,
+    dialogTurn,
+    roundId,
+    toolEvent.tool_id,
+    updates,
+    () => ({
+      id: toolEvent.tool_id,
+      type: 'tool',
+      toolName: toolEvent.tool_name,
+      toolCall: {
+        input: {},
+        id: toolEvent.tool_id,
+      },
+      timestamp: Date.now(),
+      ...updates,
+    }),
+  );
 
   store.clearSessionNeedsAttention(sessionId);
 
@@ -602,13 +727,15 @@ function handleCancelled(
   store: FlowChatStore,
   sessionId: string,
   turnId: string,
+  roundId: string,
+  dialogTurn: DialogTurn,
   toolEvent: CancelledToolEvent
 ): void {
   const existingToolItem = store.findToolItem(sessionId, turnId, toolEvent.tool_id);
   const currentStatus = existingToolItem?.status;
   const finalStatus = currentStatus === 'confirmed' ? 'confirmed' : 'cancelled';
 
-  store.updateModelRoundItem(sessionId, turnId, toolEvent.tool_id, {
+  const updates = {
     toolResult: {
       result: null,
       success: false,
@@ -624,7 +751,28 @@ function handleCancelled(
     preflightMs: toolEvent.preflight_ms,
     confirmationWaitMs: toolEvent.confirmation_wait_ms,
     executionMs: toolEvent.execution_ms
-  } as any);
+  };
+
+  applyToolItemUpdateOrInsert(
+    store,
+    sessionId,
+    turnId,
+    dialogTurn,
+    roundId,
+    toolEvent.tool_id,
+    updates,
+    () => ({
+      id: toolEvent.tool_id,
+      type: 'tool',
+      toolName: toolEvent.tool_name,
+      toolCall: {
+        input: {},
+        id: toolEvent.tool_id,
+      },
+      timestamp: Date.now(),
+      ...updates,
+    }),
+  );
 
   store.clearSessionNeedsAttention(sessionId);
 
@@ -639,21 +787,44 @@ function handleRejected(
   store: FlowChatStore,
   sessionId: string,
   turnId: string,
+  roundId: string,
+  dialogTurn: DialogTurn,
   toolEvent: RejectedToolEvent
 ): void {
-  store.updateModelRoundItem(sessionId, turnId, toolEvent.tool_id, {
+  const updates = {
     toolResult: {
       result: null,
       success: false,
       error: 'User rejected operation',
     },
-    status: 'rejected',
+    status: 'rejected' as const,
     userConfirmed: false,
     requiresConfirmation: false,
     acpPermission: undefined,
     isParamsStreaming: false,
     endTime: Date.now(),
-  } as any);
+  };
+
+  applyToolItemUpdateOrInsert(
+    store,
+    sessionId,
+    turnId,
+    dialogTurn,
+    roundId,
+    toolEvent.tool_id,
+    updates,
+    () => ({
+      id: toolEvent.tool_id,
+      type: 'tool',
+      toolName: toolEvent.tool_name,
+      toolCall: {
+        input: {},
+        id: toolEvent.tool_id,
+      },
+      timestamp: Date.now(),
+      ...updates,
+    }),
+  );
 
   store.clearSessionNeedsAttention(sessionId);
 
@@ -669,6 +840,11 @@ function handleConfirmationNeeded(
   turnId: string,
   toolEvent: ConfirmationNeededToolEvent
 ): void {
+  const existing = store.findToolItem(sessionId, turnId, toolEvent.tool_id);
+  if (isTerminalToolStatus(existing?.status)) {
+    return;
+  }
+
   store.updateModelRoundItem(sessionId, turnId, toolEvent.tool_id, {
     toolName: toolEvent.tool_name,
     toolCall: {

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/ToolEventModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/ToolEventModule.ts
@@ -733,7 +733,11 @@ function handleCancelled(
 ): void {
   const existingToolItem = store.findToolItem(sessionId, turnId, toolEvent.tool_id);
   const currentStatus = existingToolItem?.status;
-  const finalStatus = currentStatus === 'confirmed' ? 'confirmed' : 'cancelled';
+  // Annotated so the literal type does not widen to `string` when it lands in
+  // the mutable `updates` object below, which the insert factory then has to
+  // satisfy as a `FlowToolItem`.
+  const finalStatus: FlowToolItem['status'] =
+    currentStatus === 'confirmed' ? 'confirmed' : 'cancelled';
 
   const updates = {
     toolResult: {

--- a/src/web-ui/src/flow_chat/session-stream/SessionStream.test.ts
+++ b/src/web-ui/src/flow_chat/session-stream/SessionStream.test.ts
@@ -34,9 +34,12 @@ describe('position ordering', () => {
     expect(comparePositions(at(4), at(2))).toBe('not-ahead');
   });
 
-  it('treats joining mid-stream as a gap', () => {
+  it('adopts a baseline when joining mid-stream instead of reporting a gap', () => {
+    // Cursors are per Session and never reset, so opening an existing Session
+    // legitimately starts at a high cursor. Nothing this client applied is
+    // missing; what came before is history.
     expect(comparePositions(null, at(1))).toBe('next');
-    expect(comparePositions(null, at(6))).toBe('ahead-with-gap');
+    expect(comparePositions(null, at(6))).toBe('next');
   });
 });
 

--- a/src/web-ui/src/flow_chat/session-stream/SessionStream.test.ts
+++ b/src/web-ui/src/flow_chat/session-stream/SessionStream.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { comparePositions } from './position';
+import {
+  resetSessionStreamsForTest,
+  sessionStream,
+} from './SessionStream';
+
+afterEach(() => {
+  resetSessionStreamsForTest();
+});
+
+function at(cursor: number, streamId = 'runtime-a') {
+  return { streamId, cursor };
+}
+
+function textAt(turnId: string) {
+  return { sessionId: 'session', turnId, text: 'x' };
+}
+
+const TEXT = 'agentic://text-chunk';
+const STARTED = 'agentic://dialog-turn-started';
+const COMPLETED = 'agentic://dialog-turn-completed';
+
+describe('position ordering', () => {
+  it('never orders cursors from different Runtime processes', () => {
+    expect(comparePositions(at(9), at(3, 'runtime-b'))).toBe('unrelated');
+    expect(comparePositions(at(9), at(30, 'runtime-b'))).toBe('unrelated');
+  });
+
+  it('separates continuing from skipping', () => {
+    expect(comparePositions(at(4), at(5))).toBe('next');
+    expect(comparePositions(at(4), at(7))).toBe('ahead-with-gap');
+    expect(comparePositions(at(4), at(4))).toBe('not-ahead');
+    expect(comparePositions(at(4), at(2))).toBe('not-ahead');
+  });
+
+  it('treats joining mid-stream as a gap', () => {
+    expect(comparePositions(null, at(1))).toBe('next');
+    expect(comparePositions(null, at(6))).toBe('ahead-with-gap');
+  });
+});
+
+describe('SessionStream', () => {
+  it('drops a write that is not ahead instead of merging it', () => {
+    const stream = sessionStream('local', 'session');
+    const applied: number[] = [];
+    const offer = (cursor: number) =>
+      stream.offer(TEXT, textAt('turn'), at(cursor), () => applied.push(cursor));
+
+    expect(offer(1)).toBe('apply');
+    expect(offer(2)).toBe('apply');
+    // A redelivery of an event already accounted for.
+    expect(offer(2)).toBe('drop');
+    expect(offer(1)).toBe('drop');
+    expect(stream.appliedPosition()).toEqual(at(2));
+  });
+
+  it('reports a gap from the order alone, and clears it when the range arrives', () => {
+    const stream = sessionStream('local', 'session');
+    stream.offer(TEXT, textAt('turn'), at(1), () => {});
+    expect(stream.hasGap()).toBe(false);
+
+    stream.offer(TEXT, textAt('turn'), at(5), () => {});
+    expect(stream.hasGap()).toBe(true);
+
+    // A backfill painted 2..5 and reported where it ended.
+    stream.commitAppliedPosition(at(5));
+    expect(stream.hasGap()).toBe(false);
+  });
+
+  it('stops the persisted record from writing an executing Turn', () => {
+    const stream = sessionStream('local', 'session');
+    stream.offer(STARTED, textAt('turn-1'), at(1), () => {});
+
+    // The Turn is running: its persisted checkpoint is identity only.
+    expect(stream.executingTurnIds()).toEqual(['turn-1']);
+
+    stream.offer(COMPLETED, textAt('turn-1'), at(2), () => {});
+    expect(stream.executingTurnIds()).toEqual([]);
+  });
+
+  it('drops a live event that arrives after its Turn settled', () => {
+    const stream = sessionStream('local', 'session');
+    stream.offer(STARTED, textAt('turn-1'), at(1), () => {});
+    stream.offer(COMPLETED, textAt('turn-1'), at(2), () => {});
+
+    // Ownership transferred to the persisted record; a straggler must not
+    // repaint content that record now owns.
+    expect(stream.offer(TEXT, textAt('turn-1'), at(3), () => {})).toBe('drop');
+  });
+
+  it('holds writes during a read and releases only those ahead of it', () => {
+    const stream = sessionStream('local', 'session');
+    stream.offer(TEXT, textAt('turn'), at(2), () => {});
+
+    const released: number[] = [];
+    const read = stream.beginRead();
+    for (const cursor of [3, 6, 7]) {
+      expect(
+        stream.offer(TEXT, textAt('turn'), at(cursor), () => released.push(cursor)),
+      ).toBe('hold');
+    }
+    expect(released).toEqual([]);
+
+    // The read established everything through cursor 5.
+    read.settle(at(5));
+    expect(released).toEqual([6, 7]);
+    expect(stream.appliedPosition()).toEqual(at(7));
+  });
+
+  it('lets an overlapping read inherit held writes instead of double-applying', () => {
+    const stream = sessionStream('local', 'session');
+    const released: number[] = [];
+    const first = stream.beginRead();
+    stream.offer(TEXT, textAt('turn'), at(4), () => released.push(4));
+
+    const second = stream.beginRead();
+    expect(first.isCurrent()).toBe(false);
+    // The superseded read must not drain onto a projection the newer read is
+    // about to establish.
+    first.settle(at(9));
+    expect(released).toEqual([]);
+
+    second.settle(at(3));
+    expect(released).toEqual([4]);
+  });
+
+  it('supersedes the old ordering wholesale when the Runtime process changes', () => {
+    const stream = sessionStream('local', 'session');
+    stream.offer(STARTED, textAt('turn-1'), at(1), () => {});
+    stream.offer(COMPLETED, textAt('turn-1'), at(2), () => {});
+
+    // A restarted Host mints a new stream. Its low cursors are not "behind",
+    // and the old Turn's settled state says nothing about the new process.
+    expect(
+      stream.offer(TEXT, textAt('turn-1'), at(1, 'runtime-b'), () => {}),
+    ).toBe('apply');
+    expect(stream.appliedPosition()).toEqual(at(1, 'runtime-b'));
+  });
+
+  it('applies an unpositioned write rather than hiding it', () => {
+    const stream = sessionStream('local', 'session');
+    stream.offer(TEXT, textAt('turn'), at(5), () => {});
+    // An older Host, or a Session-scoped event with no cursor: there is no
+    // ordering to violate.
+    expect(stream.offer('session_title_generated', { sessionId: 'session' }, null, () => {}))
+      .toBe('apply');
+    expect(stream.appliedPosition()).toEqual(at(5));
+  });
+
+  it('keeps identity per surface so two devices cannot share a position', () => {
+    const local = sessionStream('local', 'session');
+    const peer = sessionStream('device-b', 'session');
+
+    local.offer(TEXT, textAt('turn'), at(7), () => {});
+    expect(peer.appliedPosition()).toBeNull();
+    expect(sessionStream('local', 'session')).toBe(local);
+    expect(sessionStream('device-b', 'session')).toBe(peer);
+  });
+});

--- a/src/web-ui/src/flow_chat/session-stream/SessionStream.ts
+++ b/src/web-ui/src/flow_chat/session-stream/SessionStream.ts
@@ -13,6 +13,7 @@
  */
 
 import {
+  getActiveSurfaceScope,
   surfaceScopedKey,
   type DeviceSurfaceId,
 } from '@/infrastructure/peer-device/deviceSurface';
@@ -72,6 +73,11 @@ export class SessionStream {
     return this.ownership.executingTurnIds();
   }
 
+  /** Whether the persisted record may write this Turn (contract 2). */
+  persistedMayWrite(turnId: string): boolean {
+    return this.ownership.persistedMayWrite(turnId);
+  }
+
   /**
    * Offer a positioned write.
    *
@@ -121,7 +127,7 @@ export class SessionStream {
       // and every ownership fact from the old process is void — a Turn id it
       // reuses is a different Turn as far as this stream is concerned.
       this.ownership.reset();
-      this.gapAt = position.cursor > 1 ? position : null;
+      this.gapAt = null;
     } else if (order === 'ahead-with-gap') {
       // A real discontinuity, independent of whether this particular event is
       // admitted below.
@@ -282,4 +288,31 @@ export function discardSessionStreams(surfaceId: DeviceSurfaceId): void {
 export function resetSessionStreamsForTest(): void {
   streams.clear();
   nextSequence = 0;
+}
+
+/**
+ * Whether the persisted record may write this Turn on the rendered surface.
+ *
+ * The persisted copy of an executing Turn is deliberately stored idle so a
+ * restart never revives work, which makes it truncated and shaped like a
+ * finished Turn. Contract 2 is what stops that copy from being painted over
+ * the Turn the runtime stream owns.
+ *
+ * No stream means nothing live has been observed for this Session here, so
+ * there is no runtime-owned content to protect and history is free to write.
+ */
+export function persistedMayWriteTurn(
+  sessionId: string,
+  turnId: string,
+  hostExecutingTurnId?: string,
+): boolean {
+  // The Host's own state is the authority on which Turn is executing. This
+  // window may never have seen that Turn start — it opened mid-flight, or the
+  // Turn was established by replaying a snapshot rather than by routed live
+  // events — and "I did not witness it" is not evidence that it finished.
+  if (hostExecutingTurnId && hostExecutingTurnId === turnId) {
+    return false;
+  }
+  const stream = peekSessionStream(getActiveSurfaceScope().surfaceId, sessionId);
+  return stream ? stream.persistedMayWrite(turnId) : true;
 }

--- a/src/web-ui/src/flow_chat/session-stream/SessionStream.ts
+++ b/src/web-ui/src/flow_chat/session-stream/SessionStream.ts
@@ -1,0 +1,285 @@
+/**
+ * One ordered stream per `(surface, session)`.
+ *
+ * Contract: [`docs/architecture/session-projection.md`](../../../../../docs/architecture/session-projection.md).
+ *
+ * This object owns the applied position, the pending queue, and Turn
+ * ownership. It decides whether a write may be applied; the caller performs
+ * the painting. That split is deliberate for the migration — writers move onto
+ * the contract one at a time without their rendering code moving with them.
+ *
+ * Nothing here reads projected content. A write is admitted because of where
+ * it sits in the order, never because of what is currently on screen.
+ */
+
+import {
+  surfaceScopedKey,
+  type DeviceSurfaceId,
+} from '@/infrastructure/peer-device/deviceSurface';
+import {
+  advancePosition,
+  comparePositions,
+  type RuntimePosition,
+} from './position';
+import { eventTurnId, TurnOwnership } from './turnOwnership';
+
+/** What the caller should do with an offered write. */
+export type StreamAdmission =
+  /** Apply it now. */
+  | 'apply'
+  /** A prefix read is in flight; the stream is holding it and will release it. */
+  | 'hold'
+  /** Already accounted for, or its Turn is settled. Applying it would regress. */
+  | 'drop';
+
+interface HeldWrite {
+  sequence: number;
+  position: RuntimePosition | null;
+  release: () => void;
+}
+
+let nextSequence = 0;
+
+export class SessionStream {
+  private applied: RuntimePosition | null = null;
+  private held: HeldWrite[] | null = null;
+  private prefixGeneration = 0;
+  private readonly ownership = new TurnOwnership();
+  /** Set when a position skipped ahead; cleared when the skipped range arrives. */
+  private gapAt: RuntimePosition | null = null;
+
+  constructor(
+    readonly surfaceId: DeviceSurfaceId,
+    readonly sessionId: string,
+  ) {}
+
+  appliedPosition(): RuntimePosition | null {
+    return this.applied;
+  }
+
+  /**
+   * Whether events between the applied position and what has arrived are
+   * missing.
+   *
+   * This is a fact derived from positions, not a flag someone sets after
+   * noticing the screen looks wrong.
+   */
+  hasGap(): boolean {
+    return this.gapAt !== null;
+  }
+
+  executingTurnIds(): string[] {
+    return this.ownership.executingTurnIds();
+  }
+
+  /**
+   * Offer a positioned write.
+   *
+   * An unpositioned write (an older Host, or a Session-scoped event that
+   * carries no cursor) is always applied: there is no ordering to violate, and
+   * refusing it would hide content rather than protect any.
+   */
+  offer(
+    eventName: string,
+    payload: unknown,
+    position: RuntimePosition | null,
+    release: () => void,
+  ): StreamAdmission {
+    if (this.held) {
+      this.held.push({ sequence: ++nextSequence, position, release });
+      return 'hold';
+    }
+    return this.admit(eventName, payload, position);
+  }
+
+  private admit(
+    eventName: string,
+    payload: unknown,
+    position: RuntimePosition | null,
+  ): StreamAdmission {
+    const turnId = eventTurnId(payload);
+    const settledHere = (): boolean =>
+      turnId !== null && !this.ownership.runtimeMayWrite(turnId);
+
+    if (!position) {
+      if (settledHere()) {
+        return 'drop';
+      }
+      this.ownership.observe(eventName, turnId);
+      return 'apply';
+    }
+
+    // Order first. Ownership facts belong to a Runtime process, so which
+    // process this position came from has to be settled before they can be
+    // consulted at all.
+    const order = comparePositions(this.applied, position);
+    if (order === 'not-ahead') {
+      return 'drop';
+    }
+    if (order === 'unrelated') {
+      // A new Runtime process. Its ordering supersedes the old one outright,
+      // and every ownership fact from the old process is void — a Turn id it
+      // reuses is a different Turn as far as this stream is concerned.
+      this.ownership.reset();
+      this.gapAt = position.cursor > 1 ? position : null;
+    } else if (order === 'ahead-with-gap') {
+      // A real discontinuity, independent of whether this particular event is
+      // admitted below.
+      this.gapAt = position;
+    } else {
+      this.gapAt = null;
+    }
+
+    if (settledHere()) {
+      // The Turn settled in this same stream. A straggler for it would repaint
+      // content the persisted record now owns.
+      return 'drop';
+    }
+    this.applied = advancePosition(this.applied, position);
+    this.ownership.observe(eventName, turnId);
+    return 'apply';
+  }
+
+  /**
+   * Begin reading a prefix (a snapshot) or a suffix (a backfill).
+   *
+   * Writes offered while the read is in flight are held rather than applied,
+   * so the read's result cannot interleave with live events that overlap it.
+   * An overlapping read supersedes the previous one and inherits its held
+   * writes; releasing them here would apply them against a projection the new
+   * read is about to establish.
+   */
+  beginRead(): SessionStreamRead {
+    const generation = ++this.prefixGeneration;
+    this.held = this.held ?? [];
+
+    const isCurrent = (): boolean => this.prefixGeneration === generation;
+    const takeHeld = (): HeldWrite[] | null => {
+      if (!isCurrent()) {
+        return null;
+      }
+      const held = this.held ?? [];
+      this.held = null;
+      return held;
+    };
+
+    return {
+      isCurrent,
+      settle: (position: RuntimePosition | null) => {
+        const held = takeHeld();
+        if (!held) {
+          return;
+        }
+        if (position) {
+          this.applied = advancePosition(this.applied, position);
+          this.gapAt = null;
+        }
+        this.releaseHeld(held);
+      },
+      abandon: () => {
+        const held = takeHeld();
+        if (held) {
+          this.releaseHeld(held);
+        }
+      },
+    };
+  }
+
+  private releaseHeld(held: HeldWrite[]): void {
+    held.sort((left, right) => left.sequence - right.sequence);
+    for (const write of held) {
+      if (!write.position) {
+        write.release();
+        continue;
+      }
+      if (comparePositions(this.applied, write.position) === 'not-ahead') {
+        continue;
+      }
+      this.applied = advancePosition(this.applied, write.position);
+      write.release();
+    }
+  }
+
+  /**
+   * Record a position reached by applying content the stream did not route —
+   * a snapshot prefix or a backfill suffix the caller painted itself.
+   */
+  commitAppliedPosition(position: RuntimePosition): void {
+    this.applied = advancePosition(this.applied, position);
+    this.gapAt = null;
+  }
+
+  /** Observe ownership for content applied outside `offer`, in order. */
+  observeApplied(eventName: string, payload: unknown): void {
+    this.ownership.observe(eventName, eventTurnId(payload));
+  }
+
+  /**
+   * The painter refused content this stream admitted.
+   *
+   * The one report that does not come from the order. Painting happens outside
+   * this object, so a projection can fall behind a position that was legally
+   * admitted — a dropped ToolEnd leaves a tool card frozen while the position
+   * says everything arrived. Recording it as a gap routes the repair through
+   * the same path a lost event uses, instead of a second staleness concept.
+   */
+  markProjectionBehind(): void {
+    this.gapAt = this.applied ?? { streamId: '', cursor: 0 };
+  }
+}
+
+export interface SessionStreamRead {
+  /** False once a newer read superseded this one. */
+  isCurrent(): boolean;
+  /** Finish at `position` and release everything ahead of it, in order. */
+  settle(position: RuntimePosition | null): void;
+  /** Give up without advancing; held writes are released unchanged. */
+  abandon(): void;
+}
+
+const streams = new Map<string, SessionStream>();
+
+function streamKey(surfaceId: DeviceSurfaceId, sessionId: string): string {
+  return surfaceScopedKey(surfaceId, 'session-stream', sessionId);
+}
+
+export function sessionStream(
+  surfaceId: DeviceSurfaceId,
+  sessionId: string,
+): SessionStream {
+  const key = streamKey(surfaceId, sessionId);
+  const existing = streams.get(key);
+  if (existing) {
+    return existing;
+  }
+  const created = new SessionStream(surfaceId, sessionId);
+  streams.set(key, created);
+  return created;
+}
+
+export function peekSessionStream(
+  surfaceId: DeviceSurfaceId,
+  sessionId: string,
+): SessionStream | undefined {
+  return streams.get(streamKey(surfaceId, sessionId));
+}
+
+/**
+ * Drop a surface's streams when its attachment is disposed.
+ *
+ * Not on a surface switch: a switch changes what is drawn, and the peer keeps
+ * running our work. Discarding the stream would forget the position we would
+ * need to catch up with on return.
+ */
+export function discardSessionStreams(surfaceId: DeviceSurfaceId): void {
+  for (const [key, stream] of [...streams.entries()]) {
+    if (stream.surfaceId === surfaceId) {
+      streams.delete(key);
+    }
+  }
+}
+
+export function resetSessionStreamsForTest(): void {
+  streams.clear();
+  nextSequence = 0;
+}

--- a/src/web-ui/src/flow_chat/session-stream/position.ts
+++ b/src/web-ui/src/flow_chat/session-stream/position.ts
@@ -1,0 +1,105 @@
+/**
+ * Positions in a Session's ordered stream.
+ *
+ * Contract: [`docs/architecture/session-projection.md`](../../../../../docs/architecture/session-projection.md).
+ *
+ * A position is the only thing that decides whether a write may be applied.
+ * Nothing here inspects projected content — that inspection is precisely what
+ * this replaces.
+ */
+
+/**
+ * A point in one Runtime process's delivery stream.
+ *
+ * `streamId` identifies the process. Cursors minted by different processes
+ * describe unrelated orderings, so they are never compared; a new `streamId`
+ * is a new stream, not progress within the old one.
+ */
+export interface RuntimePosition {
+  streamId: string;
+  cursor: number;
+}
+
+/** Ordering of two positions in the same stream. */
+export type PositionOrder =
+  /** `candidate` continues directly from `applied`. */
+  | 'next'
+  /** `candidate` is ahead, but events between it and `applied` are missing. */
+  | 'ahead-with-gap'
+  /** `candidate` is at or behind `applied`; it has already been accounted for. */
+  | 'not-ahead'
+  /** Different streams: no ordering exists between them. */
+  | 'unrelated';
+
+export function isRuntimePosition(value: unknown): value is RuntimePosition {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const candidate = value as Partial<RuntimePosition>;
+  return (
+    typeof candidate.streamId === 'string' &&
+    candidate.streamId.length > 0 &&
+    typeof candidate.cursor === 'number' &&
+    Number.isSafeInteger(candidate.cursor) &&
+    candidate.cursor >= 0
+  );
+}
+
+/**
+ * Where `candidate` sits relative to what has already been applied.
+ *
+ * `applied` being `null` means nothing has been applied yet, so the first
+ * position of a stream continues it and any later one leaves a gap — a client
+ * joining mid-stream has missed the beginning and must say so.
+ */
+export function comparePositions(
+  applied: RuntimePosition | null,
+  candidate: RuntimePosition,
+): PositionOrder {
+  if (!applied) {
+    return candidate.cursor <= 1 ? 'next' : 'ahead-with-gap';
+  }
+  if (applied.streamId !== candidate.streamId) {
+    return 'unrelated';
+  }
+  if (candidate.cursor <= applied.cursor) {
+    return 'not-ahead';
+  }
+  return candidate.cursor === applied.cursor + 1 ? 'next' : 'ahead-with-gap';
+}
+
+/**
+ * The position to record after applying `candidate`.
+ *
+ * Monotonic by construction: a position that is not ahead leaves the applied
+ * position unchanged, so the projection cannot regress no matter which source
+ * produced the write.
+ */
+export function advancePosition(
+  applied: RuntimePosition | null,
+  candidate: RuntimePosition,
+): RuntimePosition {
+  switch (comparePositions(applied, candidate)) {
+    case 'not-ahead':
+      return applied as RuntimePosition;
+    case 'unrelated':
+      // A different Runtime process supersedes the old ordering wholesale.
+      return candidate;
+    default:
+      return candidate;
+  }
+}
+
+export function positionsEqual(
+  left: RuntimePosition | null,
+  right: RuntimePosition | null,
+): boolean {
+  if (!left || !right) {
+    return left === right;
+  }
+  return left.streamId === right.streamId && left.cursor === right.cursor;
+}
+
+export function formatPosition(position: RuntimePosition | null): string {
+  return position ? `${position.streamId}@${position.cursor}` : 'unset';
+}

--- a/src/web-ui/src/flow_chat/session-stream/position.ts
+++ b/src/web-ui/src/flow_chat/session-stream/position.ts
@@ -48,16 +48,22 @@ export function isRuntimePosition(value: unknown): value is RuntimePosition {
 /**
  * Where `candidate` sits relative to what has already been applied.
  *
- * `applied` being `null` means nothing has been applied yet, so the first
- * position of a stream continues it and any later one leaves a gap — a client
- * joining mid-stream has missed the beginning and must say so.
+ * `applied` being `null` adopts `candidate` as the baseline rather than
+ * reporting a gap. Cursors are per Session and never reset, so a window that
+ * opens an existing Session sees its first live event at a high cursor — that
+ * is not a discontinuity in anything this client applied, and treating it as
+ * one made every freshly opened Session schedule a repair, fence its own live
+ * events behind that request, and appear to stall until the response released
+ * them (regression: 2026-08-17).
+ *
+ * What came before the baseline is history, and the hydrate path owns it.
  */
 export function comparePositions(
   applied: RuntimePosition | null,
   candidate: RuntimePosition,
 ): PositionOrder {
   if (!applied) {
-    return candidate.cursor <= 1 ? 'next' : 'ahead-with-gap';
+    return 'next';
   }
   if (applied.streamId !== candidate.streamId) {
     return 'unrelated';

--- a/src/web-ui/src/flow_chat/session-stream/turnOwnership.ts
+++ b/src/web-ui/src/flow_chat/session-stream/turnOwnership.ts
@@ -1,0 +1,112 @@
+/**
+ * Which writer owns a Turn.
+ *
+ * Contract 2 of [`docs/architecture/session-projection.md`](../../../../../docs/architecture/session-projection.md):
+ * an executing Turn is owned by the runtime stream, a settled Turn by the
+ * persisted record, and ownership transfers exactly once on the terminal
+ * event.
+ *
+ * This is what lets history and live events share one projection without
+ * racing: they are never both authoritative for the same Turn, so there is
+ * nothing to reconcile between them.
+ */
+
+/** Frontend event names that settle the Turn they name. */
+const TERMINAL_TURN_EVENTS = new Set([
+  'agentic://dialog-turn-completed',
+  'agentic://dialog-turn-cancelled',
+  'agentic://dialog-turn-failed',
+]);
+
+/** Frontend event name that opens a Turn. */
+const TURN_STARTED_EVENT = 'agentic://dialog-turn-started';
+
+export type TurnOwner =
+  /** The runtime stream. Persisted content for this Turn is identity only. */
+  | 'runtime'
+  /** The persisted record. Live events for this Turn are stale and dropped. */
+  | 'persisted';
+
+export function isTurnStartedEvent(eventName: string): boolean {
+  return eventName === TURN_STARTED_EVENT;
+}
+
+export function isTerminalTurnEvent(eventName: string): boolean {
+  return TERMINAL_TURN_EVENTS.has(eventName);
+}
+
+/**
+ * Read the Turn an event belongs to.
+ *
+ * An event with no Turn is Session-scoped (title, state, history changed) and
+ * is not subject to Turn ownership.
+ */
+export function eventTurnId(payload: unknown): string | null {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+  const turnId = (payload as Record<string, unknown>).turnId;
+  return typeof turnId === 'string' && turnId ? turnId : null;
+}
+
+/**
+ * Ownership of every Turn this stream has observed.
+ *
+ * Deliberately not derived from the projection: asking "does this Turn look
+ * finished on screen" is the inspection this contract removes. Ownership is
+ * decided by the ordered events themselves.
+ */
+export class TurnOwnership {
+  private readonly settled = new Set<string>();
+  private readonly executing = new Set<string>();
+
+  /** Record what an event does to its Turn's ownership. */
+  observe(eventName: string, turnId: string | null): void {
+    if (!turnId) {
+      return;
+    }
+    if (isTurnStartedEvent(eventName)) {
+      // A Turn can only be reopened by a new Runtime stream, which resets this
+      // whole object; within one stream, started-then-settled is one-way.
+      if (!this.settled.has(turnId)) {
+        this.executing.add(turnId);
+      }
+      return;
+    }
+    if (isTerminalTurnEvent(eventName)) {
+      this.executing.delete(turnId);
+      this.settled.add(turnId);
+    }
+  }
+
+  /** A Turn this stream never saw start is history, and history is persisted. */
+  ownerOf(turnId: string): TurnOwner {
+    return this.executing.has(turnId) ? 'runtime' : 'persisted';
+  }
+
+  /**
+   * Whether the persisted record may write this Turn.
+   *
+   * False exactly while the runtime stream owns it — which is what stops a
+   * lagging checkpoint from painting an in-progress Turn as interrupted
+   * history.
+   */
+  persistedMayWrite(turnId: string): boolean {
+    return !this.executing.has(turnId);
+  }
+
+  /** Whether a live event may still write this Turn. */
+  runtimeMayWrite(turnId: string): boolean {
+    return !this.settled.has(turnId);
+  }
+
+  executingTurnIds(): string[] {
+    return [...this.executing];
+  }
+
+  /** A new Runtime process invalidates every ownership fact from the old one. */
+  reset(): void {
+    this.settled.clear();
+    this.executing.clear();
+  }
+}

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
@@ -1657,6 +1657,167 @@ describe('FlowChatStore historical session hydration state', () => {
     );
   });
 
+  it('does not paint a lagging persist of the current Turn when the Runtime journal is present', async () => {
+    peerModeFlagMock.active = true;
+    apiMocks.restoreSessionView.mockResolvedValueOnce({
+      session: {
+        sessionId: 'history-1',
+        sessionName: 'History 1',
+        agentType: 'agentic',
+        state: 'Processing { current_turn_id: "turn-live", phase: ToolExecution }',
+        turnCount: 1,
+        createdAt: 1,
+      },
+      turns: [{
+        turnId: 'turn-live',
+        turnIndex: 0,
+        sessionId: 'history-1',
+        timestamp: 1,
+        userMessage: { id: 'user-live', content: 'analyze the project', timestamp: 1 },
+        modelRounds: [{
+          id: 'round-live',
+          turnId: 'turn-live',
+          roundIndex: 0,
+          timestamp: 1,
+          textItems: [],
+          toolItems: [{
+            id: 'read-readme',
+            toolName: 'Read',
+            status: 'running',
+            timestamp: 2,
+            toolCall: { id: 'read-readme', input: { path: 'README.md' } },
+          }],
+          thinkingItems: [],
+          startTime: 1,
+          status: 'streaming',
+        }],
+        startTime: 1,
+        status: 'inprogress',
+      }],
+      runtimeEventSnapshot: {
+        sessionId: 'history-1',
+        streamId: 'runtime-a',
+        cursor: 40,
+        activeTurnId: 'turn-live',
+        events: [{
+          eventName: 'agentic://dialog-turn-started',
+          payload: { sessionId: 'history-1', turnId: 'turn-live' },
+        }],
+      },
+      contextRestoreState: 'pending',
+    });
+    flowChatStore.setState(() => ({
+      sessions: new Map([
+        ['history-1', createSession({
+          sessionId: 'history-1',
+          isHistorical: true,
+          historyState: 'metadata-only',
+        })],
+      ]),
+      activeSessionId: 'history-1',
+    }));
+
+    await flowChatStore.loadSessionHistory('history-1', '/Users/host/project');
+
+    expect(flowChatStore.getState().sessions.get('history-1')?.dialogTurns[0]).toMatchObject({
+      id: 'turn-live',
+      status: 'pending',
+      modelRounds: [],
+    });
+  });
+
+  it('does not let a lagging history load overwrite a live current-Turn projection', async () => {
+    peerModeFlagMock.active = true;
+    const liveTurn = {
+      id: 'turn-live',
+      sessionId: 'history-1',
+      userMessage: { id: 'user-live', content: 'analyze the project', timestamp: 1 },
+      modelRounds: [{
+        id: 'round-live',
+        index: 0,
+        items: [{
+          id: 'read-readme',
+          type: 'tool' as const,
+          toolName: 'Read',
+          status: 'completed' as const,
+          timestamp: 2,
+          toolCall: { id: 'read-readme', input: { path: 'README.md' } },
+          toolResult: { success: true },
+        }],
+        isStreaming: true,
+        isComplete: false,
+        status: 'streaming' as const,
+        startTime: 2,
+      }],
+      status: 'processing' as const,
+      startTime: 1,
+    };
+    flowChatStore.setState(() => ({
+      sessions: new Map([
+        ['history-1', createSession({
+          sessionId: 'history-1',
+          workspacePath: '/Users/host/project',
+          historyState: 'ready',
+          dialogTurns: [liveTurn],
+        })],
+      ]),
+      activeSessionId: 'history-1',
+    }));
+    apiMocks.restoreSessionView.mockResolvedValueOnce({
+      session: {
+        sessionId: 'history-1',
+        sessionName: 'History 1',
+        agentType: 'agentic',
+        state: 'Processing { current_turn_id: "turn-live", phase: ToolExecution }',
+        turnCount: 1,
+        createdAt: 1,
+      },
+      turns: [{
+        turnId: 'turn-live',
+        turnIndex: 0,
+        sessionId: 'history-1',
+        timestamp: 1,
+        userMessage: { id: 'user-live', content: 'analyze the project', timestamp: 1 },
+        modelRounds: [{
+          id: 'round-live',
+          turnId: 'turn-live',
+          roundIndex: 0,
+          timestamp: 1,
+          textItems: [],
+          toolItems: [{
+            id: 'read-readme',
+            toolName: 'Read',
+            status: 'running',
+            timestamp: 2,
+            toolCall: { id: 'read-readme', input: { path: 'README.md' } },
+          }],
+          thinkingItems: [],
+          startTime: 1,
+          status: 'streaming',
+        }],
+        startTime: 1,
+        status: 'inprogress',
+      }],
+      runtimeEventSnapshot: {
+        sessionId: 'history-1',
+        streamId: 'runtime-a',
+        cursor: 40,
+        activeTurnId: 'turn-live',
+        events: [],
+      },
+      contextRestoreState: 'pending',
+    });
+
+    await flowChatStore.loadSessionHistory('history-1', '/Users/host/project');
+
+    expect(
+      flowChatStore.getState().sessions.get('history-1')?.dialogTurns[0].modelRounds[0].items[0],
+    ).toMatchObject({
+      id: 'read-readme',
+      status: 'completed',
+    });
+  });
+
   it('re-attaches a missed AskUserQuestion mailbox without restarting the running turn', async () => {
     peerModeFlagMock.active = true;
     const pendingQuestion = {
@@ -2051,6 +2212,109 @@ describe('FlowChatStore historical session hydration state', () => {
       flowChatStore.getState().sessions.get('history-1')
         ?.dialogTurns[0].modelRounds[0].items[0],
     ).toMatchObject({ id: 'live-text', content: 'already rendered' });
+  });
+
+  it('still returns the Runtime journal when a live update wins the restore race', async () => {
+    peerModeFlagMock.active = true;
+    apiMocks.restoreSessionView.mockImplementationOnce(async () => {
+      flowChatStore.setState(prev => {
+        const current = prev.sessions.get('history-1');
+        if (!current) {
+          return prev;
+        }
+        return {
+          ...prev,
+          sessions: new Map([
+            ['history-1', {
+              ...current,
+              currentTokenUsage: {
+                inputTokens: 1,
+                outputTokens: 1,
+                totalTokens: 2,
+                timestamp: 2,
+              },
+            }],
+          ]),
+        };
+      });
+      return {
+        session: {
+          sessionId: 'history-1',
+          sessionName: 'History 1',
+          agentType: 'agentic',
+          state: 'Processing { current_turn_id: "turn-live", phase: Streaming }',
+          turnCount: 1,
+          createdAt: 1,
+        },
+        turns: [{
+          turnId: 'turn-live',
+          turnIndex: 0,
+          sessionId: 'history-1',
+          timestamp: 1,
+          userMessage: { id: 'user-live', content: 'keep streaming', timestamp: 1 },
+          modelRounds: [],
+          startTime: 1,
+          status: 'inprogress',
+        }],
+        runtimeEventSnapshot: {
+          sessionId: 'history-1',
+          streamId: 'runtime-a',
+          cursor: 20,
+          activeTurnId: 'turn-live',
+          events: [{
+            eventName: 'agentic://text-chunk',
+            payload: { sessionId: 'history-1', turnId: 'turn-live', text: 'host' },
+          }],
+        },
+        contextRestoreState: 'pending',
+      };
+    });
+    const liveTurn = {
+      id: 'turn-live',
+      sessionId: 'history-1',
+      userMessage: { id: 'user-live', content: 'keep streaming', timestamp: 1 },
+      modelRounds: [{
+        id: 'round-live',
+        index: 0,
+        items: [{
+          id: 'read-readme',
+          type: 'tool' as const,
+          toolName: 'Read',
+          status: 'running' as const,
+          timestamp: 2,
+        }],
+        isStreaming: true,
+        isComplete: false,
+        status: 'streaming' as const,
+        startTime: 2,
+      }],
+      status: 'processing' as const,
+      startTime: 1,
+    };
+    flowChatStore.setState(() => ({
+      sessions: new Map([
+        ['history-1', createSession({
+          sessionId: 'history-1',
+          workspacePath: '/Users/host/project',
+          historyState: 'ready',
+          dialogTurns: [liveTurn],
+        })],
+      ]),
+      activeSessionId: 'history-1',
+    }));
+
+    const result = await flowChatStore.refreshPeerSessionSnapshot(
+      'history-1',
+      '/Users/host/project',
+      { shouldReplayRuntimeSnapshot: () => true },
+    );
+
+    expect(result.runtimeEventSnapshot).toMatchObject({
+      streamId: 'runtime-a',
+      cursor: 20,
+      activeTurnId: 'turn-live',
+    });
+    expect(result.runtimeEventReplayRequired).toBe(true);
   });
 
   it('advances a running Peer turn from a newer persisted checkpoint', async () => {

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.ts
@@ -702,10 +702,14 @@ function snapshotDropsProjectedTurnContent(
  *
  * Contract 2 of docs/architecture/session-projection.md: the runtime stream
  * owns an executing Turn, so its persisted copy — deliberately stored idle so a
- * restart never revives work, and therefore truncated, token-less, and shaped
- * like a finished Turn — must not be painted over it. Doing so showed a
- * completed Turn on a controller while the Host was still streaming
- * (regression: 2026-08-17).
+ * restart never revives work, and therefore lagging and shaped like a finished
+ * Turn — must not be painted over it. Doing so left a controller showing less
+ * of a Turn than the Host, and showing it as finished while the Host was still
+ * streaming (regression: 2026-08-17).
+ *
+ * Those two symptoms together are the signature. Missing token usage is not
+ * part of it: a provider that returns no usage stats produces the same empty
+ * field on a perfectly healthy Turn.
  *
  * Two cases keep a content comparison, and both are places the contract does
  * not yet reach:

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.ts
@@ -35,6 +35,7 @@ import {
 import { elapsedMs, nowMs } from '@/shared/utils/timing';
 import { normalizeRemoteSessionScope } from '@/shared/utils/remoteSessionScope';
 import { isPeerDeviceModeActive } from '@/infrastructure/peer-device/peerModeFlag';
+import { isSurfaceReconcileEnabled } from '@/infrastructure/peer-device/deviceSurfaceReconcile';
 import {
   getActiveSurfaceId,
   getActiveSurfaceScope,
@@ -43,6 +44,10 @@ import {
   surfaceScopedKey,
   type DeviceSurfaceId,
 } from '@/infrastructure/peer-device/deviceSurface';
+import {
+  isRuntimeSessionAttachmentInFlight,
+  markRuntimeSessionProjectionStale,
+} from '@/infrastructure/peer-device/runtimeSessionEventGate';
 import { i18nService } from '@/infrastructure/i18n/core/I18nService';
 import type {
   DialogTurnData,
@@ -344,7 +349,7 @@ export interface PeerSessionSnapshotRefreshResult {
   backendState: string;
   latestTurnId?: string;
   latestTurnStatus?: DialogTurn['status'];
-  /** Present only when this refresh acquired a coherent running-Turn base. */
+  /** Present whenever the host sent a valid journal and this surface is still current. */
   runtimeEventSnapshot?: SessionRuntimeEventSnapshot;
   /** False when the rendered projection already includes this cursor. */
   runtimeEventReplayRequired?: boolean;
@@ -689,6 +694,50 @@ function snapshotDropsProjectedTurnContent(
   }
 
   return false;
+}
+
+/** Empty current-Turn shell so Runtime journal replay cannot overlap a persist checkpoint. */
+function asRuntimeReplayTurn(turn: DialogTurn): DialogTurn {
+  return {
+    ...turn,
+    modelRounds: [],
+    status: 'pending',
+    endTime: undefined,
+    error: undefined,
+    errorDetail: undefined,
+    success: undefined,
+    finishReason: undefined,
+    hasFinalResponse: undefined,
+    recovery: undefined,
+  };
+}
+
+function coerceRuntimeEventSnapshot(
+  snapshot: SessionRuntimeEventSnapshot | null | undefined,
+  sessionId: string,
+  backendActive: boolean,
+  fallbackActiveTurnId?: string,
+): SessionRuntimeEventSnapshot | undefined {
+  if (
+    !backendActive ||
+    snapshot?.sessionId !== sessionId ||
+    typeof snapshot.streamId !== 'string' ||
+    !snapshot.streamId ||
+    !Number.isSafeInteger(snapshot.cursor) ||
+    !Array.isArray(snapshot.events)
+  ) {
+    return undefined;
+  }
+  const activeTurnId = snapshot.activeTurnId || fallbackActiveTurnId;
+  if (!activeTurnId) {
+    return undefined;
+  }
+  if (snapshot.activeTurnId && snapshot.activeTurnId !== activeTurnId) {
+    return undefined;
+  }
+  return snapshot.activeTurnId
+    ? snapshot
+    : { ...snapshot, activeTurnId };
 }
 
 interface PendingUserQuestionReconcileResult {
@@ -5938,9 +5987,9 @@ export class FlowChatStore {
     }
   }
 
-  public updateModelRoundItem(sessionId: string, dialogTurnId: string, itemId: string, updates: Partial<FlowItem>): void {
+  public updateModelRoundItem(sessionId: string, dialogTurnId: string, itemId: string, updates: Partial<FlowItem>): boolean {
+    let updated = false;
     this.updateDialogTurn(sessionId, dialogTurnId, turn => {
-      let updated = false;
       
       const updatedModelRounds = turn.modelRounds.map(modelRound => {
         if (updated) return modelRound;
@@ -5998,17 +6047,21 @@ export class FlowChatStore {
         modelRounds: updatedModelRounds
       };
     });
+    if (!updated) {
+      markRuntimeSessionProjectionStale(getActiveSurfaceScope().surfaceId, sessionId);
+    }
+    return updated;
   }
 
   /**
    * Silent update ModelRound item (does not trigger listeners)
    * Used for batch update scenarios
    */
-  public updateModelRoundItemSilent(sessionId: string, dialogTurnId: string, itemId: string, updates: Partial<FlowItem>): void {
+  public updateModelRoundItemSilent(sessionId: string, dialogTurnId: string, itemId: string, updates: Partial<FlowItem>): boolean {
     const prevSilentMode = this.silentMode;
     this.silentMode = true;
     try {
-      this.updateModelRoundItem(sessionId, dialogTurnId, itemId, updates);
+      return this.updateModelRoundItem(sessionId, dialogTurnId, itemId, updates);
     } finally {
       this.silentMode = prevSilentMode;
     }
@@ -7308,22 +7361,16 @@ export class FlowChatStore {
       );
     }
     const backendActive = isBackendSessionActivelyProcessing(restored.session.state);
-    const runtimeSnapshotCandidate =
-      restored.runtimeEventSnapshot?.sessionId === sessionId
-        ? restored.runtimeEventSnapshot
-        : undefined;
+    const persistTailTurnId = restored.turns[restored.turns.length - 1]?.turnId;
+    const runtimeEventSnapshot = coerceRuntimeEventSnapshot(
+      restored.runtimeEventSnapshot,
+      sessionId,
+      backendActive,
+      persistTailTurnId,
+    );
     const activeTurnId = backendActive
-      ? runtimeSnapshotCandidate?.activeTurnId ?? restored.turns[restored.turns.length - 1]?.turnId
+      ? runtimeEventSnapshot?.activeTurnId ?? persistTailTurnId
       : undefined;
-    const runtimeEventSnapshot =
-      backendActive &&
-      runtimeSnapshotCandidate !== undefined &&
-      runtimeSnapshotCandidate.activeTurnId === activeTurnId &&
-      typeof runtimeSnapshotCandidate.streamId === 'string' &&
-      Number.isSafeInteger(runtimeSnapshotCandidate.cursor) &&
-      Array.isArray(runtimeSnapshotCandidate.events)
-        ? runtimeSnapshotCandidate
-        : undefined;
     const runtimeEventReplayRequired = runtimeEventSnapshot
       ? options?.shouldReplayRuntimeSnapshot?.(runtimeEventSnapshot) ?? true
       : false;
@@ -7332,21 +7379,7 @@ export class FlowChatStore {
       : undefined;
     const snapshotTurns = this.convertToDialogTurns(restored.turns, { activeTurnId }).map(turn =>
       runtimeReplaySnapshot && turn.id === runtimeReplaySnapshot.activeTurnId
-        ? {
-            ...turn,
-            // Runtime event replay is authoritative for the current Turn.
-            // Start from the persisted identity/user message, never from a
-            // UI-written partial projection that may overlap the replay.
-            modelRounds: [],
-            status: 'pending' as const,
-            endTime: undefined,
-            error: undefined,
-            errorDetail: undefined,
-            success: undefined,
-            finishReason: undefined,
-            hasFinalResponse: undefined,
-            recovery: undefined,
-          }
+        ? asRuntimeReplayTurn(turn)
         : turn
     );
     const pendingUserQuestions =
@@ -7356,7 +7389,6 @@ export class FlowChatStore {
     const replaceExistingTurns =
       !backendActive || options?.replaceRunningSnapshot === true;
     let applied = false;
-    let snapshotAccepted = false;
 
     this.setState(prev => {
       if (
@@ -7370,12 +7402,47 @@ export class FlowChatStore {
       }
 
       const session = prev.sessions.get(sessionId);
-      // A live event or another refresh won the race while HostInvoke was in
-      // flight. Do not overwrite that newer local projection.
-      if (!session || session !== initialSession) {
+      if (!session) {
         return prev;
       }
-      snapshotAccepted = true;
+      const persistMergeSafe = session === initialSession;
+      // A live event or hydrate won the race while HostInvoke was in flight.
+      // Persisted-turn merge is then unsafe, but a required Runtime replay
+      // still needs an empty current-Turn shell — hiding the journal used to
+      // leave in-progress tool cards frozen.
+      if (!persistMergeSafe && !runtimeReplaySnapshot) {
+        return prev;
+      }
+
+      if (!persistMergeSafe && runtimeReplaySnapshot) {
+        const replayTurnId = runtimeReplaySnapshot.activeTurnId;
+        if (!replayTurnId) {
+          return prev;
+        }
+        const mergedTurns = [...session.dialogTurns];
+        const existingIndex = mergedTurns.findIndex(turn => turn.id === replayTurnId);
+        if (existingIndex === -1) {
+          const shell = snapshotTurns.find(turn => turn.id === replayTurnId);
+          if (!shell) {
+            return prev;
+          }
+          mergedTurns.push(shell);
+        } else {
+          mergedTurns[existingIndex] = asRuntimeReplayTurn(mergedTurns[existingIndex]);
+        }
+        const newSessions = new Map(prev.sessions);
+        newSessions.set(sessionId, {
+          ...session,
+          dialogTurns: mergedTurns,
+          isHistorical: false,
+          historyState: 'ready',
+        });
+        applied = true;
+        return {
+          ...prev,
+          sessions: newSessions,
+        };
+      }
 
       let mergedTurns = [...session.dialogTurns];
       let turnsChanged = false;
@@ -7488,7 +7555,7 @@ export class FlowChatStore {
       backendState: restored.session.state,
       latestTurnId: latestTurn?.id,
       latestTurnStatus: latestTurn?.status,
-      ...(snapshotAccepted && runtimeEventSnapshot
+      ...(runtimeEventSnapshot && scope.isCurrent()
         ? {
             runtimeEventSnapshot,
             runtimeEventReplayRequired,
@@ -7496,6 +7563,31 @@ export class FlowChatStore {
           }
         : {}),
     };
+  }
+
+  /** Empty the current Turn so journal replay cannot overlap a persist checkpoint. */
+  public prepareRuntimeTurnReplay(sessionId: string, turnId: string): void {
+    this.setState(prev => {
+      const session = prev.sessions.get(sessionId);
+      if (!session) {
+        return prev;
+      }
+      const index = session.dialogTurns.findIndex(turn => turn.id === turnId);
+      if (index === -1) {
+        return prev;
+      }
+      const dialogTurns = [...session.dialogTurns];
+      dialogTurns[index] = asRuntimeReplayTurn(dialogTurns[index]);
+      const sessions = new Map(prev.sessions);
+      sessions.set(sessionId, {
+        ...session,
+        dialogTurns,
+      });
+      return {
+        ...prev,
+        sessions,
+      };
+    });
   }
 
   /** Reconcile blocking user questions after Runtime event replay. */
@@ -7643,6 +7735,7 @@ export class FlowChatStore {
       let restoredTurnCatalog: SessionTurnCatalog | undefined;
       let restoredTiming: SessionViewRestoreTiming | undefined;
       let restoredCurrentContextUsage: SessionContextUsage | null | undefined;
+      let restoredRuntimeEventSnapshot: SessionRuntimeEventSnapshot | undefined;
 
       // Finish or resume relay history import before Core restores its model
       // context. Ordinary local sessions return after one metadata read, while
@@ -7784,6 +7877,12 @@ export class FlowChatStore {
                 : undefined;
               restoredTiming = restored.timings;
               restoredCurrentContextUsage = restored.currentContextUsage;
+              restoredRuntimeEventSnapshot = coerceRuntimeEventSnapshot(
+                restored.runtimeEventSnapshot,
+                sessionId,
+                isBackendSessionActivelyProcessing(restored.session.state),
+                restored.turns[restored.turns.length - 1]?.turnId,
+              );
             } catch (error) {
               if (!isUnsupportedTauriCommandError(error, 'restore_session_view')) {
                 throw error;
@@ -7931,9 +8030,13 @@ export class FlowChatStore {
       
       const convertStartedAt = nowMs();
       const activeTurnId = isBackendSessionActivelyProcessing(restoredSessionInfo?.state)
-        ? turns[turns.length - 1]?.turnId
+        ? restoredRuntimeEventSnapshot?.activeTurnId ?? turns[turns.length - 1]?.turnId
         : undefined;
-      const dialogTurns = this.convertToDialogTurns(turns, { activeTurnId });
+      const dialogTurns = this.convertToDialogTurns(turns, { activeTurnId }).map(turn =>
+        restoredRuntimeEventSnapshot && turn.id === activeTurnId
+          ? asRuntimeReplayTurn(turn)
+          : turn
+      );
       const restoredLastUserDialogMode =
         restoredSessionInfo?.lastUserDialogAgentType || this.deriveLastUserDialogMode(dialogTurns);
       startupTrace.markPhase('historical_session_convert_end', {
@@ -7951,10 +8054,21 @@ export class FlowChatStore {
 
         const restoredAgentType =
           restoredSessionInfo?.agentType || session.mode || session.config.agentType;
+        const mergedTurns = dialogTurns.map(loaded => {
+          const existing = session.dialogTurns.find(turn => turn.id === loaded.id);
+          if (
+            existing &&
+            loaded.id === activeTurnId &&
+            snapshotDropsProjectedTurnContent(existing, loaded)
+          ) {
+            return existing;
+          }
+          return loaded;
+        });
 
         const updatedSession = {
           ...session,
-          dialogTurns,
+          dialogTurns: mergedTurns,
           isHistorical: false,
           historyState: 'ready' as const,
           contextRestoreState,
@@ -7979,7 +8093,7 @@ export class FlowChatStore {
           currentTokenUsage: reconcileRestoreViewCurrentTokenUsage(
             session.currentTokenUsage,
             restoredCurrentContextUsage,
-            dialogTurns,
+            mergedTurns,
             restoredAgentType,
           ),
         };
@@ -8024,12 +8138,22 @@ export class FlowChatStore {
       // owns a live turn (notably a Peer Host), keep the controller state
       // machine aligned so subsequent streamed chunks are accepted even though
       // their DialogTurnStarted event happened before the controller attached.
-      stateMachineManager.reset(sessionId);
-      if (activeTurnId) {
-        await stateMachineManager.transition(sessionId, SessionExecutionEvent.START, {
-          taskId: sessionId,
-          dialogTurnId: activeTurnId,
-        });
+      // An in-flight Runtime attach already owns that machine; resetting here
+      // would drop the journal replay and freeze in-progress tool cards.
+      if (!isRuntimeSessionAttachmentInFlight(scope.surfaceId, sessionId)) {
+        stateMachineManager.reset(sessionId);
+        if (activeTurnId) {
+          await stateMachineManager.transition(sessionId, SessionExecutionEvent.START, {
+            taskId: sessionId,
+            dialogTurnId: activeTurnId,
+          });
+        }
+      }
+      if (activeTurnId && isSurfaceReconcileEnabled()) {
+        const { requestPeerSessionRefresh } = await import(
+          '../services/flow-chat-manager/PeerSessionRefreshModule'
+        );
+        requestPeerSessionRefresh(sessionId);
       }
       completeSessionMutationReconciliation(sessionId);
       startupTrace.markPhase('historical_session_hydrate_end', {

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.ts
@@ -36,6 +36,7 @@ import { elapsedMs, nowMs } from '@/shared/utils/timing';
 import { normalizeRemoteSessionScope } from '@/shared/utils/remoteSessionScope';
 import { isPeerDeviceModeActive } from '@/infrastructure/peer-device/peerModeFlag';
 import { isSurfaceReconcileEnabled } from '@/infrastructure/peer-device/deviceSurfaceReconcile';
+import { persistedMayWriteTurn } from '@/flow_chat/session-stream/SessionStream';
 import {
   getActiveSurfaceId,
   getActiveSurfaceScope,
@@ -694,6 +695,44 @@ function snapshotDropsProjectedTurnContent(
   }
 
   return false;
+}
+
+/**
+ * Whether a persisted-record read may replace the Turn already projected.
+ *
+ * Contract 2 of docs/architecture/session-projection.md: the runtime stream
+ * owns an executing Turn, so its persisted copy — deliberately stored idle so a
+ * restart never revives work, and therefore truncated, token-less, and shaped
+ * like a finished Turn — must not be painted over it. Doing so showed a
+ * completed Turn on a controller while the Host was still streaming
+ * (regression: 2026-08-17).
+ *
+ * Two cases keep a content comparison, and both are places the contract does
+ * not yet reach:
+ *
+ * - An older Host serves no runtime projection at all. With no runtime stream
+ *   to own the Turn, its checkpoint is the only progress there is, so forward
+ *   progress is still admitted.
+ * - A settled Turn belongs to the persisted record, but a windowed or
+ *   not-yet-checkpointed read can name a Turn while carrying none of its work.
+ *   A history read carries no position for content it omitted, so "does this
+ *   write lose content" is still the only question available. This guard is
+ *   deletable once a read reports its own completeness.
+ */
+function persistedReadMayReplaceTurn(
+  sessionId: string,
+  projected: DialogTurn,
+  incoming: DialogTurn,
+  hostExecutingTurnId: string | undefined,
+  hostServesRuntimeProjection: boolean,
+): boolean {
+  if (!persistedMayWriteTurn(sessionId, incoming.id, hostExecutingTurnId)) {
+    return (
+      !hostServesRuntimeProjection &&
+      isRunningSnapshotForwardProgress(projected, incoming)
+    );
+  }
+  return !snapshotDropsProjectedTurnContent(projected, incoming);
 }
 
 /** Empty current-Turn shell so Runtime journal replay cannot overlap a persist checkpoint. */
@@ -7322,7 +7361,6 @@ export class FlowChatStore {
     sessionId: string,
     workspacePath: string,
     options?: {
-      replaceRunningSnapshot?: boolean;
       requireActiveSession?: boolean;
       shouldApply?: () => boolean;
       shouldReplayRuntimeSnapshot?: (snapshot: SessionRuntimeEventSnapshot) => boolean;
@@ -7386,8 +7424,6 @@ export class FlowChatStore {
       restored.interactionSnapshot?.sessionId === sessionId
         ? restored.interactionSnapshot.userQuestions
         : undefined;
-    const replaceExistingTurns =
-      !backendActive || options?.replaceRunningSnapshot === true;
     let applied = false;
 
     this.setState(prev => {
@@ -7452,11 +7488,17 @@ export class FlowChatStore {
           mergedTurns.push(snapshotTurn);
           turnsChanged = true;
         } else if (
-          (runtimeReplaySnapshot && snapshotTurn.id === runtimeReplaySnapshot.activeTurnId)
+          // The Runtime journal replay *is* the runtime writer, so it always
+          // establishes its own active Turn.
+          runtimeReplaySnapshot && snapshotTurn.id === runtimeReplaySnapshot.activeTurnId
             ? true
-            : replaceExistingTurns
-            ? !snapshotDropsProjectedTurnContent(mergedTurns[existingIndex], snapshotTurn)
-            : isRunningSnapshotForwardProgress(mergedTurns[existingIndex], snapshotTurn)
+            : persistedReadMayReplaceTurn(
+                sessionId,
+                mergedTurns[existingIndex],
+                snapshotTurn,
+                activeTurnId,
+                Boolean(runtimeEventSnapshot),
+              )
         ) {
           mergedTurns[existingIndex] = snapshotTurn;
           turnsChanged = true;
@@ -8056,10 +8098,17 @@ export class FlowChatStore {
           restoredSessionInfo?.agentType || session.mode || session.config.agentType;
         const mergedTurns = dialogTurns.map(loaded => {
           const existing = session.dialogTurns.find(turn => turn.id === loaded.id);
+          // Disk hydrate is the persisted record, so the same ownership rule
+          // applies: it may not overwrite the Turn the runtime stream owns.
           if (
             existing &&
-            loaded.id === activeTurnId &&
-            snapshotDropsProjectedTurnContent(existing, loaded)
+            !persistedReadMayReplaceTurn(
+              sessionId,
+              existing,
+              loaded,
+              activeTurnId,
+              Boolean(restoredRuntimeEventSnapshot),
+            )
           ) {
             return existing;
           }

--- a/src/web-ui/src/infrastructure/api/adapters/peer-device-adapter.ts
+++ b/src/web-ui/src/infrastructure/api/adapters/peer-device-adapter.ts
@@ -136,6 +136,7 @@ const LOCAL_ONLY_COMMANDS = new Set([
  */
 const HIGH_PRIORITY_COMMANDS = new Set([
   'restore_session_view',
+  'load_session_event_backfill',
   'restore_session_with_turns',
   'restore_session',
   'load_session_turn_window',
@@ -187,6 +188,7 @@ const HIGH_PRIORITY_COMMANDS = new Set([
 const RETRYABLE_READ_COMMANDS = new Set([
   'initialize_workspace_startup_state',
   'restore_session_view',
+  'load_session_event_backfill',
   'restore_session_with_turns',
   'load_session_turn_window',
   'load_session_turns',

--- a/src/web-ui/src/infrastructure/api/service-api/AgentAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/AgentAPI.ts
@@ -201,6 +201,23 @@ export interface SessionRuntimeEventSnapshot {
   events: RuntimeProjectedAgenticEvent[];
 }
 
+/**
+ * Everything this client missed after the cursor it already applied.
+ *
+ * `delta` is contiguous: apply the events in order and the projection is
+ * repaired in place. `snapshotRequired` means the Host cannot prove
+ * contiguity — the cursor aged out of its replay window, it belongs to an
+ * older Runtime process, or the Host keeps no journal at all.
+ */
+export type SessionEventBackfill =
+  | {
+      kind: 'delta';
+      streamId: string;
+      cursor: number;
+      events: RuntimeProjectedAgenticEvent[];
+    }
+  | { kind: 'snapshotRequired' };
+
 export type PermissionRequestEvent =
   | { event: 'asked'; request: PermissionRequest }
   | { event: 'replied'; requestId: string; reply: { reply: PermissionReplyKind }; source: string }
@@ -1072,6 +1089,24 @@ export class AgentAPI {
       });
     } catch (error) {
       throw createTauriCommandError('restore_session_view', error, { sessionId, workspacePath });
+    }
+  }
+
+  async loadSessionEventBackfill(
+    sessionId: string,
+    streamId: string,
+    cursor: number,
+  ): Promise<SessionEventBackfill> {
+    try {
+      return await api.invoke<SessionEventBackfill>('load_session_event_backfill', {
+        request: { sessionId, streamId, cursor },
+      });
+    } catch (error) {
+      throw createTauriCommandError('load_session_event_backfill', error, {
+        sessionId,
+        streamId,
+        cursor,
+      });
     }
   }
 

--- a/src/web-ui/src/infrastructure/api/service-api/AgentAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/AgentAPI.ts
@@ -215,6 +215,11 @@ export type SessionEventBackfill =
       streamId: string;
       cursor: number;
       events: RuntimeProjectedAgenticEvent[];
+      /**
+       * Replaying events rebuilds a blocking interaction's card; only the
+       * mailbox makes it answerable.
+       */
+      interactionSnapshot?: SessionInteractionSnapshot | null;
     }
   | { kind: 'snapshotRequired' };
 

--- a/src/web-ui/src/infrastructure/peer-device/README.md
+++ b/src/web-ui/src/infrastructure/peer-device/README.md
@@ -3,6 +3,29 @@
 Controller-side React/transport layer for Peer Device Mode. Architecture:
 [`docs/architecture/peer-device-mode.md`](../../../../../docs/architecture/peer-device-mode.md).
 
+## Migrating to the Session Projection contract
+
+The invariants below are pairwise rules between writers that carry no shared
+position. They are being replaced by one contract —
+[`docs/architecture/session-projection.md`](../../../../../docs/architecture/session-projection.md)
+— under which a write is admitted by its position in the order rather than by
+what it would do to painted content. **This list shrinking is the measure of
+that migration**; a change that adds a rule here is going the wrong way.
+
+Already owned by the contract (`flow_chat/session-stream/`):
+
+- The stream position, the delivery gap, and the attach fence in invariant 12.
+  `runtimeSessionEventGate` is now an adapter over `SessionStream`, not a
+  second owner of that state.
+- Surface-scoped Session identity in invariant 0: a stream is keyed by
+  `(DeviceSurfaceId, SessionId)` by construction.
+
+Still to migrate, in order: the snapshot writer
+(`replaceRunningSnapshot`, `snapshotDropsProjectedTurnContent`,
+`isRunningSnapshotForwardProgress` — replaced by "the persisted record may
+write a Turn only when it is not executing"), the interaction mailbox, then
+history.
+
 ## Invariants (do not regress)
 
 0. **A surface switch is a view change, not a teardown.** Attachments and the

--- a/src/web-ui/src/infrastructure/peer-device/README.md
+++ b/src/web-ui/src/infrastructure/peer-device/README.md
@@ -158,6 +158,25 @@ Controller-side React/transport layer for Peer Device Mode. Architecture:
     projection; their persisted snapshot must still never overwrite newer live
     content.
 
+    **Delivery is not acceptance, and persist is not the current Turn.** A
+    live event that the state machine drops still advances the gate cursor.
+    Mark that projection stale so the next attach replays the journal instead
+    of treating the cursor as current and leaving in-progress tool cards
+    frozen. `finish()` may cover live events only after replay (or an
+    equivalent apply) proves the painted tools/text have caught up with the
+    Host journal — a matching cursor is not that proof. Overlapping attach
+    transfers the fence instead of draining it onto a state machine that is
+    about to reset. A 3s `staleOnly` tick, a hidden document, or a
+    `FINISHING` machine must not skip repair while `hasGap` is set; TextChunk
+    heartbeats are not evidence that a dropped ToolEnd was applied.
+    `loadSessionHistory` and `refreshPeerSessionSnapshot` both read
+    `runtimeEventSnapshot`: the persisted checkpoint of an executing Turn is
+    only identity, never the painted rounds. A session-object identity change
+    during restore must still return the journal — hiding it used to abort
+    attach and freeze the receiver while the Host kept streaming.
+    A CLI Peer Host still filters Host-local turns with `owns()`; that is a
+    CLI Host limitation, not a reason for a Desktop receiver to freeze.
+
     **The subscription and the attach loop must never be able to disable each
     other.** The agentic subscription is this window's only live view of a
     running Turn, and a surface switch tears it down. Rebuilding it used to be

--- a/src/web-ui/src/infrastructure/peer-device/README.md
+++ b/src/web-ui/src/infrastructure/peer-device/README.md
@@ -20,11 +20,16 @@ Already owned by the contract (`flow_chat/session-stream/`):
 - Surface-scoped Session identity in invariant 0: a stream is keyed by
   `(DeviceSurfaceId, SessionId)` by construction.
 
-Still to migrate, in order: the snapshot writer
-(`replaceRunningSnapshot`, `snapshotDropsProjectedTurnContent`,
-`isRunningSnapshotForwardProgress` — replaced by "the persisted record may
-write a Turn only when it is not executing"), the interaction mailbox, then
-history.
+Also owned: which read may write a Turn. `replaceRunningSnapshot` is gone —
+the persisted record (snapshot merge *and* disk hydrate) may not write the Turn
+the runtime stream owns, and the Host's declared executing Turn is part of that
+ownership. `snapshotDropsProjectedTurnContent` and
+`isRunningSnapshotForwardProgress` survive inside `persistedReadMayReplaceTurn`
+for the two gaps the contract does not yet close (a Host with no runtime
+projection, and a partial history read); see the contract doc before touching
+them.
+
+Still to migrate, in order: the interaction mailbox, then history positions.
 
 ## Invariants (do not regress)
 

--- a/src/web-ui/src/infrastructure/peer-device/runtimeSessionEventGate.test.ts
+++ b/src/web-ui/src/infrastructure/peer-device/runtimeSessionEventGate.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   beginRuntimeSessionAttachment,
+  isRuntimeSessionProjectionStale,
+  markRuntimeSessionProjectionStale,
   resetRuntimeSessionEventGateForTest,
   routeRuntimeSessionEvent,
   RUNTIME_EVENT_CURSOR_KEY,
@@ -88,6 +90,27 @@ describe('runtimeSessionEventGate', () => {
     attachment.abort({ discard: true });
   });
 
+  it('requires replay after a dropped event even when the live cursor matches', () => {
+    for (const cursor of [1, 2, 3]) {
+      routeRuntimeSessionEvent(
+        'local',
+        'agentic://text-chunk',
+        payload('session', 'runtime-a', cursor, 'live'),
+        vi.fn(),
+      );
+    }
+
+    markRuntimeSessionProjectionStale('local', 'session');
+
+    const attachment = beginRuntimeSessionAttachment('local', 'session');
+    expect(attachment.requiresReplay({ streamId: 'runtime-a', cursor: 3 })).toBe(true);
+    attachment.finish({ streamId: 'runtime-a', cursor: 3 });
+
+    const nextAttachment = beginRuntimeSessionAttachment('local', 'session');
+    expect(nextAttachment.requiresReplay({ streamId: 'runtime-a', cursor: 3 })).toBe(false);
+    nextAttachment.abort({ discard: true });
+  });
+
   it('requires replay after detecting a missing live cursor', () => {
     const gapListener = vi.fn();
     subscribeRuntimeSessionEventGaps(gapListener);
@@ -125,6 +148,61 @@ describe('runtimeSessionEventGate', () => {
       sessionId: 'session',
       title: 'Keep me live',
     });
+  });
+
+  it('keeps the projection dirty when finish cannot prove the UI caught up', () => {
+    for (const cursor of [1, 2, 3]) {
+      routeRuntimeSessionEvent(
+        'local',
+        'agentic://tool-event',
+        payload('session', 'runtime-a', cursor, 'tool'),
+        vi.fn(),
+      );
+    }
+
+    const attachment = beginRuntimeSessionAttachment('local', 'session');
+    attachment.finish(
+      { streamId: 'runtime-a', cursor: 3 },
+      { projectionCaughtUp: false },
+    );
+
+    expect(isRuntimeSessionProjectionStale('local', 'session')).toBe(true);
+    const nextAttachment = beginRuntimeSessionAttachment('local', 'session');
+    expect(nextAttachment.requiresReplay({ streamId: 'runtime-a', cursor: 3 })).toBe(true);
+    nextAttachment.abort({ discard: true });
+  });
+
+  it('transfers an overlapping fence instead of delivering it onto a resetting machine', () => {
+    const delivered: string[] = [];
+    const first = beginRuntimeSessionAttachment('local', 'session');
+    routeRuntimeSessionEvent(
+      'local',
+      'agentic://tool-event',
+      payload('session', 'runtime-a', 4, 'started'),
+      event => delivered.push(event.text),
+    );
+    routeRuntimeSessionEvent(
+      'local',
+      'agentic://tool-event',
+      payload('session', 'runtime-a', 5, 'completed'),
+      event => delivered.push(event.text),
+    );
+
+    const second = beginRuntimeSessionAttachment('local', 'session');
+    expect(first.isCurrent()).toBe(false);
+    expect(second.isCurrent()).toBe(true);
+    expect(delivered).toEqual([]);
+
+    first.finish({ streamId: 'runtime-a', cursor: 5 });
+    expect(delivered).toEqual([]);
+    expect(isRuntimeSessionProjectionStale('local', 'session')).toBe(false);
+
+    second.finish(
+      { streamId: 'runtime-a', cursor: 5 },
+      { projectionCaughtUp: false },
+    );
+    expect(delivered).toEqual([]);
+    expect(isRuntimeSessionProjectionStale('local', 'session')).toBe(true);
   });
 
   it('isolates identical Session ids on different device Surfaces', () => {

--- a/src/web-ui/src/infrastructure/peer-device/runtimeSessionEventGate.test.ts
+++ b/src/web-ui/src/infrastructure/peer-device/runtimeSessionEventGate.test.ts
@@ -3,6 +3,7 @@ import {
   beginRuntimeSessionAttachment,
   isRuntimeSessionProjectionStale,
   markRuntimeSessionProjectionStale,
+  readRuntimeSessionProgress,
   resetRuntimeSessionEventGateForTest,
   routeRuntimeSessionEvent,
   RUNTIME_EVENT_CURSOR_KEY,
@@ -226,5 +227,27 @@ describe('runtimeSessionEventGate', () => {
     expect(localDelivered).not.toHaveBeenCalled();
     expect(peerDelivered).toHaveBeenCalledTimes(1);
     attachment.abort({ discard: true });
+  });
+
+  it('reports the applied position only once a cursor anchors it', () => {
+    // Nothing observed yet: a caller must not ask the Host for a delta it has
+    // no cursor to be contiguous with.
+    expect(readRuntimeSessionProgress('local', 'session')).toBeNull();
+
+    routeRuntimeSessionEvent(
+      'local',
+      'agentic://text-chunk',
+      payload('session', 'runtime-a', 5, 'a'),
+      () => {},
+    );
+
+    expect(readRuntimeSessionProgress('local', 'session')).toEqual({
+      streamId: 'runtime-a',
+      cursor: 5,
+    });
+
+    // A projection marked stale without ever seeing a cursor stays unanchored.
+    markRuntimeSessionProjectionStale('local', 'other-session');
+    expect(readRuntimeSessionProgress('local', 'other-session')).toBeNull();
   });
 });

--- a/src/web-ui/src/infrastructure/peer-device/runtimeSessionEventGate.ts
+++ b/src/web-ui/src/infrastructure/peer-device/runtimeSessionEventGate.ts
@@ -162,6 +162,25 @@ export function markRuntimeSessionProjectionStale(
   }
 }
 
+/**
+ * The stream position this Surface/Session has already applied.
+ *
+ * `null` when nothing usable has been observed yet — no live event carried a
+ * cursor, or the position came from a projection marked stale without one. A
+ * caller can only ask the Host for an incremental delta when it can name the
+ * exact cursor it is contiguous with.
+ */
+export function readRuntimeSessionProgress(
+  surfaceId: DeviceSurfaceId,
+  sessionId: string,
+): { streamId: string; cursor: number } | null {
+  const current = progress.get(attachmentKey(surfaceId, sessionId));
+  if (!current || !current.streamId) {
+    return null;
+  }
+  return { streamId: current.streamId, cursor: current.cursor };
+}
+
 export function isRuntimeSessionAttachmentInFlight(
   surfaceId: DeviceSurfaceId,
   sessionId: string,

--- a/src/web-ui/src/infrastructure/peer-device/runtimeSessionEventGate.ts
+++ b/src/web-ui/src/infrastructure/peer-device/runtimeSessionEventGate.ts
@@ -120,8 +120,12 @@ function drain(events: QueuedRuntimeEvent[], shouldDeliver: (event: QueuedRuntim
 }
 
 export interface RuntimeSessionAttachmentHandle {
+  isCurrent(): boolean;
   requiresReplay(snapshot: { streamId: string; cursor: number }): boolean;
-  finish(snapshot: { streamId: string; cursor: number }): void;
+  finish(
+    snapshot: { streamId: string; cursor: number },
+    options?: { projectionCaughtUp?: boolean },
+  ): void;
   abort(options?: { discard?: boolean }): void;
 }
 
@@ -132,11 +136,44 @@ export function subscribeRuntimeSessionEventGaps(
   return () => gapListeners.delete(listener);
 }
 
+/**
+ * Mark the rendered projection as behind the Host journal.
+ *
+ * Delivery to a product listener is not acceptance. A TextChunk / ToolEvent
+ * that the state machine drops still advances the live cursor, and a later
+ * snapshot at that same cursor would otherwise skip replay — leaving
+ * in-progress tool cards frozen while the Host has moved on.
+ */
+export function markRuntimeSessionProjectionStale(
+  surfaceId: DeviceSurfaceId,
+  sessionId: string,
+): void {
+  const key = attachmentKey(surfaceId, sessionId);
+  const current = progress.get(key);
+  const alreadyStale = current?.hasGap === true;
+  progress.set(key, current
+    ? { ...current, hasGap: true }
+    : { streamId: '', cursor: 0, hasGap: true });
+  if (alreadyStale) {
+    return;
+  }
+  for (const listener of gapListeners) {
+    listener(surfaceId, sessionId);
+  }
+}
+
 export function isRuntimeSessionAttachmentInFlight(
   surfaceId: DeviceSurfaceId,
   sessionId: string,
 ): boolean {
   return attachments.has(attachmentKey(surfaceId, sessionId));
+}
+
+export function isRuntimeSessionProjectionStale(
+  surfaceId: DeviceSurfaceId,
+  sessionId: string,
+): boolean {
+  return progress.get(attachmentKey(surfaceId, sessionId))?.hasGap === true;
 }
 
 export function beginRuntimeSessionAttachment(
@@ -145,15 +182,16 @@ export function beginRuntimeSessionAttachment(
 ): RuntimeSessionAttachmentHandle {
   const key = attachmentKey(surfaceId, sessionId);
   const previous = attachments.get(key);
+  // Transfer the fence. Delivering the previous queue here would apply
+  // events against a state machine that the newer attach is about to reset,
+  // then the new finish() would cover those same cursors and skip replay.
+  const carried = previous?.queued ?? [];
   if (previous) {
     attachments.delete(key);
-    // Overlapping attachment is not expected, but live events must never be
-    // silently lost if a newer reconciliation supersedes an older one.
-    drain(previous.queued, () => true);
   }
 
   const generation = ++nextGeneration;
-  const attachment: RuntimeSessionAttachment = { generation, queued: [] };
+  const attachment: RuntimeSessionAttachment = { generation, queued: carried };
   attachments.set(key, attachment);
 
   const takeOwnedQueue = (): QueuedRuntimeEvent[] | null => {
@@ -166,6 +204,10 @@ export function beginRuntimeSessionAttachment(
   };
 
   return {
+    isCurrent() {
+      const current = attachments.get(key);
+      return Boolean(current && current.generation === generation);
+    },
     requiresReplay(snapshot) {
       const current = progress.get(key);
       return (
@@ -175,12 +217,13 @@ export function beginRuntimeSessionAttachment(
         current.cursor < snapshot.cursor
       );
     },
-    finish(snapshot) {
+    finish(snapshot, options) {
       const queued = takeOwnedQueue();
       if (!queued) {
         return;
       }
-      progress.set(key, { ...snapshot, hasGap: false });
+      const projectionCaughtUp = options?.projectionCaughtUp !== false;
+      progress.set(key, { ...snapshot, hasGap: !projectionCaughtUp });
       drain(queued, event => (
         event.streamId !== snapshot.streamId ||
         event.cursor === undefined ||

--- a/src/web-ui/src/infrastructure/peer-device/runtimeSessionEventGate.ts
+++ b/src/web-ui/src/infrastructure/peer-device/runtimeSessionEventGate.ts
@@ -1,65 +1,43 @@
 /**
- * Cursor fence for attaching a UI Surface to a running Runtime Session.
+ * Transport-side adapter onto a Session's ordered stream.
  *
- * A restore request and the live event stream race by definition. While the
- * Runtime snapshot is in flight, live events for that Surface/Session are held
- * here. Snapshot replay establishes the state at `cursor`; finishing the
- * attachment drops already-covered events and releases only newer ones.
+ * Contract: [`docs/architecture/session-projection.md`](../../../../../docs/architecture/session-projection.md).
+ *
+ * This module used to own its own copy of the stream position, its own gap
+ * flag, and its own fence. All three now live on `SessionStream`, the single
+ * owner of what has been applied for one `(surface, session)`. What remains
+ * here is the transport concern: reading the reserved cursor keys off a
+ * delivery envelope, and stripping them before product listeners see them.
  */
 
+import type { DeviceSurfaceId } from './deviceSurface';
 import {
-  surfaceScopedKey,
-  type DeviceSurfaceId,
-} from './deviceSurface';
+  peekSessionStream,
+  resetSessionStreamsForTest,
+  sessionStream,
+  type SessionStreamRead,
+} from '@/flow_chat/session-stream/SessionStream';
+import {
+  isRuntimePosition,
+  type RuntimePosition,
+} from '@/flow_chat/session-stream/position';
 
 /** Keep in sync with the Rust `SessionEventJournal` delivery-envelope keys. */
 export const RUNTIME_EVENT_STREAM_ID_KEY = '__bitfunRuntimeStreamId';
 export const RUNTIME_EVENT_CURSOR_KEY = '__bitfunRuntimeEventCursor';
 
-interface QueuedRuntimeEvent {
-  sequence: number;
-  streamId?: string;
-  cursor?: number;
-  deliver: () => void;
-}
-
-interface RuntimeSessionAttachment {
-  generation: number;
-  queued: QueuedRuntimeEvent[];
-}
-
-interface RuntimeSessionProgress {
-  streamId: string;
-  cursor: number;
-  hasGap: boolean;
-}
-
-const attachments = new Map<string, RuntimeSessionAttachment>();
-const progress = new Map<string, RuntimeSessionProgress>();
 const gapListeners = new Set<(surfaceId: DeviceSurfaceId, sessionId: string) => void>();
-let nextGeneration = 0;
-let nextSequence = 0;
 
-function attachmentKey(surfaceId: DeviceSurfaceId, sessionId: string): string {
-  return surfaceScopedKey(surfaceId, 'runtime-session-attachment', sessionId);
-}
-
-function readEventMetadata(payload: unknown): {
-  streamId?: string;
-  cursor?: number;
-} {
+function readEventPosition(payload: unknown): RuntimePosition | null {
   if (!payload || typeof payload !== 'object') {
-    return {};
+    return null;
   }
   const record = payload as Record<string, unknown>;
-  const streamId = record[RUNTIME_EVENT_STREAM_ID_KEY];
-  const cursor = record[RUNTIME_EVENT_CURSOR_KEY];
-  return {
-    ...(typeof streamId === 'string' && streamId ? { streamId } : {}),
-    ...(typeof cursor === 'number' && Number.isSafeInteger(cursor) && cursor >= 0
-      ? { cursor }
-      : {}),
+  const candidate = {
+    streamId: record[RUNTIME_EVENT_STREAM_ID_KEY],
+    cursor: record[RUNTIME_EVENT_CURSOR_KEY],
   };
+  return isRuntimePosition(candidate) ? candidate : null;
 }
 
 function stripEventMetadata<T>(payload: T): T {
@@ -81,41 +59,9 @@ function stripEventMetadata<T>(payload: T): T {
   return productPayload as T;
 }
 
-function advanceProgress(
-  key: string,
-  metadata: { streamId?: string; cursor?: number },
-): boolean {
-  if (metadata.streamId === undefined || metadata.cursor === undefined) {
-    return false;
-  }
-  const current = progress.get(key);
-  if (!current || current.streamId !== metadata.streamId) {
-    const hasGap = metadata.cursor > 1;
-    progress.set(key, {
-      streamId: metadata.streamId,
-      cursor: metadata.cursor,
-      hasGap,
-    });
-    return hasGap;
-  }
-  if (metadata.cursor > current.cursor) {
-    const detectedGap = !current.hasGap && metadata.cursor > current.cursor + 1;
-    progress.set(key, {
-      streamId: current.streamId,
-      cursor: metadata.cursor,
-      hasGap: current.hasGap || detectedGap,
-    });
-    return detectedGap;
-  }
-  return false;
-}
-
-function drain(events: QueuedRuntimeEvent[], shouldDeliver: (event: QueuedRuntimeEvent) => boolean) {
-  events.sort((left, right) => left.sequence - right.sequence);
-  for (const event of events) {
-    if (shouldDeliver(event)) {
-      event.deliver();
-    }
+function notifyGap(surfaceId: DeviceSurfaceId, sessionId: string): void {
+  for (const listener of gapListeners) {
+    listener(surfaceId, sessionId);
   }
 }
 
@@ -137,131 +83,102 @@ export function subscribeRuntimeSessionEventGaps(
 }
 
 /**
- * Mark the rendered projection as behind the Host journal.
+ * Report that the painter refused content the stream admitted.
  *
- * Delivery to a product listener is not acceptance. A TextChunk / ToolEvent
- * that the state machine drops still advances the live cursor, and a later
- * snapshot at that same cursor would otherwise skip replay — leaving
- * in-progress tool cards frozen while the Host has moved on.
+ * Delivery is not acceptance: a TextChunk or ToolEvent the state machine drops
+ * still advanced the position, so without this the position would claim a
+ * screen state that never happened. Recording it as a gap routes the repair
+ * through the same path a lost event uses.
  */
 export function markRuntimeSessionProjectionStale(
   surfaceId: DeviceSurfaceId,
   sessionId: string,
 ): void {
-  const key = attachmentKey(surfaceId, sessionId);
-  const current = progress.get(key);
-  const alreadyStale = current?.hasGap === true;
-  progress.set(key, current
-    ? { ...current, hasGap: true }
-    : { streamId: '', cursor: 0, hasGap: true });
-  if (alreadyStale) {
+  const stream = sessionStream(surfaceId, sessionId);
+  if (stream.hasGap()) {
     return;
   }
-  for (const listener of gapListeners) {
-    listener(surfaceId, sessionId);
-  }
-}
-
-/**
- * The stream position this Surface/Session has already applied.
- *
- * `null` when nothing usable has been observed yet — no live event carried a
- * cursor, or the position came from a projection marked stale without one. A
- * caller can only ask the Host for an incremental delta when it can name the
- * exact cursor it is contiguous with.
- */
-export function readRuntimeSessionProgress(
-  surfaceId: DeviceSurfaceId,
-  sessionId: string,
-): { streamId: string; cursor: number } | null {
-  const current = progress.get(attachmentKey(surfaceId, sessionId));
-  if (!current || !current.streamId) {
-    return null;
-  }
-  return { streamId: current.streamId, cursor: current.cursor };
-}
-
-export function isRuntimeSessionAttachmentInFlight(
-  surfaceId: DeviceSurfaceId,
-  sessionId: string,
-): boolean {
-  return attachments.has(attachmentKey(surfaceId, sessionId));
+  stream.markProjectionBehind();
+  notifyGap(surfaceId, sessionId);
 }
 
 export function isRuntimeSessionProjectionStale(
   surfaceId: DeviceSurfaceId,
   sessionId: string,
 ): boolean {
-  return progress.get(attachmentKey(surfaceId, sessionId))?.hasGap === true;
+  return peekSessionStream(surfaceId, sessionId)?.hasGap() === true;
+}
+
+/**
+ * The position this Surface/Session has applied, or `null` when nothing
+ * positioned has been seen — a caller can only ask a Host for a delta when it
+ * can name the exact position it is contiguous with.
+ */
+export function readRuntimeSessionProgress(
+  surfaceId: DeviceSurfaceId,
+  sessionId: string,
+): RuntimePosition | null {
+  return peekSessionStream(surfaceId, sessionId)?.appliedPosition() ?? null;
+}
+
+const inFlightReads = new Map<string, SessionStreamRead>();
+
+function readKey(surfaceId: DeviceSurfaceId, sessionId: string): string {
+  return JSON.stringify([surfaceId, sessionId]);
+}
+
+export function isRuntimeSessionAttachmentInFlight(
+  surfaceId: DeviceSurfaceId,
+  sessionId: string,
+): boolean {
+  return inFlightReads.get(readKey(surfaceId, sessionId))?.isCurrent() === true;
 }
 
 export function beginRuntimeSessionAttachment(
   surfaceId: DeviceSurfaceId,
   sessionId: string,
 ): RuntimeSessionAttachmentHandle {
-  const key = attachmentKey(surfaceId, sessionId);
-  const previous = attachments.get(key);
-  // Transfer the fence. Delivering the previous queue here would apply
-  // events against a state machine that the newer attach is about to reset,
-  // then the new finish() would cover those same cursors and skip replay.
-  const carried = previous?.queued ?? [];
-  if (previous) {
-    attachments.delete(key);
-  }
-
-  const generation = ++nextGeneration;
-  const attachment: RuntimeSessionAttachment = { generation, queued: carried };
-  attachments.set(key, attachment);
-
-  const takeOwnedQueue = (): QueuedRuntimeEvent[] | null => {
-    const current = attachments.get(key);
-    if (!current || current.generation !== generation) {
-      return null;
-    }
-    attachments.delete(key);
-    return current.queued;
-  };
+  const stream = sessionStream(surfaceId, sessionId);
+  const read = stream.beginRead();
+  inFlightReads.set(readKey(surfaceId, sessionId), read);
 
   return {
-    isCurrent() {
-      const current = attachments.get(key);
-      return Boolean(current && current.generation === generation);
-    },
+    isCurrent: () => read.isCurrent(),
     requiresReplay(snapshot) {
-      const current = progress.get(key);
-      return (
-        !current ||
-        current.streamId !== snapshot.streamId ||
-        current.hasGap ||
-        current.cursor < snapshot.cursor
-      );
+      // Under the contract this is ordering, not inspection: replay when the
+      // snapshot reaches past what is applied, when it belongs to another
+      // Runtime process, or when the painter reported it fell behind.
+      const applied = stream.appliedPosition();
+      if (stream.hasGap() || !applied) {
+        return true;
+      }
+      return applied.streamId !== snapshot.streamId || applied.cursor < snapshot.cursor;
     },
     finish(snapshot, options) {
-      const queued = takeOwnedQueue();
-      if (!queued) {
-        return;
+      read.settle(isRuntimePosition(snapshot) ? snapshot : null);
+      if (options?.projectionCaughtUp === false) {
+        // Mark only. Notifying here would schedule a repair for a read that
+        // just ran, and the caller reports it through
+        // `markRuntimeSessionProjectionStale` — which dedupes against this
+        // same flag and correctly stays silent.
+        stream.markProjectionBehind();
       }
-      const projectionCaughtUp = options?.projectionCaughtUp !== false;
-      progress.set(key, { ...snapshot, hasGap: !projectionCaughtUp });
-      drain(queued, event => (
-        event.streamId !== snapshot.streamId ||
-        event.cursor === undefined ||
-        event.cursor > snapshot.cursor
-      ));
     },
     abort(options) {
-      const queued = takeOwnedQueue();
-      if (!queued || options?.discard === true) {
+      if (options?.discard === true) {
+        // Held writes belong to whichever read supersedes this one; releasing
+        // them here would apply them against a projection it is rebuilding.
+        read.settle(null);
         return;
       }
-      drain(queued, () => true);
+      read.abandon();
     },
   };
 }
 
 /**
- * Route one already surface-selected transport event through an in-flight
- * Session attachment. Product listeners never see the reserved cursor keys.
+ * Route one already surface-selected transport event through its Session
+ * stream. Product listeners never see the reserved cursor keys.
  */
 export function routeRuntimeSessionEvent<T>(
   surfaceId: DeviceSurfaceId,
@@ -284,34 +201,26 @@ export function routeRuntimeSessionEvent<T>(
     return;
   }
 
-  const attachment = attachments.get(attachmentKey(surfaceId, sessionId));
-  const key = attachmentKey(surfaceId, sessionId);
-  const metadata = readEventMetadata(payload);
-  const deliverWithProgress = (): void => {
-    const gapDetected = advanceProgress(key, metadata);
+  const stream = sessionStream(surfaceId, sessionId);
+  const hadGap = stream.hasGap();
+  const admission = stream.offer(
+    eventName,
+    payload,
+    readEventPosition(payload),
+    () => deliver(productPayload),
+  );
+  if (admission === 'apply') {
     deliver(productPayload);
-    if (gapDetected) {
-      for (const listener of gapListeners) {
-        listener(surfaceId, sessionId);
-      }
-    }
-  };
-  if (!attachment) {
-    deliverWithProgress();
-    return;
   }
-
-  attachment.queued.push({
-    sequence: ++nextSequence,
-    ...metadata,
-    deliver: deliverWithProgress,
-  });
+  if (!hadGap && stream.hasGap()) {
+    notifyGap(surfaceId, sessionId);
+  }
 }
 
 export function resetRuntimeSessionEventGateForTest(): void {
-  attachments.clear();
-  progress.clear();
   gapListeners.clear();
-  nextGeneration = 0;
-  nextSequence = 0;
+  inFlightReads.clear();
+  // Positions live on the streams now, so clearing only this module's maps
+  // would leak applied state between tests.
+  resetSessionStreamsForTest();
 }


### PR DESCRIPTION
Multi-device remote control was accumulating regressions faster than they were
being fixed — six in two weeks, each one adding another entry to the fourteen
"do not regress" invariants in `peer-device/README.md`. This PR treats the rule
list itself as the defect and starts removing it.

## Why the rules keep growing

Seven independent writers produce a Session's on-screen state, and none of them
carries a position the others can compare against:

| # | Writer | Entry point |
|---|---|---|
| 1 | Live agentic events | `AgenticEventListener` → `eventBatcher` |
| 2 | Disk hydrate | `loadSessionHistory` → `restore_session_view` |
| 3 | Windowed history | `load_session_turn_window` |
| 4 | Snapshot reconcile | `refreshPeerSessionSnapshot` |
| 5 | Journal snapshot replay | `dispatchExternal(snapshot.events)` |
| 6 | Interaction mailbox | `reconcilePendingUserQuestions` |
| 7 | Backfill delta | `load_session_event_backfill` |

Every pair therefore needs its own conflict rule, and the rules are written in
terms of painted content: `snapshotDropsProjectedTurnContent` decided whether a
write was safe by counting rounds and progress entries. Counting pixels to
decide whether a write is safe is what a missing position looks like.

The count also grows quadratically, and adding writer 7 in this PR proved it:
shipping it without its 7↔1 and 7↔6 rules produced two defects, both fixed here
(`ed0fa5941`, `e426b146e`).

## What this changes

**A delivery gap becomes a question with an answer.** The Session journal is a
materialized projection — text chunks accumulate into the entry before them, a
new Turn clears the vector — so it can say what a Turn looks like now but not
what came after position N. A client that detected a gap had exactly one
repair: throw the rendered projection away and replay a whole snapshot, which
is the all-or-nothing move the surrounding heuristics exist to make safe. An
append-only tail now sits beside the compacted projection, and `events_since`
returns either a delta contiguous with the client's cursor or
`snapshotRequired`. Both Peer Hosts serve it as `load_session_event_backfill`;
the controller applies a delta straight through the live path, so the
projection continues instead of being rebuilt. The snapshot path is demoted to
the fallback it should always have been.

**A Session's projection gets one owner.** `docs/architecture/session-projection.md`
states the contract and `flow_chat/session-stream/` implements it: a position
orders writes and cursors from different Runtime processes are never comparable;
a write that is not ahead is dropped rather than merged, so there is no replace
operation; a Turn has one writer decided by whether it is executing,
transferring once on its terminal event — which is why history and live events
cannot race. Identity is `(surface, session)` by construction rather than an
argument each feature remembers to thread through.

`runtimeSessionEventGate` is the first writer moved onto it and stops owning
state: its position map, gap flag, and fence are deleted. Its existing tests
pass unchanged, which is the point — this is a change of owner, not behaviour.

**The CLI Host becomes a peer of the account.** It only journaled and forwarded
Turns a controller had submitted, so a Turn started in its own TUI was invisible
to every attached Desktop client — filtered out of the event fan-out, the
permission stream, and the `restore_session_view` interaction and
runtime-projection snapshots. Submission also required an attached controller,
so the Host could not admit a Turn while the controller was between devices.
Ownership and visibility were one gate; they are now separate concerns, and
`owned_terminal_turn` is the only seam that reads ownership — its return type
cannot express "suppress the event". The CLI also gains the
`idempotent_dialog_submit` contract it advertised nowhere: a Desktop Host
inherits it from the webview bridge's cache, so a Relay timeout to a CLI Host
left the controller unable to tell "never arrived" from "already running".

## Two user-visible defects fixed

- **A controller showed a Turn as finished while the Host was still streaming
  it, with the tail of the text missing.** The persisted copy of an executing
  Turn is stored idle on purpose so a restart never revives work, which makes it
  lagging and shaped like a completed Turn. Both the snapshot merge and disk
  hydrate could paint it over the live projection, because the guard was
  `replaceRunningSnapshot` plus a content comparison and a projection rebuilt
  after a surface switch has no state machines — so every Turn read as idle and
  qualified. Contract 2 decides it now, and the Host's declared executing Turn
  is part of that ownership: this window not having witnessed a Turn start is
  not evidence that it finished.

- **A local session stalled after sending and then flooded.** Cursors are per
  Session and never reset, so a window opening an existing Session sees its
  first live event at a high cursor; treating that as a discontinuity made every
  freshly opened Session schedule a repair and fence its own live events behind
  that request. A first observation is now a baseline. The catch-up fence also
  had three exits that neither settled nor handed it off, one of which held a
  Session's events indefinitely.

## What is deliberately not done

Deleting the content comparisons outright failed four behavioural tests, and
they were right — contract 2 does not yet cover a Host that serves no runtime
projection (its checkpoint is the only progress there is) or a partial history
read (which holds no position for content it omitted). Both comparisons survive
inside `persistedReadMayReplaceTurn` with those gaps written down, so the next
step deletes them by closing the gaps rather than by removing the guard.

Writers 2, 3, and 6 are still to migrate. The README records the order and
states that **the invariant list shrinking is the measure of progress**; a
change that adds a rule to it is going the wrong way.

`d26593dd5` predates this work and was already on the branch.

## Verification

AI-assisted. **Lightly tested.**

- `bitfun-agent-runtime` 315 pass, `bitfun-cli` peer_host 77 pass,
  `bitfun-desktop` 313 pass.
- Web UI: `src/infrastructure` + `src/flow_chat` at 2543 pass / 14 fail, the
  same 14 as before this branch (`modelResolution.test.ts`,
  `AcpAgentsConfig.test.tsx`). `type-check:web` at the same 4 pre-existing
  errors (missing `@/generated/api` artifacts plus one `ToolEventModule` type).
- Real multi-device: both user-visible defects above were reproduced and
  confirmed fixed on two Desktop clients over Relay.
- **Not verified on real hardware:** the CLI Peer Host changes. Their unit
  tests pass, but no Desktop-controlling-CLI session was run, so the "a Turn
  started in the CLI's own TUI is visible to a Desktop controller" behaviour is
  untested end to end. Worth a reviewer's attention there.
- No UI-visual changes, so no screenshots.
