### PR TITLE
fix(peer): route Tauri events once

### DIFF
--- a/src/web-ui/src/infrastructure/api/adapters/tauri-adapter.test.ts
+++ b/src/web-ui/src/infrastructure/api/adapters/tauri-adapter.test.ts
@@ -1,19 +1,29 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { isExpectedTauriRequestError, TauriTransportAdapter } from './tauri-adapter';
+import {
+  beginRuntimeSessionAttachment,
+  resetRuntimeSessionEventGateForTest,
+  RUNTIME_EVENT_CURSOR_KEY,
+  RUNTIME_EVENT_STREAM_ID_KEY,
+} from '@/infrastructure/peer-device/runtimeSessionEventGate';
+import { setActiveSurfaceDeviceId } from '@/infrastructure/peer-device/deviceSurfaceRouting';
 
 const invokeMock = vi.hoisted(() => vi.fn());
+const listenMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: invokeMock,
 }));
 
 vi.mock('@tauri-apps/api/event', () => ({
-  listen: vi.fn(),
+  listen: listenMock,
 }));
 
 describe('Tauri adapter expected errors', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetRuntimeSessionEventGateForTest();
+    setActiveSurfaceDeviceId(null);
   });
 
   it('classifies optional get_config not found as expected', () => {
@@ -81,5 +91,119 @@ describe('Tauri adapter expected errors', () => {
     expect(timing.adapterInitDurationMs).toEqual(expect.any(Number));
     expect(timing.invokeDurationMs).toEqual(expect.any(Number));
     expect(timing.transportDurationMs).toEqual(expect.any(Number));
+  });
+
+  it('routes a positioned Tauri event once across adapter instances', async () => {
+    const handlers = new Map<string, (event: { payload: unknown }) => void>();
+    const underlyingUnlisten = vi.fn();
+    listenMock.mockImplementation(async (event: string, handler: (event: { payload: unknown }) => void) => {
+      handlers.set(event, handler);
+      return underlyingUnlisten;
+    });
+
+    const firstAdapter = new TauriTransportAdapter();
+    const secondAdapter = new TauriTransportAdapter();
+    const first = vi.fn();
+    const second = vi.fn();
+    const unlistenFirst = firstAdapter.listen('agentic://dialog-turn-completed', first);
+    await firstAdapter.waitForListenerRegistrations();
+    const unlistenSecond = secondAdapter.listen('agentic://dialog-turn-completed', second);
+    await secondAdapter.waitForListenerRegistrations();
+
+    expect(listenMock).toHaveBeenCalledTimes(1);
+    handlers.get('agentic://dialog-turn-completed')?.({
+      payload: {
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        success: true,
+        [RUNTIME_EVENT_STREAM_ID_KEY]: 'runtime-1',
+        [RUNTIME_EVENT_CURSOR_KEY]: 14,
+      },
+    });
+
+    const expectedPayload = {
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      success: true,
+    };
+    expect(first).toHaveBeenCalledOnce();
+    expect(first).toHaveBeenCalledWith(expectedPayload);
+    expect(second).toHaveBeenCalledOnce();
+    expect(second).toHaveBeenCalledWith(expectedPayload);
+
+    unlistenFirst();
+    expect(underlyingUnlisten).not.toHaveBeenCalled();
+    unlistenSecond();
+    expect(underlyingUnlisten).toHaveBeenCalledOnce();
+  });
+
+  it('disconnects only the subscriptions owned by that adapter', async () => {
+    const handlers = new Map<string, (event: { payload: unknown }) => void>();
+    const underlyingUnlisten = vi.fn();
+    listenMock.mockImplementation(async (event: string, handler: (event: { payload: unknown }) => void) => {
+      handlers.set(event, handler);
+      return underlyingUnlisten;
+    });
+
+    const firstAdapter = new TauriTransportAdapter();
+    const secondAdapter = new TauriTransportAdapter();
+    const first = vi.fn();
+    const second = vi.fn();
+    firstAdapter.listen('account://login-state', first);
+    secondAdapter.listen('account://login-state', second);
+    await Promise.all([
+      firstAdapter.waitForListenerRegistrations(),
+      secondAdapter.waitForListenerRegistrations(),
+    ]);
+
+    await firstAdapter.disconnect();
+    expect(underlyingUnlisten).not.toHaveBeenCalled();
+
+    handlers.get('account://login-state')?.({ payload: { logged_in: true } });
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledOnce();
+    expect(second).toHaveBeenCalledWith({ logged_in: true });
+
+    await secondAdapter.disconnect();
+    expect(underlyingUnlisten).toHaveBeenCalledOnce();
+  });
+
+  it('releases a held event to the subscribers that owned it on arrival', async () => {
+    const handlers = new Map<string, (event: { payload: unknown }) => void>();
+    listenMock.mockImplementation(async (event: string, handler: (event: { payload: unknown }) => void) => {
+      handlers.set(event, handler);
+      return vi.fn();
+    });
+
+    const firstAdapter = new TauriTransportAdapter();
+    const first = vi.fn();
+    const unlistenFirst = firstAdapter.listen('agentic://text-chunk', first);
+    await firstAdapter.waitForListenerRegistrations();
+
+    const attachment = beginRuntimeSessionAttachment('local', 'session-1');
+    handlers.get('agentic://text-chunk')?.({
+      payload: {
+        sessionId: 'session-1',
+        text: 'held',
+        [RUNTIME_EVENT_STREAM_ID_KEY]: 'runtime-1',
+        [RUNTIME_EVENT_CURSOR_KEY]: 2,
+      },
+    });
+    unlistenFirst();
+
+    const secondAdapter = new TauriTransportAdapter();
+    const second = vi.fn();
+    const unlistenSecond = secondAdapter.listen('agentic://text-chunk', second);
+    await secondAdapter.waitForListenerRegistrations();
+
+    attachment.finish({ streamId: 'runtime-1', cursor: 1 });
+    expect(first).toHaveBeenCalledOnce();
+    expect(first).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      text: 'held',
+    });
+    expect(second).not.toHaveBeenCalled();
+
+    unlistenSecond();
   });
 });

