### PR TITLE
fix(web-ui): give portaled overlays their own stacking layer

### DIFF
--- a/src/web-ui/src/component-library/styles/tokens.scss
+++ b/src/web-ui/src/component-library/styles/tokens.scss
@@ -74,6 +74,14 @@ $z-overlay: 100;
 $z-modal: 200;
 $z-modal-active: 250;
 $z-fullscreen: 280;
+// The appearance overlay host owns this single level in the document, and every
+// portaled overlay stacks inside it. That is what lets detached UI clear the
+// container it escaped from whatever z-index that container picked — so a
+// container that hosts app UI (panels, canvases, the floating mini chat) has to
+// stay below this line. The overlay levels below only order overlays against
+// each other inside the host; chrome that must outrank every overlay keeps its
+// own level in the document instead.
+$z-overlay-host: 300;
 $z-tooltip: 350;
 $z-popover: 360;
 $z-notification: 400;

--- a/src/web-ui/src/infrastructure/appearance/runtime/AppearanceOverlayHost.scss
+++ b/src/web-ui/src/infrastructure/appearance/runtime/AppearanceOverlayHost.scss
@@ -1,0 +1,39 @@
+/**
+ * The one layer every portaled overlay lands in.
+ *
+ * An overlay portals out of its component subtree precisely because that
+ * subtree clips or out-stacks it. Landing it on a bare `<body>` child only
+ * moves the contest: the overlay's own z-index then competes, in the root
+ * stacking context, with whatever container it escaped from. A container that
+ * legitimately floats above app content — the floating mini chat panel at
+ * `$z-overlay + 1`, a maximized canvas — therefore paints over popovers that
+ * use the ordinary `$z-dropdown` level, which reads as a dead control: the menu
+ * opens behind the panel, and the panel's own backdrop takes the clicks.
+ *
+ * So the host itself takes one level, above every container that hosts app UI
+ * and below the chrome that must outrank overlays (notifications, context
+ * menus). Overlay z-indexes then only order overlays against each other, inside
+ * this stacking context.
+ *
+ * The box mirrors the initial containing block the host used to sit in, so
+ * absolutely positioned overlays resolve against the same rect as before.
+ * Nothing here may establish a containing block for fixed-position children —
+ * no transform, filter, backdrop-filter, will-change or contain — or every
+ * viewport-anchored overlay would shift.
+ */
+
+@use '../../../component-library/styles/tokens' as *;
+
+#bitfun-appearance-overlay-host {
+  position: fixed;
+  inset: 0;
+  z-index: $z-overlay-host;
+  // The layer spans the viewport; only the overlays in it are hit-testable.
+  pointer-events: none;
+}
+
+// Hand hit testing back to the overlays themselves. Zero specificity, so an
+// overlay that deliberately opts out — a tooltip — keeps its own declaration.
+:where(#bitfun-appearance-overlay-host) > :where(*) {
+  pointer-events: auto;
+}

