### PR TITLE
perf(cargo): enforce third-party capability ownership

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,6 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             pkg-config \
             build-essential \
-            libssl-dev \
             libxcb1-dev \
             libxcb-render0-dev \
             libxcb-shape0-dev \

--- a/.github/workflows/cli-package-manual.yml
+++ b/.github/workflows/cli-package-manual.yml
@@ -135,7 +135,6 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             pkg-config \
             build-essential \
-            libssl-dev \
             libxcb1-dev \
             libxcb-render0-dev \
             libxcb-shape0-dev \

--- a/.github/workflows/linux-binaries.yml
+++ b/.github/workflows/linux-binaries.yml
@@ -66,7 +66,6 @@ jobs:
             clang \
             cmake \
             curl \
-            libssl-dev \
             libxcb1-dev \
             libxcb-render0-dev \
             libxcb-shape0-dev \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4138,9 +4138,6 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe 0.1.6",
- "openssl-sys",
- "url",
 ]
 
 [[package]]
@@ -5516,7 +5513,6 @@ dependencies = [
  "cc",
  "libc",
  "libz-sys",
- "openssl-sys",
  "pkg-config",
 ]
 
@@ -6613,37 +6609,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-src"
-version = "300.6.1+3.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
-dependencies = [
- "cc",
- "libc",
- "openssl-src",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -8640,7 +8608,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
- "openssl-probe 0.2.1",
+ "openssl-probe",
  "rustls-pki-types",
  "schannel",
  "security-framework",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ regex = "1"
 base64 = "0.22"
 # Keep macOS Tauri's dispatch2/bitflags expansion on the known-good bitflags release.
 bitflags = "=2.11.1"
-image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp", "bmp"] }
+image = { version = "0.25", default-features = false }
 md5 = "0.7"
 dashmap = "6"
 indexmap = "2"
@@ -138,8 +138,8 @@ reqwest = { version = "0.13.4", default-features = false }
 semver = "1.0"
 
 # Debug Log HTTP Server
-axum = { version = "0.8", features = ["json", "ws"] }
-tower-http = { version = "0.6.11", features = ["cors", "fs"] }
+axum = { version = "0.8", features = ["json"] }
+tower-http = "0.6.11"
 
 # File system
 glob = "0.3"
@@ -163,7 +163,7 @@ zstd = "0.13"
 toml = "0.9"
 
 # Git
-git2 = { version = "0.21", default-features = false, features = ["https", "vendored-libgit2"] }
+git2 = { version = "0.21", default-features = false, features = ["vendored-libgit2"] }
 
 # Terminal
 portable-pty = "0.8"
@@ -259,7 +259,7 @@ hostname = "0.4"
 qrcode = { version = "0.14", default-features = false }
 
 # WebSocket client
-tokio-tungstenite = { version = "0.29", features = ["rustls-tls-native-roots"] }
+tokio-tungstenite = "0.29"
 
 # Local speech recognition
 sherpa-onnx = "1.13.4"

--- a/scripts/check-core-boundaries.test.mjs
+++ b/scripts/check-core-boundaries.test.mjs
@@ -12,10 +12,13 @@ import {
   findFeatureGatedTestTargetViolations,
   findProductEntrypointCoreFeatureViolations,
   findReqwestDependencyFeatureViolations,
+  findResolvedThirdPartyCapabilityFeatureViolations,
   findRuntimeServicesTestSupportFeatureViolations,
   findResolvedReqwestNativeTlsViolations,
+  findServicesIntegrationsPlatformDependencyFeatureViolations,
   findServicesIntegrationsReqwestFeatureViolations,
   findServicesIntegrationsTokioFeatureViolations,
+  findThirdPartyCapabilityFeatureViolations,
   findTokioDependencyFeatureViolations,
 } from './core-boundaries/cargo-dependency-boundaries.mjs';
 import {
@@ -2658,6 +2661,182 @@ test('Reqwest consumers inherit the workspace version without duplicating featur
   }
 });
 
