### PR TITLE
fix(sessions): stabilize durable history reconciliation

### DIFF
--- a/docs/architecture/session-projection.md
+++ b/docs/architecture/session-projection.md
@@ -61,12 +61,28 @@ invariant 2.
   checkpoint, or snapshot of that Turn may write it.
 - A **settled** Turn is owned by the persisted record. No live event may
   write it.
-- Ownership transfers **once**, on the Turn's terminal event, driven by
-  position — never by inspecting what is on screen.
+- A terminal event starts client settlement, but it is not proof that the
+  terminal record is durable. Ownership transfers **once**, at the Runtime's
+  post-persistence history fence, driven by position — never by inspecting
+  what is on screen.
 
 This is why history and live events cannot race: they are never both
 authoritative for the same Turn. The persisted checkpoint of an executing Turn
 is identity only; it names the Turn and carries none of its content.
+
+Native Runtime completion is rebuilt from the complete generation journal under
+the same per-Session mutation lock used by projected saves. A projected
+checkpoint may contribute additive display metadata, but it cannot shorten
+canonical text or thinking, remove a round or tool result, or turn a settled
+record back into an executing one. Externally projected sessions such as ACP
+remain owned by their external projection.
+
+After the terminal record is committed, `SessionHistoryChanged` is the durable
+fence. Local and Peer Device surfaces re-read the affected tail Turn. Remote
+Connect polling sends an optional authoritative `message_snapshot`, because an
+already-counted assistant message can grow from a streamed prefix to its full
+persisted content without changing message count. New clients accept the
+snapshot; older clients continue to use the existing additive fields.
 
 ### 3. Identity is `(surface, session)` by construction
 
@@ -129,7 +145,8 @@ They are why `snapshotDropsProjectedTurnContent` and
   its work. Such a read holds no position for the content it omitted, so
   writing the Turn from it is lossy rather than advancing. Closing this needs
   the read to report its own completeness; until then "would this write lose
-  content" is the only question available.
+  content" is the only question available. The comparison includes content
+  prefix progress and completed tool results, not only round or item counts.
 
 Deleting either guard without first closing its gap reintroduces a real defect,
 not just a test failure.

