### PR TITLE
perf(app-server): isolate TypeScript generation from RPC

### DIFF
--- a/docs/performance/01-compile-performance.md
+++ b/docs/performance/01-compile-performance.md
@@ -379,6 +379,22 @@ Web 实际引用的 19 个直接类型及其递归导入闭包保持生成内容
 导出文件全部视为兼容面。根 `Cargo.lock` package 集合和版本不变，只从 App Server package
 记录删除不再直接消费的依赖边；`.github`、CI job 和矩阵均不变。
 
+后续在 `6cbb62d08` 基线上继续收敛 protocol 内部闭包：默认 `rpc` feature 保持现有
+JSON-RPC trait、role 和 transport 兼容，独立的 `ts` feature 只编译 wire DTO 与 TS derive，
+不再带入 `agent-client-protocol` 及其 Tokio/RMCP runtime 子图。同一 Windows 主机、两个全新
+`CARGO_TARGET_DIR`、相同 `pnpm --dir src/web-ui run gen:types` 命令的 focused A/B 如下；
+package 数按 `normal,build` 边、`{p}` package identity 去重，因此不与上方三平台
+`normal,build,dev` 表混用：
+
+| Protocol TS focused 指标 | 变更前 | 变更后 | 收敛 |
+|---|---:|---:|---:|
+| unique normal/build package | 192 | 94 | -98（-51.0%） |
+| 冷 `gen:types` wall-clock | 34.41 s | 26.78 s | -7.63 s（-22.2%） |
+
+两侧生成目录的 48 个文件逐文件 SHA-256 差异为 0；默认 RPC 编译路径另行通过 focused check。
+该 wall-clock 只代表同机单次冷样本，不外推为 CI 或完整产品构建收益。根 `Cargo.lock`、
+`.github`、CI job 和矩阵均不变。
+
 ### 3.4 CI 与本地验证
 
 - 现有 CI 覆盖 workspace check、Core/Desktop lib、平台敏感 owner 测试和独立 runtime/CLI 验证。四次成功的纯 Web `main` 样本中，两个 CLI job 与三个 Rust Build Check job 没有消费变更，却合计占用 `58.9–68.2` runner-minutes；最长单 job 为 `17.3–22.7` 分钟。runner-minutes 为五个 job 的 `completed_at - started_at` 之和，不等于可直接相加的用户等待时间。
@@ -393,7 +409,7 @@ Web 实际引用的 19 个直接类型及其递归导入闭包保持生成内容
 - 当前 CI 增加一个无依赖安装的影响分类 job 和一个稳定结果汇总 job，不增加平台矩阵。只有活动路径全部属于 `src/web-ui/**` 才跳过上述五个 Rust/CLI job；仓库根目录/`docs/**` Markdown 与 `png/**` 作为已知中性路径。其他嵌套 Markdown 可能被 Rust 编译期嵌入，因此 workflow 不再宽泛忽略全部 Markdown，它们与 `.github/**`、`scripts/**`、其他 Web 产品、Rust/build 输入和未知路径一样运行完整矩阵；diff 不可验证时也 fail-closed。PR 按 merge-base range 分类，`main` push 按 before/head direct range 分类。
 - Desktop 的 Rust 测试不再编译期读取 Web API 源码；Desktop 注册与 Web 调用分别在各自 owner 验证。影响分类在 diff 前扫描 Git 跟踪的全仓 Rust 源码；除精确登记的既有测试 fixture 外，任何非注释 `web-ui` 路径 token 都直接使分类失败，因此目录嵌入、分段路径和间接读取也不能绕过。Frontend job 另行执行 boundary contract tests 与真实 repository check。
 - 昂贵的 Rust/CLI 子 job 在 concurrency cancellation 时不再启动；轻量汇总始终读取上游 result，把分类失败、取消、异常 skipped 和 matrix 失败统一报告为失败。该汇总目前只是在已触发 CI run 内提供稳定结果；workflow 仍忽略 `png/**`，接入全局 required check 前必须先补齐所有受保护提交的 trigger 覆盖。
-- 本 PR 自身修改 CI、脚本和 Rust 边界，因此按设计必须运行完整 Rust/CLI matrix。跳过后的实际 runner-minutes 与等待时间要等合入后的首个纯 Web PR/main run 再记录；当前只能报告历史可避免成本和目标调度行为，不能把目标值表述为已实测收益。
+- 引入该 CI 收敛的变更自身修改了 CI、脚本和 Rust 边界，因此当时按设计运行完整 Rust/CLI matrix。跳过后的实际 runner-minutes 与等待时间要用合入后的纯 Web PR/main run 记录；在取得样本前只能报告历史可避免成本和目标调度行为，不能把目标值表述为已实测收益。
 - CI 不负责穷举所有测试；新增验证只有具备独立 owner、平台矩阵或失败归因价值时才进入既有流水线，否则由最近模块的 focused command 维护。
 - 本地从 owner 文档的最小 package/target/feature 入口开始；仅名称过滤不能阻止无关 target 编译。
 - CI 收敛必须先有多次 job/step 耗时、缓存状态和失败历史；`SKIPPED`、未触发或只编译未运行都不算通过证据。
@@ -417,6 +433,7 @@ Web 实际引用的 19 个直接类型及其递归导入闭包保持生成内容
 | Services 测试 | 两个服务 crate 使用显式 target；选中闭包少 8 个 integration executable，进程/feature/external-system 边界保持独立 |
 | External Sources 测试 | 四个 adapter/assembly crate 从 22 个 target 收敛到 7 个；MCP、插件服务和脚本 runtime 继续独立 |
 | Contracts/AI/Assembly 测试 | 五个 crate 从 28 个 target 收敛到 10 个；AI loopback 与纯协议、Product Domains 各 owner feature 保持独立 |
+| App Server TS 闭包 | protocol 默认保持 RPC 兼容，独立 `ts` 导出不再编译 ACP/Tokio/RMCP runtime 子图；生成文件哈希不变 |
 | 未使用直接依赖 | 删除 CLI/Desktop/Core/MiniApp Market/Page Function 的失效直接边；保留 Syntect 实际 Oniguruma 后端，根 lock 只减 7 个 package |
 
 内置 Agent 内容已经移到无第三方依赖的 `bitfun-agent-content`，减少了 Core build-script 工作；
@@ -431,7 +448,7 @@ Web 实际引用的 19 个直接类型及其递归导入闭包保持生成内容
 |---|---|
 | CI 收敛 | 观察首个合入后的纯 Web PR/main 样本，核对五个 Rust/CLI job 均为 skipped、稳定汇总通过且 Frontend Build 正常；只有出现新的同类浪费和充分证据时才扩大范围 |
 | Desktop 截图后端 | 新候选同时满足三平台行为等价、区域捕获无性能回退、系统依赖可 feature-gate，且根 lock package 不增加 |
-| App Server / Server | 观察 protocol 单一 schema owner 合入后的 Frontend Build 样本；没有新的生产 owner 或稳定行为收益前，不继续拆 handler 路径 |
+| App Server / Server | 观察 protocol TS/RPC 闭包隔离合入后的 Frontend Build 样本；没有新的生产 owner 或稳定行为收益前，不继续拆 handler 路径 |
 | 其他产品入口重型 capability | 证明入口不消费该能力，具备 typed unsupported/fallback 行为，并能让一个真实重依赖子图退出 |
 | 重复 native/sys 库版本 | 同一 owner 能升级收敛且三平台打包/ABI 有证据；不因版本数字重复强行 patch |
 

