### PR TITLE
fix(rollback): disambiguate local workspace identity

### DIFF
--- a/src/apps/cli/src/peer_host/commands/snapshot.rs
+++ b/src/apps/cli/src/peer_host/commands/snapshot.rs
@@ -6,7 +6,7 @@ use serde_json::{json, Value};
 
 use bitfun_core::service::remote_ssh::workspace_state::is_remote_path;
 use bitfun_runtime_ports::{
-    AgentSessionRollbackToTurnRequest, LocalWorkspaceSnapshotPort,
+    AgentSessionRollbackToTurnRequest, AgentSessionWorkspaceLocation, LocalWorkspaceSnapshotPort,
     LocalWorkspaceSnapshotSessionRequest, LocalWorkspaceSnapshotStats, PortError, PortErrorKind,
 };
 
@@ -33,10 +33,12 @@ pub(super) async fn require_local_snapshot_workspace(
 async fn require_complete_rollback_workspace(
     request: &Value,
     workspace_path: &str,
+    explicit_location: Option<AgentSessionWorkspaceLocation>,
 ) -> Result<(), String> {
     let is_remote = optional_string(request, "remoteConnectionId").is_some()
         || optional_string(request, "remoteSshHost").is_some()
-        || is_remote_path(workspace_path).await;
+        || explicit_location == Some(AgentSessionWorkspaceLocation::Remote)
+        || (explicit_location.is_none() && is_remote_path(workspace_path).await);
     if is_remote {
         return Err(format!(
             "Complete rollback is not supported for remote workspaces because remote file snapshots are not recorded. No workspace files or session messages were changed: {workspace_path}"
@@ -134,7 +136,12 @@ pub(crate) async fn rollback_session_to_turn(
             .map_err(|error| format!("Invalid targeted Session rollback request: {error}"))?;
 
     bitfun_agent_runtime::session_control::validate_session_id(&rollback_request.session_id)?;
-    require_complete_rollback_workspace(request, &rollback_request.workspace_path).await?;
+    require_complete_rollback_workspace(
+        request,
+        &rollback_request.workspace_path,
+        rollback_request.explicit_workspace_location(),
+    )
+    .await?;
     ensure_session_workspace_runtime_ownership(state, request)?;
     let outcome = state
         .agent_runtime
@@ -227,6 +234,7 @@ mod tests {
         let rollback_error = require_complete_rollback_workspace(
             &json!({ "remoteConnectionId": "remote-1" }),
             "/root/repos",
+            None,
         )
         .await
         .expect_err("complete remote rollback must report missing snapshot coverage");
@@ -240,12 +248,40 @@ mod tests {
             .find("pub(crate) async fn rollback_session_to_turn")
             .expect("rollback handler must exist")..];
         let remote_guard = rollback_source
-            .find("require_complete_rollback_workspace(request, &rollback_request.workspace_path)")
+            .find("require_complete_rollback_workspace(")
             .expect("rollback must have an explicit remote guard");
         let runtime_call = rollback_source
             .find(".rollback_session_to_turn(")
             .expect("rollback must delegate to the Agent Session runtime");
         assert!(remote_guard < runtime_call);
+    }
+
+    #[tokio::test]
+    async fn explicit_local_rollback_identity_wins_over_a_remote_path_collision() {
+        let workspace = tempfile::tempdir().expect("create local workspace");
+        let workspace_path = workspace.path().to_string_lossy().to_string();
+        let remote =
+            bitfun_core::service::remote_ssh::workspace_state::init_remote_workspace_manager();
+        remote
+            .register_remote_workspace(
+                workspace_path.clone(),
+                "peer-rollback-path-collision".to_string(),
+                "Peer rollback collision test".to_string(),
+                "remote.example".to_string(),
+            )
+            .await;
+
+        require_complete_rollback_workspace(
+            &json!({ "workspaceId": "local_workspace-1" }),
+            &workspace_path,
+            Some(bitfun_runtime_ports::AgentSessionWorkspaceLocation::Local),
+        )
+        .await
+        .expect("explicit local identity must disambiguate the registered remote path");
+
+        remote
+            .unregister_remote_workspace("peer-rollback-path-collision", &workspace_path)
+            .await;
     }
 
     #[tokio::test]

--- a/src/apps/desktop/src/api/app_state.rs
+++ b/src/apps/desktop/src/api/app_state.rs
@@ -244,10 +244,14 @@ impl AppState {
         }
 
         // Initialize SSH Remote services synchronously so they're ready before app starts
-        let ssh_data_dir = dirs::data_local_dir()
-            .unwrap_or_else(|| std::path::PathBuf::from("."))
-            .join("BitFun")
-            .join("ssh");
+        let ssh_data_dir = if crate::e2e_storage_guard_enabled() {
+            workspace_service.path_manager().user_data_dir().join("ssh")
+        } else {
+            dirs::data_local_dir()
+                .unwrap_or_else(|| std::path::PathBuf::from("."))
+                .join("BitFun")
+                .join("ssh")
+        };
         let ssh_manager = Arc::new(RwLock::new(None));
         let ssh_manager_clone = ssh_manager.clone();
         let remote_file_service = Arc::new(RwLock::new(None));

--- a/src/apps/desktop/src/api/snapshot_service.rs
+++ b/src/apps/desktop/src/api/snapshot_service.rs
@@ -9,7 +9,7 @@ use bitfun_core::service::snapshot::{
     initialize_snapshot_manager_for_workspace, open_snapshot_manager_for_view, FileChangeEntry,
     OperationType, SnapshotConfig, SnapshotManager,
 };
-use bitfun_runtime_ports::SessionStoragePathRequest;
+use bitfun_runtime_ports::{AgentSessionWorkspaceLocation, SessionStoragePathRequest};
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
@@ -370,8 +370,12 @@ async fn ensure_local_snapshot_mutation_path(
 async fn ensure_complete_rollback_supported(
     workspace_path: &str,
     remote_scope: &SnapshotRemoteScope,
+    explicit_location: Option<AgentSessionWorkspaceLocation>,
 ) -> Result<(), String> {
-    if remote_scope.declares_remote() || is_remote_path(workspace_path).await {
+    let is_remote = remote_scope.declares_remote()
+        || explicit_location == Some(AgentSessionWorkspaceLocation::Remote)
+        || (explicit_location.is_none() && is_remote_path(workspace_path).await);
+    if is_remote {
         return Err(format!(
             "Complete rollback is not supported for remote workspaces because remote file snapshots are not recorded. No workspace files or session messages were changed: {workspace_path}"
         ));
@@ -552,7 +556,8 @@ pub async fn rollback_session(
     runtime: State<'_, DesktopRuntimeContext>,
     request: RollbackSessionRequest,
 ) -> Result<Vec<String>, String> {
-    ensure_complete_rollback_supported(&request.workspace_path, &request.remote_scope).await?;
+    ensure_complete_rollback_supported(&request.workspace_path, &request.remote_scope, None)
+        .await?;
     ensure_local_runtime_ownership(runtime.inner(), &request.workspace_path).await?;
     let _history_mutation = begin_snapshot_history_mutation(
         runtime.inner(),
@@ -595,7 +600,12 @@ pub async fn rollback_session_to_turn(
         remote_connection_id: request.remote_connection_id.clone(),
         remote_ssh_host: request.remote_ssh_host.clone(),
     };
-    ensure_complete_rollback_supported(&request.workspace_path, &remote_scope).await?;
+    ensure_complete_rollback_supported(
+        &request.workspace_path,
+        &remote_scope,
+        request.explicit_workspace_location(),
+    )
+    .await?;
     ensure_local_runtime_ownership(runtime.inner(), &request.workspace_path).await?;
     runtime
         .session_application()
@@ -1346,7 +1356,7 @@ mod tests {
             remote_ssh_host: Some("example.com".to_string()),
         };
 
-        let error = ensure_complete_rollback_supported("/root/repos", &scope)
+        let error = ensure_complete_rollback_supported("/root/repos", &scope, None)
             .await
             .expect_err("remote rollback must fail before changing files or history");
 
@@ -1354,6 +1364,40 @@ mod tests {
             error,
             "Complete rollback is not supported for remote workspaces because remote file snapshots are not recorded. No workspace files or session messages were changed: /root/repos"
         );
+    }
+
+    #[tokio::test]
+    async fn explicit_local_rollback_identity_wins_over_a_remote_path_collision() {
+        let workspace = tempfile::tempdir().expect("create local workspace");
+        let workspace_path = workspace.path().to_string_lossy().to_string();
+        let remote =
+            bitfun_core::service::remote_ssh::workspace_state::init_remote_workspace_manager();
+        remote
+            .register_remote_workspace(
+                workspace_path.clone(),
+                "rollback-path-collision".to_string(),
+                "Rollback collision test".to_string(),
+                "remote.example".to_string(),
+            )
+            .await;
+
+        let legacy_error =
+            ensure_complete_rollback_supported(&workspace_path, &Default::default(), None)
+                .await
+                .expect_err("legacy path-only requests must retain remote fallback behavior");
+        assert!(legacy_error.contains("not supported for remote workspaces"));
+
+        ensure_complete_rollback_supported(
+            &workspace_path,
+            &Default::default(),
+            Some(bitfun_runtime_ports::AgentSessionWorkspaceLocation::Local),
+        )
+        .await
+        .expect("explicit local identity must disambiguate the registered remote path");
+
+        remote
+            .unregister_remote_workspace("rollback-path-collision", &workspace_path)
+            .await;
     }
 
     #[test]

--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -315,6 +315,12 @@ fn handle_secondary_launch(app: &tauri::AppHandle) {
     }
 }
 
+pub(crate) fn e2e_storage_guard_enabled() -> bool {
+    std::env::var("BITFUN_E2E_STORAGE_GUARD")
+        .ok()
+        .is_some_and(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+}
+
 fn main_window_state_flags() -> StateFlags {
     StateFlags::SIZE | StateFlags::POSITION | StateFlags::MAXIMIZED | StateFlags::FULLSCREEN
 }
@@ -697,8 +703,11 @@ pub async fn run() {
 
     let mut builder = tauri::Builder::default();
 
+    let is_e2e_webdriver =
+        e2e_storage_guard_enabled() && std::env::var_os("BITFUN_WEBDRIVER_PORT").is_some();
+
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-    {
+    if !is_e2e_webdriver {
         builder = builder.plugin(tauri_plugin_single_instance::init(|app, args, cwd| {
             log::info!(
                 "Existing BitFun Desktop instance received launch request: args_count={}, cwd={}",

--- a/src/crates/contracts/runtime-ports/src/agent_api.rs
+++ b/src/crates/contracts/runtime-ports/src/agent_api.rs
@@ -1601,6 +1601,14 @@ pub struct AgentSessionRevertRequest {
 #[serde(rename_all = "camelCase")]
 pub struct AgentSessionRollbackToTurnRequest {
     pub workspace_path: String,
+    /// Stable workspace identity supplied by newer product surfaces. This is
+    /// optional so older clients keep using the path-based compatibility path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_id: Option<String>,
+    /// Persisted workspace host identity. `localhost` is the local sentinel;
+    /// any other non-empty value identifies a remote workspace.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_hostname: Option<String>,
     pub session_id: String,
     pub target_turn_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1611,6 +1619,52 @@ pub struct AgentSessionRollbackToTurnRequest {
     pub remote_connection_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub remote_ssh_host: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentSessionWorkspaceLocation {
+    Local,
+    Remote,
+}
+
+impl AgentSessionRollbackToTurnRequest {
+    /// Returns the structured workspace location when the request declares one.
+    /// Explicit remote facts win over conflicting local facts so malformed
+    /// requests cannot bypass remote snapshot restrictions.
+    pub fn explicit_workspace_location(&self) -> Option<AgentSessionWorkspaceLocation> {
+        let workspace_id = self
+            .workspace_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+        let workspace_hostname = self
+            .workspace_hostname
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+
+        if self
+            .remote_connection_id
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty())
+            || self
+                .remote_ssh_host
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty())
+            || workspace_id.is_some_and(|value| value.starts_with("remote_"))
+            || workspace_hostname.is_some_and(|value| !value.eq_ignore_ascii_case("localhost"))
+        {
+            return Some(AgentSessionWorkspaceLocation::Remote);
+        }
+
+        if workspace_id.is_some_and(|value| value.starts_with("local_"))
+            || workspace_hostname.is_some_and(|value| value.eq_ignore_ascii_case("localhost"))
+        {
+            return Some(AgentSessionWorkspaceLocation::Local);
+        }
+
+        None
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -2022,6 +2076,8 @@ mod tests {
     fn targeted_session_rollback_contract_uses_camel_case_and_typed_outcomes() {
         let request = AgentSessionRollbackToTurnRequest {
             workspace_path: "E:/workspace".to_string(),
+            workspace_id: Some("local_workspace-1".to_string()),
+            workspace_hostname: Some("localhost".to_string()),
             session_id: "session-1".to_string(),
             target_turn_id: "turn-7".to_string(),
             expected_storage_turn_index: Some(7),
@@ -2031,6 +2087,8 @@ mod tests {
         };
         let request_json = serde_json::to_value(&request).expect("serialize rollback request");
         assert_eq!(request_json["workspacePath"], "E:/workspace");
+        assert_eq!(request_json["workspaceId"], "local_workspace-1");
+        assert_eq!(request_json["workspaceHostname"], "localhost");
         assert_eq!(request_json["targetTurnId"], "turn-7");
         assert_eq!(request_json["expectedStorageTurnIndex"], 7);
         assert_eq!(request_json["expectedCatalogRevision"], "catalog-3");
@@ -2038,6 +2096,35 @@ mod tests {
             serde_json::from_value::<AgentSessionRollbackToTurnRequest>(request_json)
                 .expect("deserialize rollback request"),
             request
+        );
+
+        let legacy_request =
+            serde_json::from_value::<AgentSessionRollbackToTurnRequest>(serde_json::json!({
+                "workspacePath": "E:/workspace",
+                "sessionId": "session-1",
+                "targetTurnId": "turn-7"
+            }))
+            .expect("deserialize pre-workspace-identity rollback request");
+        assert_eq!(legacy_request.workspace_id, None);
+        assert_eq!(legacy_request.workspace_hostname, None);
+        assert_eq!(legacy_request.explicit_workspace_location(), None);
+
+        let local_request = AgentSessionRollbackToTurnRequest {
+            workspace_id: Some("local_workspace-1".to_string()),
+            workspace_hostname: None,
+            ..legacy_request.clone()
+        };
+        assert_eq!(
+            local_request.explicit_workspace_location(),
+            Some(AgentSessionWorkspaceLocation::Local)
+        );
+        let conflicting_request = AgentSessionRollbackToTurnRequest {
+            remote_connection_id: Some("connection-1".to_string()),
+            ..local_request
+        };
+        assert_eq!(
+            conflicting_request.explicit_workspace_location(),
+            Some(AgentSessionWorkspaceLocation::Remote)
         );
 
         let completed = AgentSessionRollbackToTurnOutcome::Completed {

--- a/src/web-ui/src/flow_chat/services/SessionRollbackService.test.ts
+++ b/src/web-ui/src/flow_chat/services/SessionRollbackService.test.ts
@@ -39,6 +39,8 @@ describe('SessionRollbackService', () => {
     sessions.set('session-1', {
       sessionId: 'session-1',
       workspacePath: 'E:/workspace',
+      workspaceId: 'local_workspace-1',
+      workspaceHostname: 'localhost',
       config: {},
       isPartial: true,
       dialogTurns: [{ id: 'turn-7', storageTurnIndex: 7 }],
@@ -66,6 +68,8 @@ describe('SessionRollbackService', () => {
 
     expect(agentApiMock.rollbackSessionToTurn).toHaveBeenCalledWith(expect.objectContaining({
       sessionId: 'session-1',
+      workspaceId: 'local_workspace-1',
+      workspaceHostname: 'localhost',
       targetTurnId: 'turn-7',
       expectedStorageTurnIndex: 7,
       expectedCatalogRevision: 'catalog-3',

--- a/src/web-ui/src/flow_chat/services/SessionRollbackService.ts
+++ b/src/web-ui/src/flow_chat/services/SessionRollbackService.ts
@@ -116,6 +116,8 @@ export async function rollbackSessionToTurn(
 
     const outcome = await agentAPI.rollbackSessionToTurn({
       workspacePath,
+      workspaceId: session.workspaceId ?? session.config.workspaceId,
+      workspaceHostname: session.workspaceHostname,
       sessionId: request.sessionId,
       targetTurnId: request.targetTurnId,
       expectedStorageTurnIndex,

--- a/src/web-ui/src/infrastructure/api/service-api/AgentAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/AgentAPI.ts
@@ -357,6 +357,8 @@ export type LoadSessionTurnWindowResponse =
 
 export interface RollbackSessionToTurnRequest {
   workspacePath: string;
+  workspaceId?: string;
+  workspaceHostname?: string;
   sessionId: string;
   targetTurnId: string;
   expectedStorageTurnIndex?: number;

--- a/tests/e2e/config/wdio.conf_l1.ts
+++ b/tests/e2e/config/wdio.conf_l1.ts
@@ -15,6 +15,7 @@ export const config = createEmbeddedConfig(
     '../specs/l1-dialog.spec.ts',
     '../specs/l1-chat.spec.ts',
     '../specs/l1-chat-scroll-whitespace.spec.ts',
+    '../specs/l1-local-rollback-path-collision.spec.ts',
   ],
   'L1'
 );

--- a/tests/e2e/specs/l1-local-rollback-path-collision.spec.ts
+++ b/tests/e2e/specs/l1-local-rollback-path-collision.spec.ts
@@ -1,0 +1,166 @@
+/**
+ * L1 regression coverage for local rollback when an SSH workspace has the
+ * same absolute path.
+ */
+
+import { browser, expect } from '@wdio/globals';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+type WorkspaceInfo = {
+  id: string;
+  rootPath: string;
+};
+
+type InvokeResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: string };
+
+async function invoke<T>(command: string, args: unknown): Promise<InvokeResult<T>> {
+  return browser.execute(async (targetCommand: string, targetArgs: unknown) => {
+    const tauri = (window as typeof window & {
+      __TAURI__?: {
+        core?: {
+          invoke?: (command: string, args?: unknown) => Promise<unknown>;
+        };
+      };
+    }).__TAURI__;
+    const tauriInvoke = tauri?.core?.invoke;
+    if (typeof tauriInvoke !== 'function') {
+      return { ok: false as const, error: 'Tauri invoke is unavailable' };
+    }
+
+    try {
+      return {
+        ok: true as const,
+        value: await tauriInvoke(targetCommand, targetArgs) as T,
+      };
+    } catch (error) {
+      return { ok: false as const, error: String(error) };
+    }
+  }, command, args);
+}
+
+async function invokeExpectingFailure(command: string, args: unknown): Promise<string> {
+  const driverPort = Number(process.env.BITFUN_E2E_WEBDRIVER_PORT || 4445);
+  const response = await fetch(
+    `http://127.0.0.1:${driverPort}/session/${browser.sessionId}/execute/sync`,
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        script: `return (async (command, args) => {
+          return window.__TAURI__.core.invoke(command, args);
+        }).apply(null, arguments);`,
+        args: [command, args],
+      }),
+    },
+  );
+  const payload = await response.json() as {
+    value?: { message?: string } | string;
+  };
+  expect(response.ok).toBe(false);
+  return typeof payload.value === 'string'
+    ? payload.value
+    : payload.value?.message || JSON.stringify(payload.value);
+}
+
+describe('L1 Local rollback workspace identity', () => {
+  const connectionId = 'e2e-rollback-path-collision';
+  let fixtureRoot = '';
+  let localWorkspaceId: string | null = null;
+  let remoteWorkspaceId: string | null = null;
+
+  before(() => {
+    fixtureRoot = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'bitfun-rollback-collision-e2e-')),
+    );
+  });
+
+  it('uses explicit local identity when a registered SSH workspace has the same path', async () => {
+    const remoteOpen = await invoke<WorkspaceInfo>('open_remote_workspace', {
+      request: {
+        remotePath: fixtureRoot,
+        connectionId,
+        connectionName: 'E2E rollback collision',
+        sshHost: 'rollback-collision.example',
+      },
+    });
+    expect(remoteOpen.ok).toBe(true);
+    if (!remoteOpen.ok) {
+      throw new Error(remoteOpen.error);
+    }
+    remoteWorkspaceId = remoteOpen.value.id;
+    expect(remoteWorkspaceId.startsWith('remote_')).toBe(true);
+
+    const localOpen = await invoke<WorkspaceInfo>('open_workspace', {
+      request: { path: fixtureRoot },
+    });
+    expect(localOpen.ok).toBe(true);
+    if (!localOpen.ok) {
+      throw new Error(localOpen.error);
+    }
+    localWorkspaceId = localOpen.value.id;
+    expect(localWorkspaceId.startsWith('local_')).toBe(true);
+    expect(localWorkspaceId).not.toBe(remoteWorkspaceId);
+
+    const baseRequest = {
+      workspacePath: fixtureRoot,
+      sessionId: 'e2e-rollback-collision-session',
+      targetTurnId: 'e2e-rollback-collision-turn',
+    };
+
+    const legacyError = await invokeExpectingFailure('rollback_session_to_turn', {
+      request: baseRequest,
+    });
+    expect(legacyError).toContain('not supported for remote workspaces');
+
+    const localIdentityError = await invokeExpectingFailure('rollback_session_to_turn', {
+      request: {
+        ...baseRequest,
+        workspaceId: localWorkspaceId,
+        workspaceHostname: 'localhost',
+      },
+    });
+    expect(localIdentityError).not.toContain('not supported for remote workspaces');
+    expect(localIdentityError).not.toContain('unavailable for remote workspaces');
+
+    const conflictingRemoteError = await invokeExpectingFailure('rollback_session_to_turn', {
+      request: {
+        ...baseRequest,
+        workspaceId: localWorkspaceId,
+        workspaceHostname: 'localhost',
+        remoteConnectionId: connectionId,
+      },
+    });
+    expect(conflictingRemoteError).toContain('not supported for remote workspaces');
+  });
+
+  after(async () => {
+    if (remoteWorkspaceId) {
+      await invoke('close_workspace', {
+        request: { workspaceId: remoteWorkspaceId },
+      });
+    } else if (fixtureRoot) {
+      await invoke('remote_remove_workspace', {
+        connectionId,
+        remotePath: fixtureRoot,
+      });
+    }
+
+    if (localWorkspaceId) {
+      await invoke('close_workspace', {
+        request: { workspaceId: localWorkspaceId },
+      });
+    }
+
+    if (
+      fixtureRoot
+      && path.basename(fixtureRoot).startsWith('bitfun-rollback-collision-e2e-')
+      && fs.existsSync(fixtureRoot)
+    ) {
+      fs.rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- pass stable workspace identity through targeted rollback requests
- prefer explicit local/remote identity over the legacy path registry fallback
- preserve path-only behavior for older clients and keep explicit remote facts authoritative
- cover Desktop, CLI Peer Host, frontend request mapping, and the same-path collision with an isolated Desktop E2E test

## Root cause

Targeted rollback classified a workspace as remote using only `workspacePath`. A registered SSH workspace could therefore make a local session with the same absolute path fail before rollback reached the local session runtime.

## Verification

- `pnpm run fmt:rs`
- `pnpm --dir src/web-ui run test:run src/flow_chat/services/SessionRollbackService.test.ts`
- `pnpm run type-check:web`
- `cargo test --locked -p bitfun-runtime-ports --no-default-features --features agent-api --lib`
- `cargo test -p bitfun-desktop api::snapshot_service::tests -- --nocapture`
- `cargo test -p bitfun-cli peer_host::commands::snapshot::tests -- --nocapture`
- `cargo build -p bitfun-desktop`
- `BITFUN_E2E_APP_MODE=debug E2E_LOG_LEVEL=warn pnpm --dir tests/e2e exec wdio run ./config/wdio.conf.ts --spec "./specs/l1-local-rollback-path-collision.spec.ts"`
- `node scripts/check-core-boundaries.mjs`

The E2E creates local and SSH workspaces with the exact same canonical absolute path. It verifies legacy fallback rejection, explicit local disambiguation, and explicit remote precedence. SSH state stays under the isolated E2E storage root.

Remote scenarios exercised: local Desktop with a registered SSH workspace collision; Peer Host command coverage. No protocol behavior changes for Remote Control or Detached Dispatch.

Fixes #2375