--- a/src/web-ui/src/infrastructure/api/adapters/tauri-adapter.ts
+++ b/src/web-ui/src/infrastructure/api/adapters/tauri-adapter.ts
@@ -11,6 +11,108 @@ import { sanitizeErrorForLog } from '../logSanitizer';
 
 const log = createLogger('TauriAdapter');
 
+interface SharedTauriEventListener {
+  subscriptions: Set<TauriEventSubscription>;
+  unlistenFn: UnlistenFn | null;
+  registrationPromise: Promise<void> | null;
+  closed: boolean;
+}
+
+interface TauriEventSubscription {
+  owner: TauriTransportAdapter;
+  event: string;
+  callback: (data: unknown) => void;
+  listener: SharedTauriEventListener;
+  active: boolean;
+}
+
+// The Tauri event bus is window-wide, while Peer Device Mode keeps multiple
+// transport adapters alive. Route each native event once before fan-out so a
+// positioned Session event cannot consume its cursor once per adapter.
+const sharedTauriEventListeners = new Map<string, SharedTauriEventListener>();
+
+function closeSharedTauriEventListener(
+  event: string,
+  shared: SharedTauriEventListener,
+): void {
+  if (shared.closed) {
+    return;
+  }
+  shared.closed = true;
+  if (sharedTauriEventListeners.get(event) === shared) {
+    sharedTauriEventListeners.delete(event);
+  }
+  if (shared.unlistenFn) {
+    try {
+      shared.unlistenFn();
+    } catch (error) {
+      log.error('Error while unlistening', sanitizeErrorForLog(error));
+    }
+    shared.unlistenFn = null;
+  }
+}
+
+function registerSharedTauriEventListener(
+  event: string,
+  shared: SharedTauriEventListener,
+): Promise<void> {
+  const registration = listen<unknown>(event, (e) => {
+    if (shared.closed) {
+      return;
+    }
+
+    // Capture the logical listeners that owned the event when it arrived. A
+    // Session read may hold delivery after accepting the write; those owners
+    // must still paint it when released, while later subscribers must not
+    // receive the native event retroactively.
+    const subscriptions = [...shared.subscriptions];
+
+    // Peer devices stay attached while the UI renders another device, so
+    // several product event streams share this bus. Only the rendered device
+    // surface may reach product listeners.
+    const route = routeSurfaceEvent(event, e.payload);
+    if (!route.deliver) {
+      return;
+    }
+
+    routeRuntimeSessionEvent(
+      surfaceIdForDevice(route.sourceDeviceId),
+      event,
+      route.payload,
+      payload => {
+        for (const subscription of subscriptions) {
+          try {
+            subscription.callback(payload);
+          } catch (error) {
+            log.error('Error in event listener callback', {
+              event,
+              error: sanitizeErrorForLog(error),
+            });
+          }
+        }
+      },
+    );
+  }).then(fn => {
+    if (shared.closed || sharedTauriEventListeners.get(event) !== shared) {
+      fn();
+    } else {
+      shared.unlistenFn = fn;
+    }
+  }).catch(error => {
+    log.error('Failed to listen event', { event, error: sanitizeErrorForLog(error) });
+    if (sharedTauriEventListeners.get(event) === shared) {
+      sharedTauriEventListeners.delete(event);
+    }
+    shared.closed = true;
+  }).finally(() => {
+    if (shared.registrationPromise === registration) {
+      shared.registrationPromise = null;
+    }
+  });
+  shared.registrationPromise = registration;
+  return registration;
+}
+
 export function isExpectedTauriRequestError(action: string, params: unknown, error: unknown): boolean {
   if (action !== 'get_config') {
     return false;
@@ -31,11 +133,11 @@ export function isExpectedTauriRequestError(action: string, params: unknown, err
 }
 
 export class TauriTransportAdapter implements ITransportAdapter {
-  private unlistenFunctions: UnlistenFn[] = [];
   private connected: boolean = false;
   private invokeFn: ((action: string, params?: any) => Promise<any>) | null = null;
   private initPromise: Promise<void> | null = null;
   private listenerRegistrationPromises = new Set<Promise<void>>();
+  private eventSubscriptions = new Set<TauriEventSubscription>();
 
   supportsSearchStreamEvents(): boolean {
     return true;
@@ -125,69 +227,62 @@ export class TauriTransportAdapter implements ITransportAdapter {
   }
 
   listen<T>(event: string, callback: (data: T) => void): () => void {
-    let unlistenFn: UnlistenFn | null = null;
-    let isUnlistened = false;
+    let shared = sharedTauriEventListeners.get(event);
+    let needsRegistration = false;
+    if (!shared) {
+      shared = {
+        subscriptions: new Set(),
+        unlistenFn: null,
+        registrationPromise: null,
+        closed: false,
+      };
+      sharedTauriEventListeners.set(event, shared);
+      needsRegistration = true;
+    }
 
-    const registration = listen<T>(event, (e) => {
-      if (!isUnlistened) {
-        // Peer devices stay attached while the UI renders another device, so
-        // several product event streams share this bus. Only the rendered
-        // device surface may reach product listeners.
-        const route = routeSurfaceEvent(event, e.payload);
-        if (!route.deliver) {
-          return;
-        }
-        routeRuntimeSessionEvent(
-          surfaceIdForDevice(route.sourceDeviceId),
-          event,
-          route.payload,
-          payload => {
-            try {
-              callback(payload);
-            } catch (error) {
-              log.error('Error in event listener callback', {
-                event,
-                error: sanitizeErrorForLog(error),
-              });
-            }
-          },
-        );
-      }
-    }).then(fn => {
-      if (isUnlistened) {
-        fn();
-      } else {
-        unlistenFn = fn;
-        this.unlistenFunctions.push(fn);
-      }
-    }).catch(error => {
-      log.error('Failed to listen event', { event, error: sanitizeErrorForLog(error) });
-    }).finally(() => {
+    const subscription: TauriEventSubscription = {
+      owner: this,
+      event,
+      callback: callback as (data: unknown) => void,
+      listener: shared,
+      active: true,
+    };
+    shared.subscriptions.add(subscription);
+    this.eventSubscriptions.add(subscription);
+
+    const registration = needsRegistration
+      ? registerSharedTauriEventListener(event, shared)
+      : shared.registrationPromise;
+    if (registration) {
+      this.trackListenerRegistration(registration);
+    }
+
+    return () => this.removeEventSubscription(subscription);
+  }
+
+  private trackListenerRegistration(registration: Promise<void>): void {
+    this.listenerRegistrationPromises.add(registration);
+    void registration.finally(() => {
       this.listenerRegistrationPromises.delete(registration);
     });
-    this.listenerRegistrationPromises.add(registration);
+  }
 
-    return () => {
-      isUnlistened = true;
-      if (unlistenFn) {
-        unlistenFn();
-        const index = this.unlistenFunctions.indexOf(unlistenFn);
-        if (index > -1) {
-          this.unlistenFunctions.splice(index, 1);
-        }
-      }
-    };
+  private removeEventSubscription(subscription: TauriEventSubscription): void {
+    if (!subscription.active || subscription.owner !== this) {
+      return;
+    }
+    subscription.active = false;
+    subscription.listener.subscriptions.delete(subscription);
+    this.eventSubscriptions.delete(subscription);
+    if (subscription.listener.subscriptions.size === 0) {
+      closeSharedTauriEventListener(subscription.event, subscription.listener);
+    }
   }
 
   async disconnect(): Promise<void> {
-    this.unlistenFunctions.forEach(fn => {
-      try {
-        fn();
-      } catch (error) {
-        log.error('Error while unlistening', sanitizeErrorForLog(error));
-      }
-    });
-    this.unlistenFunctions = [];
+    for (const subscription of [...this.eventSubscriptions]) {
+      this.removeEventSubscription(subscription);
+    }
     this.connected = false;
   }
 


### PR DESCRIPTION
## Summary

Fixes the busy-hang where a conversation never settles after a turn completes, so every later message is stuck in the pending queue and only a new conversation recovers.

`14c4b5c73` (#2325) moved the stateful runtime-session cursor routing into every *logical* Tauri listener. `SessionStream` is a per-`(surface, session)` ordering gate whose cursor dedup exists to suppress a re-delivered event (snapshot/live overlap), so it must decide about a **delivery**. With one native listener per logical subscriber, a single delivery was pushed through that gate once per subscriber: the first advanced the applied cursor, and every later subscriber was refused as `not-ahead` and dropped.

`agentic://dialog-turn-completed` has several independent subscribers (turn settlement in `AgenticEventListener`, `useAssistantBootstrap`, `useDialogCompletionNotify`, `useAcpPlan`), so which one received it depended on registration order. Whenever the settlement subscriber was not the winner, the frontend state machine stayed in `PROCESSING` forever. `agentic://dialog-turn-started` and `agentic://dialog-turn-interrupted` have a single subscriber each, which is why only the terminal event was affected.

This cherry-picks the fix from `1.0.0-explore` (`5bb566c14`, authored by @wsp) onto `main` unchanged, so the two branches do not diverge. Each native Tauri listener is shared across all adapter instances, surface and cursor routing run once per delivery, and logical subscribers are then fanned out. Subscription ownership stays isolated per adapter and held-event delivery semantics are preserved — that also closes the cross-adapter variant that Peer Device Mode can hit while several transport adapters are alive.

Closes #2381

## Runtime evidence

Diagnosed on macOS Desktop with instrumentation at the emit site, the host delivery site, the surface gate, the `SessionStream` admission point and the settlement handler.

Before, for every completed turn: the backend emitted once (`emit_lifecycle_events: true`, `success: true`) and the host delivered once, but the webview surface gate saw the event **3 times** and `SessionStream` returned **1 `apply` + 2 `drop`**. On the reproducing run the settlement subscriber was a `drop`, so `handleDialogTurnComplete` never ran and the machine stayed in `PROCESSING` while the backend was already `Idle` with the turn persisted.

After, across 13 consecutive turns in 5 sessions: **1 arrival, 1 `apply`, 0 `drop`** per completed turn, settlement reached `finalizeTurnCompletionState` 13/13, and 3 messages queued while busy all drained.

Note for the issue reporter: the report attributed the regression to #2372 lock contention. Instrumentation rejected that — the completion path held the mutation lock for ~4 ms, the backend reset to `Idle` correctly, and the second message was never submitted to the backend at all. The regression source is #2325.

## Test plan

- [x] `pnpm --dir src/web-ui run test:run src/infrastructure/api/adapters src/infrastructure/peer-device src/flow_chat/session-stream` — 14 files, 137 tests pass
- [x] `pnpm run type-check:web` — no errors in changed files (3 pre-existing `@/generated/api` errors come from the gitignored codegen artifact, `.gitignore:51`)
- [x] Desktop, local workspace: 13 turns across 5 sessions settle, including turns with 13/20/28/31/40 tool rounds, session switches mid-turn, and messages queued while busy
- [ ] Peer Device Mode cross-adapter fan-out — covered by the added regression tests, not exercised on hardware