--- a/scripts/check-core-boundaries.test.mjs
+++ b/scripts/check-core-boundaries.test.mjs
@@ -70,7 +70,7 @@ const MODULES = [
 
 const TEST_ROOT = join('C:', 'repo');
 
-test('App Server TypeScript capability is owned by the protocol crate', () => {
+test('App Server TypeScript capability is owned by the protocol crate and independent from RPC', () => {
   const appServerTs = coreClosedFeatureProfileRules.find(
     (rule) => rule.manifestPath === 'src/crates/interfaces/app-server/Cargo.toml'
       && rule.featureName === 'ts',
@@ -80,10 +80,31 @@ test('App Server TypeScript capability is owned by the protocol crate', () => {
   ]);
   assert.equal(appServerTs?.exact, true);
 
-  const protocolTs = coreClosedFeatureProfileRules.find(
-    (rule) => rule.manifestPath === 'src/crates/interfaces/app-server-protocol/Cargo.toml'
-      && rule.featureName === 'ts',
+  const protocolProfiles = new Map(
+    coreClosedFeatureProfileRules
+      .filter(
+        (rule) => rule.manifestPath
+          === 'src/crates/interfaces/app-server-protocol/Cargo.toml',
+      )
+      .map((rule) => [rule.featureName, rule]),
   );
+
+  const protocolDefault = protocolProfiles.get('default');
+  assert.deepEqual(protocolDefault?.requiredFeatureRefs, ['rpc']);
+  assert.equal(protocolDefault?.exact, true);
+
+  const protocolRpc = protocolProfiles.get('rpc');
+  assert.deepEqual(protocolRpc?.requiredFeatureRefs, ['dep:agent-client-protocol']);
+  assert.equal(protocolRpc?.exact, true);
+
+  const protocolOptionalOwners = optionalDependencyFeatureOwnerRules.find(
+    (rule) => rule.crateName === 'app-server-protocol',
+  );
+  assert.deepEqual(protocolOptionalOwners?.dependencies, [
+    { depName: 'agent-client-protocol', ownerFeatures: ['rpc'] },
+  ]);
+
+  const protocolTs = protocolProfiles.get('ts');
   assert.deepEqual(protocolTs?.requiredFeatureRefs, [
     'bitfun-core-types/ts',
     'bitfun-product-domains/ts',

--- a/scripts/core-boundaries/rules/feature-rules.mjs
+++ b/scripts/core-boundaries/rules/feature-rules.mjs
@@ -30,6 +30,14 @@ export const guardedEmptyInternalDefaultManifestPaths = [
 
 export const optionalDependencyFeatureOwnerRules = [
   {
+    crateName: 'app-server-protocol',
+    reason:
+      'App Server Protocol must keep the ACP runtime dependency behind its RPC integration',
+    dependencies: [
+      { depName: 'agent-client-protocol', ownerFeatures: ['rpc'] },
+    ],
+  },
+  {
     crateName: 'services-core',
     reason:
       'services-core optional implementation dependencies must stay behind their exact owner capability',
@@ -757,6 +765,20 @@ export const coreClosedFeatureProfileRules = [
     requiredFeatureRefs: ['bitfun-app-server-protocol/ts'],
     exact: true,
     reason: 'App Server must delegate TypeScript wire export to the protocol owner',
+  },
+  {
+    manifestPath: 'src/crates/interfaces/app-server-protocol/Cargo.toml',
+    featureName: 'default',
+    requiredFeatureRefs: ['rpc'],
+    exact: true,
+    reason: 'App Server Protocol must preserve RPC compatibility for default consumers',
+  },
+  {
+    manifestPath: 'src/crates/interfaces/app-server-protocol/Cargo.toml',
+    featureName: 'rpc',
+    requiredFeatureRefs: ['dep:agent-client-protocol'],
+    exact: true,
+    reason: 'App Server Protocol RPC bindings must own the ACP runtime dependency',
   },
   {
     manifestPath: 'src/crates/interfaces/app-server-protocol/Cargo.toml',

--- a/src/crates/interfaces/app-server-protocol/Cargo.toml
+++ b/src/crates/interfaces/app-server-protocol/Cargo.toml
@@ -9,7 +9,7 @@ description = "Behavior-light wire contracts and roles for the BitFun App Server
 name = "bitfun_app_server_protocol"
 
 [dependencies]
-agent-client-protocol = { workspace = true }
+agent-client-protocol = { workspace = true, optional = true }
 bitfun-events = { path = "../../contracts/events" }
 bitfun-core-types = { path = "../../contracts/core-types" }
 bitfun-product-domains = { path = "../../contracts/product-domains", features = ["external-sources"] }
@@ -19,7 +19,8 @@ serde_json = { workspace = true }
 ts-rs = { workspace = true, optional = true }
 
 [features]
-default = []
+default = ["rpc"]
+rpc = ["dep:agent-client-protocol"]
 ts = [
     "dep:ts-rs",
     "bitfun-core-types/ts",

--- a/src/crates/interfaces/app-server-protocol/src/config.rs
+++ b/src/crates/interfaces/app-server-protocol/src/config.rs
@@ -3,6 +3,7 @@
 //! These payloads intentionally contain only wire-owned data. Server adapters
 //! translate them to the configuration service's domain request/result types.
 
+#[cfg(feature = "rpc")]
 use agent_client_protocol::{JsonRpcRequest, JsonRpcResponse};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
@@ -21,37 +22,44 @@ pub struct AgentProfileView {
     pub enabled_user_skills: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "config/getAgentProfileConfigs", response = GetAgentProfileConfigsResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "config/getAgentProfileConfigs", response = GetAgentProfileConfigsResponse))]
 pub struct GetAgentProfileConfigsMessage {}
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct GetAgentProfileConfigsResponse {
     pub profiles: HashMap<String, AgentProfileView>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
-#[request(method = "config/getAgentProfileConfig", response = GetAgentProfileConfigResponse)]
+#[cfg_attr(feature = "rpc", request(method = "config/getAgentProfileConfig", response = GetAgentProfileConfigResponse))]
 pub struct GetAgentProfileConfigMessage {
     pub agent_id: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct GetAgentProfileConfigResponse(pub AgentProfileView);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "config/getModelConfigs", response = GetModelConfigsResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "config/getModelConfigs", response = GetModelConfigsResponse))]
 pub struct GetModelConfigsMessage {}
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct GetModelConfigsResponse {
     pub models: Vec<serde_json::Value>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
 #[serde(rename_all = "camelCase")]
-#[request(method = "config/getConfig", response = GetConfigResponse)]
+#[cfg_attr(feature = "rpc", request(method = "config/getConfig", response = GetConfigResponse))]
 pub struct GetConfigMessage {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
@@ -59,56 +67,65 @@ pub struct GetConfigMessage {
     pub skip_retry_on_not_found: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct GetConfigResponse(pub serde_json::Value);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
 #[serde(rename_all = "camelCase")]
-#[request(method = "config/getConfigs", response = GetConfigsResponse)]
+#[cfg_attr(feature = "rpc", request(method = "config/getConfigs", response = GetConfigsResponse))]
 pub struct GetConfigsMessage {
     pub paths: Vec<String>,
     #[serde(default, skip_serializing_if = "skip_if_false")]
     pub skip_retry_on_not_found: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct GetConfigsResponse {
     pub configs: BTreeMap<String, serde_json::Value>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
 #[serde(rename_all = "camelCase")]
-#[request(method = "config/setConfig", response = SetConfigResponse)]
+#[cfg_attr(feature = "rpc", request(method = "config/setConfig", response = SetConfigResponse))]
 pub struct SetConfigMessage {
     pub path: String,
     pub value: serde_json::Value,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct SetConfigResponse {}
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 #[serde(rename_all = "camelCase")]
-#[request(method = "config/setAgentProfileConfig", response = SetAgentProfileConfigResponse)]
+#[cfg_attr(feature = "rpc", request(method = "config/setAgentProfileConfig", response = SetAgentProfileConfigResponse))]
 pub struct SetAgentProfileConfigMessage {
     pub agent_id: String,
     pub config: serde_json::Value,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub struct SetAgentProfileConfigResponse(pub AgentProfileView);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 #[serde(rename_all = "camelCase")]
-#[request(method = "config/resetAgentProfileConfig", response = ResetAgentProfileConfigResponse)]
+#[cfg_attr(feature = "rpc", request(method = "config/resetAgentProfileConfig", response = ResetAgentProfileConfigResponse))]
 pub struct ResetAgentProfileConfigMessage {
     pub agent_id: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub struct ResetAgentProfileConfigResponse(pub AgentProfileView);
 
@@ -131,9 +148,10 @@ pub struct SaveCloudSpeechConfigRequest {
     pub api_key: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
-#[request(method = "config/saveCloudSpeechConfig", response = SaveCloudSpeechConfigResponse)]
+#[cfg_attr(feature = "rpc", request(method = "config/saveCloudSpeechConfig", response = SaveCloudSpeechConfigResponse))]
 pub struct SaveCloudSpeechConfigMessage {
     pub request: SaveCloudSpeechConfigRequest,
 }
@@ -146,15 +164,18 @@ pub struct SaveCloudSpeechConfigResult {
     pub created: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub struct SaveCloudSpeechConfigResponse(pub SaveCloudSpeechConfigResult);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "config/validateConfig", response = ValidateConfigResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "config/validateConfig", response = ValidateConfigResponse))]
 pub struct ValidateConfigMessage {}
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct ValidateConfigResponse(pub serde_json::Value);
 
 #[cfg(test)]

--- a/src/crates/interfaces/app-server-protocol/src/lib.rs
+++ b/src/crates/interfaces/app-server-protocol/src/lib.rs
@@ -6,12 +6,18 @@
 //! Wire schemas live under [`schemas`] and are grouped into modules named after
 //! their JSON-RPC method domain; shared event envelopes remain in
 //! [`schemas::event`].
+//! The default `rpc` feature attaches ACP JSON-RPC traits and exposes the role
+//! and transport helpers. The independent `ts` feature exports wire DTOs
+//! without compiling that runtime integration.
 
 pub mod config;
+#[cfg(feature = "rpc")]
 pub mod role;
 pub mod schemas;
+#[cfg(feature = "rpc")]
 pub mod transport;
 
+#[cfg(feature = "rpc")]
 pub use role::{AppClient, AppServer};
 // Keep the established public domain paths while the schema sources live in a
 // single physical directory.

--- a/src/crates/interfaces/app-server-protocol/src/schemas/account.rs
+++ b/src/crates/interfaces/app-server-protocol/src/schemas/account.rs
@@ -1,5 +1,6 @@
 //! Account and settings-sync App Server wire schemas.
 
+#[cfg(feature = "rpc")]
 use agent_client_protocol::{JsonRpcRequest, JsonRpcResponse};
 use serde::{Deserialize, Serialize};
 
@@ -7,8 +8,9 @@ pub use bitfun_product_domains::account::{
     AccountDevice, AccountInfo, SettingsSyncProgress, SettingsSyncStatus,
 };
 
-#[derive(Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "account/snapshot", response = AccountSnapshotResponse)]
+#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "account/snapshot", response = AccountSnapshotResponse))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct AccountSnapshotRequest {
     pub workspace_path: String,
@@ -23,7 +25,8 @@ impl std::fmt::Debug for AccountSnapshotRequest {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 #[serde(rename_all = "camelCase")]
 pub struct AccountSnapshotResponse {
     pub logged_in: bool,
@@ -35,8 +38,9 @@ pub struct AccountSnapshotResponse {
     pub sync: SettingsSyncProgress,
 }
 
-#[derive(Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "account/login", response = AccountLoginResponse)]
+#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "account/login", response = AccountLoginResponse))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct AccountLoginRequest {
     pub operation_id: String,
@@ -57,7 +61,8 @@ impl std::fmt::Debug for AccountLoginRequest {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 #[serde(rename_all = "camelCase")]
 pub struct AccountLoginResponse {
     pub user_id: String,
@@ -66,8 +71,9 @@ pub struct AccountLoginResponse {
     pub status_message: String,
 }
 
-#[derive(Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "account/finalizeLogin", response = AccountSnapshotResponse)]
+#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "account/finalizeLogin", response = AccountSnapshotResponse))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct AccountFinalizeLoginRequest {
     pub operation_id: String,
@@ -93,8 +99,9 @@ impl std::fmt::Debug for AccountFinalizeLoginRequest {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "account/logout", response = AccountSnapshotResponse)]
+#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "account/logout", response = AccountSnapshotResponse))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct AccountLogoutRequest {
     pub operation_id: String,
@@ -111,8 +118,9 @@ impl std::fmt::Debug for AccountLogoutRequest {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "settingsSync/start", response = SettingsSyncResponse)]
+#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "settingsSync/start", response = SettingsSyncResponse))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SettingsSyncStartRequest {
     pub operation_id: String,
@@ -131,8 +139,9 @@ impl std::fmt::Debug for SettingsSyncStartRequest {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "settingsSync/snapshot", response = SettingsSyncResponse)]
+#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "settingsSync/snapshot", response = SettingsSyncResponse))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SettingsSyncSnapshotRequest {
     pub workspace_path: String,
@@ -147,8 +156,9 @@ impl std::fmt::Debug for SettingsSyncSnapshotRequest {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "settingsSync/cancel", response = SettingsSyncResponse)]
+#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "settingsSync/cancel", response = SettingsSyncResponse))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SettingsSyncCancelRequest {
     pub operation_id: String,
@@ -165,8 +175,9 @@ impl std::fmt::Debug for SettingsSyncCancelRequest {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "settingsSync/localChanged", response = SettingsSyncResponse)]
+#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "settingsSync/localChanged", response = SettingsSyncResponse))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SettingsSyncLocalChangedRequest {
     pub operation_id: String,
@@ -183,7 +194,8 @@ impl std::fmt::Debug for SettingsSyncLocalChangedRequest {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 #[serde(rename_all = "camelCase")]
 pub struct SettingsSyncResponse {
     pub progress: SettingsSyncProgress,

--- a/src/crates/interfaces/app-server-protocol/src/schemas/agent.rs
+++ b/src/crates/interfaces/app-server-protocol/src/schemas/agent.rs
@@ -1,5 +1,6 @@
 //! Agent-domain App Server wire schemas.
 
+#[cfg(feature = "rpc")]
 use agent_client_protocol::{JsonRpcRequest, JsonRpcResponse};
 use bitfun_product_domains::tool_permissions::{PermissionReply, PermissionRequest};
 use bitfun_runtime_ports::{
@@ -14,13 +15,15 @@ use serde::{Deserialize, Serialize};
 
 macro_rules! unit_response {
     ($name:ident) => {
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+        #[derive(Debug, Clone, Serialize, Deserialize)]
+        #[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
         pub struct $name {}
     };
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "agent/listModes", response = ListAgentModesResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "agent/listModes", response = ListAgentModesResponse))]
 #[serde(rename_all = "camelCase")]
 pub struct ListAgentModesRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -29,7 +32,8 @@ pub struct ListAgentModesRequest {
     pub include_external: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct ListAgentModesResponse {
     pub modes: Vec<AgentModeSummary>,
 }
@@ -45,35 +49,42 @@ pub struct AgentModeSummary {
     pub is_external: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "agent/listSessions", response = ListSessionsResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "agent/listSessions", response = ListSessionsResponse))]
 pub struct ListSessionsRequest(pub AgentSessionListRequest);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 /// `agent/listSessions` response body.
 pub struct ListSessionsResponse {
     pub sessions: Vec<AgentSessionSummary>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "agent/steerTurn", response = SteerTurnResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "agent/steerTurn", response = SteerTurnResponse))]
 pub struct SteerTurnRequest(pub AgentDialogSteerRequest);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct SteerTurnResponse {
     pub steering_id: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "agent/runUserShellCommand", response = RunUserShellCommandResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "agent/runUserShellCommand", response = RunUserShellCommandResponse))]
 pub struct RunUserShellCommandRequest(pub AgentUserShellCommandRequest);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct RunUserShellCommandResponse(pub AgentUserShellCommandResult);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "agent/submitUserAnswers", response = SubmitUserAnswersResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "agent/submitUserAnswers", response = SubmitUserAnswersResponse))]
 pub struct SubmitUserAnswersRequest {
     pub tool_id: String,
     pub answers: serde_json::Value,
@@ -81,21 +92,25 @@ pub struct SubmitUserAnswersRequest {
 
 unit_response!(SubmitUserAnswersResponse);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "agent/createSession", response = CreateSessionResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "agent/createSession", response = CreateSessionResponse))]
 pub struct CreateSessionRequest(pub AgentSessionCreateRequest);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct CreateSessionResponse(pub AgentSessionCreateResult);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "agent/deleteSession", response = DeleteSessionResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "agent/deleteSession", response = DeleteSessionResponse))]
 pub struct DeleteSessionRequest(pub AgentSessionDeleteRequest);
 
 unit_response!(DeleteSessionResponse);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "agent/submitDialogTurn", response = SubmitDialogTurnResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "agent/submitDialogTurn", response = SubmitDialogTurnResponse))]
 pub struct SubmitDialogTurnRequest(pub SubmitDialogTurnBody);
 
 pub use SubmitDialogTurnRequest as SubmitDialogTurnMessage;
@@ -173,7 +188,8 @@ impl From<AgentDialogTurnRequest> for SubmitDialogTurnRequest {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 #[serde(rename_all = "camelCase", tag = "status")]
 /// `agent/submitDialogTurn` response body.
@@ -182,9 +198,10 @@ pub enum SubmitDialogTurnResponse {
     Queued { session_id: String, turn_id: String },
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
-#[request(method = "agent/respondPermission", response = RespondPermissionResponse)]
+#[cfg_attr(feature = "rpc", request(method = "agent/respondPermission", response = RespondPermissionResponse))]
 pub struct RespondPermissionRequest {
     pub request_id: String,
     pub reply: PermissionReply,
@@ -192,20 +209,24 @@ pub struct RespondPermissionRequest {
 
 unit_response!(RespondPermissionResponse);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "agent/listPendingPermissionRequests", response = PendingPermissionsResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "agent/listPendingPermissionRequests", response = PendingPermissionsResponse))]
 pub struct PendingPermissionsRequest {}
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct PendingPermissionsResponse {
     pub requests: Vec<PermissionRequest>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "agent/cancelTurn", response = CancelTurnResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "agent/cancelTurn", response = CancelTurnResponse))]
 pub struct CancelTurnRequest(pub AgentTurnCancellationRequest);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct CancelTurnResponse(pub AgentTurnCancellationResult);
 
 pub use CancelTurnRequest as CancelTurnMessage;
@@ -213,15 +234,18 @@ pub use CreateSessionRequest as CreateSessionMessage;
 pub use DeleteSessionRequest as DeleteSessionMessage;
 pub use ListSessionsRequest as ListSessionsMessage;
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "agent/submitTurn", response = SubmitTurnResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "agent/submitTurn", response = SubmitTurnResponse))]
 pub struct SubmitTurnMessage(pub AgentSubmissionRequest);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct SubmitTurnResponse(pub AgentSubmissionResult);
 
 /// `agent/run` response body.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 #[serde(rename_all = "camelCase")]
 pub struct RunResponse {
@@ -249,8 +273,9 @@ pub enum RunSessionSpec {
 }
 
 /// Compatibility request for `agent/run`.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "agent/run", response = RunResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "agent/run", response = RunResponse))]
 #[serde(rename_all = "camelCase")]
 pub struct RunMessage {
     pub session: RunSessionSpec,

--- a/src/crates/interfaces/app-server-protocol/src/schemas/app.rs
+++ b/src/crates/interfaces/app-server-protocol/src/schemas/app.rs
@@ -1,5 +1,6 @@
 //! Connection initialization, capability, and health wire schemas.
 
+#[cfg(feature = "rpc")]
 use agent_client_protocol::{JsonRpcRequest, JsonRpcResponse};
 use serde::{Deserialize, Serialize};
 
@@ -42,15 +43,17 @@ pub struct CapabilityDescriptor {
     pub methods: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "app/initialize", response = InitializeResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "app/initialize", response = InitializeResponse))]
 #[serde(rename_all = "camelCase")]
 pub struct InitializeRequest {
     pub protocol_version: u32,
     pub client: ClientInfo,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 #[serde(rename_all = "camelCase")]
 pub struct InitializeResponse {
     pub protocol_version: u32,
@@ -76,11 +79,13 @@ impl InitializeResponse {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "app/health", response = HealthResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "app/health", response = HealthResponse))]
 pub struct HealthRequest {}
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 #[serde(rename_all = "camelCase")]
 pub struct HealthResponse {
     pub status: HealthStatus,

--- a/src/crates/interfaces/app-server-protocol/src/schemas/event.rs
+++ b/src/crates/interfaces/app-server-protocol/src/schemas/event.rs
@@ -1,14 +1,16 @@
 //! Authoritative, sequenced App Server event schemas.
 
+#[cfg(feature = "rpc")]
 use agent_client_protocol::{JsonRpcNotification, JsonRpcRequest, JsonRpcResponse};
 use bitfun_events::AgenticEventEnvelope;
 use bitfun_product_domains::tool_permissions::{PermissionRequest, PermissionRequestEvent};
 use serde::{Deserialize, Serialize};
 
 /// Browser-facing projected runtime or permission event.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcNotification)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcNotification))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
-#[notification(method = "agent/frontendEvent")]
+#[cfg_attr(feature = "rpc", notification(method = "agent/frontendEvent"))]
 pub struct FrontendEventNotification {
     pub event: String,
     pub payload: serde_json::Value,
@@ -31,32 +33,36 @@ pub struct EventCursor {
     pub sequence: u64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcNotification)]
-#[notification(method = "agent/event")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcNotification))]
+#[cfg_attr(feature = "rpc", notification(method = "agent/event"))]
 #[serde(rename_all = "camelCase")]
 pub struct AgentEventNotification {
     pub cursor: EventCursor,
     pub event: AgenticEventEnvelope,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcNotification)]