+test('third-party capability profiles reject ambient feature unions and unreviewed owners', () => {
+  const validPackages = [
+    packageAt('bitfun-cli', 'src/apps/cli/Cargo.toml', [{
+      name: 'image',
+      kind: null,
+      optional: false,
+      uses_default_features: false,
+      features: ['gif', 'jpeg', 'png', 'webp'],
+    }]),
+    packageAt('bitfun-server', 'src/apps/server/Cargo.toml', [{
+      name: 'axum',
+      kind: null,
+      optional: false,
+      uses_default_features: true,
+      features: ['json', 'ws'],
+    }]),
+    packageAt('bitfun-core', 'src/crates/assembly/core/Cargo.toml', [{
+      name: 'tokio-tungstenite',
+      kind: null,
+      optional: true,
+      uses_default_features: true,
+      features: [],
+    }]),
+    packageAt('bitfun-services-core', 'src/crates/services/services-core/Cargo.toml', [{
+      name: 'git2',
+      kind: null,
+      optional: true,
+      uses_default_features: false,
+      features: ['vendored-libgit2'],
+    }]),
+  ];
+
+  assert.deepEqual(findThirdPartyCapabilityFeatureViolations(validPackages), []);
+
+  const mutatedPackages = structuredClone(validPackages);
+  mutatedPackages[0].dependencies[0].features.push('bmp');
+  mutatedPackages[1].dependencies[0].features = ['json'];
+  mutatedPackages[2].dependencies[0].features.push('rustls-tls-native-roots');
+  mutatedPackages[3].dependencies[0].features.push('https');
+  mutatedPackages[3].dependencies[0].rename = 'private-git2';
+  mutatedPackages.push(packageAt('future-image-owner', 'src/apps/future/Cargo.toml', [{
+    name: 'image',
+    kind: null,
+    optional: false,
+    uses_default_features: false,
+    features: ['png'],
+  }]));
+
+  const messages = findThirdPartyCapabilityFeatureViolations(mutatedPackages)
+    .map((violation) => violation.message)
+    .join('\n');
+  assert.match(messages, /bitfun-cli Image dependency has unexpected features: bmp/);
+  assert.match(messages, /bitfun-server Axum dependency missing features: ws/);
+  assert.match(messages, /bitfun-core Tokio Tungstenite dependency has unexpected features: rustls-tls-native-roots/);
+  assert.match(messages, /bitfun-services-core Git2 dependency has unexpected features: https/);
+  assert.match(messages, /bitfun-services-core Git2 dependency does not match its reviewed owner shape/);
+  assert.match(messages, /future-image-owner Image dependency is missing a reviewed owner profile/);
+});
+
+test('services integrations image codecs stay attached to exact product owners', () => {
+  const pkg = {
+    ...packageAt('bitfun-services-integrations', 'src/crates/services/services-integrations/Cargo.toml', [{
+      name: 'image',
+      kind: null,
+      optional: true,
+      uses_default_features: false,
+      features: [],
+    }]),
+    features: {
+      image: ['dep:image'],
+      'miniapp-market': ['image', 'image/gif', 'image/jpeg', 'image/png', 'image/webp'],
+      'remote-connect': [
+        'image',
+        'image/bmp',
+        'image/gif',
+        'image/jpeg',
+        'image/png',
+        'image/webp',
+      ],
+    },
+  };
+
+  assert.deepEqual(findThirdPartyCapabilityFeatureViolations([pkg]), []);
+
+  const mutated = structuredClone(pkg);
+  mutated.features.image.push('image/png');
+  mutated.features['miniapp-market'].push('image/bmp');
+  mutated.features['remote-connect'] = mutated.features['remote-connect']
+    .filter((reference) => reference !== 'image/gif');
+  mutated.features.default = ['image/png'];
+  const messages = findThirdPartyCapabilityFeatureViolations([mutated])
+    .map((violation) => violation.message)
+    .join('\n');
+  assert.match(messages, /miniapp-market.*unexpected Image capabilities: bmp/);
+  assert.match(messages, /remote-connect.*missing Image capabilities: gif/);
+  assert.match(messages, /default enables Image outside its reviewed owner features/);
+  assert.match(messages, /image shared Image activation alias must not select capabilities: png/);
+});
+
+test('services integrations WebSocket TLS stays attached to remote-connect', () => {
+  const pkg = {
+    ...packageAt('bitfun-services-integrations', 'src/crates/services/services-integrations/Cargo.toml', [{
+      name: 'tokio-tungstenite',
+      kind: null,
+      optional: true,
+      uses_default_features: true,
+      features: [],
+    }]),
+    features: {
+      'remote-connect': [
+        'dep:tokio-tungstenite',
+        'tokio-tungstenite?/rustls-tls-native-roots',
+      ],
+    },
+  };
+
+  assert.deepEqual(findThirdPartyCapabilityFeatureViolations([pkg]), []);
+
+  const mutated = structuredClone(pkg);
+  mutated.features['tokio-tungstenite'] = ['dep:tokio-tungstenite'];
+  mutated.features['future-non-remote-owner'] = ['dep:tokio-tungstenite'];
+  const messages = findThirdPartyCapabilityFeatureViolations([mutated])
+    .map((violation) => violation.message)
+    .join('\n');
+  assert.match(messages, /future-non-remote-owner enables Tokio Tungstenite outside its reviewed owner features/);
+  assert.match(messages, /tokio-tungstenite enables Tokio Tungstenite outside its reviewed owner features/);
+});
+
+test('resolved third-party feature unions reject global capability regressions', () => {
+  const validRecords = [
+    {
+      name: 'git2',
+      version: '0.21.0',
+      features: ['vendored-libgit2'],
+    },
+    {
+      name: 'image',
+      version: '0.24.9',
+      features: ['default', 'exr', 'tiff'],
+    },
+    {
+      name: 'image',
+      version: '0.25.10',
+      features: ['bmp', 'gif', 'jpeg', 'png', 'tiff', 'webp'],
+    },
+    {
+      name: 'libgit2-sys',
+      version: '0.18.7+1.9.6',
+      features: ['vendored'],
+    },
+  ];
+
+  assert.deepEqual(
+    findResolvedThirdPartyCapabilityFeatureViolations(validRecords, { root: TEST_ROOT }),
+    [],
+  );
+
+  const mutated = structuredClone(validRecords);
+  mutated[0].features.push('https', 'vendored-openssl');
+  mutated[2].features.push('exr');
+  mutated[3].features.push('https', 'openssl-sys', 'vendored-openssl');
+  mutated.push({
+    name: 'image',
+    version: '0.26.0',
+    features: ['avif', 'default', 'exr'],
+  });
+  const messages = findResolvedThirdPartyCapabilityFeatureViolations(
+    mutated,
+    { root: TEST_ROOT },
+  ).map((violation) => violation.message).join('\n');
+  assert.match(messages, /resolved git2.*https, vendored-openssl/);
+  assert.match(messages, /resolved image 0\.25\.10.*exr/);
+  assert.match(messages, /resolved libgit2-sys.*https, openssl-sys, vendored-openssl/);
+  assert.match(messages, /resolved image 0\.26\.0 uses an unreviewed version family/);
+});
+
 test('resolved Reqwest feature union rejects every native TLS backend alias', () => {
   const violations = findResolvedReqwestNativeTlsViolations(
     [
@@ -3575,6 +3754,53 @@ test('services-core Windows API capabilities stay feature-owned', async () => {
     ]),
     [],
   );
+});
+
+test('services-integrations Windows dependency keeps only APIs used by its owners', () => {
+  const pkg = packageAt(
+    'bitfun-services-integrations',
+    'src/crates/services/services-integrations/Cargo.toml',
+    [{
+      name: 'windows',
+      kind: null,
+      optional: true,
+      target: 'cfg(windows)',
+      features: [
+        'Win32_Foundation',
+        'Win32_Storage_FileSystem',
+        'Win32_System_Diagnostics_ToolHelp',
+      ],
+    }],
+  );
+
+  const violations = findServicesIntegrationsPlatformDependencyFeatureViolations([pkg]);
+  assert.equal(violations.length, 1);
+  assert.match(violations[0].message, /unexpected Windows API capabilities: Win32_System_Diagnostics_ToolHelp/);
+
+  pkg.dependencies[0].features = ['Win32_Foundation', 'Win32_Storage_FileSystem'];
+  assert.deepEqual(findServicesIntegrationsPlatformDependencyFeatureViolations([pkg]), []);
+
+  pkg.dependencies[0].target = 'cfg(all(windows, target_arch = "x86_64"))';
+  const targetViolations = findServicesIntegrationsPlatformDependencyFeatureViolations([pkg]);
+  assert.equal(targetViolations.length, 1);
+  assert.match(targetViolations[0].message, /must declare exactly one reviewed Windows dependency/);
+
+  pkg.dependencies[0].target = 'cfg(windows)';
+  pkg.dependencies.push({
+    name: 'windows',
+    kind: null,
+    optional: false,
+    target: null,
+    features: ['Win32_System_Threading'],
+  });
+  const duplicateViolations = findServicesIntegrationsPlatformDependencyFeatureViolations([pkg]);
+  assert.equal(duplicateViolations.length, 1);
+  assert.match(duplicateViolations[0].message, /must declare exactly one reviewed Windows dependency/);
+
+  pkg.dependencies = [];
+  const missingViolations = findServicesIntegrationsPlatformDependencyFeatureViolations([pkg]);
+  assert.equal(missingViolations.length, 1);
+  assert.match(missingViolations[0].message, /must declare exactly one reviewed Windows dependency/);
 });
 
 test('closed feature profiles reject product-full hidden behind a child feature', async () => {

--- a/scripts/check-github-config.test.mjs
+++ b/scripts/check-github-config.test.mjs
@@ -543,3 +543,18 @@ test('nightly and beta use the shared build-version projection', () => {
   );
   assert.match(signingStep.run, /write-minisign-public-key\.mjs/);
 });
+
+test('Linux Rust workflows do not install an unused native OpenSSL toolchain', () => {
+  for (const workflowPath of [
+    '.github/workflows/ci.yml',
+    '.github/workflows/cli-package-manual.yml',
+    '.github/workflows/linux-binaries.yml',
+  ]) {
+    const workflow = readFileSync(path.join(repoRoot, workflowPath), 'utf8');
+    assert.doesNotMatch(
+      workflow,
+      /\blibssl-dev\b/,
+      `${workflowPath} must rely on the reviewed Cargo-owned Git2 build profile`,
+    );
+  }
+});

--- a/scripts/core-boundaries/cargo-dependency-boundaries.mjs
+++ b/scripts/core-boundaries/cargo-dependency-boundaries.mjs
@@ -449,6 +449,386 @@ export function findReqwestDependencyFeatureViolations(packages) {
   });
 }
 
