### PR TITLE
fix(nav): align child session connectors

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.scss
+++ b/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.scss
@@ -173,13 +173,13 @@
       margin-top: -2px;
       min-height: 24px;
       font-size: var(--bf-appearance-token-font-size-xs);
-      padding-left: calc(#{$size-gap-1} + 14px);
+      padding-left: calc(var(--bf-nav-session-rail) + 14px);
       position: relative;
 
       &::before {
         content: '';
         position: absolute;
-        left: 8px;
+        left: calc(var(--bf-nav-session-rail) + 2px);
         top: 0;
         width: 1px;
         height: 50%;
@@ -190,7 +190,7 @@
       &::after {
         content: '';
         position: absolute;
-        left: 8px;
+        left: calc(var(--bf-nav-session-rail) + 2px);
         top: 50%;
         width: 10px;
         height: 1px;

--- a/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSectionLayout.test.ts
+++ b/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSectionLayout.test.ts
@@ -122,6 +122,18 @@ describe('SessionsSection layout styles', () => {
     }
   });
 
+  it('indents child connectors from the parent session text rail', () => {
+    const stylesheet = readSessionsSectionStylesheet();
+
+    expect(stylesheet).toContain(
+      'padding-left: calc(var(--bf-nav-session-rail) + 14px);',
+    );
+    expect(
+      stylesheet.match(/left: calc\(var\(--bf-nav-session-rail\) \+ 2px\);/g),
+    ).toHaveLength(2);
+    expect(stylesheet).not.toContain('left: 8px;');
+  });
+
   it('keeps the remaining session count in a compact trailing chip', () => {
     const stylesheet = readSessionsSectionStylesheet();
     const countBlock = extractBlock(stylesheet, '&__inline-toggle-count');

--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSection.scss
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSection.scss
@@ -1060,10 +1060,6 @@
 
     .bitfun-nav-panel__inline-item {
       height: 28px;
-
-      &.is-child {
-        padding-left: 44px;
-      }
     }
 
     .bitfun-nav-panel__inline-empty {
@@ -1402,10 +1398,6 @@
 
     .bitfun-nav-panel__inline-item {
       height: 28px;
-
-      &.is-child {
-        padding-left: 44px;
-      }
     }
 
     .bitfun-nav-panel__inline-empty {

--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSectionLayout.test.ts
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSectionLayout.test.ts
@@ -125,13 +125,12 @@ describe('WorkspaceListSection layout styles', () => {
       /\.bitfun-nav-panel__inline-list \{\n\s+\/\/[^\n]+\n\s+margin-left: 0;/g,
     );
     const sessionRails = stylesheet.match(/--bf-nav-session-rail: 30px;/g);
-    const indentedChildRows = stylesheet.match(
-      /\.bitfun-nav-panel__inline-item \{\n\s+height: 28px;\n\n\s+&\.is-child \{\n\s+padding-left: 44px;/g,
-    );
 
     expect(fullWidthSessionLists).toHaveLength(2);
     expect(sessionRails).toHaveLength(2);
-    expect(indentedChildRows).toHaveLength(2);
+    // SessionsSection derives both the child connector and title offsets from
+    // this rail. Context-specific child padding would split those axes again.
+    expect(stylesheet).not.toMatch(/&\.is-child\s*\{\s*padding-left:/);
     expect(stylesheet).not.toContain('margin-left: 22px;');
     expect(stylesheet).toContain(
       '&__workspace-item.is-active:has(&__workspace-item-sessions &__inline-item.is-active)',


### PR DESCRIPTION
Derive child-session connector and title offsets from the shared session text rail. This keeps nested BTW rows aligned when workspace and assistant groups use a wider parent-session indent.
