### PR TITLE
fix(terminal): streamline terminal lifecycle

### DIFF
--- a/src/web-ui/src/app/components/panels/content-canvas/ContentCanvas.tsx
+++ b/src/web-ui/src/app/components/panels/content-canvas/ContentCanvas.tsx
@@ -114,8 +114,8 @@ export const ContentCanvas: React.FC<ContentCanvasProps> = ({
     void openMainSession(activeBtwSessionData.parentSessionId);
   }, [activeBtwSessionData?.parentSessionId, activeBtwSessionData?.workspacePath, activeBtwSessionTab?.id, mode, workspacePath]);
 
-  // Keep the editor area mounted for hidden terminal tabs. Closing a terminal
-  // tab backgrounds it without destroying the xterm instance.
+  // Keep the editor area mounted for legacy hidden terminal tabs restored from
+  // an older canvas snapshot. New terminal closes destroy and remove the tab.
   const hasRenderableTabs = useMemo(() => {
     const groups = [primaryGroup, secondaryGroup, tertiaryGroup];
     return groups.some(group =>

--- a/src/web-ui/src/app/components/panels/content-canvas/hooks/useTabLifecycle.ts
+++ b/src/web-ui/src/app/components/panels/content-canvas/hooks/useTabLifecycle.ts
@@ -21,6 +21,10 @@ import { TAB_EVENTS } from '../types';
 import { useI18n } from '@/infrastructure/i18n';
 import { drainPendingTabs } from '@/shared/services/pendingTabQueue';
 import { confirmDialog } from '@/component-library/components/ConfirmDialog/confirmService';
+import { createLogger } from '@/shared/utils/logger';
+import { destroyTerminalSession } from '@/shared/services/destroyTerminalSession';
+
+const log = createLogger('useTabLifecycle');
 interface UseTabLifecycleOptions {
   /** App mode / target canvas */
   mode?: 'agent' | 'project' | 'git' | 'bottom-terminal';
@@ -82,6 +86,21 @@ export const useTabLifecycle = (options: UseTabLifecycleOptions = {}): UseTabLif
     layout,
     setSplitMode,
   } = useCanvasStore();
+
+  const closeTerminalSession = useCallback(async (tab: { content: PanelContent }): Promise<boolean> => {
+    if (tab.content.type !== 'terminal') return true;
+
+    const sessionId = tab.content.data?.sessionId;
+    if (!sessionId) return true;
+
+    try {
+      await destroyTerminalSession(sessionId);
+      return true;
+    } catch (error) {
+      log.error('Failed to close terminal session from tab', { sessionId, error });
+      return false;
+    }
+  }, []);
 
   /**
    * Open in preview mode (replaces current preview tab).
@@ -173,9 +192,13 @@ export const useTabLifecycle = (options: UseTabLifecycleOptions = {}): UseTabLif
       }
     }
 
-    closeTab(tabId, groupId);
+    if (!await closeTerminalSession(tab)) {
+      return false;
+    }
+
+    closeTab(tabId, groupId, { forceRemove: tab.content.type === 'terminal' });
     return true;
-  }, [canvasStoreApi, closeTab, t]);
+  }, [canvasStoreApi, closeTab, closeTerminalSession, t]);
 
   /**
    * Dirty check before closing all tabs.
@@ -195,6 +218,11 @@ export const useTabLifecycle = (options: UseTabLifecycleOptions = {}): UseTabLif
     const dirtyTabs = closableTabs.filter(t => t.isDirty);
 
     if (closableTabs.length === 0 || dirtyTabs.length === 0) {
+      for (const tab of closableTabs) {
+        if (!await closeTerminalSession(tab)) {
+          return false;
+        }
+      }
       closeAllTabs(groupId);
       return true;
     }
@@ -212,12 +240,18 @@ export const useTabLifecycle = (options: UseTabLifecycleOptions = {}): UseTabLif
       return false;
     }
 
+    for (const tab of closableTabs) {
+      if (!await closeTerminalSession(tab)) {
+        return false;
+      }
+    }
+
     closeAllTabs(groupId);
     return true;
-  }, [canvasStoreApi, closeAllTabs, t]);
+  }, [canvasStoreApi, closeAllTabs, closeTerminalSession, t]);
 
   /**
-   * Listen for left-panel terminal close events to sync right-panel tabs.
+   * Remove tabs when their terminal session is destroyed by any surface.
    */
   useEffect(() => {
     const store = mode === 'project' ? useProjectCanvasStore
@@ -238,7 +272,7 @@ export const useTabLifecycle = (options: UseTabLifecycleOptions = {}): UseTabLif
   }, [mode]);
 
   /**
-   * Listen for left-panel terminal rename events to sync right-panel tabs.
+   * Keep terminal tab titles synchronized with session renames.
    */
   useEffect(() => {
     const store = mode === 'project' ? useProjectCanvasStore

--- a/src/web-ui/src/app/components/panels/content-canvas/stores/canvasStore.terminal.test.ts
+++ b/src/web-ui/src/app/components/panels/content-canvas/stores/canvasStore.terminal.test.ts
@@ -1,0 +1,25 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useAgentCanvasStore } from './canvasStore';
+
+describe('canvasStore terminal lifecycle', () => {
+  beforeEach(() => {
+    useAgentCanvasStore.getState().reset();
+  });
+
+  it('removes a closed terminal tab instead of hiding or recording it', () => {
+    const store = useAgentCanvasStore.getState();
+    store.addTab({
+      type: 'terminal',
+      title: 'Shell 1',
+      data: { sessionId: 'terminal-1', sessionName: 'Shell 1' },
+      metadata: { sessionId: 'terminal-1' },
+    }, 'active', 'primary');
+
+    const tabId = useAgentCanvasStore.getState().primaryGroup.tabs[0].id;
+    useAgentCanvasStore.getState().closeTab(tabId, 'primary');
+
+    const next = useAgentCanvasStore.getState();
+    expect(next.primaryGroup.tabs).toEqual([]);
+    expect(next.closedTabs).toEqual([]);
+  });
+});

--- a/src/web-ui/src/app/components/panels/content-canvas/stores/canvasStore.ts
+++ b/src/web-ui/src/app/components/panels/content-canvas/stores/canvasStore.ts
@@ -48,13 +48,13 @@ interface CanvasStoreActions {
   /** Add tab */
   addTab: (content: PanelContent, state?: TabState, groupId?: EditorGroupId) => void;
   
-  /** Close tab; forceRemove removes terminal tab instead of hiding */
+  /** Close tab; terminal tabs are always removed and cannot be restored. */
   closeTab: (tabId: string, groupId: EditorGroupId, options?: { forceRemove?: boolean }) => void;
 
-  /** Close and remove tab by terminal sessionId (sync when left panel closes terminal) */
+  /** Close and remove a tab after its terminal session is destroyed. */
   closeTerminalTabBySessionId: (sessionId: string) => void;
 
-  /** Rename terminal tab by sessionId (sync when left panel renames terminal) */
+  /** Rename a terminal tab by sessionId. */
   renameTerminalTabBySessionId: (sessionId: string, newName: string) => void;
   
   /** Close all tabs */
@@ -252,21 +252,11 @@ const createCanvasStoreHook = () => create<CanvasStore>()(
           if (tabIndex === -1) return;
           
           const tab = group.tabs[tabIndex];
-          const forceRemove = options?.forceRemove === true;
-
-          // For terminal tabs without force remove, hide instead of delete for reactivation
-          if (tab.content.type === 'terminal' && !forceRemove) {
-            tab.isHidden = true;
-            
-            // If closing active tab, switch to next visible tab
-            if (group.activeTabId === tabId) {
-              const visibleTabs = group.tabs.filter(t => !t.isHidden);
-              group.activeTabId = visibleTabs[0]?.id || null;
-            }
-            return;
-          }
+          // Closing a terminal tab must destroy its PTY. Keep the explicit option
+          // for callers that already use it, but never hide terminals for reuse.
+          const forceRemove = options?.forceRemove === true || tab.content.type === 'terminal';
           
-          // Skip history when terminal is force-removed
+          // Skip history for terminal tabs: a closed PTY cannot be restored.
           if (!(tab.content.type === 'terminal' && forceRemove)) {
             // Record in close history
             draft.closedTabs.unshift({

--- a/src/web-ui/src/app/global-search/globalSearchArchitecture.test.ts
+++ b/src/web-ui/src/app/global-search/globalSearchArchitecture.test.ts
@@ -30,6 +30,15 @@ describe('global search ownership', () => {
     expect(footer).not.toContain('data-testid="shell-panel-entry"');
     expect(activator).toContain("case 'surface.browser.open':");
     expect(activator).toContain("case 'surface.terminal.open':");
+    expect(activator).toContain("new CustomEvent('terminal-create-requested')");
+    expect(activator).not.toContain("openNavScene('shell')");
+  });
+
+  it('does not register a Shell navigation surface in the left panel', () => {
+    const navRegistry = source('src/app/scenes/nav-registry.ts');
+
+    expect(navRegistry).not.toContain("import('./shell/ShellNav')");
+    expect(navRegistry).not.toContain('shell: lazy(');
   });
 
   it('removes the superseded navigation-owned dialog', () => {

--- a/src/web-ui/src/app/global-search/productActionActivator.ts
+++ b/src/web-ui/src/app/global-search/productActionActivator.ts
@@ -1,4 +1,3 @@
-import { useNavSceneStore } from '@/app/stores/navSceneStore';
 import { useSceneStore } from '@/app/stores/sceneStore';
 import { useSettingsStore } from '@/app/scenes/settings/settingsStore';
 import { workspaceManager } from '@/infrastructure/services/business/workspaceManager';
@@ -48,16 +47,7 @@ export async function activateProductAction(
       }
       return;
     case 'surface.terminal.open': {
-      const navStore = useNavSceneStore.getState();
-      if (
-        options.behavior === 'toggle'
-        && navStore.showSceneNav
-        && navStore.navSceneId === 'shell'
-      ) {
-        navStore.closeNavScene();
-      } else {
-        navStore.openNavScene('shell');
-      }
+      window.dispatchEvent(new CustomEvent('terminal-create-requested'));
       return;
     }
     case 'surface.files.open':

--- a/src/web-ui/src/app/layout/WorkspaceBody.tsx
+++ b/src/web-ui/src/app/layout/WorkspaceBody.tsx
@@ -16,6 +16,7 @@ import { NavBar } from '../components/NavBar';
 import NavPanel from '../components/NavPanel/NavPanel';
 import { SceneBar } from '../components/SceneBar';
 import { SceneViewport } from '../scenes';
+import TerminalActionBridge from '../scenes/terminal/TerminalActionBridge';
 import { useApp } from '../hooks/useApp';
 import './WorkspaceBody.scss';
 
@@ -155,6 +156,8 @@ const WorkspaceBody: React.FC<WorkspaceBodyProps> = ({
         <NavBar onExpandNav={toggleLeftPanel} onMaximize={onMaximize} />
         <NavPanel className="bitfun-workspace-body__nav-panel" />
       </div>
+
+      <TerminalActionBridge />
 
       {/* Resize divider — placed at workspace-body level to avoid overflow:hidden clipping */}
       {!isNavCollapsed && (

--- a/src/web-ui/src/app/scenes/nav-registry.ts
+++ b/src/web-ui/src/app/scenes/nav-registry.ts
@@ -27,19 +27,16 @@ const loadSettingsNav = async () => {
   return navModule;
 };
 const loadFileViewerNav = () => import('./file-viewer/FileViewerNav');
-const loadShellNav = () => import('./shell/ShellNav');
 
 const SCENE_NAV_REGISTRY: Partial<Record<SceneTabId, LazyNavComponent>> = {
   settings: lazy(loadSettingsNav),
   'file-viewer': lazy(loadFileViewerNav),
-  shell: lazy(loadShellNav),
   // terminal: lazy(() => import('./terminal/TerminalNav')),
 };
 
 const SCENE_NAV_LOADERS: Partial<Record<SceneTabId, () => Promise<unknown>>> = {
   settings: loadSettingsNav,
   'file-viewer': loadFileViewerNav,
-  shell: loadShellNav,
 };
 
 /**

--- a/src/web-ui/src/app/scenes/terminal/TerminalActionBridge.tsx
+++ b/src/web-ui/src/app/scenes/terminal/TerminalActionBridge.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useRef, type FC } from 'react';
+import { useCurrentWorkspace } from '@/infrastructure/contexts/WorkspaceContext';
+import { createManualTerminalSession } from '@/shared/services/createManualTerminalSession';
+import { openShellSessionTarget } from '@/shared/services/openShellSessionTarget';
+import { createLogger } from '@/shared/utils/logger';
+
+const log = createLogger('TerminalActionBridge');
+
+/** Handles global terminal actions while keeping terminal creation out of NavPanel. */
+export const TerminalActionBridge: FC = () => {
+  const { workspacePath, workspace } = useCurrentWorkspace();
+  const creatingRef = useRef(false);
+
+  useEffect(() => {
+    const handleCreate = () => {
+      if (creatingRef.current) return;
+      creatingRef.current = true;
+
+      void createManualTerminalSession({
+        workspacePath,
+        connectionId: workspace?.connectionId,
+      })
+        .then((session) => {
+          openShellSessionTarget({ sessionId: session.id, sessionName: session.name });
+        })
+        .catch((error) => {
+          log.error('Failed to create terminal from global action', error);
+        })
+        .finally(() => {
+          creatingRef.current = false;
+        });
+    };
+
+    window.addEventListener('terminal-create-requested', handleCreate);
+    return () => window.removeEventListener('terminal-create-requested', handleCreate);
+  }, [workspace?.connectionId, workspacePath]);
+
+  return null;
+};
+
+export default TerminalActionBridge;

--- a/src/web-ui/src/app/scenes/terminal/TerminalScene.tsx
+++ b/src/web-ui/src/app/scenes/terminal/TerminalScene.tsx
@@ -1,9 +1,9 @@
 /**
  * TerminalScene — renders a ConnectedTerminal for the session selected
- * via terminalSceneStore (set from the Shell navigation).
+ * via terminalSceneStore.
  *
  * When no session is active, shows a minimal empty state prompting the
- * user to open a terminal from the navigation panel.
+ * user that no terminal is currently open.
  */
 
 import React, { useCallback } from 'react';

--- a/src/web-ui/src/app/stores/sceneStore.ts
+++ b/src/web-ui/src/app/stores/sceneStore.ts
@@ -67,10 +67,6 @@ function buildSceneTab(id: SceneTabId, now: number): SceneTab {
 }
 
 function resolveNavSceneId(sceneId: SceneTabId): SceneTabId | null {
-  if (sceneId === 'terminal') {
-    return 'shell';
-  }
-
   return getSceneNav(sceneId) ? sceneId : null;
 }
 

--- a/src/web-ui/src/locales/en-US/common.json
+++ b/src/web-ui/src/locales/en-US/common.json
@@ -163,7 +163,7 @@
       "actionDescriptions": {
         "newSession": "Start a conversation using the canonical session flow",
         "openBrowser": "Open the browser in the current working context",
-        "openTerminal": "Open the persistent project shell",
+        "openTerminal": "Create a terminal in the active project",
         "openProject": "Choose and open a local or peer-hosted project",
         "newProject": "Create a project from a template or empty workspace",
         "openFiles": "Browse and edit files in the active project",

--- a/src/web-ui/src/locales/en-US/panels/terminal.json
+++ b/src/web-ui/src/locales/en-US/panels/terminal.json
@@ -1,6 +1,6 @@
 {
   "title": "Terminal",
-  "emptyState": "Open a terminal from the Shell navigation",
+  "emptyState": "No terminal is open",
   "dialog": {
     "editTerminal": {
       "title": "Edit Terminal",

--- a/src/web-ui/src/locales/en-US/settings/basics.json
+++ b/src/web-ui/src/locales/en-US/settings/basics.json
@@ -200,7 +200,7 @@
     },
     "panelPosition": {
       "label": "Open terminal in",
-      "description": "Where terminal tabs open when launched from the Shell navigation in a session",
+      "description": "Where new terminal tabs open in a session",
       "placeholder": "Select terminal location",
       "options": {
         "right": "Right panel",

--- a/src/web-ui/src/locales/zh-CN/common.json
+++ b/src/web-ui/src/locales/zh-CN/common.json
@@ -163,7 +163,7 @@
       "actionDescriptions": {
         "newSession": "通过统一会话流程开始新对话",
         "openBrowser": "在当前工作上下文中打开浏览器",
-        "openTerminal": "打开项目的持久化 Shell",
+        "openTerminal": "在当前项目中新建终端",
         "openProject": "选择并打开本地或对端设备上的项目",
         "newProject": "从模板或空工作区创建项目",
         "openFiles": "浏览和编辑当前项目文件",

--- a/src/web-ui/src/locales/zh-CN/panels/terminal.json
+++ b/src/web-ui/src/locales/zh-CN/panels/terminal.json
@@ -1,6 +1,6 @@
 {
   "title": "终端",
-  "emptyState": "从 Shell 导航中打开终端",
+  "emptyState": "当前没有打开的终端",
   "dialog": {
     "editTerminal": {
       "title": "编辑终端",

--- a/src/web-ui/src/locales/zh-CN/settings/basics.json
+++ b/src/web-ui/src/locales/zh-CN/settings/basics.json
@@ -200,7 +200,7 @@
     },
     "panelPosition": {
       "label": "终端打开位置",
-      "description": "在会话中从 Shell 导航打开终端时显示的位置",
+      "description": "在会话中新建的终端标签页显示的位置",
       "placeholder": "选择终端显示位置",
       "options": {
         "right": "右侧面板",

--- a/src/web-ui/src/locales/zh-TW/common.json
+++ b/src/web-ui/src/locales/zh-TW/common.json
@@ -163,7 +163,7 @@
       "actionDescriptions": {
         "newSession": "透過統一會話流程開始新對話",
         "openBrowser": "在目前工作上下文中開啟瀏覽器",
-        "openTerminal": "開啟項目的持久化 Shell",
+        "openTerminal": "在目前項目中新增終端機",
         "openProject": "選擇並開啟本機或對端裝置上的項目",
         "newProject": "從範本或空白工作區建立項目",
         "openFiles": "瀏覽和編輯目前項目檔案",

--- a/src/web-ui/src/locales/zh-TW/panels/terminal.json
+++ b/src/web-ui/src/locales/zh-TW/panels/terminal.json
@@ -1,6 +1,6 @@
 {
   "title": "終端",
-  "emptyState": "從 Shell 導航中開啟終端",
+  "emptyState": "目前沒有開啟的終端",
   "dialog": {
     "editTerminal": {
       "title": "編輯終端",

--- a/src/web-ui/src/locales/zh-TW/settings/basics.json
+++ b/src/web-ui/src/locales/zh-TW/settings/basics.json
@@ -186,7 +186,7 @@
     },
     "panelPosition": {
       "label": "終端開啟位置",
-      "description": "在會話中從 Shell 導航開啟終端時顯示的位置",
+      "description": "在會話中新建的終端分頁顯示的位置",
       "placeholder": "選擇終端顯示位置",
       "options": {
         "right": "右側面板",

--- a/src/web-ui/src/shared/services/createManualTerminalSession.test.ts
+++ b/src/web-ui/src/shared/services/createManualTerminalSession.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  connect: vi.fn(),
+  listSessions: vi.fn(),
+  createSession: vi.fn(),
+  getConfig: vi.fn(),
+}));
+
+vi.mock('@/tools/terminal/services/TerminalService', () => ({
+  getTerminalService: () => ({
+    connect: mocks.connect,
+    listSessions: mocks.listSessions,
+    createSession: mocks.createSession,
+  }),
+}));
+
+vi.mock('@/infrastructure/config/services/ConfigManager', () => ({
+  configManager: { getConfig: mocks.getConfig },
+}));
+
+import { createManualTerminalSession } from './createManualTerminalSession';
+
+describe('createManualTerminalSession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.connect.mockResolvedValue(undefined);
+    mocks.getConfig.mockResolvedValue({ default_shell: 'PowerShell' });
+    mocks.listSessions.mockResolvedValue([
+      { id: 'manual-1', source: 'manual' },
+      { id: 'agent-1', source: 'agent' },
+    ]);
+    mocks.createSession.mockResolvedValue({ id: 'manual-2', name: 'Shell 2' });
+  });
+
+  it('creates a terminal directly for the active workspace and connection', async () => {
+    await expect(createManualTerminalSession({
+      workspacePath: '/workspace/project',
+      connectionId: 'ssh-1',
+    })).resolves.toEqual({ id: 'manual-2', name: 'Shell 2' });
+
+    expect(mocks.connect).toHaveBeenCalledOnce();
+    expect(mocks.createSession).toHaveBeenCalledWith({
+      workingDirectory: '/workspace/project',
+      connectionId: 'ssh-1',
+      name: 'Shell 2',
+      shellType: 'PowerShell',
+      source: 'manual',
+    });
+  });
+});

--- a/src/web-ui/src/shared/services/createManualTerminalSession.ts
+++ b/src/web-ui/src/shared/services/createManualTerminalSession.ts
@@ -1,0 +1,38 @@
+import { configManager } from '@/infrastructure/config/services/ConfigManager';
+import type { TerminalConfig } from '@/infrastructure/config/types';
+import { getTerminalService } from '@/tools/terminal/services/TerminalService';
+import type { SessionResponse } from '@/tools/terminal/types/session';
+
+export interface CreateManualTerminalSessionOptions {
+  workspacePath?: string;
+  connectionId?: string | null;
+}
+
+async function getDefaultShellType(): Promise<string | undefined> {
+  try {
+    const config = await configManager.getConfig<TerminalConfig>('terminal');
+    return config?.default_shell || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Create a regular user terminal without requiring the Shell navigation UI. */
+export async function createManualTerminalSession(
+  options: CreateManualTerminalSessionOptions,
+): Promise<SessionResponse> {
+  const service = getTerminalService();
+  await service.connect();
+
+  const sessions = await service.listSessions();
+  const manualCount = sessions.filter((session) => session.source === 'manual').length;
+  const shellType = await getDefaultShellType();
+
+  return service.createSession({
+    workingDirectory: options.workspacePath,
+    connectionId: options.connectionId ?? undefined,
+    name: `Shell ${manualCount + 1}`,
+    shellType,
+    source: 'manual',
+  });
+}

--- a/src/web-ui/src/shared/services/destroyTerminalSession.test.ts
+++ b/src/web-ui/src/shared/services/destroyTerminalSession.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  connect: vi.fn(),
+  listSessions: vi.fn(),
+  closeSession: vi.fn(),
+}));
+
+vi.mock('@/tools/terminal/services/TerminalService', () => ({
+  getTerminalService: () => ({
+    connect: mocks.connect,
+    listSessions: mocks.listSessions,
+    closeSession: mocks.closeSession,
+  }),
+}));
+
+import { destroyTerminalSession } from './destroyTerminalSession';
+
+describe('destroyTerminalSession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.connect.mockResolvedValue(undefined);
+    mocks.listSessions.mockResolvedValue([{ id: 'terminal-1' }]);
+    mocks.closeSession.mockResolvedValue(undefined);
+  });
+
+  it('closes the PTY before announcing that the session was destroyed', async () => {
+    const destroyed = vi.fn();
+    window.addEventListener('terminal-session-destroyed', destroyed);
+
+    await destroyTerminalSession('terminal-1');
+
+    expect(mocks.closeSession).toHaveBeenCalledWith('terminal-1');
+    expect(destroyed).toHaveBeenCalledOnce();
+    expect((destroyed.mock.calls[0][0] as CustomEvent).detail).toEqual({ sessionId: 'terminal-1' });
+
+    window.removeEventListener('terminal-session-destroyed', destroyed);
+  });
+});

--- a/src/web-ui/src/shared/services/destroyTerminalSession.ts
+++ b/src/web-ui/src/shared/services/destroyTerminalSession.ts
@@ -1,0 +1,14 @@
+import { getTerminalService } from '@/tools/terminal/services/TerminalService';
+
+/** Destroy a terminal PTY and notify every mounted terminal surface. */
+export async function destroyTerminalSession(sessionId: string): Promise<void> {
+  const terminalService = getTerminalService();
+  await terminalService.connect();
+
+  const sessions = await terminalService.listSessions();
+  if (sessions.some((session) => session.id === sessionId)) {
+    await terminalService.closeSession(sessionId);
+  }
+
+  window.dispatchEvent(new CustomEvent('terminal-session-destroyed', { detail: { sessionId } }));
+}

--- a/src/web-ui/src/shared/services/openShellSessionTarget.ts
+++ b/src/web-ui/src/shared/services/openShellSessionTarget.ts
@@ -13,7 +13,7 @@ function openStandaloneShellSession(sessionId: string): void {
   const { openScene } = useSceneStore.getState();
   const terminalState = useTerminalSceneStore.getState();
 
-  openScene('shell' as SceneTabId);
+  openScene('terminal' as SceneTabId);
 
   // Force a remount when reopening the same session so the terminal view
   // can recover from stale/error state and always reflect the latest selection.

--- a/src/web-ui/src/shared/services/sceneOpenTargetResolver.ts
+++ b/src/web-ui/src/shared/services/sceneOpenTargetResolver.ts
@@ -42,7 +42,7 @@ export function resolveOpenTarget(intent: OpenIntent, context: OpenTargetContext
 
   // Non-agent scenes route to their dedicated host scenes.
   if (intent === 'terminal') {
-    return { mode: 'project', targetSceneId: 'shell', sceneJustOpened: false };
+    return { mode: 'project', targetSceneId: 'terminal', sceneJustOpened: false };
   }
 
   return { mode: 'project', targetSceneId: 'file-viewer', sceneJustOpened: false };


### PR DESCRIPTION
Create terminal sessions directly from the right-panel action instead of routing through the Shell navigation.

Destroy the backing PTY when a terminal tab closes, remove terminal tabs instead of hiding them, and unregister the left-side Shell navigation surface.

Add focused lifecycle and navigation regression coverage and update related localized copy.
