### PR TITLE
fix(permission): inherit mode in subagents

### DIFF
--- a/src/crates/assembly/core/src/agentic/tools/tool_context_runtime.rs
+++ b/src/crates/assembly/core/src/agentic/tools/tool_context_runtime.rs
@@ -37,7 +37,7 @@ use bitfun_agent_runtime::checkpoint::GitStatusCheckpointFacts;
 use bitfun_agent_runtime::checkpoint::{
     build_light_checkpoint as build_runtime_light_checkpoint, LightCheckpointWorkspaceFacts,
 };
-use bitfun_agent_runtime::permission::AUTO_APPROVE_ASK_CONTEXT_KEY;
+use bitfun_agent_runtime::permission::{AUTO_APPROVE_ASK_CONTEXT_KEY, PERMISSION_MODE_CONTEXT_KEY};
 use bitfun_agent_runtime::remote_file_delivery::TOOL_CONTEXT_REMOTE_FILE_DELIVERY_KEY;
 use bitfun_agent_runtime::user_questions::{
     USER_INPUT_AVAILABLE_CONTEXT_KEY, USER_INPUT_MODEL_ROUND_CONTEXT_KEY,
@@ -47,7 +47,9 @@ use bitfun_agent_tools::{
 };
 #[cfg(feature = "canvas-runtime")]
 use bitfun_product_domains::canvas::CanvasStoragePort;
-use bitfun_runtime_ports::{DelegationPolicy, RemoteExecPort, TerminalPort, ToolRuntimeHandles};
+use bitfun_runtime_ports::{
+    DelegationPolicy, PermissionMode, RemoteExecPort, TerminalPort, ToolRuntimeHandles,
+};
 #[cfg(feature = "canvas-runtime")]
 use bitfun_services_integrations::canvas::CanvasService;
 #[cfg(feature = "git")]
@@ -354,6 +356,19 @@ fn build_tool_context_custom_data(context: &ToolExecutionContext) -> HashMap<Str
         deep_review_parent,
         &mut extension_custom_data,
     );
+    // Preserve the turn's already-resolved permission mode for Task
+    // delegation. Without this projection, Task sees only the global default
+    // when it forwards permission context to a fresh subagent.
+    if let Some(mode) = context
+        .context_vars
+        .get(PERMISSION_MODE_CONTEXT_KEY)
+        .and_then(|value| PermissionMode::parse(value))
+    {
+        extension_custom_data.insert(
+            PERMISSION_MODE_CONTEXT_KEY.to_string(),
+            Value::String(mode.as_str().to_string()),
+        );
+    }
     for key in [
         USER_INPUT_AVAILABLE_CONTEXT_KEY,
         AUTO_APPROVE_ASK_CONTEXT_KEY,
@@ -1471,6 +1486,7 @@ mod task_context_tests {
     };
     use crate::agentic::tools::ToolRuntimeRestrictions;
     use bitfun_agent_runtime::permission::AUTO_APPROVE_ASK_CONTEXT_KEY;
+    use bitfun_agent_runtime::permission::PERMISSION_MODE_CONTEXT_KEY;
     use bitfun_agent_runtime::user_questions::{
         USER_INPUT_AVAILABLE_CONTEXT_KEY, USER_INPUT_MODEL_ROUND_CONTEXT_KEY,
     };
@@ -1499,6 +1515,10 @@ mod task_context_tests {
         context_vars.insert(
             AUTO_APPROVE_ASK_CONTEXT_KEY.to_string(),
             "false".to_string(),
+        );
+        context_vars.insert(
+            PERMISSION_MODE_CONTEXT_KEY.to_string(),
+            "auto_approve".to_string(),
         );
         context_vars.insert(
             "deep_review_run_manifest".to_string(),
@@ -1603,6 +1623,10 @@ mod task_context_tests {
         assert_eq!(
             context.custom_data[AUTO_APPROVE_ASK_CONTEXT_KEY],
             json!(false)
+        );
+        assert_eq!(
+            context.custom_data[PERMISSION_MODE_CONTEXT_KEY],
+            json!("auto_approve")
         );
         assert_eq!(
             context.custom_data["deep_review_run_manifest"],


### PR DESCRIPTION
Project the resolved per-round permission mode into tool custom data so
Task delegation forwards the parent's effective mode instead of falling
back to the global default.

Extend tool-context materialization coverage for auto_approve mode.
