### PR TITLE
fix(terminal): Honor configured shell

### DIFF
--- a/src/web-ui/src/shared/services/createManualTerminalSession.test.ts
+++ b/src/web-ui/src/shared/services/createManualTerminalSession.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   connect: vi.fn(),
   listSessions: vi.fn(),
+  getAvailableShells: vi.fn(),
   createSession: vi.fn(),
   getConfig: vi.fn(),
 }));
@@ -11,6 +12,7 @@ vi.mock('@/tools/terminal/services/TerminalService', () => ({
   getTerminalService: () => ({
     connect: mocks.connect,
     listSessions: mocks.listSessions,
+    getAvailableShells: mocks.getAvailableShells,
     createSession: mocks.createSession,
   }),
 }));
@@ -25,7 +27,16 @@ describe('createManualTerminalSession', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.connect.mockResolvedValue(undefined);
-    mocks.getConfig.mockResolvedValue({ default_shell: 'PowerShell' });
+    mocks.getConfig.mockResolvedValue({ default_shell: 'C:\\Program Files\\Git\\bin\\bash.exe' });
+    mocks.getAvailableShells.mockResolvedValue([
+      {
+        id: 'bash:c:/program files/git/bin/bash.exe',
+        shellType: 'Bash',
+        name: 'Git Bash',
+        path: 'C:\\Program Files\\Git\\bin\\bash.exe',
+        available: true,
+      },
+    ]);
     mocks.listSessions.mockResolvedValue([
       { id: 'manual-1', source: 'manual' },
       { id: 'agent-1', source: 'agent' },
@@ -33,18 +44,58 @@ describe('createManualTerminalSession', () => {
     mocks.createSession.mockResolvedValue({ id: 'manual-2', name: 'Shell 2' });
   });
 
-  it('creates a terminal directly for the active workspace and connection', async () => {
+  it('creates the selected Git Bash terminal directly for the active workspace', async () => {
     await expect(createManualTerminalSession({
       workspacePath: '/workspace/project',
-      connectionId: 'ssh-1',
     })).resolves.toEqual({ id: 'manual-2', name: 'Shell 2' });
 
     expect(mocks.connect).toHaveBeenCalledOnce();
     expect(mocks.createSession).toHaveBeenCalledWith({
       workingDirectory: '/workspace/project',
+      connectionId: undefined,
+      name: 'Shell 2',
+      shellId: 'bash:c:/program files/git/bin/bash.exe',
+      shellType: 'Bash',
+      source: 'manual',
+    });
+  });
+
+  it('forwards an explicit remote connection to terminal creation', async () => {
+    mocks.getConfig.mockResolvedValue({ default_shell: '' });
+
+    await createManualTerminalSession({ connectionId: 'ssh-1' });
+
+    expect(mocks.createSession).toHaveBeenCalledWith({
+      workingDirectory: undefined,
       connectionId: 'ssh-1',
       name: 'Shell 2',
-      shellType: 'PowerShell',
+      source: 'manual',
+    });
+  });
+
+  it('uses automatic shell selection when no default shell is configured', async () => {
+    mocks.getConfig.mockResolvedValue({ default_shell: '' });
+
+    await createManualTerminalSession({ workspacePath: '/workspace/project' });
+
+    expect(mocks.getAvailableShells).not.toHaveBeenCalled();
+    expect(mocks.createSession).toHaveBeenCalledWith({
+      workingDirectory: '/workspace/project',
+      connectionId: undefined,
+      name: 'Shell 2',
+      source: 'manual',
+    });
+  });
+
+  it('falls back to automatic shell selection when the configured path is unavailable', async () => {
+    mocks.getConfig.mockResolvedValue({ default_shell: 'C:\\missing\\bash.exe' });
+
+    await createManualTerminalSession({ workspacePath: '/workspace/project' });
+
+    expect(mocks.createSession).toHaveBeenCalledWith({
+      workingDirectory: '/workspace/project',
+      connectionId: undefined,
+      name: 'Shell 2',
       source: 'manual',
     });
   });

--- a/src/web-ui/src/shared/services/createManualTerminalSession.ts
+++ b/src/web-ui/src/shared/services/createManualTerminalSession.ts
@@ -1,19 +1,37 @@
 import { configManager } from '@/infrastructure/config/services/ConfigManager';
 import type { TerminalConfig } from '@/infrastructure/config/types';
 import { getTerminalService } from '@/tools/terminal/services/TerminalService';
-import type { SessionResponse } from '@/tools/terminal/types/session';
+import type { CreateSessionRequest, SessionResponse } from '@/tools/terminal/types/session';
 
 export interface CreateManualTerminalSessionOptions {
   workspacePath?: string;
   connectionId?: string | null;
 }
 
-async function getDefaultShellType(): Promise<string | undefined> {
+async function getDefaultShellPreference(): Promise<string | undefined> {
   try {
     const config = await configManager.getConfig<TerminalConfig>('terminal');
     return config?.default_shell || undefined;
   } catch {
     return undefined;
+  }
+}
+
+async function resolveDefaultShellSelection(
+  service: ReturnType<typeof getTerminalService>,
+): Promise<Pick<CreateSessionRequest, 'shellId' | 'shellType'>> {
+  const preference = await getDefaultShellPreference();
+  if (!preference) {
+    return {};
+  }
+
+  try {
+    const shell = (await service.getAvailableShells()).find(
+      (candidate) => candidate.path === preference,
+    );
+    return shell ? { shellId: shell.id, shellType: shell.shellType } : {};
+  } catch {
+    return {};
   }
 }
 
@@ -24,15 +42,17 @@ export async function createManualTerminalSession(
   const service = getTerminalService();
   await service.connect();
 
-  const sessions = await service.listSessions();
+  const [sessions, shellSelection] = await Promise.all([
+    service.listSessions(),
+    resolveDefaultShellSelection(service),
+  ]);
   const manualCount = sessions.filter((session) => session.source === 'manual').length;
-  const shellType = await getDefaultShellType();
 
   return service.createSession({
     workingDirectory: options.workspacePath,
     connectionId: options.connectionId ?? undefined,
     name: `Shell ${manualCount + 1}`,
-    shellType,
+    ...shellSelection,
     source: 'manual',
   });
 }

--- a/src/web-ui/src/tools/terminal/types/session.ts
+++ b/src/web-ui/src/tools/terminal/types/session.ts
@@ -18,6 +18,8 @@ export interface CreateSessionRequest {
   sessionId?: string;
   name?: string;
   shellType?: ShellType | string;
+  /** Stable identifier for an exact discovered shell executable. */
+  shellId?: string;
   workingDirectory?: string;
   /** Open a remote PTY on this SSH connection without a registered workspace. */
   connectionId?: string;
@@ -42,7 +44,7 @@ export interface SessionResponse {
 
 export interface ShellInfo {
   /** Stable identifier for a discovered executable. */
-  id?: string;
+  id: string;
   shellType: string;
   name: string;
   path: string;
@@ -183,4 +185,3 @@ export type TerminalEvent =
 export type TerminalEventCallback = (event: TerminalEvent) => void;
 
 export type UnsubscribeFunction = () => void;
-


### PR DESCRIPTION
Resolve the stored executable path against discovered shells before creating a manual terminal. Send the stable shell ID and type so the backend launches the selected executable instead of falling back to the platform default.

Keep automatic fallback behavior when the preference is empty, unavailable, or cannot be queried.