+function dependencyProfile(features, options = {}) {
+  return {
+    features,
+    kind: options.kind ?? null,
+    optional: options.optional ?? false,
+    target: options.target ?? null,
+    useDefaultFeatures: options.useDefaultFeatures ?? true,
+    allowDependencyFeatureAlias: options.allowDependencyFeatureAlias ?? false,
+    ownerFeatureCapabilities: options.ownerFeatureCapabilities,
+  };
+}
+
+const THIRD_PARTY_CAPABILITY_PROFILES = new Map([
+  ['axum', {
+    label: 'Axum',
+    packages: new Map([
+      ['bitfun-ai-adapters', dependencyProfile(['json'], { kind: 'dev' })],
+      ['bitfun-core', dependencyProfile(['json'], { optional: true })],
+      ['bitfun-desktop', dependencyProfile(['json'])],
+      ['bitfun-miniapp-market-server', dependencyProfile(['json'])],
+      ['bitfun-miniapp-market-service', dependencyProfile(['json'])],
+      ['bitfun-relay-server', dependencyProfile([])],
+      ['bitfun-relay-service', dependencyProfile(['json', 'ws'])],
+      ['bitfun-server', dependencyProfile(['json', 'ws'])],
+      ['bitfun-skin-market-server', dependencyProfile(['json'])],
+      ['bitfun-skin-market-service', dependencyProfile(['json'])],
+      ['bitfun-webdriver', dependencyProfile(['json'])],
+    ]),
+  }],
+  ['git2', {
+    label: 'Git2',
+    packages: new Map([
+      ['bitfun-services-core', dependencyProfile(['vendored-libgit2'], {
+        optional: true,
+        useDefaultFeatures: false,
+      })],
+      ['bitfun-services-integrations', dependencyProfile(['vendored-libgit2'], {
+        optional: true,
+        useDefaultFeatures: false,
+      })],
+    ]),
+  }],
+  ['image', {
+    label: 'Image',
+    packages: new Map([
+      ['bitfun-cli', dependencyProfile(['gif', 'jpeg', 'png', 'webp'], {
+        useDefaultFeatures: false,
+      })],
+      ['bitfun-core', dependencyProfile(['bmp', 'gif', 'jpeg', 'png', 'webp'], {
+        optional: true,
+        useDefaultFeatures: false,
+      })],
+      ['bitfun-desktop', dependencyProfile(['jpeg', 'png'], {
+        useDefaultFeatures: false,
+      })],
+      ['bitfun-miniapp-market-service', dependencyProfile(['jpeg', 'png', 'webp'], {
+        useDefaultFeatures: false,
+      })],
+      ['bitfun-services-integrations', dependencyProfile([], {
+        allowDependencyFeatureAlias: true,
+        optional: true,
+        useDefaultFeatures: false,
+        ownerFeatureCapabilities: new Map([
+          ['miniapp-market', ['gif', 'jpeg', 'png', 'webp']],
+          ['remote-connect', ['bmp', 'gif', 'jpeg', 'png', 'webp']],
+        ]),
+      })],
+      ['bitfun-skin-market-service', dependencyProfile(['gif', 'jpeg', 'png', 'webp'], {
+        useDefaultFeatures: false,
+      })],
+      ['bitfun-webdriver', dependencyProfile(['png'], {
+        useDefaultFeatures: false,
+      })],
+    ]),
+  }],
+  ['tokio-tungstenite', {
+    label: 'Tokio Tungstenite',
+    packages: new Map([
+      ['bitfun-core', dependencyProfile([], { optional: true })],
+      ['bitfun-services-integrations', dependencyProfile([], {
+        optional: true,
+        ownerFeatureCapabilities: new Map([
+          ['remote-connect', ['rustls-tls-native-roots']],
+        ]),
+      })],
+    ]),
+  }],
+  ['tower-http', {
+    label: 'Tower HTTP',
+    packages: new Map([
+      ['bitfun-core', dependencyProfile(['cors'], { optional: true })],
+      ['bitfun-desktop', dependencyProfile(['fs'])],
+      ['bitfun-miniapp-market-service', dependencyProfile(['fs', 'set-header', 'trace'])],
+      ['bitfun-relay-server', dependencyProfile(['fs'])],
+      ['bitfun-relay-service', dependencyProfile(['cors'])],
+      ['bitfun-server', dependencyProfile(['cors'])],
+      ['bitfun-skin-market-service', dependencyProfile(['fs'])],
+    ]),
+  }],
+]);
+
+function externalDependencyReference(reference, dependencyName) {
+  if (reference === dependencyName || reference === `dep:${dependencyName}`) {
+    return { activates: true, capability: null };
+  }
+  const match = reference.match(/^([^/?]+)(\?)?\/(.+)$/);
+  if (match?.[1] !== dependencyName) {
+    return null;
+  }
+  return { activates: !match[2], capability: match[3] };
+}
+
+function effectiveExternalDependencyState(
+  feature,
+  featureGraph,
+  dependencyName,
+  visiting = new Set(),
+) {
+  if (visiting.has(feature)) {
+    return { activates: false, capabilities: new Set() };
+  }
+  visiting.add(feature);
+  let activates = false;
+  const capabilities = new Set();
+  for (const reference of featureGraph[feature] ?? []) {
+    const external = externalDependencyReference(reference, dependencyName);
+    if (external) {
+      activates ||= external.activates;
+      if (external.capability) {
+        capabilities.add(external.capability);
+      }
+      continue;
+    }
+    if (Object.hasOwn(featureGraph, reference)) {
+      const nested = effectiveExternalDependencyState(
+        reference,
+        featureGraph,
+        dependencyName,
+        visiting,
+      );
+      activates ||= nested.activates;
+      for (const capability of nested.capabilities) {
+        capabilities.add(capability);
+      }
+    }
+  }
+  visiting.delete(feature);
+  return { activates, capabilities };
+}
+
+function featureOwnedDependencyViolations(pkg, dependencyName, label, profile) {
+  const ownerProfiles = profile.ownerFeatureCapabilities;
+  if (!ownerProfiles) {
+    return [];
+  }
+  const violations = [];
+  const ownerFeatures = new Set(ownerProfiles.keys());
+  const featureGraph = pkg.features ?? {};
+
+  for (const [feature, expectedCapabilities] of ownerProfiles) {
+    const state = effectiveExternalDependencyState(feature, featureGraph, dependencyName);
+    if (!state.activates) {
+      violations.push({
+        path: pkg.manifest_path,
+        line: 1,
+        message: `${pkg.name}:${feature} must explicitly enable ${label}`,
+      });
+    }
+    const actual = [...state.capabilities].sort();
+    const expected = [...expectedCapabilities].sort();
+    const missing = expected.filter((capability) => !actual.includes(capability));
+    const unexpected = actual.filter((capability) => !expected.includes(capability));
+    if (missing.length > 0) {
+      violations.push({
+        path: pkg.manifest_path,
+        line: 1,
+        message: `${pkg.name}:${feature} missing ${label} capabilities: ${missing.join(', ')}`,
+      });
+    }
+    if (unexpected.length > 0) {
+      violations.push({
+        path: pkg.manifest_path,
+        line: 1,
+        message: `${pkg.name}:${feature} has unexpected ${label} capabilities: ${unexpected.join(', ')}`,
+      });
+    }
+  }
+
+  for (const [feature, references] of Object.entries(featureGraph)) {
+    if (ownerFeatures.has(feature)) {
+      continue;
+    }
+    if (feature === dependencyName && profile.allowDependencyFeatureAlias) {
+      const state = effectiveExternalDependencyState(feature, featureGraph, dependencyName);
+      if (!state.activates) {
+        violations.push({
+          path: pkg.manifest_path,
+          line: 1,
+          message: `${pkg.name}:${feature} shared ${label} activation alias must activate the dependency`,
+        });
+      }
+      if (state.capabilities.size > 0) {
+        violations.push({
+          path: pkg.manifest_path,
+          line: 1,
+          message:
+            `${pkg.name}:${feature} shared ${label} activation alias must not select capabilities: `
+            + [...state.capabilities].sort().join(', '),
+        });
+      }
+      continue;
+    }
+    if (references.some((reference) => externalDependencyReference(reference, dependencyName))) {
+      violations.push({
+        path: pkg.manifest_path,
+        line: 1,
+        message: `${pkg.name}:${feature} enables ${label} outside its reviewed owner features`,
+      });
+    }
+  }
+
+  return violations;
+}
+
+function thirdPartyDependencyProfileViolations(pkg, dependencyName, policy, profile) {
+  const violations = [];
+  const dependencies = (pkg.dependencies ?? []).filter(
+    (dependency) => dependency.name === dependencyName,
+  );
+  if (dependencies.length !== 1) {
+    return [{
+      path: pkg.manifest_path,
+      line: 1,
+      message: `${pkg.name} must declare exactly one reviewed ${policy.label} dependency`,
+    }];
+  }
+  const dependency = dependencies[0];
+  if (
+    (dependency.kind ?? null) !== profile.kind
+    || (dependency.rename ?? null) !== null
+    || (dependency.target ?? null) !== profile.target
+    || dependency.optional !== profile.optional
+  ) {
+    violations.push({
+      path: pkg.manifest_path,
+      line: 1,
+      message: `${pkg.name} ${policy.label} dependency does not match its reviewed owner shape`,
+    });
+  }
+  if ((dependency.uses_default_features !== false) !== profile.useDefaultFeatures) {
+    violations.push({
+      path: pkg.manifest_path,
+      line: 1,
+      message: `${pkg.name} ${policy.label} dependency default-feature policy does not match its owner profile`,
+    });
+  }
+  const actual = new Set(dependency.features ?? []);
+  const expected = new Set(profile.features);
+  const missing = [...expected].filter((feature) => !actual.has(feature));
+  const unexpected = [...actual].filter((feature) => !expected.has(feature));
+  if (missing.length > 0) {
+    violations.push({
+      path: pkg.manifest_path,
+      line: 1,
+      message: `${pkg.name} ${policy.label} dependency missing features: ${missing.join(', ')}`,
+    });
+  }
+  if (unexpected.length > 0) {
+    violations.push({
+      path: pkg.manifest_path,
+      line: 1,
+      message: `${pkg.name} ${policy.label} dependency has unexpected features: ${unexpected.join(', ')}`,
+    });
+  }
+  violations.push(...featureOwnedDependencyViolations(
+    pkg,
+    dependencyName,
+    policy.label,
+    profile,
+  ));
+  return violations;
+}
+
+export function findThirdPartyCapabilityFeatureViolations(packages) {
+  const violations = [];
+  for (const pkg of packages) {
+    for (const [dependencyName, policy] of THIRD_PARTY_CAPABILITY_PROFILES) {
+      if (!(pkg.dependencies ?? []).some((dependency) => dependency.name === dependencyName)) {
+        continue;
+      }
+      const profile = policy.packages.get(pkg.name);
+      if (!profile) {
+        violations.push({
+          path: pkg.manifest_path,
+          line: 1,
+          message: `${pkg.name} ${policy.label} dependency is missing a reviewed owner profile`,
+        });
+        continue;
+      }
+      violations.push(...thirdPartyDependencyProfileViolations(
+        pkg,
+        dependencyName,
+        policy,
+        profile,
+      ));
+    }
+  }
+  return violations;
+}
+
+const RESOLVED_THIRD_PARTY_CAPABILITY_POLICIES = new Map([
+  ['git2', {
+    forbiddenFeatures: new Set(['https', 'vendored-openssl']),
+  }],
+  ['libgit2-sys', {
+    forbiddenFeatures: new Set(['https', 'openssl-sys', 'vendored-openssl']),
+  }],
+  ['image', {
+    versionPrefix: '0.25.',
+    ignoredVersionPrefixes: ['0.24.'],
+    // macOS clipboard support currently adds TIFF through arboard. The other
+    // formats are the codecs selected by reviewed BitFun owners.
+    allowedFeatures: new Set(['bmp', 'gif', 'jpeg', 'png', 'tiff', 'webp']),
+  }],
+]);
+
+export function findResolvedThirdPartyCapabilityFeatureViolations(records, { root }) {
+  const violations = [];
+
+  for (const [dependencyName, policy] of RESOLVED_THIRD_PARTY_CAPABILITY_POLICIES) {
+    const namedRecords = records.filter((record) => record.name === dependencyName);
+    const governedRecords = policy.versionPrefix
+      ? namedRecords.filter((record) => record.version.startsWith(policy.versionPrefix))
+      : namedRecords;
+    for (const record of namedRecords) {
+      if (
+        !policy.versionPrefix
+        || record.version.startsWith(policy.versionPrefix)
+        || policy.ignoredVersionPrefixes?.some((prefix) => record.version.startsWith(prefix))
+      ) {
+        continue;
+      }
+      violations.push({
+        path: join(root, 'Cargo.toml'),
+        line: 1,
+        message: `resolved ${dependencyName} ${record.version} uses an unreviewed version family`,
+      });
+    }
+    if (policy.versionPrefix && namedRecords.length > 0 && governedRecords.length === 0) {
+      violations.push({
+        path: join(root, 'Cargo.toml'),
+        line: 1,
+        message:
+          `resolved ${dependencyName} graph has no evidence for reviewed version family `
+          + policy.versionPrefix,
+      });
+      continue;
+    }
+
+    for (const record of governedRecords) {
+      const features = record.features ?? [];
+      const unexpected = policy.forbiddenFeatures
+        ? features.filter((feature) => policy.forbiddenFeatures.has(feature))
+        : features.filter((feature) => !policy.allowedFeatures.has(feature));
+      if (unexpected.length === 0) {
+        continue;
+      }
+      violations.push({
+        path: join(root, 'Cargo.toml'),
+        line: 1,
+        message:
+          `resolved ${dependencyName} ${record.version} feature union enables unreviewed capabilities: `
+          + unexpected.join(', '),
+      });
+    }
+  }
+
+  return violations;
+}
+
 export function findRuntimeServicesTestSupportFeatureViolations(packages) {
   const violations = [];
 
@@ -689,6 +1069,57 @@ export function findServicesCorePlatformDependencyFeatureViolations(packages) {
         line: 1,
         message:
           'windows API capabilities must be selected by services-core owner features, not the dependency declaration',
+      });
+    }
+  }
+
+  return violations;
+}
+
+export function findServicesIntegrationsPlatformDependencyFeatureViolations(packages) {
+  const expectedFeatures = new Set([
+    'Win32_Foundation',
+    'Win32_Storage_FileSystem',
+  ]);
+  const violations = [];
+
+  for (const pkg of packages) {
+    if (pkg.name !== 'bitfun-services-integrations') {
+      continue;
+    }
+    const dependencies = (pkg.dependencies ?? []).filter(
+      (dependency) => dependency.name === 'windows',
+    );
+    const dependency = dependencies[0];
+    if (
+      dependencies.length !== 1
+      || (dependency.kind ?? null) !== null
+      || (dependency.rename ?? null) !== null
+      || dependency.optional !== true
+      || dependency.target !== 'cfg(windows)'
+    ) {
+      violations.push({
+        path: pkg.manifest_path,
+        line: 1,
+        message: `${pkg.name} must declare exactly one reviewed Windows dependency`,
+      });
+      continue;
+    }
+    const actual = new Set(dependency.features ?? []);
+    const missing = [...expectedFeatures].filter((feature) => !actual.has(feature));
+    const unexpected = [...actual].filter((feature) => !expectedFeatures.has(feature));
+    if (missing.length > 0) {
+      violations.push({
+        path: pkg.manifest_path,
+        line: 1,
+        message: `${pkg.name} Windows dependency missing API capabilities: ${missing.join(', ')}`,
+      });
+    }
+    if (unexpected.length > 0) {
+      violations.push({
+        path: pkg.manifest_path,
+        line: 1,
+        message: `${pkg.name} Windows dependency has unexpected Windows API capabilities: ${unexpected.join(', ')}`,
       });
     }
   }
@@ -2182,8 +2613,11 @@ export function checkCargoDependencyBoundaries({ root, crateLayoutRules }) {
     ...findRuntimeServicesTestSupportFeatureViolations(packages),
     ...findTokioDependencyFeatureViolations(packages),
     ...findReqwestDependencyFeatureViolations(packages),
+    ...findThirdPartyCapabilityFeatureViolations(packages),
+    ...findResolvedThirdPartyCapabilityFeatureViolations(resolvedPackageFeatures, { root }),
     ...findResolvedReqwestNativeTlsViolations(resolvedPackageFeatures, { root }),
     ...findServicesCorePlatformDependencyFeatureViolations(packages),
+    ...findServicesIntegrationsPlatformDependencyFeatureViolations(packages),
   ];
 }
 