-#[notification(method = "agent/permissionEvent")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcNotification))]
+#[cfg_attr(feature = "rpc", notification(method = "agent/permissionEvent"))]
 #[serde(rename_all = "camelCase")]
 pub struct PermissionEventNotification {
     pub cursor: EventCursor,
     pub event: PermissionRequestEvent,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcNotification)]
-#[notification(method = "config/event")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcNotification))]
+#[cfg_attr(feature = "rpc", notification(method = "config/event"))]
 #[serde(rename_all = "camelCase")]
 pub struct ConfigEventNotification {
     pub cursor: EventCursor,
     pub event: ConfigUpdate,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcNotification)]
-#[notification(method = "app/eventStreamState")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcNotification))]
+#[cfg_attr(feature = "rpc", notification(method = "app/eventStreamState"))]
 #[serde(rename_all = "camelCase")]
 pub struct EventStreamStateNotification {
     pub cursor: EventCursor,
@@ -84,14 +90,16 @@ pub struct ResyncDirective {
     pub reason: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "app/syncEvents", response = SyncEventsResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "app/syncEvents", response = SyncEventsResponse))]
 #[serde(rename_all = "camelCase")]
 pub struct SyncEventsRequest {
     pub streams: Vec<EventStream>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 #[serde(rename_all = "camelCase")]
 pub struct SyncEventsResponse {
     pub cursors: Vec<EventCursor>,

--- a/src/crates/interfaces/app-server-protocol/src/schemas/external_source.rs
+++ b/src/crates/interfaces/app-server-protocol/src/schemas/external_source.rs
@@ -3,6 +3,7 @@
 //! These DTOs reuse the stable product-domain projections. Executable source
 //! definitions and provider-private configuration never cross this boundary.
 
+#[cfg(feature = "rpc")]
 use agent_client_protocol::{JsonRpcNotification, JsonRpcRequest, JsonRpcResponse};
 use bitfun_product_domains::external_source_control::{
     ExternalSourceControlRequestV1, ExternalSourceControlSnapshotV1,
@@ -18,15 +19,17 @@ use serde::{Deserialize, Serialize};
 
 pub use bitfun_product_domains::external_sources::ExternalSourceConflictPreferences;
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "externalSource/snapshot", response = ExternalSourceSnapshotResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "externalSource/snapshot", response = ExternalSourceSnapshotResponse))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ExternalSourceSnapshotRequest {
     pub workspace_path: String,
     pub force_refresh: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ExternalSourceSnapshotResponse {
     pub control: ExternalSourceControlSnapshotV1,
@@ -34,8 +37,9 @@ pub struct ExternalSourceSnapshotResponse {
     pub preferences: ExternalSourceConflictPreferences,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcNotification)]
-#[notification(method = "externalSource/event")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcNotification))]
+#[cfg_attr(feature = "rpc", notification(method = "externalSource/event"))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ExternalSourceEventNotification {
     pub cursor: crate::event::EventCursor,
@@ -43,23 +47,26 @@ pub struct ExternalSourceEventNotification {
     pub snapshot: ExternalSourcePublicSnapshot,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "externalSource/control", response = ExternalSourceControlResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "externalSource/control", response = ExternalSourceControlResponse))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ExternalSourceControlRequest {
     pub workspace_path: String,
     pub request: ExternalSourceControlRequestV1,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ExternalSourceControlResponse {
     pub surface: ExternalSourceSurfaceSnapshotV1,
     pub snapshot: ExternalSourceSnapshotResponse,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "externalSource/review", response = ExternalSourceReviewResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "externalSource/review", response = ExternalSourceReviewResponse))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ExternalSourceReviewRequest {
     pub workspace_path: String,
@@ -114,13 +121,18 @@ pub enum ExternalSourceReviewAction {
     },
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct ExternalSourceReviewResponse(pub ExternalSourceSnapshotResponse);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(
-    method = "externalSource/setNativeCommandChoice",
-    response = SetNativeCommandChoiceResponse
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(
+    feature = "rpc",
+    request(
+        method = "externalSource/setNativeCommandChoice",
+        response = SetNativeCommandChoiceResponse
+    )
 )]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SetNativeCommandChoiceRequest {
@@ -131,15 +143,17 @@ pub struct SetNativeCommandChoiceRequest {
     pub expected_preference_revision: u64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SetNativeCommandChoiceResponse {
     pub conflicts: NativePromptCommandConflictSnapshot,
     pub preferences: ExternalSourceConflictPreferences,
 }
 
-#[derive(Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "externalSource/expandCommand", response = ExpandExternalCommandResponse)]
+#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "externalSource/expandCommand", response = ExpandExternalCommandResponse))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ExpandExternalCommandRequest {
     pub workspace_path: String,
@@ -178,7 +192,8 @@ impl std::fmt::Debug for ExpandExternalCommandRequest {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct ExpandExternalCommandResponse(pub PromptCommandInvocationOutcome);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/crates/interfaces/app-server-protocol/src/schemas/git.rs
+++ b/src/crates/interfaces/app-server-protocol/src/schemas/git.rs
@@ -1,20 +1,25 @@
 //! Git-domain App Server wire schemas.
 
+#[cfg(feature = "rpc")]
 use agent_client_protocol::{JsonRpcRequest, JsonRpcResponse};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "git/isRepository", response = GitIsRepositoryResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "git/isRepository", response = GitIsRepositoryResponse))]
 pub struct GitIsRepositoryMessage(pub GitRepositoryPathRequest);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct GitIsRepositoryResponse(pub bool);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "git/getStatus", response = GitGetStatusResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "git/getStatus", response = GitGetStatusResponse))]
 pub struct GitGetStatusMessage(pub GitRepositoryPathRequest);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct GitGetStatusResponse(pub GitStatus);
 
 /// Read-only ownership-trust probe.
