### PR TITLE
fix(web): follow the agents scene part rename in the compiler test

### DIFF
--- a/src/web-ui/src/infrastructure/appearance/compiler/AppearanceCompiler.test.ts
+++ b/src/web-ui/src/infrastructure/appearance/compiler/AppearanceCompiler.test.ts
@@ -755,7 +755,7 @@ describe('AppearanceCompiler', () => {
       scenes: {
         agents: {
           parts: {
-            coreGrid: { base: { borderColor: accent } },
+            catalogGrid: { base: { borderColor: accent } },
           },
         },
       },
@@ -774,7 +774,7 @@ describe('AppearanceCompiler', () => {
     expect(snapshot.cssText).toContain('[data-bf-component="sessions-section"][data-bf-part="row"][data-bf-state~="active"]');
     expect(snapshot.cssText).toContain('[data-bf-component="files-panel"][data-bf-part="search"][data-bf-search-mode="content"]');
     expect(snapshot.cssText).toContain('[data-bf-component="remote-connect-dialog"][data-bf-part="groupTab"][data-bf-group="account"][data-bf-state~="active"]');
-    expect(snapshot.cssText).toContain('[data-bf-scene="agents"][data-bf-part="coreGrid"]');
+    expect(snapshot.cssText).toContain('[data-bf-scene="agents"][data-bf-part="catalogGrid"]');
     expect(snapshot.cssText).toContain('[data-bf-component="session-usage-panel"][data-bf-part="tab"][data-bf-tab="models"][data-bf-state~="active"]');
     expect(snapshot.cssText).toContain('[data-bf-component="file-operation-tool-card"][data-bf-part="root"][data-bf-action="modify"][data-bf-state~="expanded"]');
     expect(snapshot.cssText).toContain('[data-bf-component="acp-agents-config"][data-bf-part="root"][data-bf-view="json"]');


### PR DESCRIPTION
## What is broken

`Frontend Build` has been red on `1.0.0-explore` since bdbc6cb53, and the failure is in the test rather than in the product:

```
AppearancePackageValidationError: Appearance package validation failed with 1 issue:
scene agents:
  - [UNKNOWN_PART] scenes.agents.parts.coreGrid: Unknown part coreGrid
```

That commit restructured the agents scene's part list -- `anchorBar`, `harnessGrid` and `coreGrid` gave way to `harnessPresentation` and `catalogGrid`, and `AgentsScene.tsx` moved to `data-bf-part="catalogGrid"` with it. `AppearanceCompiler.test.ts` was not carried along: it still authors its package against `coreGrid`, so the validator rejects the part and `compile` throws before a single assertion in the case runs.

## The fix

Two occurrences renamed to `catalogGrid`. The case is about a scene part reaching the compiled selector, not about which part it happens to be, so it follows the scene rather than the descriptor regaining a part nothing draws.

## Not included

`src/crates/assembly/core/builtin_skills/create-bitfun-skin/references/appearance-registry.json` still carries the pre-rename `coreGrid` too. Nothing in CI validates that snapshot, `SKILL.md` says not to hand-edit it, and `scripts/sync_registry.py` is what regenerates it -- so it is left for whoever owns that skill.

## Verification

- Reproduced first on a clean `1.0.0-explore` checkout: `1 failed | 14 passed`
- After the change, that file is `15 passed`
- `pnpm --dir src/web-ui run test:run`: 523 files, 3835 tests, 0 failures
- `pnpm run lint:web`: clean