--- a/src/apps/cli/Cargo.toml
+++ b/src/apps/cli/Cargo.toml
@@ -120,7 +120,7 @@ flate2 = { workspace = true }
 futures-util = { workspace = true }
 fs2 = { workspace = true }
 base64 = { workspace = true }
-image = { workspace = true }
+image = { workspace = true, features = ["gif", "jpeg", "png", "webp"] }
 minisign-verify = "0.2"
 reqwest = { workspace = true, features = ["http2", "rustls", "stream"] }
 sha2 = { workspace = true }

--- a/src/apps/desktop/Cargo.toml
+++ b/src/apps/desktop/Cargo.toml
@@ -77,12 +77,12 @@ thiserror = { workspace = true }
 futures = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true }
-tower-http = { workspace = true }
+tower-http = { workspace = true, features = ["fs"] }
 sha1 = { workspace = true }
 sha2 = { workspace = true }
 screenshots = { workspace = true }
 enigo = { workspace = true }
-image = { workspace = true }
+image = { workspace = true, features = ["jpeg", "png"] }
 resvg = { workspace = true }
 tempfile = { workspace = true }
 

--- a/src/apps/server/Cargo.toml
+++ b/src/apps/server/Cargo.toml
@@ -22,8 +22,8 @@ bitfun-events = { path = "../../crates/contracts/events" }
 agent-client-protocol = { workspace = true }
 
 # Web framework