--- a/src/web-ui/src/infrastructure/appearance/runtime/AppearanceOverlayHost.test.ts
+++ b/src/web-ui/src/infrastructure/appearance/runtime/AppearanceOverlayHost.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { getAppearanceOverlayHost } from './AppearanceOverlayHost';
+
+// Read as text rather than imported: the bundler hands stylesheets to the test
+// runner as empty modules, and these assertions are about the CSS itself.
+const readSource = (fromProjectRoot: string): string =>
+  readFileSync(resolve(process.cwd(), fromProjectRoot), 'utf8');
+
+const layerStyles = readSource('src/infrastructure/appearance/runtime/AppearanceOverlayHost.scss');
+const tokens = readSource('src/component-library/styles/tokens.scss');
+
+/** Numeric value of a `$z-*` token, so the ordering below is read, not assumed. */
+const zLevel = (token: string): number => {
+  const match = tokens.match(new RegExp(`^\\$${token}:\\s*(\\d+);`, 'm'));
+  if (!match) throw new Error(`missing z token: $${token}`);
+  return Number(match[1]);
+};
+
+/** The host's own rule block, without the child rule that follows it. */
+const hostRule = layerStyles.slice(
+  layerStyles.indexOf('#bitfun-appearance-overlay-host {'),
+  layerStyles.indexOf('}', layerStyles.indexOf('#bitfun-appearance-overlay-host {')),
+);
+
+describe('appearance overlay host', () => {
+  afterEach(() => {
+    document.getElementById('bitfun-appearance-overlay-host')?.remove();
+  });
+
+  it('mounts one reusable host on the body', () => {
+    const host = getAppearanceOverlayHost();
+
+    expect(host.parentElement).toBe(document.body);
+    expect(host.getAttribute('data-bf-overlay-host')).toBe('true');
+    expect(getAppearanceOverlayHost()).toBe(host);
+    expect(document.querySelectorAll('[data-bf-overlay-host]')).toHaveLength(1);
+  });
+
+  // The host is a stacking layer, not just a mount point. Drop either half and
+  // an overlay portaled out of a container that floats above app content — the
+  // floating mini chat panel, a maximized canvas — paints behind that container
+  // and never receives its clicks.
+  it('gives portaled overlays their own stacking context', () => {
+    expect(hostRule).toMatch(/position:\s*fixed/);
+    expect(hostRule).toMatch(/z-index:\s*\$z-overlay-host/);
+  });
+
+  it('stacks above containers that host app UI and below always-on-top chrome', () => {
+    expect(zLevel('z-overlay-host')).toBeGreaterThan(zLevel('z-overlay'));
+    expect(zLevel('z-overlay-host')).toBeLessThan(zLevel('z-notification'));
+    expect(zLevel('z-overlay-host')).toBeLessThan(zLevel('z-context-menu'));
+  });
+
+  // A containing block on the host would re-anchor every `position: fixed`
+  // overlay to the host box instead of the viewport, moving all of them.
+  it('never becomes a containing block for fixed-position overlays', () => {
+    expect(hostRule).not.toMatch(/(^|[^-])(transform|filter|backdrop-filter|will-change|contain):/);
+  });
+
+  it('keeps the layer itself click-through and its overlays hit-testable', () => {
+    expect(hostRule).toMatch(/pointer-events:\s*none/);
+    expect(layerStyles).toMatch(
+      /:where\(#bitfun-appearance-overlay-host\)\s*>\s*:where\(\*\)\s*\{\s*pointer-events:\s*auto/,
+    );
+  });
+});

--- a/src/web-ui/src/infrastructure/appearance/runtime/AppearanceOverlayHost.ts
+++ b/src/web-ui/src/infrastructure/appearance/runtime/AppearanceOverlayHost.ts
@@ -1,3 +1,14 @@
+/**
+ * Shared mount point for portaled overlays (menus, popovers, modals, tooltips).
+ *
+ * The host is a layer, not just a container: the stylesheet imported here gives
+ * it a stacking context above every container that hosts app UI, which is what
+ * keeps an overlay visible and clickable no matter how high the z-index of the
+ * subtree it portaled out of. See AppearanceOverlayHost.scss.
+ */
+
+import './AppearanceOverlayHost.scss';
+
 const OVERLAY_HOST_ID = 'bitfun-appearance-overlay-host';
 
 export function getAppearanceOverlayHost(): HTMLDivElement {


### PR DESCRIPTION
Same fix as https://github.com/GCWing/BitFun/pull/2389, cherry-picked onto `1.0.0-explore` — the overlay host and `.bitfun-fmc` are byte-identical on both branches, so the bug and the fix carry over unchanged.

## Summary

The `+` (add-boost) button in the floating chat bubble's composer did nothing when clicked. The menu was opening — it was just painted behind the bubble panel, whose full-screen backdrop then swallowed the clicks.

Root cause is not in the bubble. `getAppearanceOverlayHost()` returned an unstyled `<div>` on `<body>`, so an overlay portaled into it still competed, in the **root stacking context**, with the container it had escaped from:

- Session UI lives inside `<main class="bitfun-app-main-workspace">`, a stacking context at `z-index: 1`. Its composer menus clear it easily at `$z-dropdown` (60) — which is why the same code works there.
- `.bitfun-fmc` is `position: fixed; z-index: $z-overlay + 1` (101) in the root context. 60 < 101, so every menu the bubble's composer opened rendered underneath the panel, and `.bitfun-fmc__backdrop` (`inset: 0`, same subtree) took the clicks.

So the host was a mount point, not a layer. This PR makes it a layer: one stacking context at a new `$z-overlay-host` (300) — above every container that hosts app UI, below the chrome that must outrank overlays (notifications 400, context menus 500, splash 9999), which therefore needs no change. Overlay `z-index` values now only order overlays against each other inside the host.

Two details are load-bearing and called out in the stylesheet:

- The host box mirrors the initial containing block it used to sit in (`position: fixed; inset: 0`), so absolutely positioned overlays keep the same reference rect, and the rule set deliberately excludes `transform` / `filter` / `backdrop-filter` / `will-change` / `contain`, which would re-anchor every `position: fixed` overlay to the host.
- Hit testing is handed back with a zero-specificity `:where()` rule, so an overlay that opts out of pointer events (tooltips) keeps its own declaration.

Fixes the same class of bug for anything else portaled out of a high-`z-index` container — the bubble's `/` slash-command picker (also `$z-dropdown`) was dead for the same reason.

## Type and Areas

Type: bug fix

Areas: web UI

## Motivation / Impact

Users of the floating chat bubble could not reach agent modes, image attachment, Skills, or "new session" — the entire `+` menu and the `/` command picker were unreachable. The fix is at the layer level, so future overlays are correct by construction instead of each one escalating its own `z-index` (the existing `9999` / `10000` values around the codebase are artifacts of that escalation; retiring them is left as separate cleanup).

## Verification

```bash
pnpm --dir src/web-ui run test:run        # 3587 passed; 14 pre-existing failures, identical with the change stashed (localStorage env, unrelated)
pnpm run type-check:web                   # clean
node scripts/audit-theme-colors.mjs       # exit 0 (tokens.scss touched)
pnpm --dir src/web-ui exec vite build     # clean; rule ships in the main CSS bundle, not a lazy chunk
pnpm --dir src/web-ui exec eslint src/infrastructure/appearance/runtime/AppearanceOverlayHost.ts
```

Behaviour was checked in a real engine on a page reproducing the app's DOM/CSS (`elementFromPoint` at each overlay's rect):

| | menu rect hits | tooltip | empty app area | `+` trigger |
|---|---|---|---|---|
| before | `fmc__panel` (buried) | — | backdrop | clickable |
| after | `menu` | stays `pointer-events: none` (click-through) | backdrop | clickable |

Fixed overlays kept identical coordinates (`[120, 400]`) before and after, confirming the fixed host does not re-anchor them.

New unit tests in `AppearanceOverlayHost.test.ts` cover the host's identity, the stacking-context contract, the ordering against the neighbouring bands, the containing-block trap, and the pointer-events handoff.

## Reviewer Notes

The value `300` is chosen so no other layer has to move: it clears `.bitfun-fmc` (101) and the workspace context (1) while staying under `$z-notification` (400) and `$z-context-menu` (500), which keep their current precedence over overlays.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable. (No string changes.)