@@ -23,18 +28,22 @@ pub struct GitGetStatusResponse(pub GitStatus);
 /// server user's global Git configuration, and a browser client is not the
 /// machine that owns the repository. The probe is what lets such a client name
 /// the folder and hand over the exact command instead of a dead end.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "git/getRepositoryTrust", response = GitGetRepositoryTrustResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "git/getRepositoryTrust", response = GitGetRepositoryTrustResponse))]
 pub struct GitGetRepositoryTrustMessage(pub GitRepositoryPathRequest);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct GitGetRepositoryTrustResponse(pub GitTrustReport);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "git/getBranches", response = GitGetBranchesResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "git/getBranches", response = GitGetBranchesResponse))]
 pub struct GitGetBranchesMessage(pub GitBranchesRequest);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct GitGetBranchesResponse {
     pub branches: Vec<GitBranch>,
 }

--- a/src/crates/interfaces/app-server-protocol/src/schemas/hook.rs
+++ b/src/crates/interfaces/app-server-protocol/src/schemas/hook.rs
@@ -4,6 +4,7 @@
 //! inspection uses a protocol-owned projection so executable commands and host
 //! filesystem paths do not cross the wire.
 
+#[cfg(feature = "rpc")]
 use agent_client_protocol::{JsonRpcRequest, JsonRpcResponse};
 use bitfun_product_domains::external_hook_import::{
     ExternalHookImportApplyRequestV1, ExternalHookImportApplyResultV1,
@@ -16,8 +17,9 @@ pub use bitfun_product_domains::native_hooks::{
     NativeHookFileSummary, NativeHookHandlerSummary, NativeHookOverview, NativeHookRuleSummary,
 };
 
-#[derive(Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "nativeHook/overview", response = NativeHookOverviewResponse)]
+#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "nativeHook/overview", response = NativeHookOverviewResponse))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct NativeHookOverviewRequest {
     pub workspace_path: String,
@@ -32,7 +34,8 @@ impl std::fmt::Debug for NativeHookOverviewRequest {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct NativeHookOverviewResponse(pub NativeHookOverview);
 
 impl std::fmt::Debug for NativeHookOverviewResponse {
@@ -49,8 +52,9 @@ impl std::fmt::Debug for NativeHookOverviewResponse {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "externalHook/snapshot", response = ExternalHookSnapshotResponse)]
+#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "externalHook/snapshot", response = ExternalHookSnapshotResponse))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ExternalHookSnapshotRequest {
     pub workspace_path: String,
@@ -67,11 +71,13 @@ impl std::fmt::Debug for ExternalHookSnapshotRequest {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct ExternalHookSnapshotResponse(pub ExternalHookImportSnapshotV1);
 
-#[derive(Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "externalHook/plan", response = ExternalHookPlanResponse)]
+#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "externalHook/plan", response = ExternalHookPlanResponse))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ExternalHookPlanRequest {
     pub workspace_path: String,
@@ -88,11 +94,13 @@ impl std::fmt::Debug for ExternalHookPlanRequest {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct ExternalHookPlanResponse(pub ExternalHookImportPlanV1);
 
-#[derive(Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "externalHook/apply", response = ExternalHookApplyResponse)]
+#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "externalHook/apply", response = ExternalHookApplyResponse))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ExternalHookApplyRequest {
     pub workspace_path: String,
@@ -112,11 +120,13 @@ impl std::fmt::Debug for ExternalHookApplyRequest {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct ExternalHookApplyResponse(pub ExternalHookImportApplyResultV1);
 
-#[derive(Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "externalHook/mutate", response = ExternalHookMutationResponse)]
+#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "externalHook/mutate", response = ExternalHookMutationResponse))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ExternalHookMutationRequest {
     pub workspace_path: String,
@@ -136,7 +146,8 @@ impl std::fmt::Debug for ExternalHookMutationRequest {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct ExternalHookMutationResponse(pub ExternalHookImportSnapshotV1);
 
 #[cfg(test)]

--- a/src/crates/interfaces/app-server-protocol/src/schemas/i18n.rs
+++ b/src/crates/interfaces/app-server-protocol/src/schemas/i18n.rs
@@ -1,42 +1,50 @@
 //! Internationalization App Server wire schemas.
 
+#[cfg(feature = "rpc")]
 use agent_client_protocol::{JsonRpcRequest, JsonRpcResponse};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "i18n/getCurrentLanguage", response = I18nGetCurrentLanguageResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "i18n/getCurrentLanguage", response = I18nGetCurrentLanguageResponse))]
 pub struct I18nGetCurrentLanguageMessage {}
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct I18nGetCurrentLanguageResponse {
     pub language: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "i18n/setLanguage", response = I18nSetLanguageResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "i18n/setLanguage", response = I18nSetLanguageResponse))]
 #[serde(rename_all = "camelCase")]
 pub struct I18nSetLanguageMessage {
     pub language: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct I18nSetLanguageResponse {
     pub language: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "i18n/getConfig", response = I18nGetConfigResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "i18n/getConfig", response = I18nGetConfigResponse))]
 pub struct I18nGetConfigMessage {}
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct I18nGetConfigResponse {
     pub current_language: String,
     pub fallback_language: String,
     pub auto_detect: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "i18n/setConfig", response = I18nSetConfigResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "i18n/setConfig", response = I18nSetConfigResponse))]
 #[serde(rename_all = "camelCase")]
 pub struct I18nSetConfigMessage {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -47,11 +55,13 @@ pub struct I18nSetConfigMessage {
     pub auto_detect: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct I18nSetConfigResponse {}
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "i18n/getSupportedLanguages", response = I18nGetSupportedLanguagesResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "i18n/getSupportedLanguages", response = I18nGetSupportedLanguagesResponse))]
 pub struct I18nGetSupportedLanguagesMessage {}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -64,7 +74,8 @@ pub struct I18nLocaleMetadata {
     pub rtl: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct I18nGetSupportedLanguagesResponse {
     pub locales: Vec<I18nLocaleMetadata>,
 }

--- a/src/crates/interfaces/app-server-protocol/src/schemas/mcp.rs
+++ b/src/crates/interfaces/app-server-protocol/src/schemas/mcp.rs
@@ -3,6 +3,7 @@
 //! Mutation payloads can contain credentials and other sensitive values. Their
 //! custom `Debug` implementations expose only configuration metadata.
 
+#[cfg(feature = "rpc")]
 use agent_client_protocol::{JsonRpcRequest, JsonRpcResponse};
 use serde::{Deserialize, Serialize};
 
@@ -12,35 +13,40 @@ pub use bitfun_product_domains::mcp::{
 
 macro_rules! unit_response {
     ($name:ident) => {
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+        #[derive(Debug, Clone, Serialize, Deserialize)]
+        #[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
         pub struct $name {}
     };
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "mcp/list", response = ListMcpServersResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "mcp/list", response = ListMcpServersResponse))]
 #[serde(rename_all = "camelCase")]
 pub struct ListMcpServersRequest {
     pub workspace_path: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct ListMcpServersResponse {
     pub servers: Vec<McpServerSummary>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub config_path: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "mcp/toggle", response = ToggleMcpServerResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "mcp/toggle", response = ToggleMcpServerResponse))]
 pub struct ToggleMcpServerRequest {
     pub server_id: String,
 }
 
 unit_response!(ToggleMcpServerResponse);
 