--- a/src/apps/desktop/src/api/snapshot_service.rs
+++ b/src/apps/desktop/src/api/snapshot_service.rs
@@ -406,6 +406,17 @@ async fn begin_snapshot_history_read(
     workspace_path: &str,
     session_id: &str,
 ) -> Result<CoreSessionReadPermit, String> {
+    // Warm the snapshot view before taking the exclusive session read permit.
+    // The first view open for a workspace loads the entire snapshot index from
+    // disk; holding the session mutation lock across that load stalls every
+    // waiter on the same session, including the next dialog-turn start. After
+    // warming, the caller's in-permit view lookup is a cache hit.
+    if !is_remote_path(workspace_path).await {
+        let workspace_dir = resolve_workspace_dir(workspace_path).await?;
+        open_snapshot_manager_for_view(&workspace_dir)
+            .await
+            .map_err(|error| format!("Failed to open snapshot view: {error}"))?;
+    }
     let compatibility = runtime.session_application().compatibility();
     let storage_path = compatibility
         .resolve_persisted_session_storage_path(SessionStoragePathRequest {

--- a/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
@@ -2974,6 +2974,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                 .enqueue(
                     AgenticEvent::SessionHistoryChanged {
                         session_id: session_id.to_string(),
+                        settled_turn_id: Some(turn_id.to_string()),
                     },
                     Some(EventPriority::Normal),
                 )
@@ -15822,8 +15823,10 @@ mod tests {
         let events = coordinator.event_queue.dequeue_batch(10).await;
         assert!(events.iter().any(|envelope| matches!(
             &envelope.event,
-            AgenticEvent::SessionHistoryChanged { session_id }
-                if session_id == &session.session_id
+            AgenticEvent::SessionHistoryChanged {
+                session_id,
+                settled_turn_id: Some(settled_turn_id),
+            } if session_id == &session.session_id && settled_turn_id == &turn_id
         )));
         session_manager
             .delete_session_by_id(&session.session_id)

--- a/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
@@ -2731,17 +2731,12 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         .await
     }
 
-    /// Ensure the completed/failed/cancelled turn is persisted to the workspace
-    /// session storage. If the frontend already saved a richer version
-    /// during streaming, we only update the final status; otherwise we create
-    /// a minimal record with the user message so the turn is never lost.
-    /// Safety-net persistence: only creates a minimal record when the frontend
-    /// has not saved anything yet.  The frontend's PersistenceModule is the
-    /// authoritative writer for turn content (model rounds, text, tools, etc.)
-    /// and final status.  This function must NOT overwrite frontend-managed
-    /// data, because the spawned task always runs before the frontend receives
-    /// the DialogTurnCompleted event via the transport layer, and the existing
-    /// disk data from debounced saves may have incomplete model rounds.
+    /// Safety-net persistence for a Turn that has no record at all. Rich native
+    /// completion is committed separately from the Runtime generation journal;
+    /// streaming frontend checkpoints may add display metadata but are not the
+    /// authority for terminal text. This fallback therefore never overwrites
+    /// an existing record, which could be either a projected checkpoint or the
+    /// completed Runtime record.
     async fn finalize_turn_in_workspace(
         session_id: &str,
         turn_id: &str,
@@ -2919,6 +2914,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                     .await
             }
         };
+        let persistence_succeeded = persistence_result.is_ok();
         if let Err(error) = persistence_result {
             error!(
                 "Failed to complete dialog turn: session_id={}, turn_id={}, error={}",
@@ -2963,6 +2959,28 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
             {
                 error!(
                     "Failed to emit recovered DialogTurnCompleted event: session_id={}, turn_id={}, error={}",
+                    session_id, turn_id, error
+                );
+            }
+        }
+
+        if persistence_succeeded && session_manager.should_persist_session_id(session_id) {
+            // Terminal chunks are a low-latency projection; this later event
+            // is the durable fence. Remote controllers use it to replace an
+            // equal-count partial assistant message with the completed
+            // persisted transcript instead of assuming message count is a
+            // content revision.
+            if let Err(error) = event_queue
+                .enqueue(
+                    AgenticEvent::SessionHistoryChanged {
+                        session_id: session_id.to_string(),
+                    },
+                    Some(EventPriority::Normal),
+                )
+                .await
+            {
+                error!(
+                    "Failed to emit completed session history change: session_id={}, turn_id={}, error={}",
                     session_id, turn_id, error
                 );
             }
@@ -14205,8 +14223,8 @@ mod tests {
     };
     use crate::agentic::events::{AgenticEvent, EventQueue, EventQueueConfig, EventRouter};
     use crate::agentic::execution::{
-        restrict_recovered_permission_mode, ExecutionEngine, ExecutionEngineConfig, RoundExecutor,
-        StreamProcessor,
+        restrict_recovered_permission_mode, ExecutionEngine, ExecutionEngineConfig,
+        ExecutionResult, FinishReason, RoundExecutor, StreamProcessor,
     };
     use crate::agentic::goal_mode::thread_goal_patch;
     use crate::agentic::persistence::PersistenceManager;
@@ -15747,6 +15765,70 @@ mod tests {
 
     fn test_coordinator() -> (ConversationCoordinator, Arc<SessionManager>) {
         test_coordinator_with_max_active_sessions(100)
+    }
+
+    #[tokio::test]
+    async fn completed_persisted_turn_emits_a_durable_history_fence() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let (coordinator, session_manager) = test_persistent_coordinator();
+        let session = session_manager
+            .create_session(
+                "Durable completion".to_string(),
+                "agentic".to_string(),
+                SessionConfig {
+                    workspace_path: Some(workspace.path().to_string_lossy().into_owned()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("create session");
+        let turn_id = session_manager
+            .start_dialog_turn(
+                &session.session_id,
+                "agentic".to_string(),
+                "finish".to_string(),
+                Some("turn-durable-fence".to_string()),
+                None,
+                None,
+            )
+            .await
+            .expect("start turn");
+        let message = Message::assistant("complete response".to_string())
+            .with_turn_id(turn_id.clone())
+            .with_round_id("round-final".to_string());
+
+        ConversationCoordinator::persist_completed_dialog_turn(
+            coordinator.event_queue.as_ref(),
+            session_manager.as_ref(),
+            None,
+            &session.session_id,
+            &turn_id,
+            &ExecutionResult {
+                final_message: message.clone(),
+                total_rounds: 1,
+                success: true,
+                new_messages: vec![message],
+                finish_reason: FinishReason::Complete,
+                total_tools: 0,
+                duration_ms: 1,
+                partial_recovery_reason: None,
+                effective_finish_reason: "complete".to_string(),
+                has_final_response: true,
+            },
+            None,
+        )
+        .await;
+
+        let events = coordinator.event_queue.dequeue_batch(10).await;
+        assert!(events.iter().any(|envelope| matches!(
+            &envelope.event,
+            AgenticEvent::SessionHistoryChanged { session_id }
+                if session_id == &session.session_id
+        )));
+        session_manager
+            .delete_session_by_id(&session.session_id)
+            .await
+            .expect("clean up persisted test session");
     }
 
     async fn create_two_turn_session(

--- a/src/crates/assembly/core/src/agentic/session/session_manager.rs
+++ b/src/crates/assembly/core/src/agentic/session/session_manager.rs
@@ -7445,12 +7445,6 @@ impl SessionManager {
             return Ok(());
         }
 
-        // Serialize Runtime completion against projected UI checkpoints. If a
-        // checkpoint wins first, the generation journal below repairs it; if
-        // completion wins first, the projected-save guard sees the terminal
-        // authoritative record and cannot replace it with an older prefix.
-        let _mutation_guard = self.acquire_session_mutation(session_id).await?;
-
         let workspace_path = self
             .effective_session_storage_path(session_id)
             .await
@@ -7465,6 +7459,28 @@ impl SessionManager {
             .get(session_id)
             .and_then(|session| session.dialog_turn_ids.iter().position(|id| id == turn_id))
             .ok_or_else(|| BitFunError::NotFound(format!("Dialog turn not found: {}", turn_id)))?;
+
+        // The context snapshot is a session-level artifact built from the
+        // in-memory context store; it does not participate in the projected
+        // checkpoint race below. Persist it before taking the mutation lock so
+        // slow storage (for example a remote SSH workspace) cannot extend the
+        // critical section and stall the next turn's start behind completion.
+        self.persist_context_snapshot_for_turn_best_effort(
+            session_id,
+            turn_index,
+            "turn_completed",
+        )
+        .await;
+
+        // Serialize Runtime completion against projected UI checkpoints. If a
+        // checkpoint wins first, the generation journal below repairs it; if
+        // completion wins first, the projected-save guard sees the terminal
+        // authoritative record and cannot replace it with an older prefix.
+        // Keep this critical section to the turn-record load, merge, and save
+        // only: the same keyed lock also serializes dialog-turn starts, so any
+        // extra work held here directly delays the next user message.
+        let _mutation_guard = self.acquire_session_mutation(session_id).await?;
+
         let mut turn = self
             .persistence_manager
             .load_dialog_turn(&workspace_path, session_id, turn_index)
@@ -7562,13 +7578,6 @@ impl SessionManager {
         turn.recovery = None;
         turn.duration_ms = Some(stats.duration_ms);
         turn.end_time = Some(completion_timestamp);
-
-        self.persist_context_snapshot_for_turn_best_effort(
-            session_id,
-            turn.turn_index,
-            "turn_completed",
-        )
-        .await;
 
         // Persist
         if self.should_persist_session_id(session_id) {

--- a/src/crates/assembly/core/src/agentic/session/session_manager.rs
+++ b/src/crates/assembly/core/src/agentic/session/session_manager.rs
@@ -7445,6 +7445,12 @@ impl SessionManager {
             return Ok(());
         }
 
+        // Serialize Runtime completion against projected UI checkpoints. If a
+        // checkpoint wins first, the generation journal below repairs it; if
+        // completion wins first, the projected-save guard sees the terminal
+        // authoritative record and cannot replace it with an older prefix.
+        let _mutation_guard = self.acquire_session_mutation(session_id).await?;
+
         let workspace_path = self
             .effective_session_storage_path(session_id)
             .await
@@ -7470,25 +7476,47 @@ impl SessionManager {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_millis() as u64;
-        let has_assistant_text = turn.model_rounds.iter().any(|round| {
-            round
-                .text_items
-                .iter()
-                .any(|item| !item.content.trim().is_empty())
-        });
-        if !has_assistant_text {
-            // Hosts that do not persist model rounds themselves (e.g. CLI)
-            // still need rich turn data on disk so other surfaces (e.g.
-            // Desktop) can render the conversation history. Build model
-            // rounds from the execution's new_messages.
-            let built_rounds = Self::build_model_rounds_from_messages(
-                new_messages,
-                &turn.turn_id,
-                completion_timestamp,
-            );
-            if !built_rounds.is_empty() {
-                turn.model_rounds = built_rounds;
-            } else if !final_response.trim().is_empty() {
+        // The Runtime generation journal is authoritative at completion. A
+        // frontend checkpoint may already contain assistant text, but that
+        // text can be only a prefix when the final stream chunks were dropped.
+        // Merge by stable round identity instead of treating any non-empty
+        // projected text as proof that the Turn is complete.
+        let turn_identity = turn.turn_id.clone();
+        let generated_count = Self::append_generation_rounds(
+            &mut turn,
+            &turn_identity,
+            new_messages,
+            completion_timestamp,
+        );
+        if generated_count == 0 && !final_response.trim().is_empty() {
+            let mut reconciled_existing_text = false;
+            for round in turn.model_rounds.iter_mut().rev() {
+                let Some(item) = round
+                    .text_items
+                    .iter_mut()
+                    .rev()
+                    .find(|item| !item.content.trim().is_empty())
+                else {
+                    continue;
+                };
+                if final_response == item.content || final_response.starts_with(&item.content) {
+                    item.content = final_response.clone();
+                    item.is_streaming = false;
+                    item.status = Some("completed".to_string());
+                    round.status = "completed".to_string();
+                    round.end_time = Some(completion_timestamp);
+                    reconciled_existing_text = true;
+                }
+                break;
+            }
+
+            let has_assistant_text = turn.model_rounds.iter().any(|round| {
+                round
+                    .text_items
+                    .iter()
+                    .any(|item| !item.content.trim().is_empty())
+            });
+            if !reconciled_existing_text && !has_assistant_text {
                 // Fallback: append a single text-only round
                 let round_index = turn.model_rounds.len();
                 turn.model_rounds.push(ModelRoundData {
@@ -7642,6 +7670,24 @@ impl SessionManager {
                         tool_item.interruption_reason = previous.interruption_reason.clone();
                     }
                 }
+                // Client-derived display cards are not part of the model's
+                // generation journal. Preserve the recognized additive card
+                // while replacing Runtime text/tool content authoritatively.
+                let generated_tool_ids = round
+                    .tool_items
+                    .iter()
+                    .map(|item| item.id.clone())
+                    .collect::<std::collections::HashSet<_>>();
+                let derived_tool_items = existing
+                    .tool_items
+                    .iter()
+                    .filter(|item| {
+                        item.id.starts_with("plan-display-")
+                            && !generated_tool_ids.contains(&item.id)
+                    })
+                    .cloned()
+                    .collect::<Vec<_>>();
+                round.tool_items.extend(derived_tool_items);
                 round.round_index = existing.round_index;
                 round.round_group_id = existing.round_group_id.clone();
                 round.timestamp = existing.timestamp;
@@ -9524,6 +9570,103 @@ mod tests {
                 prompt_cache_policy: PromptCachePolicy::default(),
             },
         )
+    }
+
+    #[tokio::test]
+    async fn completion_replaces_a_projected_text_prefix_with_runtime_generation_content() {
+        let workspace = TestWorkspace::new();
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(workspace.path_manager()).expect("persistence manager"),
+        );
+        let manager = test_manager(persistence_manager.clone());
+        let session = manager
+            .create_session(
+                "Completion merge".to_string(),
+                "agentic".to_string(),
+                SessionConfig {
+                    workspace_path: Some(workspace.path().to_string_lossy().to_string()),
+                    ..SessionConfig::default()
+                },
+            )
+            .await
+            .expect("session should create");
+        let turn_id = manager
+            .start_dialog_turn(
+                &session.session_id,
+                "agentic".to_string(),
+                "finish the response".to_string(),
+                Some("turn-completion-prefix".to_string()),
+                None,
+                None,
+            )
+            .await
+            .expect("turn should start");
+
+        let projected_prefix = Message::assistant("Saved prefix: 1.".to_string())
+            .with_turn_id(turn_id.clone())
+            .with_round_id("round-final".to_string());
+        let mut persisted_turn = persistence_manager
+            .load_dialog_turn(workspace.path(), &session.session_id, 0)
+            .await
+            .expect("turn should load")
+            .expect("turn should exist");
+        persisted_turn.model_rounds =
+            SessionManager::build_model_rounds_from_messages(&[projected_prefix], &turn_id, 1);
+        persisted_turn.model_rounds[0].tool_items.push(
+            serde_json::from_value(serde_json::json!({
+                "id": "plan-display-test",
+                "toolName": "CreatePlan",
+                "toolCall": { "id": "", "input": {} },
+                "toolResult": {
+                    "result": { "plan_file_path": "/tmp/plan.md" },
+                    "success": true
+                },
+                "startTime": 1,
+                "status": "completed"
+            }))
+            .expect("derived plan display tool"),
+        );
+        persistence_manager
+            .save_dialog_turn(workspace.path(), &persisted_turn)
+            .await
+            .expect("projected prefix should persist");
+
+        let complete_response = "Saved prefix: 1. first item\n2. second item";
+        manager
+            .complete_dialog_turn(
+                &session.session_id,
+                &turn_id,
+                complete_response.to_string(),
+                &[Message::assistant(complete_response.to_string())
+                    .with_turn_id(turn_id.clone())
+                    .with_round_id("round-final".to_string())],
+                TurnStats {
+                    total_rounds: 1,
+                    total_tools: 0,
+                    total_tokens: 0,
+                    duration_ms: 1,
+                },
+            )
+            .await
+            .expect("completion should persist");
+
+        let completed = persistence_manager
+            .load_dialog_turn(workspace.path(), &session.session_id, 0)
+            .await
+            .expect("turn should load")
+            .expect("turn should exist");
+        assert_eq!(completed.status, TurnStatus::Completed);
+        assert_eq!(completed.model_rounds.len(), 1);
+        assert_eq!(completed.model_rounds[0].id, "round-final");
+        assert_eq!(
+            completed.model_rounds[0].text_items[0].content,
+            complete_response,
+        );
+        assert_eq!(completed.model_rounds[0].tool_items.len(), 1);
+        assert_eq!(
+            completed.model_rounds[0].tool_items[0].id,
+            "plan-display-test",
+        );
     }
 
     async fn reopen_interrupted_turn_for_test(

--- a/src/crates/assembly/core/src/product_runtime.rs
+++ b/src/crates/assembly/core/src/product_runtime.rs
@@ -78,6 +78,52 @@ fn projected_turn_save_would_overwrite_runtime_state(
     persisted: &DialogTurnData,
     projected: &DialogTurnData,
 ) -> bool {
+    let projected_drops_persisted_content =
+        || {
+            if projected.model_rounds.len() < persisted.model_rounds.len() {
+                return true;
+            }
+            persisted.model_rounds.iter().any(|persisted_round| {
+                let Some(projected_round) = projected
+                    .model_rounds
+                    .iter()
+                    .find(|round| round.id == persisted_round.id)
+                else {
+                    return true;
+                };
+
+                let text_was_shortened =
+                    persisted_round
+                        .text_items
+                        .iter()
+                        .enumerate()
+                        .any(|(index, persisted_item)| {
+                            projected_round.text_items.get(index).is_none_or(|item| {
+                                !item.content.starts_with(&persisted_item.content)
+                            })
+                        });
+                let thinking_was_shortened = persisted_round.thinking_items.iter().enumerate().any(
+                    |(index, persisted_item)| {
+                        projected_round
+                            .thinking_items
+                            .get(index)
+                            .is_none_or(|item| !item.content.starts_with(&persisted_item.content))
+                    },
+                );
+                let tool_was_dropped = persisted_round.tool_items.iter().any(|persisted_tool| {
+                    projected_round
+                        .tool_items
+                        .iter()
+                        .find(|tool| tool.id == persisted_tool.id)
+                        .is_none_or(|tool| {
+                            persisted_tool.tool_result.is_some() && tool.tool_result.is_none()
+                        })
+                });
+
+                text_was_shortened || thinking_was_shortened || tool_was_dropped
+            })
+        };
+
     persisted.recovery.is_some()
         || persisted.recovery_epoch.is_some()
         || projected.recovery.is_some()
@@ -85,7 +131,8 @@ fn projected_turn_save_would_overwrite_runtime_state(
         || (matches!(
             persisted.status,
             TurnStatus::Completed | TurnStatus::Cancelled | TurnStatus::Error
-        ) && projected.status == TurnStatus::InProgress)
+        ) && (projected.status == TurnStatus::InProgress
+            || projected_drops_persisted_content()))
 }
 
 fn merge_runtime_owned_turn_facts(
@@ -2143,6 +2190,39 @@ mod tests {
         ));
         assert!(!projected_turn_save_would_overwrite_runtime_state(
             &projected, &projected
+        ));
+
+        // Exercise content-loss protection independently from the recovery
+        // ownership guard above.
+        completed.recovery_epoch = None;
+        completed.model_rounds = serde_json::from_value(serde_json::json!([{
+            "id": "round-1",
+            "turnId": "turn-1",
+            "roundIndex": 0,
+            "timestamp": 2,
+            "textItems": [{
+                "id": "runtime-text",
+                "content": "complete authoritative response",
+                "isStreaming": false,
+                "timestamp": 2
+            }],
+            "startTime": 2,
+            "status": "completed"
+        }]))
+        .expect("runtime round");
+        let mut terminal_prefix = completed.clone();
+        terminal_prefix.model_rounds[0].text_items[0].content =
+            "complete authoritative".to_string();
+        assert!(projected_turn_save_would_overwrite_runtime_state(
+            &completed,
+            &terminal_prefix,
+        ));
+
+        terminal_prefix.model_rounds[0].text_items[0].content =
+            "complete authoritative response with UI metadata".to_string();
+        assert!(!projected_turn_save_would_overwrite_runtime_state(
+            &completed,
+            &terminal_prefix,
         ));
     }
 

--- a/src/crates/assembly/core/src/service/remote_connect/remote_server.rs
+++ b/src/crates/assembly/core/src/service/remote_connect/remote_server.rs
@@ -638,6 +638,7 @@ mod tests {
             title: Some("session title".to_string()),
             new_messages: None,
             total_msg_count: None,
+            message_snapshot: None,
             active_turn: Some(active_turn),
             model_catalog: Box::new(None),
         })

--- a/src/crates/assembly/core/src/service/snapshot/manager.rs
+++ b/src/crates/assembly/core/src/service/snapshot/manager.rs
@@ -457,6 +457,17 @@ fn snapshot_managers() -> &'static StdRwLock<HashMap<PathBuf, Arc<SnapshotManage
     SNAPSHOT_MANAGERS.get_or_init(|| StdRwLock::new(HashMap::new()))
 }
 
+/// Read-only view managers, cached separately from writers. Loading the
+/// snapshot index is expensive (it reads every persisted metadata file), so a
+/// view is built once per workspace and reused until a writer supersedes it.
+/// Views never see writes anyway: in-process writers register in
+/// `snapshot_managers` (checked first), and that registration evicts the view.
+fn snapshot_view_managers() -> &'static StdRwLock<HashMap<PathBuf, Arc<SnapshotManager>>> {
+    static SNAPSHOT_VIEW_MANAGERS: OnceLock<StdRwLock<HashMap<PathBuf, Arc<SnapshotManager>>>> =
+        OnceLock::new();
+    SNAPSHOT_VIEW_MANAGERS.get_or_init(|| StdRwLock::new(HashMap::new()))
+}
+
 fn snapshot_manager_init_locks() -> &'static AsyncMutex<HashMap<PathBuf, Arc<AsyncMutex<()>>>> {
     static SNAPSHOT_MANAGER_INIT_LOCKS: OnceLock<
         AsyncMutex<HashMap<PathBuf, Arc<AsyncMutex<()>>>>,
@@ -532,6 +543,9 @@ fn set_snapshot_manager_new_delay_for_test(delay: Duration) {
 pub(crate) fn clear_snapshot_manager_for_test(workspace_dir: &Path) {
     if let Ok(mut managers) = snapshot_managers().write() {
         managers.remove(&snapshot_workspace_key(workspace_dir));
+    }
+    if let Ok(mut views) = snapshot_view_managers().write() {
+        views.remove(&snapshot_workspace_key(workspace_dir));
     }
 }
 
@@ -1003,7 +1017,12 @@ pub async fn get_or_create_snapshot_manager(
         if let Some(existing) = managers.get(&workspace_key) {
             return Ok(existing.clone());
         }
-        managers.insert(workspace_key, manager.clone());
+        managers.insert(workspace_key.clone(), manager.clone());
+    }
+    // The writer now owns live state for this workspace; a cached read-only
+    // view would keep serving the pre-writer index, so drop it.
+    if let Ok(mut views) = snapshot_view_managers().write() {
+        views.remove(&workspace_key);
     }
     info!(
         "Snapshot manager cold initialization completed: duration_ms={}",
@@ -1030,20 +1049,43 @@ pub async fn open_snapshot_manager_for_view(
     if let Some(manager) = get_snapshot_manager_for_workspace(&workspace_key) {
         return Ok(manager);
     }
+    if let Some(view) = get_snapshot_view_manager_for_workspace(&workspace_key) {
+        return Ok(view);
+    }
 
     let init_lock = snapshot_manager_init_lock(&workspace_key).await;
     let _init_guard = init_lock.lock().await;
     if let Some(manager) = get_snapshot_manager_for_workspace(&workspace_key) {
         return Ok(manager);
     }
+    if let Some(view) = get_snapshot_view_manager_for_workspace(&workspace_key) {
+        return Ok(view);
+    }
 
+    let started_at = Instant::now();
     let runtime_context =
         get_workspace_runtime_service_arc().context_for_local_workspace(&workspace_key);
-    let mut snapshot_service = SnapshotService::new(workspace_key, runtime_context, None);
+    let mut snapshot_service = SnapshotService::new(workspace_key.clone(), runtime_context, None);
     snapshot_service.initialize_for_view().await?;
-    Ok(Arc::new(SnapshotManager {
+    let view = Arc::new(SnapshotManager {
         snapshot_service: Arc::new(RwLock::new(snapshot_service)),
-    }))
+    });
+    if let Ok(mut views) = snapshot_view_managers().write() {
+        views.insert(workspace_key, view.clone());
+    }
+    info!(
+        "Snapshot view initialized and cached: workspace={} duration_ms={}",
+        workspace_dir.display(),
+        started_at.elapsed().as_millis()
+    );
+    Ok(view)
+}
+
+fn get_snapshot_view_manager_for_workspace(workspace_key: &Path) -> Option<Arc<SnapshotManager>> {
+    snapshot_view_managers()
+        .read()
+        .ok()
+        .and_then(|views| views.get(workspace_key).cloned())
 }
 
 pub fn ensure_snapshot_manager_for_workspace(
@@ -1296,6 +1338,43 @@ mod tests {
             .await
             .expect_err("read-only view must reject mutations");
         assert!(error.to_string().contains("read-only"), "{error}");
+    }
+
+    #[tokio::test]
+    async fn view_manager_is_cached_and_superseded_by_a_later_writer() {
+        let workspace = TestWorkspace::new();
+        let _runtime_guard = set_workspace_runtime_service_for_current_test(Arc::new(
+            WorkspaceRuntimeService::new(Arc::new(PathManager::with_user_root_for_tests(
+                workspace.path().join("user-root"),
+            ))),
+        ));
+        clear_snapshot_manager_for_test(workspace.path());
+
+        let first_view = open_snapshot_manager_for_view(workspace.path())
+            .await
+            .expect("first view");
+        let second_view = open_snapshot_manager_for_view(workspace.path())
+            .await
+            .expect("second view");
+        assert!(
+            Arc::ptr_eq(&first_view, &second_view),
+            "repeated view opens must reuse the cached view instead of reloading the index"
+        );
+
+        let writer = get_or_create_snapshot_manager(workspace.path().to_path_buf(), None)
+            .await
+            .expect("writer manager");
+        let view_after_writer = open_snapshot_manager_for_view(workspace.path())
+            .await
+            .expect("view after writer");
+        assert!(
+            Arc::ptr_eq(&view_after_writer, &writer),
+            "a registered writer must supersede the cached read-only view"
+        );
+        assert!(
+            !Arc::ptr_eq(&view_after_writer, &first_view),
+            "the stale pre-writer view must not be served once a writer owns live state"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/crates/assembly/core/src/service/snapshot/snapshot_system.rs
+++ b/src/crates/assembly/core/src/service/snapshot/snapshot_system.rs
@@ -277,6 +277,11 @@ impl FileSnapshotSystem {
     }
 
     /// Loads the existing snapshot index.
+    ///
+    /// Workspaces accumulate thousands of small metadata files, and this load
+    /// gates the first snapshot view of a workspace. Reading them sequentially
+    /// on one thread costs seconds, so the files are read and parsed on a
+    /// bounded set of blocking threads and merged on the async side.
     async fn load_snapshot_index(&mut self) -> SnapshotResult<()> {
         let started_at = Instant::now();
         let metadata_dir = self.snapshot_metadata_dir.clone();
@@ -285,31 +290,59 @@ impl FileSnapshotSystem {
             return Ok(());
         }
 
-        let mut loaded_count = 0;
-
+        let mut metadata_paths = Vec::new();
         for entry in fs::read_dir(&metadata_dir)? {
-            let entry = entry?;
-            let path = entry.path();
-
+            let path = entry?.path();
             if path.extension().and_then(|s| s.to_str()) == Some("json") {
-                match self.load_snapshot_metadata(&path).await {
-                    Ok(snapshot) => {
-                        self.hash_to_path.insert(
-                            snapshot.content_hash.clone(),
-                            self.get_content_path(&snapshot.content_hash),
-                        );
-                        self.active_snapshots
-                            .insert(snapshot.snapshot_id.clone(), snapshot);
-                        loaded_count += 1;
-                    }
-                    Err(e) => {
-                        warn!(
-                            "Failed to load snapshot metadata: path={} error={}",
-                            path.display(),
-                            e
-                        );
+                metadata_paths.push(path);
+            }
+        }
+
+        const MAX_LOAD_THREADS: usize = 8;
+        const MIN_FILES_PER_THREAD: usize = 64;
+        let thread_count = (metadata_paths.len() / MIN_FILES_PER_THREAD).clamp(1, MAX_LOAD_THREADS);
+        let chunk_size = metadata_paths.len().div_ceil(thread_count).max(1);
+
+        let mut load_tasks = Vec::with_capacity(thread_count);
+        for chunk in metadata_paths.chunks(chunk_size) {
+            let chunk = chunk.to_vec();
+            load_tasks.push(tokio::task::spawn_blocking(move || {
+                let mut snapshots = Vec::with_capacity(chunk.len());
+                for path in chunk {
+                    let parsed = fs::read_to_string(&path)
+                        .map_err(SnapshotError::from)
+                        .and_then(|content| {
+                            serde_json::from_str::<FileSnapshot>(&content)
+                                .map_err(SnapshotError::from)
+                        });
+                    match parsed {
+                        Ok(snapshot) => snapshots.push(snapshot),
+                        Err(e) => {
+                            warn!(
+                                "Failed to load snapshot metadata: path={} error={}",
+                                path.display(),
+                                e
+                            );
+                        }
                     }
                 }
+                snapshots
+            }));
+        }
+
+        let mut loaded_count = 0;
+        for task in load_tasks {
+            let snapshots = task.await.map_err(|e| {
+                SnapshotError::ConfigError(format!("Snapshot metadata load task failed: {e}"))
+            })?;
+            for snapshot in snapshots {
+                self.hash_to_path.insert(
+                    snapshot.content_hash.clone(),
+                    self.get_content_path(&snapshot.content_hash),
+                );
+                self.active_snapshots
+                    .insert(snapshot.snapshot_id.clone(), snapshot);
+                loaded_count += 1;
             }
         }
 

--- a/src/crates/assembly/core/src/service_agent_runtime.rs
+++ b/src/crates/assembly/core/src/service_agent_runtime.rs
@@ -620,6 +620,7 @@ impl ScheduledSessionManagementPort {
             self.coordinator
                 .emit_event(AgenticEvent::SessionHistoryChanged {
                     session_id: request.session_id.clone(),
+                    settled_turn_id: None,
                 })
                 .await;
         }
@@ -773,6 +774,7 @@ impl AgentSessionRevertPort for ScheduledSessionManagementPort {
         self.coordinator
             .emit_event(AgenticEvent::SessionHistoryChanged {
                 session_id: request.session_id.clone(),
+                settled_turn_id: None,
             })
             .await;
         let mut retired_turn_ids = maintenance.retired_turn_ids().to_vec();

--- a/src/crates/contracts/events/src/agentic.rs
+++ b/src/crates/contracts/events/src/agentic.rs
@@ -108,6 +108,14 @@ pub enum AgenticEvent {
     /// session and reload them from the owning runtime.
     SessionHistoryChanged {
         session_id: String,
+        /// Present when this event is the per-Turn durable fence emitted after
+        /// a settled Turn's terminal record was committed. Consumers may then
+        /// repair only the settled tail instead of dropping a live projection
+        /// of a newer executing Turn. Absent for out-of-lifecycle history
+        /// edits such as undo/redo, which still require full invalidation.
+        /// Optional so payloads from older hosts keep deserializing.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        settled_turn_id: Option<String>,
     },
 
     SessionDeleted {
@@ -628,7 +636,7 @@ impl AgenticEvent {
         match self {
             Self::SessionCreated { session_id, .. }
             | Self::SessionStateChanged { session_id, .. }
-            | Self::SessionHistoryChanged { session_id }
+            | Self::SessionHistoryChanged { session_id, .. }
             | Self::SessionDeleted { session_id }
             | Self::SessionTitleGenerated { session_id, .. }
             | Self::ImageAnalysisStarted { session_id, .. }

--- a/src/crates/contracts/events/src/frontend_projection.rs
+++ b/src/crates/contracts/events/src/frontend_projection.rs
@@ -386,9 +386,15 @@ pub fn project_agentic_frontend_event(event: AgenticEvent) -> Option<AgenticFron
                 "newState": new_state,
             }),
         )),
-        AgenticEvent::SessionHistoryChanged { session_id } => Some(AgenticFrontendEvent::new(
+        AgenticEvent::SessionHistoryChanged {
+            session_id,
+            settled_turn_id,
+        } => Some(AgenticFrontendEvent::new(
             "agentic://session-history-changed",
-            json!({ "sessionId": session_id }),
+            json!({
+                "sessionId": session_id,
+                "settledTurnId": settled_turn_id,
+            }),
         )),
         AgenticEvent::SessionModelAutoMigrated {
             session_id,

--- a/src/crates/services/services-integrations/src/remote_connect.rs
+++ b/src/crates/services/services-integrations/src/remote_connect.rs
@@ -1501,6 +1501,12 @@ where
         Ok(messages) => messages,
         Err(message) => return RemoteResponse::Error { message },
     };
+    // A history invalidation has no active projection to append against. Send
+    // a replacement snapshot so an equal-count message whose content grew at
+    // completion is repaired on remote controllers.
+    let message_snapshot = tracker
+        .is_history_snapshot_required()
+        .then(|| all_chat_messages.clone());
     let total_msg_count = all_chat_messages.len();
     let new_messages = all_chat_messages
         .into_iter()
@@ -1512,6 +1518,7 @@ where
         current_version,
         new_messages,
         total_msg_count,
+        message_snapshot,
         model_catalog_delta.catalog,
     )
 }
@@ -2425,6 +2432,8 @@ pub enum RemoteResponse {
         #[serde(skip_serializing_if = "Option::is_none")]
         total_msg_count: Option<usize>,
         #[serde(skip_serializing_if = "Option::is_none")]
+        message_snapshot: Option<Vec<ChatMessage>>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         active_turn: Option<ActiveTurnSnapshot>,
         #[serde(skip_serializing_if = "Option::is_none")]
         model_catalog: Box<Option<RemoteModelCatalog>>,
@@ -2687,6 +2696,7 @@ struct TrackerState {
     round_index: usize,
     active_items: Vec<ChatMessageItem>,
     persistence_dirty: bool,
+    history_snapshot_required: bool,
     linked_subagent_sessions: HashMap<String, String>,
 }
 
@@ -2744,6 +2754,7 @@ impl RemoteSessionStateTracker {
                 round_index: 0,
                 active_items: Vec::new(),
                 persistence_dirty: true,
+                history_snapshot_required: false,
                 linked_subagent_sessions: HashMap::new(),
             }),
             event_tx,
@@ -2880,7 +2891,23 @@ impl RemoteSessionStateTracker {
     }
 
     pub fn mark_persistence_clean(&self) {
-        self.state.write().unwrap().persistence_dirty = false;
+        let mut state = self.state.write().unwrap();
+        state.persistence_dirty = false;
+        state.history_snapshot_required = false;
+    }
+
+    fn mark_persistence_clean_if_version(&self, observed_version: u64) -> bool {
+        let mut state = self.state.write().unwrap();
+        if self.version() != observed_version {
+            return false;
+        }
+        state.persistence_dirty = false;
+        state.history_snapshot_required = false;
+        true
+    }
+
+    pub fn is_history_snapshot_required(&self) -> bool {
+        self.state.read().unwrap().history_snapshot_required
     }
 
     fn invalidate_history_projection(&self) {
@@ -2893,7 +2920,7 @@ impl RemoteSessionStateTracker {
         state.active_items.clear();
         state.session_state = "idle".to_string();
         state.persistence_dirty = true;
-        drop(state);
+        state.history_snapshot_required = true;
         self.bump_version();
     }
 
@@ -3290,7 +3317,6 @@ impl RemoteSessionStateTracker {
                 state.round_index = 0;
                 state.session_state = "running".to_string();
                 state.persistence_dirty = true;
-                drop(state);
                 self.bump_version();
             }
             AE::DialogTurnCompleted { turn_id, .. } if is_direct => {
@@ -3298,7 +3324,6 @@ impl RemoteSessionStateTracker {
                 state.turn_status = "completed".to_string();
                 state.session_state = "idle".to_string();
                 state.persistence_dirty = true;
-                drop(state);
                 self.bump_version();
                 let _ = self.event_tx.send(TrackerEvent::TurnCompleted {
                     turn_id: turn_id.clone(),
@@ -3309,7 +3334,6 @@ impl RemoteSessionStateTracker {
                 state.turn_status = "failed".to_string();
                 state.session_state = "idle".to_string();
                 state.persistence_dirty = true;
-                drop(state);
                 self.bump_version();
                 let _ = self.event_tx.send(TrackerEvent::TurnFailed {
                     turn_id: turn_id.clone(),
@@ -3321,7 +3345,6 @@ impl RemoteSessionStateTracker {
                 state.turn_status = "cancelled".to_string();
                 state.session_state = "idle".to_string();
                 state.persistence_dirty = true;
-                drop(state);
                 self.bump_version();
                 let _ = self.event_tx.send(TrackerEvent::TurnCancelled {
                     turn_id: turn_id.clone(),
@@ -3449,6 +3472,7 @@ pub fn remote_no_change_poll_response(version: u64) -> RemoteResponse {
         title: None,
         new_messages: None,
         total_msg_count: None,
+        message_snapshot: None,
         active_turn: None,
         model_catalog: Box::new(None),
     }
@@ -3469,6 +3493,7 @@ pub fn remote_snapshot_poll_response(
         title: non_empty_title(title),
         new_messages: None,
         total_msg_count: None,
+        message_snapshot: None,
         active_turn,
         model_catalog: Box::new(model_catalog),
     }
@@ -3479,6 +3504,7 @@ pub fn remote_persisted_poll_response(
     version: u64,
     new_messages: Vec<ChatMessage>,
     total_msg_count: usize,
+    message_snapshot: Option<Vec<ChatMessage>>,
     model_catalog: Option<RemoteModelCatalog>,
 ) -> RemoteResponse {
     let turn_finished = tracker.is_turn_finished();
@@ -3495,20 +3521,25 @@ pub fn remote_persisted_poll_response(
             tracker.snapshot_active_turn()
         } else {
             tracker.finalize_completed_turn();
-            tracker.mark_persistence_clean();
+            tracker.mark_persistence_clean_if_version(version);
             None
         }
     } else {
         tracker.snapshot_active_turn()
     };
 
-    let (send_messages, send_total) = if turn_finished && !has_assistant_msg {
-        (None, None)
+    let (send_messages, send_total, send_snapshot) = if let Some(snapshot) = message_snapshot {
+        tracker.mark_persistence_clean_if_version(version);
+        // Keep the additive delta for older clients that do not know the
+        // optional replacement field yet.
+        (Some(new_messages), Some(total_msg_count), Some(snapshot))
+    } else if turn_finished && !has_assistant_msg {
+        (None, None, None)
     } else {
         if !new_messages.is_empty() || active_turn.is_none() {
-            tracker.mark_persistence_clean();
+            tracker.mark_persistence_clean_if_version(version);
         }
-        (Some(new_messages), Some(total_msg_count))
+        (Some(new_messages), Some(total_msg_count), None)
     };
 
     let session_state = tracker.session_state();
@@ -3520,6 +3551,7 @@ pub fn remote_persisted_poll_response(
         title: non_empty_title(title),
         new_messages: send_messages,
         total_msg_count: send_total,
+        message_snapshot: send_snapshot,
         active_turn,
         model_catalog: Box::new(model_catalog),
     }
@@ -3995,6 +4027,53 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn initial_remote_poll_remains_an_additive_delta() {
+        let message = ChatMessage {
+            id: "message-visible".to_string(),
+            role: "user".to_string(),
+            content: "visible".to_string(),
+            timestamp: "1".to_string(),
+            metadata: None,
+            tools: None,
+            thinking: None,
+            items: None,
+            images: None,
+        };
+        let host = FakePollHost {
+            tracker: Arc::new(RemoteSessionStateTracker::new("session-a".to_string())),
+            storage_dir: Some(PathBuf::from("/workspace/project/.bitfun/sessions")),
+            messages: vec![message.clone()],
+            history_read_count: Arc::new(AtomicUsize::new(0)),
+        };
+
+        let response = handle_remote_poll_command(
+            &host,
+            &RemoteCommand::PollSession {
+                session_id: "session-a".to_string(),
+                since_version: 0,
+                known_msg_count: 0,
+                known_model_catalog_version: None,
+            },
+        )
+        .await;
+
+        assert_eq!(
+            response,
+            RemoteResponse::SessionPoll {
+                version: 0,
+                changed: true,
+                session_state: Some("idle".to_string()),
+                title: None,
+                new_messages: Some(vec![message]),
+                total_msg_count: Some(1),
+                message_snapshot: None,
+                active_turn: None,
+                model_catalog: Box::new(None),
+            }
+        );
+    }
+
+    #[tokio::test]
     async fn history_change_invalidates_clean_poll_cache_and_reports_a_shorter_projection() {
         let tracker = Arc::new(RemoteSessionStateTracker::new("session-a".to_string()));
         tracker.handle_agentic_event(&AgenticEvent::DialogTurnStarted {
@@ -4031,6 +4110,9 @@ mod tests {
 
         assert_eq!(tracker.version(), previous_version + 1);
         assert!(tracker.is_persistence_dirty());
+        assert!(tracker.is_history_snapshot_required());
+        assert!(!tracker.mark_persistence_clean_if_version(previous_version));
+        assert!(tracker.is_persistence_dirty());
         assert!(tracker.snapshot_active_turn().is_none());
         let response = handle_remote_poll_command(
             &host,
@@ -4053,11 +4135,23 @@ mod tests {
                 title: None,
                 new_messages: Some(Vec::new()),
                 total_msg_count: Some(1),
+                message_snapshot: Some(vec![ChatMessage {
+                    id: "message-visible".to_string(),
+                    role: "user".to_string(),
+                    content: "visible".to_string(),
+                    timestamp: "1".to_string(),
+                    metadata: None,
+                    tools: None,
+                    thinking: None,
+                    items: None,
+                    images: None,
+                }]),
                 active_turn: None,
                 model_catalog: Box::new(None),
             }
         );
         assert!(!tracker.is_persistence_dirty());
+        assert!(!tracker.is_history_snapshot_required());
     }
 
     #[derive(Default)]

--- a/src/crates/services/services-integrations/src/remote_connect.rs
+++ b/src/crates/services/services-integrations/src/remote_connect.rs
@@ -2924,6 +2924,25 @@ impl RemoteSessionStateTracker {
         self.bump_version();
     }
 
+    /// Handle the per-Turn durable fence. Unlike a full history invalidation,
+    /// this must not drop the live projection: the fence can land after the
+    /// next Turn already started (queued sends, slow persistence), and wiping
+    /// that Turn's stream would blank remote controllers until the next
+    /// direct event. Only the settled Turn's persisted repair is requested.
+    fn require_settled_history_snapshot(&self, settled_turn_id: &str) {
+        let mut state = self.state.write().unwrap();
+        if state.turn_id.as_deref() == Some(settled_turn_id) {
+            // The tracker missed this Turn's terminal event (fences exist
+            // because terminal chunks can be lost); settle it from the fence.
+            state.turn_status = "completed".to_string();
+            state.session_state = "idle".to_string();
+        }
+        state.persistence_dirty = true;
+        state.history_snapshot_required = true;
+        drop(state);
+        self.bump_version();
+    }
+
     fn find_mergeable_item(
         items: &[ChatMessageItem],
         target_type: &str,
@@ -3362,9 +3381,12 @@ impl RemoteSessionStateTracker {
                 drop(state);
                 self.bump_version();
             }
-            AE::SessionHistoryChanged { .. } if is_direct => {
-                self.invalidate_history_projection();
-            }
+            AE::SessionHistoryChanged {
+                settled_turn_id, ..
+            } if is_direct => match settled_turn_id {
+                Some(turn_id) => self.require_settled_history_snapshot(turn_id),
+                None => self.invalidate_history_projection(),
+            },
             AE::SessionTitleGenerated { title, .. } if is_direct => {
                 let mut state = self.state.write().unwrap();
                 state.title = title.clone();
@@ -4106,6 +4128,7 @@ mod tests {
 
         tracker.handle_agentic_event(&AgenticEvent::SessionHistoryChanged {
             session_id: "session-a".to_string(),
+            settled_turn_id: None,
         });
 
         assert_eq!(tracker.version(), previous_version + 1);
@@ -4152,6 +4175,55 @@ mod tests {
         );
         assert!(!tracker.is_persistence_dirty());
         assert!(!tracker.is_history_snapshot_required());
+    }
+
+    #[tokio::test]
+    async fn per_turn_durable_fence_requests_a_snapshot_without_dropping_a_newer_live_turn() {
+        let tracker = Arc::new(RemoteSessionStateTracker::new("session-a".to_string()));
+        tracker.handle_agentic_event(&AgenticEvent::DialogTurnStarted {
+            session_id: "session-a".to_string(),
+            turn_id: "turn-next".to_string(),
+            turn_index: 2,
+            user_input: "queued follow-up".to_string(),
+            original_user_input: None,
+            user_message_metadata: None,
+        });
+        tracker.handle_agentic_event(&AgenticEvent::TextChunk {
+            session_id: "session-a".to_string(),
+            turn_id: "turn-next".to_string(),
+            round_id: "round-1".to_string(),
+            attempt_id: None,
+            attempt_index: None,
+            text: "live".to_string(),
+        });
+        tracker.mark_persistence_clean();
+        let previous_version = tracker.version();
+
+        // The previous turn's durable fence lands after the next turn already
+        // started streaming: the live projection must survive.
+        tracker.handle_agentic_event(&AgenticEvent::SessionHistoryChanged {
+            session_id: "session-a".to_string(),
+            settled_turn_id: Some("turn-previous".to_string()),
+        });
+
+        assert_eq!(tracker.version(), previous_version + 1);
+        assert!(tracker.is_persistence_dirty());
+        assert!(tracker.is_history_snapshot_required());
+        assert_eq!(tracker.session_state(), "running");
+        let live_turn = tracker
+            .snapshot_active_turn()
+            .expect("live turn projection must survive the previous turn's fence");
+        assert_eq!(live_turn.turn_id, "turn-next");
+
+        // A fence for the tracked turn itself means the terminal event was
+        // lost; the fence settles the projection instead of leaving a phantom
+        // running turn.
+        tracker.handle_agentic_event(&AgenticEvent::SessionHistoryChanged {
+            session_id: "session-a".to_string(),
+            settled_turn_id: Some("turn-next".to_string()),
+        });
+        assert_eq!(tracker.session_state(), "idle");
+        assert!(tracker.is_history_snapshot_required());
     }
 
     #[derive(Default)]

--- a/src/crates/services/services-integrations/tests/remote_connect_contracts.rs
+++ b/src/crates/services/services-integrations/tests/remote_connect_contracts.rs
@@ -876,6 +876,7 @@ impl RemoteCommandRuntimeHost for RecordingCommandHost {
             title: None,
             new_messages: None,
             total_msg_count: None,
+            message_snapshot: None,
             active_turn: None,
             model_catalog: Box::new(None),
         }
@@ -2122,6 +2123,7 @@ fn remote_connect_response_wire_shape_lives_in_owner_contract() {
         title: Some("session title".to_string()),
         new_messages: None,
         total_msg_count: None,
+        message_snapshot: None,
         active_turn: Some(active_turn),
         model_catalog: Box::new(Some(sample_remote_model_catalog(11))),
     })
@@ -2732,6 +2734,7 @@ fn remote_connect_poll_helpers_preserve_delta_and_completion_policy() {
         Vec::new(),
         0,
         None,
+        None,
     ))
     .expect("serialize completed poll without assistant message");
     assert!(waiting_for_persistence.get("new_messages").is_none());
@@ -2757,6 +2760,7 @@ fn remote_connect_poll_helpers_preserve_delta_and_completion_policy() {
         tracker.version(),
         vec![assistant_message],
         2,
+        None,
         None,
     ))
     .expect("serialize completed poll with assistant message");

--- a/src/mobile-web/src/pages/ChatPage.tsx
+++ b/src/mobile-web/src/pages/ChatPage.tsx
@@ -2716,7 +2716,12 @@ const ChatPage: React.FC<ChatPageProps> = ({ sessionMgr, sessionId, sessionName,
 
       const poller = new SessionPoller(sessionMgr, sessionId, (resp: PollResponse) => {
         if (!isInitCurrent()) return;
-        if (resp.new_messages && resp.new_messages.length > 0) {
+        if (resp.message_snapshot) {
+          // Completion can grow the content of an already-counted assistant
+          // message. Replace from the host's durable transcript; message count
+          // alone cannot detect that repair.
+          setMessages(sessionId, resp.message_snapshot);
+        } else if (resp.new_messages && resp.new_messages.length > 0) {
           appendNewMessages(sessionId, resp.new_messages);
         }
 
@@ -2767,6 +2772,7 @@ const ChatPage: React.FC<ChatPageProps> = ({ sessionMgr, sessionId, sessionName,
     sessionId,
     sessionMgr,
     setActiveTurn,
+    setMessages,
     updateSessionName,
   ]);
 

--- a/src/mobile-web/src/services/RemoteSessionManager.ts
+++ b/src/mobile-web/src/services/RemoteSessionManager.ts
@@ -182,6 +182,8 @@ export interface PollResponse {
   title?: string;
   new_messages?: ChatMessage[];
   total_msg_count?: number;
+  /** Authoritative replacement after persisted history changes in place. */
+  message_snapshot?: ChatMessage[];
   active_turn?: ActiveTurnSnapshot | null;
   model_catalog?: RemoteModelCatalog;
 }
@@ -721,7 +723,10 @@ export class SessionPoller {
         }
         
         // Clear the grace period once new messages arrive.
-        if (resp.new_messages && resp.new_messages.length > 0) {
+        if (
+          (resp.new_messages && resp.new_messages.length > 0)
+          || resp.message_snapshot
+        ) {
           this.turnJustEndedAt = null;
         }
         

--- a/src/web-ui/src/flow_chat/services/AgenticEventListener.ts
+++ b/src/web-ui/src/flow_chat/services/AgenticEventListener.ts
@@ -36,6 +36,7 @@ export interface AgenticEventCallbacks {
   onSessionCreated?: (event: AgenticEvent) => void;
   onSessionDeleted?: (event: AgenticEvent) => void;
   onSessionStateChanged?: (event: AgenticEvent) => void;
+  onSessionHistoryChanged?: (event: AgenticEvent) => void;
   onImageAnalysisStarted?: (event: ImageAnalysisEvent) => void;
   onImageAnalysisCompleted?: (event: ImageAnalysisEvent) => void;
   onDialogTurnStarted?: (event: AgenticEvent) => void;
@@ -101,6 +102,14 @@ export class AgenticEventListener {
         const unlisten = agentAPI.onSessionStateChanged((event) => {
           logger.debug('Session state changed:', event);
           callbacks.onSessionStateChanged?.(event);
+        });
+        this.unlistenFunctions.push(unlisten);
+      }
+
+      if (callbacks.onSessionHistoryChanged) {
+        const unlisten = agentAPI.onSessionHistoryChanged((event) => {
+          logger.debug('Session history changed:', event);
+          callbacks.onSessionHistoryChanged?.(event);
         });
         this.unlistenFunctions.push(unlisten);
       }
@@ -343,6 +352,9 @@ export class AgenticEventListener {
         break;
       case 'agentic://session-state-changed':
         callbacks.onSessionStateChanged?.(payload as AgenticEvent);
+        break;
+      case 'agentic://session-history-changed':
+        callbacks.onSessionHistoryChanged?.(payload as AgenticEvent);
         break;
       case 'agentic://image-analysis-started':
         callbacks.onImageAnalysisStarted?.(payload as unknown as ImageAnalysisEvent);

--- a/src/web-ui/src/flow_chat/services/FlowChatManager.ts
+++ b/src/web-ui/src/flow_chat/services/FlowChatManager.ts
@@ -112,6 +112,7 @@ export class FlowChatManager {
       deferredStorageIdentitySaves: new Set(),
       runtimeStatusTimers: new Map(),
       userCancelledSessionIds: new Set(),
+      pendingHistoryFenceSessions: new Set(),
       handledTerminalTurnEvents: new Set(),
       currentWorkspacePath: null,
       ensureLiveSubscription: () => this.ensureEventListeners(),

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import {
   __test_only__,
   handleDialogTurnComplete,
+  handleSessionHistoryChanged,
   handleSessionStateChanged,
   insertSteeringItemIfAbsent,
   isAppWindowFocused,
@@ -1442,11 +1443,48 @@ describe('handleSessionStateChanged', () => {
   });
 });
 
+describe('handleSessionHistoryChanged', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    resetFlowChatStore();
+  });
+
+  afterEach(() => {
+    resetFlowChatStore();
+  });
+
+  it('reconciles the latest settled native turn after the durable history fence', async () => {
+    createSessionWithTurn({
+      id: 'turn-1',
+      sessionId: 'session-1',
+      agentType: 'agentic',
+      userMessage: { id: 'user-1', content: 'request', timestamp: 1 },
+      modelRounds: [],
+      status: 'completed',
+      startTime: 1,
+      endTime: 2,
+    });
+    const reconcile = vi.spyOn(
+      FlowChatStore.getInstance(),
+      'reconcileSettledDialogTurn',
+    ).mockResolvedValue(true);
+
+    handleSessionHistoryChanged(createFlowChatContext(), {
+      sessionId: 'session-1',
+    });
+    await Promise.resolve();
+
+    expect(reconcile).toHaveBeenCalledWith('session-1', 'turn-1');
+  });
+});
+
 describe('handleDialogTurnComplete', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     resetFlowChatStore();
     stateMachineManager.clear();
+    vi.spyOn(FlowChatStore.getInstance(), 'reconcileSettledDialogTurn')
+      .mockResolvedValue(false);
   });
 
   afterEach(() => {
@@ -1530,6 +1568,8 @@ describe('handleDialogTurnComplete', () => {
       ?.dialogTurns[0];
     expect(finalizedTurn?.status).toBe('completed');
     expect(finalizedTurn?.endTime).toBe(eventOwnedEndTime);
+    expect(FlowChatStore.getInstance().reconcileSettledDialogTurn)
+      .toHaveBeenCalledWith('session-1', 'turn-1');
   });
 
   it('clears the cancellation gate when the same turn completes during cancel', async () => {

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.test.ts
@@ -1274,6 +1274,7 @@ function createFlowChatContext(): FlowChatContext {
     deferredStorageIdentitySaves: new Set(),
     runtimeStatusTimers: new Map(),
     userCancelledSessionIds: new Set(),
+    pendingHistoryFenceSessions: new Set(),
     handledTerminalTurnEvents: new Set(),
     currentWorkspacePath: null,
   };
@@ -1469,12 +1470,39 @@ describe('handleSessionHistoryChanged', () => {
       'reconcileSettledDialogTurn',
     ).mockResolvedValue(true);
 
-    handleSessionHistoryChanged(createFlowChatContext(), {
+    const context = createFlowChatContext();
+    handleSessionHistoryChanged(context, {
       sessionId: 'session-1',
     });
     await Promise.resolve();
 
     expect(reconcile).toHaveBeenCalledWith('session-1', 'turn-1');
+    expect(context.pendingHistoryFenceSessions.has('session-1')).toBe(false);
+  });
+
+  it('parks the fence for the completion finalizer while the turn is still settling', async () => {
+    createSessionWithTurn({
+      id: 'turn-1',
+      sessionId: 'session-1',
+      agentType: 'agentic',
+      userMessage: { id: 'user-1', content: 'request', timestamp: 1 },
+      modelRounds: [],
+      status: 'finishing',
+      startTime: 1,
+    });
+    const reconcile = vi.spyOn(
+      FlowChatStore.getInstance(),
+      'reconcileSettledDialogTurn',
+    ).mockResolvedValue(true);
+
+    const context = createFlowChatContext();
+    handleSessionHistoryChanged(context, {
+      sessionId: 'session-1',
+    });
+    await Promise.resolve();
+
+    expect(reconcile).not.toHaveBeenCalled();
+    expect(context.pendingHistoryFenceSessions.has('session-1')).toBe(true);
   });
 });
 
@@ -1557,6 +1585,13 @@ describe('handleDialogTurnComplete', () => {
       .sessions.get('session-1')
       ?.dialogTurns[0].endTime).toBe(eventOwnedEndTime);
 
+    // Durable fence lands while the turn is still finalizing: it must be
+    // parked instead of racing the persistence commit with an extra read.
+    handleSessionHistoryChanged(context, { sessionId: 'session-1' });
+    expect(FlowChatStore.getInstance().reconcileSettledDialogTurn)
+      .not.toHaveBeenCalled();
+    expect(context.pendingHistoryFenceSessions.has('session-1')).toBe(true);
+
     handleSessionStateChanged(context, {
       sessionId: 'session-1',
       newState: 'Idle',
@@ -1569,7 +1604,36 @@ describe('handleDialogTurnComplete', () => {
     expect(finalizedTurn?.status).toBe('completed');
     expect(finalizedTurn?.endTime).toBe(eventOwnedEndTime);
     expect(FlowChatStore.getInstance().reconcileSettledDialogTurn)
+      .toHaveBeenCalledTimes(1);
+    expect(FlowChatStore.getInstance().reconcileSettledDialogTurn)
       .toHaveBeenCalledWith('session-1', 'turn-1');
+    expect(context.pendingHistoryFenceSessions.has('session-1')).toBe(false);
+  });
+
+  it('skips the settled-turn reconcile when no durable fence has been observed', async () => {
+    putFinishingSessionInStore();
+    const context = createFlowChatContext();
+    await setFinishingMachine();
+
+    handleDialogTurnComplete(context, {
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      success: true,
+      finishReason: 'stop',
+      hasFinalResponse: true,
+    }, vi.fn());
+
+    handleSessionStateChanged(context, {
+      sessionId: 'session-1',
+      newState: 'Idle',
+    });
+
+    expect(FlowChatStore.getInstance()
+      .getState()
+      .sessions.get('session-1')
+      ?.dialogTurns[0].status).toBe('completed');
+    expect(FlowChatStore.getInstance().reconcileSettledDialogTurn)
+      .not.toHaveBeenCalled();
   });
 
   it('clears the cancellation gate when the same turn completes during cancel', async () => {

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
@@ -1176,9 +1176,19 @@ function finalizeTurnCompletionState(
       log.warn('Failed to save dialog turn (non-critical)', { sessionId, turnId, error });
     });
   }
-  if (shouldReconcileRuntimeTurn) {
+  // Reconcile from the host tail only once the durable history fence for this
+  // session has been observed. Reading before the fence races the Runtime's
+  // persistence commit and can only return a pre-terminal record; when the
+  // fence arrives after this finalizer, `handleSessionHistoryChanged` performs
+  // the (single) reconcile instead.
+  if (shouldReconcileRuntimeTurn && context.pendingHistoryFenceSessions.delete(sessionId)) {
     void context.flowChatStore
       .reconcileSettledDialogTurn(sessionId, turnId)
+      .then(applied => {
+        if (applied) {
+          reconcileBackgroundSubagentSession(sessionId);
+        }
+      })
       .catch(error => {
         log.warn('Failed to reconcile settled dialog turn', { sessionId, turnId, error });
       });
@@ -1427,6 +1437,7 @@ function handleSessionDeleted(context: FlowChatContext, event: any): void {
   removedSessionIds.forEach(id => {
     clearPendingTurnCompletion(context, id);
     pendingImageAnalysisTurns.delete(id);
+    context.pendingHistoryFenceSessions.delete(id);
     stateMachineManager.delete(id);
     context.processingManager.clearSessionStatus(id);
     cleanupSaveState(context, id);
@@ -1498,6 +1509,13 @@ export function handleSessionStateChanged(context: FlowChatContext, event: any):
  * durable. DialogTurnCompleted is intentionally lower latency than the final
  * persistence write, so relying on that event alone can preserve a painted
  * prefix when the last TextChunk was missed.
+ *
+ * The fence usually lands while the local Turn is still inside its completion
+ * quiet window. Reading the host tail at that moment wastes a restore round
+ * trip on a record the finalizer will re-read anyway, so the fence is parked
+ * and consumed by `finalizeTurnCompletionState`. Each settled Turn therefore
+ * performs exactly one reconcile, and only after the terminal record is
+ * durable.
  */
 export function handleSessionHistoryChanged(context: FlowChatContext, event: any): void {
   const sessionId = event?.sessionId ?? event?.session_id;
@@ -1510,6 +1528,14 @@ export function handleSessionHistoryChanged(context: FlowChatContext, event: any
     return;
   }
 
+  const latestTurn = session.dialogTurns[session.dialogTurns.length - 1];
+  if (latestTurn && !['completed', 'cancelled', 'error'].includes(latestTurn.status)) {
+    // The local projection has not settled yet (completion quiet window, or
+    // the next Turn already started). Defer to the completion finalizer.
+    context.pendingHistoryFenceSessions.add(sessionId);
+    return;
+  }
+
   const settledTurn = [...session.dialogTurns]
     .reverse()
     .find(turn => ['completed', 'cancelled', 'error'].includes(turn.status));
@@ -1517,8 +1543,17 @@ export function handleSessionHistoryChanged(context: FlowChatContext, event: any
     return;
   }
 
+  context.pendingHistoryFenceSessions.delete(sessionId);
+  reconcileDurableSessionHistory(context, sessionId, settledTurn.id);
+}
+
+function reconcileDurableSessionHistory(
+  context: FlowChatContext,
+  sessionId: string,
+  turnId: string,
+): void {
   void context.flowChatStore
-    .reconcileSettledDialogTurn(sessionId, settledTurn.id)
+    .reconcileSettledDialogTurn(sessionId, turnId)
     .then(applied => {
       if (applied) {
         reconcileBackgroundSubagentSession(sessionId);
@@ -1527,7 +1562,7 @@ export function handleSessionHistoryChanged(context: FlowChatContext, event: any
     .catch(error => {
       log.warn('Failed to reconcile durable session history', {
         sessionId,
-        turnId: settledTurn.id,
+        turnId,
         error,
       });
     });

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/EventHandlerModule.ts
@@ -89,6 +89,7 @@ import {
   sessionPendingTurnAdoptionKey,
   stripOptimisticTurnAdoption,
 } from '../../utils/optimisticTurnAdoption';
+import { isAcpFlowSession } from '../../utils/acpSession';
 
 const log = createLogger('EventHandlerModule');
 const TURN_COMPLETION_QUIET_WINDOW_MS = 500;
@@ -807,6 +808,9 @@ export async function initializeEventListeners(
     onSessionStateChanged: (event) => {
       handleSessionStateChanged(context, event);
     },
+    onSessionHistoryChanged: (event) => {
+      handleSessionHistoryChanged(context, event);
+    },
     onImageAnalysisStarted: (event) => {
       handleImageAnalysisStarted(context, event as ImageAnalysisEvent);
     },
@@ -1118,6 +1122,7 @@ function finalizeTurnCompletionState(
   const runtimeOwnsTurnPersistence = Boolean(
     session.dialogTurns.find(turn => turn.id === turnId)?.recovery,
   );
+  const shouldReconcileRuntimeTurn = !isAcpFlowSession(session);
 
   completeActiveTextItems(context, sessionId, turnId);
   clearRuntimeStatus(context, sessionId, turnId);
@@ -1170,6 +1175,13 @@ function finalizeTurnCompletionState(
     saveDialogTurnToDisk(context, sessionId, turnId).catch(error => {
       log.warn('Failed to save dialog turn (non-critical)', { sessionId, turnId, error });
     });
+  }
+  if (shouldReconcileRuntimeTurn) {
+    void context.flowChatStore
+      .reconcileSettledDialogTurn(sessionId, turnId)
+      .catch(error => {
+        log.warn('Failed to reconcile settled dialog turn', { sessionId, turnId, error });
+      });
   }
 
   context.userCancelledSessionIds.delete(sessionId);
@@ -1479,6 +1491,46 @@ export function handleSessionStateChanged(context: FlowChatContext, event: any):
       rawBackendState: newState
     });
   }
+}
+
+/**
+ * Re-read the terminal tail only after the Runtime announces that its Turn is
+ * durable. DialogTurnCompleted is intentionally lower latency than the final
+ * persistence write, so relying on that event alone can preserve a painted
+ * prefix when the last TextChunk was missed.
+ */
+export function handleSessionHistoryChanged(context: FlowChatContext, event: any): void {
+  const sessionId = event?.sessionId ?? event?.session_id;
+  if (!sessionId) {
+    return;
+  }
+
+  const session = context.flowChatStore.getState().sessions.get(sessionId);
+  if (!session || isAcpFlowSession(session)) {
+    return;
+  }
+
+  const settledTurn = [...session.dialogTurns]
+    .reverse()
+    .find(turn => ['completed', 'cancelled', 'error'].includes(turn.status));
+  if (!settledTurn) {
+    return;
+  }
+
+  void context.flowChatStore
+    .reconcileSettledDialogTurn(sessionId, settledTurn.id)
+    .then(applied => {
+      if (applied) {
+        reconcileBackgroundSubagentSession(sessionId);
+      }
+    })
+    .catch(error => {
+      log.warn('Failed to reconcile durable session history', {
+        sessionId,
+        turnId: settledTurn.id,
+        error,
+      });
+    });
 }
 
 /**

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/types.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/types.ts
@@ -53,6 +53,13 @@ export interface FlowChatContext {
   /** Session IDs that the user explicitly cancelled; used to skip unread marking */
   userCancelledSessionIds: Set<string>;
   /**
+   * Sessions whose durable history fence (`SessionHistoryChanged`) arrived
+   * while the local Turn was still finalizing. Consumed by the completion
+   * finalizer so each settled Turn performs exactly one host-tail reconcile,
+   * and only after the Runtime committed the terminal record.
+   */
+  pendingHistoryFenceSessions: Set<string>;
+  /**
    * Turn IDs whose terminal lifecycle event (cancelled / failed / completed)
    * has already been applied. Backend may emit the same terminal event twice
    * (e.g. cancelled emitted both by the execution engine when a cancel is

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
@@ -6678,6 +6678,85 @@ describe('FlowChatStore reconcile snapshot content safety', () => {
     ).toBe('round-0');
   });
 
+  it('refuses an equal-item-count checkpoint that shortens rendered text', async () => {
+    await hydrateSessionWithContent();
+
+    apiMocks.restoreSessionView.mockResolvedValueOnce({
+      session: hostSession(),
+      turns: [{
+        ...createPersistedTurn(0),
+        modelRounds: [{
+          ...HYDRATED_ROUND,
+          textItems: [{ id: 'text-0', content: 'BitFun is', timestamp: 2 }],
+        }],
+      }],
+      contextRestoreState: 'ready',
+    });
+
+    const result = await flowChatStore.refreshPeerSessionSnapshot(
+      'history-1',
+      '/repo/BitFun',
+      { requireActiveSession: true },
+    );
+
+    expect(result.applied).toBe(false);
+    expect(
+      flowChatStore.getState().sessions.get('history-1')
+        ?.dialogTurns[0].modelRounds[0].items[0],
+    ).toMatchObject({ content: 'BitFun is an agentic IDE…' });
+  });
+
+  it('repairs a settled local or Peer projection from the host tail', async () => {
+    await hydrateSessionWithContent();
+    const completeContent = 'BitFun is an agentic IDE… with a complete persisted response.';
+    flowChatStore.addModelRoundItem('history-1', 'turn-0', {
+      id: 'plan-display-test',
+      type: 'tool',
+      toolName: 'CreatePlan',
+      toolCall: { id: '', input: {} },
+      toolResult: {
+        result: { plan_file_path: '/tmp/plan.md' },
+        success: true,
+      },
+      timestamp: 2,
+      status: 'completed',
+    }, 'round-0');
+
+    apiMocks.restoreSessionView.mockResolvedValueOnce({
+      session: hostSession(),
+      turns: [{
+        ...createPersistedTurn(0),
+        modelRounds: [{
+          ...HYDRATED_ROUND,
+          textItems: [{ id: 'text-0', content: completeContent, timestamp: 2 }],
+        }],
+        endTime: 3,
+      }],
+      contextRestoreState: 'ready',
+    });
+
+    await expect(
+      flowChatStore.reconcileSettledDialogTurn('history-1', 'turn-0'),
+    ).resolves.toBe(true);
+    expect(apiMocks.restoreSessionView).toHaveBeenLastCalledWith(
+      'history-1',
+      '/repo/BitFun',
+      undefined,
+      undefined,
+      'settled-turn-turn-0',
+      false,
+      1,
+    );
+    expect(
+      flowChatStore.getState().sessions.get('history-1')
+        ?.dialogTurns[0].modelRounds[0].items[0],
+    ).toMatchObject({ content: completeContent });
+    expect(
+      flowChatStore.getState().sessions.get('history-1')
+        ?.dialogTurns[0].modelRounds[0].items,
+    ).toContainEqual(expect.objectContaining({ id: 'plan-display-test' }));
+  });
+
   it('still adopts the host copy when the snapshot carries the projected work', async () => {
     // The guard must not disable wholesale replacement, which is how a settled
     // turn picks up the host's authoritative copy.

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.ts
@@ -331,6 +331,7 @@ const HISTORICAL_SESSION_INITIAL_LOCAL_TAIL_TURN_COUNT = 3;
 const HISTORICAL_SESSION_FULL_HISTORY_IDLE_TIMEOUT_MS = 1500;
 const HISTORICAL_SESSION_PREVIOUS_WINDOW_TURN_COUNT = 12;
 const PEER_SESSION_REFRESH_TAIL_TURN_COUNT = 3;
+const SETTLED_TURN_RECONCILE_TAIL_TURN_COUNT = 1;
 const SESSION_TURN_WINDOW_DEFAULT_BEFORE = 4;
 const SESSION_TURN_WINDOW_DEFAULT_AFTER = 12;
 const SESSION_HISTORY_PRESENTATION_SOFT_TURN_BUDGET = 48;
@@ -686,15 +687,57 @@ function snapshotDropsProjectedTurnContent(
     if (!snapshotRound) {
       return true;
     }
-    if (streamProgressEntries(snapshotRound).size < streamProgressEntries(currentRound).size) {
-      return true;
+    const currentStreams = streamProgressEntries(currentRound);
+    const snapshotStreams = streamProgressEntries(snapshotRound);
+    for (const [key, currentItem] of currentStreams) {
+      const snapshotItem = snapshotStreams.get(key);
+      // The same text/thinking item can still be only an earlier checkpoint
+      // prefix. Item counts alone therefore do not make replacement lossless.
+      if (!snapshotItem || !snapshotItem.content.startsWith(currentItem.content)) {
+        return true;
+      }
     }
-    if (toolProgressEntries(snapshotRound).size < toolProgressEntries(currentRound).size) {
-      return true;
+
+    const currentTools = toolProgressEntries(currentRound);
+    const snapshotTools = toolProgressEntries(snapshotRound);
+    for (const [key, currentTool] of currentTools) {
+      const snapshotTool = snapshotTools.get(key);
+      if (!snapshotTool || (currentTool.toolResult && !snapshotTool.toolResult)) {
+        return true;
+      }
     }
   }
 
   return false;
+}
+
+function preserveClientDerivedDisplayItems(
+  current: DialogTurn,
+  persisted: DialogTurn,
+): DialogTurn {
+  let changed = false;
+  const modelRounds = persisted.modelRounds.map(persistedRound => {
+    const currentRound = current.modelRounds.find(round => round.id === persistedRound.id);
+    if (!currentRound) {
+      return persistedRound;
+    }
+    const persistedIds = new Set(persistedRound.items.map(item => item.id));
+    const derivedItems = currentRound.items.filter(item =>
+      item.type === 'tool'
+      && item.id.startsWith('plan-display-')
+      && !persistedIds.has(item.id),
+    );
+    if (derivedItems.length === 0) {
+      return persistedRound;
+    }
+    changed = true;
+    return {
+      ...persistedRound,
+      items: [...persistedRound.items, ...derivedItems],
+    };
+  });
+
+  return changed ? { ...persisted, modelRounds } : persisted;
 }
 
 /**
@@ -7609,6 +7652,111 @@ export class FlowChatStore {
           }
         : {}),
     };
+  }
+
+  /**
+   * Repair one terminal Turn from the host's canonical persisted record.
+   *
+   * Runtime chunks are optimized for latency and can be lost while a window is
+   * suspended or a Peer controller reconnects. Once the Runtime has settled,
+   * persistence owns the Turn, so local and device surfaces both perform this
+   * small tail read instead of treating the last painted chunk as complete.
+   */
+  public async reconcileSettledDialogTurn(
+    sessionId: string,
+    turnId: string,
+  ): Promise<boolean> {
+    const scope = getActiveSurfaceScope();
+    const initialSession = this.state.sessions.get(sessionId);
+    const workspacePath = initialSession
+      ? sessionProjectWorkspacePath(initialSession)
+      : undefined;
+    if (!initialSession || !workspacePath) {
+      return false;
+    }
+
+    const restored = await agentAPI.restoreSessionView(
+      sessionId,
+      workspacePath,
+      initialSession.remoteConnectionId,
+      initialSession.remoteSshHost,
+      `settled-turn-${turnId.slice(0, 8)}`,
+      initialSession.sessionKind === 'subagent',
+      SETTLED_TURN_RECONCILE_TAIL_TURN_COUNT,
+    );
+    scope.assertCurrent('reconcileSettledDialogTurn');
+
+    const backendActive = isBackendSessionActivelyProcessing(restored.session.state);
+    const persistedTailTurnId = restored.turns[restored.turns.length - 1]?.turnId;
+    const runtimeSnapshot = coerceRuntimeEventSnapshot(
+      restored.runtimeEventSnapshot,
+      sessionId,
+      backendActive,
+      persistedTailTurnId,
+    );
+    const hostExecutingTurnId = backendActive
+      ? runtimeSnapshot?.activeTurnId ?? persistedTailTurnId
+      : undefined;
+    if (hostExecutingTurnId === turnId) {
+      return false;
+    }
+
+    const incoming = this.convertToDialogTurns(restored.turns)
+      .find(turn => turn.id === turnId);
+    if (
+      !incoming
+      || !['completed', 'cancelled', 'error'].includes(incoming.status)
+    ) {
+      return false;
+    }
+
+    let applied = false;
+    this.setState(prev => {
+      const session = prev.sessions.get(sessionId);
+      if (!session) {
+        return prev;
+      }
+      const turnIndex = session.dialogTurns.findIndex(turn => turn.id === turnId);
+      if (turnIndex < 0) {
+        return prev;
+      }
+      const current = session.dialogTurns[turnIndex];
+      const reconciled = preserveClientDerivedDisplayItems(current, incoming);
+      if (
+        !['completed', 'cancelled', 'error'].includes(current.status)
+        || !persistedReadMayReplaceTurn(
+          sessionId,
+          current,
+          reconciled,
+          hostExecutingTurnId,
+          Boolean(runtimeSnapshot),
+        )
+      ) {
+        return prev;
+      }
+
+      const dialogTurns = [...session.dialogTurns];
+      dialogTurns[turnIndex] = {
+        ...current,
+        ...reconciled,
+        tokenUsage: reconciled.tokenUsage ?? current.tokenUsage,
+        success: reconciled.success ?? current.success,
+        finishReason: reconciled.finishReason ?? current.finishReason,
+        hasFinalResponse: reconciled.hasFinalResponse ?? current.hasFinalResponse,
+      };
+      const sessions = new Map(prev.sessions);
+      sessions.set(sessionId, {
+        ...session,
+        dialogTurns,
+      });
+      applied = true;
+      return {
+        ...prev,
+        sessions,
+      };
+    });
+
+    return applied;
   }
 
   /** Empty the current Turn so journal replay cannot overlap a persist checkpoint. */

--- a/src/web-ui/src/infrastructure/api/service-api/AgentAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/AgentAPI.ts
@@ -1367,6 +1367,10 @@ export class AgentAPI {
     return api.listen<AgenticEvent>('agentic://session-state-changed', callback);
   }
 
+  onSessionHistoryChanged(callback: (event: AgenticEvent) => void): () => void {
+    return api.listen<AgenticEvent>('agentic://session-history-changed', callback);
+  }
+
   onSessionModelAutoMigrated(
     callback: (event: SessionModelAutoMigratedEvent) => void
   ): () => void {

--- a/src/web-ui/src/infrastructure/peer-device/README.md
+++ b/src/web-ui/src/infrastructure/peer-device/README.md
@@ -80,7 +80,11 @@ Still to migrate, in order: the interaction mailbox, then history positions.
      *every* turn reads as idle and qualifies for replacement.
      That combination erased the whole response and left only the prompt on
      screen (regression: 2026-08-15). `snapshotDropsProjectedTurnContent` gates
-     the replace; the refresh loop still re-attaches an executing turn when a
+     the replace. Equal item counts are not sufficient: text and thinking must
+     preserve prefix progress, and completed tool results may not disappear.
+     Recognized client-derived display cards are carried across the terminal
+     host-tail repair instead of blocking authoritative text reconciliation.
+     The refresh loop still re-attaches an executing turn when a
      snapshot is refused, or a rebuilt surface would render it as static
      history.
    - **Surface-scoped events must stay routed by source device.** Background
@@ -204,6 +208,13 @@ Still to migrate, in order: the interaction mailbox, then history positions.
     attach and freeze the receiver while the Host kept streaming.
     A CLI Peer Host still filters Host-local turns with `owns()`; that is a
     CLI Host limitation, not a reason for a Desktop receiver to freeze.
+
+    **Terminal delivery is not the durability fence.** The Host may publish
+    `DialogTurnCompleted` before its complete generation journal has been
+    committed. After the commit it publishes `SessionHistoryChanged`; local and
+    Peer surfaces then reconcile the terminal tail from that Host. The
+    controller must not echo a shorter painted prefix over the settled record,
+    even when the prefix has the same round and item counts.
 
     **The subscription and the attach loop must never be able to disable each
     other.** The agentic subscription is this window's only live view of a


### PR DESCRIPTION
## Summary

- Port `1f29e82a1` and `e666b6e62` from `1.0.0-explore` onto the latest `main`.
- Make Runtime completion authoritative for settled Turn content and emit a per-Turn durable history fence after persistence succeeds.
- Repair Desktop, Peer Device, and Mobile projections from persisted history without dropping a newer live Turn.
- Cache read-only snapshot managers and load large snapshot metadata indexes on bounded blocking workers to reduce restore stalls.

## Type and Areas

Type: regression fix / performance fix

Areas: Rust core, event contracts, desktop/Tauri, Remote Connect, Web UI, Mobile Web, Peer Device Mode, architecture docs

## Motivation / Impact

Terminal stream chunks can be missed while a window is suspended, a remote controller reconnects, or persistence races the frontend completion finalizer. A client could therefore keep a completed assistant response prefix, or a late history fence could erase the projection of a newer running Turn. Large snapshot indexes also made the repair path hold session coordination for seconds.

This change makes the persisted terminal Turn the repair authority, adds a backward-compatible settled-Turn fence, preserves newer live projections, and avoids repeatedly loading snapshot metadata.

## Verification

- `cargo check -p bitfun-events` — passed
- `cargo check -p bitfun-desktop` — passed
- `cargo test -p bitfun-core --no-default-features --features agent-runtime --lib stale_projected_turn_saves_cannot_overwrite_runtime_recovery_state` — passed
- `cargo test -p bitfun-core --no-default-features --features agent-runtime --lib completion_replaces_a_projected_text_prefix_with_runtime_generation_content` — passed
- `cargo test -p bitfun-core --no-default-features --features agent-runtime --lib completed_persisted_turn_emits_a_durable_history_fence` — passed
- `cargo test -p bitfun-core --no-default-features --features agent-runtime --lib view_manager_is_cached_and_superseded_by_a_later_writer` — passed
- `cargo test -p bitfun-services-integrations --no-default-features --features remote-connect --lib remote_connect::tests::` — 9 passed
- `cargo test -p bitfun-services-integrations --no-default-features --features remote-connect --test remote_connect_contracts` — 55 passed
- `pnpm --dir src/web-ui run gen:types && pnpm run type-check:web` — passed
- `pnpm --dir src/web-ui run test:run src/flow_chat/services/flow-chat-manager/EventHandlerModule.test.ts src/flow_chat/store/FlowChatStore.test.ts` — 172 passed
- `pnpm --dir src/mobile-web run type-check && pnpm run build:mobile-web` — passed
- `git diff --check upstream/main...HEAD` — passed

Remote scenario coverage:

- Local/Desktop: Core unit coverage and Desktop compile check.
- Remote control: Remote Connect unit/contract coverage and Mobile Web type/build checks.
- Peer Device Mode: settled local/Peer projection regression coverage in FlowChatStore tests.
- Remote workspace and Detached Dispatch: not manually exercised; the event field and poll replacement field are optional for cross-version compatibility.

No manual browser/device run was performed.

## Reviewer Notes

- `settled_turn_id` is optional and omitted when absent, so older event payloads continue to deserialize.
- `message_snapshot` is optional; the additive delta remains populated for older Mobile Web clients.
- The second commit is a follow-up to the first and should be reviewed/applied as a pair.
- AI-assisted port; verification level is focused automated testing as listed above.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.
