### PR TITLE
fix(web-ui): keep the settings scene routing test off the real transport

### DIFF
--- a/src/web-ui/src/app/scenes/settings/SettingsScene.test.tsx
+++ b/src/web-ui/src/app/scenes/settings/SettingsScene.test.tsx
@@ -63,6 +63,19 @@ vi.mock('../../../infrastructure/config/components/SessionConfig', () => ({
   SessionPermissionsConfig: () => <div data-testid="session-permissions-config" />,
 }));
 
+/**
+ * The scene runs its own external-application lookup on mount, which reaches
+ * the real transport: outside Tauri that is the WebSocket adapter, and once its
+ * connection to a server nobody started fails it keeps retrying — and logging —
+ * on a timer that outlives this file. A console write from that timer can land
+ * in a worker whose rpc is already closing, failing the run with an
+ * EnvironmentTeardownError attributed here. Tab routing is what this file
+ * covers; the lookup is chrome it does not assert on.
+ */
+vi.mock('../../../infrastructure/config/components/external-sources/useExternalAppAwareness', () => ({
+  useExternalAppAwareness: () => {},
+}));
+
 vi.mock('./components/ArchivedSessionsConfig', () => ({
   default: () => <div data-testid="archived-sessions-config" />,
 }));


### PR DESCRIPTION
## Summary

`Frontend Build` can fail with every web UI test passing:

```
Test Files  490 passed (490)
Tests  3627 passed (3627)
Errors  1 error

EnvironmentTeardownError: [vitest-worker]: Closing rpc while "onUserConsoleLog" was pending
This error originated in "src/app/scenes/settings/SettingsScene.test.tsx"
```

`SettingsScene` mounts `useExternalAppAwareness`, which calls the external sources API on mount. Outside Tauri `createTransportAdapter()` resolves to the WebSocket adapter, so the routing test opens a real socket to `ws://localhost:8080/ws`; the connection fails, and `scheduleReconnect` keeps retrying and logging on a timer that outlives the file. A console write from that timer reaching a worker whose rpc is already closing is what fails the job — the test file itself is green.

It only surfaces on a runner slow enough for the lookup to reach the transport before the file ends, which is why it reads as an intermittent flake rather than a broken test.

This mocks the hook, the way the file already mocks every panel it renders. Tab routing is what it covers; the awareness lookup is chrome it never asserts on.

## Type and Areas

Type: regression fix (test)

Areas: web UI

## Motivation / Impact

Removes a CI failure mode that can hit any PR and is invisible in the test summary. No product code changes.

## Verification

Reproduced on this branch first, then fixed. Reproduced deterministically by copying the file, stubbing the `WebSocket` global to record constructions, and draining macrotasks after the first test the way a slower runner would:

```
before: PROBE sockets opened: ["ws://localhost:8080/ws"]
after:  PROBE sockets opened: []
```

```bash
pnpm --dir src/web-ui run test:run src/app/scenes/settings/SettingsScene.test.tsx   # 7 passed
```

## Reviewer Notes

Port of #2393 (merged to `main` as b3eb18b5c). This branch carries the same scene and the same test file, and the probe reproduces the socket here too, so the leak is present independently of that merge.

The adapter's retry loop is doing what it should — the bug is that a unit test reached it at all. If it is worth going further, a shared vitest setup that stubs the transport for every test would close the whole class; this change stays with the one file that opens the socket.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable. (No string changes.)
