### PR TITLE
fix(web-ui): follow the agents scene part rename in the compiler test

### DIFF
--- a/src/web-ui/src/infrastructure/appearance/compiler/AppearanceCompiler.test.ts
+++ b/src/web-ui/src/infrastructure/appearance/compiler/AppearanceCompiler.test.ts
@@ -755,7 +755,7 @@ describe('AppearanceCompiler', () => {
       scenes: {
         agents: {
           parts: {
-            coreGrid: { base: { borderColor: accent } },
+            catalogGrid: { base: { borderColor: accent } },
           },
         },
       },
@@ -774,7 +774,7 @@ describe('AppearanceCompiler', () => {
     expect(snapshot.cssText).toContain('[data-bf-component="sessions-section"][data-bf-part="row"][data-bf-state~="active"]');
     expect(snapshot.cssText).toContain('[data-bf-component="files-panel"][data-bf-part="search"][data-bf-search-mode="content"]');
     expect(snapshot.cssText).toContain('[data-bf-component="remote-connect-dialog"][data-bf-part="groupTab"][data-bf-group="account"][data-bf-state~="active"]');
-    expect(snapshot.cssText).toContain('[data-bf-scene="agents"][data-bf-part="coreGrid"]');
+    expect(snapshot.cssText).toContain('[data-bf-scene="agents"][data-bf-part="catalogGrid"]');
     expect(snapshot.cssText).toContain('[data-bf-component="session-usage-panel"][data-bf-part="tab"][data-bf-tab="models"][data-bf-state~="active"]');
     expect(snapshot.cssText).toContain('[data-bf-component="file-operation-tool-card"][data-bf-part="root"][data-bf-action="modify"][data-bf-state~="expanded"]');
     expect(snapshot.cssText).toContain('[data-bf-component="acp-agents-config"][data-bf-part="root"][data-bf-view="json"]');


### PR DESCRIPTION
## Summary

`Frontend Build` has been failing on `1.0.0-explore` since bdbc6cb53 — the last five runs on the branch are red, including its current head.

That commit reshaped the agents scene surface and renamed its `coreGrid` part to `catalogGrid` in both `agentsAppearanceDescriptor` and `AgentsScene.tsx`. `AppearanceCompiler.test.ts` still compiles a package against the old id, so the validator rejects it:

```
AppearancePackageValidationError: Appearance package validation failed with 1 issue:
scene agents:
  - [UNKNOWN_PART] scenes.agents.parts.coreGrid: Unknown part coreGrid
```

`coreGrid` has no remaining producer on this branch — the two occurrences in this test are the only ones left — so this points the fixture and its selector assertion at the part the descriptor and the scene actually declare.

## Type and Areas

Type: regression fix (test)

Areas: web UI

## Motivation / Impact

Unblocks CI on `1.0.0-explore`; every PR targeting this branch currently inherits the red job. No product code changes.

## Verification

```bash
pnpm --dir src/web-ui run test:run src/infrastructure/appearance/compiler/AppearanceCompiler.test.ts   # 15 passed (was 14 passed | 1 failed)
```

Reproduced first at the pristine branch head to confirm the failure is pre-existing and not inherited from any open PR.

## Reviewer Notes

`main` is unaffected: the descriptor there still declares `coreGrid`, so the same test passes as written. This change belongs only on `1.0.0-explore`.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable. (No string changes.)