-#[derive(Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "mcp/add", response = AddMcpServerResponse)]
+#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "mcp/add", response = AddMcpServerResponse))]
 pub struct AddMcpServerRequest {
     pub name: String,
     pub config: McpServerMutation,
@@ -58,16 +64,18 @@ impl std::fmt::Debug for AddMcpServerRequest {
 
 unit_response!(AddMcpServerResponse);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "mcp/delete", response = DeleteMcpServerResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "mcp/delete", response = DeleteMcpServerResponse))]
 pub struct DeleteMcpServerRequest {
     pub server_id: String,
 }
 
 unit_response!(DeleteMcpServerResponse);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "mcp/externalDecision", response = ExternalMcpDecisionResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "mcp/externalDecision", response = ExternalMcpDecisionResponse))]
 #[serde(rename_all = "camelCase")]
 pub struct ExternalMcpDecisionRequest {
     pub workspace_path: String,
@@ -80,8 +88,9 @@ pub struct ExternalMcpDecisionRequest {
 
 unit_response!(ExternalMcpDecisionResponse);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "mcp/conflictChoice", response = McpConflictChoiceResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "mcp/conflictChoice", response = McpConflictChoiceResponse))]
 #[serde(rename_all = "camelCase")]
 pub struct McpConflictChoiceRequest {
     pub workspace_path: String,

--- a/src/crates/interfaces/app-server-protocol/src/schemas/model.rs
+++ b/src/crates/interfaces/app-server-protocol/src/schemas/model.rs
@@ -4,6 +4,7 @@
 //! payloads. Secret-bearing values are accepted only by mutation requests and
 //! are never returned by the server.
 
+#[cfg(feature = "rpc")]
 use agent_client_protocol::{JsonRpcRequest, JsonRpcResponse};
 use bitfun_core_types::{
     ProviderCatalog, ReasoningCatalogProjection, ReasoningCatalogProjectionRequest,
@@ -16,16 +17,19 @@ pub use bitfun_core_types::model::{
 
 macro_rules! unit_response {
     ($name:ident) => {
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+        #[derive(Debug, Clone, Serialize, Deserialize)]
+        #[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
         pub struct $name {}
     };
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "model/list", response = ListModelsResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "model/list", response = ListModelsResponse))]
 pub struct ListModelsRequest {}
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct ListModelsResponse {
     pub models: Vec<ModelSummary>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -36,42 +40,49 @@ pub struct ListModelsResponse {
     pub mode_default_model_id: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "model/get", response = GetModelResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "model/get", response = GetModelResponse))]
 pub struct GetModelRequest {
     pub model_id: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct GetModelResponse {
     pub model: ModelEditProjection,
 }
 
 /// Provider and reasoning facts needed by model configuration surfaces.
 /// API keys and provider-specific execution metadata remain host-owned.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "config/getTuiModelCatalog", response = TuiModelCatalogResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "config/getTuiModelCatalog", response = TuiModelCatalogResponse))]
 pub struct TuiModelCatalogRequest {}
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 #[serde(rename_all = "camelCase")]
 pub struct TuiModelCatalogResponse {
     pub provider_catalog: ProviderCatalog,
     pub reasoning_presets_by_model: std::collections::BTreeMap<String, Vec<String>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "model/projectReasoningCatalog", response = ProjectReasoningCatalogResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "model/projectReasoningCatalog", response = ProjectReasoningCatalogResponse))]
 #[serde(transparent)]
 pub struct ProjectReasoningCatalogRequest(pub ReasoningCatalogProjectionRequest);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct ProjectReasoningCatalogResponse {
     pub projection: ReasoningCatalogProjection,
 }
 
