### PR TITLE
fix(flowchat): stabilize viewport across window restore

### DIFF
--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
@@ -16,9 +16,11 @@ const mocks = vi.hoisted(() => ({
   scrollToOffset: vi.fn(),
   cancelAim: vi.fn(),
   setVisibleTurnInfo: vi.fn(),
+  handleViewportResize: vi.fn(),
   enterFollowOutput: vi.fn(),
   exitFollowOutput: vi.fn(),
   handleUserScrollIntent: vi.fn(),
+  handleFollowScroll: vi.fn(),
   /**
    * The two answers to "does follow own the viewport", which the real hook
    * gives at two different moments: `isFollowingOutput` is a render value, and
@@ -50,6 +52,7 @@ const BOTTOM_INSET = 168;
  * supplied: the scroller's own box, and where a user message sits inside it.
  */
 function fakeLayout(options: {
+  clientWidth?: number;
   clientHeight: number;
   /** A function where the range has to grow, as it does when history arrives. */
   scrollHeight: number | (() => number);
@@ -58,11 +61,14 @@ function fakeLayout(options: {
   const readScrollHeight = typeof options.scrollHeight === 'function'
     ? options.scrollHeight
     : () => options.scrollHeight as number;
-  const originals = (['clientHeight', 'scrollHeight'] as const).map(name => {
+  const originals = (['clientWidth', 'clientHeight', 'scrollHeight'] as const).map(name => {
     const descriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, name);
     Object.defineProperty(HTMLElement.prototype, name, {
       configurable: true,
-      get: () => (name === 'clientHeight' ? options.clientHeight : readScrollHeight()),
+      get: () => {
+        if (name === 'clientWidth') return options.clientWidth ?? 1000;
+        return name === 'clientHeight' ? options.clientHeight : readScrollHeight();
+      },
     });
     return [name, descriptor] as const;
   });
@@ -183,8 +189,8 @@ vi.mock('./useFlowChatFollowOutput', () => ({
         mocks.handleUserScrollIntent();
       },
       handleTurnsRolledBack: vi.fn(),
-      handleScroll: vi.fn(),
-      handleViewportResize: vi.fn(),
+      handleScroll: mocks.handleFollowScroll,
+      handleViewportResize: mocks.handleViewportResize,
       // Follow owns nothing here, which is what the real hook returns when
       // `isFollowingOutput` is false.
       getFollowTargetScrollTop: () => null,
@@ -231,6 +237,31 @@ describe('VirtualMessageList natural scroll contract', () => {
   let root: Root;
   let animationFrames: Map<number, FrameRequestCallback>;
   let nextAnimationFrameId: number;
+  let resizeObservers: TestResizeObserver[];
+
+  class TestResizeObserver {
+    readonly targets = new Set<Element>();
+
+    constructor(private readonly callback: ResizeObserverCallback) {
+      resizeObservers.push(this);
+    }
+
+    observe(target: Element) {
+      this.targets.add(target);
+    }
+
+    unobserve(target: Element) {
+      this.targets.delete(target);
+    }
+
+    disconnect() {
+      this.targets.clear();
+    }
+
+    notify() {
+      this.callback([], this as unknown as ResizeObserver);
+    }
+  }
 
   /**
    * Run the opening reveal to its end, which is what mounting a transcript
@@ -264,6 +295,7 @@ describe('VirtualMessageList natural scroll contract', () => {
     root = createRoot(container);
     animationFrames = new Map();
     nextAnimationFrameId = 0;
+    resizeObservers = [];
     mocks.items = [
       userMessage('turn-1', 'message-1', 'First'),
       userMessage('turn-2', 'message-2', 'Second'),
@@ -277,17 +309,16 @@ describe('VirtualMessageList natural scroll contract', () => {
     mocks.scrollItemIntoView.mockReset();
     mocks.scrollToOffset.mockReset();
     mocks.cancelAim.mockReset();
+    mocks.handleViewportResize.mockReset();
     mocks.enterFollowOutput.mockReset();
     mocks.exitFollowOutput.mockReset();
     mocks.handleUserScrollIntent.mockReset();
+    mocks.handleFollowScroll.mockReset();
     mocks.scheduleFollowToLatest.mockReset();
     mocks.viewportOwner = null;
     mocks.setVisibleTurnInfo.mockReset();
     mocks.renderItemMetadata = true;
-    vi.stubGlobal('ResizeObserver', class {
-      observe() {}
-      disconnect() {}
-    });
+    vi.stubGlobal('ResizeObserver', TestResizeObserver);
     vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
       nextAnimationFrameId += 1;
       animationFrames.set(nextAnimationFrameId, callback);
@@ -315,10 +346,12 @@ describe('VirtualMessageList natural scroll contract', () => {
     // The session opens on the end of *real content*, which is above this
     // reservation. Nothing aligns to the last item any more: the end of the
     // scroll range is reserved blank, and opening there is opening on nothing.
-    const originalClientHeight = Object.getOwnPropertyDescriptor(
-      HTMLElement.prototype,
-      'clientHeight',
-    );
+    const originalClientHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight');
+    const originalClientWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientWidth');
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+      configurable: true,
+      get: () => 1000,
+    });
     Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
       configurable: true,
       get: () => 600,
@@ -341,6 +374,69 @@ describe('VirtualMessageList natural scroll contract', () => {
       } else {
         delete (HTMLElement.prototype as unknown as Record<string, unknown>).clientHeight;
       }
+      if (originalClientWidth) {
+        Object.defineProperty(HTMLElement.prototype, 'clientWidth', originalClientWidth);
+      } else {
+        delete (HTMLElement.prototype as unknown as Record<string, unknown>).clientWidth;
+      }
+    }
+  });
+
+  it('suspends viewport writers until the frame after a minimized zero-size sample resumes', () => {
+    const layout = {
+      clientWidth: 1000,
+      clientHeight: 600,
+      scrollHeight: 3000,
+      turnTopFromScrollerTop: 500,
+    };
+    const restoreLayout = fakeLayout(layout);
+    try {
+      act(() => root.render(<VirtualMessageList />));
+      const scroller = container.querySelector<HTMLElement>('[data-flowchat-scroller]')!;
+      const observer = resizeObservers.find(candidate => candidate.targets.has(scroller));
+      expect(observer).toBeDefined();
+      if (!observer) throw new Error('Expected a ResizeObserver for the FlowChat scroller');
+      const spacer = container.querySelector<HTMLElement>('.message-list-tail-spacer')!;
+      const spacerBeforeMinimize = spacer.style.height;
+
+      mocks.handleViewportResize.mockClear();
+      mocks.scheduleFollowToLatest.mockClear();
+      mocks.setVisibleTurnInfo.mockClear();
+      animationFrames.clear();
+
+      layout.clientWidth = 390;
+      layout.clientHeight = 0;
+      act(() => observer.notify());
+
+      expect(mocks.handleViewportResize).not.toHaveBeenCalled();
+      expect(mocks.scheduleFollowToLatest).not.toHaveBeenCalled();
+      expect(mocks.setVisibleTurnInfo).not.toHaveBeenCalled();
+      expect(spacer.style.height).toBe(spacerBeforeMinimize);
+      expect(animationFrames.size).toBe(0);
+
+      act(() => scroller.dispatchEvent(new Event('scroll')));
+      expect(mocks.handleFollowScroll).not.toHaveBeenCalled();
+
+      layout.clientWidth = 1000;
+      layout.clientHeight = 700;
+      act(() => observer.notify());
+
+      // The first positive rectangle is still part of host recovery. Treating
+      // it as a normal resize replays zero-height scroll events as a tail
+      // follow or measurement correction before the old reading position can
+      // be restored.
+      expect(mocks.handleViewportResize).not.toHaveBeenCalled();
+      expect(mocks.scheduleFollowToLatest).not.toHaveBeenCalled();
+
+      const [resume] = [...animationFrames.values()];
+      expect(resume).toBeDefined();
+      if (!resume) throw new Error('Expected a deferred viewport recovery frame');
+      act(() => resume(16));
+
+      expect(mocks.handleViewportResize).not.toHaveBeenCalled();
+      expect(mocks.scheduleFollowToLatest).toHaveBeenCalledTimes(1);
+    } finally {
+      restoreLayout();
     }
   });
 

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
@@ -56,7 +56,10 @@ import {
   tailSpacerPxForViewport,
   turnTopAlignmentEntersReservedBlank,
 } from './flowChatTailFollow';
-import { useFlowChatVirtualizer } from './useFlowChatVirtualizer';
+import {
+  isUsableFlowChatViewportRect,
+  useFlowChatVirtualizer,
+} from './useFlowChatVirtualizer';
 import { useFlowChatViewportOwner } from './useFlowChatViewportOwner';
 import {
   ONE_SHOT_NAVIGATION_HOLD_MS,
@@ -411,7 +414,11 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
   const [viewportHeightPx, setViewportHeightPx] = useState(0);
   const [viewportWidthPx, setViewportWidthPx] = useState(0);
   /** Last scroller box the resize observer saw, to tell it apart from a content change. */
-  const observedViewportBoxRef = useRef({ width: 0, height: 0 });
+  const observedViewportBoxRef = useRef<{ width: number; height: number } | null>(null);
+  /** Native minimization withdraws the scroller without unmounting the session. */
+  const isViewportSuspendedRef = useRef(false);
+  const suspendedViewportScrollTopRef = useRef<number | null>(null);
+  const viewportResumeFrameRef = useRef<number | null>(null);
   /** Remaining resize callbacks over which to keep a resting viewport at the end. */
   const tailRealignCallbacksRef = useRef(0);
   /** Synchronous mirror of `isAtBottom`, read by a resize for the pre-resize answer. */
@@ -495,6 +502,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
         .map(([groupId, expanded]) => `${groupId}:${expanded ? 1 : 0}`)
         .join(','),
     ].join('|'),
+    isViewportSuspended: () => isViewportSuspendedRef.current,
     scrollPaddingStartPx: FLOWCHAT_TURN_TOP_GAP_PX,
     writeViewport: viewportOwner.write,
     shiftViewport: viewportOwner.shift,
@@ -643,6 +651,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     virtualItemCount: virtualItems.length,
     isStreaming: isStreamingOutput,
     isViewportActive,
+    isViewportSuspended: () => isViewportSuspendedRef.current,
     scrollerRef: scrollerElementRef,
     getTailSpacerPx,
     scrollToContentEnd,
@@ -701,7 +710,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
    * follow-output — see `flowChatViewportOwnership.ts`.
    */
   const isViewportOwnedElsewhere = useCallback(() => (
-    !viewportOwner.canShift() || isOpeningViewport()
+    isViewportSuspendedRef.current || !viewportOwner.canShift() || isOpeningViewport()
   ), [isOpeningViewport, viewportOwner]);
 
   const shiftAnchorCorrection = useCallback((byPx: number) => {
@@ -755,6 +764,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     if (!scroller) return;
     const previousScrollHeightPx = previousScrollHeightRef.current;
     previousScrollHeightRef.current = scroller.scrollHeight;
+    if (isViewportSuspendedRef.current) return;
     if (previousFirstKey === null || previousFirstKey === nextFirstKey) return;
     // Absent means the head was trimmed rather than extended, and there is no
     // prepended height to account for.
@@ -1154,6 +1164,72 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     updateIsAtBottom();
   }, [isFollowingOutput, updateIsAtBottom]);
 
+  const resumeSuspendedViewport = useCallback(() => {
+    viewportResumeFrameRef.current = null;
+    if (!isViewportSuspendedRef.current) return;
+
+    isViewportSuspendedRef.current = false;
+    const suspendedScrollTopPx = suspendedViewportScrollTopRef.current;
+    suspendedViewportScrollTopRef.current = null;
+    const scrollTopBeforeRecoveryPx = scrollerElementRef.current?.scrollTop ?? null;
+    const wasFollowingOutput = isFollowingOutputNow();
+    let restoredAnchor = false;
+    let restoredScrollTopFallback = false;
+
+    if (!wasFollowingOutput) {
+      restoredAnchor = viewportAnchor.restoreAnchorAfterViewportResume();
+      if (!restoredAnchor && suspendedScrollTopPx !== null) {
+        viewportOwner.write({
+          owner: 'layout-correction',
+          topPx: suspendedScrollTopPx,
+        });
+        restoredScrollTopFallback = true;
+      }
+      viewportAnchor.openSettleWindow();
+    }
+
+    traceViewport({
+      location: 'viewport.hostResumeRecovered',
+      message: 'native host viewport recovery completed',
+      data: () => {
+        const scroller = scrollerElementRef.current;
+        return {
+          wasFollowingOutput,
+          restoredAnchor,
+          restoredScrollTopFallback,
+          suspendedScrollTopPx: suspendedScrollTopPx === null
+            ? null
+            : roundViewportPx(suspendedScrollTopPx),
+          scrollTopBeforeRecoveryPx: scrollTopBeforeRecoveryPx === null
+            ? null
+            : roundViewportPx(scrollTopBeforeRecoveryPx),
+          scrollTopAfterRecoveryPx: scroller ? roundViewportPx(scroller.scrollTop) : null,
+          viewportBox: scroller
+            ? { width: scroller.clientWidth, height: scroller.clientHeight }
+            : null,
+        };
+      },
+    });
+
+    scheduleFollowToLatest();
+    scheduleVisibleTurnInfoUpdate();
+    updateIsAtBottom();
+  }, [
+    isFollowingOutputNow,
+    scheduleFollowToLatest,
+    scheduleVisibleTurnInfoUpdate,
+    updateIsAtBottom,
+    viewportAnchor,
+    viewportOwner,
+  ]);
+
+  useEffect(() => () => {
+    if (viewportResumeFrameRef.current !== null) {
+      cancelAnimationFrame(viewportResumeFrameRef.current);
+      viewportResumeFrameRef.current = null;
+    }
+  }, []);
+
   /*
    * A rollback removed Turns from the session, so the transcript ends somewhere
    * it did not a moment ago — and the Turn follow-output was pinning may be one
@@ -1176,6 +1252,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
   useEffect(() => {
     if (!scrollerElement) return;
     const handleNativeScroll = () => {
+      if (isViewportSuspendedRef.current) return;
       /*
        * A scroll under a scrollbar press is the one case where a plain scroll
        * event does carry intent — the press is what qualifies it. Left
@@ -1243,6 +1320,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     scrollerElement,
     updateIsAtBottom,
     viewportAnchor,
+    viewportOwner,
   ]);
 
   useEffect(() => {
@@ -1253,6 +1331,64 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
         height: scrollerElement.clientHeight,
       };
       /*
+       * A minimized WebView2 window reports a zero-height scroller while the
+       * document remains visible. That is suspension, not a layout request:
+       * accepting it would collapse the tail spacer, empty the virtual window,
+       * clear the visible Turn and run a full-height scroll correction. Keep
+       * every downstream owner on the last usable box until layout returns.
+       */
+      if (!isUsableFlowChatViewportRect(nextViewportBox)) {
+        if (!isViewportSuspendedRef.current) {
+          isViewportSuspendedRef.current = true;
+          suspendedViewportScrollTopRef.current = scrollerElement.scrollTop;
+          tailRealignCallbacksRef.current = 0;
+          traceViewport({
+            location: 'viewport.hostSuspended',
+            message: 'native host withdrew the viewport from layout',
+            data: () => ({
+              receivedViewportBox: nextViewportBox,
+              lastUsableViewportBox: observedViewportBoxRef.current,
+              scrollTopPx: roundViewportPx(scrollerElement.scrollTop),
+              scrollHeightPx: roundViewportPx(scrollerElement.scrollHeight),
+              renderedRowCount: scrollerElement.querySelectorAll('[data-virtual-index]').length,
+              tailSpacerPx: roundViewportPx(tailSpacerPxRef.current),
+              isAtTail: isAtTailRef.current,
+              viewportOwner: viewportOwner.currentOwner(),
+            }),
+          });
+        }
+        if (viewportResumeFrameRef.current !== null) {
+          cancelAnimationFrame(viewportResumeFrameRef.current);
+          viewportResumeFrameRef.current = null;
+        }
+        return;
+      }
+      const isResumingSuspendedViewport = isViewportSuspendedRef.current;
+      if (isResumingSuspendedViewport) {
+        traceViewport({
+          location: 'viewport.hostResumeDetected',
+          message: 'native host returned viewport geometry',
+          data: () => ({
+            recoveredViewportBox: nextViewportBox,
+            lastUsableViewportBox: observedViewportBoxRef.current,
+            suspendedScrollTopPx: suspendedViewportScrollTopRef.current === null
+              ? null
+              : roundViewportPx(suspendedViewportScrollTopRef.current),
+            scrollTopPx: roundViewportPx(scrollerElement.scrollTop),
+            scrollHeightPx: roundViewportPx(scrollerElement.scrollHeight),
+            renderedRowCount: scrollerElement.querySelectorAll('[data-virtual-index]').length,
+            tailSpacerPx: roundViewportPx(tailSpacerPxRef.current),
+          }),
+        });
+        observedViewportBoxRef.current = nextViewportBox;
+        setViewportHeightPx(nextViewportBox.height);
+        setViewportWidthPx(nextViewportBox.width);
+        if (viewportResumeFrameRef.current === null) {
+          viewportResumeFrameRef.current = requestAnimationFrame(resumeSuspendedViewport);
+        }
+        return;
+      }
+      /*
        * This observer watches the content too. Content growth moves the follow
        * target away from a resting viewport and can never strand it, so only a
        * change to the scroller's own box opens the re-alignment window — a
@@ -1260,10 +1396,12 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
        * end directly, and both keep settling for a few callbacks afterwards.
        */
       const previousViewportBox = observedViewportBoxRef.current;
-      const viewportBoxChanged = nextViewportBox.width !== previousViewportBox.width
-        || nextViewportBox.height !== previousViewportBox.height;
+      const viewportBoxChanged = previousViewportBox !== null && (
+        nextViewportBox.width !== previousViewportBox.width
+        || nextViewportBox.height !== previousViewportBox.height
+      );
+      observedViewportBoxRef.current = nextViewportBox;
       if (viewportBoxChanged) {
-        observedViewportBoxRef.current = nextViewportBox;
         tailRealignCallbacksRef.current = TAIL_REALIGN_RESIZE_CALLBACKS;
       }
       setViewportHeightPx(nextViewportBox.height);
@@ -1314,11 +1452,13 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     return () => observer.disconnect();
   }, [
     handleViewportResize,
+    resumeSuspendedViewport,
     scheduleFollowToLatest,
     scheduleVisibleTurnInfoUpdate,
     scrollerElement,
     updateIsAtBottom,
     viewportAnchor,
+    viewportOwner,
   ]);
 
   /**
@@ -1965,12 +2105,16 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       if (!scroller.hasAttribute('tabindex')) {
         scroller.tabIndex = -1;
       }
-      setViewportHeightPx(scroller.clientHeight);
-      // Seed the box so the observer's first callback is not read as a resize.
-      observedViewportBoxRef.current = {
+      const initialViewportBox = {
         width: scroller.clientWidth,
         height: scroller.clientHeight,
       };
+      if (isUsableFlowChatViewportRect(initialViewportBox)) {
+        setViewportHeightPx(initialViewportBox.height);
+        setViewportWidthPx(initialViewportBox.width);
+        // Seed the box so the observer's first callback is not read as a resize.
+        observedViewportBoxRef.current = initialViewportBox;
+      }
     }
   }, []);
 

--- a/src/web-ui/src/flow_chat/components/modern/useFlowChatFollowOutput.ts
+++ b/src/web-ui/src/flow_chat/components/modern/useFlowChatFollowOutput.ts
@@ -68,6 +68,8 @@ interface UseFlowChatFollowOutputOptions {
   virtualItemCount: number;
   isStreaming: boolean;
   isViewportActive: boolean;
+  /** The native host has temporarily withdrawn the scroller from layout. */
+  isViewportSuspended?: () => boolean;
   scrollerRef: RefObject<HTMLElement | null>;
   /** Height of the resident tail spacer currently rendered below the content. */
   getTailSpacerPx: () => number;
@@ -205,6 +207,7 @@ export function useFlowChatFollowOutput({
   virtualItemCount,
   isStreaming,
   isViewportActive,
+  isViewportSuspended = () => false,
   scrollerRef,
   getTailSpacerPx,
   scrollToContentEnd,
@@ -219,6 +222,8 @@ export function useFlowChatFollowOutput({
   const isStreamingRef = useRef(isStreaming);
   const isViewportActiveRef = useRef(isViewportActive);
   const latestTurnIdRef = useRef(latestTurnId);
+  const isViewportSuspendedRef = useRef(isViewportSuspended);
+  isViewportSuspendedRef.current = isViewportSuspended;
   const followFrameRef = useRef<number | null>(null);
   const previousSessionIdRef = useRef(activeSessionId);
   const previousLatestTurnIdRef = useRef<string | null>(latestTurnId);
@@ -619,7 +624,7 @@ export function useFlowChatFollowOutput({
   /** Move the viewport to whatever the follow state currently owns. */
   const applyFollowTarget = useCallback(() => {
     const scroller = scrollerRef.current;
-    if (!scroller) {
+    if (!scroller || isViewportSuspendedRef.current()) {
       return;
     }
 
@@ -811,6 +816,8 @@ export function useFlowChatFollowOutput({
       ? 'not-following'
       : !isViewportActiveRef.current
         ? 'viewport-inactive'
+        : isViewportSuspendedRef.current()
+          ? 'viewport-suspended'
         : document.hidden
           ? 'document-hidden'
           : (!isStreamingRef.current && settleFramesRef.current <= 0)
@@ -846,6 +853,7 @@ export function useFlowChatFollowOutput({
     if (
       followFrameRef.current === null &&
       isFollowingOutputRef.current &&
+      !isViewportSuspendedRef.current() &&
       (isStreamingRef.current || settleFramesRef.current > 0)
     ) {
       followFrameRef.current = requestAnimationFrame(runFollowFrame);
@@ -1110,7 +1118,7 @@ export function useFlowChatFollowOutput({
     const watch = tailWatchRef.current;
     if (!watch) return;
     const scroller = scrollerRef.current;
-    if (!scroller) return;
+    if (!scroller || isViewportSuspendedRef.current()) return;
 
     const scrollTopPx = scroller.scrollTop;
     const contentEndPx = readContentEndScrollTop(scroller);
@@ -1201,6 +1209,7 @@ export function useFlowChatFollowOutput({
    * down.
    */
   const scheduleFollowToLatest = useCallback(() => {
+    if (isViewportSuspendedRef.current()) return;
     if (!isFollowingOutputRef.current || !isViewportActiveRef.current) {
       /*
        * This is the transcript's content-change signal — the resize observer
@@ -1250,6 +1259,7 @@ export function useFlowChatFollowOutput({
   }, [enterFollowOutput]);
 
   const handleScroll = useCallback(() => {
+    if (isViewportSuspendedRef.current()) return;
     // Scroll events describe the resulting viewport position, but do not prove user intent.
     // Layout growth and virtualizer remeasurement can emit them while output follow still owns
     // the viewport. Explicit wheel, touch, and keyboard handlers release that ownership instead.
@@ -1311,7 +1321,7 @@ export function useFlowChatFollowOutput({
    */
   const handleViewportResize = useCallback((input: ViewportResizeInput) => {
     const scroller = scrollerRef.current;
-    if (!scroller || isFollowingOutputRef.current) {
+    if (!scroller || isViewportSuspendedRef.current() || isFollowingOutputRef.current) {
       // Follow re-asserts its own target through `scheduleFollowToLatest`.
       return;
     }

--- a/src/web-ui/src/flow_chat/components/modern/useFlowChatViewportAnchor.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/useFlowChatViewportAnchor.test.tsx
@@ -427,6 +427,24 @@ describe('useFlowChatViewportAnchor', () => {
     expect(scroller.scrollTop).toBeCloseTo(446.7, 6);
   });
 
+  it('does not credit a native viewport resume to the reader', () => {
+    scroller.scrollTop = 1_000;
+    layoutTurns({ 'turn-3': 1_100 });
+    api.captureAnchor();
+
+    // A minimized WebView can return with a transient viewport offset before
+    // its scroll event arrives. This is host recovery, not a reader choice.
+    scroller.scrollTop = 1_132;
+
+    expect(api.restoreAnchorAfterViewportResume()).toBe(true);
+    expect(scroller.scrollTop).toBe(1_000);
+
+    // The recovery correction becomes the new baseline, so ordinary settles do
+    // not borrow it back as an unclaimed scroll on their next frame.
+    expect(api.restoreAnchor()).toBe(true);
+    expect(scroller.scrollTop).toBe(1_000);
+  });
+
   it('does not re-owe a correction it has just made', () => {
     /*
      * The same two halves, on the other branch. The shift puts the Turn back at

--- a/src/web-ui/src/flow_chat/components/modern/useFlowChatViewportAnchor.ts
+++ b/src/web-ui/src/flow_chat/components/modern/useFlowChatViewportAnchor.ts
@@ -158,6 +158,14 @@ export interface FlowChatViewportAnchorApi {
    */
   restoreAnchor: () => boolean;
   /**
+   * Restore the reading position after the native host temporarily withdrew the
+   * viewport from layout.
+   *
+   * Host recovery is not reader input. Keep its transient `scrollTop` delta
+   * out of the anchor until the pre-suspension relationship is restored.
+   */
+  restoreAnchorAfterViewportResume: () => boolean;
+  /**
    * Correct now, and hold the anchor across the settle that follows.
    *
    * One callback per change is not enough, and no callback covers all of it, so
@@ -232,6 +240,12 @@ export function useFlowChatViewportAnchor({
    * DOM in that same task anchors to whatever the reader was moved off.
    */
   const recaptureOnNextSettleRef = useRef(false);
+  /**
+   * A zero-sized native-host viewport is not a reader scroll. This remains set
+   * while its anchor waits for a virtual row to return, so the settle frame
+   * that finally sees the row does not accept host recovery as reader travel.
+   */
+  const isRestoringViewportResumeRef = useRef(false);
   const settleFrameRef = useRef<number | null>(null);
   /*
    * The settle loop is installed once and outlives every render, so it cannot
@@ -474,7 +488,10 @@ export function useFlowChatViewportAnchor({
   const attemptRestore = useCallback((): AnchorRestoreOutcome => {
     const scroller = scrollerRef.current;
     const anchor = anchorRef.current;
-    if (!scroller || !anchor) return 'no-anchor';
+    if (!scroller || !anchor) {
+      isRestoringViewportResumeRef.current = false;
+      return 'no-anchor';
+    }
     /*
      * Every way this declines is silent and looks like the transcript simply
      * not moving, which is why each of them is traced. Standing down for
@@ -482,6 +499,7 @@ export function useFlowChatViewportAnchor({
      * position gets lost, and they have both happened.
      */
     if (isViewportOwnedElsewhereRef.current()) {
+      isRestoringViewportResumeRef.current = false;
       traceViewportRepeating('anchor|owned-elsewhere', {
         location: 'anchor.stoodDown',
         message: 'anchor stood down for another owner',
@@ -521,6 +539,7 @@ export function useFlowChatViewportAnchor({
       if (givingUp) {
         reportMissingTurnWait(scroller, anchor.turnId, 'given-up');
         anchorRef.current = null;
+        isRestoringViewportResumeRef.current = false;
         return 'no-anchor';
       }
       return 'awaiting-turn';
@@ -546,7 +565,10 @@ export function useFlowChatViewportAnchor({
      * exactly itself with `scrolledSincePx: 0`.
      */
     const scrolledSincePx = scroller.scrollTop - anchorScrollTopRef.current;
-    carryAnchorThroughScroll(scroller, 'viewport-moved');
+    const isRestoringViewportResume = isRestoringViewportResumeRef.current;
+    if (!isRestoringViewportResume) {
+      carryAnchorThroughScroll(scroller, 'viewport-moved');
+    }
     const rebased = anchorRef.current ?? anchor;
     const correction = viewportAnchorCorrectionPx(
       rebased,
@@ -560,6 +582,10 @@ export function useFlowChatViewportAnchor({
      * quietly stopped meaning anything would sit unnoticed.
      */
     if (Math.abs(correction) < ANCHOR_CORRECTION_EPSILON_PX) {
+      if (isRestoringViewportResume) {
+        anchorScrollTopRef.current = scroller.scrollTop;
+        isRestoringViewportResumeRef.current = false;
+      }
       traceViewportRepeating(`anchor|in-place|${rebased.turnId}`, {
         location: 'anchor.inPlace',
         message: 'the reading position is where it belongs',
@@ -625,6 +651,7 @@ export function useFlowChatViewportAnchor({
      * `scrollTop` that must not be taken into the offset — it is the repair.
      */
     anchorScrollTopRef.current = scroller.scrollTop;
+    isRestoringViewportResumeRef.current = false;
     return 'corrected';
   }, [carryAnchorThroughScroll, reportMissingTurnWait, scrollerRef]);
 
@@ -637,6 +664,12 @@ export function useFlowChatViewportAnchor({
    * loop only ever needed the two.
    */
   const restoreAnchor = useCallback((): boolean => {
+    const outcome = attemptRestoreRef.current();
+    return outcome === 'corrected' || outcome === 'in-place';
+  }, []);
+
+  const restoreAnchorAfterViewportResume = useCallback((): boolean => {
+    isRestoringViewportResumeRef.current = true;
     const outcome = attemptRestoreRef.current();
     return outcome === 'corrected' || outcome === 'in-place';
   }, []);
@@ -722,6 +755,7 @@ export function useFlowChatViewportAnchor({
     captureAnchorForScroll,
     markUserScrollIntent,
     restoreAnchor,
+    restoreAnchorAfterViewportResume,
     openSettleWindow,
   }), [
     absorbViewportShift,
@@ -731,5 +765,6 @@ export function useFlowChatViewportAnchor({
     openSettleWindow,
     reanchorAfterNavigation,
     restoreAnchor,
+    restoreAnchorAfterViewportResume,
   ]);
 }

--- a/src/web-ui/src/flow_chat/components/modern/useFlowChatVirtualizer.measurement.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/useFlowChatVirtualizer.measurement.test.tsx
@@ -31,9 +31,10 @@ interface HarnessProps {
   header: HTMLElement;
   items: Item[];
   onApi: (api: FlowChatVirtualizer) => void;
+  isViewportSuspended?: () => boolean;
 }
 
-function Harness({ scroller, header, items, onApi }: HarnessProps) {
+function Harness({ scroller, header, items, onApi, isViewportSuspended }: HarnessProps) {
   const scrollerRef = React.useRef<HTMLElement | null>(scroller);
   const headerRef = React.useRef<HTMLElement | null>(header);
   onApi(useFlowChatVirtualizer({
@@ -42,6 +43,7 @@ function Harness({ scroller, header, items, onApi }: HarnessProps) {
     headerRef,
     getItemKey: (item: Item) => item.key,
     estimateItemHeightPx: () => ESTIMATE_PX,
+    isViewportSuspended,
     scrollPaddingStartPx: 0,
     writeViewport: () => true,
   }));
@@ -140,6 +142,24 @@ describe('useFlowChatVirtualizer measurement', () => {
     expect(measureAndRead([0, 1])).toEqual([
       { startPx: 0, endPx: REAL_PX },
       { startPx: REAL_PX, endPx: REAL_PX + ESTIMATE_PX },
+    ]);
+  });
+
+  it('does not measure rendered rows while the native host has suspended the viewport', () => {
+    act(() => root.render(
+      <Harness
+        scroller={scroller}
+        header={header}
+        items={[{ key: 'a' }, { key: 'b' }, { key: 'c' }]}
+        onApi={next => { api = next; }}
+        isViewportSuspended={() => true}
+      />,
+    ));
+    renderRow(0, REAL_PX);
+
+    expect(measureAndRead([0, 1])).toEqual([
+      { startPx: 0, endPx: ESTIMATE_PX },
+      { startPx: ESTIMATE_PX, endPx: ESTIMATE_PX * 2 },
     ]);
   });
 

--- a/src/web-ui/src/flow_chat/components/modern/useFlowChatVirtualizer.ts
+++ b/src/web-ui/src/flow_chat/components/modern/useFlowChatVirtualizer.ts
@@ -26,7 +26,12 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from 'react';
-import { useVirtualizer } from '@tanstack/react-virtual';
+import {
+  observeElementRect as observeTanStackElementRect,
+  useVirtualizer,
+  type Rect,
+  type Virtualizer,
+} from '@tanstack/react-virtual';
 import {
   roundViewportPx,
   traceViewport,
@@ -81,6 +86,36 @@ export interface FlowChatItemBounds {
   endPx: number;
 }
 
+/** A viewport box that can describe what the reader can actually see. */
+export function isUsableFlowChatViewportRect(rect: Rect): boolean {
+  return Number.isFinite(rect.width)
+    && Number.isFinite(rect.height)
+    && rect.width > 0
+    && rect.height > 0;
+}
+
+/**
+ * Keep transient minimized-window geometry out of TanStack's viewport state.
+ *
+ * WebView2 reports a zero-height scroller while the native window is minimized.
+ * Publishing that sample makes the rendered window empty and throws away the
+ * last reader position even though the React tree never left the screen. The
+ * next positive sample is an ordinary reflow from the last usable rectangle.
+ */
+export function observeFlowChatViewportRect<
+  TScrollElement extends Element,
+  TItemElement extends Element,
+>(
+  instance: Virtualizer<TScrollElement, TItemElement>,
+  callback: (rect: Rect) => void,
+): void | (() => void) {
+  return observeTanStackElementRect(instance, rect => {
+    if (isUsableFlowChatViewportRect(rect)) {
+      callback(rect);
+    }
+  });
+}
+
 /** A resize can shift the reader only when the whole row is above it. */
 export function isItemFullyAboveViewport(itemEndPx: number, scrollTopPx: number): boolean {
   return itemEndPx <= scrollTopPx;
@@ -126,6 +161,8 @@ export interface UseFlowChatVirtualizerOptions<T> {
   estimateContext?: VirtualItemHeightEstimateContext;
   /** Stable identity for data that changes an unmeasured row's estimate. */
   estimateContextRevision?: string | number;
+  /** The host has temporarily withdrawn the scroller, such as window minimization. */
+  isViewportSuspended?: () => boolean;
   /**
    * Gap kept above a Turn that has been scrolled to the top of the viewport.
    * Applied by the virtualizer itself so that its re-aim, which runs while
@@ -288,6 +325,7 @@ export function useFlowChatVirtualizer<T>({
   estimateItemHeightPx,
   estimateContext,
   estimateContextRevision,
+  isViewportSuspended = () => false,
   scrollPaddingStartPx,
   writeViewport,
   shiftViewport = () => false,
@@ -330,6 +368,8 @@ export function useFlowChatVirtualizer<T>({
   estimateItemHeightRef.current = estimateItemHeightPx;
   const estimateContextRef = useRef(estimateContext);
   estimateContextRef.current = estimateContext;
+  const isViewportSuspendedRef = useRef(isViewportSuspended);
+  isViewportSuspendedRef.current = isViewportSuspended;
 
   const [contentStartPx, setContentStartPx] = useState(0);
   useEffect(() => {
@@ -367,6 +407,7 @@ export function useFlowChatVirtualizer<T>({
   const virtualizer = useVirtualizer({
     count: items.length,
     getScrollElement: () => scrollerRef.current,
+    observeElementRect: observeFlowChatViewportRect,
     estimateSize,
     getItemKey: resolveItemKey,
     // Items carry their own index attribute already; measuring reads it back.
@@ -381,6 +422,7 @@ export function useFlowChatVirtualizer<T>({
      * by whatever outranks the aim it came from.
      */
     scrollToFn: (offsetPx, { behavior }) => {
+      if (isViewportSuspendedRef.current()) return;
       writeViewportRef.current({
         owner: aimOwnerRef.current,
         topPx: offsetPx,
@@ -394,6 +436,7 @@ export function useFlowChatVirtualizer<T>({
   virtualizer.shouldAdjustScrollPositionOnItemSizeChange = (item, delta) => {
     const scroller = scrollerRef.current;
     if (!scroller) return false;
+    if (isViewportSuspendedRef.current()) return false;
     const beforeScrollTopPx = scroller.scrollTop;
     const beforeScrollHeightPx = scroller.scrollHeight;
     // A row that merely starts above the viewport may still be visible. Its
@@ -506,7 +549,7 @@ export function useFlowChatVirtualizer<T>({
    */
   const measureRenderedItems = useCallback(() => {
     const scroller = scrollerRef.current;
-    if (!scroller) return;
+    if (!scroller || isViewportSuspendedRef.current()) return;
     const elements = scroller.querySelectorAll<HTMLElement>('[data-virtual-index]');
     for (const element of elements) {
       const index = Number(element.getAttribute('data-virtual-index'));

--- a/src/web-ui/src/flow_chat/components/modern/useFlowChatVirtualizer.viewport-rect.test.ts
+++ b/src/web-ui/src/flow_chat/components/modern/useFlowChatVirtualizer.viewport-rect.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Virtualizer } from '@tanstack/react-virtual';
+import { observeFlowChatViewportRect } from './useFlowChatVirtualizer';
+
+class TestResizeObserver {
+  static instances: TestResizeObserver[] = [];
+
+  constructor(private readonly callback: ResizeObserverCallback) {
+    TestResizeObserver.instances.push(this);
+  }
+
+  observe() {}
+
+  unobserve() {}
+
+  emit() {
+    this.callback([], this as unknown as ResizeObserver);
+  }
+}
+
+describe('observeFlowChatViewportRect', () => {
+  afterEach(() => {
+    TestResizeObserver.instances = [];
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps the last positive virtualizer rectangle while a WebView is minimized', () => {
+    vi.stubGlobal('ResizeObserver', TestResizeObserver);
+    let width = 1000;
+    let height = 600;
+    const element = document.createElement('div');
+    Object.defineProperties(element, {
+      offsetWidth: { configurable: true, get: () => width },
+      offsetHeight: { configurable: true, get: () => height },
+    });
+    const instance = {
+      scrollElement: element,
+      targetWindow: window,
+      options: { useAnimationFrameWithResizeObserver: false },
+    } as unknown as Virtualizer<HTMLElement, HTMLElement>;
+    const rectangles: Array<{ width: number; height: number }> = [];
+
+    const cleanup = observeFlowChatViewportRect(instance, rectangle => {
+      rectangles.push(rectangle);
+    });
+
+    expect(rectangles).toEqual([{ width: 1000, height: 600 }]);
+
+    width = 390;
+    height = 0;
+    TestResizeObserver.instances[0].emit();
+    expect(rectangles).toEqual([{ width: 1000, height: 600 }]);
+
+    width = 1000;
+    height = 700;
+    TestResizeObserver.instances[0].emit();
+    expect(rectangles).toEqual([
+      { width: 1000, height: 600 },
+      { width: 1000, height: 700 },
+    ]);
+
+    cleanup?.();
+  });
+});


### PR DESCRIPTION
Treat zero-sized WebView2 viewport geometry as a temporary suspension
instead of a real resize, preventing follow-output, virtualization, and
scroll handlers from rewriting the reader's position while the window is
minimized.

Restore the anchored reading position after valid geometry returns without
crediting host recovery movement as user scrolling. Add focused regression
coverage for invalid viewport rectangles, anchor recovery, measurement
compensation, and follow-output behavior.

Keep low-frequency minimize/restore diagnostics behind the existing
flow_chat_diagnostics switch.
