### PR TITLE
chore(appearance): sync create-bitfun-skin contract

### DIFF
--- a/src/crates/assembly/core/builtin_skills/create-bitfun-skin/SKILL.md
+++ b/src/crates/assembly/core/builtin_skills/create-bitfun-skin/SKILL.md
@@ -105,6 +105,8 @@ Treat the bundled registry as the offline authority. Confirm it before targeting
 python scripts/sync_registry.py <bitfun-repo> --check
 ```
 
+The check compares the exported Appearance contract, not provenance-only commit or timestamp fields. Unrelated BitFun commits do not invalidate a compatible snapshot.
+
 Refresh it only from a clean checkout after BitFun changes Appearance descriptors:
 
 ```powershell

--- a/src/crates/assembly/core/builtin_skills/create-bitfun-skin/examples/cinematic-animated-wallpaper/references/surface-plan.json
+++ b/src/crates/assembly/core/builtin_skills/create-bitfun-skin/examples/cinematic-animated-wallpaper/references/surface-plan.json
@@ -3,7 +3,7 @@
   "schemaVersion": 1,
   "scope": "example-style-selection",
   "styleId": "cinematic-animated-wallpaper",
-  "validatedAgainstRegistryRevision": "71fbdbb26757c930eedfef5cfda55ca12e008ae1",
+  "validatedAgainstRegistryRevision": "869bde45876aaf486a2e339bc37afa6343e30e3f",
   "scenes": {
     "workbench": {
       "parts": {

--- a/src/crates/assembly/core/builtin_skills/create-bitfun-skin/examples/cinematic-animated-wallpaper/references/surface-plan.json
+++ b/src/crates/assembly/core/builtin_skills/create-bitfun-skin/examples/cinematic-animated-wallpaper/references/surface-plan.json
@@ -3,7 +3,7 @@
   "schemaVersion": 1,
   "scope": "example-style-selection",
   "styleId": "cinematic-animated-wallpaper",
-  "validatedAgainstRegistryRevision": "869bde45876aaf486a2e339bc37afa6343e30e3f",
+  "validatedAgainstRegistryRevision": "b5869b8d2ff5ffd03a558e0839e8a96837873c11",
   "scenes": {
     "workbench": {
       "parts": {

--- a/src/crates/assembly/core/builtin_skills/create-bitfun-skin/references/appearance-registry.json
+++ b/src/crates/assembly/core/builtin_skills/create-bitfun-skin/references/appearance-registry.json
@@ -1,9 +1,9 @@
 {
   "schema": "bitfun.appearance.registry",
   "schemaVersion": 1,
-  "generatedFrom": "869bde45876aaf486a2e339bc37afa6343e30e3f",
-  "generatedAt": "2026-08-20T07:09:03.732279+00:00",
-  "sourceRevision": "869bde45876aaf486a2e339bc37afa6343e30e3f",
+  "generatedFrom": "b5869b8d2ff5ffd03a558e0839e8a96837873c11",
+  "generatedAt": "2026-08-21T10:23:12.731577+00:00",
+  "sourceRevision": "b5869b8d2ff5ffd03a558e0839e8a96837873c11",
   "sourceDirty": false,
   "sourceTreeHash": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
   "components": [
@@ -5455,6 +5455,20 @@
       ],
       "facets": [],
       "states": [
+        {
+          "id": "active",
+          "selector": {
+            "kind": "self",
+            "suffix": "[data-bf-state~=\"active\"]"
+          }
+        },
+        {
+          "id": "completed",
+          "selector": {
+            "kind": "self",
+            "suffix": "[data-bf-state~=\"completed\"]"
+          }
+        },
         {
           "id": "cancelled",
           "selector": {

--- a/src/crates/assembly/core/builtin_skills/create-bitfun-skin/references/appearance-registry.json
+++ b/src/crates/assembly/core/builtin_skills/create-bitfun-skin/references/appearance-registry.json
@@ -1,9 +1,9 @@
 {
   "schema": "bitfun.appearance.registry",
   "schemaVersion": 1,
-  "generatedFrom": "bc77e2c28c7b847abc175b6307ac18f84a89265a",
-  "generatedAt": "2026-08-16T16:09:40.016459+00:00",
-  "sourceRevision": "bc77e2c28c7b847abc175b6307ac18f84a89265a",
+  "generatedFrom": "869bde45876aaf486a2e339bc37afa6343e30e3f",
+  "generatedAt": "2026-08-20T07:09:03.732279+00:00",
+  "sourceRevision": "869bde45876aaf486a2e339bc37afa6343e30e3f",
   "sourceDirty": false,
   "sourceTreeHash": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
   "components": [
@@ -3046,6 +3046,52 @@
     },
     {
       "id": "reasoning-preset-selector",
+      "parts": [
+        {
+          "id": "root",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "trigger",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "label",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "menu",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "header",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "option",
+          "propertyProfile": "container"
+        }
+      ],
+      "facets": [],
+      "states": [
+        {
+          "id": "open",
+          "selector": {
+            "kind": "self",
+            "suffix": "[data-bf-state~=\"open\"]"
+          }
+        },
+        {
+          "id": "selected",
+          "selector": {
+            "kind": "self",
+            "suffix": "[data-bf-state~=\"selected\"]"
+          }
+        }
+      ]
+    },
+    {
+      "id": "acp-mode-selector",
       "parts": [
         {
           "id": "root",
@@ -11352,6 +11398,41 @@
       ]
     },
     {
+      "id": "usage-statistics-config",
+      "parts": [
+        {
+          "id": "root",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "filters",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "summary",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "distributions",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "modelHitRate",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "trendPanel",
+          "propertyProfile": "container"
+        },
+        {
+          "id": "empty",
+          "propertyProfile": "container"
+        }
+      ],
+      "facets": [],
+      "states": []
+    },
+    {
       "id": "settings-nav",
       "parts": [
         {
@@ -15839,37 +15920,10 @@
         {
           "id": "root",
           "propertyProfile": "container"
-        },
-        {
-          "id": "content",
-          "propertyProfile": "container"
-        },
-        {
-          "id": "expanded",
-          "propertyProfile": "container"
-        },
-        {
-          "id": "section",
-          "propertyProfile": "container"
-        },
-        {
-          "id": "label",
-          "propertyProfile": "container"
-        },
-        {
-          "id": "description",
-          "propertyProfile": "container"
         }
       ],
       "facets": [],
       "states": [
-        {
-          "id": "expanded",
-          "selector": {
-            "kind": "self",
-            "suffix": "[data-bf-state~=\"expanded\"]"
-          }
-        },
         {
           "id": "failed",
           "selector": {

--- a/src/crates/assembly/core/builtin_skills/create-bitfun-skin/references/package-contract.md
+++ b/src/crates/assembly/core/builtin_skills/create-bitfun-skin/references/package-contract.md
@@ -117,7 +117,7 @@ The package rejects unsafe ZIP paths, symlinks, undeclared files, unsupported me
 
 ## Registry provenance
 
-`appearance-registry.json` is a self-contained production registry snapshot. Consumers of this skill do not need BitFun source code for offline authoring. Query the snapshot through the script instead of editing it by hand. When a checkout is available, run `python scripts/sync_registry.py <bitfun-repo> --check` before relying on the snapshot.
+`appearance-registry.json` is a self-contained production registry snapshot. Consumers of this skill do not need BitFun source code for offline authoring. Query the snapshot through the script instead of editing it by hand. When a checkout is available, run `python scripts/sync_registry.py <bitfun-repo> --check` before relying on the snapshot. The check compares exported contract content and ignores provenance-only commit or timestamp differences.
 
 Maintainers synchronize it with `scripts/sync_registry.py`. Provenance includes the source revision, dirty state, tree evidence hash, and generation timestamp; a matching commit hash alone does not prove that a dirty working tree is synchronized.
 

--- a/src/crates/assembly/core/builtin_skills/create-bitfun-skin/scripts/sync_registry.py
+++ b/src/crates/assembly/core/builtin_skills/create-bitfun-skin/scripts/sync_registry.py
@@ -14,10 +14,26 @@ from typing import Any
 
 
 DEFAULT_OUTPUT = Path(__file__).resolve().parent.parent / "references" / "appearance-registry.json"
+CONTRACT_KEYS = (
+    "components",
+    "scenes",
+    "renderers",
+    "defaultForceableProperties",
+    "cssTokenNames",
+    "widgetVariableNames",
+)
 
 
 class SyncError(Exception):
     pass
+
+
+def contract_view(value: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "schema": value.get("schema"),
+        "schemaVersion": value.get("schemaVersion"),
+        **{key: value.get(key) for key in CONTRACT_KEYS},
+    }
 
 
 def run(command: list[str], cwd: Path) -> str:
@@ -114,16 +130,15 @@ def main() -> int:
                 current = json.loads(output.read_text(encoding="utf-8"))
             except (OSError, json.JSONDecodeError) as error:
                 raise SyncError(f"Could not read bundled registry: {error}") from error
-            comparable_expected = {key: value for key, value in output_value.items() if key != "generatedAt"}
-            comparable_current = {key: value for key, value in current.items() if key != "generatedAt"}
-            if comparable_current != comparable_expected:
+            if contract_view(current) != contract_view(output_value):
                 raise SyncError(
                     "Bundled registry differs from the selected BitFun checkout; "
                     "run sync_registry.py without --check to refresh it"
                 )
             print(json.dumps({
                 "output": str(output),
-                "revision": revision,
+                "snapshotRevision": current.get("sourceRevision"),
+                "checkoutRevision": revision,
                 "dirty": dirty,
                 "synchronized": True,
             }, indent=2))

--- a/src/crates/assembly/core/builtin_skills/create-bitfun-skin/scripts/test_bitfun_appearance.py
+++ b/src/crates/assembly/core/builtin_skills/create-bitfun-skin/scripts/test_bitfun_appearance.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import unittest
 
 import bitfun_appearance as appearance
+import sync_registry as registry_sync
 
 
 def base_manifest() -> dict[str, object]:
@@ -111,6 +112,30 @@ class ManifestValidatorTests(unittest.TestCase):
         formatted_button = appearance.format_descriptor(button, "component")
         self.assertTrue(formatted_button["states"])
         self.assertTrue(all("selector" in state for state in formatted_button["states"]))
+
+    def test_registry_contract_comparison_ignores_provenance_only_changes(self) -> None:
+        current = {
+            "schema": "bitfun.appearance.registry",
+            "schemaVersion": 1,
+            "sourceRevision": "old-revision",
+            "generatedAt": "old-time",
+            **{key: [] for key in registry_sync.CONTRACT_KEYS},
+        }
+        checkout = {
+            **current,
+            "sourceRevision": "new-revision",
+            "generatedAt": "new-time",
+        }
+        self.assertEqual(
+            registry_sync.contract_view(current),
+            registry_sync.contract_view(checkout),
+        )
+
+        checkout["components"] = [{"id": "new-component"}]
+        self.assertNotEqual(
+            registry_sync.contract_view(current),
+            registry_sync.contract_view(checkout),
+        )
 
 
 if __name__ == "__main__":

--- a/src/crates/assembly/core/builtin_skills/create-bitfun-skin/scripts/test_cinematic_tools.py
+++ b/src/crates/assembly/core/builtin_skills/create-bitfun-skin/scripts/test_cinematic_tools.py
@@ -64,7 +64,10 @@ class CinematicContractTests(unittest.TestCase):
         plan = contract.load_surface_plan()
         self.assertEqual("example-style-selection", plan["scope"])
         self.assertEqual("cinematic-animated-wallpaper", plan["styleId"])
-        self.assertIsInstance(plan["validatedAgainstRegistryRevision"], str)
+        self.assertEqual(
+            build_support.registry_provenance()["sourceRevision"],
+            plan["validatedAgainstRegistryRevision"],
+        )
         resolved = contract.resolve_palette_values(plan, palette["colors"])
         serialized = json.dumps(resolved)
         self.assertNotIn('"kind": "palette"', serialized)


### PR DESCRIPTION
## Summary

- Sync the bundled `create-bitfun-skin` skill with the current BitFun Appearance contract.
- Refresh the registry snapshot to 255 components, 19 scenes, and 6 renderer adapters.
- Make registry checks compare contract content instead of provenance-only revisions.
- Add regression coverage for registry comparison and cinematic surface-plan provenance.

Fixes #

## Type and Areas

Type:

Bug fix / docs / test

Areas:

Rust core built-in Agent skills, Web UI Appearance contract, developer tooling

## Motivation / Impact

The bundled skin-authoring skill had an outdated Appearance registry. It could not discover newly registered surfaces and could accept owners that have since been removed.

Registry synchronization also compared the BitFun checkout commit directly, causing unrelated commits to report a false contract mismatch. The updated check compares exported contract content while retaining revision metadata for provenance.

Existing Appearance packages remain compatible. Twelve existing example skins were verified against the current production Validator and Compiler with no errors or warnings.

## Verification

- `python <skill-creator>/scripts/quick_validate.py <create-bitfun-skin-path>`
  - Passed for both the standalone and bundled skill.
- `python -B scripts/test_bitfun_appearance.py`
  - 6 tests passed.
- `python -B scripts/test_cinematic_tools.py`
  - 6 tests passed, including the complete build/check pipeline.
- `python scripts/sync_registry.py <bitfun-repo> --check`
  - Passed from a clean checkout after the commit, despite the provenance revision differing from the new repository HEAD.
- `cargo test -p bitfun-core --no-default-features --features agent-runtime --lib create_bitfun_skin_embeds_authoring_contract_and_example`
  - 1 test passed; 1,415 tests filtered out.
  - Existing unrelated unused-import warnings remain.
- `git diff --check`
  - Passed.
- Batch host verification of 12 existing `.bitfun-appearance` examples:
  - 12/12 accepted by the current production Validator and Compiler.
  - No errors or warnings.

Remote workspace, remote control, Peer Device Mode, and Detached Dispatch were not exercised because this change only updates bundled skill content and offline authoring validation.

## Reviewer Notes

- The registry snapshot records the clean source revision from which the Appearance contract was exported.
- The snapshot revision is intentionally not required to equal the commit containing the generated file. `--check` now detects actual contract drift rather than unrelated repository commits.
- No package schema, persisted data, runtime behavior, or migration contract changed.
- Existing skins do not need rebuilding or version bumps solely because of this registry refresh.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.