-#[derive(Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "model/add", response = AddModelResponse)]
+#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "model/add", response = AddModelResponse))]
 pub struct AddModelRequest {
     pub model: ModelMutation,
     #[serde(default)]
@@ -90,8 +101,9 @@ impl std::fmt::Debug for AddModelRequest {
 
 unit_response!(AddModelResponse);
 
-#[derive(Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "model/update", response = UpdateModelResponse)]
+#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "model/update", response = UpdateModelResponse))]
 pub struct UpdateModelRequest {
     pub model_id: String,
     pub model: ModelMutation,
@@ -109,16 +121,18 @@ impl std::fmt::Debug for UpdateModelRequest {
 
 unit_response!(UpdateModelResponse);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "model/delete", response = DeleteModelResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "model/delete", response = DeleteModelResponse))]
 pub struct DeleteModelRequest {
     pub model_id: String,
 }
 
 unit_response!(DeleteModelResponse);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "model/setDefault", response = SetModelDefaultResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "model/setDefault", response = SetModelDefaultResponse))]
 pub struct SetModelDefaultRequest {
     pub slot: ModelDefaultSlot,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/crates/interfaces/app-server-protocol/src/schemas/permission.rs
+++ b/src/crates/interfaces/app-server-protocol/src/schemas/permission.rs
@@ -1,5 +1,6 @@
 //! Permission-domain App Server wire schemas.
 
+#[cfg(feature = "rpc")]
 use agent_client_protocol::{JsonRpcRequest, JsonRpcResponse};
 use bitfun_product_domains::tool_permissions::{
     PermissionAuditRecord, PermissionGrant, PermissionGrantKey, PermissionReply,
@@ -8,14 +9,16 @@ use serde::{Deserialize, Serialize};
 
 pub type RespondPermissionMessage = super::agent::RespondPermissionRequest;
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "agent/respondPermissionBatch", response = RespondPermissionBatchResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "agent/respondPermissionBatch", response = RespondPermissionBatchResponse))]
 pub struct RespondPermissionBatchMessage {
     pub request_id: String,
     pub reply: PermissionReply,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct RespondPermissionBatchResponse {
     pub request_ids: Vec<String>,
 }
@@ -23,46 +26,54 @@ pub struct RespondPermissionBatchResponse {
 pub type ListPendingPermissionRequestsMessage = super::agent::PendingPermissionsRequest;
 pub type ListPendingPermissionRequestsResponse = super::agent::PendingPermissionsResponse;
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "agent/listProjectPermissionGrants", response = ListProjectPermissionGrantsResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "agent/listProjectPermissionGrants", response = ListProjectPermissionGrantsResponse))]
 pub struct ListProjectPermissionGrantsMessage {
     pub project_id: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub struct ListProjectPermissionGrantsResponse {
     pub grants: Vec<PermissionGrant>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "agent/removeProjectPermissionGrant", response = RemoveProjectPermissionGrantResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "agent/removeProjectPermissionGrant", response = RemoveProjectPermissionGrantResponse))]
 pub struct RemoveProjectPermissionGrantMessage(pub PermissionGrantKey);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub struct RemoveProjectPermissionGrantResponse {
     pub removed: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "agent/clearProjectPermissionGrants", response = ClearProjectPermissionGrantsResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "agent/clearProjectPermissionGrants", response = ClearProjectPermissionGrantsResponse))]
 pub struct ClearProjectPermissionGrantsMessage {
     pub project_id: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct ClearProjectPermissionGrantsResponse {
     pub cleared: usize,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "agent/listProjectPermissionAudit", response = ListProjectPermissionAuditResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "agent/listProjectPermissionAudit", response = ListProjectPermissionAuditResponse))]
 pub struct ListProjectPermissionAuditMessage {
     pub project_id: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct ListProjectPermissionAuditResponse {
     pub records: Vec<PermissionAuditRecord>,
 }

--- a/src/crates/interfaces/app-server-protocol/src/schemas/session.rs
+++ b/src/crates/interfaces/app-server-protocol/src/schemas/session.rs
@@ -1,5 +1,6 @@
 //! Session-domain App Server wire schemas.
 
+#[cfg(feature = "rpc")]
 use agent_client_protocol::{JsonRpcRequest, JsonRpcResponse};
 use bitfun_core_types::SessionUsageReport;
 use bitfun_product_domains::tool_permissions::PermissionRequest;
@@ -18,13 +19,15 @@ use serde::{Deserialize, Serialize};
 
 macro_rules! unit_response {
     ($name:ident) => {
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+        #[derive(Debug, Clone, Serialize, Deserialize)]
+        #[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
         pub struct $name {}
     };
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "session/sync", response = SyncSessionResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "session/sync", response = SyncSessionResponse))]
 #[serde(rename_all = "camelCase")]
 pub struct SyncSessionRequest {
     pub workspace_path: String,
@@ -37,7 +40,8 @@ pub struct SyncSessionRequest {
     pub remote_ssh_host: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 #[serde(rename_all = "camelCase")]
 pub struct SyncSessionResponse {
     pub session: AgentSessionSummary,
@@ -80,9 +84,10 @@ pub enum SessionProcessingPhase {
 }
 
 /// Compatibility request for `session/restore`.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
-#[request(method = "session/restore", response = RestoreSessionResponse)]
+#[cfg_attr(feature = "rpc", request(method = "session/restore", response = RestoreSessionResponse))]
 #[serde(rename_all = "camelCase")]
 pub struct RestoreSessionMessage {
     pub workspace_path: String,
@@ -95,7 +100,8 @@ pub struct RestoreSessionMessage {
     pub remote_ssh_host: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 #[serde(rename_all = "camelCase")]
 pub struct RestoreSessionResponse {
@@ -103,104 +109,129 @@ pub struct RestoreSessionResponse {
     pub state: SessionRuntimeState,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "session/readTranscript", response = ReadTranscriptResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "session/readTranscript", response = ReadTranscriptResponse))]
 pub struct ReadTranscriptRequest(pub SessionTranscriptRequest);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct ReadTranscriptResponse(pub SessionTranscript);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "session/resolveWorkspace", response = ResolveWorkspaceResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "session/resolveWorkspace", response = ResolveWorkspaceResponse))]
 pub struct ResolveWorkspaceRequest(pub AgentSessionWorkspaceRequest);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct ResolveWorkspaceResponse(pub Option<AgentSessionWorkspaceBinding>);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "session/rename", response = RenameSessionResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "session/rename", response = RenameSessionResponse))]
 pub struct RenameSessionRequest(pub AgentSessionRenameRequest);
 
 unit_response!(RenameSessionResponse);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "session/compact", response = CompactSessionResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "session/compact", response = CompactSessionResponse))]
 pub struct CompactSessionRequest(pub AgentSessionCompactionRequest);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct CompactSessionResponse(pub AgentSessionCompactionResult);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "session/undo", response = RevertSessionResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "session/undo", response = RevertSessionResponse))]
 pub struct UndoSessionRequest(pub AgentSessionRevertRequest);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "session/redo", response = RevertSessionResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "session/redo", response = RevertSessionResponse))]
 pub struct RedoSessionRequest(pub AgentSessionRevertRequest);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct RevertSessionResponse(pub AgentSessionRevertResult);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "session/reloadContext", response = ReloadContextResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "session/reloadContext", response = ReloadContextResponse))]
 pub struct ReloadContextRequest(pub AgentContextReloadRequest);
 
 unit_response!(ReloadContextResponse);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "session/usage", response = SessionUsageResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "session/usage", response = SessionUsageResponse))]
 pub struct SessionUsageRequest(pub AgentSessionUsageRequest);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct SessionUsageResponse(pub SessionUsageReport);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "session/waitForSettlement", response = WaitForSettlementResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "session/waitForSettlement", response = WaitForSettlementResponse))]
 pub struct WaitForSettlementRequest(pub AgentTurnSettlementRequest);
 
 unit_response!(WaitForSettlementResponse);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "session/lineage", response = SessionLineageResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "session/lineage", response = SessionLineageResponse))]
 pub struct SessionLineageRequest(pub AgentSessionLineageRequest);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct SessionLineageResponse(pub Option<AgentSessionLineageSnapshot>);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "session/inspectLineage", response = InspectLineageResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "session/inspectLineage", response = InspectLineageResponse))]
 pub struct InspectLineageRequest(pub AgentSessionLineageTranscriptRequest);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct InspectLineageResponse(pub AgentSessionLineageInspection);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "session/cancelLineage", response = CancelLineageResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "session/cancelLineage", response = CancelLineageResponse))]
 pub struct CancelLineageRequest(pub AgentSessionLineageCancellationRequest);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct CancelLineageResponse(pub AgentTurnCancellationResult);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "session/fork", response = ForkSessionResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "session/fork", response = ForkSessionResponse))]
 pub struct ForkSessionRequest(pub AgentSessionForkRequest);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "session/forkBeforeTurn", response = ForkSessionResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "session/forkBeforeTurn", response = ForkSessionResponse))]
 pub struct ForkSessionBeforeTurnRequest(pub AgentSessionForkBeforeTurnRequest);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub struct ForkSessionResponse(pub AgentSessionForkResult);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "session/updateModel", response = UpdateSessionModelResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "session/updateModel", response = UpdateSessionModelResponse))]
 pub struct UpdateSessionModelRequest(pub AgentSessionModelUpdateRequest);
 
 unit_response!(UpdateSessionModelResponse);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "session/updateMode", response = UpdateSessionModeResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "session/updateMode", response = UpdateSessionModeResponse))]
 pub struct UpdateSessionModeRequest(pub AgentSessionModeUpdateRequest);
 
 unit_response!(UpdateSessionModeResponse);
