### PR TITLE
perf(ci): skip Rust validation for proven Web-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,10 @@ on:
   pull_request:
     branches: [main]
     paths-ignore:
-      - '**/*.md'
       - 'png/**'
   push:
     branches: [main]
     paths-ignore:
-      - '**/*.md'
       - 'png/**'
 
 # Cancel previous runs on same branch/PR
@@ -21,6 +19,36 @@ permissions:
   contents: read
 
 jobs:
+  # ── Rust / CLI impact: conservative scheduling decision ────────────
+  rust-impact:
+    name: Rust / CLI Impact
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      rust_required: ${{ steps.classify.outputs.rust_required }}
+      reason: ${{ steps.classify.outputs.reason }}
+      changed_count: ${{ steps.classify.outputs.changed_count }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # Pull requests need both base/head objects; main pushes need the
+          # previous commit even after a non-fast-forward update.
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: package.json
+          package-manager-cache: false
+
+      - name: Classify Rust and CLI impact
+        id: classify
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          RANGE_MODE: ${{ github.event_name == 'pull_request' && 'merge-base' || 'direct' }}
+        run: node scripts/ci/classify-rust-impact.mjs --base "$BASE_SHA" --head "$HEAD_SHA" --range-mode "$RANGE_MODE"
+
   # ── Shell deploy assets: LF endings + syntax ───────────────────────
   # Relay one-click deploy embeds these scripts into the Desktop binary and
   # uploads them verbatim to a Linux host, where a single CR aborts the deploy
@@ -81,6 +109,8 @@ jobs:
   # ── CLI: independent tests ─────────────────────────────────────────
   cli-test:
     name: CLI Tests (${{ matrix.os }})
+    needs: rust-impact
+    if: ${{ !cancelled() && needs.rust-impact.outputs.rust_required != 'false' }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     strategy:
@@ -139,6 +169,8 @@ jobs:
   # ── Rust: build check ─────────────────────────────────────────────
   rust-build-check:
     name: Rust Build Check (${{ matrix.os }})
+    needs: rust-impact
+    if: ${{ !cancelled() && needs.rust-impact.outputs.rust_required != 'false' }}
     runs-on: ${{ matrix.os }}
     env:
       # Keep the workspace check plus desktop test profiles within hosted-runner disk limits.
@@ -277,6 +309,44 @@ jobs:
       - name: Run search tool tests
         run: "cargo test --locked -p tool-runtime --lib search::"
 
+  # Stable Rust/CLI result for CI runs: matrix jobs may be skipped for a proven
+  # Web-only change, but this result verifies why they ran or skipped.
+  rust-validation-result:
+    name: Rust / CLI Validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ always() }}
+    needs: [rust-impact, cli-test, rust-build-check]
+    steps:
+      - name: Verify Rust and CLI result
+        shell: pwsh
+        env:
+          RUST_REQUIRED: ${{ needs.rust-impact.outputs.rust_required }}
+          IMPACT_RESULT: ${{ needs.rust-impact.result }}
+          CLI_RESULT: ${{ needs.cli-test.result }}
+          RUST_RESULT: ${{ needs.rust-build-check.result }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if ($env:IMPACT_RESULT -ne 'success') {
+            throw "Rust impact classification did not succeed: $env:IMPACT_RESULT"
+          }
+
+          switch ($env:RUST_REQUIRED) {
+            'false' {
+              if ($env:CLI_RESULT -ne 'skipped' -or $env:RUST_RESULT -ne 'skipped') {
+                throw "Expected skipped Rust and CLI jobs for a Web-only change; CLI=$env:CLI_RESULT Rust=$env:RUST_RESULT"
+              }
+            }
+            'true' {
+              if ($env:CLI_RESULT -ne 'success' -or $env:RUST_RESULT -ne 'success') {
+                throw "Expected successful Rust and CLI jobs; CLI=$env:CLI_RESULT Rust=$env:RUST_RESULT"
+              }
+            }
+            default {
+              throw "Unexpected rust_required value: '$env:RUST_REQUIRED'"
+            }
+          }
+
   # ── DeepSeek Harness bridge: profile packaging on Windows ──────────
   # `prepare:dsh-profile` runs from `frontend:build-all` / official desktop
   # packaging, not from desktop:dev or cargo check. Until this job existed,
@@ -354,8 +424,11 @@ jobs:
       - name: Check repository hygiene
         run: pnpm run check:repo-hygiene
 
+      - name: Test core boundary contracts
+        run: pnpm run check:core-boundaries:test
+
       - name: Check core boundaries
-        run: node --test scripts/check-core-boundaries.test.mjs
+        run: pnpm run check:core-boundaries
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/docs/architecture/rust-build-dependency-boundaries.md
+++ b/docs/architecture/rust-build-dependency-boundaries.md
@@ -217,6 +217,10 @@ CI 负责 workspace 级检查、真实产品 feature 组合、跨平台、完整
 ### 7.1 Hosted CI 关键路径与缓存
 
 - 验证 job 只依赖自身的编译期前置条件。Tauri `check`/`test` 只要求配置中的前端和资源目录存在时，Rust job 自行创建空目录，不等待或传递可发布前端产物；真实静态资源仍由前端构建和产品打包 owner 负责。
+- Rust/CLI 影响分类必须保守且 fail-closed：只有活动路径全部位于 `src/web-ui/**` 时才允许跳过 Rust 与 CLI matrix；仓库根目录/`docs/**` 的 Markdown 和 `png/**` 可作为已知中性伴随路径。其他嵌套 Markdown 可能是 `include_str!`/`include_bytes!` 输入，workflow 不得宽泛忽略全部 Markdown。空变更、非法或不可用 diff range、Rust/build 输入、CI 脚本、其他产品 surface 和所有未识别路径都必须运行完整验证，不能依赖易漏维护的“已知 Rust 目录”名单。PR 使用 base/head 的 merge-base range，只分类 PR 自身改动；`main` push 使用事件 before/head 的 direct range，保留 force-push 或回退提交的实际影响。
+- “纯 Web”前提必须是可执行边界：影响分类 job 在计算 diff 前，从 Git 跟踪文件列表扫描全仓 `.rs`（包括 workspace 外 Installer 和根 build script）。除逐行精确登记的既有测试 fixture 外，非注释 Rust 源码不得出现 `web-ui` 路径 token；因此 `include_dir!`、编译嵌入、分段 `PathBuf::join` 和间接路径变量都会在分类前失败。Frontend job 同时显式运行边界 contract tests 和真实 repository boundary check；跨 surface 的命令注册和调用分别由 owner 测试看护。新增类似源码读取时应修复所有权，而不是给影响分类器追加隐式例外。
+- 可跳过的 matrix 必须汇总到一个稳定的 `Rust / CLI Validation` 结果：分类失败或输出缺失时下游按需要 Rust 处理；分类为 Web-only 时只接受 matrix 全部 skipped，分类为需要 Rust 时只接受全部 success。昂贵的 Rust/CLI 子 job 保留 `!cancelled()`，无 checkout 的轻量汇总使用 `always()` 检查上游 result，因此旧 run 被 concurrency 取消时明确失败而不是被当成 skipped success。
+- 该汇总只保证已触发 CI run 内的稳定结果；在 workflow 仍忽略 `png/**` 时不能直接宣称为全局 required check。若未来接入 branch protection，必须先保证所有受保护提交都会产生该 check，或同步调整 trigger 覆盖。
 - Pull Request 可以恢复可信分支产生的 Cargo 缓存，但不得写入 merge-ref 缓存。只有可信 `main` push 可以保存共享缓存；若依赖编译已经完成而后段测试失败，允许该可信构建保存依赖缓存，避免下一次跨平台构建无谓冷启动。
 - 未先修改 Cargo manifest 的 PR/main 验证 job 以仓库提交的 `Cargo.lock` 为唯一解析结果并通过 `--locked` 验证，不在 cache restore 前重新生成 lockfile。依赖解析更新必须作为可评审的源码变更提交，不能让同一 commit 因上游兼容版本发布而自然产生新的 cache key；先改写版本号的发布 job 不属于该前提。
 - 缓存只承载可复用依赖产物，不为追求命中率启用 workspace crate 或 incremental artifact 缓存；缓存容量、失效粒度和可信边界优先于单次命中率。

--- a/docs/performance/01-compile-performance.md
+++ b/docs/performance/01-compile-performance.md
@@ -381,7 +381,19 @@ Web 实际引用的 19 个直接类型及其递归导入闭包保持生成内容
 
 ### 3.4 CI 与本地验证
 
-- 现有 CI 已覆盖 workspace check、Core/Desktop lib、平台敏感 owner 测试和独立 runtime/CLI 验证；本轮不新增 job、矩阵或 changed-path 分类器。
+- 现有 CI 覆盖 workspace check、Core/Desktop lib、平台敏感 owner 测试和独立 runtime/CLI 验证。四次成功的纯 Web `main` 样本中，两个 CLI job 与三个 Rust Build Check job 没有消费变更，却合计占用 `58.9–68.2` runner-minutes；最长单 job 为 `17.3–22.7` 分钟。runner-minutes 为五个 job 的 `completed_at - started_at` 之和，不等于可直接相加的用户等待时间。
+
+| main 样本 | CI run | Rust + CLI runner-minutes | 最长 Rust/CLI job |
+|---|---:|---:|---:|
+| `b3eb18b5`（2026-08-20） | 32350538939 | 62.6 | 21.8 min |
+| `f43611e7`（2026-08-20） | 32348769484 | 58.9 | 17.3 min |
+| `b1d7c6b9`（2026-08-17） | 32018012719 | 67.1 | 22.7 min |
+| `b5ed01e3`（2026-08-17） | 31989419631 | 68.2 | 21.0 min |
+
+- 当前 CI 增加一个无依赖安装的影响分类 job 和一个稳定结果汇总 job，不增加平台矩阵。只有活动路径全部属于 `src/web-ui/**` 才跳过上述五个 Rust/CLI job；仓库根目录/`docs/**` Markdown 与 `png/**` 作为已知中性路径。其他嵌套 Markdown 可能被 Rust 编译期嵌入，因此 workflow 不再宽泛忽略全部 Markdown，它们与 `.github/**`、`scripts/**`、其他 Web 产品、Rust/build 输入和未知路径一样运行完整矩阵；diff 不可验证时也 fail-closed。PR 按 merge-base range 分类，`main` push 按 before/head direct range 分类。
+- Desktop 的 Rust 测试不再编译期读取 Web API 源码；Desktop 注册与 Web 调用分别在各自 owner 验证。影响分类在 diff 前扫描 Git 跟踪的全仓 Rust 源码；除精确登记的既有测试 fixture 外，任何非注释 `web-ui` 路径 token 都直接使分类失败，因此目录嵌入、分段路径和间接读取也不能绕过。Frontend job 另行执行 boundary contract tests 与真实 repository check。
+- 昂贵的 Rust/CLI 子 job 在 concurrency cancellation 时不再启动；轻量汇总始终读取上游 result，把分类失败、取消、异常 skipped 和 matrix 失败统一报告为失败。该汇总目前只是在已触发 CI run 内提供稳定结果；workflow 仍忽略 `png/**`，接入全局 required check 前必须先补齐所有受保护提交的 trigger 覆盖。
+- 本 PR 自身修改 CI、脚本和 Rust 边界，因此按设计必须运行完整 Rust/CLI matrix。跳过后的实际 runner-minutes 与等待时间要等合入后的首个纯 Web PR/main run 再记录；当前只能报告历史可避免成本和目标调度行为，不能把目标值表述为已实测收益。
 - CI 不负责穷举所有测试；新增验证只有具备独立 owner、平台矩阵或失败归因价值时才进入既有流水线，否则由最近模块的 focused command 维护。
 - 本地从 owner 文档的最小 package/target/feature 入口开始；仅名称过滤不能阻止无关 target 编译。
 - CI 收敛必须先有多次 job/step 耗时、缓存状态和失败历史；`SKIPPED`、未触发或只编译未运行都不算通过证据。
@@ -394,7 +406,7 @@ Web 实际引用的 19 个直接类型及其递归导入闭包保持生成内容
 | 开发循环 | mobile-web 支持输入 mtime 短路；Vite 默认使用原生文件事件；前端准备步骤已并行 |
 | Rust profile | release 使用 thin LTO；dev 使用 `line-tables-only` 和高 codegen-units，并保留调试逃生口 |
 | 可复现解析 | 根 lockfile 已提交，普通 CI 使用 `--locked`；build.rs 输出已排序 |
-| CI 拓扑 | Rust job 不再等待完整前端构建，自建 Tauri 检查所需资源目录 |
+| CI 拓扑 | Rust job 不再等待完整前端构建，自建 Tauri 检查所需资源目录；经 fail-closed 证明的纯 Web 变更跳过 Rust/CLI matrix，并由稳定结果 job 汇总 |
 | 依赖收敛 | Desktop 直接 image 版本和 Reqwest TLS 双栈已治理 |
 | Agent Runtime 闭包 | Core 基线不再暗带具体 capability；完整产品和 CLI 显式保持原能力，ACP 退出未选择闭包 |
 | Core/ACP 默认与角色 | Core 默认 feature 为空；ACP 默认精确保持 client + server，Desktop client-only、CLI 双角色均由现有边界检查锁定 |
@@ -417,7 +429,7 @@ Web 实际引用的 19 个直接类型及其递归导入闭包保持生成内容
 
 | 范围 | 启动条件 |
 |---|---|
-| CI 收敛 | 先积累多次相同 owner 的 step wall-clock、cache hit/miss 和失败历史；只有能证明收益且不会静默缩小覆盖时再独立设计 |
+| CI 收敛 | 观察首个合入后的纯 Web PR/main 样本，核对五个 Rust/CLI job 均为 skipped、稳定汇总通过且 Frontend Build 正常；只有出现新的同类浪费和充分证据时才扩大范围 |
 | Desktop 截图后端 | 新候选同时满足三平台行为等价、区域捕获无性能回退、系统依赖可 feature-gate，且根 lock package 不增加 |
 | App Server / Server | 观察 protocol 单一 schema owner 合入后的 Frontend Build 样本；没有新的生产 owner 或稳定行为收益前，不继续拆 handler 路径 |
 | 其他产品入口重型 capability | 证明入口不消费该能力，具备 typed unsupported/fallback 行为，并能让一个真实重依赖子图退出 |

--- a/scripts/check-core-boundaries.test.mjs
+++ b/scripts/check-core-boundaries.test.mjs
@@ -34,6 +34,7 @@ import {
   validateExplicitIntegrationTestTopology,
 } from './core-boundaries/explicit-test-topology.mjs';
 import { crateLayoutRules } from './core-boundaries/rules/crate-layout.mjs';
+import { findForbiddenContentMatches } from './core-boundaries/source-content-checks.mjs';
 import {
   capabilityContractDependencyRules,
   coreClosedFeatureProfileRules,
@@ -44,6 +45,7 @@ import {
 import {
   agentRuntimeRootPublicModules,
   forbiddenContentRules,
+  forbiddenContentUnderRules,
   publicApiAllowlistRules,
   requiredContentRules,
 } from './core-boundaries/rules/source-rules.mjs';
@@ -54,6 +56,7 @@ const MODULES = [
   './core-boundaries/cargo-dependency-boundaries.mjs',
   './core-boundaries/explicit-test-topology.mjs',
   './core-boundaries/manifest-feature-helpers.mjs',
+  './core-boundaries/source-content-checks.mjs',
   './core-boundaries/self-test.mjs',
   './core-boundaries/tui-boundary-ratchet.mjs',
   './core-boundaries/rules/crate-rules.mjs',
@@ -874,6 +877,71 @@ test('external source integration tests keep reviewed owner and process boundari
   assert.deepEqual(
     checkExternalSourceIntegrationTestTopologies(repositoryRoot),
     [],
+  );
+});
+
+test('Web UI command contracts do not become Rust compilation inputs', async () => {
+  const webApiPath = 'src/web-ui/src/infrastructure/api/service-api/ExternalSourcesAPI.ts';
+  const webCommandRule = requiredContentRules.find(
+    (rule) => rule.path === webApiPath
+      && rule.reason.includes('stable Desktop command'),
+  );
+  assert.ok(webCommandRule, 'Web API must retain a boundary-owned stable command contract');
+
+  const webCommandPattern = webCommandRule.patterns.find(
+    (pattern) => pattern.message.includes('external-source control snapshot'),
+  )?.regex;
+  assert.ok(webCommandPattern, 'Web API command contract must name the control snapshot');
+
+  const webApi = await readFile(new URL(`../${webApiPath}`, import.meta.url), 'utf8');
+  assert.equal(webCommandPattern.test(webApi), true);
+  assert.equal(
+    webCommandPattern.test(
+      webApi.replace('get_external_source_control_snapshot', 'get_renamed_snapshot'),
+    ),
+    false,
+    'renaming the invoked command must break the cross-surface contract',
+  );
+
+  const rustSourceRule = forbiddenContentUnderRules.find(
+    (rule) => rule.path === '.'
+      && rule.reason.includes('Rust source must not reference the Web UI source tree'),
+  );
+  assert.ok(rustSourceRule, 'all tracked Rust sources must reject Web UI file inputs');
+  for (const mutation of [
+    'let web = include_str!(\n  "../../web-ui/src/infrastructure/api.ts"\n);',
+    'let web = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../web-ui/src/api.ts"));',
+    'let web = include!("../../web-ui/public/generated.rs");',
+    'let web = include_dir!("../../web-ui/src");',
+    'let path = PathBuf::from("../../web-ui/src/api.ts");',
+    'let path = PathBuf::from("../../").join("web-ui").join("src");',
+    'const WEB_UI_DIR: &str = "web-ui"; let body = fs::read_to_string(WEB_UI_DIR);',
+    'let example = r#"include_str!(\"../../web-ui/src/api.ts\")"#;',
+  ]) {
+    assert.equal(
+      findForbiddenContentMatches(mutation, rustSourceRule.patterns, 'src/example.rs').length,
+      1,
+      `Rust/Web input guard must reject: ${mutation}`,
+    );
+  }
+  for (const allowed of [
+    '// include_str!("../../web-ui/src/comment-only.ts")',
+    '/* PathBuf::from("../../web-ui/public/comment-only.json") */',
+    'const REVIEW_SCOPE: &str = "src/frontend/src/**/*.ts";',
+  ]) {
+    assert.deepEqual(
+      findForbiddenContentMatches(allowed, rustSourceRule.patterns, 'src/example.rs'),
+      [],
+      `Rust/Web input guard must ignore non-input text: ${allowed}`,
+    );
+  }
+  assert.deepEqual(
+    findForbiddenContentMatches(
+      'allowed\nforbidden',
+      [{ regex: /forbidden/, message: 'line-based guard' }],
+      'src/example.rs',
+    ),
+    [{ line: 2, message: 'line-based guard' }],
   );
 });
 
@@ -3138,6 +3206,11 @@ test('core boundary check is split into focused modules', async () => {
     checker.split(/\r?\n/).length <= 1200,
     'checker should stay focused on orchestration and shared check helpers',
   );
+  assert.match(
+    checker,
+    /listTrackedRustRepoPaths/,
+    'recursive source boundary checks must inspect tracked Rust files only',
+  );
 
   const sourceRuleEntry = await readFile(
     new URL('./core-boundaries/rules/source-rules.mjs', import.meta.url),
@@ -3269,7 +3342,7 @@ test('desktop preview rebuild inputs use the current crate layout', async () => 
   );
 });
 
-test('split core boundary check keeps self-test and default execution behavior', () => {
+test('split core boundary check keeps self-test execution behavior', () => {
   const selfTest = spawnSync(
     process.execPath,
     ['scripts/check-core-boundaries.mjs'],
@@ -3281,13 +3354,6 @@ test('split core boundary check keeps self-test and default execution behavior',
   );
   assert.equal(selfTest.status, 0, selfTest.stderr || selfTest.stdout);
   assert.match(selfTest.stdout, /Core boundary check self-test passed\./);
-
-  const defaultRun = spawnSync(process.execPath, ['scripts/check-core-boundaries.mjs'], {
-    cwd: new URL('..', import.meta.url),
-    encoding: 'utf8',
-  });
-  assert.equal(defaultRun.status, 0, defaultRun.stderr || defaultRun.stdout);
-  assert.match(defaultRun.stdout, /Core boundary check passed\./);
 });
 
 test('optional dependency ownership rejects undeclared direct feature owners', async () => {

--- a/scripts/check-github-config.test.mjs
+++ b/scripts/check-github-config.test.mjs
@@ -214,7 +214,7 @@ test('keeps Rust CI independent, restore-only on PRs, and target-focused', () =>
 
   assert.equal(
     rustJob.needs,
-    undefined,
+    'rust-impact',
     'Rust validation must not wait for the frontend build',
   );
   assert.equal(
@@ -324,6 +324,144 @@ test('keeps Rust CI independent, restore-only on PRs, and target-focused', () =>
     commandByStep.get('Run search tool tests'),
     'cargo test --locked -p tool-runtime --lib search::',
   );
+});
+
+test('gates Rust and CLI validation behind one fail-closed impact decision', () => {
+  const workflow = yaml.parse(
+    readFileSync(path.join(repoRoot, '.github/workflows/ci.yml'), 'utf8'),
+  );
+  for (const eventName of ['pull_request', 'push']) {
+    assert.deepEqual(
+      workflow.on[eventName]?.['paths-ignore'],
+      ['png/**'],
+      'nested Markdown may be a Rust compile-time input and must trigger classification',
+    );
+  }
+  const impactJob = workflow.jobs['rust-impact'];
+  const cliJob = workflow.jobs['cli-test'];
+  const rustJob = workflow.jobs['rust-build-check'];
+  const resultJob = workflow.jobs['rust-validation-result'];
+  const frontendJob = workflow.jobs['frontend-build'];
+
+  assert.equal(
+    frontendJob.steps.find((step) => step.name === 'Test core boundary contracts')?.run,
+    'pnpm run check:core-boundaries:test',
+  );
+  assert.equal(
+    frontendJob.steps.find((step) => step.name === 'Check core boundaries')?.run,
+    'pnpm run check:core-boundaries',
+  );
+
+  assert.equal(impactJob.name, 'Rust / CLI Impact');
+  assert.equal(impactJob['timeout-minutes'], 5);
+  assert.equal(
+    impactJob.outputs.rust_required,
+    '${{ steps.classify.outputs.rust_required }}',
+  );
+  const checkout = impactJob.steps.find((step) => step.uses?.startsWith('actions/checkout@'));
+  assert.equal(checkout?.with?.['fetch-depth'], 0);
+  const classify = impactJob.steps.find((step) => step.id === 'classify');
+  assert.match(classify?.run ?? '', /scripts\/ci\/classify-rust-impact\.mjs/);
+  assert.equal(
+    classify?.env?.BASE_SHA,
+    '${{ github.event.pull_request.base.sha || github.event.before }}',
+  );
+  assert.equal(
+    classify?.env?.HEAD_SHA,
+    '${{ github.event.pull_request.head.sha || github.sha }}',
+  );
+  assert.equal(
+    classify?.env?.RANGE_MODE,
+    "${{ github.event_name == 'pull_request' && 'merge-base' || 'direct' }}",
+  );
+  assert.match(classify?.run ?? '', /--range-mode "\$RANGE_MODE"/);
+
+  for (const job of [cliJob, rustJob]) {
+    assert.equal(job.needs, 'rust-impact');
+    assert.match(job.if, /!cancelled\(\)/);
+    assert.doesNotMatch(job.if, /always\(\)/);
+    assert.match(job.if, /rust_required != 'false'/);
+  }
+
+  assert.equal(resultJob.name, 'Rust / CLI Validation');
+  assert.equal(resultJob.if, '${{ always() }}');
+  assert.deepEqual(
+    [...resultJob.needs].sort(),
+    ['cli-test', 'rust-build-check', 'rust-impact'],
+  );
+  const verify = resultJob.steps.find((step) => step.name === 'Verify Rust and CLI result');
+  assert.equal(verify?.env?.RUST_REQUIRED, '${{ needs.rust-impact.outputs.rust_required }}');
+  assert.equal(verify?.env?.IMPACT_RESULT, '${{ needs.rust-impact.result }}');
+  assert.equal(verify?.env?.CLI_RESULT, '${{ needs.cli-test.result }}');
+  assert.equal(verify?.env?.RUST_RESULT, '${{ needs.rust-build-check.result }}');
+  assert.equal(verify?.shell, 'pwsh');
+  assert.match(verify?.run ?? '', /expected skipped Rust and CLI jobs/i);
+  assert.match(verify?.run ?? '', /expected successful Rust and CLI jobs/i);
+
+  const statuses = ['success', 'skipped', 'failure', 'cancelled'];
+  const cases = [];
+  for (const impactResult of statuses.filter((status) => status !== 'success')) {
+    cases.push({
+      rustRequired: 'true',
+      impactResult,
+      cliResult: 'success',
+      rustResult: 'success',
+      expectedSuccess: false,
+    });
+  }
+  for (const rustRequired of ['false', 'true']) {
+    for (const cliResult of statuses) {
+      for (const rustResult of statuses) {
+        cases.push({
+          rustRequired,
+          impactResult: 'success',
+          cliResult,
+          rustResult,
+          expectedSuccess: rustRequired === 'false'
+            ? cliResult === 'skipped' && rustResult === 'skipped'
+            : cliResult === 'success' && rustResult === 'success',
+        });
+      }
+    }
+  }
+  cases.push({
+    rustRequired: '',
+    impactResult: 'success',
+    cliResult: 'skipped',
+    rustResult: 'skipped',
+    expectedSuccess: false,
+  });
+  const truthTable = spawnSync(
+    'pwsh',
+    [
+      '-NoProfile',
+      '-NonInteractive',
+      '-Command',
+      `$cases = ConvertFrom-Json @'
+${JSON.stringify(cases)}
+'@
+$verify = {
+${verify.run}
+}
+foreach ($case in $cases) {
+  $env:RUST_REQUIRED = [string]$case.rustRequired
+  $env:IMPACT_RESULT = [string]$case.impactResult
+  $env:CLI_RESULT = [string]$case.cliResult
+  $env:RUST_RESULT = [string]$case.rustResult
+  $succeeded = $true
+  try { & $verify } catch { $succeeded = $false }
+  if ($succeeded -ne [bool]$case.expectedSuccess) {
+    throw "Unexpected result: $($case | ConvertTo-Json -Compress) succeeded=$succeeded"
+  }
+}`,
+    ],
+    {
+      cwd: repoRoot,
+      env: process.env,
+      encoding: 'utf8',
+    },
+  );
+  assert.equal(truthTable.status, 0, `${truthTable.stdout}${truthTable.stderr}`);
 });
 
 test('generates web API bindings before nightly web type-check', () => {

--- a/scripts/ci/classify-rust-impact.mjs
+++ b/scripts/ci/classify-rust-impact.mjs
@@ -1,0 +1,174 @@
+import { appendFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+import { rustWebUiSourceBoundaryRule } from '../core-boundaries/rules/source-rules.mjs';
+import { scanForbiddenContentUnder } from '../core-boundaries/source-content-checks.mjs';
+
+function readArg(args, name) {
+  const index = args.indexOf(name);
+  return index >= 0 ? args[index + 1] : undefined;
+}
+
+function changedPaths(base, head, rangeMode) {
+  const rangeArgs = rangeMode === 'merge-base'
+    ? [`${base}...${head}`]
+    : [base, head];
+  const result = spawnSync(
+    'git',
+    ['diff', '--no-renames', '--name-only', '-z', ...rangeArgs, '--'],
+    { encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 },
+  );
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || 'git diff failed');
+  }
+  return result.stdout.split('\0').filter(Boolean);
+}
+
+export function classifyRustImpact(paths) {
+  const result = (rustRequired, reason) => ({
+    rustRequired,
+    reason,
+    changedCount: paths.length,
+  });
+  if (paths.length === 0) {
+    return result(true, 'no-changes');
+  }
+  if (paths.some((file) => !isValidRepositoryPath(file))) {
+    return result(true, 'invalid-path');
+  }
+  if (paths.some(isRustBuildInput)) {
+    return result(true, 'rust-build-input');
+  }
+
+  const activePaths = paths.filter((file) => !isKnownNeutralPath(file));
+  if (activePaths.length === 0) {
+    return result(false, 'ci-ignored-only');
+  }
+  if (activePaths.every((file) => file.startsWith('src/web-ui/'))) {
+    return result(false, 'web-ui-only');
+  }
+  return result(true, 'outside-web-ui');
+}
+
+function isValidRepositoryPath(file) {
+  return typeof file === 'string'
+    && file.length > 0
+    && !file.startsWith('/')
+    && !/^[A-Za-z]:/.test(file)
+    && !file.includes('\\')
+    && !/[\r\n\0]/.test(file)
+    && file.split('/').every((segment) => segment !== '' && segment !== '.' && segment !== '..');
+}
+
+function isRustBuildInput(file) {
+  const segments = file.split('/');
+  const name = segments.at(-1);
+  return file.endsWith('.rs')
+    || name === 'Cargo.toml'
+    || name === 'Cargo.lock'
+    || name === 'build.rs'
+    || name === 'rust-toolchain'
+    || name === 'rust-toolchain.toml'
+    || segments.includes('.cargo');
+}
+
+function isKnownNeutralPath(file) {
+  const isKnownDocumentation = file.endsWith('.md')
+    && (!file.includes('/') || file.startsWith('docs/'));
+  return isKnownDocumentation || file.startsWith('png/');
+}
+
+export function run(args = process.argv.slice(2), env = process.env) {
+  const base = readArg(args, '--base');
+  const head = readArg(args, '--head');
+  const rangeMode = readArg(args, '--range-mode') ?? 'direct';
+  if (!base || !head) {
+    throw new Error(
+      'Usage: classify-rust-impact.mjs --base <sha> --head <sha> '
+      + '[--range-mode direct|merge-base]',
+    );
+  }
+
+  const boundaryFindings = scanForbiddenContentUnder(
+    process.cwd(),
+    rustWebUiSourceBoundaryRule,
+  );
+  if (boundaryFindings.length > 0) {
+    const details = boundaryFindings
+      .slice(0, 20)
+      .map((finding) => `${finding.repoPath}:${finding.line}: ${finding.message}`)
+      .join('\n');
+    throw new Error(`${rustWebUiSourceBoundaryRule.reason}\n${details}`);
+  }
+
+  let paths = [];
+  let result;
+  if (
+    !isUsableCommitSha(base)
+    || !isUsableCommitSha(head)
+    || !['direct', 'merge-base'].includes(rangeMode)
+  ) {
+    result = { rustRequired: true, reason: 'invalid-range', changedCount: 0 };
+  } else {
+    try {
+      paths = changedPaths(base, head, rangeMode);
+      result = classifyRustImpact(paths);
+    } catch {
+      result = { rustRequired: true, reason: 'unavailable-range', changedCount: 0 };
+    }
+  }
+  const lines = [
+    `rust_required=${result.rustRequired}`,
+    `reason=${result.reason}`,
+    `changed_count=${result.changedCount}`,
+  ];
+  if (env.GITHUB_OUTPUT) {
+    appendFileSync(env.GITHUB_OUTPUT, `${lines.join('\n')}\n`);
+  } else {
+    process.stdout.write(`${lines.join('\n')}\n`);
+  }
+  if (env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(env.GITHUB_STEP_SUMMARY, renderSummary(result, paths));
+  }
+  return result;
+}
+
+function isUsableCommitSha(value) {
+  return /^[0-9a-f]{40}$/i.test(value) && !/^0{40}$/.test(value);
+}
+
+function renderSummary(result, paths) {
+  const shownPaths = paths.slice(0, 20);
+  const lines = [
+    '### Rust/CLI impact classification',
+    '',
+    `- <strong>Required:</strong> ${result.rustRequired}`,
+    `- <strong>Reason:</strong> ${result.reason}`,
+    `- <strong>Changed files:</strong> ${result.changedCount}`,
+  ];
+  if (shownPaths.length > 0) {
+    lines.push('', ...shownPaths.map((file) => `- <code>${escapeHtml(file)}</code>`));
+  }
+  if (paths.length > shownPaths.length) {
+    lines.push(`- ${paths.length - shownPaths.length} additional changed file(s) omitted`);
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+function escapeHtml(value) {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('\r', '\\r')
+    .replaceAll('\n', '\\n');
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    run();
+  } catch (error) {
+    process.stderr.write(`${error.message || String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/ci/classify-rust-impact.test.mjs
+++ b/scripts/ci/classify-rust-impact.test.mjs
@@ -1,0 +1,231 @@
+import assert from 'node:assert/strict';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { classifyRustImpact } from './classify-rust-impact.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const scriptPath = path.join(repoRoot, 'scripts/ci/classify-rust-impact.mjs');
+
+function git(root, args) {
+  const result = spawnSync('git', args, {
+    cwd: root,
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout.trim();
+}
+
+function commit(root, message) {
+  git(root, ['add', '--all']);
+  git(root, [
+    '-c',
+    'user.name=CI Impact Test',
+    '-c',
+    'user.email=ci-impact@example.invalid',
+    'commit',
+    '-m',
+    message,
+  ]);
+  return git(root, ['rev-parse', 'HEAD']);
+}
+
+function parseOutputs(file) {
+  return Object.fromEntries(
+    readFileSync(file, 'utf8')
+      .trim()
+      .split(/\r?\n/)
+      .map((line) => line.split('=', 2)),
+  );
+}
+
+function runClassifier(root, base, head, rangeMode = 'direct') {
+  const output = path.join(root, `github-output-${Date.now()}-${Math.random()}.txt`);
+  const summary = path.join(root, `github-summary-${Date.now()}-${Math.random()}.md`);
+  const result = spawnSync(
+    process.execPath,
+    [scriptPath, '--base', base, '--head', head, '--range-mode', rangeMode],
+    {
+      cwd: root,
+      env: {
+        ...process.env,
+        GITHUB_OUTPUT: output,
+        GITHUB_STEP_SUMMARY: summary,
+      },
+      encoding: 'utf8',
+    },
+  );
+  return {
+    ...result,
+    outputs: result.status === 0 ? parseOutputs(output) : undefined,
+    summary: existsSync(summary) ? readFileSync(summary, 'utf8') : undefined,
+  };
+}
+
+test('skips Rust validation when a commit changes only Web UI files', (t) => {
+  const root = mkdtempSync(path.join(tmpdir(), 'bitfun-rust-impact-'));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  git(root, ['init', '--initial-branch=main']);
+  writeFileSync(path.join(root, 'README.md'), 'baseline\n');
+  const base = commit(root, 'baseline');
+
+  const webFile = path.join(root, 'src/web-ui/src/example.ts');
+  mkdirSync(path.dirname(webFile), { recursive: true });
+  writeFileSync(webFile, 'export const example = true;\n');
+  const head = commit(root, 'web change');
+
+  const result = runClassifier(root, base, head);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(result.outputs, {
+    rust_required: 'false',
+    reason: 'web-ui-only',
+    changed_count: '1',
+  });
+  assert.match(result.summary, /Rust\/CLI impact classification/);
+  assert.match(result.summary, /Required:<\/strong> false/);
+  assert.match(result.summary, /Reason:<\/strong> web-ui-only/);
+  assert.match(result.summary, /<code>src\/web-ui\/src\/example\.ts<\/code>/);
+});
+
+test('uses a merge-base range for pull requests but a direct range for pushes', (t) => {
+  const root = mkdtempSync(path.join(tmpdir(), 'bitfun-rust-impact-diverged-'));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  git(root, ['init', '--initial-branch=main']);
+  writeFileSync(path.join(root, 'README.md'), 'baseline\n');
+  commit(root, 'baseline');
+
+  git(root, ['switch', '-c', 'feature']);
+  const webFile = path.join(root, 'src/web-ui/src/example.ts');
+  mkdirSync(path.dirname(webFile), { recursive: true });
+  writeFileSync(webFile, 'export const example = true;\n');
+  const head = commit(root, 'web change');
+
+  git(root, ['switch', 'main']);
+  const rustFile = path.join(root, 'src/apps/desktop/src/lib.rs');
+  mkdirSync(path.dirname(rustFile), { recursive: true });
+  writeFileSync(rustFile, 'pub fn base_change() {}\n');
+  const currentBase = commit(root, 'base Rust change');
+
+  assert.deepEqual(runClassifier(root, currentBase, head, 'merge-base').outputs, {
+    rust_required: 'false',
+    reason: 'web-ui-only',
+    changed_count: '1',
+  });
+  assert.deepEqual(runClassifier(root, currentBase, head, 'direct').outputs, {
+    rust_required: 'true',
+    reason: 'rust-build-input',
+    changed_count: '2',
+  });
+});
+
+test('keeps workflow-ignored documentation neutral beside Web UI changes', () => {
+  assert.deepEqual(
+    classifyRustImpact([
+      'src/web-ui/src/example.ts',
+      'src/web-ui/README.md',
+      'docs/review-notes.md',
+      'png/example/screenshot.png',
+    ]),
+    {
+      rustRequired: false,
+      reason: 'web-ui-only',
+      changedCount: 4,
+    },
+  );
+  assert.deepEqual(classifyRustImpact(['docs/review-notes.md', 'png/example.png']), {
+    rustRequired: false,
+    reason: 'ci-ignored-only',
+    changedCount: 2,
+  });
+  assert.deepEqual(
+    classifyRustImpact([
+      'src/web-ui/src/example.ts',
+      'src/crates/assembly/agent-content/prompts/agents/example.md',
+    ]),
+    {
+      rustRequired: true,
+      reason: 'outside-web-ui',
+      changedCount: 2,
+    },
+    'nested Markdown may be a Rust include input and must fail closed',
+  );
+});
+
+test('requires Rust for ambiguous, native, or cross-boundary path sets', () => {
+  for (const [paths, reason] of [
+    [[], 'no-changes'],
+    [['src/apps/desktop/src/lib.rs'], 'rust-build-input'],
+    [['src/web-ui/native/build.rs'], 'rust-build-input'],
+    [['src/web-ui/native/Cargo.toml'], 'rust-build-input'],
+    [['src/web-ui/src/example.ts', 'scripts/check-core-boundaries.mjs'], 'outside-web-ui'],
+    [['src/web-ui/../apps/desktop/src/lib.rs'], 'invalid-path'],
+    [['src\\web-ui\\src\\example.ts'], 'invalid-path'],
+  ]) {
+    assert.deepEqual(classifyRustImpact(paths), {
+      rustRequired: true,
+      reason,
+      changedCount: paths.length,
+    });
+  }
+});
+
+test('requires Rust when the event range is invalid or unavailable', (t) => {
+  const root = mkdtempSync(path.join(tmpdir(), 'bitfun-rust-impact-range-'));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  git(root, ['init', '--initial-branch=main']);
+  writeFileSync(path.join(root, 'README.md'), 'baseline\n');
+  const head = commit(root, 'baseline');
+
+  for (const [base, reason] of [
+    ['0'.repeat(40), 'invalid-range'],
+    ['f'.repeat(40), 'unavailable-range'],
+  ]) {
+    const result = runClassifier(root, base, head);
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(result.outputs, {
+      rust_required: 'true',
+      reason,
+      changed_count: '0',
+    });
+  }
+
+  const invalidMode = runClassifier(root, head, head, 'unsupported');
+  assert.equal(invalidMode.status, 0, invalidMode.stderr);
+  assert.deepEqual(invalidMode.outputs, {
+    rust_required: 'true',
+    reason: 'invalid-range',
+    changed_count: '0',
+  });
+});
+
+test('rejects tracked Rust sources that spell a Web UI input token', (t) => {
+  const root = mkdtempSync(path.join(tmpdir(), 'bitfun-rust-impact-boundary-'));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  git(root, ['init', '--initial-branch=main']);
+  writeFileSync(path.join(root, 'README.md'), 'baseline\n');
+  const base = commit(root, 'baseline');
+
+  const rustFile = path.join(root, 'src/lib.rs');
+  mkdirSync(path.dirname(rustFile), { recursive: true });
+  writeFileSync(rustFile, 'const WEB: &str = include_dir!("../web-ui/src");\n');
+  const head = commit(root, 'forbidden Rust input');
+
+  const result = runClassifier(root, base, head);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Rust source must not reference the Web UI source tree/);
+});

--- a/scripts/core-boundaries/checker.mjs
+++ b/scripts/core-boundaries/checker.mjs
@@ -41,6 +41,10 @@ import {
 import { checkCargoDependencyBoundariesSafely } from './cargo-dependency-boundaries.mjs';
 import { checkPeerCommandPolicySync } from './peer-command-policy.mjs';
 import {
+  listTrackedRustRepoPaths,
+  scanForbiddenContentUnder,
+} from './source-content-checks.mjs';
+import {
   agentRuntimeIntegrationTestTargets,
   checkAgentRuntimeIntegrationTestTopology,
   checkCliIntegrationTestTopology,
@@ -1055,29 +1059,15 @@ function checkPublicApiAllowlist(rule) {
   }
 }
 
-function checkForbiddenContentUnder(repoDir, patterns, reason) {
-  const dir = repoPathToFsPath(repoDir);
-  walkFiles(dir, (path) => {
-    if (!path.endsWith('.rs')) {
-      return;
-    }
-    const repoPath = toRepoPath(path);
-    const lines = readText(path).split(/\r?\n/);
-    lines.forEach((line, index) => {
-      for (const pattern of patterns) {
-        if (pattern.allowPaths?.includes(repoPath)) {
-          continue;
-        }
-        if (pattern.regex.test(line)) {
-          failures.push({
-            path,
-            line: index + 1,
-            message: `${reason}; ${pattern.message}`,
-          });
-        }
-      }
+function checkForbiddenContentUnder(repoDir, patterns, reason, trackedRustRepoPaths) {
+  const rule = { path: repoDir, patterns };
+  for (const finding of scanForbiddenContentUnder(ROOT, rule, trackedRustRepoPaths)) {
+    failures.push({
+      path: finding.path,
+      line: finding.line,
+      message: `${reason}; ${finding.message}`,
     });
-  });
+  }
 }
 
 export function runCoreBoundaryCheck() {
@@ -1127,6 +1117,7 @@ export function runCoreBoundaryCheck() {
   failures.push(...checkCliIntegrationTestTopology(ROOT));
   failures.push(...checkExternalSourceIntegrationTestTopologies(ROOT), ...checkReviewedIntegrationTestTopologies(ROOT));
   failures.push(...checkPeerCommandPolicySync(ROOT));
+  const trackedRustRepoPaths = listTrackedRustRepoPaths(ROOT);
 
   for (const rule of forbiddenManifestDependencyRules) {
     checkForbiddenManifestDependencyRule(rule);
@@ -1177,7 +1168,7 @@ export function runCoreBoundaryCheck() {
   }
 
   for (const rule of forbiddenContentUnderRules) {
-    checkForbiddenContentUnder(rule.path, rule.patterns, rule.reason);
+    checkForbiddenContentUnder(rule.path, rule.patterns, rule.reason, trackedRustRepoPaths);
   }
 
   for (const rule of requiredContentRules) {

--- a/scripts/core-boundaries/rules/source-rules.mjs
+++ b/scripts/core-boundaries/rules/source-rules.mjs
@@ -4,6 +4,7 @@ export { facadeOnlyFiles } from './source/facade-rules.mjs';
 export {
   forbiddenContentRules,
   forbiddenContentUnderRules,
+  rustWebUiSourceBoundaryRule,
 } from './source/forbidden-rules.mjs';
 export {
   agentRuntimeRootPublicModules,

--- a/scripts/core-boundaries/rules/source/forbidden-rules.mjs
+++ b/scripts/core-boundaries/rules/source/forbidden-rules.mjs
@@ -4064,7 +4064,53 @@ export const forbiddenContentRules = [
   },
 ];
 
+export const rustWebUiSourceBoundaryRule = {
+  path: '.',
+  reason:
+    'Rust source must not reference the Web UI source tree; cross-surface contracts belong in surface tests and repository boundary checks',
+  patterns: [
+    {
+      regex: /\bweb-ui\b/g,
+      wholeFile: true,
+      ignoreRustComments: true,
+      allowLines: [
+        {
+          path: 'src/crates/assembly/core/src/agentic/tools/implementations/code_review_tool.rs',
+          text: 'touched_files: vec!["src/web-ui/src/flow_chat/utils/codeReviewReport.ts".to_string()],',
+        },
+        {
+          path: 'src/crates/assembly/core/src/agentic/tools/implementations/code_review_tool.rs',
+          text: 'target: "pnpm --dir src/web-ui run test:run".to_string(),',
+        },
+        {
+          path: 'src/crates/execution/agent-runtime/src/deep_review/manifest.rs',
+          text: '"changed_files": ["src/web-ui/src/locales/en-US/flow-chat.json"],',
+        },
+        {
+          path: 'src/crates/execution/agent-runtime/src/deep_review/manifest.rs',
+          text: '"file_path": "src/web-ui/src/locales/en-US/flow-chat.json",',
+        },
+        {
+          path: 'src/crates/execution/agent-runtime/src/deep_review/manifest.rs',
+          text: '"src/web-ui/src/locales/en-US/flow-chat.json"',
+        },
+        {
+          path: 'src/crates/services/services-integrations/src/canvas/compiler/tests.rs',
+          text: "nodes: [{ id: 'web-ui' }, { id: 'core' }],",
+        },
+        {
+          path: 'src/crates/services/services-integrations/src/canvas/compiler/tests.rs',
+          text: "edges: [{ from: 'web-ui', to: 'core' }],",
+        },
+      ],
+      message:
+        'non-comment Rust source must not spell the web-ui path token outside reviewed fixture lines',
+    },
+  ],
+};
+
 export const forbiddenContentUnderRules = [
+  rustWebUiSourceBoundaryRule,
   {
     path: 'src/crates/adapters/agent-runtime-ipc/src',
     reason: 'agent-runtime-ipc transport is restricted to Named Pipe and Unix Domain Socket',

--- a/scripts/core-boundaries/rules/source/required-rules.mjs
+++ b/scripts/core-boundaries/rules/source/required-rules.mjs
@@ -4,6 +4,18 @@ import { agentRuntimeRootPublicModules } from './public-api-rules.mjs';
 
 export const requiredContentRules = [
   {
+    path: 'src/web-ui/src/infrastructure/api/service-api/ExternalSourcesAPI.ts',
+    reason:
+      'the Web API must continue invoking the stable Desktop command without making Web source a Rust compilation input',
+    patterns: [
+      {
+        regex:
+          /\binvokeSurfaceSnapshot\(\s*['"]get_external_source_control_snapshot['"]/,
+        message: 'missing stable external-source control snapshot invocation',
+      },
+    ],
+  },
+  {
     path: 'src/crates/adapters/agent-runtime-ipc/Cargo.toml',
     reason:
       'agent-runtime-ipc must keep the exact feature-free bitfun-transport dependency',

--- a/scripts/core-boundaries/source-content-checks.mjs
+++ b/scripts/core-boundaries/source-content-checks.mjs
@@ -1,0 +1,167 @@
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export function listTrackedRustRepoPaths(root) {
+  const result = spawnSync(
+    'git',
+    ['-C', root, 'ls-files', '-z', '--', '*.rs'],
+    { encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 },
+  );
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || 'git ls-files failed');
+  }
+  return result.stdout.split('\0').filter(Boolean);
+}
+
+function stripRustComments(text) {
+  const chars = text.split('');
+  let state = 'code';
+  let blockDepth = 0;
+  let rawTerminator = '';
+
+  const blank = (index) => {
+    if (chars[index] !== '\r' && chars[index] !== '\n') {
+      chars[index] = ' ';
+    }
+  };
+
+  for (let index = 0; index < chars.length; index += 1) {
+    const current = chars[index];
+    const next = chars[index + 1];
+
+    if (state === 'line-comment') {
+      if (current === '\n') {
+        state = 'code';
+      } else {
+        blank(index);
+      }
+      continue;
+    }
+    if (state === 'block-comment') {
+      if (current === '/' && next === '*') {
+        blank(index);
+        blank(index + 1);
+        blockDepth += 1;
+        index += 1;
+      } else if (current === '*' && next === '/') {
+        blank(index);
+        blank(index + 1);
+        blockDepth -= 1;
+        index += 1;
+        if (blockDepth === 0) {
+          state = 'code';
+        }
+      } else {
+        blank(index);
+      }
+      continue;
+    }
+    if (state === 'string') {
+      if (current === '\\') {
+        index += 1;
+      } else if (current === '"') {
+        state = 'code';
+      }
+      continue;
+    }
+    if (state === 'raw-string') {
+      if (text.startsWith(rawTerminator, index)) {
+        index += rawTerminator.length - 1;
+        state = 'code';
+      }
+      continue;
+    }
+
+    if (current === '/' && next === '/') {
+      blank(index);
+      blank(index + 1);
+      state = 'line-comment';
+      index += 1;
+    } else if (current === '/' && next === '*') {
+      blank(index);
+      blank(index + 1);
+      state = 'block-comment';
+      blockDepth = 1;
+      index += 1;
+    } else if (current === '"') {
+      state = 'string';
+    } else if (current === 'r' || (current === 'b' && next === 'r')) {
+      let cursor = current === 'r' ? index + 1 : index + 2;
+      while (chars[cursor] === '#') {
+        cursor += 1;
+      }
+      if (chars[cursor] === '"') {
+        rawTerminator = `"${'#'.repeat(cursor - index - (current === 'r' ? 1 : 2))}`;
+        state = 'raw-string';
+        index = cursor;
+      }
+    }
+  }
+  return chars.join('');
+}
+
+function isAllowedWholeFileMatch(text, match, pattern, repoPath) {
+  const lineStart = text.lastIndexOf('\n', match.index - 1) + 1;
+  const nextNewline = text.indexOf('\n', match.index);
+  const lineEnd = nextNewline === -1 ? text.length : nextNewline;
+  const lineText = text.slice(lineStart, lineEnd).trim();
+  return pattern.allowLines?.some(
+    (allowed) => allowed.path === repoPath && allowed.text === lineText,
+  ) ?? false;
+}
+
+export function findForbiddenContentMatches(text, patterns, repoPath) {
+  const matches = [];
+  const lines = text.split(/\r?\n/);
+  for (const pattern of patterns) {
+    if (pattern.allowPaths?.includes(repoPath)) {
+      continue;
+    }
+    if (pattern.wholeFile) {
+      const searchableText = pattern.ignoreRustComments ? stripRustComments(text) : text;
+      pattern.regex.lastIndex = 0;
+      let match = pattern.regex.exec(searchableText);
+      while (match) {
+        if (!isAllowedWholeFileMatch(text, match, pattern, repoPath)) {
+          matches.push({
+            line: text.slice(0, match.index).split(/\r?\n/).length,
+            message: pattern.message,
+          });
+        }
+        if (!pattern.regex.global) {
+          break;
+        }
+        if (match[0].length === 0) {
+          pattern.regex.lastIndex += 1;
+        }
+        match = pattern.regex.exec(searchableText);
+      }
+      continue;
+    }
+    lines.forEach((line, index) => {
+      pattern.regex.lastIndex = 0;
+      if (pattern.regex.test(line)) {
+        matches.push({ line: index + 1, message: pattern.message });
+      }
+    });
+  }
+  return matches;
+}
+
+export function scanForbiddenContentUnder(root, rule, trackedRustRepoPaths) {
+  const trackedPaths = trackedRustRepoPaths ?? listTrackedRustRepoPaths(root);
+  const prefix = rule.path === '.' ? '' : `${rule.path.replace(/\/$/, '')}/`;
+  const findings = [];
+  for (const repoPath of trackedPaths) {
+    if (prefix && !repoPath.startsWith(prefix)) {
+      continue;
+    }
+    const path = join(root, ...repoPath.split('/'));
+    const text = readFileSync(path, 'utf8');
+    for (const match of findForbiddenContentMatches(text, rule.patterns, repoPath)) {
+      findings.push({ repoPath, path, ...match });
+    }
+  }
+  return findings;
+}

--- a/src/apps/desktop/src/api/remote_workspace_policy.rs
+++ b/src/apps/desktop/src/api/remote_workspace_policy.rs
@@ -2199,19 +2199,11 @@ mod tests {
     }
 
     #[test]
-    fn external_source_control_web_command_is_registered() {
+    fn external_source_control_command_is_registered() {
         const COMMAND: &str = "get_external_source_control_snapshot";
-        let web_api = include_str!(
-            "../../../../web-ui/src/infrastructure/api/service-api/ExternalSourcesAPI.ts"
-        );
-
-        assert!(
-            web_api.contains(&format!("invokeSurfaceSnapshot('{COMMAND}'")),
-            "Web UI must invoke the stable external-source control command"
-        );
         assert!(
             registered_commands().contains(COMMAND),
-            "Desktop must register the external-source control command invoked by Web UI"
+            "Desktop must register the external-source control command"
         );
     }
 


### PR DESCRIPTION
## Summary

- add a conservative Rust/CLI impact classifier that skips the two CLI and three Rust matrix jobs only for proven Web UI-only changes
- use a merge-base range for pull requests and the direct before/head range for main pushes; invalid or unavailable ranges fail closed
- keep classification safe by scanning every tracked Rust source before the diff and rejecting non-comment `web-ui` path tokens outside exact reviewed fixture lines
- remove the Desktop Rust test's compile-time dependency on Web API source and keep the Desktop registration and Web invocation contracts in their owning tests
- publish one stable `Rust / CLI Validation` result for triggered CI runs, with cancellation and matrix-result behavior covered by an executable truth table

## Architecture and safety

- No Cargo dependency, feature closure, product capability, or runtime behavior changes.
- The classifier does not maintain a list of Rust directories. Rust/build inputs, CI scripts, other product surfaces, unknown paths, invalid paths, and empty ranges all run the full matrix.
- Pull requests classify `base...head`; main pushes classify `before head`, preserving force-push/revert impact.
- Both expensive child jobs retain cancellation checks. The lightweight aggregate always evaluates upstream results and fails for classification failure, cancellation, unexpected skips, missing outputs, or matrix failure.
- The Frontend job now runs both boundary contract tests and the real repository boundary check explicitly.
- The broad Markdown `paths-ignore` rule is removed because nested Markdown is compiled into several Rust owners. `png/**` remains ignored, so this PR does not propose the aggregate as a global required check.

## Measured opportunity

The five Rust/CLI jobs consumed the following runner time on successful Web-only main runs. Runner-minutes are the sum of each job's `completed_at - started_at`, not user-visible wall time.

| Main commit | CI run | Rust + CLI runner-minutes | Longest Rust/CLI job |
|---|---:|---:|---:|
| `b3eb18b5` | [32350538939](https://github.com/GCWing/BitFun/actions/runs/32350538939) | 62.6 | 21.8 min |
| `f43611e7` | [32348769484](https://github.com/GCWing/BitFun/actions/runs/32348769484) | 58.9 | 17.3 min |
| `b1d7c6b9` | [32018012719](https://github.com/GCWing/BitFun/actions/runs/32018012719) | 67.1 | 22.7 min |
| `b5ed01e3` | [31989419631](https://github.com/GCWing/BitFun/actions/runs/31989419631) | 68.2 | 21.0 min |

This PR changes CI, scripts, and Rust test boundaries, so it must run the full Rust/CLI matrix. Actual post-merge savings remain unmeasured until the first subsequent Web-only PR/main run.

## Verification

- `node --test scripts/ci/classify-rust-impact.test.mjs` (6/6)
- `pnpm run check:github-config` (16/16, including the production aggregate truth table)
- `pnpm run check:core-boundaries:test` (126/126)
- `pnpm run check:core-boundaries`
- `pnpm run check:repo-hygiene`
- `pnpm --dir src/web-ui exec vitest run src/infrastructure/api/service-api/ExternalSourcesAPI.test.ts` (30/30)
- `cargo test --locked -p bitfun-desktop --lib external_source_control_command_is_registered` (1/1)
- `pnpm run fmt:rs`
- `git diff --check`

Two independent adversarial review passes were completed. The final pass found no remaining blocker after the CI execution, range, cancellation, tracked-file scanning, token-boundary, and truth-table fixes.
