### PR TITLE
fix: backport standalone 1.0.0-explore fixes

### DIFF
--- a/scripts/cargo-target-gc.mjs
+++ b/scripts/cargo-target-gc.mjs
@@ -314,12 +314,15 @@ function sleepMs(ms) {
 export function isCompilerBusy({ exec = execFileSync, platform = process.platform } = {}) {
   try {
     if (platform === 'win32') {
-      const out = exec(
-        'cmd.exe',
-        ['/d', '/s', '/c', 'tasklist /FI "IMAGENAME eq cargo.exe" & tasklist /FI "IMAGENAME eq rustc.exe"'],
-        { encoding: 'utf8' }
-      );
-      return /\bcargo\.exe\b/i.test(out) || /\brustc\.exe\b/i.test(out);
+      for (const imageName of ['cargo.exe', 'rustc.exe']) {
+        const out = exec('tasklist', ['/FI', `IMAGENAME eq ${imageName}`, '/NH'], {
+          encoding: 'utf8',
+        });
+        if (out.toLowerCase().includes(imageName)) {
+          return true;
+        }
+      }
+      return false;
     }
     const cargo = exec('pgrep', ['-x', 'cargo'], { encoding: 'utf8' }).trim();
     if (cargo) {

--- a/scripts/cargo-target-gc.test.mjs
+++ b/scripts/cargo-target-gc.test.mjs
@@ -6,6 +6,7 @@ import test from 'node:test';
 import {
   collectGcPlan,
   extractDepsArtifactHash,
+  isCompilerBusy,
   isTargetProfileBusy,
   parseGcArgs,
   profileFromTauriBuildArgs,
@@ -248,6 +249,29 @@ test('runCargoTargetGc prunes old generations and honors dry-run', () => {
   } finally {
     cleanup();
   }
+});
+
+test('Windows compiler detection passes each tasklist filter as one argument', () => {
+  const calls = [];
+  const busy = isCompilerBusy({
+    platform: 'win32',
+    exec(command, args) {
+      calls.push({ command, args });
+      return args.includes('IMAGENAME eq rustc.exe') ? 'rustc.exe 123 Console 1 10,000 K\n' : '';
+    },
+  });
+
+  assert.equal(busy, true);
+  assert.deepEqual(calls, [
+    {
+      command: 'tasklist',
+      args: ['/FI', 'IMAGENAME eq cargo.exe', '/NH'],
+    },
+    {
+      command: 'tasklist',
+      args: ['/FI', 'IMAGENAME eq rustc.exe', '/NH'],
+    },
+  ]);
 });
 
 test('target busy detection scopes Cargo locks to the selected profile', () => {

--- a/src/web-ui/index.html
+++ b/src/web-ui/index.html
@@ -346,7 +346,7 @@
     <script type="module" src="/src/main.tsx"></script>
     <div id="root"></div>
     <div id="bitfun-startup-overlay">
-      <div class="splash-screen" aria-hidden="true">
+      <div class="splash-screen">
         <div class="bitfun-startup-window-controls" data-startup-window-controls hidden>
           <button class="bitfun-startup-window-controls__btn" type="button" data-startup-window-action="minimize">
             <span class="bitfun-startup-window-controls__glyph bitfun-startup-window-controls__glyph--minimize" aria-hidden="true"></span>

--- a/src/web-ui/src/app/scenes/SceneViewport.scss
+++ b/src/web-ui/src/app/scenes/SceneViewport.scss
@@ -102,22 +102,25 @@
   &__scene {
     position: absolute;
     inset: 0;
-    display: none;
+    display: flex;
+    flex-direction: row;
+    min-width: 0;
+    min-height: 0;
     overflow: hidden;
+    visibility: hidden;
+    pointer-events: none;
 
-    &--visible {
-      display: flex;
-      flex-direction: row;
+    > * {
+      flex: 1 1 auto;
       min-width: 0;
       min-height: 0;
+      width: 100%;
+      height: 100%;
+    }
 
-      > * {
-        flex: 1 1 auto;
-        min-width: 0;
-        min-height: 0;
-        width: 100%;
-        height: 100%;
-      }
+    &--visible {
+      visibility: visible;
+      pointer-events: auto;
     }
 
     &--active {

--- a/src/web-ui/src/app/scenes/SceneViewport.test.tsx
+++ b/src/web-ui/src/app/scenes/SceneViewport.test.tsx
@@ -90,12 +90,13 @@ describe('SceneViewport transitions', () => {
 
   function visibleScenes(): Element[] {
     return Array.from(container.querySelectorAll('[data-testid="scene-viewport-scene"]'))
-      .filter(scene => !scene.hasAttribute('hidden'));
+      .filter(scene => scene.classList.contains('bitfun-scene-viewport__scene--visible'));
   }
 
   it('keeps one scene visible while a lazy pointer target becomes ready', async () => {
     act(() => root.render(<SceneViewport />));
     expect(visibleScenes().map(scene => scene.getAttribute('data-scene-id'))).toEqual(['session']);
+    expect(container.querySelector('[data-scene-id="session"]')?.hasAttribute('hidden')).toBe(false);
 
     sceneHarness.state = {
       openTabs: [
@@ -120,7 +121,8 @@ describe('SceneViewport transitions', () => {
     });
 
     expect(visibleScenes().map(scene => scene.getAttribute('data-scene-id'))).toEqual(['agents']);
-    expect(container.querySelector('[data-scene-id="session"]')?.hasAttribute('hidden')).toBe(true);
+    expect(container.querySelector('[data-scene-id="session"]')?.getAttribute('aria-hidden')).toBe('true');
+    expect(container.querySelector('[data-scene-id="session"]')?.hasAttribute('inert')).toBe(true);
     expect(container.querySelector('[data-scene-id="agents"]')?.classList.contains(
       'bitfun-scene-viewport__scene--incoming',
     )).toBe(true);
@@ -148,6 +150,8 @@ describe('SceneViewport transitions', () => {
     act(() => root.render(<SceneViewport />));
 
     expect(visibleScenes().map(scene => scene.getAttribute('data-scene-id'))).toEqual(['session']);
-    expect(container.querySelector('[data-scene-id="agents"]')?.hasAttribute('hidden')).toBe(true);
+    expect(container.querySelector('[data-scene-id="agents"]')?.getAttribute('aria-hidden')).toBe('true');
+    expect(container.querySelector('[data-scene-id="agents"]')?.hasAttribute('inert')).toBe(true);
+    expect(container.querySelector('[data-scene-id="agents"]')?.hasAttribute('hidden')).toBe(false);
   });
 });

--- a/src/web-ui/src/app/scenes/SceneViewport.tsx
+++ b/src/web-ui/src/app/scenes/SceneViewport.tsx
@@ -233,9 +233,8 @@ const SceneViewport: React.FC<SceneViewportProps> = ({ workspacePath, isEntering
                 isIncoming && 'bitfun-scene-viewport__scene--incoming',
                 isOutgoing && 'bitfun-scene-viewport__scene--outgoing',
               ].filter(Boolean).join(' ')}
-              hidden={!isVisible}
-              aria-hidden={!isActive}
-              {...(!isActive ? { inert: '' } : {})}
+              aria-hidden={!isActive || !isVisible}
+              {...(!isActive || !isVisible ? { inert: '' } : {})}
               data-testid="scene-viewport-scene"
               data-scene-id={tabId}
               data-scene-active={isActive ? 'true' : 'false'}

--- a/src/web-ui/src/app/startup/startupOverlay.test.ts
+++ b/src/web-ui/src/app/startup/startupOverlay.test.ts
@@ -31,6 +31,30 @@ describe('startupOverlay', () => {
     expect(isStartupOverlayPresent()).toBe(false);
   });
 
+  it('releases startup-control focus before hiding the exiting overlay', async () => {
+    vi.useFakeTimers();
+    document.body.innerHTML = `
+      <div id="bitfun-startup-overlay">
+        <button type="button" data-startup-window-action="close">Close</button>
+      </div>
+    `;
+    const closeButton = document.querySelector<HTMLButtonElement>(
+      '[data-startup-window-action="close"]',
+    );
+    closeButton?.focus();
+    expect(document.activeElement).toBe(closeButton);
+
+    const hidden = hideStartupOverlay();
+    const overlay = document.getElementById('bitfun-startup-overlay');
+
+    expect(document.activeElement).not.toBe(closeButton);
+    expect(overlay?.hasAttribute('inert')).toBe(true);
+    expect(overlay?.getAttribute('aria-hidden')).toBe('true');
+
+    overlay?.dispatchEvent(new Event('animationend'));
+    await hidden;
+  });
+
   it('falls back to a timer when the exit animation event is not delivered', async () => {
     vi.useFakeTimers();
     document.body.innerHTML = '<div id="bitfun-startup-overlay"></div>';

--- a/src/web-ui/src/app/startup/startupOverlay.ts
+++ b/src/web-ui/src/app/startup/startupOverlay.ts
@@ -67,6 +67,15 @@ export async function hideStartupOverlay(): Promise<void> {
   }
 
   overlay.classList.add(EXIT_CLASS);
+  // Static startup window controls can still own focus when the React shell
+  // becomes ready. Release that focus before hiding the overlay from the
+  // accessibility tree, then make the exiting surface non-interactive so it
+  // cannot reclaim focus during its final animation.
+  const activeElement = document.activeElement;
+  if (activeElement instanceof HTMLElement && overlay.contains(activeElement)) {
+    activeElement.blur();
+  }
+  overlay.setAttribute('inert', '');
   overlay.setAttribute('aria-hidden', 'true');
   await waitForOverlayExitAnimation(overlay);
   overlay.remove();

--- a/src/web-ui/src/app/startup/startupPreload.test.ts
+++ b/src/web-ui/src/app/startup/startupPreload.test.ts
@@ -36,6 +36,7 @@ describe('startup preload shell', () => {
 
     const controls = dom.window.document.querySelector<HTMLElement>('[data-startup-window-controls]');
     expect(controls?.hidden).toBe(false);
+    expect(dom.window.document.querySelector('.splash-screen')?.hasAttribute('aria-hidden')).toBe(false);
 
     const closeButton = dom.window.document.querySelector<HTMLButtonElement>('[data-startup-window-action="close"]');
     expect(closeButton?.getAttribute('aria-label')).toBe('关闭');

--- a/src/web-ui/src/flow_chat/components/ModelSelector.scss
+++ b/src/web-ui/src/flow_chat/components/ModelSelector.scss
@@ -138,6 +138,7 @@
     --bitfun-model-dropdown-offset: -4px;
 
     position: fixed;
+    box-sizing: border-box;
     min-width: clamp(0px, 220px, calc(100vw - 16px));
     max-width: clamp(0px, 280px, calc(100vw - 16px));
     color: var(--bf-appearance-token-color-text-primary);
@@ -146,7 +147,9 @@
     background: var(--bf-appearance-token-color-bg-elevated);
     border: 1px solid var(--bf-appearance-token-color-overlay-white-12);
     border-radius: 6px;
-    overflow: hidden;
+    overflow-x: hidden;
+    overflow-y: auto;
+    overscroll-behavior: contain;
     backdrop-filter: blur(20px) saturate(1.2);
     -webkit-backdrop-filter: blur(20px) saturate(1.2);
     box-shadow: 
@@ -179,6 +182,19 @@
 
     &[data-keyboard-open='true'] {
       transition: none;
+    }
+
+    &::-webkit-scrollbar {
+      width: 3px;
+    }
+
+    &::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      background: var(--bf-appearance-token-color-overlay-white-15);
+      border-radius: 2px;
     }
   }
   
@@ -373,6 +389,10 @@
         0 4px 18px var(--bf-appearance-token-color-overlay-slate-04),
         0 1px 3px var(--bf-appearance-token-color-overlay-slate-04),
         inset 0 1px 0 var(--bf-appearance-token-color-overlay-white-95);
+
+      &::-webkit-scrollbar-thumb {
+        background: var(--bf-appearance-token-color-overlay-slate-08);
+      }
     }
 
     &__dropdown-header {

--- a/src/web-ui/src/flow_chat/components/ModelSelector.tsx
+++ b/src/web-ui/src/flow_chat/components/ModelSelector.tsx
@@ -446,7 +446,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
     };
   }, [dropdownOpen]);
 
-  // Calculate portal dropdown position relative to the trigger container.
+  // Calculate the portalled dropdown position relative to the trigger button.
   useEffect(() => {
     if (!dropdownOpen || !dropdownRef.current) return;
 
@@ -457,10 +457,19 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
       const anchor = triggerRef.current ?? dropdownRef.current;
       if (!anchor || !portalDropdownRef.current) return;
       const anchorRect = anchor.getBoundingClientRect();
-      const dropdownRect = portalDropdownRef.current.getBoundingClientRect();
+      const dropdown = portalDropdownRef.current;
+      const dropdownRect = dropdown.getBoundingClientRect();
+      // max-height can make the rendered box shorter than its contents. Keep
+      // measuring the intrinsic height so a later resize can still choose the
+      // correct side and then size the scrollable surface to that side.
+      const intrinsicDropdownWidth = Math.max(dropdownRect.width, dropdown.offsetWidth);
+      const intrinsicDropdownHeight = Math.max(
+        dropdownRect.height,
+        dropdown.scrollHeight + Math.max(0, dropdown.offsetHeight - dropdown.clientHeight),
+      );
       const layout = getModelSelectorDropdownLayout(
         anchorRect,
-        dropdownRect,
+        { width: intrinsicDropdownWidth, height: intrinsicDropdownHeight },
         dropdownPlacement,
         { width: window.innerWidth, height: window.innerHeight },
         // The trigger lives near the composer's right side, so a start-aligned

--- a/src/web-ui/src/flow_chat/components/ModelSelector.tsx
+++ b/src/web-ui/src/flow_chat/components/ModelSelector.tsx
@@ -451,14 +451,21 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
     if (!dropdownOpen || !dropdownRef.current) return;
 
     const updatePosition = () => {
-      if (!dropdownRef.current || !portalDropdownRef.current) return;
-      const anchorRect = dropdownRef.current.getBoundingClientRect();
+      // Anchor on the trigger button, not the container: when a reasoning
+      // preset selector sits beside it the container's right edge is not the
+      // button's, and the menu is asked to right-align with the button.
+      const anchor = triggerRef.current ?? dropdownRef.current;
+      if (!anchor || !portalDropdownRef.current) return;
+      const anchorRect = anchor.getBoundingClientRect();
       const dropdownRect = portalDropdownRef.current.getBoundingClientRect();
       const layout = getModelSelectorDropdownLayout(
         anchorRect,
         dropdownRect,
         dropdownPlacement,
         { width: window.innerWidth, height: window.innerHeight },
+        // The trigger lives near the composer's right side, so a start-aligned
+        // wide menu overflows the window; right edges align instead.
+        'end',
       );
       setDropdownStyle(layout.style);
       setResolvedDropdownPlacement(layout.placement);

--- a/src/web-ui/src/flow_chat/components/modelSelectorDropdownPosition.test.ts
+++ b/src/web-ui/src/flow_chat/components/modelSelectorDropdownPosition.test.ts
@@ -58,6 +58,22 @@ describe('getModelSelectorDropdownStyle', () => {
     expect(style.top).toBe('194px');
   });
 
+  it('shrinks a tall menu to the space above instead of overlapping the trigger', () => {
+    const layout = getModelSelectorDropdownLayout(
+      { left: 700, right: 820, top: 380, bottom: 410 },
+      { width: 268, height: 392 },
+      'top',
+      { width: 900, height: 500 },
+      'end',
+    );
+
+    // The viewport has 366 px between its 8 px inset and the trigger's 6 px gap.
+    expect(layout.style.left).toBe('552px');
+    expect(layout.style.top).toBe('8px');
+    expect(layout.style.maxHeight).toBe('366px');
+    expect(layout.placement).toBe('top');
+  });
+
   it('flips below the trigger when the preferred top placement does not fit', () => {
     const layout = getModelSelectorDropdownLayout(
       { left: 24, top: 20, bottom: 44 },

--- a/src/web-ui/src/flow_chat/components/modelSelectorDropdownPosition.test.ts
+++ b/src/web-ui/src/flow_chat/components/modelSelectorDropdownPosition.test.ts
@@ -30,6 +30,34 @@ describe('getModelSelectorDropdownStyle', () => {
     expect(style.top).toBe('194px');
   });
 
+  it('aligns the menu right edge with the trigger when end-aligned', () => {
+    const style = getModelSelectorDropdownStyle(
+      { left: 700, right: 820, top: 700, bottom: 724 },
+      { width: 268, height: 300 },
+      'top',
+      { width: 900, height: 900 },
+      'end',
+    );
+
+    // 820 - 268: the menu's right edge lands on the button's right edge.
+    expect(style.left).toBe('552px');
+    expect(style.top).toBe('394px');
+  });
+
+  it('still clamps an end-aligned menu into a narrow viewport', () => {
+    const style = getModelSelectorDropdownStyle(
+      { left: 24, right: 120, top: 500, bottom: 524 },
+      { width: 268, height: 300 },
+      'top',
+      { width: 200, height: 700 },
+      'end',
+    );
+
+    // 200 - 268 - 8 would be negative, so the padding clamp owns the left edge.
+    expect(style.left).toBe('8px');
+    expect(style.top).toBe('194px');
+  });
+
   it('flips below the trigger when the preferred top placement does not fit', () => {
     const layout = getModelSelectorDropdownLayout(
       { left: 24, top: 20, bottom: 44 },

--- a/src/web-ui/src/flow_chat/components/modelSelectorDropdownPosition.ts
+++ b/src/web-ui/src/flow_chat/components/modelSelectorDropdownPosition.ts
@@ -1,11 +1,13 @@
 import {
   computeFixedPopoverPositionInViewport,
+  type FixedPopoverAlignment,
   type FixedPopoverPlacement,
   type FixedPopoverViewport,
 } from '@/shared/utils/fixedPopoverViewport';
 
 interface ModelSelectorDropdownAnchorRect {
   left: number;
+  right?: number;
   top: number;
   bottom: number;
 }
@@ -33,13 +35,14 @@ export function getModelSelectorDropdownLayout(
   dropdownSize: ModelSelectorDropdownSize,
   preferredPlacement: FixedPopoverPlacement,
   viewport: FixedPopoverViewport,
+  alignment: FixedPopoverAlignment = 'start',
 ): ModelSelectorDropdownLayout {
   const position = computeFixedPopoverPositionInViewport(
     anchorRect,
     dropdownSize.width,
     dropdownSize.height,
     viewport,
-    { preferredPlacement },
+    { preferredPlacement, alignment },
   );
   const placement = position.top + dropdownSize.height <= anchorRect.top
     ? 'top'
@@ -64,11 +67,13 @@ export function getModelSelectorDropdownStyle(
   dropdownSize: ModelSelectorDropdownSize,
   preferredPlacement: FixedPopoverPlacement,
   viewport: FixedPopoverViewport,
+  alignment: FixedPopoverAlignment = 'start',
 ): ModelSelectorDropdownStyle {
   return getModelSelectorDropdownLayout(
     anchorRect,
     dropdownSize,
     preferredPlacement,
     viewport,
+    alignment,
   ).style;
 }

--- a/src/web-ui/src/flow_chat/components/modelSelectorDropdownPosition.ts
+++ b/src/web-ui/src/flow_chat/components/modelSelectorDropdownPosition.ts
@@ -1,9 +1,12 @@
 import {
   computeFixedPopoverPositionInViewport,
+  DEFAULT_POPOVER_VIEWPORT_PADDING,
   type FixedPopoverAlignment,
   type FixedPopoverPlacement,
   type FixedPopoverViewport,
 } from '@/shared/utils/fixedPopoverViewport';
+
+const MODEL_SELECTOR_DROPDOWN_GAP = 6;
 
 interface ModelSelectorDropdownAnchorRect {
   left: number;
@@ -23,6 +26,7 @@ interface ModelSelectorDropdownStyle {
   left: string;
   top: string;
   bottom: 'auto';
+  maxHeight: string;
 }
 
 export interface ModelSelectorDropdownLayout {
@@ -37,18 +41,39 @@ export function getModelSelectorDropdownLayout(
   viewport: FixedPopoverViewport,
   alignment: FixedPopoverAlignment = 'start',
 ): ModelSelectorDropdownLayout {
+  const availableHeight = (placement: FixedPopoverPlacement): number => {
+    const height = placement === 'top'
+      ? anchorRect.top - MODEL_SELECTOR_DROPDOWN_GAP - DEFAULT_POPOVER_VIEWPORT_PADDING
+      : viewport.height
+        - anchorRect.bottom
+        - MODEL_SELECTOR_DROPDOWN_GAP
+        - DEFAULT_POPOVER_VIEWPORT_PADDING;
+    return Math.max(0, height);
+  };
+  const alternatePlacement = preferredPlacement === 'top' ? 'bottom' : 'top';
+  const preferredAvailableHeight = availableHeight(preferredPlacement);
+  const alternateAvailableHeight = availableHeight(alternatePlacement);
+  const placement = dropdownSize.height <= preferredAvailableHeight
+    ? preferredPlacement
+    : dropdownSize.height <= alternateAvailableHeight
+      ? alternatePlacement
+      : preferredAvailableHeight >= alternateAvailableHeight
+        ? preferredPlacement
+        : alternatePlacement;
+  const maxHeight = availableHeight(placement);
+  const renderedHeight = Math.min(dropdownSize.height, maxHeight);
   const position = computeFixedPopoverPositionInViewport(
     anchorRect,
     dropdownSize.width,
-    dropdownSize.height,
+    renderedHeight,
     viewport,
-    { preferredPlacement, alignment },
+    {
+      preferredPlacement: placement,
+      alignment,
+      gap: MODEL_SELECTOR_DROPDOWN_GAP,
+      padding: DEFAULT_POPOVER_VIEWPORT_PADDING,
+    },
   );
-  const placement = position.top + dropdownSize.height <= anchorRect.top
-    ? 'top'
-    : position.top >= anchorRect.bottom
-      ? 'bottom'
-      : preferredPlacement;
 
   return {
     placement,
@@ -58,6 +83,7 @@ export function getModelSelectorDropdownLayout(
       left: `${position.left}px`,
       top: `${position.top}px`,
       bottom: 'auto',
+      maxHeight: `${maxHeight}px`,
     },
   };
 }

--- a/src/web-ui/src/flow_chat/components/modern/AGENTS.md
+++ b/src/web-ui/src/flow_chat/components/modern/AGENTS.md
@@ -11,7 +11,7 @@ Also follow the repository and Web UI instructions in the parent guides.
 
 | Changing | Read |
 |---|---|
-| the tail spacer, the follow target, pinning, holding, resizing, the footer, the reveal | `FLOWCHAT_SCROLL_STABILITY.md` |
+| the tail spacer, the follow target, new-Turn revealing, holding, resizing, the footer | `FLOWCHAT_SCROLL_STABILITY.md` |
 | history paging, the prepend, the viewport anchor, history presentation | `FLOWCHAT_HISTORY_PAGING.md` |
 | anything that writes `scrollTop`, one-shot navigation, the diagnostic trail | `FLOWCHAT_VIEWPORT_REGISTER.md` |
 | the virtualizer, item measurement, item keys, anything a row renders | `FLOWCHAT_VIRTUALIZATION.md` |
@@ -21,8 +21,8 @@ before reporting a defect as new.
 
 ## Reservation and Follow
 
-- FlowChat reserves a resident tail spacer of about one viewport, sized from
-  `scroller.clientHeight` and nothing else.
+- FlowChat caps the input footer plus resident tail spacer at three quarters of
+  `scroller.clientHeight`; the spacer also depends on the current footer inset.
 - Static reservation is allowed; reactive compensation is not. Do not derive any
   reserved height from a measured content height, a collapse delta, an animation
   duration, or a streaming rate.
@@ -31,7 +31,11 @@ before reporting a defect as new.
 - The follow target lives in `flowChatTailFollow.ts` as pure functions over
   geometry. Keep it free of timers and mutation observers.
 - `scheduleFollowToLatest` must not force the content end — the hold rule is
-  what keeps a collapse from moving the viewport.
+  what keeps a collapse from moving the viewport. During `revealing-tail` it
+  samples the blank crossing and performs no viewport write.
+- A new Turn gets one physical-bottom placement after it enters the live-tail
+  projection. Streaming consumes the exposed spacer at fixed `scrollTop`, then
+  hands off to `hold-tail` when the blank closes.
 - `useFlowChatFollowOutput` is the only continuous outer viewport writer.
 - The follow's **write** may be eased; its **target** may not. Everything that
   reads the follow — the settle budget and the at-tail band — reads
@@ -161,10 +165,10 @@ before reporting a defect as new.
   Virtualizer-specific compensation stays in `VirtualMessageList`.
 - "A new Turn" is `activeSession.dialogTurns.at(-1)`, never the end of the
   projection. Do not qualify that identity by whether the Turn is on screen —
-  that belongs to the response, which defers until the Turn can be aligned.
+  that belongs to the response, which defers until the Turn can be revealed.
 - Detecting one means the ledger **grew**, not that the identity changed. A
   rollback truncates `dialogTurns` and moves that identity backwards onto a Turn
-  that was always there; read as an arrival it pins the survivor to the top.
+  that was always there; read as an arrival it reveals the survivor as new.
 - An action that rewrites `dialogTurns` and wants the viewport moved announces
   it — `FLOWCHAT_MESSAGE_SUBMITTED_EVENT` for giving up a navigated history
   window, `FLOWCHAT_TURNS_ROLLED_BACK_EVENT` for settling on a new tail. The

--- a/src/web-ui/src/flow_chat/components/modern/ExploreGroupRenderer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ExploreGroupRenderer.tsx
@@ -141,15 +141,17 @@ export const ExploreGroupRenderer: React.FC<ExploreGroupRendererProps> = React.m
 
     log.debug('explore group cut by critical', { groupId });
 
-    applyExpandedState(true, false, () => {
-      onCollapseGroup?.(groupId);
-    });
+    // The collapsed value is derived from wasCutByCritical. Do not persist an
+    // automatic collapse as explicit user state: a provisional later round
+    // can become explore-only again and return this group to the live tail.
+    applyExpandedState(true, false, () => {});
   }, [
     applyExpandedState,
     groupId,
     hasExplicitState,
+    isExpanded,
+    turnId,
     wasCutByCritical,
-    onCollapseGroup,
   ]);
   
   // Auto-scroll to bottom while the group is still the tail and new items arrive.

--- a/src/web-ui/src/flow_chat/components/modern/ExploreGroupRenderer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ExploreGroupRenderer.tsx
@@ -4,14 +4,11 @@
  * Renders merged explore-only rounds as a collapsible region.
  */
 
-import React, { useRef, useMemo, useCallback, useEffect, useLayoutEffect, useState } from 'react';
+import React, { useRef, useMemo, useCallback, useEffect, useState } from 'react';
 import { ChevronRight } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { FlowItem, FlowToolItem, FlowTextItem, FlowThinkingItem, ToolRejectOptions } from '../../types/flow-chat';
 import type { ExploreGroupData } from '../../store/modernFlowChatStore';
-import { createLogger } from '@/shared/utils/logger';
-
-const log = createLogger('ExploreGroupRenderer');
 import { FlowTextBlock } from '../FlowTextBlock';
 import { FlowToolCard } from '../FlowToolCard';
 import { ModelThinkingDisplay } from '../../tool-cards/ModelThinkingDisplay';
@@ -69,7 +66,6 @@ export const ExploreGroupRenderer: React.FC<ExploreGroupRendererProps> = React.m
     isLastGroupInTurn,
     wasCutByCritical,
   } = data;
-  const prevWasCutRef = useRef(wasCutByCritical);
   const {
     cardRootRef,
     applyExpandedState,
@@ -80,8 +76,9 @@ export const ExploreGroupRenderer: React.FC<ExploreGroupRendererProps> = React.m
   
   const hasExplicitState = exploreGroupStates?.has(groupId) ?? false;
   const explicitExpanded = exploreGroupStates?.get(groupId) ?? false;
-  // Default: expanded while the group is still the tail; collapsed once cut.
-  const defaultExpanded = !wasCutByCritical;
+  // Exploration is low-density history. Keep every group collapsed unless the
+  // user explicitly expands it.
+  const defaultExpanded = false;
   const isExpanded = hasExplicitState ? explicitExpanded : defaultExpanded;
   const isCollapsed = !isExpanded;
   const groupKind = getExploreGroupKind(stats, allItems.length);
@@ -126,35 +123,8 @@ export const ExploreGroupRenderer: React.FC<ExploreGroupRendererProps> = React.m
     }
   }, []);
 
-  // One-shot auto-collapse: fires exactly once when the group transitions from
-  // tail (wasCutByCritical=false) to cut (wasCutByCritical=true).
-  //
-  // Do not use `isExpanded` to guard this effect. The render that flips
-  // `wasCutByCritical` also recomputes the default expanded state. No explicit
-  // state means the live-tail default may collapse naturally; an explicit
-  // state is user intent and must not be overwritten.
-  useLayoutEffect(() => {
-    const justGotCut = wasCutByCritical && !prevWasCutRef.current;
-    prevWasCutRef.current = wasCutByCritical;
-
-    if (!justGotCut || hasExplicitState) return;
-
-    log.debug('explore group cut by critical', { groupId });
-
-    // The collapsed value is derived from wasCutByCritical. Do not persist an
-    // automatic collapse as explicit user state: a provisional later round
-    // can become explore-only again and return this group to the live tail.
-    applyExpandedState(true, false, () => {});
-  }, [
-    applyExpandedState,
-    groupId,
-    hasExplicitState,
-    isExpanded,
-    turnId,
-    wasCutByCritical,
-  ]);
-  
-  // Auto-scroll to bottom while the group is still the tail and new items arrive.
+  // Auto-scroll to bottom when an explicitly expanded tail gains a newly
+  // settled round.
   // Use double requestAnimationFrame to ensure the browser has completed
   // layout of newly added content before we measure scrollHeight.
   useEffect(() => {

--- a/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_HISTORY_PAGING.md
+++ b/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_HISTORY_PAGING.md
@@ -526,8 +526,9 @@ mistake this separates.
 **A tail-anchored window must grow with the session.** It stops at the newest
 Turn that existed when it was cut, and nothing moves its end afterwards, so an
 appended Turn is simply not rendered. That is worse than it sounds: `latestTurnId`
-is read off the rendered items, so follow-output never learns the Turn exists —
-no pin, no follow, and nothing to scroll to. `resolveTailWindowGrowth` is
+comes from the ledger, so follow-output learns the Turn exists but cannot reveal
+it from a projection that has no matching item; the arrival remains pending with
+nothing to scroll to. `resolveTailWindowGrowth` is
 level-triggered for that reason. An edge — "it reached the tail last render and
 does not now" — is consumed whether or not the extension succeeded, stranding
 the window permanently on one failure; the current state stays `'extend'` until
@@ -544,7 +545,7 @@ fallback, but it is the only branch that always shows the message just sent.
 *ends*, and a history window re-cut moves that to a Turn which has existed for
 hours: measured, navigating to Turn 2 landed correctly and was then overwritten
 twice, because each window loaded on the way ended somewhere new and each of
-those read as a submission, pinning the window's last Turn to the top.
+those read as a submission, moving the window's last Turn as though it were new.
 
 **Whether the Turn can be acted on is a second question, and it does not belong
 in the identity.** Qualifying `latestTurnId` by "and it is on screen" makes a
@@ -555,7 +556,7 @@ and it is how navigating to Turn 29 ended on Turn 38.
 to *detect* one, and the detector asked whether `latestTurnId` differed from
 last render. A rollback truncates `dialogTurns`, which moves that identity
 backwards onto a Turn that has been there all along — so undoing a message
-pinned the Turn *before* it to the viewport top. `dialogTurnCount` separates the
+moved the Turn *before* it as though it had just arrived. `dialogTurnCount` separates the
 two: an arrival grows the ledger, and nothing else that rewrites `dialogTurns`
 — a history page merging in above, a window re-cut, a hydration — moves the
 last Turn at all, so requiring growth costs nothing and excludes every
@@ -566,8 +567,7 @@ truncation.
 two dozen call sites write that array; inferring an action from its size is the
 same mistake as inferring intent from `scrollTop`. So the rollback announces
 itself through `FLOWCHAT_TURNS_ROLLED_BACK_EVENT`, exactly as a submission does,
-and the transcript settles on the new tail — the Turn it was pinning is one of
-the ones that stopped existing.
+and the transcript settles on the new tail.
 
 It takes the viewport whether or not follow owned it. A rollback at Turn N
 removes N *and everything after
@@ -588,13 +588,13 @@ already been committed to. Edit-and-rerun does not announce: its truncation is
 followed by a rerun whose Turn really is new, and announcing would spend a
 visible movement on the way to it.
 
-So the response carries it instead. A new Turn is answered by pinning it to the
-viewport top; until it is in the transcript on screen there is nothing to align,
-and the fallback — the end of real content — is not a stand-in, because it
-would leave the Turn unpinned or pull a reader out of a history window. The
-answer is therefore **deferred, not dropped**: held in `pendingNewTurnIdRef` and
-retried when the transcript next changes, which is exactly when the presentation
-is restored to the live tail.
+So the response carries it instead. A new Turn is answered by revealing the
+resident tail blank with one physical-bottom placement; until the Turn is in the
+live-tail projection there is nothing to reveal, and the old content end is not
+a stand-in because it can pull a reader out of a history window before the new
+Turn exists there. The answer is therefore **deferred, not dropped**: held in
+`pendingNewTurnIdRef` and retried when the transcript next changes, which is
+exactly when the presentation is restored to the live tail.
 
 **Submitting is what gives up a navigated window.** `resolveTailWindowGrowth`
 leaves such a window alone as the session grows, and that is right — a Turn

--- a/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_HISTORY_PAGING.md
+++ b/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_HISTORY_PAGING.md
@@ -612,17 +612,23 @@ nothing to align.
 Switching sessions remounts the virtual list, so preserving a reading position
 cannot depend on keeping the old scroller or virtualizer alive. The container
 keeps a session-scoped snapshot of the rendered history presentation, viewport
-intent, and the first visible Turn's offset from the viewport top. Restoring the
-session reinstates the presentation first, then restores that Turn-and-offset
-relationship through `viewportOwner.shift` and opens the ordinary anchor settle
-window so later measurements keep it stable.
+intent, and the first visible virtual row's stable key and offset from the
+viewport top. The Turn id remains a compatibility fallback, but a long Turn may
+have its user message offscreen while a model round is visible, so the exact row
+is the authoritative identity. Restoring the session reinstates the presentation
+first, then restores that row-and-offset relationship through
+`viewportOwner.shift` and opens the ordinary anchor settle window so later
+measurements keep it stable.
 
 The saved `scrollTop` is only a materialization hint when the anchor Turn has
 not entered the rendered virtual window yet. It is never the final answer: once
 the Turn exists in the DOM, its semantic offset is authoritative. A snapshot
 whose reader was away from the tail also suppresses the session-open tail
 follow, including when the reader was using the ordinary tail projection rather
-than an explicit history window.
+than an explicit history window. Snapshot publication remains gated until that
+relationship is within rounding error for two painted frames: provisional mount
+geometry must not replace the saved snapshot or re-enable automatic tail
+placement while restoration is still in flight.
 
 ## Diagnosing History Paging
 

--- a/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_HISTORY_PAGING.md
+++ b/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_HISTORY_PAGING.md
@@ -607,6 +607,23 @@ existed: a message sent while parked on the first Turn left the transcript on a
 24-item window it was never in, with follow-output holding an answer it had
 nothing to align.
 
+## Restoring a Session Reading Position
+
+Switching sessions remounts the virtual list, so preserving a reading position
+cannot depend on keeping the old scroller or virtualizer alive. The container
+keeps a session-scoped snapshot of the rendered history presentation, viewport
+intent, and the first visible Turn's offset from the viewport top. Restoring the
+session reinstates the presentation first, then restores that Turn-and-offset
+relationship through `viewportOwner.shift` and opens the ordinary anchor settle
+window so later measurements keep it stable.
+
+The saved `scrollTop` is only a materialization hint when the anchor Turn has
+not entered the rendered virtual window yet. It is never the final answer: once
+the Turn exists in the DOM, its semantic offset is authoritative. A snapshot
+whose reader was away from the tail also suppresses the session-open tail
+follow, including when the reader was using the ordinary tail projection rather
+than an explicit history window.
+
 ## Diagnosing History Paging
 
 Older Turns are paged in when the viewport reaches the head of the loaded

--- a/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_SCROLL_STABILITY.md
+++ b/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_SCROLL_STABILITY.md
@@ -2,8 +2,8 @@
 
 FlowChat reserves a resident tail spacer below the transcript, and pairs it with
 a follow target that does not move backwards for free. Together these give a
-newly submitted Turn a top-aligned position and keep a tool-card collapse from
-dragging earlier content down.
+newly submitted Turn a one-shot reveal with room below it and keep a tool-card
+collapse from dragging earlier content down.
 
 That is this document. Four siblings carry the rest.
 
@@ -11,7 +11,7 @@ That is this document. Four siblings carry the rest.
 
 | Changing | Read |
 |---|---|
-| the tail spacer, the follow target, pinning, holding, resizing, the footer | this file |
+| the tail spacer, the follow target, new-Turn reveal, holding, resizing, the footer | this file |
 | history paging, the prepend, the viewport anchor, history presentation | `FLOWCHAT_HISTORY_PAGING.md` |
 | anything that writes `scrollTop`, one-shot navigation, the diagnostic trail | `FLOWCHAT_VIEWPORT_REGISTER.md` |
 | the virtualizer, item measurement, item keys, anything a row renders | `FLOWCHAT_VIRTUALIZATION.md` |
@@ -33,30 +33,22 @@ that under a new name.
 
 ## How Much To Reserve
 
-The spacer keeps two offsets inside the scroll range, and is the larger of what
-they need. Both are bounds, not estimates: reserving more than the larger one is
-pure blank at the end of the scroll range, and reserving less than either is a
-clamp.
+The input-stack footer and spacer together occupy at most three quarters of the
+viewport:
 
-- **A pinned Turn.** Worst case its user message is the newest item with nothing
-  answering it yet, so the message, the input inset and the spacer are all that
-  lie below the message top. `clientHeight - bottomInsetPx -
-  PINNED_TURN_MIN_ITEM_HEIGHT_PX` is exactly enough to put it on the top edge.
-- **A held collapse gap.** `hold-tail` parks up to `tailHoldMaxGapPx` past the
-  content end, and an offset the browser clamps is one the hold rule does not
-  actually get to hold.
+```text
+tailSpacerPx = max(0, round(clientHeight * 0.75 - bottomInsetPx))
+```
 
-`PINNED_TURN_MIN_ITEM_HEIGHT_PX` must stay an **under**estimate of a
-user-message item. Too low costs a few spare pixels of blank; too high puts the
-pinned offset past the end of the scroll range, and the Turn is clamped back
-down from the viewport top while the follow loop rewrites the clamped offset
-every frame.
+At the physical bottom this leaves at least one quarter of the viewport showing
+transcript content. For an 800px viewport and a 168px footer, the spacer is
+432px and 200px of transcript remains visible. An expanded composer consumes
+the reservation first; the spacer never becomes negative.
 
-While the pin reserve is the binding bound, the spacer and the footer sum to a
-constant: growing the composer moves the content end without moving the end of
-the scroll range. Under the hold-gap floor the spacer stops tracking the inset
-and the range grows with the composer, exactly as it did when the spacer was a
-flat viewport.
+`hold-tail` still needs its collapse allowance to exist inside the physical
+scroll range, so its effective maximum is the smaller of 60% of the viewport
+and the rendered spacer. This makes the reservation the hard bound rather than
+silently asking the browser to hold an offset it must clamp.
 
 ## Why Both Halves Are Required
 
@@ -65,17 +57,13 @@ clamp when content shrinks, which is *permission* to hold position. A follow
 target that re-aligns the content end to the viewport bottom every frame will
 still drag earlier content down by the collapse delta, spacer or not.
 
-`flowChatTailFollow.ts` supplies the second half:
-
-- `pin-turn-top` holds a freshly submitted Turn's user message at the viewport
-  top while its answer is shorter than one viewport, then hands off at the
-  crossover. The blank below a pinned Turn is the mode, not a defect.
-- `hold-tail` keeps its previous offset when content shrinks, and gives ground
+`flowChatTailFollow.ts` supplies the second half: `hold-tail` keeps its previous
+offset when content shrinks, and gives ground
   only once the blank below the live output exceeds `tailHoldMaxGapPx`
-  (a share of the viewport, not a measured delta).
+  (a share of the viewport capped by the physical spacer, not a measured delta).
 
-Both are pure functions over geometry. They hold no timers and observe no
-mutation.
+These rules are pure functions over geometry. They hold no timers and observe
+no mutation.
 
 `useFlowChatFollowOutput` is the only continuous outer viewport writer. Three
 things about how it runs are load-bearing:
@@ -83,11 +71,11 @@ things about how it runs are load-bearing:
 - **`scheduleFollowToLatest` re-asserts ownership after a layout change but does
   not force the content end.** A collapse resizes content too, and the hold rule
   is what keeps that from moving the viewport.
-- **The pinned Turn's offset is re-resolved from live layout every frame.**
-  Items above it are estimates until they are measured, so a cached absolute
-  offset would drift.
+- **A new Turn reveal runs no follow frame.** It places the viewport at the
+  physical bottom once and samples only whether streamed output has consumed
+  the blank.
 - **When streaming stops, `hold-tail` settles any remaining blank with one
-  smooth scroll.** A pinned Turn does not settle.
+  smooth scroll.** A short new-Turn reveal remains at its reveal position.
 
 `tailHoldMaxGapPx` is a **streaming allowance**. Blank below the live output is
 tolerable only because more output is about to fill it. Do not reuse it to
@@ -131,40 +119,53 @@ stop changing. Before the virtualizer renders anything, `scrollHeight` and the
 end sit unchanged at their unmeasured values, which is indistinguishable from
 having finished; a stability test reveals on frame 3 and shows the whole settle.
 
+## Revealing a New Turn
+
+A newly submitted Turn does not enter continuous follow immediately. Once that
+Turn exists in the live-tail projection, follow-output performs one placement at
+the **physical bottom** (`scrollHeight - clientHeight`). That exposes the whole
+resident spacer at once. The reveal then keeps viewport ownership, but runs no
+RAF scroll writer:
+
+```text
+idle -> revealing-tail -> following-tail
+```
+
+As output streams, `scrollTop` stays fixed while `contentEndScrollTop` rises, so
+the visible blank shrinks naturally. The transcript history therefore stays
+still; content consumes the blank instead of a follow write moving history up.
+When `blankPx = scrollTop - contentEndScrollTop` crosses from positive to zero,
+the existing `content-caught-up` path enters ordinary `hold-tail` without a
+one-shot correction. Subsequent growth follows normally.
+
+A short response may never consume the blank. That is intentional: the reveal
+position remains, and stopping streaming does not settle it. A user gesture
+releases reveal ownership and opens the ordinary user-departure watch. A delayed
+`jump-to-latest` from presentation restoration is ignored while reveal is
+active, because the reveal already is the latest placement.
+
+The arrival can precede the live-tail projection that renders it, especially
+when submission starts from a history window. `pendingNewTurnIdRef` preserves
+that arrival and retries the same one-shot placement when the presentation next
+changes; it does not substitute the old content end.
+
 ## User-Controlled Reserved Blank
 
-The spacer is a full viewport the user can scroll into. Once a reader exits
-follow-output, their own scroll position is preserved even when it lands in the
-blank. There is no `scrollend` correction or quiet-period fallback that takes
-the viewport back. Explicit actions such as opening a session, submitting a new
-Turn, navigating a Turn, rolling back, or choosing jump-to-latest remain the
-ways to re-enter follow-output.
+The spacer is bounded by the three-quarter reservation the user can scroll into.
+Once a reader exits follow-output, their own scroll position is preserved even
+when it lands in the blank. There is no `scrollend` correction or quiet-period
+fallback that takes the viewport back. Explicit actions such as opening a
+session, submitting a new Turn, navigating a Turn, rolling back, or choosing
+jump-to-latest remain the ways to re-enter follow-output.
 
 The remaining follow rules carry the live-tail design:
 
-**The target is the follow target, never the content end.** A short new Turn is
-pinned above the content end, so aiming at the content end would scroll *up*
-and shove the message the user just sent into the middle of the viewport. A
-held collapse gap is likewise a legitimate offset up to `tailHoldMaxGapPx` past
-the content end; judged against the content end it would read as an overshoot
-and fight the hold rule on every collapse. `memorylessFollowState` computes the
-target from live geometry with no remembered offset, because the offset the hold
-rule was protecting stopped being meaningful the moment the user took over.
-
-The pin's *identity* therefore outlives a user takeover; only its *activity*
-stops. Three things retire a pin: the crossover to `hold-tail`, a newer Turn,
-and a session change. The crossover has to be one-way — a collapse can pull
-content back under one viewport, and re-pinning there would jump the viewport
-backwards. Since nothing re-pins a Turn whose identity was dropped, that is
-automatic.
-
-**Where a jump to latest lands.** Every entry into follow-output resumes at the
-end of real content, with one exception: a jump to latest while the **newest**
-Turn is still pinned returns to the pin. That mode only holds while the Turn's
-answer is shorter than one viewport, so everything it has produced is already on
-screen, and aiming at the content end would scroll *up* and shove the message
-the user just sent into the middle. The exemption therefore outlives the Turn:
-a short Turn stays pinned until a newer one replaces it.
+**The target is the follow target, never unconditionally the content end.** A
+held collapse gap is a legitimate offset up to `tailHoldMaxGapPx` past the
+content end; judged against the content end it would read as an overshoot and
+fight the hold rule on every collapse. Once a user takes over, ordinary resume
+starts from live geometry because the offset the hold rule protected no longer
+belongs to follow-output.
 
 ## Output Catching Up With a Reader in the Blank
 
@@ -173,10 +174,10 @@ looking at reserved blank, and whom output then overtakes.
 
 Scrolling up gives the follow away permanently, and that is right only for a
 reader who left the live region. A small scroll up may not have. The blank is up
-to `tailHoldMaxGapPx` under `hold-tail` and the whole gap under a pinned Turn,
-so the reader can be a few hundred pixels off the tail with nothing hidden from
-them at all — until output grows past the bottom edge, and they silently stop
-seeing it with no affordance saying so.
+to `tailHoldMaxGapPx` under `hold-tail` and starts at the whole spacer during a
+new-Turn reveal, so the reader can be a few hundred pixels off the tail with
+nothing hidden from them at all — until output grows past the bottom edge, and
+they silently stop seeing it with no affordance saying so.
 
 So a watch runs for as long as the reader holds the viewport — from the scroll
 that took it to whatever hands it back. `scrollTop > contentEnd` is the
@@ -232,9 +233,8 @@ the reader was standing before it.
 Resuming does not scroll. The blank closing *is* the two offsets meeting, so
 what remains is one sample of growth, and the follow loop's ease covers it; a
 one-shot scroll here would be a snap the reader can see for a correction they
-cannot. It also retires the pin, even when the departure happened under one: the
-pin's reservation is the blank the reader just scrolled out of, and restoring it
-would pull them back down to the offset they left.
+cannot. A reveal uses the same crossing before any gesture, while a gesture
+replaces it with the reader-owned form of the watch.
 
 The whole watch is a ref. `followOutput.tailWatch` and
 `followOutput.tailWatchEnded` bracket it — the second carrying `crossings`, so a
@@ -298,16 +298,15 @@ against a nominal 0.25, which is also the evidence that nothing else was
 writing the viewport in between.
 
 "At bottom" is a band, not a point: from the end of real content down to
-whatever the follow rule owns. A pinned Turn and a held collapse gap are both
-inside it, so neither raises the jump-to-latest affordance; the reserved blank
-is outside it, so parking there does. No virtualizer-reported "at bottom" can
-express this: the end of the scroll range is the bottom of the reserved blank,
-not the end of content.
+whatever the follow rule owns. A reveal position and a held collapse gap are
+inside it while follow-output owns them, so neither raises the jump-to-latest
+affordance; reader-owned reserved blank is outside it. No virtualizer-reported
+"at bottom" can express this: the end of the scroll range is the bottom of the
+reserved blank, not the end of content.
 
 The band is recomputed on scroll, on resize, **and when follow ownership
 changes** — its lower edge is the follow target, which can move while the
-viewport is perfectly still. A jump to latest that lands on a pin the viewport
-already sits on writes
+viewport is perfectly still. A delayed jump to latest during a reveal writes
 nothing at all. Driving the band from scroll events alone left the affordance
 visible over a viewport that was at the tail, and clicking it then had nothing
 to do — an inert button is worse than a missing one.
@@ -402,7 +401,7 @@ through more of an animation they cannot read.
 
 The other `'smooth'` request in `useFlowChatFollowOutput`, the post-streaming
 settle, needs no such test: the gap it closes is bounded by `tailHoldMaxGapPx`,
-which is 60% of one viewport.
+which is at most 60% of one viewport and never larger than the spacer.
 
 `followOutput.jumpBehavior` records the decision and the distance in viewports.
 It is also how the constant is checked: if `followOutput.animatedScrollEnded`

--- a/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_VERIFICATION.md
+++ b/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_VERIFICATION.md
@@ -51,6 +51,12 @@ group does not renumber the others.
    measure. This is the per-item estimate doing its job, and it is the single
    most visible symptom if the estimate ever regresses.
 4. Session switching and history paging do not restore stale footer height.
+5. Scroll up in session A, switch to session B, then return to A. The same Turn
+   must remain at the same viewport offset, both in the ordinary tail projection
+   and after navigating into an explicit history window.
+6. From that reading position, switch to Settings and back. The session scene
+   remains mounted with usable geometry while inactive, and the viewport must
+   not enter host suspension or move to the tail.
 
 ### Submitting and revealing
 

--- a/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_VERIFICATION.md
+++ b/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_VERIFICATION.md
@@ -16,9 +16,9 @@ each missing what the other had.
 
 | Test | Contract it holds |
 |---|---|
-| `flowChatTailFollow.test.ts` | the follow target, `pin-turn-top`, `hold-tail` |
+| `flowChatTailFollow.test.ts` | the three-quarter reservation and `hold-tail` geometry |
 | `flowChatCollapseMotion.test.ts` | collapse does not move earlier content |
-| `useFlowChatFollowOutput.test.tsx` | the frame loop, user-controlled blank, resize realign |
+| `useFlowChatFollowOutput.test.tsx` | one-shot new-Turn reveal, frame loop, blank crossing, resize realign |
 | `../../tool-cards/useToolCardHeightContract.test.tsx` | tool cards reflow rather than compensate |
 | `flowChatHistoryBoundary.test.ts` | the screenful lead, and the latch's own predicate |
 | `flowChatLiveTailWindow.test.ts` | "does the transcript still reach the newest Turn" |
@@ -52,35 +52,34 @@ group does not renumber the others.
    most visible symptom if the estimate ever regresses.
 4. Session switching and history paging do not restore stale footer height.
 
-### Submitting and pinning
+### Submitting and revealing
 
-1. A newly submitted Turn opens at the viewport top with room below it.
-2. Send a one-line message and let it pin. It must come to rest at the top with
-   the same small gap above it as the very first Turn of the session, and the
-   pin must hold steady rather than creeping down — a pinned offset past the
-   end of the scroll range is clamped, and the follow loop will rewrite it
-   every frame.
-3. Scroll down into the blank and let go right after submitting a short Turn:
-   it returns that Turn to the viewport top, not to the content end.
+1. A newly submitted Turn performs one physical-bottom placement, exposing the
+   full resident spacer while leaving at least one quarter of the transcript
+   visible above the input footer.
+2. Send a one-line message and leave the short response alone. The viewport must
+   remain at that reveal position; no frame loop may creep toward the content end.
+3. While the answer grows but has not filled the blank, history stays visually
+   fixed and the blank shrinks. When output reaches the viewport bottom, follow
+   starts without a snap and subsequent growth follows normally.
 4. Send a message from the live tail, and again while parked deep in history.
-   Both must end with the new Turn at the viewport top; the second also has to
+   Both must reveal the new live tail; the second also has to
    leave the history window to get there.
-5. Send a message, let it pin, then roll it back from its own message actions.
+5. Send a message, let it reveal, then roll it back from its own message actions.
    The transcript must come to rest with the surviving last Turn at the
-   *bottom* — not with it pinned to the top, which is what reading the
-   truncation as an arrival used to do.
+   *content end*, not at the old reveal position.
 6. Roll a Turn back from further up a transcript, having scrolled to reach it.
    The surviving last Turn must end at the bottom here too — scrolling to reach
    the button hands the viewport to the reader, and the answer has to run
    anyway. Leaving it to the anchor is what showed Turns 2..6 of an 8-Turn
    session with the new last Turn's answer below the fold.
 7. Edit a message and rerun it. There must be one movement, not two — the
-   truncation is silent and the rerun's Turn pins as usual.
+   truncation is silent and the rerun's Turn reveals as usual.
 
 ### Streaming and follow
 
-1. Streaming follows the tail until the user scrolls, and the pinned Turn hands
-   off once its answer overflows the viewport.
+1. A new-Turn reveal stays fixed until output consumes its blank, then hands off
+   to ordinary tail following.
 2. With output streaming, scroll up and hold still. Follow must not write while
    the gesture is recent, and must resume once it goes quiet.
 3. Jump to latest from a screen or two up is animated rather than an instant
@@ -121,12 +120,13 @@ group does not renumber the others.
    opens.
 4. Wheel down into the reserved blank and stop. The transcript must remain
    still and the jump-to-latest affordance must stay available.
-5. With a short Turn pinned, scroll up and jump to latest. The explicit jump
-   must still return to the pin rather than the physical bottom of the spacer.
+5. Trigger the delayed jump-to-latest that accompanies live-tail restoration
+   while a short Turn reveal is active. It must be a no-op and must not replace
+   the reveal with a content-end scroll.
 
 ### Output catching up with a reader in the blank
 
-1. Send a message so a short Turn pins with blank below it, then wheel up a
+1. Send a message so its one-shot reveal has blank below it, then wheel up a
    little — far enough to leave the tail, not far enough to push the blank off
    screen — and take your hand off. As the answer grows past the bottom edge the
    transcript must resume following, easing rather than snapping, and the
@@ -147,8 +147,8 @@ group does not renumber the others.
 
 1. Drag the scrollbar to the very bottom. The screen must not be entirely
    blank: the last Turn and the input clearance stay visible above the
-   reservation. Repeat with the composer expanded, which is where the reserve
-   falls back to the hold-gap floor.
+   reservation. Repeat with the composer expanded, which consumes the spacer
+   before the three-quarter cap can be exceeded.
 2. Drag the scrollbar, without touching the wheel first, down into the reserved
    blank and let go: it must stay there. Then drag it while output streams: the
    transcript must follow the thumb without the frame loop fighting it. A press
@@ -168,7 +168,7 @@ group does not renumber the others.
 1. Open a session long enough to be `isPartial` — the loaded tail is shorter
    than the viewport, so it pages older Turns in on its own. No jump-to-latest
    bar should appear, and streaming output should be followed. Then send a
-   message: it must appear immediately and pin to the viewport top, with the
+   message: it must appear immediately in the one-shot tail reveal, with the
    history above neither moving nor reloading.
 2. Scroll up to a junction. **One** page loads, the Turn under the cursor stays
    where it is, and paging stops until the head is reached again. Then keep

--- a/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_VIEWPORT_REGISTER.md
+++ b/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_VIEWPORT_REGISTER.md
@@ -106,8 +106,8 @@ but not a second visible movement.
 
 **Turn navigation never scrolls into the reserved blank to top-align a Turn.** A
 Turn whose top lies past the content end is stopped at the content end instead,
-which is where the tail rests. The blank belongs to follow-output — `pin-turn-top`
-holds it for output that is arriving, and nothing arrives under a Turn the user
+which is where the tail rests. The blank belongs to follow-output's passive
+new-Turn reveal, and nothing arrives under a Turn the user
 navigated to. There is no "is this the last Turn" test and no measurement of
 what lies below it: a Turn with a viewport of content under it has its top above
 the content end already, so the clamp does not bind and the final Turns of a
@@ -119,8 +119,8 @@ message**, not at the message itself. The first Turn already sits below that gap
 for free, because `.message-list-header` occupies it at the head of the scroll
 content; every other Turn used to land flat on the top edge, and the two read as
 different alignments. The header renders at the same constant so they cannot
-drift. Both the one-shot scroll and the offset the follow loop re-asserts every
-frame carry it — if only one did, they would fight.
+drift. This remains a Turn-navigation contract; new-Turn reveal no longer asks
+for or re-asserts a Turn-top offset.
 
 **A gesture preempts a navigation still in flight, and ends it.** The library's
 re-aim keeps computing for up to 5s after the aim that started it, recomputing

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.history-state.test.tsx
@@ -18,4 +18,11 @@ describe('ModernFlowChatContainer natural navigation contract', () => {
     expect(componentSource).not.toContain('pinTurnToTop');
     expect(componentSource).not.toContain('prepareTurnPinToTop');
   });
+
+  it('keeps provisional mount snapshots and auto-tail placement out of session restoration', () => {
+    expect(componentSource).toContain('viewportRestorePendingSessionIdRef');
+    expect(componentSource).toContain('viewport.sessionSnapshotIgnoredDuringRestore');
+    expect(componentSource).toContain('onViewportRestoreSettled={handleViewportRestoreSettled}');
+    expect(componentSource).toContain('viewportRestorePendingSessionId === sessionId');
+  });
 });

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
@@ -81,6 +81,10 @@ import {
   shouldUseLatestTurnFollowOutput,
 } from '../../utils/flowChatTurnScrollPolicy';
 import { isRemoteTraceContext, startupTrace } from '@/shared/utils/startupTrace';
+import {
+  traceViewport,
+  traceViewportRepeating,
+} from '@/infrastructure/diagnostics/flowChatViewportDiagnostics';
 import { scheduleAfterStartupPaint } from '@/shared/utils/startupTaskScheduling';
 import { agentAPI } from '@/infrastructure/api/service-api/AgentAPI';
 import { notificationService } from '@/shared/notification-system';
@@ -117,6 +121,7 @@ import {
   projectedSessionTurnCount,
   resolveTurnOrdinal,
 } from '../../utils/flowChatTurnIdentity';
+import type { FlowChatViewportSnapshot } from './flowChatViewportSnapshot';
 
 const log = createLogger('ModernFlowChatContainer');
 
@@ -144,6 +149,12 @@ interface FlowChatTurnSummary {
 interface FlowChatHistoryPresentationState extends SessionHistoryPresentation {
   sessionId: string;
   revision: number;
+}
+
+interface SessionViewportState {
+  snapshot: FlowChatViewportSnapshot | null;
+  historyPresentation: FlowChatHistoryPresentationState | null;
+  viewportIntent: FlowChatViewportIntent | null;
 }
 
 type FlowChatViewportIntent =
@@ -512,6 +523,16 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
   const virtualListRef = useRef<VirtualMessageListRef>(null);
   const chatScopeRef = useRef<HTMLDivElement>(null);
   const activeSessionIdRef = useRef<string | null>(null);
+  const sessionViewportStateRef = useRef<Map<string, SessionViewportState>>(new Map());
+  const activeSessionViewportSnapshot = activeSession?.sessionId
+    ? sessionViewportStateRef.current.get(activeSession.sessionId)?.snapshot ?? null
+    : null;
+  const isRestoringRememberedReadingPosition = Boolean(
+    activeSessionViewportSnapshot
+    && !activeSessionViewportSnapshot.isAtTail
+    && activeSessionViewportSnapshot.anchorTurnId !== null
+    && activeSessionViewportSnapshot.anchorOffsetPx !== null
+  );
   const [historyInitialContentReadyKey, setHistoryInitialContentReadyKey] = useState<string | null>(null);
   const [historyInitialContentPostPaintKey, setHistoryInitialContentPostPaintKey] = useState<string | null>(null);
   const { workspacePath, activeWorkspace } = useWorkspaceContext();
@@ -521,6 +542,40 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     historyState === 'ready' &&
     (activeSession?.dialogTurns.length ?? 0) > 0 &&
     virtualItems.length === 0;
+
+  const rememberSessionViewportState = useCallback((
+    sessionId: string,
+    patch: Partial<SessionViewportState>,
+  ) => {
+    const previous = sessionViewportStateRef.current.get(sessionId);
+    sessionViewportStateRef.current.set(sessionId, {
+      snapshot: patch.snapshot !== undefined ? patch.snapshot : previous?.snapshot ?? null,
+      historyPresentation: patch.historyPresentation !== undefined
+        ? patch.historyPresentation
+        : previous?.historyPresentation ?? null,
+      viewportIntent: patch.viewportIntent !== undefined
+        ? patch.viewportIntent
+        : previous?.viewportIntent ?? null,
+    });
+  }, []);
+
+  const handleViewportSnapshot = useCallback((snapshot: FlowChatViewportSnapshot) => {
+    rememberSessionViewportState(snapshot.sessionId, { snapshot });
+    traceViewportRepeating(`sessionSnapshot|${snapshot.sessionId}|${snapshot.presentationMode}`, {
+      location: 'viewport.sessionSnapshotCaptured',
+      message: 'FlowChat stored a semantic viewport snapshot for a session',
+      data: () => ({
+        sessionId: snapshot.sessionId,
+        presentationMode: snapshot.presentationMode,
+        viewportMode: snapshot.viewportMode,
+        historyWindow: snapshot.historyWindow,
+        anchorTurnId: snapshot.anchorTurnId,
+        anchorOffsetPx: snapshot.anchorOffsetPx,
+        scrollTopPx: snapshot.scrollTopPx,
+        isAtTail: snapshot.isAtTail,
+      }),
+    });
+  }, [rememberSessionViewportState]);
   const showHistoryPlaceholder = virtualItems.length === 0 && (
     historyState === 'metadata-only' ||
     historyState === 'hydrating' ||
@@ -598,28 +653,73 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
       historyPresentationRef.current = null;
       setHistoryPresentation(null);
     }
+    rememberSessionViewportState(sessionId, { snapshot: null });
     updateViewportIntent({ kind: 'live-tail', sessionId });
     setHistoryBoundaryState(IDLE_HISTORY_BOUNDARY_STATE);
     setQueuedTurnNavigation(null);
-  }, [activeSession?.sessionId, continuousHistoryProjectionEligible, updateViewportIntent]);
+  }, [
+    activeSession?.sessionId,
+    continuousHistoryProjectionEligible,
+    rememberSessionViewportState,
+    updateViewportIntent,
+  ]);
 
   useEffect(() => {
     historyPresentationRef.current = historyPresentation;
-  }, [historyPresentation]);
+    if (historyPresentation?.sessionId) {
+      rememberSessionViewportState(historyPresentation.sessionId, { historyPresentation });
+    }
+  }, [historyPresentation, rememberSessionViewportState]);
+
+  useEffect(() => {
+    const intent = viewportIntent;
+    if (intent?.sessionId) {
+      rememberSessionViewportState(intent.sessionId, { viewportIntent: intent });
+    }
+  }, [rememberSessionViewportState, viewportIntent]);
 
   useLayoutEffect(() => {
     const sessionId = activeSession?.sessionId;
+    const previousSessionId = activeSessionIdRef.current;
+    if (previousSessionId && previousSessionId !== sessionId) {
+      rememberSessionViewportState(previousSessionId, {
+        historyPresentation: historyPresentationRef.current?.sessionId === previousSessionId
+          ? historyPresentationRef.current
+          : null,
+        viewportIntent: viewportIntentRef.current?.sessionId === previousSessionId
+          ? viewportIntentRef.current
+          : null,
+      });
+    }
+    activeSessionIdRef.current = sessionId ?? null;
+    const remembered = sessionId ? sessionViewportStateRef.current.get(sessionId) : undefined;
     historyPresentationOwnerGenerationRef.current += 1;
-    historyPresentationRef.current = null;
-    setHistoryPresentation(null);
+    const restoredHistoryPresentation = remembered?.historyPresentation ?? null;
+    historyPresentationRef.current = restoredHistoryPresentation;
+    setHistoryPresentation(restoredHistoryPresentation);
     setContinuousProjectionSessionId(null);
-    updateViewportIntent(sessionId ? { kind: 'live-tail', sessionId } : null);
+    const restoredIntent = remembered?.viewportIntent
+      ?? (sessionId ? { kind: 'live-tail', sessionId } : null);
+    updateViewportIntent(restoredIntent);
     setHistoryBoundaryState(IDLE_HISTORY_BOUNDARY_STATE);
     historyBoundaryRequestsRef.current = { before: null, after: null };
     if (sessionId) {
-      flowChatStore.restoreSessionTailPresentation(sessionId);
+      if (!restoredHistoryPresentation) {
+        flowChatStore.restoreSessionTailPresentation(sessionId);
+      }
+      traceViewport({
+        location: 'viewport.sessionStateRestored',
+        message: 'FlowChat restored the remembered session viewport state',
+        data: () => ({
+          sessionId,
+          previousSessionId,
+          restoredPresentationMode: restoredHistoryPresentation ? 'history-window' : 'tail',
+          restoredViewportIntent: restoredIntent,
+          snapshot: remembered?.snapshot ?? null,
+        }),
+      });
     }
-  }, [activeSession?.sessionId, updateViewportIntent]);
+  }, [activeSession?.sessionId, rememberSessionViewportState, updateViewportIntent]);
 
   useEffect(() => {
     const retainedSessionId = continuousProjectionSessionId;
@@ -1247,6 +1347,7 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
       !isViewportActive ||
       !sessionId ||
       isReadingTurnViewport ||
+      isRestoringRememberedReadingPosition ||
       !latestTurnId ||
       !latestTurnKey ||
       autoTailTurnKeyRef.current === latestTurnKey
@@ -1281,6 +1382,7 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
   }, [
     activeSession?.sessionId,
     isReadingTurnViewport,
+    isRestoringRememberedReadingPosition,
     isViewportActive,
     latestTurnId,
     latestTurnUsesFollowOutput,
@@ -1816,10 +1918,6 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     const sessionId = activeSession?.sessionId;
     if (!sessionId) return;
     void FlowChatManager.getInstance().switchChatSession(sessionId);
-  }, [activeSession?.sessionId]);
-
-  useEffect(() => {
-    activeSessionIdRef.current = activeSession?.sessionId ?? null;
   }, [activeSession?.sessionId]);
 
   const handleHistoryWindowBoundaryIntent = useCallback((
@@ -2574,6 +2672,8 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
                   onHistoryWindowBoundaryIntent={handleHistoryWindowBoundaryIntent}
                   onRequestJumpToLatest={jumpToLiveTail}
                   onUserScrollIntent={handleVirtualListUserScrollIntent}
+                  onViewportSnapshot={handleViewportSnapshot}
+                  initialViewportSnapshot={activeSessionViewportSnapshot}
                 />
               </>
             )}

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
@@ -524,6 +524,8 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
   const chatScopeRef = useRef<HTMLDivElement>(null);
   const activeSessionIdRef = useRef<string | null>(null);
   const sessionViewportStateRef = useRef<Map<string, SessionViewportState>>(new Map());
+  const viewportRestorePendingSessionIdRef = useRef<string | null>(null);
+  const [viewportRestorePendingSessionId, setViewportRestorePendingSessionId] = useState<string | null>(null);
   const activeSessionViewportSnapshot = activeSession?.sessionId
     ? sessionViewportStateRef.current.get(activeSession.sessionId)?.snapshot ?? null
     : null;
@@ -533,6 +535,13 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     && activeSessionViewportSnapshot.anchorTurnId !== null
     && activeSessionViewportSnapshot.anchorOffsetPx !== null
   );
+  const restoreGateSessionId = viewportRestorePendingSessionId
+    ?? (
+      activeSession?.sessionId !== activeSessionIdRef.current
+      && isRestoringRememberedReadingPosition
+        ? activeSession?.sessionId ?? null
+        : null
+    );
   const [historyInitialContentReadyKey, setHistoryInitialContentReadyKey] = useState<string | null>(null);
   const [historyInitialContentPostPaintKey, setHistoryInitialContentPostPaintKey] = useState<string | null>(null);
   const { workspacePath, activeWorkspace } = useWorkspaceContext();
@@ -559,7 +568,7 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     });
   }, []);
 
-  const handleViewportSnapshot = useCallback((snapshot: FlowChatViewportSnapshot) => {
+  const acceptViewportSnapshot = useCallback((snapshot: FlowChatViewportSnapshot) => {
     rememberSessionViewportState(snapshot.sessionId, { snapshot });
     traceViewportRepeating(`sessionSnapshot|${snapshot.sessionId}|${snapshot.presentationMode}`, {
       location: 'viewport.sessionSnapshotCaptured',
@@ -569,6 +578,8 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
         presentationMode: snapshot.presentationMode,
         viewportMode: snapshot.viewportMode,
         historyWindow: snapshot.historyWindow,
+        anchorItemKey: snapshot.anchorItemKey,
+        anchorItemType: snapshot.anchorItemType,
         anchorTurnId: snapshot.anchorTurnId,
         anchorOffsetPx: snapshot.anchorOffsetPx,
         scrollTopPx: snapshot.scrollTopPx,
@@ -576,6 +587,46 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
       }),
     });
   }, [rememberSessionViewportState]);
+
+  const handleViewportSnapshot = useCallback((snapshot: FlowChatViewportSnapshot) => {
+    if (
+      viewportRestorePendingSessionIdRef.current === snapshot.sessionId
+      || restoreGateSessionId === snapshot.sessionId
+    ) {
+      traceViewportRepeating(`sessionSnapshotIgnored|${snapshot.sessionId}`, {
+        location: 'viewport.sessionSnapshotIgnoredDuringRestore',
+        message: 'FlowChat ignored a provisional viewport snapshot while restoring a session',
+        data: () => ({
+          sessionId: snapshot.sessionId,
+          anchorItemKey: snapshot.anchorItemKey,
+          anchorItemType: snapshot.anchorItemType,
+          anchorTurnId: snapshot.anchorTurnId,
+          anchorOffsetPx: snapshot.anchorOffsetPx,
+          scrollTopPx: snapshot.scrollTopPx,
+          isAtTail: snapshot.isAtTail,
+        }),
+      });
+      return;
+    }
+    acceptViewportSnapshot(snapshot);
+  }, [acceptViewportSnapshot, restoreGateSessionId]);
+
+  const handleViewportRestoreSettled = useCallback((sessionId: string) => {
+    if (viewportRestorePendingSessionIdRef.current !== sessionId) return;
+    viewportRestorePendingSessionIdRef.current = null;
+    setViewportRestorePendingSessionId(null);
+    const capturedSnapshot = virtualListRef.current?.captureViewportSnapshot() ?? null;
+    if (capturedSnapshot?.sessionId === sessionId) {
+      // Restoration started from an explicit reader-owned position. A scroll
+      // event that recomputes the tail band can trail the final layout frame,
+      // so its old ref value must not turn that restored position back into a
+      // session-open tail request at the hand-off boundary.
+      acceptViewportSnapshot({
+        ...capturedSnapshot,
+        isAtTail: false,
+      });
+    }
+  }, [acceptViewportSnapshot]);
   const showHistoryPlaceholder = virtualItems.length === 0 && (
     historyState === 'metadata-only' ||
     historyState === 'hydrating' ||
@@ -700,6 +751,17 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     setContinuousProjectionSessionId(null);
     const restoredIntent = remembered?.viewportIntent
       ?? (sessionId ? { kind: 'live-tail', sessionId } : null);
+    const rememberedSnapshot = remembered?.snapshot ?? null;
+    const shouldRestoreRememberedViewport = Boolean(
+      rememberedSnapshot
+      && !rememberedSnapshot.isAtTail
+      && rememberedSnapshot.anchorTurnId !== null
+      && rememberedSnapshot.anchorOffsetPx !== null
+    );
+    viewportRestorePendingSessionIdRef.current = shouldRestoreRememberedViewport
+      ? sessionId ?? null
+      : null;
+    setViewportRestorePendingSessionId(viewportRestorePendingSessionIdRef.current);
     updateViewportIntent(restoredIntent);
     setHistoryBoundaryState(IDLE_HISTORY_BOUNDARY_STATE);
     historyBoundaryRequestsRef.current = { before: null, after: null };
@@ -715,7 +777,7 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
           previousSessionId,
           restoredPresentationMode: restoredHistoryPresentation ? 'history-window' : 'tail',
           restoredViewportIntent: restoredIntent,
-          snapshot: remembered?.snapshot ?? null,
+          snapshot: rememberedSnapshot,
         }),
       });
     }
@@ -1346,6 +1408,7 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     if (
       !isViewportActive ||
       !sessionId ||
+      viewportRestorePendingSessionId === sessionId ||
       isReadingTurnViewport ||
       isRestoringRememberedReadingPosition ||
       !latestTurnId ||
@@ -1387,6 +1450,7 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     latestTurnId,
     latestTurnUsesFollowOutput,
     turnSummaries.length,
+    viewportRestorePendingSessionId,
   ]);
 
   useEffect(() => {
@@ -2673,6 +2737,7 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
                   onRequestJumpToLatest={jumpToLiveTail}
                   onUserScrollIntent={handleVirtualListUserScrollIntent}
                   onViewportSnapshot={handleViewportSnapshot}
+                  onViewportRestoreSettled={handleViewportRestoreSettled}
                   initialViewportSnapshot={activeSessionViewportSnapshot}
                 />
               </>

--- a/src/web-ui/src/flow_chat/components/modern/VirtualItemRenderer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualItemRenderer.tsx
@@ -14,6 +14,7 @@ import { useFlowChatVolatileContext } from './FlowChatContext';
 import { TurnCompletionNoticeItem } from './TurnCompletionNoticeItem';
 import { TurnFailureNoticeItem } from './TurnFailureNoticeItem';
 import './VirtualItemRenderer.scss';
+import { getVirtualItemStableKey } from './virtualItemIdentity';
 
 interface VirtualItemRendererProps {
   item: VirtualItem;
@@ -125,6 +126,7 @@ export const VirtualItemRenderer = React.memo<VirtualItemRendererProps>(
         data-testid="flowchat-message-item"
         data-turn-id={item.turnId}
         data-item-type={item.type}
+        data-virtual-item-key={getVirtualItemStableKey(item)}
         data-virtual-index={index}
         data-item-index={index}
       >

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.layout.test.ts
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.layout.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   estimateTextHeightFromLength,
+  describeVirtualItemEstimate,
   estimateVirtualMessageItemHeightWithContext,
   estimateVirtualMessageItemHeight,
   getVirtualMessageDefaultItemHeight,
@@ -179,15 +180,18 @@ describe('estimateVirtualMessageItemHeight', () => {
         rounds: [],
         isGroupStreaming: false,
         isLastGroupInTurn: true,
-        wasCutByCritical: true,
+        wasCutByCritical: false,
       },
     } as VirtualItem;
     const collapsed = estimateVirtualMessageItemHeightWithContext(exploreItem, {
       exploreGroupStates: new Map([['group-1', false]]),
     });
+    const defaultHeight = estimateVirtualMessageItemHeightWithContext(exploreItem);
     const expanded = estimateVirtualMessageItemHeightWithContext(exploreItem, {
       exploreGroupStates: new Map([['group-1', true]]),
     });
+    expect(describeVirtualItemEstimate(exploreItem)).toMatchObject({ defaultExpanded: false });
+    expect(defaultHeight).toBe(collapsed);
     expect(expanded).toBeGreaterThan(collapsed);
   });
 });

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
@@ -31,6 +31,7 @@ const mocks = vi.hoisted(() => ({
   isFollowingOutput: false,
   followsNow: false,
   scheduleFollowToLatest: vi.fn(),
+  startAtTailOnMount: true,
   revealNewTurnTail: null as null | ((turnId: string) => boolean),
   /**
    * The register the list built, reached through the hook it hands it to.
@@ -174,9 +175,11 @@ vi.mock('./useFlowChatFollowOutput', () => ({
   useFlowChatFollowOutput: (options: {
     viewportOwner: { claim: (owner: string) => boolean };
     revealNewTurnTail: (turnId: string) => boolean;
+    startAtTailOnMount?: boolean;
   }) => {
     mocks.viewportOwner = options.viewportOwner;
     mocks.revealNewTurnTail = options.revealNewTurnTail;
+    mocks.startAtTailOnMount = options.startAtTailOnMount ?? true;
     return {
       isFollowingOutput: mocks.isFollowingOutput,
       enterFollowOutput: mocks.enterFollowOutput,
@@ -318,6 +321,7 @@ describe('VirtualMessageList natural scroll contract', () => {
     mocks.handleUserScrollIntent.mockReset();
     mocks.handleFollowScroll.mockReset();
     mocks.scheduleFollowToLatest.mockReset();
+    mocks.startAtTailOnMount = true;
     mocks.revealNewTurnTail = null;
     mocks.viewportOwner = null;
     mocks.setVisibleTurnInfo.mockReset();
@@ -1075,5 +1079,95 @@ describe('VirtualMessageList natural scroll contract', () => {
     act(() => root.render(<VirtualMessageList ref={listRef} />));
     expect(listRef.current?.prepareTurnNavigation('turn-2')).toBe('pending');
     expect(container.querySelector('.message-list-footer')?.getAttribute('style')).toContain('168px');
+  });
+
+  it('captures and restores a history viewport by Turn and viewport offset', () => {
+    const listRef = React.createRef<VirtualMessageListRef>();
+    const layout = {
+      clientHeight: 600,
+      scrollHeight: 2000,
+      turnTopFromScrollerTop: 120,
+    };
+    const restoreLayout = fakeLayout(layout);
+    try {
+      act(() => root.render(
+        <VirtualMessageList
+          ref={listRef}
+          presentationMode="history-window"
+          viewportMode="history-reading"
+          historyWindow={{ startOrdinal: 4, endOrdinalExclusive: 8 }}
+        />,
+      ));
+      const scroller = container.querySelector<HTMLElement>('[data-flowchat-scroller]')!;
+      scroller.getBoundingClientRect = () => (
+        { ...new DOMRect(0, 0, 1000, 600), top: 0, bottom: 600 } as DOMRect
+      );
+      Object.defineProperty(scroller, 'scrollTop', {
+        configurable: true,
+        writable: true,
+        value: 400,
+      });
+
+      const snapshot = listRef.current?.captureViewportSnapshot();
+      expect(snapshot).toMatchObject({
+        sessionId: 'session-1',
+        presentationMode: 'history-window',
+        viewportMode: 'history-reading',
+        historyWindow: { startOrdinal: 4, endOrdinalExclusive: 8 },
+        anchorTurnId: 'turn-1',
+        anchorOffsetPx: 120,
+        scrollTopPx: 400,
+      });
+
+      layout.turnTopFromScrollerTop = 260;
+      let restored = false;
+      act(() => {
+        restored = snapshot ? listRef.current?.restoreViewportSnapshot(snapshot) ?? false : false;
+      });
+
+      expect(restored).toBe(true);
+      expect(scroller.scrollTop).toBe(540);
+    } finally {
+      restoreLayout();
+    }
+  });
+
+  it('materializes and restores a saved reading position without starting tail follow', () => {
+    const listRef = React.createRef<VirtualMessageListRef>();
+    const initialViewportSnapshot = {
+      sessionId: 'session-1',
+      presentationMode: 'tail' as const,
+      viewportMode: 'live-tail' as const,
+      historyWindow: null,
+      anchorTurnId: 'turn-1',
+      anchorOffsetPx: 120,
+      scrollTopPx: 400,
+      isAtTail: false,
+      capturedAtMs: 1,
+    };
+    const layout = {
+      clientHeight: 600,
+      scrollHeight: 2000,
+      turnTopFromScrollerTop: 260,
+    };
+    const restoreLayout = fakeLayout(layout);
+    try {
+      act(() => root.render(
+        <VirtualMessageList
+          ref={listRef}
+          initialViewportSnapshot={initialViewportSnapshot}
+        />,
+      ));
+      const scroller = container.querySelector<HTMLElement>('[data-flowchat-scroller]')!;
+      scroller.getBoundingClientRect = () => (
+        { ...new DOMRect(0, 0, 1000, 600), top: 0, bottom: 600 } as DOMRect
+      );
+
+      expect(mocks.startAtTailOnMount).toBe(false);
+      expect(scroller.scrollTop).toBe(140);
+      expect(container.querySelector('[data-open-viewport-settled="true"]')).not.toBeNull();
+    } finally {
+      restoreLayout();
+    }
   });
 });

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
@@ -215,6 +215,7 @@ vi.mock('./VirtualItemRenderer', () => ({
       className="virtual-item-wrapper"
       data-item-type={mocks.renderItemMetadata ? item.type : undefined}
       data-turn-id={item.turnId}
+      data-virtual-item-key={`${item.type}:${item.turnId}:${item.data?.id ?? item.data?.groupId ?? ''}`}
       data-virtual-index={index}
     >
       {item.data?.content ?? item.turnId}
@@ -235,6 +236,16 @@ function userMessage(turnId: string, id: string, content: string) {
     type: 'user-message',
     turnId,
     data: { id, content },
+  };
+}
+
+function modelRound(turnId: string, id: string, content: string) {
+  return {
+    type: 'model-round',
+    turnId,
+    data: { id, content, items: [] },
+    isLastRound: true,
+    isTurnComplete: true,
   };
 }
 
@@ -1132,7 +1143,58 @@ describe('VirtualMessageList natural scroll contract', () => {
     }
   });
 
-  it('materializes and restores a saved reading position without starting tail follow', () => {
+  it('restores the exact visible virtual row instead of the Turn header', () => {
+    mocks.items = [
+      userMessage('turn-1', 'message-1', 'Question'),
+      modelRound('turn-1', 'round-1', 'Long answer'),
+    ];
+    const listRef = React.createRef<VirtualMessageListRef>();
+    const restoreLayout = fakeLayout({
+      clientHeight: 600,
+      scrollHeight: 2000,
+      turnTopFromScrollerTop: 120,
+    });
+    try {
+      act(() => root.render(<VirtualMessageList ref={listRef} />));
+      const scroller = container.querySelector<HTMLElement>('[data-flowchat-scroller]')!;
+      scroller.getBoundingClientRect = () => (
+        { ...new DOMRect(0, 0, 1000, 600), top: 0, bottom: 600 } as DOMRect
+      );
+      Object.defineProperty(scroller, 'scrollTop', {
+        configurable: true,
+        writable: true,
+        value: 400,
+      });
+      const [turnHeader, modelRoundElement] = Array.from(
+        container.querySelectorAll<HTMLElement>('.virtual-item-wrapper'),
+      );
+      turnHeader.getBoundingClientRect = () => (
+        { ...new DOMRect(0, -300, 1000, 40), top: -300, bottom: -260 } as DOMRect
+      );
+      let modelRoundTop = -80;
+      modelRoundElement.getBoundingClientRect = () => (
+        { ...new DOMRect(0, modelRoundTop, 1000, 900), top: modelRoundTop, bottom: modelRoundTop + 900 } as DOMRect
+      );
+
+      const snapshot = listRef.current?.captureViewportSnapshot();
+      expect(snapshot).toMatchObject({
+        anchorItemKey: 'model-round:turn-1:round-1',
+        anchorItemType: 'model-round',
+        anchorTurnId: 'turn-1',
+        anchorOffsetPx: -80,
+      });
+
+      modelRoundTop = 170;
+      act(() => {
+        expect(snapshot && listRef.current?.restoreViewportSnapshot(snapshot)).toBe(true);
+      });
+      expect(scroller.scrollTop).toBe(650);
+    } finally {
+      restoreLayout();
+    }
+  });
+
+  it('materializes and restores a saved reading position without starting tail follow', async () => {
     const listRef = React.createRef<VirtualMessageListRef>();
     const initialViewportSnapshot = {
       sessionId: 'session-1',
@@ -1165,6 +1227,7 @@ describe('VirtualMessageList natural scroll contract', () => {
 
       expect(mocks.startAtTailOnMount).toBe(false);
       expect(scroller.scrollTop).toBe(140);
+      await settleOpenReveal();
       expect(container.querySelector('[data-open-viewport-settled="true"]')).not.toBeNull();
     } finally {
       restoreLayout();

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
@@ -16,9 +16,11 @@ const mocks = vi.hoisted(() => ({
   scrollToOffset: vi.fn(),
   cancelAim: vi.fn(),
   setVisibleTurnInfo: vi.fn(),
+  handleViewportResize: vi.fn(),
   enterFollowOutput: vi.fn(),
   exitFollowOutput: vi.fn(),
   handleUserScrollIntent: vi.fn(),
+  handleFollowScroll: vi.fn(),
   /**
    * The two answers to "does follow own the viewport", which the real hook
    * gives at two different moments: `isFollowingOutput` is a render value, and
@@ -50,6 +52,7 @@ const BOTTOM_INSET = 168;
  * supplied: the scroller's own box, and where a user message sits inside it.
  */
 function fakeLayout(options: {
+  clientWidth?: number;
   clientHeight: number;
   /** A function where the range has to grow, as it does when history arrives. */
   scrollHeight: number | (() => number);
@@ -58,11 +61,14 @@ function fakeLayout(options: {
   const readScrollHeight = typeof options.scrollHeight === 'function'
     ? options.scrollHeight
     : () => options.scrollHeight as number;
-  const originals = (['clientHeight', 'scrollHeight'] as const).map(name => {
+  const originals = (['clientWidth', 'clientHeight', 'scrollHeight'] as const).map(name => {
     const descriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, name);
     Object.defineProperty(HTMLElement.prototype, name, {
       configurable: true,
-      get: () => (name === 'clientHeight' ? options.clientHeight : readScrollHeight()),
+      get: () => {
+        if (name === 'clientWidth') return options.clientWidth ?? 1000;
+        return name === 'clientHeight' ? options.clientHeight : readScrollHeight();
+      },
     });
     return [name, descriptor] as const;
   });
@@ -183,8 +189,8 @@ vi.mock('./useFlowChatFollowOutput', () => ({
         mocks.handleUserScrollIntent();
       },
       handleTurnsRolledBack: vi.fn(),
-      handleScroll: vi.fn(),
-      handleViewportResize: vi.fn(),
+      handleScroll: mocks.handleFollowScroll,
+      handleViewportResize: mocks.handleViewportResize,
       // Follow owns nothing here, which is what the real hook returns when
       // `isFollowingOutput` is false.
       getFollowTargetScrollTop: () => null,
@@ -231,6 +237,31 @@ describe('VirtualMessageList natural scroll contract', () => {
   let root: Root;
   let animationFrames: Map<number, FrameRequestCallback>;
   let nextAnimationFrameId: number;
+  let resizeObservers: TestResizeObserver[];
+
+  class TestResizeObserver {
+    readonly targets = new Set<Element>();
+
+    constructor(private readonly callback: ResizeObserverCallback) {
+      resizeObservers.push(this);
+    }
+
+    observe(target: Element) {
+      this.targets.add(target);
+    }
+
+    unobserve(target: Element) {
+      this.targets.delete(target);
+    }
+
+    disconnect() {
+      this.targets.clear();
+    }
+
+    notify() {
+      this.callback([], this as unknown as ResizeObserver);
+    }
+  }
 
   /**
    * Run the opening reveal to its end, which is what mounting a transcript
@@ -264,6 +295,7 @@ describe('VirtualMessageList natural scroll contract', () => {
     root = createRoot(container);
     animationFrames = new Map();
     nextAnimationFrameId = 0;
+    resizeObservers = [];
     mocks.items = [
       userMessage('turn-1', 'message-1', 'First'),
       userMessage('turn-2', 'message-2', 'Second'),
@@ -277,17 +309,16 @@ describe('VirtualMessageList natural scroll contract', () => {
     mocks.scrollItemIntoView.mockReset();
     mocks.scrollToOffset.mockReset();
     mocks.cancelAim.mockReset();
+    mocks.handleViewportResize.mockReset();
     mocks.enterFollowOutput.mockReset();
     mocks.exitFollowOutput.mockReset();
     mocks.handleUserScrollIntent.mockReset();
+    mocks.handleFollowScroll.mockReset();
     mocks.scheduleFollowToLatest.mockReset();
     mocks.viewportOwner = null;
     mocks.setVisibleTurnInfo.mockReset();
     mocks.renderItemMetadata = true;
-    vi.stubGlobal('ResizeObserver', class {
-      observe() {}
-      disconnect() {}
-    });
+    vi.stubGlobal('ResizeObserver', TestResizeObserver);
     vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
       nextAnimationFrameId += 1;
       animationFrames.set(nextAnimationFrameId, callback);
@@ -315,10 +346,12 @@ describe('VirtualMessageList natural scroll contract', () => {
     // The session opens on the end of *real content*, which is above this
     // reservation. Nothing aligns to the last item any more: the end of the
     // scroll range is reserved blank, and opening there is opening on nothing.
-    const originalClientHeight = Object.getOwnPropertyDescriptor(
-      HTMLElement.prototype,
-      'clientHeight',
-    );
+    const originalClientHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight');
+    const originalClientWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientWidth');
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+      configurable: true,
+      get: () => 1000,
+    });
     Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
       configurable: true,
       get: () => 600,
@@ -341,6 +374,69 @@ describe('VirtualMessageList natural scroll contract', () => {
       } else {
         delete (HTMLElement.prototype as unknown as Record<string, unknown>).clientHeight;
       }
+      if (originalClientWidth) {
+        Object.defineProperty(HTMLElement.prototype, 'clientWidth', originalClientWidth);
+      } else {
+        delete (HTMLElement.prototype as unknown as Record<string, unknown>).clientWidth;
+      }
+    }
+  });
+
+  it('suspends viewport writers until the frame after a minimized zero-size sample resumes', () => {
+    const layout = {
+      clientWidth: 1000,
+      clientHeight: 600,
+      scrollHeight: 3000,
+      turnTopFromScrollerTop: 500,
+    };
+    const restoreLayout = fakeLayout(layout);
+    try {
+      act(() => root.render(<VirtualMessageList />));
+      const scroller = container.querySelector<HTMLElement>('[data-flowchat-scroller]')!;
+      const observer = resizeObservers.find(candidate => candidate.targets.has(scroller));
+      expect(observer).toBeDefined();
+      if (!observer) throw new Error('Expected a ResizeObserver for the FlowChat scroller');
+      const spacer = container.querySelector<HTMLElement>('.message-list-tail-spacer')!;
+      const spacerBeforeMinimize = spacer.style.height;
+
+      mocks.handleViewportResize.mockClear();
+      mocks.scheduleFollowToLatest.mockClear();
+      mocks.setVisibleTurnInfo.mockClear();
+      animationFrames.clear();
+
+      layout.clientWidth = 390;
+      layout.clientHeight = 0;
+      act(() => observer.notify());
+
+      expect(mocks.handleViewportResize).not.toHaveBeenCalled();
+      expect(mocks.scheduleFollowToLatest).not.toHaveBeenCalled();
+      expect(mocks.setVisibleTurnInfo).not.toHaveBeenCalled();
+      expect(spacer.style.height).toBe(spacerBeforeMinimize);
+      expect(animationFrames.size).toBe(0);
+
+      act(() => scroller.dispatchEvent(new Event('scroll')));
+      expect(mocks.handleFollowScroll).not.toHaveBeenCalled();
+
+      layout.clientWidth = 1000;
+      layout.clientHeight = 700;
+      act(() => observer.notify());
+
+      // The first positive rectangle is still part of host recovery. Treating
+      // it as a normal resize replays zero-height scroll events as a tail
+      // follow or measurement correction before the old reading position can
+      // be restored.
+      expect(mocks.handleViewportResize).not.toHaveBeenCalled();
+      expect(mocks.scheduleFollowToLatest).not.toHaveBeenCalled();
+
+      const [resume] = [...animationFrames.values()];
+      expect(resume).toBeDefined();
+      if (!resume) throw new Error('Expected a deferred viewport recovery frame');
+      act(() => resume(16));
+
+      expect(mocks.handleViewportResize).not.toHaveBeenCalled();
+      expect(mocks.scheduleFollowToLatest).toHaveBeenCalledTimes(1);
+    } finally {
+      restoreLayout();
     }
   });
 

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
@@ -31,6 +31,7 @@ const mocks = vi.hoisted(() => ({
   isFollowingOutput: false,
   followsNow: false,
   scheduleFollowToLatest: vi.fn(),
+  revealNewTurnTail: null as null | ((turnId: string) => boolean),
   /**
    * The register the list built, reached through the hook it hands it to.
    *
@@ -172,8 +173,10 @@ vi.mock('../../store/chatInputStateStore', () => ({
 vi.mock('./useFlowChatFollowOutput', () => ({
   useFlowChatFollowOutput: (options: {
     viewportOwner: { claim: (owner: string) => boolean };
+    revealNewTurnTail: (turnId: string) => boolean;
   }) => {
     mocks.viewportOwner = options.viewportOwner;
+    mocks.revealNewTurnTail = options.revealNewTurnTail;
     return {
       isFollowingOutput: mocks.isFollowingOutput,
       enterFollowOutput: mocks.enterFollowOutput,
@@ -315,6 +318,7 @@ describe('VirtualMessageList natural scroll contract', () => {
     mocks.handleUserScrollIntent.mockReset();
     mocks.handleFollowScroll.mockReset();
     mocks.scheduleFollowToLatest.mockReset();
+    mocks.revealNewTurnTail = null;
     mocks.viewportOwner = null;
     mocks.setVisibleTurnInfo.mockReset();
     mocks.renderItemMetadata = true;
@@ -342,7 +346,7 @@ describe('VirtualMessageList natural scroll contract', () => {
     expect(footer?.style.minHeight).toBe('168px');
   });
 
-  it('reserves a tail spacer sized from the viewport and nothing else', () => {
+  it('reserves a tail spacer from the viewport and input-stack inset', () => {
     // The session opens on the end of *real content*, which is above this
     // reservation. Nothing aligns to the last item any more: the end of the
     // scroll range is reserved blank, and opening there is opening on nothing.
@@ -379,6 +383,25 @@ describe('VirtualMessageList natural scroll contract', () => {
       } else {
         delete (HTMLElement.prototype as unknown as Record<string, unknown>).clientWidth;
       }
+    }
+  });
+
+  it('reveals a rendered new Turn at the physical bottom through the viewport register', () => {
+    const restoreLayout = fakeLayout({
+      clientHeight: 600,
+      scrollHeight: 1400,
+      turnTopFromScrollerTop: 500,
+    });
+    try {
+      act(() => root.render(<VirtualMessageList />));
+      const scroller = container.querySelector<HTMLElement>('[data-flowchat-scroller]')!;
+      scroller.scrollTop = 100;
+
+      expect(mocks.revealNewTurnTail?.('turn-2')).toBe(true);
+      expect(scroller.scrollTop).toBe(800);
+      expect(mocks.scrollToOffset).not.toHaveBeenCalled();
+    } finally {
+      restoreLayout();
     }
   });
 
@@ -708,7 +731,10 @@ describe('VirtualMessageList natural scroll contract', () => {
        * where the reserved blank begins — which, since
        * paging happens only while scrolling up, it then does every time.
        */
-      const contentEndPx = 1000 - tailSpacerPxForViewport(600, BOTTOM_INSET) - 600;
+       const contentEndPx = Math.min(
+         100,
+         1000 - tailSpacerPxForViewport(600, BOTTOM_INSET) - 600,
+       );
       withGrowingRange({ scrollHeightPx: 900, growthPx: 100, scrollTopPx: 0 }, scroller => {
         prependOlderTurns(3);
         expect(scroller.scrollTop).toBe(contentEndPx);

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
@@ -79,6 +79,7 @@ import {
 } from './virtualMessageListLayout';
 import { resolveVisibleFlowChatTurnIds } from './flowChatVisibleTurns';
 import type { FlowChatViewportSnapshot } from './flowChatViewportSnapshot';
+import { getVirtualItemStableKey } from './virtualItemIdentity';
 import { warnHistoryPagingRefusedWithPendingTurns } from '../../services/historySessionDiagnostics';
 import {
   VIEWPORT_PLACEMENT_SETTLE_MS,
@@ -194,6 +195,7 @@ export interface VirtualMessageListProps {
   onRequestJumpToLatest?: () => void;
   onUserScrollIntent?: () => void;
   onViewportSnapshot?: (snapshot: FlowChatViewportSnapshot) => void;
+  onViewportRestoreSettled?: (sessionId: string) => void;
   initialViewportSnapshot?: FlowChatViewportSnapshot | null;
 }
 
@@ -306,23 +308,6 @@ function normalizeBoundaryResult(
   return result;
 }
 
-function getVirtualItemStableKey(item: VirtualItem): string {
-  switch (item.type) {
-    case 'user-message':
-    case 'user-steering-message':
-      return `${item.type}:${item.turnId}:${item.data.id}`;
-    case 'model-round':
-      return `${item.type}:${item.turnId}:${item.data.id}`;
-    case 'explore-group':
-      return `${item.type}:${item.turnId}:${item.data.groupId}`;
-    case 'turn-completion-notice':
-      return `${item.type}:${item.turnId}:${item.data.reasonCode}`;
-    case 'turn-failure-notice':
-    case 'image-analyzing':
-      return `${item.type}:${item.turnId}`;
-  }
-}
-
 /**
  * Whether a pointer press landed on the scroller's scrollbar rather than on the
  * transcript.
@@ -358,6 +343,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
   onRequestJumpToLatest,
   onUserScrollIntent,
   onViewportSnapshot,
+  onViewportRestoreSettled,
   initialViewportSnapshot = null,
 }, ref) => {
   const { t } = useTranslation('flow-chat');
@@ -433,6 +419,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
   /** A pointer is held on the scrollbar, so the scrolling it causes is intent. */
   const isScrollbarPressRef = useRef(false);
   const viewportSnapshotFrameRef = useRef<number | null>(null);
+  const lastSnapshotRestoreErrorPxRef = useRef(Number.POSITIVE_INFINITY);
   const onViewportSnapshotRef = useRef(onViewportSnapshot);
   onViewportSnapshotRef.current = onViewportSnapshot;
   const [isAtBottom, setIsAtBottom] = useState(true);
@@ -1029,19 +1016,16 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
         element,
         turnId: element.dataset.turnId ?? null,
         itemType: element.dataset.itemType ?? null,
+        itemKey: element.dataset.virtualItemKey ?? null,
         top: rect.top,
         bottom: rect.bottom,
       };
     });
-    const visibleTurnIds = resolveVisibleFlowChatTurnIds(
-      entries,
-      scrollerRect.top,
-      scrollerRect.bottom,
-    );
-    const anchorTurnId = visibleTurnIds[0] ?? null;
-    const anchorElement = anchorTurnId
-      ? entries.find(entry => entry.turnId === anchorTurnId)?.element
-      : undefined;
+    const anchorEntry = entries.find(entry => (
+      entry.bottom > scrollerRect.top && entry.top < scrollerRect.bottom
+    ));
+    const anchorTurnId = anchorEntry?.turnId ?? null;
+    const anchorElement = anchorEntry?.element;
     const anchorRect = anchorElement?.getBoundingClientRect();
 
     return {
@@ -1049,6 +1033,8 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       presentationMode,
       viewportMode,
       historyWindow,
+      anchorItemKey: anchorEntry?.itemKey ?? null,
+      anchorItemType: anchorEntry?.itemType ?? null,
       anchorTurnId,
       anchorOffsetPx: anchorRect
         ? roundViewportPx(anchorRect.top - scrollerRect.top)
@@ -1065,8 +1051,23 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     if (!scroller || snapshot.anchorTurnId === null || snapshot.anchorOffsetPx === null) {
       return false;
     }
-    const anchor = findRenderedTurnAnchorElement(scroller, snapshot.anchorTurnId);
+    const exactAnchor = snapshot.anchorItemKey
+      ? Array.from(
+        scroller.querySelectorAll<HTMLElement>('.virtual-item-wrapper[data-virtual-item-key]'),
+      ).find(element => element.dataset.virtualItemKey === snapshot.anchorItemKey) ?? null
+      : null;
+    const exactAnchorIndex = snapshot.anchorItemKey
+      ? virtualItems.findIndex(item => getVirtualItemStableKey(item) === snapshot.anchorItemKey)
+      : -1;
+    const mustMaterializeExactAnchor = snapshot.anchorItemKey !== null
+      && snapshot.anchorItemKey !== undefined
+      && exactAnchorIndex >= 0
+      && exactAnchor === null;
+    const anchor = mustMaterializeExactAnchor
+      ? null
+      : exactAnchor ?? findRenderedTurnAnchorElement(scroller, snapshot.anchorTurnId);
     if (!anchor) {
+      lastSnapshotRestoreErrorPxRef.current = Number.POSITIVE_INFINITY;
       const materializeByPx = snapshot.scrollTopPx - scroller.scrollTop;
       if (Math.abs(materializeByPx) > 0.5 && viewportOwner.shift(materializeByPx)) {
         traceViewport({
@@ -1074,6 +1075,8 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
           message: 'FlowChat used the saved offset to materialize the semantic session anchor',
           data: () => ({
             sessionId: snapshot.sessionId,
+            anchorItemKey: snapshot.anchorItemKey,
+            anchorItemType: snapshot.anchorItemType,
             anchorTurnId: snapshot.anchorTurnId,
             approximateScrollTopPx: snapshot.scrollTopPx,
             shiftedPx: roundViewportPx(materializeByPx),
@@ -1084,6 +1087,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     }
     const currentOffsetPx = anchor.getBoundingClientRect().top - scroller.getBoundingClientRect().top;
     const correctionPx = currentOffsetPx - snapshot.anchorOffsetPx;
+    lastSnapshotRestoreErrorPxRef.current = Math.abs(correctionPx);
     if (Math.abs(correctionPx) > 0.5) {
       if (!viewportOwner.shift(correctionPx)) return false;
     }
@@ -1096,6 +1100,9 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       message: 'FlowChat restored a session anchor from its semantic snapshot',
       data: () => ({
         sessionId: snapshot.sessionId,
+        anchorItemKey: snapshot.anchorItemKey,
+        anchorItemType: snapshot.anchorItemType,
+        resolvedBy: exactAnchor ? 'virtual-item' : 'turn-fallback',
         anchorTurnId: snapshot.anchorTurnId,
         expectedOffsetPx: snapshot.anchorOffsetPx,
         currentOffsetPx: roundViewportPx(currentOffsetPx),
@@ -1103,7 +1110,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       }),
     });
     return true;
-  }, [activeSessionId, viewportAnchor, viewportOwner]);
+  }, [activeSessionId, viewportAnchor, viewportOwner, virtualItems]);
 
   const publishViewportSnapshot = useCallback(() => {
     const snapshot = captureViewportSnapshot();
@@ -1190,12 +1197,32 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     let cancelled = false;
     let frameId: number | null = null;
     let attempts = 0;
+    let quietFrames = 0;
     const restore = () => {
       if (cancelled) return;
       attempts += 1;
       if (restoreViewportSnapshot(initialViewportSnapshot)) {
-        setIsOpenViewportSettled(true);
-        return;
+        quietFrames = lastSnapshotRestoreErrorPxRef.current <= 0.5
+          ? quietFrames + 1
+          : 0;
+        if (quietFrames >= 2) {
+          traceViewport({
+            location: 'viewport.sessionSnapshotSettled',
+            message: 'FlowChat session snapshot remained stable across painted frames',
+            data: () => ({
+              sessionId: initialViewportSnapshot.sessionId,
+              anchorItemKey: initialViewportSnapshot.anchorItemKey,
+              anchorItemType: initialViewportSnapshot.anchorItemType,
+              anchorTurnId: initialViewportSnapshot.anchorTurnId,
+              attempts,
+              quietFrames,
+              finalErrorPx: roundViewportPx(lastSnapshotRestoreErrorPxRef.current),
+            }),
+          });
+          onViewportRestoreSettled?.(initialViewportSnapshot.sessionId);
+          setIsOpenViewportSettled(true);
+          return;
+        }
       }
       if (attempts < 12) {
         frameId = requestAnimationFrame(restore);
@@ -1206,11 +1233,14 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
         message: 'FlowChat could not materialize the saved session anchor',
         data: () => ({
           sessionId: initialViewportSnapshot.sessionId,
+          anchorItemKey: initialViewportSnapshot.anchorItemKey,
+          anchorItemType: initialViewportSnapshot.anchorItemType,
           anchorTurnId: initialViewportSnapshot.anchorTurnId,
           attempts,
           itemCount: virtualItems.length,
         }),
       });
+      onViewportRestoreSettled?.(initialViewportSnapshot.sessionId);
       setIsOpenViewportSettled(true);
     };
     restore();
@@ -1221,6 +1251,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
   }, [
     initialViewportSnapshot,
     isOpenViewportSettled,
+    onViewportRestoreSettled,
     restoreViewportSnapshot,
     shouldRestoreInitialSnapshot,
     virtualItems.length,

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
@@ -78,6 +78,7 @@ import {
   type VirtualItemHeightEstimateContext,
 } from './virtualMessageListLayout';
 import { resolveVisibleFlowChatTurnIds } from './flowChatVisibleTurns';
+import type { FlowChatViewportSnapshot } from './flowChatViewportSnapshot';
 import { warnHistoryPagingRefusedWithPendingTurns } from '../../services/historySessionDiagnostics';
 import {
   VIEWPORT_PLACEMENT_SETTLE_MS,
@@ -174,6 +175,8 @@ export interface VirtualMessageListRef {
    * `false` means it is not rendered yet, so the caller should ask again.
    */
   focusFlowItem: (flowItemId: string) => boolean;
+  captureViewportSnapshot: () => FlowChatViewportSnapshot | null;
+  restoreViewportSnapshot: (snapshot: FlowChatViewportSnapshot) => boolean;
 }
 
 export interface VirtualMessageListProps {
@@ -190,6 +193,8 @@ export interface VirtualMessageListProps {
   ) => HistoryWindowBoundaryIntentResponse | Promise<HistoryWindowBoundaryIntentResponse>;
   onRequestJumpToLatest?: () => void;
   onUserScrollIntent?: () => void;
+  onViewportSnapshot?: (snapshot: FlowChatViewportSnapshot) => void;
+  initialViewportSnapshot?: FlowChatViewportSnapshot | null;
 }
 
 type PreparedTurnNavigation = {
@@ -352,6 +357,8 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
   onHistoryWindowBoundaryIntent,
   onRequestJumpToLatest,
   onUserScrollIntent,
+  onViewportSnapshot,
+  initialViewportSnapshot = null,
 }, ref) => {
   const { t } = useTranslation('flow-chat');
   /**
@@ -425,8 +432,18 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
   const isAtTailRef = useRef(true);
   /** A pointer is held on the scrollbar, so the scrolling it causes is intent. */
   const isScrollbarPressRef = useRef(false);
+  const viewportSnapshotFrameRef = useRef<number | null>(null);
+  const onViewportSnapshotRef = useRef(onViewportSnapshot);
+  onViewportSnapshotRef.current = onViewportSnapshot;
   const [isAtBottom, setIsAtBottom] = useState(true);
   const [isOpenViewportSettled, setIsOpenViewportSettled] = useState(false);
+  const shouldRestoreInitialSnapshot = Boolean(
+    initialViewportSnapshot
+    && initialViewportSnapshot.sessionId === activeSessionId
+    && !initialViewportSnapshot.isAtTail
+    && initialViewportSnapshot.anchorTurnId !== null
+    && initialViewportSnapshot.anchorOffsetPx !== null
+  );
   const preparedTurnNavigationRef = useRef<PreparedTurnNavigation | null>(null);
   const boundaryRequestRef = useRef<Record<SessionHistoryWindowDirection, Promise<void> | null>>({
     before: null,
@@ -658,6 +675,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     virtualItemCount: virtualItems.length,
     isStreaming: isStreamingOutput,
     isViewportActive,
+    startAtTailOnMount: presentationMode !== 'history-window' && !shouldRestoreInitialSnapshot,
     isViewportSuspended: () => isViewportSuspendedRef.current,
     scrollerRef: scrollerElementRef,
     getTailSpacerPx,
@@ -667,38 +685,6 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     viewportOwner,
     viewportId,
   });
-
-  /*
-   * The transcript's own lifetime, which every viewport line above is relative
-   * to. A remount resets the scroller to offset 0, empties the measurement
-   * cache and re-arms the opening reveal — so a placement that looks like it
-   * was undone is often a placement made to a scroller that no longer exists.
-   */
-  useEffect(() => {
-    traceViewport({
-      location: 'virtualMessageList.mounted',
-      message: 'a transcript was mounted',
-      data: () => ({
-        viewportId,
-        sessionId: activeSessionIdRef.current,
-        itemCount: itemCountRef.current,
-        isViewportActive: isViewportActiveRef.current,
-      }),
-    });
-    return () => {
-      traceViewport({
-        location: 'virtualMessageList.unmounted',
-        message: 'a transcript was unmounted',
-        data: () => ({
-          viewportId,
-          sessionId: activeSessionIdRef.current,
-          itemCount: itemCountRef.current,
-          scrollTopPx: roundViewportPx(scrollerElementRef.current?.scrollTop ?? 0),
-        }),
-      });
-    };
-  }, [viewportId]);
-
 
   /**
    * The anchor stands down for anyone aiming at a target of their own — and for
@@ -1025,12 +1011,220 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     });
   }, [updateVisibleTurnInfoFromViewport]);
 
+  const captureViewportSnapshot = useCallback((): FlowChatViewportSnapshot | null => {
+    const scroller = scrollerElementRef.current;
+    if (!scroller || !activeSessionId || !isUsableFlowChatViewportRect({
+      width: scroller.clientWidth,
+      height: scroller.clientHeight,
+    })) {
+      return null;
+    }
+
+    const scrollerRect = scroller.getBoundingClientRect();
+    const entries = Array.from(
+      scroller.querySelectorAll<HTMLElement>('.virtual-item-wrapper[data-turn-id]'),
+    ).map(element => {
+      const rect = element.getBoundingClientRect();
+      return {
+        element,
+        turnId: element.dataset.turnId ?? null,
+        itemType: element.dataset.itemType ?? null,
+        top: rect.top,
+        bottom: rect.bottom,
+      };
+    });
+    const visibleTurnIds = resolveVisibleFlowChatTurnIds(
+      entries,
+      scrollerRect.top,
+      scrollerRect.bottom,
+    );
+    const anchorTurnId = visibleTurnIds[0] ?? null;
+    const anchorElement = anchorTurnId
+      ? entries.find(entry => entry.turnId === anchorTurnId)?.element
+      : undefined;
+    const anchorRect = anchorElement?.getBoundingClientRect();
+
+    return {
+      sessionId: activeSessionId,
+      presentationMode,
+      viewportMode,
+      historyWindow,
+      anchorTurnId,
+      anchorOffsetPx: anchorRect
+        ? roundViewportPx(anchorRect.top - scrollerRect.top)
+        : null,
+      scrollTopPx: roundViewportPx(scroller.scrollTop),
+      isAtTail: isAtTailRef.current,
+      capturedAtMs: Math.round(performance.now()),
+    };
+  }, [activeSessionId, historyWindow, presentationMode, viewportMode]);
+
+  const restoreViewportSnapshot = useCallback((snapshot: FlowChatViewportSnapshot): boolean => {
+    if (snapshot.sessionId !== activeSessionId) return false;
+    const scroller = scrollerElementRef.current;
+    if (!scroller || snapshot.anchorTurnId === null || snapshot.anchorOffsetPx === null) {
+      return false;
+    }
+    const anchor = findRenderedTurnAnchorElement(scroller, snapshot.anchorTurnId);
+    if (!anchor) {
+      const materializeByPx = snapshot.scrollTopPx - scroller.scrollTop;
+      if (Math.abs(materializeByPx) > 0.5 && viewportOwner.shift(materializeByPx)) {
+        traceViewport({
+          location: 'viewport.sessionSnapshotMaterializing',
+          message: 'FlowChat used the saved offset to materialize the semantic session anchor',
+          data: () => ({
+            sessionId: snapshot.sessionId,
+            anchorTurnId: snapshot.anchorTurnId,
+            approximateScrollTopPx: snapshot.scrollTopPx,
+            shiftedPx: roundViewportPx(materializeByPx),
+          }),
+        });
+      }
+      return false;
+    }
+    const currentOffsetPx = anchor.getBoundingClientRect().top - scroller.getBoundingClientRect().top;
+    const correctionPx = currentOffsetPx - snapshot.anchorOffsetPx;
+    if (Math.abs(correctionPx) > 0.5) {
+      if (!viewportOwner.shift(correctionPx)) return false;
+    }
+    // Seed the ordinary settle loop from the restored relationship so later
+    // virtual-item measurements keep the same Turn at the same viewport offset.
+    viewportAnchor.captureAnchor();
+    viewportAnchor.openSettleWindow();
+    traceViewport({
+      location: 'viewport.sessionSnapshotRestored',
+      message: 'FlowChat restored a session anchor from its semantic snapshot',
+      data: () => ({
+        sessionId: snapshot.sessionId,
+        anchorTurnId: snapshot.anchorTurnId,
+        expectedOffsetPx: snapshot.anchorOffsetPx,
+        currentOffsetPx: roundViewportPx(currentOffsetPx),
+        correctionPx: roundViewportPx(correctionPx),
+      }),
+    });
+    return true;
+  }, [activeSessionId, viewportAnchor, viewportOwner]);
+
+  const publishViewportSnapshot = useCallback(() => {
+    const snapshot = captureViewportSnapshot();
+    if (snapshot) onViewportSnapshotRef.current?.(snapshot);
+  }, [captureViewportSnapshot]);
+
+  const scheduleViewportSnapshot = useCallback(() => {
+    if (viewportSnapshotFrameRef.current !== null) return;
+    viewportSnapshotFrameRef.current = requestAnimationFrame(() => {
+      viewportSnapshotFrameRef.current = null;
+      publishViewportSnapshot();
+    });
+  }, [publishViewportSnapshot]);
+
   useEffect(() => () => {
     if (visibleTurnUpdateFrameRef.current !== null) {
       cancelAnimationFrame(visibleTurnUpdateFrameRef.current);
       visibleTurnUpdateFrameRef.current = null;
     }
+    if (viewportSnapshotFrameRef.current !== null) {
+      cancelAnimationFrame(viewportSnapshotFrameRef.current);
+      viewportSnapshotFrameRef.current = null;
+    }
   }, []);
+
+  useLayoutEffect(() => {
+    scheduleViewportSnapshot();
+  }, [historyWindow, presentationMode, scheduleViewportSnapshot, virtualItems, viewportMode]);
+
+  useLayoutEffect(() => {
+    traceViewport({
+      location: isViewportActive ? 'viewport.sceneActivated' : 'viewport.sceneDeactivated',
+      message: isViewportActive
+        ? 'FlowChat viewport became active'
+        : 'FlowChat viewport became inactive but remained mounted',
+      data: () => ({
+        viewportId,
+        sessionId: activeSessionIdRef.current,
+        isViewportActive,
+        snapshot: captureViewportSnapshot(),
+      }),
+    });
+    if (!isViewportActive) publishViewportSnapshot();
+    else scheduleViewportSnapshot();
+  }, [captureViewportSnapshot, isViewportActive, publishViewportSnapshot, scheduleViewportSnapshot, viewportId]);
+
+  /*
+   * The transcript's own lifetime, which every viewport line above is relative
+   * to. A remount resets the scroller to offset 0, empties the measurement
+   * cache and re-arms the opening reveal — so a placement that looks like it
+   * was undone is often a placement made to a scroller that no longer exists.
+   * The layout cleanup captures while the outgoing scroller still has geometry.
+   */
+  useLayoutEffect(() => {
+    traceViewport({
+      location: 'virtualMessageList.mounted',
+      message: 'a transcript was mounted',
+      data: () => ({
+        viewportId,
+        sessionId: activeSessionIdRef.current,
+        itemCount: itemCountRef.current,
+        isViewportActive: isViewportActiveRef.current,
+      }),
+    });
+    return () => {
+      publishViewportSnapshot();
+      traceViewport({
+        location: 'virtualMessageList.unmounted',
+        message: 'a transcript was unmounted',
+        data: () => ({
+          viewportId,
+          sessionId: activeSessionIdRef.current,
+          itemCount: itemCountRef.current,
+          scrollTopPx: roundViewportPx(scrollerElementRef.current?.scrollTop ?? 0),
+        }),
+      });
+    };
+  }, [publishViewportSnapshot, viewportId]);
+
+  useLayoutEffect(() => {
+    if (!shouldRestoreInitialSnapshot || !initialViewportSnapshot || isOpenViewportSettled) {
+      return;
+    }
+    let cancelled = false;
+    let frameId: number | null = null;
+    let attempts = 0;
+    const restore = () => {
+      if (cancelled) return;
+      attempts += 1;
+      if (restoreViewportSnapshot(initialViewportSnapshot)) {
+        setIsOpenViewportSettled(true);
+        return;
+      }
+      if (attempts < 12) {
+        frameId = requestAnimationFrame(restore);
+        return;
+      }
+      traceViewport({
+        location: 'viewport.sessionSnapshotRestoreAbandoned',
+        message: 'FlowChat could not materialize the saved session anchor',
+        data: () => ({
+          sessionId: initialViewportSnapshot.sessionId,
+          anchorTurnId: initialViewportSnapshot.anchorTurnId,
+          attempts,
+          itemCount: virtualItems.length,
+        }),
+      });
+      setIsOpenViewportSettled(true);
+    };
+    restore();
+    return () => {
+      cancelled = true;
+      if (frameId !== null) cancelAnimationFrame(frameId);
+    };
+  }, [
+    initialViewportSnapshot,
+    isOpenViewportSettled,
+    restoreViewportSnapshot,
+    shouldRestoreInitialSnapshot,
+    virtualItems.length,
+  ]);
 
   /*
    * Opening reveal.
@@ -1043,7 +1237,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
    * out and measurable, just not painted — until it stops moving.
    */
   useLayoutEffect(() => {
-    if (!scrollerElement || isOpenViewportSettled) return;
+    if (!scrollerElement || isOpenViewportSettled || shouldRestoreInitialSnapshot) return;
 
     let frame = 0;
     let quietFrames = 0;
@@ -1115,6 +1309,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     isOpenViewportSettled,
     readContentEndScrollTop,
     scrollerElement,
+    shouldRestoreInitialSnapshot,
     viewportId,
     virtualItems.length,
   ]);
@@ -1219,10 +1414,12 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
 
     scheduleFollowToLatest();
     scheduleVisibleTurnInfoUpdate();
+    scheduleViewportSnapshot();
     updateIsAtBottom();
   }, [
     isFollowingOutputNow,
     scheduleFollowToLatest,
+    scheduleViewportSnapshot,
     scheduleVisibleTurnInfoUpdate,
     updateIsAtBottom,
     viewportAnchor,
@@ -1276,6 +1473,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
        */
       viewportAnchor.captureAnchorForScroll();
       scheduleVisibleTurnInfoUpdate();
+      publishViewportSnapshot();
       /*
        * Paging is a question about where the reader is, so a scroll is its
        * primary input. Through a ref: this listener must not be torn down and
@@ -1322,6 +1520,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
   }, [
     handleScroll,
     notifyUserScrollIntent,
+    publishViewportSnapshot,
     scheduleVisibleTurnInfoUpdate,
     scrollerElement,
     updateIsAtBottom,
@@ -1442,6 +1641,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
 
       scheduleFollowToLatest();
       scheduleVisibleTurnInfoUpdate();
+      scheduleViewportSnapshot();
       updateIsAtBottom();
     });
     /*
@@ -1460,6 +1660,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     handleViewportResize,
     resumeSuspendedViewport,
     scheduleFollowToLatest,
+    scheduleViewportSnapshot,
     scheduleVisibleTurnInfoUpdate,
     scrollerElement,
     updateIsAtBottom,
@@ -2151,7 +2352,10 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     navigateToTurnWithStatus,
     prepareTurnNavigation,
     focusFlowItem,
+    captureViewportSnapshot,
+    restoreViewportSnapshot,
   }), [
+    captureViewportSnapshot,
     clearSearchMatch,
     focusFlowItem,
     isTurnRenderedInViewport,
@@ -2165,6 +2369,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     scrollToSearchMatch,
     scrollToTurn,
     scrollToTurnEnd,
+    restoreViewportSnapshot,
   ]);
 
   const visibleTurnInfo = useModernFlowChatStore(state => state.visibleTurnInfo);

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
@@ -606,19 +606,26 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     scrollToContentEndThroughVirtualizer(behavior === 'smooth' ? 'smooth' : 'auto');
   }, [readContentEndScrollTop, scrollToContentEndThroughVirtualizer, viewportOwner]);
 
-  const scrollTurnToTop = useCallback((turnId: string) => {
+  const revealNewTurnTail = useCallback((turnId: string) => {
     const targetIndex = virtualItems.findIndex(item => (
       item.turnId === turnId && item.type === 'user-message'
     ));
     if (targetIndex < 0) return false;
-    // Follow-output's answer to a new Turn, not a navigation: it is the same
-    // continuous writer, and a pin it cannot hold is not a pin.
-    virtualizer.scrollItemIntoView(targetIndex, { align: 'start', owner: 'follow-output' });
-    return true;
-  }, [virtualItems, virtualizer]);
+    const scroller = scrollerElementRef.current;
+    if (!scroller) return false;
 
-  // Must agree with `scrollTurnToTop` down to the pixel: this is the offset the
-  // follow loop re-asserts every frame, so a disagreement is a fight.
+    // This placement is intentionally one-shot. Streaming growth then consumes
+    // the resident blank without a re-aim moving historical content upward.
+    virtualizer.measureRenderedItems();
+    return viewportOwner.write({
+      topPx: Math.max(0, scroller.scrollHeight - scroller.clientHeight),
+      behavior: 'auto',
+      owner: 'follow-output',
+    });
+  }, [viewportOwner, virtualItems, virtualizer]);
+
+  // Turn navigation still needs the rendered top offset independently of the
+  // new-Turn reveal, which targets the physical bottom only once.
   const resolveTurnTopScrollTop = useCallback((turnId: string) => {
     const scroller = scrollerElementRef.current;
     const element = getRenderedUserMessageElement(turnId);
@@ -655,8 +662,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     scrollerRef: scrollerElementRef,
     getTailSpacerPx,
     scrollToContentEnd,
-    scrollTurnToTop,
-    resolveTurnTopScrollTop,
+    revealNewTurnTail,
     isOpeningViewport,
     viewportOwner,
     viewportId,

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
@@ -56,7 +56,10 @@ import {
   tailSpacerPxForViewport,
   turnTopAlignmentEntersReservedBlank,
 } from './flowChatTailFollow';
-import { useFlowChatVirtualizer } from './useFlowChatVirtualizer';
+import {
+  isUsableFlowChatViewportRect,
+  useFlowChatVirtualizer,
+} from './useFlowChatVirtualizer';
 import { useFlowChatViewportOwner } from './useFlowChatViewportOwner';
 import {
   ONE_SHOT_NAVIGATION_HOLD_MS,
@@ -411,7 +414,11 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
   const [viewportHeightPx, setViewportHeightPx] = useState(0);
   const [viewportWidthPx, setViewportWidthPx] = useState(0);
   /** Last scroller box the resize observer saw, to tell it apart from a content change. */
-  const observedViewportBoxRef = useRef({ width: 0, height: 0 });
+  const observedViewportBoxRef = useRef<{ width: number; height: number } | null>(null);
+  /** Native minimization withdraws the scroller without unmounting the session. */
+  const isViewportSuspendedRef = useRef(false);
+  const suspendedViewportScrollTopRef = useRef<number | null>(null);
+  const viewportResumeFrameRef = useRef<number | null>(null);
   /** Remaining resize callbacks over which to keep a resting viewport at the end. */
   const tailRealignCallbacksRef = useRef(0);
   /** Synchronous mirror of `isAtBottom`, read by a resize for the pre-resize answer. */
@@ -495,6 +502,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
         .map(([groupId, expanded]) => `${groupId}:${expanded ? 1 : 0}`)
         .join(','),
     ].join('|'),
+    isViewportSuspended: () => isViewportSuspendedRef.current,
     scrollPaddingStartPx: FLOWCHAT_TURN_TOP_GAP_PX,
     writeViewport: viewportOwner.write,
     shiftViewport: viewportOwner.shift,
@@ -643,6 +651,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     virtualItemCount: virtualItems.length,
     isStreaming: isStreamingOutput,
     isViewportActive,
+    isViewportSuspended: () => isViewportSuspendedRef.current,
     scrollerRef: scrollerElementRef,
     getTailSpacerPx,
     scrollToContentEnd,
@@ -701,7 +710,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
    * follow-output — see `flowChatViewportOwnership.ts`.
    */
   const isViewportOwnedElsewhere = useCallback(() => (
-    !viewportOwner.canShift() || isOpeningViewport()
+    isViewportSuspendedRef.current || !viewportOwner.canShift() || isOpeningViewport()
   ), [isOpeningViewport, viewportOwner]);
 
   const shiftAnchorCorrection = useCallback((byPx: number) => {
@@ -755,6 +764,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     if (!scroller) return;
     const previousScrollHeightPx = previousScrollHeightRef.current;
     previousScrollHeightRef.current = scroller.scrollHeight;
+    if (isViewportSuspendedRef.current) return;
     if (previousFirstKey === null || previousFirstKey === nextFirstKey) return;
     // Absent means the head was trimmed rather than extended, and there is no
     // prepended height to account for.
@@ -1154,6 +1164,72 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     updateIsAtBottom();
   }, [isFollowingOutput, updateIsAtBottom]);
 
+  const resumeSuspendedViewport = useCallback(() => {
+    viewportResumeFrameRef.current = null;
+    if (!isViewportSuspendedRef.current) return;
+
+    isViewportSuspendedRef.current = false;
+    const suspendedScrollTopPx = suspendedViewportScrollTopRef.current;
+    suspendedViewportScrollTopRef.current = null;
+    const scrollTopBeforeRecoveryPx = scrollerElementRef.current?.scrollTop ?? null;
+    const wasFollowingOutput = isFollowingOutputNow();
+    let restoredAnchor = false;
+    let restoredScrollTopFallback = false;
+
+    if (!wasFollowingOutput) {
+      restoredAnchor = viewportAnchor.restoreAnchorAfterViewportResume();
+      if (!restoredAnchor && suspendedScrollTopPx !== null) {
+        viewportOwner.write({
+          owner: 'layout-correction',
+          topPx: suspendedScrollTopPx,
+        });
+        restoredScrollTopFallback = true;
+      }
+      viewportAnchor.openSettleWindow();
+    }
+
+    traceViewport({
+      location: 'viewport.hostResumeRecovered',
+      message: 'native host viewport recovery completed',
+      data: () => {
+        const scroller = scrollerElementRef.current;
+        return {
+          wasFollowingOutput,
+          restoredAnchor,
+          restoredScrollTopFallback,
+          suspendedScrollTopPx: suspendedScrollTopPx === null
+            ? null
+            : roundViewportPx(suspendedScrollTopPx),
+          scrollTopBeforeRecoveryPx: scrollTopBeforeRecoveryPx === null
+            ? null
+            : roundViewportPx(scrollTopBeforeRecoveryPx),
+          scrollTopAfterRecoveryPx: scroller ? roundViewportPx(scroller.scrollTop) : null,
+          viewportBox: scroller
+            ? { width: scroller.clientWidth, height: scroller.clientHeight }
+            : null,
+        };
+      },
+    });
+
+    scheduleFollowToLatest();
+    scheduleVisibleTurnInfoUpdate();
+    updateIsAtBottom();
+  }, [
+    isFollowingOutputNow,
+    scheduleFollowToLatest,
+    scheduleVisibleTurnInfoUpdate,
+    updateIsAtBottom,
+    viewportAnchor,
+    viewportOwner,
+  ]);
+
+  useEffect(() => () => {
+    if (viewportResumeFrameRef.current !== null) {
+      cancelAnimationFrame(viewportResumeFrameRef.current);
+      viewportResumeFrameRef.current = null;
+    }
+  }, []);
+
   /*
    * A rollback removed Turns from the session, so the transcript ends somewhere
    * it did not a moment ago — and the Turn follow-output was pinning may be one
@@ -1176,6 +1252,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
   useEffect(() => {
     if (!scrollerElement) return;
     const handleNativeScroll = () => {
+      if (isViewportSuspendedRef.current) return;
       /*
        * A scroll under a scrollbar press is the one case where a plain scroll
        * event does carry intent — the press is what qualifies it. Left
@@ -1243,6 +1320,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     scrollerElement,
     updateIsAtBottom,
     viewportAnchor,
+    viewportOwner,
   ]);
 
   useEffect(() => {
@@ -1253,6 +1331,64 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
         height: scrollerElement.clientHeight,
       };
       /*
+       * A minimized WebView2 window reports a zero-height scroller while the
+       * document remains visible. That is suspension, not a layout request:
+       * accepting it would collapse the tail spacer, empty the virtual window,
+       * clear the visible Turn and run a full-height scroll correction. Keep
+       * every downstream owner on the last usable box until layout returns.
+       */
+      if (!isUsableFlowChatViewportRect(nextViewportBox)) {
+        if (!isViewportSuspendedRef.current) {
+          isViewportSuspendedRef.current = true;
+          suspendedViewportScrollTopRef.current = scrollerElement.scrollTop;
+          tailRealignCallbacksRef.current = 0;
+          traceViewport({
+            location: 'viewport.hostSuspended',
+            message: 'native host withdrew the viewport from layout',
+            data: () => ({
+              receivedViewportBox: nextViewportBox,
+              lastUsableViewportBox: observedViewportBoxRef.current,
+              scrollTopPx: roundViewportPx(scrollerElement.scrollTop),
+              scrollHeightPx: roundViewportPx(scrollerElement.scrollHeight),
+              renderedRowCount: scrollerElement.querySelectorAll('[data-virtual-index]').length,
+              tailSpacerPx: roundViewportPx(tailSpacerPxRef.current),
+              isAtTail: isAtTailRef.current,
+              viewportOwner: viewportOwner.currentOwner(),
+            }),
+          });
+        }
+        if (viewportResumeFrameRef.current !== null) {
+          cancelAnimationFrame(viewportResumeFrameRef.current);
+          viewportResumeFrameRef.current = null;
+        }
+        return;
+      }
+      const isResumingSuspendedViewport = isViewportSuspendedRef.current;
+      if (isResumingSuspendedViewport) {
+        traceViewport({
+          location: 'viewport.hostResumeDetected',
+          message: 'native host returned viewport geometry',
+          data: () => ({
+            recoveredViewportBox: nextViewportBox,
+            lastUsableViewportBox: observedViewportBoxRef.current,
+            suspendedScrollTopPx: suspendedViewportScrollTopRef.current === null
+              ? null
+              : roundViewportPx(suspendedViewportScrollTopRef.current),
+            scrollTopPx: roundViewportPx(scrollerElement.scrollTop),
+            scrollHeightPx: roundViewportPx(scrollerElement.scrollHeight),
+            renderedRowCount: scrollerElement.querySelectorAll('[data-virtual-index]').length,
+            tailSpacerPx: roundViewportPx(tailSpacerPxRef.current),
+          }),
+        });
+        observedViewportBoxRef.current = nextViewportBox;
+        setViewportHeightPx(nextViewportBox.height);
+        setViewportWidthPx(nextViewportBox.width);
+        if (viewportResumeFrameRef.current === null) {
+          viewportResumeFrameRef.current = requestAnimationFrame(resumeSuspendedViewport);
+        }
+        return;
+      }
+      /*
        * This observer watches the content too. Content growth moves the follow
        * target away from a resting viewport and can never strand it, so only a
        * change to the scroller's own box opens the re-alignment window — a
@@ -1260,10 +1396,12 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
        * end directly, and both keep settling for a few callbacks afterwards.
        */
       const previousViewportBox = observedViewportBoxRef.current;
-      const viewportBoxChanged = nextViewportBox.width !== previousViewportBox.width
-        || nextViewportBox.height !== previousViewportBox.height;
+      const viewportBoxChanged = previousViewportBox !== null && (
+        nextViewportBox.width !== previousViewportBox.width
+        || nextViewportBox.height !== previousViewportBox.height
+      );
+      observedViewportBoxRef.current = nextViewportBox;
       if (viewportBoxChanged) {
-        observedViewportBoxRef.current = nextViewportBox;
         tailRealignCallbacksRef.current = TAIL_REALIGN_RESIZE_CALLBACKS;
       }
       setViewportHeightPx(nextViewportBox.height);
@@ -1314,11 +1452,13 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     return () => observer.disconnect();
   }, [
     handleViewportResize,
+    resumeSuspendedViewport,
     scheduleFollowToLatest,
     scheduleVisibleTurnInfoUpdate,
     scrollerElement,
     updateIsAtBottom,
     viewportAnchor,
+    viewportOwner,
   ]);
 
   /**
@@ -1965,12 +2105,16 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       if (!scroller.hasAttribute('tabindex')) {
         scroller.tabIndex = -1;
       }
-      setViewportHeightPx(scroller.clientHeight);
-      // Seed the box so the observer's first callback is not read as a resize.
-      observedViewportBoxRef.current = {
+      const initialViewportBox = {
         width: scroller.clientWidth,
         height: scroller.clientHeight,
       };
+      if (isUsableFlowChatViewportRect(initialViewportBox)) {
+        setViewportHeightPx(initialViewportBox.height);
+        setViewportWidthPx(initialViewportBox.width);
+        // Seed the box so the observer's first callback is not read as a resize.
+        observedViewportBoxRef.current = initialViewportBox;
+      }
     }
   }, []);
 

--- a/src/web-ui/src/flow_chat/components/modern/flowChatTailFollow.test.ts
+++ b/src/web-ui/src/flow_chat/components/modern/flowChatTailFollow.test.ts
@@ -5,7 +5,6 @@ import {
   FLOWCHAT_AT_CONTENT_END_THRESHOLD_PX,
   isTailBlankMeasurable,
   isViewportAtTail,
-  memorylessFollowState,
   nextTailFollowState,
   resolveAnimatedJumpBehavior,
   resolveTailDepartureCrossing,
@@ -19,35 +18,22 @@ import {
 const VIEWPORT = 800;
 const BOTTOM_INSET = 168;
 const SPACER = tailSpacerPxForViewport(VIEWPORT, BOTTOM_INSET);
-const MAX_GAP = tailHoldMaxGapPx(VIEWPORT);
+const MAX_GAP = tailHoldMaxGapPx(VIEWPORT, SPACER);
 const THRESHOLD = FLOWCHAT_AT_CONTENT_END_THRESHOLD_PX;
 
 function holding(target: number): TailFollowState {
-  return { mode: 'hold-tail', target };
-}
-
-function pinning(target: number): TailFollowState {
-  return { mode: 'pin-turn-top', target };
+  return { target };
 }
 
 describe('tailSpacerPxForViewport', () => {
-  it('reserves exactly enough to put a bare new Turn on the top edge', () => {
-    // Worst case for the pin: the user message is the newest item and nothing
-    // has answered it, so the message, the input inset and the spacer are all
-    // that lie below its top. One viewport of them is what the pin needs.
+  it('caps the footer and spacer at three quarters of the viewport', () => {
     const spacer = tailSpacerPxForViewport(VIEWPORT, BOTTOM_INSET);
-    const smallestUserMessagePx = VIEWPORT - BOTTOM_INSET - spacer;
-    expect(smallestUserMessagePx).toBeGreaterThan(0);
-    expect(smallestUserMessagePx).toBeLessThan(64);
+    expect(BOTTOM_INSET + spacer).toBe(Math.round(VIEWPORT * 0.75));
+    expect(VIEWPORT - BOTTOM_INSET - spacer).toBe(200);
   });
 
-  it('never reserves less than the gap the hold rule may be holding', () => {
-    // A composer expanded most of the way up the viewport leaves the pin almost
-    // nothing to reserve, but `hold-tail` still parks up to `tailHoldMaxGapPx`
-    // past the content end — and an offset the browser clamps is an offset the
-    // hold rule does not get to hold.
-    expect(tailSpacerPxForViewport(VIEWPORT, VIEWPORT - 80))
-      .toBe(tailHoldMaxGapPx(VIEWPORT));
+  it('lets an expanded footer consume the reservation without making spacer negative', () => {
+    expect(tailSpacerPxForViewport(VIEWPORT, VIEWPORT - 80)).toBe(0);
   });
 
   it('stays well under a full viewport, so the scroll range does not end in blank', () => {
@@ -56,6 +42,11 @@ describe('tailSpacerPxForViewport', () => {
 
   it('reserves nothing before the scroller has been measured', () => {
     expect(tailSpacerPxForViewport(0, BOTTOM_INSET)).toBe(0);
+  });
+
+  it('never lets the hold gap exceed the physical spacer', () => {
+    expect(tailHoldMaxGapPx(VIEWPORT, 120)).toBe(120);
+    expect(tailHoldMaxGapPx(VIEWPORT, SPACER)).toBe(SPACER);
   });
 });
 
@@ -115,10 +106,9 @@ describe('nextTailFollowState hold-tail', () => {
   it('follows content growth', () => {
     const next = nextTailFollowState(holding(4000), {
       desiredScrollTop: 4200,
-      pinScrollTop: null,
       maxGapPx: MAX_GAP,
     });
-    expect(next).toEqual({ mode: 'hold-tail', target: 4200 });
+    expect(next).toEqual({ target: 4200 });
   });
 
   it('holds its offset when a collapse fits the tolerated gap', () => {
@@ -126,7 +116,6 @@ describe('nextTailFollowState hold-tail', () => {
     // viewport must not move or earlier content would visually drop by 300px.
     const next = nextTailFollowState(holding(4000), {
       desiredScrollTop: 3700,
-      pinScrollTop: null,
       maxGapPx: MAX_GAP,
     });
     expect(next.target).toBe(4000);
@@ -135,7 +124,6 @@ describe('nextTailFollowState hold-tail', () => {
   it('gives ground only past the tolerated gap, and only by the excess', () => {
     const next = nextTailFollowState(holding(4000), {
       desiredScrollTop: 1000,
-      pinScrollTop: null,
       maxGapPx: MAX_GAP,
     });
     expect(next.target).toBe(1000 + MAX_GAP);
@@ -144,109 +132,9 @@ describe('nextTailFollowState hold-tail', () => {
   it('never drops below the content-end target', () => {
     const next = nextTailFollowState(holding(100), {
       desiredScrollTop: 900,
-      pinScrollTop: null,
       maxGapPx: MAX_GAP,
     });
     expect(next.target).toBe(900);
-  });
-});
-
-describe('nextTailFollowState pin-turn-top', () => {
-  it('holds a new Turn at the viewport top while its answer is short', () => {
-    const next = nextTailFollowState(pinning(0), {
-      desiredScrollTop: 4300,
-      pinScrollTop: 5000,
-      maxGapPx: MAX_GAP,
-    });
-    expect(next).toEqual({ mode: 'pin-turn-top', target: 5000 });
-  });
-
-  it('ignores the gap tolerance while pinned', () => {
-    // The blank below a freshly submitted Turn is the point of the mode.
-    const next = nextTailFollowState(pinning(5000), {
-      desiredScrollTop: 4300,
-      pinScrollTop: 5000,
-      maxGapPx: 10,
-    });
-    expect(next.target).toBe(5000);
-  });
-
-  it('stays put while a collapse shrinks content under the pin', () => {
-    const first = nextTailFollowState(pinning(0), {
-      desiredScrollTop: 4400,
-      pinScrollTop: 5000,
-      maxGapPx: MAX_GAP,
-    });
-    const afterCollapse = nextTailFollowState(first, {
-      desiredScrollTop: 4100,
-      pinScrollTop: 5000,
-      maxGapPx: MAX_GAP,
-    });
-    expect(afterCollapse.target).toBe(5000);
-  });
-
-  it('hands off to hold-tail once the answer overflows the viewport', () => {
-    const next = nextTailFollowState(pinning(5000), {
-      desiredScrollTop: 5000,
-      pinScrollTop: 5000,
-      maxGapPx: MAX_GAP,
-    });
-    expect(next).toEqual({ mode: 'hold-tail', target: 5000 });
-  });
-
-  it('does not regress after handing off', () => {
-    const handoff = nextTailFollowState(pinning(5000), {
-      desiredScrollTop: 5200,
-      pinScrollTop: 5000,
-      maxGapPx: MAX_GAP,
-    });
-    expect(handoff.mode).toBe('hold-tail');
-    const afterCollapse = nextTailFollowState(handoff, {
-      desiredScrollTop: 5000,
-      pinScrollTop: 5000,
-      maxGapPx: MAX_GAP,
-    });
-    expect(afterCollapse.target).toBe(5200);
-  });
-
-  it('falls back to the tail target until the Turn can be measured', () => {
-    const next = nextTailFollowState(pinning(0), {
-      desiredScrollTop: 4300,
-      pinScrollTop: null,
-      maxGapPx: MAX_GAP,
-    });
-    expect(next).toEqual({ mode: 'pin-turn-top', target: 4300 });
-  });
-});
-
-describe('memorylessFollowState', () => {
-  it('drops a held collapse gap the user has already scrolled away from', () => {
-    // The hold rule's refusal to move backwards protects a viewport it has been
-    // holding continuously. After a takeover there is nothing left to protect,
-    // and reinstating the old offset would land on a position nobody chose.
-    expect(memorylessFollowState('hold-tail', {
-      desiredScrollTop: 3700,
-      pinScrollTop: null,
-      maxGapPx: MAX_GAP,
-    }).target).toBe(3700);
-  });
-
-  it('still prefers a pinned Turn over the content end', () => {
-    expect(memorylessFollowState('pin-turn-top', {
-      desiredScrollTop: 4300,
-      pinScrollTop: 5000,
-      maxGapPx: MAX_GAP,
-    })).toEqual({ mode: 'pin-turn-top', target: 5000 });
-  });
-
-  it('reports the crossover so a suspended pin can be retired', () => {
-    // No frame loop runs while the user owns the viewport, so this is the only
-    // place a pin whose answer outgrew the viewport can be noticed.
-    expect(memorylessFollowState('pin-turn-top', {
-      desiredScrollTop: 5200,
-      pinScrollTop: 5000,
-      maxGapPx: MAX_GAP,
-    })).toEqual({ mode: 'hold-tail', target: 5200 });
   });
 });
 
@@ -262,7 +150,7 @@ describe('isViewportAtTail', () => {
     })).toBe(true);
   });
 
-  it('counts a pinned Turn, which is at the tail by its own rule', () => {
+  it('counts a reveal position owned by follow-output', () => {
     expect(isViewportAtTail({
       scrollTop: 5000,
       contentEndScrollTop: contentEnd,
@@ -303,9 +191,7 @@ describe('resolveAnimatedJumpBehavior', () => {
     })).toBe('smooth');
   });
 
-  it('animates a pinned Turn coming back into place, which is under a screen', () => {
-    // The `pin-turn-top` branch of a jump to latest, where the newest Turn's
-    // answer is shorter than the viewport by construction.
+  it('animates a nearby follow target coming back into place', () => {
     expect(resolveAnimatedJumpBehavior({
       fromPx: 12_000,
       targetPx: 12_180,
@@ -356,8 +242,7 @@ describe('resolveAnimatedJumpBehavior', () => {
   });
 
   it('judges the distance travelled, whichever way it goes', () => {
-    // A jump to latest normally scrolls down, but `pin-turn-top` can aim above
-    // the viewport when a restored tail presentation arrives under a pin.
+    // A follow target can be above the viewport. Distance is absolute either way.
     expect(resolveAnimatedJumpBehavior({
       fromPx: 9000,
       targetPx: 9000 - budget - 1,

--- a/src/web-ui/src/flow_chat/components/modern/flowChatTailFollow.ts
+++ b/src/web-ui/src/flow_chat/components/modern/flowChatTailFollow.ts
@@ -15,6 +15,9 @@
 /** Blank tail tolerated below the live output, as a share of the viewport. */
 export const FLOWCHAT_TAIL_HOLD_GAP_RATIO = 0.6;
 
+/** Maximum combined height of the input footer and resident tail spacer. */
+export const FLOWCHAT_TAIL_RESERVATION_RATIO = 0.75;
+
 /**
  * Distance from an owned offset still treated as being on it.
  *
@@ -25,10 +28,7 @@ export const FLOWCHAT_TAIL_HOLD_GAP_RATIO = 0.6;
  */
 export const FLOWCHAT_AT_CONTENT_END_THRESHOLD_PX = 50;
 
-export type TailFollowMode = 'pin-turn-top' | 'hold-tail';
-
 export interface TailFollowState {
-  mode: TailFollowMode;
   /** Scroll offset the viewport currently owns. */
   target: number;
 }
@@ -42,8 +42,6 @@ export interface TailFollowGeometry {
 export interface TailFollowInput {
   /** Offset placing the end of real content at the viewport bottom. */
   desiredScrollTop: number;
-  /** Offset placing the pinned Turn's user message at the viewport top. */
-  pinScrollTop: number | null;
   /** Largest blank tail the hold rule accepts before it gives ground. */
   maxGapPx: number;
 }
@@ -62,45 +60,22 @@ export interface TailFollowInput {
 export const FLOWCHAT_TURN_TOP_GAP_PX = 8;
 
 /**
- * Lower bound on the rendered height of a user-message item.
- *
- * This sizes the pin reserve below, so it must be an *under*estimate. Too low
- * only leaves the pin a few spare pixels; too high makes the pinned offset
- * exceed the scroll range, and the browser clamps the Turn back down from the
- * viewport top with the follow loop rewriting the clamped offset every frame.
- * A single line with no timestamp row is comfortably above this at any
- * supported font size, and the item is free to be taller.
- */
-const PINNED_TURN_MIN_ITEM_HEIGHT_PX = 40;
-
-/**
  * Height of the resident tail spacer.
  *
- * The spacer exists to keep two offsets inside the scroll range, and it is
- * sized to the larger of what they need — one viewport was simply the cheapest
- * bound that covered both, and it costs a full screen of blank at the end of
- * the scroll range.
- *
- * - **A pinned Turn.** Worst case its user message is the newest item and
- *   nothing has answered it yet, so everything below the message top is the
- *   message, the input-stack inset, and this spacer. Reserving
- *   `clientHeight - bottomInsetPx - PINNED_TURN_MIN_ITEM_HEIGHT_PX` is exactly
- *   enough to put that message on the top edge.
- * - **A held collapse gap.** `hold-tail` keeps an offset up to
- *   `tailHoldMaxGapPx` past the content end, and an offset the browser clamps
- *   is an offset the hold rule does not actually get to hold.
- *
- * `bottomInsetPx` is the input-stack footer, which grows as the composer does.
- * That is a layout input, not a content measurement — and while the pin reserve
- * is the binding bound the two sum to a constant, so growing the composer moves
- * the content end without moving the end of the scroll range.
+ * A new Turn is revealed by scrolling to the physical bottom once, then
+ * allowing streamed output to consume this blank without further writes. The
+ * footer and spacer together are capped at three quarters of the viewport, so
+ * the reveal always leaves at least one quarter of the transcript visible.
+ * `bottomInsetPx` is layout input only; no content measurement feeds this size.
  */
 export function tailSpacerPxForViewport(
   clientHeight: number,
   bottomInsetPx: number,
 ): number {
-  const pinnedTurnReservePx = clientHeight - bottomInsetPx - PINNED_TURN_MIN_ITEM_HEIGHT_PX;
-  return Math.max(0, Math.round(Math.max(pinnedTurnReservePx, tailHoldMaxGapPx(clientHeight))));
+  return Math.max(
+    0,
+    Math.round(clientHeight * FLOWCHAT_TAIL_RESERVATION_RATIO - bottomInsetPx),
+  );
 }
 
 /**
@@ -114,8 +89,11 @@ export function contentEndScrollTop(geometry: TailFollowGeometry): number {
   );
 }
 
-export function tailHoldMaxGapPx(clientHeight: number): number {
-  return Math.max(0, Math.round(clientHeight * FLOWCHAT_TAIL_HOLD_GAP_RATIO));
+export function tailHoldMaxGapPx(clientHeight: number, tailSpacerPx: number): number {
+  return Math.max(
+    0,
+    Math.min(Math.round(clientHeight * FLOWCHAT_TAIL_HOLD_GAP_RATIO), tailSpacerPx),
+  );
 }
 
 export interface TurnTopAlignmentInput {
@@ -127,8 +105,8 @@ export interface TurnTopAlignmentInput {
 /**
  * Whether top-aligning a Turn would park the viewport in the reserved blank.
  *
- * The blank belongs to follow-output. `pin-turn-top` holds it for output that
- * is on its way, and nothing is on its way under a Turn the user navigated to
+ * The blank belongs to follow-output's new-Turn reveal, and nothing is on its
+ * way under a Turn the user navigated to
  * — so a navigation that lands there shows a screen of nothing, and the snap
  * back then reclaims it as a second, visible movement.
  *
@@ -148,11 +126,6 @@ export function turnTopAlignmentEntersReservedBlank(
 /**
  * Resolve the next follow target.
  *
- * `pin-turn-top` holds a freshly submitted Turn at the viewport top while its
- * answer is still shorter than one viewport, then hands off to `hold-tail` at
- * the crossover. The pinned phase ignores `maxGapPx`: the blank below a new
- * Turn is the point of the mode, not a failure of it.
- *
  * `hold-tail` never moves backwards for free. It keeps its previous offset when
  * content shrinks, which is what leaves earlier content visually still, and
  * only gives ground once the blank below the live output exceeds `maxGapPx`.
@@ -161,47 +134,12 @@ export function nextTailFollowState(
   previous: TailFollowState,
   input: TailFollowInput,
 ): TailFollowState {
-  if (previous.mode === 'pin-turn-top') {
-    if (input.pinScrollTop === null) {
-      // The Turn is not measurable yet; behave like a plain tail follow so the
-      // viewport is never stranded, and pin once the element resolves.
-      return { mode: 'pin-turn-top', target: input.desiredScrollTop };
-    }
-    if (input.desiredScrollTop < input.pinScrollTop) {
-      return { mode: 'pin-turn-top', target: input.pinScrollTop };
-    }
-    return { mode: 'hold-tail', target: input.desiredScrollTop };
-  }
-
   return {
-    mode: 'hold-tail',
     target: Math.max(
       input.desiredScrollTop,
       Math.min(previous.target, input.desiredScrollTop + input.maxGapPx),
     ),
   };
-}
-
-/**
- * The state the follow rule would hold right now, judged from live geometry
- * alone.
- *
- * `hold-tail` normally refuses to move backwards, and that refusal is what
- * keeps a collapse from dragging earlier content down. The memory it refuses
- * with belongs to a viewport the follow rule has been holding continuously;
- * once the user has taken over and come to rest somewhere else there is nothing
- * left to preserve, and carrying the stale offset forward would land them on a
- * position neither side chose.
- *
- * The returned mode still matters: a pinned Turn whose answer has outgrown the
- * viewport reports `hold-tail`, which is how a caller learns the pin has
- * crossed over even though no follow loop was running to notice.
- */
-export function memorylessFollowState(
-  mode: TailFollowMode,
-  input: TailFollowInput,
-): TailFollowState {
-  return nextTailFollowState({ mode, target: input.desiredScrollTop }, input);
 }
 
 export type TailDepartureCrossing =
@@ -218,12 +156,12 @@ export type TailDepartureCrossing =
  *
  * Losing the follow permanently is right only for a reader who left the live
  * region, and `scrollTop > contentEnd` says they have not. The reserved blank
- * is up to `tailHoldMaxGapPx` under `hold-tail` and the whole gap under a
- * pinned Turn, so a small scroll up can leave the reader looking at empty space
- * below the newest output — nothing hidden from them yet — until output grows
- * past the bottom edge and they silently stop seeing it.
+ * is up to `tailHoldMaxGapPx` under `hold-tail`, while a new-Turn reveal starts
+ * at the physical bottom. A small scroll up can therefore leave the reader
+ * looking at empty space below the newest output — nothing hidden from them yet
+ * — until output grows past the bottom edge and they silently stop seeing it.
  *
- * The follow target may sit inside the blank while a new Turn is pinned, but
+ * The reveal position sits inside the blank after a new Turn arrives, but
  * this watch deliberately uses the real content end: it only observes output
  * catching up with a reader, never a user's resting position.
  *
@@ -328,7 +266,7 @@ export interface ViewportAtTailInput {
  * Whether the viewport counts as being at the end of the transcript.
  *
  * The band runs from the content end down to whatever the follow rule owns, so
- * a pinned Turn and a held collapse gap both sit inside it — neither is a
+ * a new-Turn reveal and a held collapse gap both sit inside it — neither is a
  * reason to offer a jump to the latest output. Past the lower bound is reserved
  * blank, which is.
  */

--- a/src/web-ui/src/flow_chat/components/modern/flowChatViewportSnapshot.ts
+++ b/src/web-ui/src/flow_chat/components/modern/flowChatViewportSnapshot.ts
@@ -1,0 +1,13 @@
+import type { ActiveTurnRenderRange } from '../../types/flow-chat';
+
+export interface FlowChatViewportSnapshot {
+  sessionId: string;
+  presentationMode: 'tail' | 'history-window';
+  viewportMode: 'live-tail' | 'history-reading';
+  historyWindow: ActiveTurnRenderRange | null;
+  anchorTurnId: string | null;
+  anchorOffsetPx: number | null;
+  scrollTopPx: number;
+  isAtTail: boolean;
+  capturedAtMs: number;
+}

--- a/src/web-ui/src/flow_chat/components/modern/flowChatViewportSnapshot.ts
+++ b/src/web-ui/src/flow_chat/components/modern/flowChatViewportSnapshot.ts
@@ -5,6 +5,9 @@ export interface FlowChatViewportSnapshot {
   presentationMode: 'tail' | 'history-window';
   viewportMode: 'live-tail' | 'history-reading';
   historyWindow: ActiveTurnRenderRange | null;
+  /** Optional for snapshots produced before exact row identity was added. */
+  anchorItemKey?: string | null;
+  anchorItemType?: string | null;
   anchorTurnId: string | null;
   anchorOffsetPx: number | null;
   scrollTopPx: number;

--- a/src/web-ui/src/flow_chat/components/modern/useFlowChatFollowOutput.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/useFlowChatFollowOutput.test.tsx
@@ -27,8 +27,8 @@ const BOTTOM_INSET = 100;
 /** The spacer the component would render for a given viewport. */
 const spacerFor = (clientHeight: number) => tailSpacerPxForViewport(clientHeight, BOTTOM_INSET);
 const TAIL_SPACER = spacerFor(VIEWPORT);
-/** Matches `tailHoldMaxGapPx(VIEWPORT)`. */
-const MAX_GAP = 300;
+/** The 60% hold gap is capped by the smaller physical spacer. */
+const MAX_GAP = TAIL_SPACER;
 
 function setScrollerMetrics(
   scroller: HTMLElement,
@@ -57,8 +57,7 @@ interface HarnessProps {
   isStreaming?: boolean;
   scroller: HTMLElement;
   scrollToContentEnd?: (behavior: ScrollBehavior) => void;
-  scrollTurnToTop?: (turnId: string) => boolean;
-  resolveTurnTopScrollTop?: (turnId: string) => number | null;
+  revealNewTurnTail?: (turnId: string) => boolean;
   isOpeningViewport?: boolean;
   onController: (controller: Controller) => void;
   /** The register the hook writes through, for a test that has to hold it. */
@@ -71,8 +70,7 @@ function Harness({
   isStreaming = true,
   scroller,
   scrollToContentEnd = () => {},
-  scrollTurnToTop = () => false,
-  resolveTurnTopScrollTop = () => null,
+  revealNewTurnTail = () => false,
   isOpeningViewport = false,
   onController,
   onViewportOwner,
@@ -93,8 +91,7 @@ function Harness({
     // Sized from live layout, exactly as the component's state does.
     getTailSpacerPx: () => tailSpacerPxForViewport(scroller.clientHeight, BOTTOM_INSET),
     scrollToContentEnd,
-    scrollTurnToTop,
-    resolveTurnTopScrollTop,
+    revealNewTurnTail,
     isOpeningViewport: () => isOpeningViewport,
     viewportOwner,
   });
@@ -141,13 +138,16 @@ describe('useFlowChatFollowOutput', () => {
     vi.unstubAllGlobals();
   });
 
-  it('opens a newly submitted Turn at the viewport top instead of the tail', () => {
-    const scrollTurnToTop = vi.fn(() => true);
+  it('reveals a newly submitted Turn at the physical bottom once', () => {
+    const revealNewTurnTail = vi.fn(() => {
+      scroller.scrollTop = 100;
+      return true;
+    });
     const scrollToContentEnd = vi.fn();
     const props = {
       scroller,
       scrollToContentEnd,
-      scrollTurnToTop,
+      revealNewTurnTail,
       onController: (next: Controller) => { controller = next; },
     };
 
@@ -162,7 +162,7 @@ describe('useFlowChatFollowOutput', () => {
       root.render(<Harness {...props} latestTurnId="turn-2" isStreaming={false} />);
     });
 
-    expect(scrollTurnToTop).toHaveBeenCalledWith('turn-2');
+    expect(revealNewTurnTail).toHaveBeenCalledWith('turn-2');
     expect(scrollToContentEnd).not.toHaveBeenCalled();
     expect(controller?.isFollowingOutput).toBe(true);
   });
@@ -174,17 +174,20 @@ describe('useFlowChatFollowOutput', () => {
      * the ledger's last Turn — but the detector asked whether the identity had
      * changed, and a truncation changes it without anything having arrived.
      */
-    const scrollTurnToTop = vi.fn(() => true);
+    const revealNewTurnTail = vi.fn(() => {
+      scroller.scrollTop = 100;
+      return true;
+    });
     const props = {
       scroller,
-      scrollTurnToTop,
+      revealNewTurnTail,
       onController: (next: Controller) => { controller = next; },
     };
 
     act(() => {
       root.render(<Harness {...props} latestTurnId="turn-2" isStreaming={false} />);
     });
-    scrollTurnToTop.mockClear();
+    revealNewTurnTail.mockClear();
 
     // The rollback removes turn-2, so the ledger's last Turn is turn-1 again.
     act(() => {
@@ -193,7 +196,7 @@ describe('useFlowChatFollowOutput', () => {
       );
     });
 
-    expect(scrollTurnToTop).not.toHaveBeenCalled();
+    expect(revealNewTurnTail).not.toHaveBeenCalled();
   });
 
   it('returns to the end of the transcript when a rollback takes the Turn it was following', () => {
@@ -201,7 +204,7 @@ describe('useFlowChatFollowOutput', () => {
     const props = {
       scroller,
       scrollToContentEnd,
-      scrollTurnToTop: () => true,
+      revealNewTurnTail: () => true,
       onController: (next: Controller) => { controller = next; },
     };
 
@@ -331,12 +334,42 @@ describe('useFlowChatFollowOutput', () => {
     expect(1000).toBeLessThan(1000 + MAX_GAP);
   });
 
-  it('falls back to the content end when the new Turn cannot be targeted', () => {
+  it('defers the reveal when the new Turn is not in the live-tail projection yet', () => {
     const scrollToContentEnd = vi.fn();
+    const revealNewTurnTail = vi.fn(() => false);
     const props = {
       scroller,
       scrollToContentEnd,
-      scrollTurnToTop: () => false,
+      revealNewTurnTail,
+      onController: (next: Controller) => { controller = next; },
+    };
+
+    act(() => {
+      root.render(<Harness {...props} latestTurnId="turn-1" isStreaming={false} />);
+    });
+    scrollToContentEnd.mockClear();
+    act(() => {
+      root.render(<Harness {...props} latestTurnId="turn-2" isStreaming={false} />);
+    });
+
+    expect(revealNewTurnTail).toHaveBeenCalledWith('turn-2');
+    expect(scrollToContentEnd).not.toHaveBeenCalled();
+    expect(controller?.isFollowingOutput).toBe(true);
+  });
+
+  it('reveals a new Turn at physical bottom once and lets growth consume the blank', () => {
+    setScrollerMetrics(scroller, {
+      scrollHeight: 1200 + TAIL_SPACER,
+      clientHeight: VIEWPORT,
+      scrollTop: 700,
+    });
+    const revealNewTurnTail = vi.fn(() => {
+      scroller.scrollTop = scroller.scrollHeight - scroller.clientHeight;
+      return true;
+    });
+    const props = {
+      scroller,
+      revealNewTurnTail,
       onController: (next: Controller) => { controller = next; },
     };
 
@@ -344,63 +377,58 @@ describe('useFlowChatFollowOutput', () => {
       root.render(<Harness {...props} latestTurnId="turn-1" isStreaming={false} />);
     });
     act(() => {
-      root.render(<Harness {...props} latestTurnId="turn-2" isStreaming={false} />);
+      root.render(<Harness {...props} latestTurnId="turn-2" />);
     });
 
-    expect(scrollToContentEnd).toHaveBeenCalledWith('auto');
-    expect(controller?.isFollowingOutput).toBe(true);
+    expect(revealNewTurnTail).toHaveBeenCalledTimes(1);
+    expect(scroller.scrollTop).toBe(700 + TAIL_SPACER);
+
+    setScrollerMetrics(scroller, {
+      scrollHeight: 1300 + TAIL_SPACER,
+      clientHeight: VIEWPORT,
+      scrollTop: 700 + TAIL_SPACER,
+    });
+    act(() => controller?.scheduleFollowToLatest());
+    expect(scroller.scrollTop).toBe(700 + TAIL_SPACER);
   });
 
-  it('holds the pinned Turn at the top while its answer is shorter than the viewport', () => {
-    // Real content ends at 1200, so the tail target is 700 — well above the
-    // pinned Turn at 900. The pin must win until the answer overflows.
+  it('starts following without a snap when streamed output consumes the reveal blank', () => {
     setScrollerMetrics(scroller, {
       scrollHeight: 1200 + TAIL_SPACER,
       clientHeight: VIEWPORT,
-      scrollTop: 900,
+      scrollTop: 700,
     });
+    const revealNewTurnTail = () => {
+      scroller.scrollTop = scroller.scrollHeight - scroller.clientHeight;
+      return true;
+    };
     const props = {
       scroller,
-      scrollTurnToTop: () => true,
-      resolveTurnTopScrollTop: () => 900,
+      revealNewTurnTail,
       onController: (next: Controller) => { controller = next; },
     };
 
     act(() => {
-      root.render(<Harness {...props} latestTurnId="turn-1" />);
+      root.render(<Harness {...props} latestTurnId="turn-1" isStreaming={false} />);
     });
     act(() => {
       root.render(<Harness {...props} latestTurnId="turn-2" />);
     });
 
-    scroller.scrollTop = 0;
-    runNextFrame();
-    expect(scroller.scrollTop).toBe(900);
-  });
-
-  it('hands the pinned Turn off to tail follow once the answer overflows', () => {
+    const revealPosition = 700 + TAIL_SPACER;
     setScrollerMetrics(scroller, {
-      scrollHeight: 2000 + TAIL_SPACER,
+      scrollHeight: 1200 + TAIL_SPACER + TAIL_SPACER + 10,
       clientHeight: VIEWPORT,
-      scrollTop: 900,
+      scrollTop: revealPosition,
     });
-    const props = {
-      scroller,
-      scrollTurnToTop: () => true,
-      resolveTurnTopScrollTop: () => 900,
-      onController: (next: Controller) => { controller = next; },
-    };
+    act(() => controller?.scheduleFollowToLatest());
+    expect(scroller.scrollTop).toBe(revealPosition);
 
-    act(() => {
-      root.render(<Harness {...props} latestTurnId="turn-1" />);
-    });
-    act(() => {
-      root.render(<Harness {...props} latestTurnId="turn-2" />);
-    });
-
+    // The first queued frame may be the cancelled opening settle. The next one
+    // is ordinary following and advances from the unchanged reveal position.
     runNextFrame();
-    // Content end (2000 - 500) has overtaken the pin, so the tail owns it.
-    expect(scroller.scrollTop).toBe(1500);
+    runNextFrame();
+    expect(scroller.scrollTop).toBeGreaterThan(revealPosition);
   });
 
   it('follows content growth against the content end, not the tail spacer', () => {
@@ -458,7 +486,7 @@ describe('useFlowChatFollowOutput', () => {
     });
     runNextFrame();
 
-    expect(scroller.scrollTop).toBe(1000);
+    expect(scroller.scrollTop).toBe(1000 - (300 - MAX_GAP));
   });
 
   it('gives ground only past the tolerated gap after a very large collapse', () => {
@@ -516,7 +544,7 @@ describe('useFlowChatFollowOutput', () => {
     act(() => controller?.scheduleFollowToLatest());
 
     expect(scrollToContentEnd).not.toHaveBeenCalled();
-    expect(scroller.scrollTop).toBe(1000);
+    expect(scroller.scrollTop).toBe(1000 - (300 - MAX_GAP));
   });
 
   it('settles the held blank once streaming stops', () => {
@@ -887,44 +915,21 @@ describe('useFlowChatFollowOutput', () => {
     });
   });
 
-  describe('jumping to latest while the newest Turn is pinned', () => {
-    /** Pins `turn-2` at 900 with real content ending at 1200 (tail target 700). */
-    function pinLatestTurn(overrides?: { resolveTurnTopScrollTop?: () => number | null }) {
-      setScrollerMetrics(scroller, {
-        scrollHeight: 1200 + TAIL_SPACER,
-        clientHeight: VIEWPORT,
-        scrollTop: 900,
-      });
-      const props = {
-        scroller,
-        scrollTurnToTop: () => true,
-        resolveTurnTopScrollTop: overrides?.resolveTurnTopScrollTop ?? (() => 900),
-        onController: (next: Controller) => { controller = next; },
-      };
-      act(() => {
-        root.render(<Harness {...props} latestTurnId="turn-1" isStreaming={false} />);
-      });
-      act(() => {
-        root.render(<Harness {...props} latestTurnId="turn-2" isStreaming={false} />);
-      });
-    }
-
-    it('returns to the pin rather than the end of content', () => {
-      // Restoring the tail presentation asks for a jump to latest one frame
-      // after the Turn that caused it got pinned, which used to overwrite the
-      // pin. Aiming at the content end here also scrolls *up*, shoving the
-      // message the user just sent into the middle of the viewport.
+  describe('new Turn reveal ownership', () => {
+    function revealLatestTurn() {
       const scrollToContentEnd = vi.fn();
       setScrollerMetrics(scroller, {
         scrollHeight: 1200 + TAIL_SPACER,
         clientHeight: VIEWPORT,
-        scrollTop: 900,
+        scrollTop: 700,
       });
       const props = {
         scroller,
         scrollToContentEnd,
-        scrollTurnToTop: () => true,
-        resolveTurnTopScrollTop: () => 900,
+        revealNewTurnTail: () => {
+          scroller.scrollTop = scroller.scrollHeight - scroller.clientHeight;
+          return true;
+        },
         onController: (next: Controller) => { controller = next; },
       };
       act(() => {
@@ -934,60 +939,25 @@ describe('useFlowChatFollowOutput', () => {
       act(() => {
         root.render(<Harness {...props} latestTurnId="turn-2" isStreaming={false} />);
       });
+      return scrollToContentEnd;
+    }
+
+    it('ignores a delayed jump-to-latest while the one-shot reveal is active', () => {
+      const scrollToContentEnd = revealLatestTurn();
+      const revealPosition = scroller.scrollTop;
 
       act(() => controller?.enterFollowOutput('jump-to-latest'));
 
       expect(scrollToContentEnd).not.toHaveBeenCalled();
-      scroller.scrollTop = 0;
-      runNextFrame();
-      expect(scroller.scrollTop).toBe(900);
+      expect(scroller.scrollTop).toBe(revealPosition);
     });
 
-    it('animates back to the pin instead of jumping', () => {
-      // The frame loop assigns scrollTop outright, so without the yield budget
-      // this branch was an instant move where every other jump to latest is
-      // animated.
-      pinLatestTurn();
-      scroller.scrollTop = 0;
-      scrollTo.mockClear();
+    it('releases reveal ownership on user intent', () => {
+      revealLatestTurn();
 
-      act(() => controller?.enterFollowOutput('jump-to-latest'));
+      act(() => controller?.handleUserScrollIntent());
 
-      expect(scrollTo).toHaveBeenCalledWith({ top: 900, behavior: 'smooth' });
-      runNextFrame();
-      // jsdom does not animate, so the loop must have left the viewport alone.
-      expect(scroller.scrollTop).toBe(0);
-    });
-
-    it('resumes at the content end once the pin has been retired', () => {
-      // The exemption is only for a Turn whose answer still fits one viewport.
-      // Past the crossover the pin is gone and the ordinary rule applies.
-      const scrollToContentEnd = vi.fn();
-      setScrollerMetrics(scroller, {
-        scrollHeight: 2000 + TAIL_SPACER,
-        clientHeight: VIEWPORT,
-        scrollTop: 900,
-      });
-      const props = {
-        scroller,
-        scrollToContentEnd,
-        scrollTurnToTop: () => true,
-        resolveTurnTopScrollTop: () => 900,
-        onController: (next: Controller) => { controller = next; },
-      };
-      act(() => {
-        root.render(<Harness {...props} latestTurnId="turn-1" isStreaming={false} />);
-      });
-      act(() => {
-        root.render(<Harness {...props} latestTurnId="turn-2" isStreaming={false} />);
-      });
-      // Content end (1500) has overtaken the pin, which retires it.
-      runNextFrame();
-      scrollToContentEnd.mockClear();
-
-      act(() => controller?.enterFollowOutput('jump-to-latest'));
-
-      expect(scrollToContentEnd).toHaveBeenCalledWith('smooth');
+      expect(controller?.isFollowingOutput).toBe(false);
     });
   });
 
@@ -1387,11 +1357,11 @@ describe('useFlowChatFollowOutput', () => {
       expect(controller?.isFollowingOutput).toBe(false);
 
       // Back down until the blank is on screen again, and stop.
-      scroller.scrollTop = CONTENT_END + 300;
+      scroller.scrollTop = CONTENT_END + 250;
       act(() => controller?.handleScroll());
       expect(controller?.isFollowingOutput).toBe(false);
 
-      setContentEnd(CONTENT_END + 300);
+      setContentEnd(CONTENT_END + 250);
       act(() => controller?.scheduleFollowToLatest());
 
       expect(controller?.isFollowingOutput).toBe(true);
@@ -1403,9 +1373,9 @@ describe('useFlowChatFollowOutput', () => {
       departWithBlank(0);
       act(() => controller?.handleUserScrollIntent());
 
-      scroller.scrollTop = CONTENT_END + 300;
+      scroller.scrollTop = CONTENT_END + 250;
       act(() => controller?.handleScroll());
-      setContentEnd(CONTENT_END + 300);
+      setContentEnd(CONTENT_END + 250);
       act(() => controller?.scheduleFollowToLatest());
 
       expect(controller?.isFollowingOutput).toBe(true);

--- a/src/web-ui/src/flow_chat/components/modern/useFlowChatFollowOutput.ts
+++ b/src/web-ui/src/flow_chat/components/modern/useFlowChatFollowOutput.ts
@@ -71,6 +71,8 @@ interface UseFlowChatFollowOutputOptions {
   virtualItemCount: number;
   isStreaming: boolean;
   isViewportActive: boolean;
+  /** Restored history presentations must not start by pinning the tail. */
+  startAtTailOnMount?: boolean;
   /** The native host has temporarily withdrawn the scroller from layout. */
   isViewportSuspended?: () => boolean;
   scrollerRef: RefObject<HTMLElement | null>;
@@ -201,6 +203,7 @@ export function useFlowChatFollowOutput({
   virtualItemCount,
   isStreaming,
   isViewportActive,
+  startAtTailOnMount = true,
   isViewportSuspended = () => false,
   scrollerRef,
   getTailSpacerPx,
@@ -1253,7 +1256,7 @@ export function useFlowChatFollowOutput({
   useEffect(() => {
     if (!hasMountedRef.current) {
       hasMountedRef.current = true;
-      if (virtualItemCount > 0) {
+      if (virtualItemCount > 0 && startAtTailOnMount) {
         enterFollowOutput(isStreaming ? 'streaming-resumed' : 'session-open');
       }
       return;
@@ -1266,7 +1269,7 @@ export function useFlowChatFollowOutput({
       exitFollowOutput('session-changed');
       // A Turn waiting to be shown belongs to the session that gained it.
       pendingNewTurnIdRef.current = null;
-      if (virtualItemCount > 0) {
+      if (virtualItemCount > 0 && startAtTailOnMount) {
         enterFollowOutput(isStreaming ? 'streaming-resumed' : 'session-open');
       }
       return;
@@ -1314,6 +1317,7 @@ export function useFlowChatFollowOutput({
     enterFollowOutput,
     exitFollowOutput,
     isStreaming,
+    startAtTailOnMount,
     latestTurnId,
     virtualItemCount,
   ]);

--- a/src/web-ui/src/flow_chat/components/modern/useFlowChatFollowOutput.ts
+++ b/src/web-ui/src/flow_chat/components/modern/useFlowChatFollowOutput.ts
@@ -19,7 +19,6 @@ import {
   contentEndScrollTop,
   FLOWCHAT_AT_CONTENT_END_THRESHOLD_PX,
   isTailBlankMeasurable,
-  memorylessFollowState,
   nextTailFollowState,
   resolveAnimatedJumpBehavior,
   resolveTailDepartureCrossing,
@@ -44,17 +43,21 @@ export type FollowOutputExitReason =
 /**
  * Why a watch over a reader who owns the viewport ended.
  *
- * All four are follow taking it back or the transcript going away. A *crossing*
- * is deliberately not on this list: the reader can climb out of the reserved
- * blank and scroll back down into it any number of times before either happens,
- * and each of those is another chance for output to catch up with them.
+ * These are follow taking it back, a reader replacing a reveal, or the
+ * transcript going away. A *crossing* is deliberately not on this list: the
+ * reader can climb out of the reserved blank and scroll back down into it any
+ * number of times before either happens, and each is another chance for output
+ * to catch up with them.
  */
 type TailWatchOutcome =
   /** Something handed the viewport back — a new Turn, a jump, a snap, this. */
   | 'followed-again'
   | 'navigated'
+  | 'reader-took-over'
   | 'session-changed'
   | 'unmounted';
+
+type TailWatchOrigin = 'new-turn-reveal' | 'user-departure';
 
 interface UseFlowChatFollowOutputOptions {
   activeSessionId?: string;
@@ -75,10 +78,8 @@ interface UseFlowChatFollowOutputOptions {
   getTailSpacerPx: () => number;
   /** One-shot scroll placing the end of real content at the viewport bottom. */
   scrollToContentEnd: (behavior: ScrollBehavior) => void;
-  /** One-shot scroll placing a Turn's user message at the viewport top. */
-  scrollTurnToTop: (turnId: string) => boolean;
-  /** Offset that would place a Turn's user message at the viewport top, if rendered. */
-  resolveTurnTopScrollTop: (turnId: string) => number | null;
+  /** Reveal a rendered new Turn by placing the viewport at the physical bottom once. */
+  revealNewTurnTail: (turnId: string) => boolean;
   /** True while the transcript is still hidden for the opening reveal. */
   isOpeningViewport: () => boolean;
   /**
@@ -137,13 +138,6 @@ interface UseFlowChatFollowOutputResult {
 }
 
 const BOTTOM_EPSILON_PX = 2;
-
-/**
- * Frames a pinned Turn may stay unmeasurable before the pin is abandoned.
- * The virtualizer renders the tail immediately, so this only guards against a Turn
- * that never mounts at all.
- */
-const PIN_RESOLVE_MAX_ATTEMPTS = 30;
 
 /**
  * How long a programmatic smooth scroll of ours may own the viewport before the
@@ -211,8 +205,7 @@ export function useFlowChatFollowOutput({
   scrollerRef,
   getTailSpacerPx,
   scrollToContentEnd,
-  scrollTurnToTop,
-  resolveTurnTopScrollTop,
+  revealNewTurnTail,
   isOpeningViewport,
   viewportOwner,
   viewportId = 0,
@@ -231,10 +224,8 @@ export function useFlowChatFollowOutput({
   const hasMountedRef = useRef(false);
   const wasStreamingRef = useRef(isStreaming);
 
-  const followStateRef = useRef<TailFollowState>({ mode: 'hold-tail', target: 0 });
-  const pinTurnIdRef = useRef<string | null>(null);
-  const pinScrollTopRef = useRef<number | null>(null);
-  const pinAttemptsRef = useRef(0);
+  const followStateRef = useRef<TailFollowState>({ target: 0 });
+  const followPhaseRef = useRef<'idle' | 'revealing-tail' | 'following-tail'>('idle');
   /**
    * A Turn that arrived while it was not in the transcript on screen.
    *
@@ -242,7 +233,7 @@ export function useFlowChatFollowOutput({
    * Turn a beat before the presentation is restored to the live tail, so the
    * one moment the arrival is *detectable* is not a moment it can be answered.
    * The answer is deferred rather than dropped — kept until the Turn can
-   * actually be aligned, which is what the reader is waiting to see.
+   * actually be revealed, which is what the reader is waiting to see.
    */
   const pendingNewTurnIdRef = useRef<string | null>(null);
   const settleFramesRef = useRef(0);
@@ -312,72 +303,14 @@ export function useFlowChatFollowOutput({
   ), [getTailSpacerPx]);
 
   /**
-   * Forget which Turn is pinned.
-   *
-   * This is the pin's *identity*, not its activity. A user takeover suspends
-   * the pin, while an explicit jump to latest may still return to it. Only
-   * three things retire a pin: the crossover to `hold-tail`, a newer Turn
-   * replacing it, and the session changing. The crossover is one-way by
-   * construction, since nothing re-pins a Turn whose identity has been
-   * dropped; a card collapse that pulls content back under one viewport must
-   * not resurrect the pin.
-   */
-  const retirePin = useCallback(() => {
-    pinTurnIdRef.current = null;
-    pinScrollTopRef.current = null;
-    pinAttemptsRef.current = 0;
-  }, []);
-
-  /**
-   * Resolve the pinned Turn's offset from live layout every frame rather than
-   * caching it once. Unrendered items are estimates until measured, and every
-   * measurement shifts the absolute offsets below it; a cached pin would drift.
-   */
-  const readPinScrollTop = useCallback((): number | null => {
-    const pinTurnId = pinTurnIdRef.current;
-    if (!pinTurnId) {
-      return null;
-    }
-
-    const resolved = resolveTurnTopScrollTop(pinTurnId);
-    if (resolved !== null) {
-      pinScrollTopRef.current = resolved;
-      pinAttemptsRef.current = 0;
-      return resolved;
-    }
-
-    if (pinScrollTopRef.current === null) {
-      pinAttemptsRef.current += 1;
-      if (pinAttemptsRef.current >= PIN_RESOLVE_MAX_ATTEMPTS) {
-        retirePin();
-      }
-    }
-    return pinScrollTopRef.current;
-  }, [retirePin, resolveTurnTopScrollTop]);
-
-  /**
    * The state the follow rule would hold for the current geometry, ignoring any
    * offset it was holding. Used to resolve explicit follow targets and to
    * resume on the live content end.
-   *
-   * Retires a pin that has crossed over on the way past: with no frame loop
-   * running, this is the only place that crossover can be noticed.
    */
   const resolveFollowState = useCallback((scroller: HTMLElement): TailFollowState => {
     const desired = readContentEndScrollTop(scroller);
-    const next = memorylessFollowState(
-      pinTurnIdRef.current ? 'pin-turn-top' : 'hold-tail',
-      {
-        desiredScrollTop: desired,
-        pinScrollTop: readPinScrollTop(),
-        maxGapPx: tailHoldMaxGapPx(scroller.clientHeight),
-      },
-    );
-    if (next.mode === 'hold-tail') {
-      retirePin();
-    }
-    return next;
-  }, [readContentEndScrollTop, readPinScrollTop, retirePin]);
+    return { target: desired };
+  }, [readContentEndScrollTop]);
 
   const resolveFollowTargetScrollTop = useCallback((scroller: HTMLElement) => (
     resolveFollowState(scroller).target
@@ -387,12 +320,10 @@ export function useFlowChatFollowOutput({
    * ---------------------------------------------------------------------------
    * A viewport in the reader's hands, watched for output catching up with them.
    *
-   * Scrolling up gives the follow away, and that is right only if the reader
-   * actually left the live region. They may not have. The reserved blank is up
-   * to 60% of a viewport under `hold-tail` and the whole gap under a pinned
-   * Turn, so a small scroll up can leave the reader still looking at empty space
-   * below the newest output — nothing is being hidden from them yet — and then
-   * output grows past the bottom edge and they silently stop seeing it.
+   * The same crossing has two origins. A new Turn reveal deliberately starts in
+   * the resident blank while follow-output still owns the viewport; a user
+   * departure starts after a gesture releases it. In both cases output reaching
+   * the fixed viewport bottom is the event that may start ordinary tail follow.
    *
    * "Still looking at the blank" is `scrollTop > contentEnd`, because
    * `contentEnd` is by definition the offset that puts the end of real content
@@ -416,12 +347,12 @@ export function useFlowChatFollowOutput({
    * ---------------------------------------------------------------------------
    */
   const tailWatchRef = useRef<{
+    origin: TailWatchOrigin;
     openedAtMs: number;
-    /** Blank on screen when the reader took the viewport. */
+    /** Blank on screen when the watch opened. */
     exitBlankPx: number;
     exitScrollTopPx: number;
     exitContentEndPx: number;
-    exitPinned: boolean;
     exitStreaming: boolean;
     /** Previous sample, so a crossing can be attributed to whatever moved. */
     lastScrollTopPx: number;
@@ -446,9 +377,12 @@ export function useFlowChatFollowOutput({
       : watch.lastContentEndPx;
     traceViewport({
       location: 'followOutput.tailWatchEnded',
-      message: 'follow-output has the viewport back',
+      message: outcome === 'reader-took-over'
+        ? 'the reader replaced the passive new Turn reveal'
+        : 'the tail watch ended',
       data: () => ({
         outcome,
+        origin: watch.origin,
         viewportId,
         forMs: Math.round(performance.now() - watch.openedAtMs),
         samples: watch.samples,
@@ -458,7 +392,6 @@ export function useFlowChatFollowOutput({
         // The two movements, over the whole life of the watch.
         contentGrewPx: roundViewportPx(contentEndPx - watch.exitContentEndPx),
         readerMovedPx: roundViewportPx(scrollTopPx - watch.exitScrollTopPx),
-        pinnedAtExit: watch.exitPinned,
         streamingAtExit: watch.exitStreaming,
         streamingNow: isStreamingRef.current,
         ...(extra ?? {}),
@@ -487,33 +420,33 @@ export function useFlowChatFollowOutput({
    * blank at any point afterwards, and the whole question is where they are when
    * output next reaches the bottom edge.
    */
-  const openTailWatch = useCallback(() => {
+  const openTailWatch = useCallback((origin: TailWatchOrigin) => {
     const scroller = scrollerRef.current;
     if (!scroller) return;
     const contentEndPx = readContentEndScrollTop(scroller);
     const blankPx = scroller.scrollTop - contentEndPx;
-    const pinned = pinTurnIdRef.current !== null;
     traceViewport({
       location: 'followOutput.tailWatch',
-      message: 'the reader has the viewport, and is watched for output catching up',
+      message: origin === 'new-turn-reveal'
+        ? 'the new Turn is revealed in the blank and watched for output catching up'
+        : 'the reader has the viewport and is watched for output catching up',
       data: () => ({
+        origin,
         viewportId,
         blankPx: roundViewportPx(blankPx),
         blankVisible: blankPx > 0,
         scrollTopPx: roundViewportPx(scroller.scrollTop),
         contentEndPx: roundViewportPx(contentEndPx),
         clientHeightPx: scroller.clientHeight,
-        // A pin is the case where the gap between the two predicates is widest.
-        pinned,
         isStreaming: isStreamingRef.current,
       }),
     });
     tailWatchRef.current = {
+      origin,
       openedAtMs: performance.now(),
       exitBlankPx: blankPx,
       exitScrollTopPx: scroller.scrollTop,
       exitContentEndPx: contentEndPx,
-      exitPinned: pinned,
       exitStreaming: isStreamingRef.current,
       lastScrollTopPx: scroller.scrollTop,
       lastContentEndPx: contentEndPx,
@@ -641,18 +574,13 @@ export function useFlowChatFollowOutput({
      * output is about to fill it.
      */
     const previous: TailFollowState = isOpeningViewport()
-      ? { mode: remembered.mode, target: desired }
+      ? { target: desired }
       : remembered;
-    const pin = readPinScrollTop();
     const next = nextTailFollowState(previous, {
       desiredScrollTop: desired,
-      pinScrollTop: pin,
-      maxGapPx: tailHoldMaxGapPx(scroller.clientHeight),
+      maxGapPx: tailHoldMaxGapPx(scroller.clientHeight, getTailSpacerPx()),
     });
     followStateRef.current = next;
-    if (next.mode === 'hold-tail') {
-      retirePin();
-    }
     // Content is still moving, so keep the settle window open.
     if (Math.abs(next.target - previous.target) > BOTTOM_EPSILON_PX) {
       settleFramesRef.current = SETTLE_FRAMES;
@@ -675,7 +603,7 @@ export function useFlowChatFollowOutput({
       // the key would be a string built sixty times a second for a switch that
       // is off.
       traceViewportRepeating(
-        `follow|frame|${onTarget}|${isOpeningViewport()}|${next.mode}`,
+        `follow|frame|${onTarget}|${isOpeningViewport()}`,
         {
           location: 'followOutput.frame',
           message: onTarget
@@ -685,11 +613,10 @@ export function useFlowChatFollowOutput({
           data: () => ({
             viewportId,
             onTarget,
-            mode: next.mode,
+            phase: followPhaseRef.current,
             isOpening: isOpeningViewport(),
             desiredPx: roundViewportPx(desired),
             targetPx: roundViewportPx(next.target),
-            pinPx: pin === null ? null : roundViewportPx(pin),
             scrollTopPx: roundViewportPx(scroller.scrollTop),
             scrollRangePx: roundViewportPx(scroller.scrollHeight),
             settleFrames: settleFramesRef.current,
@@ -791,10 +718,9 @@ export function useFlowChatFollowOutput({
     }
   }, [
     endSmoothScrollYield,
+    getTailSpacerPx,
     isOpeningViewport,
     readContentEndScrollTop,
-    readPinScrollTop,
-    retirePin,
     scrollerRef,
     viewportId,
     viewportOwner,
@@ -814,6 +740,8 @@ export function useFlowChatFollowOutput({
      */
     const standDownReason = !isFollowingOutputRef.current
       ? 'not-following'
+      : followPhaseRef.current !== 'following-tail'
+        ? 'revealing-tail'
       : !isViewportActiveRef.current
         ? 'viewport-inactive'
         : isViewportSuspendedRef.current()
@@ -853,6 +781,7 @@ export function useFlowChatFollowOutput({
     if (
       followFrameRef.current === null &&
       isFollowingOutputRef.current &&
+      followPhaseRef.current === 'following-tail' &&
       !isViewportSuspendedRef.current() &&
       (isStreamingRef.current || settleFramesRef.current > 0)
     ) {
@@ -881,22 +810,22 @@ export function useFlowChatFollowOutput({
       return;
     }
 
-    /*
-     * A newly submitted Turn opens at the viewport top, and that is the whole
-     * of the answer to one arriving. Until it is in the transcript on screen
-     * there is nothing to align, and the fallback below — the end of real
-     * content — is not a stand-in for it: it would leave the Turn unpinned
-     * where the reader was, or pull them out of a history window entirely.
-     *
-     * So the answer waits for the Turn instead. Resolved before ownership
-     * changes hands, because waiting has to leave the viewport exactly as it
-     * was found.
-     */
-    const pinTurnId = reason === 'new-turn' ? latestTurnIdRef.current : null;
-    const pinnedTurnToTop = pinTurnId !== null && scrollTurnToTop(pinTurnId);
+    if (reason === 'jump-to-latest' && followPhaseRef.current === 'revealing-tail') {
+      traceViewportRepeating('follow|jumpIgnored|revealing-tail', {
+        location: 'followOutput.jumpIgnored',
+        message: 'jump to latest was already satisfied by the new Turn reveal',
+        data: () => ({ viewportId }),
+      });
+      return;
+    }
+
+    /* A new Turn may arrive before the live-tail projection contains it. The
+     * one detectable arrival is retained until its one-shot reveal can run. */
+    const revealTurnId = reason === 'new-turn' ? latestTurnIdRef.current : null;
+    const revealedNewTurn = revealTurnId !== null && revealNewTurnTail(revealTurnId);
     if (reason === 'new-turn') {
-      pendingNewTurnIdRef.current = pinnedTurnToTop ? null : pinTurnId;
-      if (!pinnedTurnToTop) {
+      pendingNewTurnIdRef.current = revealedNewTurn ? null : revealTurnId;
+      if (!revealedNewTurn) {
         /*
          * The viewport is deliberately left exactly as it was, so the only
          * evidence that a submission was answered at all is this line. A
@@ -905,8 +834,8 @@ export function useFlowChatFollowOutput({
          */
         traceViewportRepeating('follow|deferred-new-turn', {
           location: 'followOutput.deferNewTurn',
-          message: 'new Turn is not in the transcript on screen yet, so the answer waits',
-          data: () => ({ turnId: pinTurnId }),
+          message: 'new Turn is not in the transcript on screen yet, so the reveal waits',
+          data: () => ({ turnId: revealTurnId }),
         });
         return;
       }
@@ -925,7 +854,7 @@ export function useFlowChatFollowOutput({
       data: () => ({
         reason,
         viewportId,
-        pinnedTurnId: pinnedTurnToTop ? pinTurnId : pinTurnIdRef.current,
+        phase: revealedNewTurn ? 'revealing-tail' : 'following-tail',
         isStreaming: isStreamingRef.current,
         scrollTopPx: roundViewportPx(scrollerRef.current?.scrollTop ?? 0),
       }),
@@ -942,62 +871,18 @@ export function useFlowChatFollowOutput({
     const scroller = scrollerRef.current;
     const contentEnd = scroller ? readContentEndScrollTop(scroller) : 0;
 
-    /*
-     * A pin on the newest Turn already satisfies "show me the latest output".
-     * The mode only holds while that Turn's answer is shorter than one
-     * viewport, so everything it has produced is on screen; re-aiming at the
-     * content end would scroll *up* and shove the message the user just sent
-     * into the middle of the viewport.
-     *
-     * This fires for real: restoring the tail presentation asks for a jump to
-     * latest one frame after the Turn that caused it got pinned, which
-     * overwrote the pin every time.
-     */
-    if (
-      reason === 'jump-to-latest' &&
-      pinTurnIdRef.current !== null &&
-      pinTurnIdRef.current === latestTurnIdRef.current
-    ) {
-      const pinTarget = readPinScrollTop() ?? scroller?.scrollTop ?? contentEnd;
-      followStateRef.current = { mode: 'pin-turn-top', target: pinTarget };
-      // Travels like every other jump to latest, animated or not. The frame
-      // loop would cancel an animation on its next tick, so it stands down for
-      // this one exactly as it does for `runContentEndScroll` — and an instant
-      // write of ours replaces whatever was still travelling.
-      if (scroller && Math.abs(scroller.scrollTop - pinTarget) > BOTTOM_EPSILON_PX) {
-        const behavior = resolveJumpBehavior(scroller, pinTarget);
-        if (behavior === 'smooth') {
-          beginSmoothScrollYield();
-        } else {
-          endSmoothScrollYield('superseded');
-        }
-        viewportOwner.write({
-          owner: 'follow-output',
-          topPx: pinTarget,
-          behavior,
-        });
-      }
-      startFollowFrame();
+    if (revealedNewTurn && scroller && scroller.scrollTop > contentEnd) {
+      followPhaseRef.current = 'revealing-tail';
+      endSmoothScrollYield('superseded');
+      followStateRef.current = { target: scroller.scrollTop };
+      stopFollowFrame();
+      openTailWatch('new-turn-reveal');
       return;
     }
 
-    // Every other entry reason resumes at the end of real content.
-    if (pinnedTurnToTop) {
-      pinTurnIdRef.current = pinTurnId;
-      pinScrollTopRef.current = null;
-      pinAttemptsRef.current = 0;
-      endSmoothScrollYield('superseded');
-      followStateRef.current = { mode: 'pin-turn-top', target: scroller?.scrollTop ?? contentEnd };
-    } else {
-      /*
-       * The pin is dropped here even when the departure happened under one, and
-       * that is deliberate. The pin's reservation is the blank the reader just
-       * scrolled out of; restoring it would pull them back down to the offset
-       * they left. Following the content end keeps them where they put
-       * themselves and shows what arrives below.
-       */
-      retirePin();
-      followStateRef.current = { mode: 'hold-tail', target: contentEnd };
+    followPhaseRef.current = 'following-tail';
+    followStateRef.current = { target: contentEnd };
+    {
       /*
        * Output that caught up with a stationary reader is already at the end —
        * the blank between them closing is what raised this — so the whole
@@ -1023,25 +908,20 @@ export function useFlowChatFollowOutput({
     startFollowFrame();
   }, [
     viewportOwner,
-    beginSmoothScrollYield,
     closeTailWatch,
     endSmoothScrollYield,
+    openTailWatch,
     readContentEndScrollTop,
-    readPinScrollTop,
+    revealNewTurnTail,
     resolveJumpBehavior,
-    retirePin,
     runContentEndScroll,
-    scrollTurnToTop,
     scrollerRef,
     startFollowFrame,
+    stopFollowFrame,
     viewportId,
   ]);
 
-  /**
-   * Release the viewport without forgetting the pin. The user owns it from
-   * here; the pin stays on record so an explicit jump to latest can restore
-   * the mode rather than fall through to the tail.
-   */
+  /** Release the viewport. A user gesture replaces any reveal watch with a reader watch. */
   const exitFollowOutput = useCallback((reason: FollowOutputExitReason) => {
     /*
      * Traced whether or not there was anything to give up. An exit that finds
@@ -1058,11 +938,12 @@ export function useFlowChatFollowOutput({
         reason,
         viewportId,
         wasFollowing: isFollowingOutputRef.current,
-        pinnedTurnId: pinTurnIdRef.current,
+        phase: followPhaseRef.current,
         scrollTopPx: roundViewportPx(scrollerRef.current?.scrollTop ?? 0),
       }),
     });
     isFollowingOutputRef.current = false;
+    followPhaseRef.current = 'idle';
     setIsFollowingOutput(false);
     endSmoothScrollYield('superseded');
     viewportOwner.release('follow-output');
@@ -1090,8 +971,11 @@ export function useFlowChatFollowOutput({
       // watch starts again from there rather than carrying offsets across it.
       closeTailWatch('navigated', { navigationReason: reason });
     }
+    if (reason === 'user-scroll' && tailWatchRef.current?.origin === 'new-turn-reveal') {
+      closeTailWatch('reader-took-over');
+    }
     if (tailWatchRef.current === null) {
-      openTailWatch();
+      openTailWatch('user-departure');
     }
   }, [
     closeTailWatch,
@@ -1178,6 +1062,7 @@ export function useFlowChatFollowOutput({
         : 'the blank closed under the reader, and follow leaves it alone',
       data: () => ({
         crossing,
+        origin: watch.origin,
         resumed,
         gestureLive,
         viewportId,
@@ -1210,6 +1095,16 @@ export function useFlowChatFollowOutput({
    */
   const scheduleFollowToLatest = useCallback(() => {
     if (isViewportSuspendedRef.current()) return;
+    if (
+      isFollowingOutputRef.current
+      && isViewportActiveRef.current
+      && followPhaseRef.current === 'revealing-tail'
+    ) {
+      // The reveal is intentionally passive: streamed growth consumes the
+      // visible blank while scrollTop stays fixed. Only the crossing is sampled.
+      sampleTailWatch();
+      return;
+    }
     if (!isFollowingOutputRef.current || !isViewportActiveRef.current) {
       /*
        * This is the transcript's content-change signal — the resize observer
@@ -1236,9 +1131,8 @@ export function useFlowChatFollowOutput({
    *
    * The ledger cannot say this on its own — a shorter `dialogTurns` is also
    * what a window re-cut and a hydration merge look like — so the rollback
-   * announces it, the same way a submission does. What it asks for is the
-   * *absence* of the pin: the Turn that was pinned is one of the ones that just
-   * stopped existing, and the transcript now ends somewhere else.
+   * announces it, the same way a submission does. The transcript now ends
+   * somewhere else, so the answer is an ordinary content-end placement.
    *
    * This takes the viewport whether or not follow owned it. A rollback at
    * Turn N removes N and everything after it, and the reader had N on screen —
@@ -1370,7 +1264,6 @@ export function useFlowChatFollowOutput({
       previousLatestTurnIdRef.current = latestTurnId;
       previousDialogTurnCountRef.current = dialogTurnCount;
       exitFollowOutput('session-changed');
-      retirePin();
       // A Turn waiting to be shown belongs to the session that gained it.
       pendingNewTurnIdRef.current = null;
       if (virtualItemCount > 0) {
@@ -1383,7 +1276,7 @@ export function useFlowChatFollowOutput({
      * An arrival, not a change. `latestTurnId` is the ledger's last Turn and it
      * is the right identity — but a rollback truncates the ledger, which moves
      * that identity *backwards* onto a Turn that has been there all along. Read
-     * as an arrival it pinned the survivor to the viewport top, which is the
+     * as an arrival it revealed the survivor as though it were new, which is the
      * reader's "I undid my message and it jumped to the one before it".
      *
      * The ledger growing is what separates the two. Nothing else that rewrites
@@ -1408,8 +1301,8 @@ export function useFlowChatFollowOutput({
     }
     /*
      * The transcript changed without a new Turn, which is the moment a deferred
-     * one can become alignable — the presentation being restored to the live
-     * tail is exactly that. A retry that still cannot align it leaves the
+     * one can become revealable — the presentation being restored to the live
+     * tail is exactly that. A retry that still cannot reveal it leaves the
      * viewport alone and stays pending.
      */
     if (pendingNewTurnIdRef.current === latestTurnId && latestTurnId !== null) {
@@ -1422,7 +1315,6 @@ export function useFlowChatFollowOutput({
     exitFollowOutput,
     isStreaming,
     latestTurnId,
-    retirePin,
     virtualItemCount,
   ]);
 
@@ -1437,14 +1329,17 @@ export function useFlowChatFollowOutput({
   }, [isFollowingOutput, isStreaming, isViewportActive, scheduleFollowToLatest, stopFollowFrame]);
 
   // Settle any blank the hold rule accumulated once output stops arriving.
-  // A pinned Turn keeps its blank: that space is the mode, not a leftover.
+  // A short new-Turn reveal keeps its blank and its fixed viewport position.
   useEffect(() => {
     const wasStreaming = wasStreamingRef.current;
     wasStreamingRef.current = isStreaming;
     if (wasStreaming === isStreaming || isStreaming) {
       return;
     }
-    if (!isFollowingOutputRef.current || followStateRef.current.mode !== 'hold-tail') {
+    if (
+      !isFollowingOutputRef.current
+      || followPhaseRef.current !== 'following-tail'
+    ) {
       return;
     }
 
@@ -1454,7 +1349,7 @@ export function useFlowChatFollowOutput({
     }
     const contentEnd = readContentEndScrollTop(scroller);
     if (followStateRef.current.target - contentEnd > BOTTOM_EPSILON_PX) {
-      followStateRef.current = { mode: 'hold-tail', target: contentEnd };
+      followStateRef.current = { target: contentEnd };
       runContentEndScroll('smooth');
     }
   }, [isStreaming, readContentEndScrollTop, runContentEndScroll, scrollerRef]);

--- a/src/web-ui/src/flow_chat/components/modern/useFlowChatFollowOutput.ts
+++ b/src/web-ui/src/flow_chat/components/modern/useFlowChatFollowOutput.ts
@@ -68,6 +68,8 @@ interface UseFlowChatFollowOutputOptions {
   virtualItemCount: number;
   isStreaming: boolean;
   isViewportActive: boolean;
+  /** The native host has temporarily withdrawn the scroller from layout. */
+  isViewportSuspended?: () => boolean;
   scrollerRef: RefObject<HTMLElement | null>;
   /** Height of the resident tail spacer currently rendered below the content. */
   getTailSpacerPx: () => number;
@@ -205,6 +207,7 @@ export function useFlowChatFollowOutput({
   virtualItemCount,
   isStreaming,
   isViewportActive,
+  isViewportSuspended = () => false,
   scrollerRef,
   getTailSpacerPx,
   scrollToContentEnd,
@@ -219,6 +222,8 @@ export function useFlowChatFollowOutput({
   const isStreamingRef = useRef(isStreaming);
   const isViewportActiveRef = useRef(isViewportActive);
   const latestTurnIdRef = useRef(latestTurnId);
+  const isViewportSuspendedRef = useRef(isViewportSuspended);
+  isViewportSuspendedRef.current = isViewportSuspended;
   const followFrameRef = useRef<number | null>(null);
   const previousSessionIdRef = useRef(activeSessionId);
   const previousLatestTurnIdRef = useRef<string | null>(latestTurnId);
@@ -619,7 +624,7 @@ export function useFlowChatFollowOutput({
   /** Move the viewport to whatever the follow state currently owns. */
   const applyFollowTarget = useCallback(() => {
     const scroller = scrollerRef.current;
-    if (!scroller) {
+    if (!scroller || isViewportSuspendedRef.current()) {
       return;
     }
 
@@ -811,6 +816,8 @@ export function useFlowChatFollowOutput({
       ? 'not-following'
       : !isViewportActiveRef.current
         ? 'viewport-inactive'
+        : isViewportSuspendedRef.current()
+          ? 'viewport-suspended'
         : document.hidden
           ? 'document-hidden'
           : (!isStreamingRef.current && settleFramesRef.current <= 0)
@@ -846,6 +853,7 @@ export function useFlowChatFollowOutput({
     if (
       followFrameRef.current === null &&
       isFollowingOutputRef.current &&
+      !isViewportSuspendedRef.current() &&
       (isStreamingRef.current || settleFramesRef.current > 0)
     ) {
       followFrameRef.current = requestAnimationFrame(runFollowFrame);
@@ -1110,7 +1118,7 @@ export function useFlowChatFollowOutput({
     const watch = tailWatchRef.current;
     if (!watch) return;
     const scroller = scrollerRef.current;
-    if (!scroller) return;
+    if (!scroller || isViewportSuspendedRef.current()) return;
 
     const scrollTopPx = scroller.scrollTop;
     const contentEndPx = readContentEndScrollTop(scroller);
@@ -1201,6 +1209,7 @@ export function useFlowChatFollowOutput({
    * down.
    */
   const scheduleFollowToLatest = useCallback(() => {
+    if (isViewportSuspendedRef.current()) return;
     if (!isFollowingOutputRef.current || !isViewportActiveRef.current) {
       /*
        * This is the transcript's content-change signal — the resize observer
@@ -1250,6 +1259,7 @@ export function useFlowChatFollowOutput({
   }, [enterFollowOutput]);
 
   const handleScroll = useCallback(() => {
+    if (isViewportSuspendedRef.current()) return;
     // Scroll events describe the resulting viewport position, but do not prove user intent.
     // Layout growth and virtualizer remeasurement can emit them while output follow still owns
     // the viewport. Explicit wheel, touch, and keyboard handlers release that ownership instead.
@@ -1311,7 +1321,7 @@ export function useFlowChatFollowOutput({
    */
   const handleViewportResize = useCallback((input: ViewportResizeInput) => {
     const scroller = scrollerRef.current;
-    if (!scroller || isFollowingOutputRef.current) {
+    if (!scroller || isViewportSuspendedRef.current() || isFollowingOutputRef.current) {
       // Follow re-asserts its own target through `scheduleFollowToLatest`.
       return;
     }

--- a/src/web-ui/src/flow_chat/components/modern/useFlowChatViewportAnchor.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/useFlowChatViewportAnchor.test.tsx
@@ -427,6 +427,24 @@ describe('useFlowChatViewportAnchor', () => {
     expect(scroller.scrollTop).toBeCloseTo(446.7, 6);
   });
 
+  it('does not credit a native viewport resume to the reader', () => {
+    scroller.scrollTop = 1_000;
+    layoutTurns({ 'turn-3': 1_100 });
+    api.captureAnchor();
+
+    // A minimized WebView can return with a transient viewport offset before
+    // its scroll event arrives. This is host recovery, not a reader choice.
+    scroller.scrollTop = 1_132;
+
+    expect(api.restoreAnchorAfterViewportResume()).toBe(true);
+    expect(scroller.scrollTop).toBe(1_000);
+
+    // The recovery correction becomes the new baseline, so ordinary settles do
+    // not borrow it back as an unclaimed scroll on their next frame.
+    expect(api.restoreAnchor()).toBe(true);
+    expect(scroller.scrollTop).toBe(1_000);
+  });
+
   it('does not re-owe a correction it has just made', () => {
     /*
      * The same two halves, on the other branch. The shift puts the Turn back at

--- a/src/web-ui/src/flow_chat/components/modern/useFlowChatViewportAnchor.ts
+++ b/src/web-ui/src/flow_chat/components/modern/useFlowChatViewportAnchor.ts
@@ -158,6 +158,14 @@ export interface FlowChatViewportAnchorApi {
    */
   restoreAnchor: () => boolean;
   /**
+   * Restore the reading position after the native host temporarily withdrew the
+   * viewport from layout.
+   *
+   * Host recovery is not reader input. Keep its transient `scrollTop` delta
+   * out of the anchor until the pre-suspension relationship is restored.
+   */
+  restoreAnchorAfterViewportResume: () => boolean;
+  /**
    * Correct now, and hold the anchor across the settle that follows.
    *
    * One callback per change is not enough, and no callback covers all of it, so
@@ -232,6 +240,12 @@ export function useFlowChatViewportAnchor({
    * DOM in that same task anchors to whatever the reader was moved off.
    */
   const recaptureOnNextSettleRef = useRef(false);
+  /**
+   * A zero-sized native-host viewport is not a reader scroll. This remains set
+   * while its anchor waits for a virtual row to return, so the settle frame
+   * that finally sees the row does not accept host recovery as reader travel.
+   */
+  const isRestoringViewportResumeRef = useRef(false);
   const settleFrameRef = useRef<number | null>(null);
   /*
    * The settle loop is installed once and outlives every render, so it cannot
@@ -474,7 +488,10 @@ export function useFlowChatViewportAnchor({
   const attemptRestore = useCallback((): AnchorRestoreOutcome => {
     const scroller = scrollerRef.current;
     const anchor = anchorRef.current;
-    if (!scroller || !anchor) return 'no-anchor';
+    if (!scroller || !anchor) {
+      isRestoringViewportResumeRef.current = false;
+      return 'no-anchor';
+    }
     /*
      * Every way this declines is silent and looks like the transcript simply
      * not moving, which is why each of them is traced. Standing down for
@@ -482,6 +499,7 @@ export function useFlowChatViewportAnchor({
      * position gets lost, and they have both happened.
      */
     if (isViewportOwnedElsewhereRef.current()) {
+      isRestoringViewportResumeRef.current = false;
       traceViewportRepeating('anchor|owned-elsewhere', {
         location: 'anchor.stoodDown',
         message: 'anchor stood down for another owner',
@@ -521,6 +539,7 @@ export function useFlowChatViewportAnchor({
       if (givingUp) {
         reportMissingTurnWait(scroller, anchor.turnId, 'given-up');
         anchorRef.current = null;
+        isRestoringViewportResumeRef.current = false;
         return 'no-anchor';
       }
       return 'awaiting-turn';
@@ -546,7 +565,10 @@ export function useFlowChatViewportAnchor({
      * exactly itself with `scrolledSincePx: 0`.
      */
     const scrolledSincePx = scroller.scrollTop - anchorScrollTopRef.current;
-    carryAnchorThroughScroll(scroller, 'viewport-moved');
+    const isRestoringViewportResume = isRestoringViewportResumeRef.current;
+    if (!isRestoringViewportResume) {
+      carryAnchorThroughScroll(scroller, 'viewport-moved');
+    }
     const rebased = anchorRef.current ?? anchor;
     const correction = viewportAnchorCorrectionPx(
       rebased,
@@ -560,6 +582,10 @@ export function useFlowChatViewportAnchor({
      * quietly stopped meaning anything would sit unnoticed.
      */
     if (Math.abs(correction) < ANCHOR_CORRECTION_EPSILON_PX) {
+      if (isRestoringViewportResume) {
+        anchorScrollTopRef.current = scroller.scrollTop;
+        isRestoringViewportResumeRef.current = false;
+      }
       traceViewportRepeating(`anchor|in-place|${rebased.turnId}`, {
         location: 'anchor.inPlace',
         message: 'the reading position is where it belongs',
@@ -625,6 +651,7 @@ export function useFlowChatViewportAnchor({
      * `scrollTop` that must not be taken into the offset — it is the repair.
      */
     anchorScrollTopRef.current = scroller.scrollTop;
+    isRestoringViewportResumeRef.current = false;
     return 'corrected';
   }, [carryAnchorThroughScroll, reportMissingTurnWait, scrollerRef]);
 
@@ -637,6 +664,12 @@ export function useFlowChatViewportAnchor({
    * loop only ever needed the two.
    */
   const restoreAnchor = useCallback((): boolean => {
+    const outcome = attemptRestoreRef.current();
+    return outcome === 'corrected' || outcome === 'in-place';
+  }, []);
+
+  const restoreAnchorAfterViewportResume = useCallback((): boolean => {
+    isRestoringViewportResumeRef.current = true;
     const outcome = attemptRestoreRef.current();
     return outcome === 'corrected' || outcome === 'in-place';
   }, []);
@@ -722,6 +755,7 @@ export function useFlowChatViewportAnchor({
     captureAnchorForScroll,
     markUserScrollIntent,
     restoreAnchor,
+    restoreAnchorAfterViewportResume,
     openSettleWindow,
   }), [
     absorbViewportShift,
@@ -731,5 +765,6 @@ export function useFlowChatViewportAnchor({
     openSettleWindow,
     reanchorAfterNavigation,
     restoreAnchor,
+    restoreAnchorAfterViewportResume,
   ]);
 }

--- a/src/web-ui/src/flow_chat/components/modern/useFlowChatVirtualizer.measurement.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/useFlowChatVirtualizer.measurement.test.tsx
@@ -31,9 +31,10 @@ interface HarnessProps {
   header: HTMLElement;
   items: Item[];
   onApi: (api: FlowChatVirtualizer) => void;
+  isViewportSuspended?: () => boolean;
 }
 
-function Harness({ scroller, header, items, onApi }: HarnessProps) {
+function Harness({ scroller, header, items, onApi, isViewportSuspended }: HarnessProps) {
   const scrollerRef = React.useRef<HTMLElement | null>(scroller);
   const headerRef = React.useRef<HTMLElement | null>(header);
   onApi(useFlowChatVirtualizer({
@@ -42,6 +43,7 @@ function Harness({ scroller, header, items, onApi }: HarnessProps) {
     headerRef,
     getItemKey: (item: Item) => item.key,
     estimateItemHeightPx: () => ESTIMATE_PX,
+    isViewportSuspended,
     scrollPaddingStartPx: 0,
     writeViewport: () => true,
   }));
@@ -140,6 +142,24 @@ describe('useFlowChatVirtualizer measurement', () => {
     expect(measureAndRead([0, 1])).toEqual([
       { startPx: 0, endPx: REAL_PX },
       { startPx: REAL_PX, endPx: REAL_PX + ESTIMATE_PX },
+    ]);
+  });
+
+  it('does not measure rendered rows while the native host has suspended the viewport', () => {
+    act(() => root.render(
+      <Harness
+        scroller={scroller}
+        header={header}
+        items={[{ key: 'a' }, { key: 'b' }, { key: 'c' }]}
+        onApi={next => { api = next; }}
+        isViewportSuspended={() => true}
+      />,
+    ));
+    renderRow(0, REAL_PX);
+
+    expect(measureAndRead([0, 1])).toEqual([
+      { startPx: 0, endPx: ESTIMATE_PX },
+      { startPx: ESTIMATE_PX, endPx: ESTIMATE_PX * 2 },
     ]);
   });
 

--- a/src/web-ui/src/flow_chat/components/modern/useFlowChatVirtualizer.ts
+++ b/src/web-ui/src/flow_chat/components/modern/useFlowChatVirtualizer.ts
@@ -26,7 +26,12 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from 'react';
-import { useVirtualizer } from '@tanstack/react-virtual';
+import {
+  observeElementRect as observeTanStackElementRect,
+  useVirtualizer,
+  type Rect,
+  type Virtualizer,
+} from '@tanstack/react-virtual';
 import {
   roundViewportPx,
   traceViewport,
@@ -81,6 +86,36 @@ export interface FlowChatItemBounds {
   endPx: number;
 }
 
+/** A viewport box that can describe what the reader can actually see. */
+export function isUsableFlowChatViewportRect(rect: Rect): boolean {
+  return Number.isFinite(rect.width)
+    && Number.isFinite(rect.height)
+    && rect.width > 0
+    && rect.height > 0;
+}
+
+/**
+ * Keep transient minimized-window geometry out of TanStack's viewport state.
+ *
+ * WebView2 reports a zero-height scroller while the native window is minimized.
+ * Publishing that sample makes the rendered window empty and throws away the
+ * last reader position even though the React tree never left the screen. The
+ * next positive sample is an ordinary reflow from the last usable rectangle.
+ */
+export function observeFlowChatViewportRect<
+  TScrollElement extends Element,
+  TItemElement extends Element,
+>(
+  instance: Virtualizer<TScrollElement, TItemElement>,
+  callback: (rect: Rect) => void,
+): void | (() => void) {
+  return observeTanStackElementRect(instance, rect => {
+    if (isUsableFlowChatViewportRect(rect)) {
+      callback(rect);
+    }
+  });
+}
+
 /** A resize can shift the reader only when the whole row is above it. */
 export function isItemFullyAboveViewport(itemEndPx: number, scrollTopPx: number): boolean {
   return itemEndPx <= scrollTopPx;
@@ -126,6 +161,8 @@ export interface UseFlowChatVirtualizerOptions<T> {
   estimateContext?: VirtualItemHeightEstimateContext;
   /** Stable identity for data that changes an unmeasured row's estimate. */
   estimateContextRevision?: string | number;
+  /** The host has temporarily withdrawn the scroller, such as window minimization. */
+  isViewportSuspended?: () => boolean;
   /**
    * Gap kept above a Turn that has been scrolled to the top of the viewport.
    * Applied by the virtualizer itself so that its re-aim, which runs while
@@ -288,6 +325,7 @@ export function useFlowChatVirtualizer<T>({
   estimateItemHeightPx,
   estimateContext,
   estimateContextRevision,
+  isViewportSuspended = () => false,
   scrollPaddingStartPx,
   writeViewport,
   shiftViewport = () => false,
@@ -330,6 +368,8 @@ export function useFlowChatVirtualizer<T>({
   estimateItemHeightRef.current = estimateItemHeightPx;
   const estimateContextRef = useRef(estimateContext);
   estimateContextRef.current = estimateContext;
+  const isViewportSuspendedRef = useRef(isViewportSuspended);
+  isViewportSuspendedRef.current = isViewportSuspended;
 
   const [contentStartPx, setContentStartPx] = useState(0);
   useEffect(() => {
@@ -367,6 +407,7 @@ export function useFlowChatVirtualizer<T>({
   const virtualizer = useVirtualizer({
     count: items.length,
     getScrollElement: () => scrollerRef.current,
+    observeElementRect: observeFlowChatViewportRect,
     estimateSize,
     getItemKey: resolveItemKey,
     // Items carry their own index attribute already; measuring reads it back.
@@ -381,6 +422,7 @@ export function useFlowChatVirtualizer<T>({
      * by whatever outranks the aim it came from.
      */
     scrollToFn: (offsetPx, { behavior }) => {
+      if (isViewportSuspendedRef.current()) return;
       writeViewportRef.current({
         owner: aimOwnerRef.current,
         topPx: offsetPx,
@@ -394,6 +436,7 @@ export function useFlowChatVirtualizer<T>({
   virtualizer.shouldAdjustScrollPositionOnItemSizeChange = (item, delta) => {
     const scroller = scrollerRef.current;
     if (!scroller) return false;
+    if (isViewportSuspendedRef.current()) return false;
     const beforeScrollTopPx = scroller.scrollTop;
     const beforeScrollHeightPx = scroller.scrollHeight;
     // A row that merely starts above the viewport may still be visible. Its
@@ -506,7 +549,7 @@ export function useFlowChatVirtualizer<T>({
    */
   const measureRenderedItems = useCallback(() => {
     const scroller = scrollerRef.current;
-    if (!scroller) return;
+    if (!scroller || isViewportSuspendedRef.current()) return;
     const elements = scroller.querySelectorAll<HTMLElement>('[data-virtual-index]');
     for (const element of elements) {
       const index = Number(element.getAttribute('data-virtual-index'));

--- a/src/web-ui/src/flow_chat/components/modern/useFlowChatVirtualizer.viewport-rect.test.ts
+++ b/src/web-ui/src/flow_chat/components/modern/useFlowChatVirtualizer.viewport-rect.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Virtualizer } from '@tanstack/react-virtual';
+import { observeFlowChatViewportRect } from './useFlowChatVirtualizer';
+
+class TestResizeObserver {
+  static instances: TestResizeObserver[] = [];
+
+  constructor(private readonly callback: ResizeObserverCallback) {
+    TestResizeObserver.instances.push(this);
+  }
+
+  observe() {}
+
+  unobserve() {}
+
+  emit() {
+    this.callback([], this as unknown as ResizeObserver);
+  }
+}
+
+describe('observeFlowChatViewportRect', () => {
+  afterEach(() => {
+    TestResizeObserver.instances = [];
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps the last positive virtualizer rectangle while a WebView is minimized', () => {
+    vi.stubGlobal('ResizeObserver', TestResizeObserver);
+    let width = 1000;
+    let height = 600;
+    const element = document.createElement('div');
+    Object.defineProperties(element, {
+      offsetWidth: { configurable: true, get: () => width },
+      offsetHeight: { configurable: true, get: () => height },
+    });
+    const instance = {
+      scrollElement: element,
+      targetWindow: window,
+      options: { useAnimationFrameWithResizeObserver: false },
+    } as unknown as Virtualizer<HTMLElement, HTMLElement>;
+    const rectangles: Array<{ width: number; height: number }> = [];
+
+    const cleanup = observeFlowChatViewportRect(instance, rectangle => {
+      rectangles.push(rectangle);
+    });
+
+    expect(rectangles).toEqual([{ width: 1000, height: 600 }]);
+
+    width = 390;
+    height = 0;
+    TestResizeObserver.instances[0].emit();
+    expect(rectangles).toEqual([{ width: 1000, height: 600 }]);
+
+    width = 1000;
+    height = 700;
+    TestResizeObserver.instances[0].emit();
+    expect(rectangles).toEqual([
+      { width: 1000, height: 600 },
+      { width: 1000, height: 700 },
+    ]);
+
+    cleanup?.();
+  });
+});

--- a/src/web-ui/src/flow_chat/components/modern/virtualItemHeightEstimators.ts
+++ b/src/web-ui/src/flow_chat/components/modern/virtualItemHeightEstimators.ts
@@ -232,7 +232,7 @@ export function estimateExploreGroupHeight(
 ): VirtualItemHeightEstimate {
   const isExpanded = context.exploreGroupStates?.has(item.data.groupId)
     ? context.exploreGroupStates.get(item.data.groupId)
-    : !item.data.wasCutByCritical;
+    : false;
   const contentHeight = item.data.allItems.reduce<number>(
     (total, flowItem) => total + estimateFlowItemHeight(flowItem as AnyFlowItem, context).heightPx,
     0,

--- a/src/web-ui/src/flow_chat/components/modern/virtualItemIdentity.ts
+++ b/src/web-ui/src/flow_chat/components/modern/virtualItemIdentity.ts
@@ -1,0 +1,19 @@
+import type { VirtualItem } from '../../store/modernFlowChatStore';
+
+/** Stable identity shared by React, the virtualizer and viewport snapshots. */
+export function getVirtualItemStableKey(item: VirtualItem): string {
+  switch (item.type) {
+    case 'user-message':
+    case 'user-steering-message':
+      return `${item.type}:${item.turnId}:${item.data.id}`;
+    case 'model-round':
+      return `${item.type}:${item.turnId}:${item.data.id}`;
+    case 'explore-group':
+      return `${item.type}:${item.turnId}:${item.data.groupId}`;
+    case 'turn-completion-notice':
+      return `${item.type}:${item.turnId}:${item.data.reasonCode}`;
+    case 'turn-failure-notice':
+    case 'image-analyzing':
+      return `${item.type}:${item.turnId}`;
+  }
+}

--- a/src/web-ui/src/flow_chat/components/modern/virtualMessageListLayout.ts
+++ b/src/web-ui/src/flow_chat/components/modern/virtualMessageListLayout.ts
@@ -130,7 +130,7 @@ export function describeVirtualItemEstimate(item: VirtualItem): Record<string, u
     return {
       estimateKind: 'explore-group',
       itemCount: item.data.allItems.length,
-      defaultExpanded: !item.data.wasCutByCritical,
+      defaultExpanded: false,
       estimatedHeightPx: estimateVirtualItemHeightByOwner(item).heightPx,
       itemEstimates,
     };

--- a/src/web-ui/src/flow_chat/store/modernFlowChatStore.test.ts
+++ b/src/web-ui/src/flow_chat/store/modernFlowChatStore.test.ts
@@ -24,6 +24,7 @@ vi.mock('../tool-cards/toolCardMetadata', () => ({
     'TerminalControl',
     'SessionControl',
     'ExecControl',
+    'AgentWait',
     'view_image',
     'ReadCanvas',
     'ControlHub',
@@ -660,6 +661,110 @@ describe('sessionToVirtualItems explore grouping', () => {
           expect.objectContaining({ id: 'tool-1' }),
           expect.objectContaining({ id: 'tool-2', status: 'running' }),
         ],
+      },
+    });
+  });
+
+  it('keeps the explore tail open while a later round is still provisional', () => {
+    const firstRound = makeRound({ id: 'round-1' });
+    const provisionalRound = (items: ModelRound['items']): ModelRound => makeRound({
+      id: 'round-2',
+      items,
+      isStreaming: true,
+      isComplete: false,
+      status: 'streaming',
+    });
+
+    const makeSessionWithRounds = (round: ModelRound) => makeSession({
+      sessionId: `provisional-tail-${round.items.length}`,
+      dialogTurns: [{
+        id: 'turn-1',
+        sessionId: 'session-1',
+        userMessage: {
+          id: 'user-1',
+          content: 'Help',
+          timestamp: 900,
+        },
+        modelRounds: [firstRound, round],
+        status: 'processing',
+        startTime: 900,
+      }],
+    });
+
+    const thinkingOnly = sessionToVirtualItems(makeSessionWithRounds(
+      provisionalRound([{
+        id: 'thinking-2',
+        type: 'thinking',
+        content: 'Waiting for the next action',
+        isStreaming: true,
+        isCollapsed: false,
+        timestamp: 1002,
+        status: 'streaming',
+      }]),
+    ));
+    expect(thinkingOnly[1]).toMatchObject({
+      type: 'explore-group',
+      data: {
+        wasCutByCritical: false,
+        isGroupStreaming: false,
+      },
+    });
+
+    const thinkingAndText = sessionToVirtualItems(makeSessionWithRounds(
+      provisionalRound([
+        {
+          id: 'thinking-2',
+          type: 'thinking',
+          content: 'Waiting for the next action',
+          isStreaming: true,
+          isCollapsed: false,
+          timestamp: 1002,
+          status: 'streaming',
+        },
+        {
+          id: 'text-2',
+          type: 'text',
+          content: 'I am checking the background agent.',
+          isStreaming: true,
+          timestamp: 1003,
+          status: 'streaming',
+        },
+      ]),
+    ));
+    expect(thinkingAndText[1]).toMatchObject({
+      type: 'explore-group',
+      data: { wasCutByCritical: false },
+    });
+
+    const withTool = sessionToVirtualItems(makeSessionWithRounds(
+      provisionalRound([
+        {
+          id: 'thinking-2',
+          type: 'thinking',
+          content: 'Waiting for the next action',
+          isStreaming: true,
+          isCollapsed: false,
+          timestamp: 1002,
+          status: 'streaming',
+        },
+        {
+          id: 'text-2',
+          type: 'text',
+          content: 'I am checking the background agent.',
+          isStreaming: false,
+          timestamp: 1003,
+          status: 'completed',
+        },
+        makeTool('tool-2', 'AgentWait', 'running'),
+      ]),
+    ));
+    expect(withTool[1]).toMatchObject({
+      type: 'explore-group',
+      data: {
+        wasCutByCritical: false,
+        isLastGroupInTurn: true,
+        isGroupStreaming: true,
+        groupId: 'round-1',
       },
     });
   });

--- a/src/web-ui/src/flow_chat/store/modernFlowChatStore.test.ts
+++ b/src/web-ui/src/flow_chat/store/modernFlowChatStore.test.ts
@@ -189,6 +189,32 @@ describe('sessionToVirtualItems explore grouping', () => {
     ]);
   });
 
+  it.each(['completed', 'cancelled', 'rejected', 'error'] as const)(
+    'allows a settled %s round to enter an explore group',
+    (status) => {
+      const session = makeSession({
+        sessionId: `terminal-explore-${status}`,
+        dialogTurns: [{
+          id: 'turn-1',
+          sessionId: `terminal-explore-${status}`,
+          userMessage: {
+            id: 'user-1',
+            content: 'Help',
+            timestamp: 900,
+          },
+          modelRounds: [makeRound({ status, isStreaming: false, isComplete: true })],
+          status: 'processing',
+          startTime: 900,
+        }],
+      });
+
+      expect(sessionToVirtualItems(session).map(item => item.type)).toEqual([
+        'user-message',
+        'explore-group',
+      ]);
+    },
+  );
+
   it.each(['Bash', 'Git', 'ExecCommand', 'TodoWrite', 'ContextCompression', 'Skill', 'SessionMessage'])(
     'keeps conditionally important %s rounds visible',
     (toolName) => {
@@ -591,7 +617,7 @@ describe('sessionToVirtualItems explore grouping', () => {
     });
   });
 
-  it('keeps trailing explore groups expanded while the turn is still processing', () => {
+  it('projects a settled explore group at the tail without treating it as critical', () => {
     const session = makeSession({
       dialogTurns: [{
         id: 'turn-1',
@@ -618,7 +644,7 @@ describe('sessionToVirtualItems explore grouping', () => {
     });
   });
 
-  it('keeps an active collapsible tool in the same trailing explore group', () => {
+  it('keeps an active collapsible tool out of explore groups until its round settles', () => {
     const session = makeSession({
       sessionId: 'active-tool-session',
       dialogTurns: [{
@@ -648,24 +674,24 @@ describe('sessionToVirtualItems explore grouping', () => {
 
     const items = sessionToVirtualItems(session);
 
-    expect(items.map(item => item.type)).toEqual(['user-message', 'explore-group']);
+    expect(items.map(item => item.type)).toEqual(['user-message', 'explore-group', 'model-round']);
     expect(items[1]).toMatchObject({
       type: 'explore-group',
+      data: { groupId: 'round-1', allItems: [
+        expect.objectContaining({ id: 'text-1' }),
+        expect.objectContaining({ id: 'tool-1' }),
+      ] },
+    });
+    expect(items[2]).toMatchObject({
+      type: 'model-round',
       data: {
-        groupId: 'round-1',
-        isGroupStreaming: true,
-        isLastGroupInTurn: true,
-        wasCutByCritical: false,
-        allItems: [
-          expect.objectContaining({ id: 'text-1' }),
-          expect.objectContaining({ id: 'tool-1' }),
-          expect.objectContaining({ id: 'tool-2', status: 'running' }),
-        ],
+        id: 'round-2',
+        items: [expect.objectContaining({ id: 'tool-2', status: 'running' })],
       },
     });
   });
 
-  it('keeps the explore tail open while a later round is still provisional', () => {
+  it('defers explore grouping until a round reaches a terminal state', () => {
     const firstRound = makeRound({ id: 'round-1' });
     const provisionalRound = (items: ModelRound['items']): ModelRound => makeRound({
       id: 'round-2',
@@ -702,13 +728,8 @@ describe('sessionToVirtualItems explore grouping', () => {
         status: 'streaming',
       }]),
     ));
-    expect(thinkingOnly[1]).toMatchObject({
-      type: 'explore-group',
-      data: {
-        wasCutByCritical: false,
-        isGroupStreaming: false,
-      },
-    });
+    expect(thinkingOnly.map(item => item.type)).toEqual(['user-message', 'explore-group', 'model-round']);
+    expect(thinkingOnly[2]).toMatchObject({ type: 'model-round', data: { id: 'round-2' } });
 
     const thinkingAndText = sessionToVirtualItems(makeSessionWithRounds(
       provisionalRound([
@@ -731,10 +752,8 @@ describe('sessionToVirtualItems explore grouping', () => {
         },
       ]),
     ));
-    expect(thinkingAndText[1]).toMatchObject({
-      type: 'explore-group',
-      data: { wasCutByCritical: false },
-    });
+    expect(thinkingAndText.map(item => item.type)).toEqual(['user-message', 'explore-group', 'model-round']);
+    expect(thinkingAndText[2]).toMatchObject({ type: 'model-round', data: { id: 'round-2' } });
 
     const withTool = sessionToVirtualItems(makeSessionWithRounds(
       provisionalRound([
@@ -758,18 +777,42 @@ describe('sessionToVirtualItems explore grouping', () => {
         makeTool('tool-2', 'AgentWait', 'running'),
       ]),
     ));
-    expect(withTool[1]).toMatchObject({
+    expect(withTool.map(item => item.type)).toEqual(['user-message', 'explore-group', 'model-round']);
+    expect(withTool[2]).toMatchObject({
+      type: 'model-round',
+      data: {
+        id: 'round-2',
+        items: expect.arrayContaining([expect.objectContaining({ id: 'tool-2', status: 'running' })]),
+      },
+    });
+
+    const settled = sessionToVirtualItems(makeSessionWithRounds(makeRound({
+      id: 'round-2',
+      items: [
+        {
+          id: 'thinking-2',
+          type: 'thinking',
+          content: 'Waiting for the next action',
+          isStreaming: false,
+          isCollapsed: false,
+          timestamp: 1002,
+          status: 'completed',
+        },
+        makeTextItem('text-2', 'I am checking the background agent.'),
+        makeTool('tool-2', 'AgentWait', 'completed'),
+      ],
+    })));
+    expect(settled.map(item => item.type)).toEqual(['user-message', 'explore-group']);
+    expect(settled[1]).toMatchObject({
       type: 'explore-group',
       data: {
-        wasCutByCritical: false,
-        isLastGroupInTurn: true,
-        isGroupStreaming: true,
         groupId: 'round-1',
+        allItems: expect.arrayContaining([expect.objectContaining({ id: 'tool-2' })]),
       },
     });
   });
 
-  it('merges a just-completed collapsible tool immediately, with no wall-clock window', () => {
+  it('groups a settled collapsible tool immediately, with no wall-clock window', () => {
     // The projection must not depend on Date.now(): a time-dependent
     // classification needs a timer to re-run it, and that timer restructures
     // and remounts the round long after the data settled.
@@ -802,10 +845,25 @@ describe('sessionToVirtualItems explore grouping', () => {
 
     // 200ms after the tool finished — inside the old 1s transient window.
     vi.setSystemTime(10_200);
-    const justFinished = sessionToVirtualItems(makeJustCompletedSession(true));
+    const stillStreaming = sessionToVirtualItems(makeJustCompletedSession(true));
 
-    expect(justFinished.map(item => item.type)).toEqual(['user-message', 'explore-group']);
-    expect(justFinished[1]).toMatchObject({
+    expect(stillStreaming.map(item => item.type)).toEqual(['user-message', 'explore-group', 'model-round']);
+    expect(stillStreaming[2]).toMatchObject({
+      type: 'model-round',
+      data: { id: 'round-2' },
+    });
+
+    // Well past the old window: time alone cannot group an active round.
+    vi.setSystemTime(999_999);
+    const longStreaming = sessionToVirtualItems(makeJustCompletedSession(true));
+    expect(longStreaming.map(item => item.type)).toEqual(stillStreaming.map(item => item.type));
+
+    // The terminal transition, rather than elapsed time, makes the round
+    // eligible to merge into the existing explore group.
+    vi.setSystemTime(10_200);
+    const settled = sessionToVirtualItems(makeJustCompletedSession(false));
+    expect(settled.map(item => item.type)).toEqual(['user-message', 'explore-group']);
+    expect(settled[1]).toMatchObject({
       type: 'explore-group',
       data: {
         groupId: 'round-1',
@@ -816,19 +874,9 @@ describe('sessionToVirtualItems explore grouping', () => {
         ],
       },
     });
-
-    // Well past the old window: same projection, so no timer can change it.
-    vi.setSystemTime(999_999);
-    const longSettled = sessionToVirtualItems(makeJustCompletedSession(true));
-    expect(longSettled.map(item => item.type)).toEqual(justFinished.map(item => item.type));
-
-    // Streaming vs settled must not change the projection either.
-    vi.setSystemTime(10_200);
-    const notStreaming = sessionToVirtualItems(makeJustCompletedSession(false));
-    expect(notStreaming.map(item => item.type)).toEqual(justFinished.map(item => item.type));
   });
 
-  it('keeps explore-group identity while thinking narrative is still streaming', () => {
+  it('moves a collapsible round into an explore group only after streaming settles', () => {
     const streamingThinking = {
       id: 'thinking-1',
       type: 'thinking' as const,
@@ -862,10 +910,10 @@ describe('sessionToVirtualItems explore grouping', () => {
     });
 
     const streamingItems = sessionToVirtualItems(session);
-    expect(streamingItems.map(item => item.type)).toEqual(['user-message', 'explore-group']);
+    expect(streamingItems.map(item => item.type)).toEqual(['user-message', 'model-round']);
     expect(streamingItems[1]).toMatchObject({
-      type: 'explore-group',
-      data: { groupId: 'round-1' },
+      type: 'model-round',
+      data: { id: 'round-1' },
     });
 
     const settledSession = makeSession({
@@ -888,14 +936,14 @@ describe('sessionToVirtualItems explore grouping', () => {
       }],
     });
     const settledItems = sessionToVirtualItems(settledSession);
-    expect(settledItems.map(item => item.type)).toEqual(streamingItems.map(item => item.type));
+    expect(settledItems.map(item => item.type)).toEqual(['user-message', 'explore-group']);
     expect(settledItems[1]).toMatchObject({
       type: 'explore-group',
       data: { groupId: 'round-1' },
     });
   });
 
-  it('keeps the same explore group id when a completed trailing tool is merged in', () => {
+  it('keeps the existing group id when a trailing round settles and joins it', () => {
     const baseTurn = {
       id: 'turn-1',
       sessionId: 'stable-group-session',
@@ -942,8 +990,8 @@ describe('sessionToVirtualItems explore grouping', () => {
     const activeItems = sessionToVirtualItems(activeSession);
     const completedItems = sessionToVirtualItems(completedSession);
 
-    expect(activeItems.map(item => item.type)).toEqual(['user-message', 'explore-group']);
-    expect(completedItems.map(item => item.type)).toEqual(activeItems.map(item => item.type));
+    expect(activeItems.map(item => item.type)).toEqual(['user-message', 'explore-group', 'model-round']);
+    expect(completedItems.map(item => item.type)).toEqual(['user-message', 'explore-group']);
     expect(activeItems[1]).toMatchObject({
       type: 'explore-group',
       data: {
@@ -951,9 +999,12 @@ describe('sessionToVirtualItems explore grouping', () => {
         allItems: [
           expect.objectContaining({ id: 'text-1' }),
           expect.objectContaining({ id: 'tool-1' }),
-          expect.objectContaining({ id: 'tool-2', status: 'running' }),
         ],
       },
+    });
+    expect(activeItems[2]).toMatchObject({
+      type: 'model-round',
+      data: { id: 'round-2', items: [expect.objectContaining({ id: 'tool-2', status: 'running' })] },
     });
     expect(completedItems[1]).toMatchObject({
       type: 'explore-group',
@@ -968,7 +1019,7 @@ describe('sessionToVirtualItems explore grouping', () => {
     });
   });
 
-  it('keeps the latest completed trailing explore group expanded', () => {
+  it('keeps the latest completed explore group marked as the trailing group', () => {
     const session = makeSession();
 
     const items = sessionToVirtualItems(session);
@@ -1049,7 +1100,7 @@ describe('sessionToVirtualItems explore grouping', () => {
     });
   });
 
-  it('auto-collapses non-trailing explore groups during an active turn', () => {
+  it('keeps an active trailing round outside earlier settled explore groups', () => {
     const session = makeSession({
       dialogTurns: [{
         id: 'turn-1',
@@ -1080,18 +1131,22 @@ describe('sessionToVirtualItems explore grouping', () => {
     const items = sessionToVirtualItems(session);
     const exploreGroups = items.filter(item => item.type === 'explore-group');
 
-    expect(exploreGroups).toHaveLength(2);
+    expect(items.map(item => item.type)).toEqual([
+      'user-message',
+      'explore-group',
+      'model-round',
+      'model-round',
+    ]);
+    expect(exploreGroups).toHaveLength(1);
     expect(exploreGroups[0]).toMatchObject({
       data: {
         isLastGroupInTurn: false,
         wasCutByCritical: true,
       },
     });
-    expect(exploreGroups[1]).toMatchObject({
-      data: {
-        isLastGroupInTurn: true,
-        wasCutByCritical: false,
-      },
+    expect(items[3]).toMatchObject({
+      type: 'model-round',
+      data: { id: 'round-3' },
     });
   });
 

--- a/src/web-ui/src/flow_chat/store/modernFlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/modernFlowChatStore.ts
@@ -178,6 +178,34 @@ function isExploreOnlyRound(round: ModelRound): boolean {
 }
 
 /**
+ * Identify a hard boundary that should close an earlier explore group.
+ *
+ * Streaming thinking/text is provisional: the same round can still receive a
+ * collapsible tool and become part of the live explore tail. Only a
+ * non-collapsible tool, explicit grouping suppression, or settled visible
+ * narrative should cut the preceding group.
+ */
+function isHardCriticalRound(round: ModelRound): boolean {
+  if (round.renderHints?.disableExploreGrouping === true) {
+    return true;
+  }
+
+  const hasNonCollapsibleTool = round.items.some(item => (
+    item.type === 'tool' && !isCollapsibleTool(getEffectiveToolName(item as FlowToolItem))
+  ));
+  if (hasNonCollapsibleTool) {
+    return true;
+  }
+
+  return (
+    isTerminalRoundStatus(round.status) &&
+    !round.isStreaming &&
+    round.isComplete !== false &&
+    hasTrailingVisibleText(round)
+  );
+}
+
+/**
  * Compute statistics for a single ModelRound
  */
 function computeRoundStats(round: ModelRound): ExploreGroupStats {
@@ -468,8 +496,11 @@ export function sessionToVirtualItems(session: Session | null): VirtualItem[] {
           // Turn completion by itself is deliberately not a cut. The live tail
           // keeps its final action visible; a later conversation item is what
           // makes the group compact.
+          const hasHardCriticalRoundAfter = rounds
+            .slice(group.endIndex + 1)
+            .some(isHardCriticalRound);
           const wasCutByCritical =
-            group.endIndex < rounds.length - 1 ||
+            hasHardCriticalRoundAfter ||
             options.collapseTrailingExploreGroup;
 
           const groupId = group.rounds[0]?.id ?? `explore-group-${turn.id}-${group.startIndex}`;

--- a/src/web-ui/src/flow_chat/store/modernFlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/modernFlowChatStore.ts
@@ -43,10 +43,9 @@ export interface ExploreGroupData {
   isGroupStreaming: boolean;
   isLastGroupInTurn: boolean;
   /**
-   * True when this group is no longer the tail of the turn — a non-explore
-   * (critical) round, a top-level notice, or a newer dialog turn has superseded
-   * the group. Turn completion alone does not cut the live tail. The renderer
-   * uses this to trigger one-shot auto-collapse.
+   * True when this group is no longer the tail of the turn. Expansion no
+   * longer depends on this flag; it is retained for bounded tail presentation
+   * and projection diagnostics.
    */
   wasCutByCritical: boolean;
 }
@@ -122,13 +121,10 @@ interface ModernFlowChatState {
  * Check if ModelRound is explore-only (contains only exploration tools)
  * Explore-only rounds can be collapsed
  * 
- * Key check: must contain at least one collapsible tool OR be a pure thinking round.
- * Pure thinking rounds (thinking without critical tools) are merged into
- * adjacent explore groups to reduce visual noise from standalone "thinking N chars" lines.
+ * Key check: the round must be fully settled and contain at least one
+ * collapsible tool. Active rounds stay as ordinary model-round items so a
+ * running tool is never hidden inside a collapsed explore group.
  * Pure text rounds (like final replies) should not be collapsed.
- * Explore-capable rounds keep explore-group identity from the first render so
- * settling a streaming narrative cannot swap virtual-item keys and remount the pane.
- * Typewriter remount risk is covered by useTypewriter(replayOnMount: false).
  */
 function hasTrailingVisibleText(round: ModelRound): boolean {
   for (let index = round.items.length - 1; index >= 0; index -= 1) {
@@ -149,6 +145,15 @@ function hasTrailingVisibleText(round: ModelRound): boolean {
 
 function isExploreOnlyRound(round: ModelRound): boolean {
   if (!round.items || round.items.length === 0) return false;
+
+  if (
+    !isTerminalRoundStatus(round.status) ||
+    round.isStreaming ||
+    !round.isComplete ||
+    round.items.some(isActiveFlowItem)
+  ) {
+    return false;
+  }
 
   if (round.renderHints?.disableExploreGrouping === true) {
     return false;
@@ -175,34 +180,6 @@ function isExploreOnlyRound(round: ModelRound): boolean {
   });
   
   return allItemsCollapsible;
-}
-
-/**
- * Identify a hard boundary that should close an earlier explore group.
- *
- * Streaming thinking/text is provisional: the same round can still receive a
- * collapsible tool and become part of the live explore tail. Only a
- * non-collapsible tool, explicit grouping suppression, or settled visible
- * narrative should cut the preceding group.
- */
-function isHardCriticalRound(round: ModelRound): boolean {
-  if (round.renderHints?.disableExploreGrouping === true) {
-    return true;
-  }
-
-  const hasNonCollapsibleTool = round.items.some(item => (
-    item.type === 'tool' && !isCollapsibleTool(getEffectiveToolName(item as FlowToolItem))
-  ));
-  if (hasNonCollapsibleTool) {
-    return true;
-  }
-
-  return (
-    isTerminalRoundStatus(round.status) &&
-    !round.isStreaming &&
-    round.isComplete !== false &&
-    hasTrailingVisibleText(round)
-  );
 }
 
 /**
@@ -459,9 +436,8 @@ export function sessionToVirtualItems(session: Session | null): VirtualItem[] {
         }
       });
 
-      // Always flush the trailing explore group so its container is stable
-      // throughout streaming. The wasCutByCritical flag distinguishes "still
-      // growing" from "permanently closed" for the renderer.
+      // Flush the trailing settled explore group. Active rounds never enter a
+      // group and remain visible as ordinary model-round items until terminal.
       if (currentGroup) {
         tempGroups.push(currentGroup);
       }
@@ -480,27 +456,8 @@ export function sessionToVirtualItems(session: Session | null): VirtualItem[] {
           const isGroupStreaming = group.rounds.some(
             r => r.isStreaming || r.items.some(isActiveFlowItem),
           );
-          // A group is "cut by critical" when it is no longer the tail of the
-          // turn. Two conditions cover all cases:
-          //   1. group.endIndex < rounds.length - 1: there are rounds after
-          //      this group's last round — they could be non-explore (critical)
-          //      rounds OR another explore group. Either way this group is no
-          //      longer the tail.
-          //      NOTE: checking !isLastGroup alone is NOT sufficient because
-          //      tempGroups only contains explore-only groups; a following
-          //      critical round (e.g. TodoWrite) is invisible to tempGroups
-          //      yet still sits after this group in the rounds array.
-          //   2. the caller knows another top-level item follows this segment
-          //      (user steering, a completion/failure notice, or a newer turn).
-          //
-          // Turn completion by itself is deliberately not a cut. The live tail
-          // keeps its final action visible; a later conversation item is what
-          // makes the group compact.
-          const hasHardCriticalRoundAfter = rounds
-            .slice(group.endIndex + 1)
-            .some(isHardCriticalRound);
           const wasCutByCritical =
-            hasHardCriticalRoundAfter ||
+            group.endIndex < rounds.length - 1 ||
             options.collapseTrailingExploreGroup;
 
           const groupId = group.rounds[0]?.id ?? `explore-group-${turn.id}-${group.startIndex}`;

--- a/src/web-ui/src/flow_chat/tool-cards/ExecProcessToolCard.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/ExecProcessToolCard.scss
@@ -1,6 +1,71 @@
 @use './TerminalToolCard.scss';
 
 .exec-process-tool-card {
+  .exec-process-output-frame {
+    position: relative;
+    overflow: hidden;
+    width: 100%;
+    box-sizing: border-box;
+
+    &--compact {
+      height: 86px;
+    }
+
+    &--expanded {
+      height: 320px;
+    }
+
+    > .terminal-execution-output,
+    > .terminal-result-output {
+      height: 100%;
+      min-height: 0;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+    }
+
+    > .terminal-execution-output.terminal-waiting {
+      min-height: 0;
+    }
+
+    .exec-process-output-copy-region,
+    .terminal-xterm-output,
+    .terminal-output-renderer,
+    .terminal-output-pre {
+      height: 100% !important;
+      max-height: 100% !important;
+    }
+
+    .exec-process-output-placeholder {
+      height: 100%;
+    }
+  }
+
+  .exec-process-stable-body {
+    // The shared terminal footer extends into the expanded container's bottom
+    // padding via its negative bottom margin. Exclude that padding from the
+    // compact body's minimum height so the footer reaches the card edge.
+    min-height: calc(
+      86px + 27.7px - var(--bf-appearance-token-flowchat-card-expanded-pad-y)
+    );
+  }
+
+  .exec-process-result-footer {
+    min-height: 27.7px;
+    height: 27.7px;
+    overflow: hidden;
+    box-sizing: border-box;
+    flex-wrap: nowrap;
+    align-items: center;
+  }
+
+  .exec-process-footer-placeholder {
+    display: block;
+    width: 100%;
+    height: 1em;
+  }
+
   .exec-process-output-copy-region {
     position: relative;
   }

--- a/src/web-ui/src/flow_chat/tool-cards/ExecProcessToolCardView.appearance.ts
+++ b/src/web-ui/src/flow_chat/tool-cards/ExecProcessToolCardView.appearance.ts
@@ -7,6 +7,8 @@ export const execProcessToolCardAppearanceDescriptor: AppearanceSurfaceDescripto
     { id: 'result' }, { id: 'footer' }, { id: 'waiting' }, { id: 'error' },
   ],
   states: [
+    { id: 'active', selector: { kind: 'self', suffix: '[data-bf-state~="active"]' } },
+    { id: 'completed', selector: { kind: 'self', suffix: '[data-bf-state~="completed"]' } },
     { id: 'cancelled', selector: { kind: 'self', suffix: '[data-bf-state~="cancelled"]' } },
     { id: 'waiting', selector: { kind: 'self', suffix: '[data-bf-state~="waiting"]' } },
     { id: 'error', selector: { kind: 'self', suffix: '[data-bf-state~="error"]' } },

--- a/src/web-ui/src/flow_chat/tool-cards/ExecProcessToolCardView.test.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/ExecProcessToolCardView.test.tsx
@@ -54,10 +54,10 @@ vi.mock('../../component-library', () => ({
 vi.mock('@/tools/terminal/components/LazyTerminalOutputRenderer', () => ({
   LazyTerminalOutputRenderer: React.forwardRef<
     { getVisibleText: () => string },
-    { content: string; className?: string }
-  >(({ content, className }, ref) => {
+    { content: string; className?: string; maxRows?: number }
+  >(({ content, className, maxRows }, ref) => {
     React.useImperativeHandle(ref, () => ({ getVisibleText: () => content }), [content]);
-    return <pre className={className}>{content}</pre>;
+    return <pre className={className} data-max-rows={maxRows}>{content}</pre>;
   }),
 }));
 
@@ -165,6 +165,9 @@ describe('ExecProcessToolCardView', () => {
     expect(container.querySelector('.compact-tool-card')).toBeNull();
     expect(container.textContent).toContain('Waiting for confirmation');
     expect(container.textContent).not.toContain('Receiving parameters...');
+    expect(container.querySelector('.exec-process-output-frame')).not.toBeNull();
+    expect(container.querySelector('.terminal-result-footer')).not.toBeNull();
+    expect(container.querySelector('.terminal-xterm-output')).toBeNull();
   });
 
   it('retains a just-completed tail result during the grace period', () => {
@@ -199,6 +202,7 @@ describe('ExecProcessToolCardView', () => {
     expect(container.querySelector('.base-tool-card')).not.toBeNull();
     expect(container.querySelector('.compact-tool-card')).toBeNull();
     expect(container.textContent).toContain('All tests passed');
+    expect(container.querySelector('.terminal-xterm-output')?.getAttribute('data-max-rows')).toBe('4');
 
     act(() => {
       root.render(
@@ -214,6 +218,73 @@ describe('ExecProcessToolCardView', () => {
     expect(container.querySelector('.base-tool-card')).not.toBeNull();
     expect(container.querySelector('.base-tool-card.expanded')).toBeNull();
     expect(container.querySelector('.compact-tool-card')).toBeNull();
+    expect(container.querySelector('.terminal-xterm-output')?.getAttribute('data-max-rows')).toBe('4');
+  });
+
+  it('uses the expanded output preview after a completed card is manually expanded', () => {
+    const resultModel: ExecProcessCardModel = {
+      ...model,
+      resultOutput: 'All tests passed',
+    };
+
+    act(() => {
+      root.render(
+        <ExecProcessToolCardView
+          toolItem={toolItem('completed')}
+          model={resultModel}
+        />,
+      );
+    });
+
+    act(() => {
+      container.querySelector<HTMLElement>('.base-tool-card')?.click();
+    });
+
+    expect(container.querySelector('.terminal-xterm-output')?.getAttribute('data-max-rows')).toBe('15');
+  });
+
+  it('keeps the output frame and footer mounted while content changes', () => {
+    const streamingItem = {
+      ...toolItem('running'),
+      _progressLogs: ['line 1\nline 2\nline 3\nline 4'],
+    } as FlowToolItem;
+    const completedModel: ExecProcessCardModel = {
+      ...model,
+      resultOutput: 'line 1\nline 2\nline 3\nline 4',
+      workdir: 'E:/workspace',
+      exitCode: 0,
+      wallTimeSeconds: 1.25,
+    };
+
+    act(() => {
+      root.render(<ExecProcessToolCardView toolItem={toolItem('running')} model={model} />);
+    });
+    const frameBeforeOutput = container.querySelector('.exec-process-output-frame');
+    const footerBeforeOutput = container.querySelector('.terminal-result-footer');
+    expect(frameBeforeOutput?.getAttribute('data-output-rows')).toBe('4');
+    expect(footerBeforeOutput?.getAttribute('data-filled')).toBe('false');
+    expect(container.querySelector('.terminal-xterm-output')).toBeNull();
+
+    act(() => {
+      root.render(<ExecProcessToolCardView toolItem={streamingItem} model={model} />);
+    });
+    expect(container.querySelector('.exec-process-output-frame')).toBe(frameBeforeOutput);
+    expect(container.querySelector('.terminal-result-footer')).toBe(footerBeforeOutput);
+    expect(container.querySelector('.terminal-xterm-output')).not.toBeNull();
+
+    act(() => {
+      root.render(
+        <ExecProcessToolCardView
+          toolItem={toolItem('completed')}
+          model={completedModel}
+          isLastItem
+        />,
+      );
+    });
+    expect(container.querySelector('.exec-process-output-frame')).toBe(frameBeforeOutput);
+    expect(container.querySelector('.terminal-result-footer')).toBe(footerBeforeOutput);
+    expect(footerBeforeOutput?.getAttribute('data-filled')).toBe('true');
+    expect(container.querySelector('.exec-process-output-frame')?.getAttribute('data-output-rows')).toBe('4');
   });
 
   it('collapses a completed tail result when the grace period expires', () => {

--- a/src/web-ui/src/flow_chat/tool-cards/ExecProcessToolCardView.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/ExecProcessToolCardView.tsx
@@ -106,7 +106,11 @@ function formatSecondsAsMs(seconds?: number): number | undefined {
     : undefined;
 }
 
-function renderFooter(model: ExecProcessCardModel, t: (key: string, options?: Record<string, unknown>) => string) {
+function renderFooter(
+  model: ExecProcessCardModel,
+  t: (key: string, options?: Record<string, unknown>) => string,
+  statusText?: { label: string; className: string },
+) {
   const hasFooter =
     model.workdir ||
     model.sessionId != null ||
@@ -115,12 +119,18 @@ function renderFooter(model: ExecProcessCardModel, t: (key: string, options?: Re
     model.remote != null ||
     model.tty != null;
 
-  if (!hasFooter) {
-    return null;
-  }
-
   return (
-    <div data-bf-component="exec-process-tool-card" data-bf-part="footer" className="terminal-result-footer exec-process-result-footer">
+    <div
+      data-bf-component="exec-process-tool-card"
+      data-bf-part="footer"
+      data-filled={hasFooter || statusText ? 'true' : 'false'}
+      className="terminal-result-footer exec-process-result-footer"
+    >
+      {statusText && (
+        <span className={`terminal-cancelled-text ${statusText.className}`}>
+          {statusText.label}
+        </span>
+      )}
       {model.workdir && (
         <span className="exec-process-footer-group exec-process-footer-group--workdir">
           <span className="terminal-result-label">{t('toolCards.terminal.workingDirectory')}</span>
@@ -156,6 +166,9 @@ function renderFooter(model: ExecProcessCardModel, t: (key: string, options?: Re
             </span>
           )}
         </span>
+      )}
+      {!hasFooter && !statusText && (
+        <span className="exec-process-footer-placeholder" aria-hidden="true">&nbsp;</span>
       )}
     </div>
   );
@@ -245,7 +258,15 @@ export const ExecProcessToolCardView: React.FC<ExecProcessToolCardViewProps> = (
     isLastItem === true &&
     isCollapsedStatus(status) &&
     !userToggledRef.current;
-  const maxRows = isRunning || compactSettledPreview
+  // Keep auto-managed completed cards on the compact preview through the
+  // collapse animation. A manually expanded card remains eligible for the
+  // full output preview.
+  const keepAutoCompletionPreview =
+    status === 'completed' &&
+    !userToggledRef.current;
+  const keepCompactCompletionPreview =
+    keepAutoCompletionPreview || compactSettledPreview;
+  const maxRows = isRunning || keepCompactCompletionPreview
     ? EXEC_OUTPUT_STREAMING_MAX_ROWS
     : EXEC_OUTPUT_EXPANDED_MAX_ROWS;
 
@@ -413,69 +434,73 @@ export const ExecProcessToolCardView: React.FC<ExecProcessToolCardViewProps> = (
   );
 
   const renderExpandedContent = () => {
-    if (status === 'completed') {
-      return (
-        <div data-bf-component="exec-process-tool-card" data-bf-part="result" className="terminal-result-container">
-          {model.resultOutput ? (
-            <div className="terminal-result-output" data-bf-component="exec-process-tool-card" data-bf-part="output">
-              {renderOutputWithCopyAction(model.resultOutput, { formatSessionPreview: true })}
+    const outputText = getOutputText();
+    const waitingText = (() => {
+      if (outputText) {
+        return null;
+      }
+      if (rejectedOrCancelled) {
+        return null;
+      }
+      if (status === 'completed') {
+        return model.resultNoticeText ?? model.noOutputText;
+      }
+      if (status === 'pending_confirmation') {
+        return t('toolCards.approval.waiting');
+      }
+      if (isParamsStreaming) {
+        return t('toolCards.terminal.receivingParams');
+      }
+      if (isRunning) {
+        return model.waitingText;
+      }
+      return null;
+    })();
+    const footerStatus = rejectedOrCancelled
+      ? {
+          label: t(cancelledStatusLabelKey),
+          className: cancelledStatusClassName,
+        }
+      : undefined;
+    const outputFrameClassName = [
+      'exec-process-output-frame',
+      keepCompactCompletionPreview || isRunning
+        ? 'exec-process-output-frame--compact'
+        : 'exec-process-output-frame--expanded',
+    ].join(' ');
+
+    return (
+      <div
+        data-bf-component="exec-process-tool-card"
+        data-bf-part="result"
+        data-bf-state={rejectedOrCancelled ? 'cancelled' : status === 'completed' ? 'completed' : 'active'}
+        className={`terminal-result-container exec-process-stable-body${rejectedOrCancelled ? ' cancelled' : ''}`}
+      >
+        <div className={outputFrameClassName} data-output-rows={maxRows}>
+          {outputText ? (
+            <div
+              className={status === 'completed' || rejectedOrCancelled ? 'terminal-result-output' : 'terminal-execution-output'}
+              data-bf-component="exec-process-tool-card"
+              data-bf-part="output"
+            >
+              {renderOutputWithCopyAction(outputText)}
             </div>
-          ) : model.resultNoticeText ? (
-            <div className="terminal-execution-output terminal-waiting exec-process-result-notice" data-bf-component="exec-process-tool-card" data-bf-part="waiting" data-bf-state="waiting">
-              <span className="waiting-text">{model.resultNoticeText}</span>
+          ) : waitingText ? (
+            <div
+              className={`terminal-execution-output terminal-waiting${status === 'completed' ? ' exec-process-empty-output' : ''}${model.resultNoticeText ? ' exec-process-result-notice' : ''}`}
+              data-bf-component="exec-process-tool-card"
+              data-bf-part="waiting"
+              data-bf-state="waiting"
+            >
+              <span className="waiting-text">{waitingText}</span>
             </div>
           ) : (
-            <div className="terminal-execution-output terminal-waiting exec-process-empty-output" data-bf-component="exec-process-tool-card" data-bf-part="waiting" data-bf-state="waiting">
-              <span className="waiting-text">{model.noOutputText}</span>
-            </div>
+            <div className="exec-process-output-placeholder" aria-hidden="true" />
           )}
-          {renderFooter(model, t)}
         </div>
-      );
-    }
-
-    if (rejectedOrCancelled) {
-      return (
-        <div data-bf-component="exec-process-tool-card" data-bf-part="result" data-bf-state="cancelled" className="terminal-result-container cancelled">
-          {liveOutput && (
-            <div className="terminal-result-output" data-bf-component="exec-process-tool-card" data-bf-part="output">
-              {renderOutputWithCopyAction(liveOutput)}
-            </div>
-          )}
-          <div className="terminal-result-footer" data-bf-component="exec-process-tool-card" data-bf-part="footer">
-            <span className="terminal-cancelled-text">
-              {t(cancelledStatusLabelKey)}
-            </span>
-          </div>
-        </div>
-      );
-    }
-
-    if (status === 'pending_confirmation') {
-      return (
-        <div data-bf-component="exec-process-tool-card" data-bf-part="waiting" data-bf-state="waiting" className="terminal-execution-output terminal-waiting">
-          <span className="waiting-text">{t('toolCards.approval.waiting')}</span>
-        </div>
-      );
-    }
-
-    if (liveOutput && isRunning) {
-      return (
-        <div data-bf-component="exec-process-tool-card" data-bf-part="output" className="terminal-execution-output">
-          {renderOutputWithCopyAction(liveOutput)}
-        </div>
-      );
-    }
-
-    if (isRunning || isParamsStreaming) {
-      return (
-        <div data-bf-component="exec-process-tool-card" data-bf-part="waiting" data-bf-state="waiting" className="terminal-execution-output terminal-waiting">
-          <span className="waiting-text">{isParamsStreaming ? t('toolCards.terminal.receivingParams') : model.waitingText}</span>
-        </div>
-      );
-    }
-
-    return null;
+        {renderFooter(model, t, footerStatus)}
+      </div>
+    );
   };
 
   const renderErrorContent = () => {

--- a/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.test.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.test.tsx
@@ -889,11 +889,12 @@ describe('FileOperationToolCard', () => {
     });
 
     expect(container.querySelector('[data-testid="chat-file-change-preview"]')).not.toBeNull();
-    expect(mocks.codePreviewProps).toHaveLength(1);
-    expect(mocks.codePreviewProps[0]).toMatchObject({
+    expect(mocks.codePreviewProps).toHaveLength(2);
+    expect(mocks.codePreviewProps.at(-1)).toMatchObject({
       isStreaming: false,
       maxHeight: 88,
     });
+    expect(mocks.inlineDiffPreviewProps).toHaveLength(0);
 
     await act(async () => {
       root.render(
@@ -908,6 +909,7 @@ describe('FileOperationToolCard', () => {
 
     // Auto-collapse animates closed; wait for SmoothHeightCollapse to unmount children.
     expect(container.querySelector('[data-testid="chat-file-change-card"]')?.getAttribute('data-expanded')).toBe('false');
+    expect(mocks.inlineDiffPreviewProps).toHaveLength(0);
     await act(async () => {
       await new Promise((resolve) => {
         window.setTimeout(resolve, 350);

--- a/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.tsx
@@ -509,16 +509,30 @@ export const FileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
   }, [sessionId, toolCall?.id, status, isFailed]);
 
   const isLoading = status === 'preparing' || status === 'streaming' || status === 'running';
+  /*
+   * Auto-managed completed cards must keep their compact streaming preview
+   * from the first completed render through the collapse commit. Waiting for
+   * the grace-period layout effect to set its state briefly renders the large
+   * diff preview, and follow-output can treat that transient height as output.
+   * A manually expanded card marks itself as user-owned and still gets the
+   * full diff preview.
+   */
+  const keepAutoCompletionPreview =
+    status === 'completed' &&
+    !isFailed &&
+    !userToggledContentRef.current;
+  const keepCompactCompletionPreview =
+    retainLiveCompletionPreview || keepAutoCompletionPreview;
   const shouldUseExpandedDiffPreviewHeight =
     status === 'completed' &&
     isContentExpanded &&
-    !retainLiveCompletionPreview;
+    !keepCompactCompletionPreview;
   const keepLiveEditPreview =
-    retainLiveCompletionPreview &&
+    keepCompactCompletionPreview &&
     toolItem.toolName === 'Edit' &&
     Boolean(newStringContent);
   const keepLiveWritePreview =
-    retainLiveCompletionPreview &&
+    keepCompactCompletionPreview &&
     toolItem.toolName === 'Write' &&
     Boolean(contentPreview);
   const previewVariant = useMemo(() => {

--- a/src/web-ui/src/flow_chat/tool-cards/TodoWriteDisplay.test.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/TodoWriteDisplay.test.tsx
@@ -32,7 +32,10 @@ const config: ToolCardConfig = {
   displayMode: 'standard',
 };
 
-function createTodoWriteItem(status: 'pending' | 'in_progress'): FlowToolItem {
+function createTodoWriteItem(
+  status: 'pending' | 'in_progress',
+  todos = [{ id: 'todo-a', content: 'Implement change', status }],
+): FlowToolItem {
   return {
     id: 'todo-tool-a',
     type: 'tool',
@@ -41,7 +44,7 @@ function createTodoWriteItem(status: 'pending' | 'in_progress'): FlowToolItem {
     status: 'streaming',
     isParamsStreaming: true,
     partialParams: {
-      todos: [{ id: 'todo-a', content: 'Implement change', status }],
+      todos,
     },
     toolCall: {
       id: 'todo-tool-a',
@@ -127,5 +130,22 @@ describe('TodoWriteDisplay expansion', () => {
       vi.advanceTimersByTime(FLOWCHAT_COLLAPSE_DURATION_MS);
     });
     expect(container.querySelector('.todo-expanded-body')).toBeNull();
+  });
+
+  it('shows the first task when all tasks are pending', () => {
+    act(() => {
+      root.render(
+        <TodoWriteDisplay
+          toolItem={createTodoWriteItem('pending', [
+            { id: 'todo-a', content: 'First task', status: 'pending' },
+            { id: 'todo-b', content: 'Second task', status: 'pending' },
+          ])}
+          config={config}
+        />,
+      );
+    });
+
+    expect(container.querySelector('.todo-header-current')?.textContent).toBe('First task');
+    expect(container.querySelector('.todo-header-more')).toBeNull();
   });
 });

--- a/src/web-ui/src/flow_chat/tool-cards/TodoWriteDisplay.test.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/TodoWriteDisplay.test.tsx
@@ -67,7 +67,7 @@ describe('createTodoRenderItems', () => {
   });
 });
 
-describe('TodoWriteDisplay automatic collapse', () => {
+describe('TodoWriteDisplay expansion', () => {
   let container: HTMLDivElement;
   let root: Root;
 
@@ -98,19 +98,31 @@ describe('TodoWriteDisplay automatic collapse', () => {
     vi.restoreAllMocks();
   });
 
-  it('lets completed todo content collapse through normal layout state', () => {
+  it('stays collapsed during streaming until the user expands it', () => {
     vi.useFakeTimers();
+    act(() => {
+      root.render(<TodoWriteDisplay toolItem={createTodoWriteItem('pending')} config={config} />);
+    });
+    expect(container.querySelector('.todo-expanded-body')).toBeNull();
+
+    act(() => {
+      root.render(<TodoWriteDisplay toolItem={createTodoWriteItem('in_progress')} config={config} />);
+    });
+    expect(container.querySelector('.todo-expanded-body')).toBeNull();
+
+    act(() => {
+      container.querySelector<HTMLElement>('[data-testid="todo-write-toggle"]')?.click();
+    });
+    expect(container.querySelector('.todo-expanded-body')).not.toBeNull();
+
     act(() => {
       root.render(<TodoWriteDisplay toolItem={createTodoWriteItem('pending')} config={config} />);
     });
     expect(container.querySelector('.todo-expanded-body')).not.toBeNull();
 
     act(() => {
-      root.render(<TodoWriteDisplay toolItem={createTodoWriteItem('in_progress')} config={config} />);
+      container.querySelector<HTMLElement>('[data-testid="todo-write-toggle"]')?.click();
     });
-
-    expect(container.querySelector('.todo-expanded-body')).not.toBeNull();
-
     act(() => {
       vi.advanceTimersByTime(FLOWCHAT_COLLAPSE_DURATION_MS);
     });

--- a/src/web-ui/src/flow_chat/tool-cards/TodoWriteDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/TodoWriteDisplay.tsx
@@ -2,7 +2,7 @@
  * Tool card for TodoWrite.
  */
 
-import React, { useState, useMemo, useCallback, useLayoutEffect } from 'react';
+import React, { useState, useMemo, useCallback } from 'react';
 import { ListTodo, CheckCircle2, Circle, XCircle } from 'lucide-react';
 import { TaskRunningIndicator } from '../../component-library';
 import { useTranslation } from 'react-i18next';
@@ -23,7 +23,7 @@ export const TodoWriteDisplay: React.FC<ToolCardProps> = ({
   const { t } = useTranslation('flow-chat');
   const { status, toolResult, partialParams, isParamsStreaming } = toolItem;
 
-  const [expandedState, setExpandedState] = useState<boolean | null>(null);
+  const [isExpanded, setIsExpanded] = useState(false);
   const toolId = toolItem.id;
   const { cardRootRef, applyExpandedState } = useToolCardHeightContract({
     toolId,
@@ -73,32 +73,6 @@ export const TodoWriteDisplay: React.FC<ToolCardProps> = ({
         ? { status: 'completed' as const, defaultIcon: 'status' as const }
         : { status, defaultIcon: 'tool' as const };
 
-  const desiredAutomaticExpanded = useMemo(() => {
-    return inProgressTasks.length === 0 && todosToDisplay.length > 0 && !isAllCompleted;
-  }, [inProgressTasks.length, todosToDisplay.length, isAllCompleted]);
-  const [automaticExpanded, setAutomaticExpanded] = useState(desiredAutomaticExpanded);
-
-  // Keep the currently rendered automatic state for one layout commit. This
-  // lets the shared height contract publish the collapse intent before the
-  // second synchronous commit removes the expanded body.
-  useLayoutEffect(() => {
-    if (expandedState !== null || automaticExpanded === desiredAutomaticExpanded) {
-      return;
-    }
-    applyExpandedState(
-      automaticExpanded,
-      desiredAutomaticExpanded,
-      setAutomaticExpanded,
-    );
-  }, [
-    applyExpandedState,
-    automaticExpanded,
-    desiredAutomaticExpanded,
-    expandedState,
-  ]);
-
-  const isExpanded = expandedState ?? automaticExpanded;
-
   const isLoading = status === 'preparing' || status === 'streaming' || status === 'running';
 
   const displayMode = config?.displayMode || 'compact';
@@ -110,9 +84,7 @@ export const TodoWriteDisplay: React.FC<ToolCardProps> = ({
 
   const handleToggleExpanded = useCallback(() => {
     if (todosToDisplay.length === 0) return;
-    applyExpandedState(isExpanded, !isExpanded, (nextExpanded) => {
-      setExpandedState(nextExpanded);
-    });
+    applyExpandedState(isExpanded, !isExpanded, setIsExpanded);
   }, [applyExpandedState, isExpanded, todosToDisplay.length]);
 
   const renderTodoItem = (todo: TodoLike, key: string) => (
@@ -246,6 +218,7 @@ export const TodoWriteDisplay: React.FC<ToolCardProps> = ({
         isExpanded={isExpanded && hasTodos}
         onClick={hasTodos ? handleToggleExpanded : undefined}
         clickable={hasTodos}
+        toggleTestId="todo-write-toggle"
         className="todo-write-card"
         header={
           <CompactToolCardHeader

--- a/src/web-ui/src/flow_chat/tool-cards/TodoWriteDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/TodoWriteDisplay.tsx
@@ -79,8 +79,14 @@ export const TodoWriteDisplay: React.FC<ToolCardProps> = ({
 
   const currentDisplayTask = useMemo(() => {
     if (inProgressTasks.length > 0) return inProgressTasks[0];
+    if (
+      todosToDisplay.length > 0 &&
+      todosToDisplay.every((todo) => todo.status === 'pending')
+    ) {
+      return todosToDisplay[0];
+    }
     return null;
-  }, [inProgressTasks]);
+  }, [inProgressTasks, todosToDisplay]);
 
   const handleToggleExpanded = useCallback(() => {
     if (todosToDisplay.length === 0) return;

--- a/src/web-ui/src/infrastructure/config/components/AIModelConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/AIModelConfig.tsx
@@ -29,7 +29,7 @@ import { ConfigPageHeader, ConfigPageLayout, ConfigPageContent, ConfigPageSectio
 import DefaultModelConfig from './DefaultModelConfig';
 import SubagentModelConfig from './SubagentModelConfig';
 import SessionTitleConfig from './SessionTitleConfig';
-import ReasoningConfigPanel from './ReasoningConfigPanel';
+import ReasoningConfigPanel, { type ReasoningConfigApplyResult } from './ReasoningConfigPanel';
 import { createLogger } from '@/shared/utils/logger';
 import { translateConnectionTestMessage } from '@/shared/utils/aiConnectionTestMessages';
 import { i18nService } from '@/infrastructure/i18n';
@@ -60,6 +60,10 @@ interface SelectedModelDraft {
   maxTokens?: number;
   reasoning: ReasoningConfig;
   reasoningProjectionCatalog?: ReasoningCatalogBinding;
+  reasoningProjectionSnapshot?: {
+    catalog: ReasoningCatalogBinding;
+    projection?: ReasoningCatalogProjection | null;
+  };
 }
 
 interface ProviderGroup {
@@ -795,6 +799,17 @@ const AIModelConfig: React.FC = () => {
     ))
   );
 
+  const resolveDraftReasoningProjection = (draft: SelectedModelDraft) => {
+    const snapshot = draft.reasoningProjectionSnapshot;
+    if (snapshot && reasoningCatalogBindingsEqual(draft.reasoning.catalog, snapshot.catalog)) {
+      return snapshot.projection ?? undefined;
+    }
+    if (reasoningCatalogBindingsEqual(draft.reasoning.catalog, draft.reasoningProjectionCatalog)) {
+      return resolveDraftCatalogEntry(draft)?.reasoning;
+    }
+    return undefined;
+  };
+
   const toggleSelectedModelCardExpanded = useCallback((draftKey: string) => {
     setExpandedModelCards(prev => {
       const next = new Set(prev);
@@ -1522,19 +1537,19 @@ const AIModelConfig: React.FC = () => {
         notification.warning(t('messages.contextWindowTooSmall'));
         return;
       }
-      if (draftsToSave.some(draft => (
-        validateReasoningConfig(
-          draft.reasoning,
-          reasoningCatalogBindingsEqual(
-            draft.reasoning.catalog,
-            draft.reasoningProjectionCatalog,
-          )
-            ? resolveDraftCatalogEntry(draft)?.reasoning?.presets
-                ?.filter(preset => preset.source !== 'model_config')
-                .map(preset => preset.id)
-            : [],
-        ) !== null
-      ))) {
+      const reasoningValidationResults = draftsToSave.map(draft => ({
+        modelName: draft.modelName,
+        reasoning: draft.reasoning,
+        projectionCatalog: draft.reasoningProjectionCatalog,
+        snapshotCatalog: draft.reasoningProjectionSnapshot?.catalog,
+        generatedPresetIds: resolveDraftReasoningProjection(draft)?.presets
+          ?.filter(preset => preset.source !== 'model_config')
+          .map(preset => preset.id) ?? [],
+      })).map(entry => ({
+        ...entry,
+        validationError: validateReasoningConfig(entry.reasoning, entry.generatedPresetIds),
+      }));
+      if (reasoningValidationResults.some(entry => entry.validationError !== null)) {
         notification.warning(t('messages.invalidReasoningPresets'));
         return;
       }
@@ -2219,11 +2234,7 @@ const AIModelConfig: React.FC = () => {
             const categoryLabel = categoryCompactLabels[draft.category] ?? draft.category;
             const canToggleExpand = selectedModelDrafts.length > 1;
             const modelDisplayName = draft.modelName;
-            const catalogEntry = resolveDraftCatalogEntry(draft);
-            const reasoningProjection = reasoningCatalogBindingsEqual(
-              draft.reasoning.catalog,
-              draft.reasoningProjectionCatalog,
-            ) ? catalogEntry?.reasoning : undefined;
+            const reasoningProjection = resolveDraftReasoningProjection(draft);
 
             return (
               <div
@@ -3092,11 +3103,7 @@ const AIModelConfig: React.FC = () => {
     ? selectedModelDrafts.find(draft => draft.key === reasoningPanelDraftKey)
     : undefined;
   const reasoningPanelProjection = reasoningPanelDraft
-    && reasoningCatalogBindingsEqual(
-      reasoningPanelDraft.reasoning.catalog,
-      reasoningPanelDraft.reasoningProjectionCatalog,
-    )
-    ? resolveDraftCatalogEntry(reasoningPanelDraft)?.reasoning
+    ? resolveDraftReasoningProjection(reasoningPanelDraft)
     : undefined;
   const reasoningPanelProjectionRequest = reasoningPanelDraft && editingConfig
     ? {
@@ -3752,9 +3759,14 @@ const AIModelConfig: React.FC = () => {
                 || reasoningPanelProjectionRequest.provider
               : undefined}
             onCancel={() => setReasoningPanelDraftKey(null)}
-            onApply={(reasoning) => {
+            onApply={(result: ReasoningConfigApplyResult) => {
               updateModelDraft(reasoningPanelDraft.modelName, {
-                reasoning,
+                reasoning: result.reasoning,
+                reasoningProjectionCatalog: result.projectionCatalog,
+                reasoningProjectionSnapshot: {
+                  catalog: result.projectionCatalog,
+                  projection: result.projection,
+                },
               });
               setReasoningPanelDraftKey(null);
             }}

--- a/src/web-ui/src/infrastructure/config/components/ReasoningConfigPanel.test.tsx
+++ b/src/web-ui/src/infrastructure/config/components/ReasoningConfigPanel.test.tsx
@@ -3,7 +3,7 @@
 import React, { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { ReasoningConfig } from '../types';
+import type { ReasoningCatalogProjection, ReasoningConfig } from '../types';
 import ReasoningConfigPanel from './ReasoningConfigPanel';
 
 const { projectReasoningCatalog } = vi.hoisted(() => ({
@@ -107,8 +107,12 @@ describe('ReasoningConfigPanel', () => {
     act(() => apply?.click());
 
     expect(onApply).toHaveBeenCalledWith({
-      catalog: { source: 'auto' },
-      presets: [{ id: 'custom', actions: [{ type: 'effort', value: 'high' }] }],
+      reasoning: {
+        catalog: { source: 'auto' },
+        presets: [{ id: 'custom', actions: [{ type: 'effort', value: 'high' }] }],
+      },
+      projectionCatalog: { source: 'auto' },
+      projection: undefined,
     });
   });
 
@@ -135,15 +139,17 @@ describe('ReasoningConfigPanel', () => {
   });
 
   it('refreshes generated presets after an explicit models.dev binding change', async () => {
+    const onApply = vi.fn();
+    const modelsDevProjection: ReasoningCatalogProjection = {
+      status: 'known',
+      presets: [
+        { id: 'low', label: 'Low', order: 0, source: 'models_dev', actions: [] },
+        { id: 'high', label: 'High', order: 1, source: 'models_dev', actions: [] },
+      ],
+    };
     projectReasoningCatalog
       .mockResolvedValueOnce({ status: 'unknown', presets: [] })
-      .mockResolvedValueOnce({
-        status: 'known',
-        presets: [
-          { id: 'low', label: 'Low', order: 0, source: 'models_dev', actions: [] },
-          { id: 'high', label: 'High', order: 1, source: 'models_dev', actions: [] },
-        ],
-      });
+      .mockResolvedValueOnce(modelsDevProjection);
 
     await act(async () => root.render(
       <ReasoningConfigPanel
@@ -154,7 +160,7 @@ describe('ReasoningConfigPanel', () => {
           baseUrl: 'https://gateway.example.com/v1',
         }}
         onCancel={vi.fn()}
-        onApply={vi.fn()}
+        onApply={onApply}
       />,
     ));
 
@@ -174,5 +180,18 @@ describe('ReasoningConfigPanel', () => {
     });
     expect(container.querySelector('[data-testid="generated-presets"]')?.textContent)
       .toBe('low,high');
+
+    const apply = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent === 'reasoningPresets.apply');
+    act(() => apply?.click());
+
+    expect(onApply).toHaveBeenCalledWith({
+      reasoning: {
+        catalog: { source: 'models_dev', provider: 'openai', model: 'gpt-test' },
+        presets: [],
+      },
+      projectionCatalog: { source: 'models_dev', provider: 'openai', model: 'gpt-test' },
+      projection: modelsDevProjection,
+    });
   });
 });

--- a/src/web-ui/src/infrastructure/config/components/ReasoningConfigPanel.tsx
+++ b/src/web-ui/src/infrastructure/config/components/ReasoningConfigPanel.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { AlertTriangle } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/component-library';
-import type { ReasoningCatalogProjection, ReasoningConfig } from '../types';
+import type { ReasoningCatalogBinding, ReasoningCatalogProjection, ReasoningConfig } from '../types';
 import type { ModelsDevReasoningCatalog } from '@/infrastructure/api/service-api/AIApi';
 import { aiApi } from '@/infrastructure/api';
 import type { ReasoningCatalogProjectionRequest } from '@/infrastructure/api/service-api/AIApi';
@@ -20,7 +20,13 @@ interface ReasoningConfigPanelProps {
   projectionRequest?: Omit<ReasoningCatalogProjectionRequest, 'reasoning'>;
   requestFormatLabel?: string;
   onCancel: () => void;
-  onApply: (value: ReasoningConfig) => void;
+  onApply: (value: ReasoningConfigApplyResult) => void;
+}
+
+export interface ReasoningConfigApplyResult {
+  reasoning: ReasoningConfig;
+  projectionCatalog: ReasoningCatalogBinding;
+  projection?: ReasoningCatalogProjection | null;
 }
 
 export const ReasoningConfigPanel: React.FC<ReasoningConfigPanelProps> = ({
@@ -134,7 +140,15 @@ export const ReasoningConfigPanel: React.FC<ReasoningConfigPanelProps> = ({
           <Button variant="secondary" onClick={onCancel}>
             {t('actions.cancel')}
           </Button>
-          <Button variant="primary" disabled={invalid} onClick={() => onApply(draft)}>
+          <Button
+            variant="primary"
+            disabled={invalid}
+            onClick={() => onApply({
+              reasoning: draft,
+              projectionCatalog: draft.catalog ?? { source: 'auto' },
+              projection: activeGeneratedProjection,
+            })}
+          >
             {t('reasoningPresets.apply')}
           </Button>
         </div>

--- a/src/web-ui/src/shared/utils/fixedPopoverViewport.ts
+++ b/src/web-ui/src/shared/utils/fixedPopoverViewport.ts
@@ -7,6 +7,11 @@ export const DEFAULT_POPOVER_VIEWPORT_PADDING = 8;
 
 export type FixedPopoverPlacement = 'top' | 'bottom';
 
+// 'start' aligns the menu's left edge with the anchor's left edge; 'end'
+// aligns the right edges instead, for anchors that sit near the window's
+// right side where a start-aligned wide menu would overflow.
+export type FixedPopoverAlignment = 'start' | 'end';
+
 export interface FixedPopoverViewport {
   width: number;
   height: number;
@@ -16,10 +21,12 @@ export interface FixedPopoverPositionOptions {
   gap?: number;
   padding?: number;
   preferredPlacement?: FixedPopoverPlacement;
+  alignment?: FixedPopoverAlignment;
 }
 
 interface FixedPopoverAnchorRect {
   left: number;
+  right?: number;
   top: number;
   bottom: number;
 }
@@ -81,7 +88,14 @@ export function computeFixedPopoverPositionInViewport(
     gap = 6,
     padding = DEFAULT_POPOVER_VIEWPORT_PADDING,
     preferredPlacement = 'bottom',
+    alignment = 'start',
   } = options;
+
+  // Without a measured right edge an end-aligned menu has nothing to align
+  // to, so it degrades to the start edge rather than to a wrong position.
+  const preferredLeft = alignment === 'end' && typeof anchorRect.right === 'number'
+    ? anchorRect.right - menuWidth
+    : anchorRect.left;
 
   return {
     top: clampFixedPopoverTopInViewport(
@@ -93,7 +107,7 @@ export function computeFixedPopoverPositionInViewport(
       padding,
     ),
     left: clampFixedPopoverLeftInViewport(
-      anchorRect.left,
+      preferredLeft,
       menuWidth,
       viewport.width,
       padding,


### PR DESCRIPTION
## Summary

Backports the fixes from `1.0.0-explore` that stand on their own against `main`. Every candidate was applied to a clean worktree and verified there; commits that depend on `1.0.0-explore`-only features stayed out (see below).

**Viewport and scroll stability (flow chat)**
- treat zero-sized WebView2 geometry as a suspension rather than a resize, so minimize/restore no longer rewrites the reader's position
- replace per-frame Turn pinning with a one-shot physical-bottom reveal
- keep inactive scene viewports mounted with stable geometry instead of `hidden`, and restore session-scoped reading positions across scene and session switches
- anchor viewport snapshots to exact virtual-item identity and publish the final snapshot only after restoration completes

**Tool cards**
- keep auto-managed completed file cards on the compact preview through collapse, so transient diff height no longer advances the tail-follow target
- keep the ExecCommand output frame and footer mounted across streaming and automatic collapse
- keep TodoWrite cards collapsed unless the user toggles them, and show the first task when every task is pending
- defer explore grouping until round completion, and keep a provisional streaming tail open

**Model selector**
- anchor the dropdown on the trigger button and align right edges, so a wide model list no longer overflows the window
- pick placement from the available height on each side and cap the menu with `max-height`

**Other**
- release startup overlay focus and mark it inert while hiding, and stop hiding the visible splash screen from assistive technology
- preserve the resolved reasoning projection and its catalog binding when applying presets, so models.dev defaults are no longer rejected as unknown
- detect cargo/rustc per image on Windows with `tasklist /NH` instead of shelling through `cmd.exe`

Three commits needed conflict resolution:
- `keep model menu inside viewport` — the explore SCSS also adopted the capsule composer's type scale; only the scrolling behaviour (`overflow-y`, `overscroll-behavior`, scrollbar) is taken, and `main`'s own surface styling is kept
- `preserve viewport state across switches` — drops the `retainedScenes` test block, which covers a scene-retention feature `main` does not have; the other three assertion updates apply unchanged
- `register ExecProcess lifecycle states` — new here. `stabilize ExecCommand card collapse layout` renders `data-bf-state="active"` and `"completed"`, but their registration lives in an explore commit whose other two hunks track explore-only agent registry and ChatInput behaviour, so only the descriptor entries are carried over

**Deliberately not backported.** Ten minimal-harness / harness-profile fixes (the feature is absent from `main`); three composer-capsule and workspace-strip fixes; the swarm delegation boundary rule (`main` still calls `delegation_policy().spawn_child()`, so the new rule would fail CI); the stale appearance registration cleanup (`main` still references those parts); the agents scene part rename follow-up (`main` still renders `coreGrid`); the execution-tier gating and surface contract alignment. `fix(nav): align session load-more toggle to the row text rail` is also left out: it conflicts across five files against the explore NavPanel layout rework and would need to be rebuilt for `main`'s layout rather than backported.

## Verification

- `pnpm --dir src/web-ui run test:run` — 491 files, 3639 tests, all passing
- `pnpm run lint:web` — clean
- `appearance:contract-audit`, `theme:color-audit`, `motion:audit`, `theme:visual-contract`, `check:core-boundaries`, `i18n:contract:test`, `i18n:audit`, `check:repo-hygiene` — all passing
- `node --test scripts/cargo-target-gc.test.mjs` — 8/8
- `tsc --noEmit` — only the three pre-existing `@/generated/api` errors that `main` also reports without a codegen run

No Rust sources are touched. The Windows `tasklist` path was not exercised on a Windows host; it is covered by the script's unit tests.