@@ -211,14 +242,16 @@ pub use RenameSessionRequest as RenameSessionMessage;
 pub use UpdateSessionModeRequest as UpdateSessionModeMessage;
 pub use UpdateSessionModelRequest as UpdateSessionModelMessage;
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
-#[request(method = "session/setArchived", response = SetSessionArchivedResponse)]
+#[cfg_attr(feature = "rpc", request(method = "session/setArchived", response = SetSessionArchivedResponse))]
 pub struct SetSessionArchivedMessage(pub AgentSessionArchiveStateRequest);
 
 unit_response!(SetSessionArchivedResponse);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
-#[request(method = "session/forkAtTurn", response = ForkSessionResponse)]
+#[cfg_attr(feature = "rpc", request(method = "session/forkAtTurn", response = ForkSessionResponse))]
 pub struct ForkSessionAtTurnMessage(pub AgentSessionForkAtTurnRequest);

--- a/src/crates/interfaces/app-server-protocol/src/schemas/skill.rs
+++ b/src/crates/interfaces/app-server-protocol/src/schemas/skill.rs
@@ -1,12 +1,14 @@
 //! Skill-domain App Server wire schemas.
 
+#[cfg(feature = "rpc")]
 use agent_client_protocol::{JsonRpcRequest, JsonRpcResponse};
 use serde::{Deserialize, Serialize};
 
 pub use bitfun_product_domains::agent_catalog::SkillSummary;
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "skill/list", response = ListSkillsResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "skill/list", response = ListSkillsResponse))]
 #[serde(rename_all = "camelCase")]
 pub struct ListSkillsRequest {
     pub workspace_path: String,
@@ -15,13 +17,15 @@ pub struct ListSkillsRequest {
     pub manageable: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct ListSkillsResponse {
     pub skills: Vec<SkillSummary>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "skill/setEnabled", response = SetSkillEnabledResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "skill/setEnabled", response = SetSkillEnabledResponse))]
 #[serde(rename_all = "camelCase")]
 pub struct SetSkillEnabledRequest {
     pub workspace_path: String,
@@ -32,5 +36,6 @@ pub struct SetSkillEnabledRequest {
     pub level: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct SetSkillEnabledResponse {}

--- a/src/crates/interfaces/app-server-protocol/src/schemas/subagent.rs
+++ b/src/crates/interfaces/app-server-protocol/src/schemas/subagent.rs
@@ -1,12 +1,14 @@
 //! Subagent-domain App Server wire schemas.
 
+#[cfg(feature = "rpc")]
 use agent_client_protocol::{JsonRpcRequest, JsonRpcResponse};
 use serde::{Deserialize, Serialize};
 
 pub use bitfun_product_domains::agent_catalog::SubagentSummary;
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "subagent/list", response = ListSubagentsResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "subagent/list", response = ListSubagentsResponse))]
 #[serde(rename_all = "camelCase")]
 pub struct ListSubagentsRequest {
     pub workspace_path: String,
@@ -15,15 +17,17 @@ pub struct ListSubagentsRequest {
     pub management: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct ListSubagentsResponse {
     pub subagents: Vec<SubagentSummary>,
     #[serde(default)]
     pub has_external: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "subagent/setEnabled", response = SetSubagentEnabledResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "subagent/setEnabled", response = SetSubagentEnabledResponse))]
 #[serde(rename_all = "camelCase")]
 pub struct SetSubagentEnabledRequest {
     pub workspace_path: String,
@@ -32,5 +36,6 @@ pub struct SetSubagentEnabledRequest {
     pub enabled: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct SetSubagentEnabledResponse {}

--- a/src/crates/interfaces/app-server-protocol/src/schemas/workspace.rs
+++ b/src/crates/interfaces/app-server-protocol/src/schemas/workspace.rs
@@ -1,5 +1,6 @@
 //! Workspace-domain App Server wire schemas.
 
+#[cfg(feature = "rpc")]
 use agent_client_protocol::{JsonRpcRequest, JsonRpcResponse};
 use bitfun_runtime_ports::{
     AgentMessageWorkspaceReferencesRequest, AgentWorkspaceReference,
@@ -8,23 +9,29 @@ use bitfun_runtime_ports::{
 };
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "workspace/diff", response = WorkspaceDiffResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "workspace/diff", response = WorkspaceDiffResponse))]
 pub struct WorkspaceDiffRequest {}
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct WorkspaceDiffResponse(pub WorkspaceDiffSnapshot);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "workspace/searchReferences", response = SearchWorkspaceReferencesResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "workspace/searchReferences", response = SearchWorkspaceReferencesResponse))]
 pub struct SearchWorkspaceReferencesRequest(pub AgentWorkspaceReferenceSearchRequest);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct SearchWorkspaceReferencesResponse(pub AgentWorkspaceReferenceSearchResult);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "workspace/messageReferences", response = MessageReferencesResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "workspace/messageReferences", response = MessageReferencesResponse))]
 pub struct MessageReferencesRequest(pub AgentMessageWorkspaceReferencesRequest);
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 pub struct MessageReferencesResponse(pub Vec<AgentWorkspaceReference>);