-axum = { workspace = true }
-tower-http = { workspace = true }
+axum = { workspace = true, features = ["ws"] }
+tower-http = { workspace = true, features = ["cors"] }
 
 # Inherited from workspace
 tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "sync"] }

--- a/src/crates/adapters/webdriver/Cargo.toml
+++ b/src/crates/adapters/webdriver/Cargo.toml
@@ -19,7 +19,7 @@ log = { workspace = true }
 tauri = { workspace = true }
 uuid = { workspace = true }
 base64 = { workspace = true }
-image = { workspace = true }
+image = { workspace = true, features = ["png"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 block2 = { workspace = true }

--- a/src/crates/assembly/core/Cargo.toml
+++ b/src/crates/assembly/core/Cargo.toml
@@ -32,7 +32,7 @@ chrono-tz = { workspace = true, optional = true }
 cron = { workspace = true, optional = true }
 regex = { workspace = true, optional = true }
 base64 = { workspace = true, optional = true }
-image = { workspace = true, optional = true }
+image = { workspace = true, features = ["bmp", "gif", "jpeg", "png", "webp"], optional = true }
 md5 = { workspace = true, optional = true }
 hex = { workspace = true }
 rusqlite = { version = "0.32", features = ["bundled"], optional = true }
@@ -44,7 +44,7 @@ semver = { workspace = true, optional = true }
 
 # Debug Log HTTP Server
 axum = { workspace = true, optional = true }
-tower-http = { workspace = true, optional = true }
+tower-http = { workspace = true, features = ["cors"], optional = true }
 
 notify = { workspace = true, optional = true }
 dirs = { workspace = true }

--- a/src/crates/services/miniapp-market-service/Cargo.toml
+++ b/src/crates/services/miniapp-market-service/Cargo.toml
@@ -15,7 +15,7 @@ base64 = { workspace = true }
 bitfun-product-domains = { path = "../../contracts/product-domains", features = ["miniapp"] }
 chrono = { workspace = true }
 hex = { workspace = true }
-image = { workspace = true }
+image = { workspace = true, features = ["jpeg", "png", "webp"] }
 rand = { workspace = true }
 reqwest = { workspace = true, features = ["form", "http2", "json", "rustls"] }
 serde = { workspace = true }

--- a/src/crates/services/miniapp-market-service/src/package.rs
+++ b/src/crates/services/miniapp-market-service/src/package.rs
@@ -596,12 +596,10 @@ mod tests {
 
     #[test]
     fn screenshot_rejects_formats_outside_png_jpeg_and_webp() {
-        let mut output = Cursor::new(Vec::new());
-        image::DynamicImage::new_rgb8(2, 2)
-            .write_to(&mut output, image::ImageFormat::Bmp)
-            .unwrap();
         assert_eq!(
-            validate_screenshot(&output.into_inner()).unwrap_err().code,
+            validate_screenshot(b"BM\0\0\0\0\0\0\0\0\0\0")
+                .unwrap_err()
+                .code,
             "unsupported_screenshot_format"
         );
     }

--- a/src/crates/services/services-core/Cargo.toml
+++ b/src/crates/services/services-core/Cargo.toml
@@ -42,10 +42,6 @@ rusqlite = { version = "0.32", features = ["bundled"], optional = true }
 win32job = { workspace = true, optional = true }
 windows = { workspace = true, optional = true }
 
-# Keep libgit2 self-contained on Unix, matching the product assembly dependency.
-[target.'cfg(not(windows))'.dependencies]
-git2 = { workspace = true, features = ["vendored-openssl"], optional = true }
-
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true, optional = true }
 

--- a/src/crates/services/services-integrations/Cargo.toml
+++ b/src/crates/services/services-integrations/Cargo.toml
@@ -76,9 +76,6 @@ ssh_config = { workspace = true, optional = true }
 terminal-core = { path = "../terminal", optional = true }
 x25519-dalek = { workspace = true, optional = true }
 
-[target.'cfg(not(windows))'.dependencies]
-git2 = { workspace = true, features = ["vendored-openssl"], optional = true }
-
 [target.'cfg(target_os = "macos")'.dependencies]
 apple-native-keyring-store = { workspace = true, optional = true }
 
@@ -88,8 +85,6 @@ windows-native-keyring-store = { workspace = true, optional = true }
 windows = { workspace = true, optional = true, features = [
     "Win32_Foundation",
     "Win32_Storage_FileSystem",
-    "Win32_System_Diagnostics_ToolHelp",
-    "Win32_System_Threading",
 ] }
 
 [target.'cfg(all(unix, not(any(target_os = "macos", target_os = "ios", target_os = "android"))))'.dependencies]
@@ -204,6 +199,10 @@ miniapp-market = [
     "dep:zbus-secret-service-keyring-store",
     "hex",
     "image",
+    "image/gif",
+    "image/jpeg",
+    "image/png",
+    "image/webp",
     "miniapp-runtime",
     "reqwest",
     "reqwest/json",
@@ -264,6 +263,11 @@ remote-connect = [
     "hostname",
     "hex",
     "image",
+    "image/bmp",
+    "image/gif",
+    "image/jpeg",
+    "image/png",
+    "image/webp",
     "local-ip-address",
     "mac_address",
     "md5",
@@ -285,7 +289,8 @@ remote-connect = [
     "tokio/rt",
     "tokio/sync",
     "tokio/time",
-    "tokio-tungstenite",
+    "dep:tokio-tungstenite",
+    "tokio-tungstenite?/rustls-tls-native-roots",
     "urlencoding",
     "uuid",
     "which",

--- a/src/crates/services/skin-market-service/Cargo.toml
+++ b/src/crates/services/skin-market-service/Cargo.toml
@@ -15,7 +15,7 @@ base64 = { workspace = true }
 bitfun-product-domains = { path = "../../contracts/product-domains", features = ["appearance-market"] }
 chrono = { workspace = true }
 hex = { workspace = true }
-image = { workspace = true }
+image = { workspace = true, features = ["gif", "jpeg", "png", "webp"] }
 hmac = { workspace = true }
 reqwest = { workspace = true, features = ["http2", "json", "rustls"] }
 semver = { workspace = true }


### PR DESCRIPTION
## Summary

- Keep workspace dependencies focused on compatible versions and common defaults, while moving Axum, Image, Tower HTTP, and WebSocket capabilities to their real crate owners.
- Keep libgit2 local-only with vendored libgit2, remove its unused HTTPS/OpenSSL feature path, and drop the now-unused Linux `libssl-dev` setup from three workflows.
- Remove unused services-integrations Windows ToolHelp and Threading API capabilities.
- Extend the existing Cargo boundary checker with exact third-party owner profiles, owner-feature checks, resolved feature-union guards, Image version-family review gates, and exact Windows dependency shapes.

## Ownership decisions

- `axum/ws`: server owners only; JSON remains common.
- `tokio-tungstenite/rustls-tls-native-roots`: only `bitfun-services-integrations/remote-connect`. The loopback CDP browser owner remains plaintext-only.
- `tower-http/cors`: Core debug and server owners; `tower-http/fs`: Desktop and static file service owners.
- `image` codecs: selected per CLI, Desktop, WebDriver, market service, Core, and feature-gated services-integrations owner.
- `git2`: `vendored-libgit2` only. Production remote push/pull paths use the Git CLI; direct libgit2 consumers operate on local repositories.

## Dependency graph evidence

Counts are unique normal+build packages from target-resolved `cargo tree` graphs, comparing exact base `b3eb18b5c` with this branch. These are graph-size measurements, not build-time claims.

| Focused closure | Windows | macOS | Linux |
| --- | ---: | ---: | ---: |
| WebDriver | 283 -> 266 (-17) | 284 -> 267 (-17) | 327 -> 310 (-17) |
| MiniApp market | 204 -> 193 (-11) | 207 -> 196 (-11) | 205 -> 194 (-11) |
| Skin market | 196 -> 186 (-10) | 199 -> 189 (-10) | 197 -> 187 (-10) |
| Core debug-log | 164 -> 151 (-13) | 155 -> 142 (-13) | 153 -> 140 (-13) |
| Services Core Git | 94 -> 66 (-28) | 85 -> 54 (-31) | 85 -> 53 (-32) |
| CLI product | 641 -> 641 (0) | 642 -> 640 (-2) | 663 -> 660 (-3) |
| Desktop product | 791 -> 791 (0) | 797 -> 795 (-2) | 888 -> 885 (-3) |
| Server product | 612 -> 611 (-1) | 602 -> 599 (-3) | 629 -> 625 (-4) |

The macOS/Linux product and Git graphs no longer resolve `openssl-sys`. Full products intentionally retain a capability when they select a real owner for it. Focused feature checks also confirm browser-control has no WebSocket TLS features while remote-connect retains native-root Rustls support.

## Validation

- `node --test scripts/check-core-boundaries.test.mjs` (125/125)
- `pnpm run check:core-boundaries`
- `pnpm run check:github-config` (15/15 tests; 11 workflow files parsed)
- `pnpm run check:repo-hygiene`
- `pnpm run fmt:rs`
- Focused Cargo checks for Services Core Git, Services Integrations Git/MiniApp/Remote Connect, Core Agent Runtime/Browser Control/Debug Log, Server, WebDriver, CLI, and Desktop
- Focused package tests for MiniApp market, Skin market, and services-integrations appearance market
- Windows/macOS/Linux target-resolved dependency graph comparison
- Independent adversarial review completed with no remaining blocker or P2 finding

## Compatibility and risk

This changes capability selection and build closure, not public APIs or runtime ownership. Local Windows owner checks and tests passed. Non-Windows compilation remains covered by CI; macOS/Linux evidence here is target-resolved dependency analysis rather than local linking.