--- a/src/crates/interfaces/app-server-protocol/src/schemas/worktree.rs
+++ b/src/crates/interfaces/app-server-protocol/src/schemas/worktree.rs
@@ -1,5 +1,6 @@
 //! Worktree-domain App Server wire schemas.
 
+#[cfg(feature = "rpc")]
 use agent_client_protocol::{JsonRpcRequest, JsonRpcResponse};
 pub use bitfun_core_types::WorktreeErrorCode;
 use bitfun_runtime_ports::AgentSessionWorkspaceBinding;
@@ -7,8 +8,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::AppServerErrorData;
 
-#[derive(Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "worktree/repositoryStatus", response = WorktreeRepositoryStatusResponse)]
+#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "worktree/repositoryStatus", response = WorktreeRepositoryStatusResponse))]
 #[serde(rename_all = "camelCase")]
 pub struct WorktreeRepositoryStatusRequest {
     pub workspace_path: String,
@@ -34,7 +36,8 @@ impl WorktreeRepositoryStatusRequest {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 #[serde(rename_all = "camelCase")]
 pub struct WorktreeRepositoryStatusResponse {
     pub is_repository: bool,
@@ -42,8 +45,9 @@ pub struct WorktreeRepositoryStatusResponse {
     pub current_branch: Option<String>,
 }
 
-#[derive(Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "worktree/bindSession", response = WorktreeBindingResponse)]
+#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "worktree/bindSession", response = WorktreeBindingResponse))]
 #[serde(rename_all = "camelCase")]
 pub struct WorktreeBindSessionRequest {
     pub operation_id: String,
@@ -74,8 +78,9 @@ impl WorktreeBindSessionRequest {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, JsonRpcRequest)]
-#[request(method = "worktree/releaseSession", response = WorktreeBindingResponse)]
+#[derive(Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcRequest))]
+#[cfg_attr(feature = "rpc", request(method = "worktree/releaseSession", response = WorktreeBindingResponse))]
 #[serde(rename_all = "camelCase")]
 pub struct WorktreeReleaseSessionRequest {
     pub operation_id: String,
@@ -106,7 +111,8 @@ impl WorktreeReleaseSessionRequest {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonRpcResponse)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "rpc", derive(JsonRpcResponse))]
 #[serde(rename_all = "camelCase")]
 pub struct WorktreeBindingResponse {
     pub workspace_binding: AgentSessionWorkspaceBinding,

--- a/src/crates/interfaces/app-server-protocol/tests/legacy_wire_contracts.rs
+++ b/src/crates/interfaces/app-server-protocol/tests/legacy_wire_contracts.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "rpc")]
 use agent_client_protocol::JsonRpcMessage;
 use bitfun_app_server_protocol::{
     agent::{RunResponse, SubmitDialogTurnMessage, SubmitDialogTurnRequest},
@@ -8,7 +9,7 @@ use bitfun_app_server_protocol::{
 use serde_json::json;
 
 #[test]
-fn legacy_submit_dialog_contract_keeps_optional_policy_and_method() {
+fn legacy_submit_dialog_contract_keeps_optional_policy() {
     let request: SubmitDialogTurnRequest = serde_json::from_value(json!({
         "sessionId": "session-1",
         "message": "hello",
@@ -20,13 +21,18 @@ fn legacy_submit_dialog_contract_keeps_optional_policy_and_method() {
     assert!(body.policy.is_none());
     assert!(body.attachments.is_empty());
     assert!(body.metadata.is_empty());
-    assert!(SubmitDialogTurnMessage::matches_method(
-        "agent/submitDialogTurn"
-    ));
     assert_eq!(
         std::any::TypeId::of::<SubmitDialogTurnMessage>(),
         std::any::TypeId::of::<SubmitDialogTurnRequest>()
     );
+}
+
+#[cfg(feature = "rpc")]
+#[test]
+fn legacy_submit_dialog_method_stays_compatible() {
+    assert!(SubmitDialogTurnMessage::matches_method(
+        "agent/submitDialogTurn"
+    ));
 }
 
 #[test]

--- a/src/crates/interfaces/app-server/AGENTS-CN.md
+++ b/src/crates/interfaces/app-server/AGENTS-CN.md
@@ -20,6 +20,9 @@ protocol/client crate。
 
 `bitfun-app-server/ts` 只保留为兼容转发 feature。protocol crate 是唯一的 TypeScript
 schema 导出 owner；不要把 `ts-rs`、Runtime 实现类型或第二条导出命令重新加入本 crate。
+protocol wire DTO 与 serde 合同不启用 feature 也必须可用。protocol crate 默认的 `rpc`
+feature 负责绑定 ACP JSON-RPC trait 并暴露 role/transport helper，以保持兼容；`ts` 必须与
+它正交，不得启用 `rpc` 或 `agent-client-protocol`。
 
 ## 护栏
 

--- a/src/crates/interfaces/app-server/AGENTS.md
+++ b/src/crates/interfaces/app-server/AGENTS.md
@@ -23,6 +23,10 @@ and client crates.
 The `bitfun-app-server/ts` feature is a compatibility forwarder only. The
 protocol crate is the sole TypeScript schema exporter; do not add `ts-rs`,
 runtime implementation types, or a second export command back to this crate.
+Protocol wire DTOs and serde contracts remain available with no feature. The
+protocol crate's default `rpc` feature attaches ACP JSON-RPC traits and exposes
+its roles and transport helpers for compatibility; `ts` must remain orthogonal
+and must not enable `rpc` or `agent-client-protocol`.
 
 ## Guardrails
 


### PR DESCRIPTION
## 背景

Web `gen:types` 已经只选择 `bitfun-app-server-protocol/ts`，但 protocol crate 仍无条件依赖 `agent-client-protocol`，导致纯 TypeScript schema 导出继续编译 ACP、Tokio、RMCP 等 RPC runtime 子图。

## 改动

- 将 `agent-client-protocol` 设为 optional，由新的 `rpc` feature 独占；`default = ["rpc"]` 保持现有消费者兼容。
- 将 JSON-RPC derive、request/notification metadata、role 与 transport helper 收敛到 `rpc`；wire DTO、serde 和 `ts` 保持独立。
- 增加 closed feature profile 与 optional dependency owner 规则，防止 `ts` 或未来 feature 重新带入 ACP runtime。
- 修正 legacy wire 测试，使纯 DTO/TS 配置继续执行 serde、wire shape 和类型别名断言，RPC method 断言只在 `rpc` 下执行。
- 更新 App Server 中英文 owner 指南和编译性能证据；未修改 CI 配置。

## 兼容性

- 普通/default 消费者仍获得完整 RPC trait、`AppServer` / `AppClient` role 与 transport helper，生产 server/client 路径不变。
- 显式 `--no-default-features` 现在表示 DTO/serde-only；若仓外消费者此前在该配置下使用 RPC API，需要显式启用 `rpc`。仓内两个生产消费者均使用 default feature。
- wire DTO、JSON shape、method/response metadata 和 TypeScript 生成结果保持不变。

## 性能证据

同一 Windows 主机、两个全新 `CARGO_TARGET_DIR`，执行相同命令：

`pnpm --dir src/web-ui run gen:types`

| Protocol TS focused 指标 | 变更前 | 变更后 | 收敛 |
|---|---:|---:|---:|
| unique normal/build package | 192 | 94 | -98（-51.0%） |
| 冷 `gen:types` wall-clock | 34.41 s | 26.78 s | -7.63 s（-22.2%） |

这是同机单次冷样本，不外推为 CI 或完整产品构建收益。两侧生成目录均为 48 个文件，逐文件 SHA-256 差异为 0；`Cargo.lock` 未变化。

## 验证

- `cargo check --locked --offline -p bitfun-app-server-protocol --no-default-features --tests`
- `cargo check --locked --offline -p bitfun-app-server-protocol --no-default-features --features ts --tests`
- `cargo test --locked --offline -p bitfun-app-server-protocol --test legacy_wire_contracts`（4/4）
- `pnpm --dir src/web-ui run gen:types`（34/34 export tests；48 个文件 hash diff 0）
- `cargo check --locked --offline -p bitfun-app-server`
- `cargo test --locked --offline -p bitfun-app-server --lib server::wire::tests`（4/4）
- `node --test scripts/check-core-boundaries.test.mjs`（126/126）
- `pnpm run check:core-boundaries`
- `pnpm run check:repo-hygiene`
- `git diff --check gcwing/main...HEAD`

未运行 workspace-wide、全平台 packaging 或发布构建，交由现有 CI 矩阵验证。
