### PR TITLE
feat(market): funnel visitors without BitFun to the download page

### DIFF
--- a/src/apps/skin-market-server/Dockerfile
+++ b/src/apps/skin-market-server/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /build
 RUN corepack enable && corepack prepare pnpm@10.15.0 --activate
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY patches/ patches/
 COPY src/skin-market-web/package.json src/skin-market-web/package.json
 RUN --mount=type=cache,id=bitfun-skin-market-pnpm,target=/root/.local/share/pnpm/store,sharing=locked \
     pnpm install --frozen-lockfile --ignore-scripts --filter bitfun-skin-market-web

--- a/src/apps/skin-market-server/Dockerfile.dockerignore
+++ b/src/apps/skin-market-server/Dockerfile.dockerignore
@@ -6,6 +6,8 @@
 !pnpm-lock.yaml
 !pnpm-workspace.yaml
 !.npmrc
+!patches/
+!patches/**
 
 !src/
 !src/**/

--- a/src/miniapp-market-web/README.md
+++ b/src/miniapp-market-web/README.md
@@ -36,6 +36,8 @@
 | `src/api.ts` | `/miniapp/api/v1` 客户端、CSRF、登录和下载 URL |
 | `src/types.ts` | 网页使用的 API DTO |
 | `src/MiniAppIcon.tsx` | 将 MiniApp 元数据中的 Lucide 图标名安全解析为图标组件 |
+| `src/GetBitfunCta.tsx` | 目录页和详情页共用的「下载 BitFun 客户端」引流入口 |
+| `src/links.ts` | 官网与下载页的对外链接常量 |
 | `src/i18n.ts` | `zh-CN`、`zh-TW`、`en-US` 文案与 fallback |
 | `src/format.ts` | 市场页面的日期和数字格式化 |
 | `src/styles.css` | 响应式布局与视觉样式 |

--- a/src/miniapp-market-web/src/App.tsx
+++ b/src/miniapp-market-web/src/App.tsx
@@ -32,7 +32,9 @@ import {
 } from '@phosphor-icons/react';
 import { downloadUrl, loginUrl, marketApi, MarketApiError } from './api';
 import { formatCompactNumber, formatMarketDate, formatMarketDateTime } from './format';
+import { GetBitfunCta } from './GetBitfunCta';
 import { useLocale, type Locale, type MessageKey } from './i18n';
+import { BITFUN_HOME_URL } from './links';
 import { MiniAppIcon } from './MiniAppIcon';
 import { marketImageSrcSet, marketImageUrl, retryOriginalMarketImage } from './marketImages';
 import { useTheme, type Theme } from './theme';
@@ -191,7 +193,7 @@ function App() {
             <span>BitFun MiniApp Market</span>
           </div>
           <span className="footer-note">{t('footerNote')}</span>
-          <a href="https://openbitfun.com/" target="_blank" rel="noreferrer">
+          <a href={BITFUN_HOME_URL} target="_blank" rel="noreferrer">
             {t('bitfunHome')}
             <ArrowSquareOut aria-hidden="true" />
           </a>
@@ -453,6 +455,7 @@ function CatalogPage({
           </div>
           <h1>{t('headline')}</h1>
           <p>{t('intro')}</p>
+          <GetBitfunCta placement="catalog" t={t} />
         </div>
         <div className="hero-visual">
           <img src="/miniapp/og.png" alt={t('heroImageAlt')} />
@@ -775,6 +778,7 @@ function DetailPage({
               </button>
             )}
           </div>
+          <GetBitfunCta placement="listing" t={t} />
           <div className="rating-control" aria-label={t('ratingLabel')}>
             {[1, 2, 3, 4, 5].map((value) => (
               <button

--- a/src/miniapp-market-web/src/GetBitfunCta.test.tsx
+++ b/src/miniapp-market-web/src/GetBitfunCta.test.tsx
@@ -1,0 +1,28 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { GetBitfunCta, type GetBitfunPlacement } from './GetBitfunCta';
+import type { MessageKey } from './i18n';
+import { BITFUN_DOWNLOAD_URL } from './links';
+
+const t = (key: MessageKey): string => key;
+
+describe('GetBitfunCta', () => {
+  it.each<GetBitfunPlacement>(['catalog', 'listing'])(
+    'sends %s visitors to the official download page',
+    (placement) => {
+      const markup = renderToStaticMarkup(<GetBitfunCta placement={placement} t={t} />);
+
+      expect(markup).toContain(`href="${BITFUN_DOWNLOAD_URL}"`);
+      expect(markup).toContain('rel="noreferrer"');
+      expect(markup).toContain('getBitfunTitle');
+      expect(markup).toContain('getBitfunAction');
+    },
+  );
+
+  it('explains the surface the visitor is actually looking at', () => {
+    expect(renderToStaticMarkup(<GetBitfunCta placement="listing" t={t} />))
+      .toContain('getBitfunListingNote');
+    expect(renderToStaticMarkup(<GetBitfunCta placement="catalog" t={t} />))
+      .toContain('getBitfunCatalogNote');
+  });
+});

--- a/src/miniapp-market-web/src/GetBitfunCta.tsx
+++ b/src/miniapp-market-web/src/GetBitfunCta.tsx
@@ -1,0 +1,38 @@
+import { ArrowRight, DownloadSimple } from '@phosphor-icons/react';
+import type { MessageKey } from './i18n';
+import { BITFUN_DOWNLOAD_URL } from './links';
+
+// A .bfminiapp package is useless without the desktop client, so the catalog
+// and every listing keep one explicit path to the official download page.
+export type GetBitfunPlacement = 'catalog' | 'listing';
+
+export function GetBitfunCta({
+  placement,
+  t,
+}: {
+  placement: GetBitfunPlacement;
+  t: (key: MessageKey) => string;
+}) {
+  return (
+    <a
+      className={`get-bitfun get-bitfun-${placement}`}
+      href={BITFUN_DOWNLOAD_URL}
+      target="_blank"
+      rel="noreferrer"
+    >
+      <span className="get-bitfun-icon">
+        <DownloadSimple weight="bold" aria-hidden="true" />
+      </span>
+      <span className="get-bitfun-copy">
+        <strong>{t('getBitfunTitle')}</strong>
+        <span>
+          {t(placement === 'listing' ? 'getBitfunListingNote' : 'getBitfunCatalogNote')}
+        </span>
+        <span className="get-bitfun-action">
+          {t('getBitfunAction')}
+          <ArrowRight weight="bold" aria-hidden="true" />
+        </span>
+      </span>
+    </a>
+  );
+}

--- a/src/miniapp-market-web/src/i18n.ts
+++ b/src/miniapp-market-web/src/i18n.ts
@@ -63,6 +63,12 @@ const messages = {
     authCompleteBody: 'You can return to BitFun. This browser tab may be closed.',
     footerNote: 'Reviewed releases / Hash-locked packages / Manual updates',
     bitfunHome: 'BitFun home',
+    getBitfunTitle: 'New to BitFun?',
+    getBitfunCatalogNote:
+      'MiniApps run inside the BitFun desktop client. Download it once, then install anything from this market.',
+    getBitfunListingNote:
+      'This MiniApp runs inside the BitFun desktop client. Download it, then open the .bfminiapp package.',
+    getBitfunAction: 'Download BitFun',
     navigationLabel: 'Marketplace navigation',
     language: 'Language',
     changeLanguage: 'Change language',
@@ -207,6 +213,12 @@ const messages = {
     authCompleteBody: '现在可以返回 BitFun，并关闭这个浏览器标签页。',
     footerNote: '人工审核版本 / 哈希锁定安装包 / 手动更新',
     bitfunHome: 'BitFun 官网',
+    getBitfunTitle: '没有 BitFun？',
+    getBitfunCatalogNote:
+      'MiniApp 需要在 BitFun 客户端里运行。下载客户端后，就能安装市场里的任意 MiniApp。',
+    getBitfunListingNote:
+      '这个 MiniApp 需要在 BitFun 客户端里运行。下载客户端后，打开 .bfminiapp 安装包即可。',
+    getBitfunAction: '下载 BitFun 客户端',
     navigationLabel: '市场导航',
     language: '语言',
     changeLanguage: '切换语言',
@@ -350,6 +362,12 @@ const messages = {
     authCompleteBody: '現在可以返回 BitFun，並關閉這個瀏覽器分頁。',
     footerNote: '人工審核版本 / 雜湊鎖定安裝包 / 手動更新',
     bitfunHome: 'BitFun 官網',
+    getBitfunTitle: '還沒有 BitFun？',
+    getBitfunCatalogNote:
+      'MiniApp 需要在 BitFun 客戶端裡執行。下載客戶端後，就能安裝市場裡的任意 MiniApp。',
+    getBitfunListingNote:
+      '這個 MiniApp 需要在 BitFun 客戶端裡執行。下載客戶端後，開啟 .bfminiapp 安裝包即可。',
+    getBitfunAction: '下載 BitFun 客戶端',
     navigationLabel: '市場導覽',
     language: '語言',
     changeLanguage: '切換語言',

--- a/src/miniapp-market-web/src/links.test.ts
+++ b/src/miniapp-market-web/src/links.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { BITFUN_DOWNLOAD_URL, BITFUN_HOME_URL } from './links';
+
+describe('MiniApp Market external links', () => {
+  it('uses the official BitFun website and download pages', () => {
+    expect(BITFUN_HOME_URL).toBe('https://openbitfun.com/');
+    expect(BITFUN_DOWNLOAD_URL).toBe('https://openbitfun.com/download');
+    expect(new URL(BITFUN_HOME_URL).protocol).toBe('https:');
+    expect(new URL(BITFUN_DOWNLOAD_URL).protocol).toBe('https:');
+  });
+});

--- a/src/miniapp-market-web/src/links.ts
+++ b/src/miniapp-market-web/src/links.ts
@@ -1,0 +1,5 @@
+// Most marketplace visitors arrive from a shared listing link and do not have
+// BitFun installed yet. Keep the official download page in one place so every
+// browse surface funnels to the same URL.
+export const BITFUN_HOME_URL = 'https://openbitfun.com/';
+export const BITFUN_DOWNLOAD_URL = 'https://openbitfun.com/download';

--- a/src/miniapp-market-web/src/styles.css
+++ b/src/miniapp-market-web/src/styles.css
@@ -534,6 +534,89 @@ main {
   color: var(--accent);
 }
 
+/* A .bfminiapp package only runs inside the desktop client, so the catalog and
+   every listing carry the same visible route to the official download page. */
+.get-bitfun {
+  max-width: 100%;
+  margin-top: 22px;
+  padding: 13px 15px;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 12px;
+  border: 1px solid var(--accent-border);
+  border-radius: var(--radius-lg);
+  background: var(--accent-soft);
+  text-decoration: none;
+  transition:
+    border-color 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.get-bitfun-listing {
+  margin-top: 16px;
+}
+
+.get-bitfun:hover {
+  border-color: var(--accent);
+  box-shadow: var(--shadow-sm);
+}
+
+.get-bitfun-icon {
+  width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+  border-radius: var(--radius-sm);
+  background: var(--accent);
+  color: var(--on-accent);
+}
+
+.get-bitfun-icon svg {
+  width: 17px;
+  height: 17px;
+}
+
+.get-bitfun-copy {
+  min-width: 0;
+  display: grid;
+  gap: 4px;
+}
+
+.get-bitfun-copy strong {
+  color: var(--text-strong);
+  font-size: 13px;
+  font-weight: 640;
+}
+
+.get-bitfun-copy > span {
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.5;
+  text-wrap: pretty;
+}
+
+.get-bitfun-action {
+  width: fit-content;
+  margin-top: 2px;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--accent);
+  font-size: 12.5px;
+  font-weight: 620;
+  white-space: nowrap;
+}
+
+.get-bitfun-action svg {
+  width: 14px;
+  height: 14px;
+  transition: transform 150ms ease;
+}
+
+.get-bitfun:hover .get-bitfun-action svg {
+  transform: translateX(2px);
+}
+
 .catalog {
   padding: 52px 0 84px;
 }

--- a/src/skin-market-web/README.md
+++ b/src/skin-market-web/README.md
@@ -8,6 +8,9 @@ Appearance packages.
 - Routes: `/skin/`, `/skin/appearances/:slug`, `/skin/submissions`, and `/skin/admin`
 - Features: catalog search and filters, release details and downloads, personal submission status and withdrawal, plus administrator review and publishing
 - Installation remains a BitFun Desktop action through Settings > Appearance.
+- Visitors without the desktop client reach `https://openbitfun.com/download`
+  from the catalog masthead and from every appearance page (`src/GetBitfunCta.tsx`,
+  `src/links.ts`).
 
 The site is self-contained and does not import the main Web UI locale or theme catalogs.
 GitHub identity is shared with the MiniApp market through its same-origin auth

--- a/src/skin-market-web/src/CatalogPage.tsx
+++ b/src/skin-market-web/src/CatalogPage.tsx
@@ -1,9 +1,4 @@
-import {
-  ArrowRight,
-  ArrowSquareOut,
-  DownloadSimple,
-  MagnifyingGlass,
-} from '@phosphor-icons/react';
+import { ArrowRight, MagnifyingGlass } from '@phosphor-icons/react';
 import {
   useCallback,
   useEffect,
@@ -12,8 +7,8 @@ import {
 } from 'react';
 import { skinMarketApi, SkinMarketApiError } from './api';
 import { formatCompactNumber, formatMarketDate } from './format';
+import { GetBitfunCta } from './GetBitfunCta';
 import type { Locale, Translate } from './i18n';
-import { BITFUN_RELEASES_URL } from './links';
 import { PosterImage } from './PosterImage';
 import type {
   AppearanceListingSummary,
@@ -160,16 +155,7 @@ export function CatalogPage({
           <h1 id="market-heading">{t('headline')}</h1>
           <p>{t('intro')}</p>
         </div>
-        <aside className="install-note" aria-labelledby="desktop-install-title">
-          <DownloadSimple size={22} weight="regular" aria-hidden="true" />
-          <a href={BITFUN_RELEASES_URL} target="_blank" rel="noreferrer">
-            <strong id="desktop-install-title">
-              {t('desktopInstallTitle')}
-              <ArrowSquareOut size={16} weight="regular" aria-hidden="true" />
-            </strong>
-            <p>{t('desktopInstallNote')}</p>
-          </a>
-        </aside>
+        <GetBitfunCta placement="catalog" t={t} />
       </section>
 
       <section className="catalog shell" aria-labelledby="catalog-heading">

--- a/src/skin-market-web/src/DetailPage.tsx
+++ b/src/skin-market-web/src/DetailPage.tsx
@@ -16,8 +16,8 @@ import {
   formatPackageSize,
   shortHash,
 } from './format';
+import { GetBitfunCta } from './GetBitfunCta';
 import type { Locale, Translate } from './i18n';
-import { BITFUN_RELEASES_URL } from './links';
 import { PosterImage } from './PosterImage';
 import type {
   AppearanceListingDetail,
@@ -184,16 +184,11 @@ export function DetailPage({ catalogSearch, isAdmin, locale, onNavigate, slug, t
                 {t('detailDownload')}
               </a>
             ) : null}
-            <div className="desktop-guidance">
-              <Desktop size={21} weight="regular" aria-hidden="true" />
-              <a href={BITFUN_RELEASES_URL} target="_blank" rel="noreferrer">
-                <strong>
-                  {t('desktopInstallTitle')}
-                  <ArrowSquareOut size={15} weight="regular" aria-hidden="true" />
-                </strong>
-                <span>{t('desktopInstallNote')}</span>
-              </a>
-            </div>
+            <p className="import-hint">
+              <Desktop size={19} weight="regular" aria-hidden="true" />
+              <span>{t('desktopInstallNote')}</span>
+            </p>
+            <GetBitfunCta placement="listing" t={t} />
           </div>
         </section>
 

--- a/src/skin-market-web/src/GetBitfunCta.test.tsx
+++ b/src/skin-market-web/src/GetBitfunCta.test.tsx
@@ -1,0 +1,28 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { GetBitfunCta, type GetBitfunPlacement } from './GetBitfunCta';
+import type { Translate } from './i18n';
+import { BITFUN_DOWNLOAD_URL } from './links';
+
+const t = ((key: string) => key) as Translate;
+
+describe('GetBitfunCta', () => {
+  it.each<GetBitfunPlacement>(['catalog', 'listing'])(
+    'sends %s visitors to the official download page',
+    (placement) => {
+      const markup = renderToStaticMarkup(<GetBitfunCta placement={placement} t={t} />);
+
+      expect(markup).toContain(`href="${BITFUN_DOWNLOAD_URL}"`);
+      expect(markup).toContain('rel="noreferrer"');
+      expect(markup).toContain('getBitfunTitle');
+      expect(markup).toContain('getBitfunAction');
+    },
+  );
+
+  it('explains the surface the visitor is actually looking at', () => {
+    expect(renderToStaticMarkup(<GetBitfunCta placement="listing" t={t} />))
+      .toContain('getBitfunListingNote');
+    expect(renderToStaticMarkup(<GetBitfunCta placement="catalog" t={t} />))
+      .toContain('getBitfunCatalogNote');
+  });
+});

--- a/src/skin-market-web/src/GetBitfunCta.tsx
+++ b/src/skin-market-web/src/GetBitfunCta.tsx
@@ -1,0 +1,38 @@
+import { ArrowRight, DownloadSimple } from '@phosphor-icons/react';
+import type { Translate } from './i18n';
+import { BITFUN_DOWNLOAD_URL } from './links';
+
+// An appearance package only applies inside the desktop client, so the catalog
+// and every listing carry the same visible route to the official download page.
+export type GetBitfunPlacement = 'catalog' | 'listing';
+
+export function GetBitfunCta({
+  placement,
+  t,
+}: {
+  placement: GetBitfunPlacement;
+  t: Translate;
+}) {
+  return (
+    <a
+      className={`get-bitfun get-bitfun--${placement}`}
+      href={BITFUN_DOWNLOAD_URL}
+      target="_blank"
+      rel="noreferrer"
+    >
+      <span className="get-bitfun__icon">
+        <DownloadSimple size={20} weight="bold" aria-hidden="true" />
+      </span>
+      <span className="get-bitfun__copy">
+        <strong>{t('getBitfunTitle')}</strong>
+        <span>
+          {t(placement === 'listing' ? 'getBitfunListingNote' : 'getBitfunCatalogNote')}
+        </span>
+        <span className="get-bitfun__action">
+          {t('getBitfunAction')}
+          <ArrowRight size={17} weight="bold" aria-hidden="true" />
+        </span>
+      </span>
+    </a>
+  );
+}

--- a/src/skin-market-web/src/i18n.ts
+++ b/src/skin-market-web/src/i18n.ts
@@ -27,7 +27,6 @@ const messages = {
     githubUnavailable: 'GitHub sign-in is being configured. Please try again shortly.',
     headline: 'A different atmosphere for BitFun.',
     intro: 'Browse reviewed appearance packages, then install the one that fits your workspace.',
-    desktopInstallTitle: 'Install with BitFun Desktop',
     desktopInstallNote: 'Download the package, then open Settings > Appearance in BitFun Desktop to import it.',
     catalogTitle: 'Reviewed appearances',
     catalogIntro: 'Each release is immutable, compatibility-labeled, and ready for local import.',
@@ -84,6 +83,12 @@ const messages = {
     backToCatalog: 'Browse appearances',
     footerNote: 'Reviewed packages. Local installation. Your appearance stays on your device.',
     bitfunHome: 'BitFun website',
+    getBitfunTitle: 'New to BitFun?',
+    getBitfunCatalogNote:
+      'Appearances apply inside the BitFun desktop client. Download it once, then install any appearance from this market.',
+    getBitfunListingNote:
+      'This appearance applies inside the BitFun desktop client. Download it first, then import the package.',
+    getBitfunAction: 'Download BitFun',
     refresh: 'Refresh',
     submissionsTitle: 'My submissions',
     submissionsIntro: 'Track appearance packages submitted from BitFun Agent and respond to review feedback.',
@@ -160,7 +165,6 @@ const messages = {
     githubUnavailable: 'GitHub 登录正在配置，请稍后再试。',
     headline: '换一种 BitFun 的气质。',
     intro: '浏览经过审核的外观包，为你的工作空间选择更合适的视觉表达。',
-    desktopInstallTitle: '使用 BitFun Desktop 安装',
     desktopInstallNote: '下载外观包后，在 BitFun Desktop 中打开「设置 > 外观」并导入。',
     catalogTitle: '已审核外观',
     catalogIntro: '每个版本都锁定内容哈希，并明确标注兼容要求，可安全导入本机。',
@@ -217,6 +221,12 @@ const messages = {
     backToCatalog: '浏览外观',
     footerNote: '人工审核安装包，本机安装，外观资源只保存在你的设备中。',
     bitfunHome: 'BitFun 官网',
+    getBitfunTitle: '没有 BitFun？',
+    getBitfunCatalogNote:
+      '外观需要在 BitFun 客户端里生效。下载客户端后，就能安装市场里的任意外观。',
+    getBitfunListingNote:
+      '这个外观需要在 BitFun 客户端里生效。先下载客户端，再导入外观包即可。',
+    getBitfunAction: '下载 BitFun 客户端',
     refresh: '刷新',
     submissionsTitle: '我的投稿',
     submissionsIntro: '查看通过 BitFun Agent 投稿的外观包，并跟进审核意见。',

--- a/src/skin-market-web/src/links.test.ts
+++ b/src/skin-market-web/src/links.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { BITFUN_HOME_URL, BITFUN_RELEASES_URL } from './links';
+import { BITFUN_DOWNLOAD_URL, BITFUN_HOME_URL } from './links';
 
 describe('Skin Market external links', () => {
-  it('uses the official BitFun website and GitHub release pages', () => {
+  it('uses the official BitFun website and download pages', () => {
     expect(BITFUN_HOME_URL).toBe('https://openbitfun.com/');
-    expect(BITFUN_RELEASES_URL).toBe('https://github.com/GCWing/BitFun/releases');
+    expect(BITFUN_DOWNLOAD_URL).toBe('https://openbitfun.com/download');
     expect(new URL(BITFUN_HOME_URL).protocol).toBe('https:');
-    expect(new URL(BITFUN_RELEASES_URL).protocol).toBe('https:');
+    expect(new URL(BITFUN_DOWNLOAD_URL).protocol).toBe('https:');
   });
 });

--- a/src/skin-market-web/src/links.ts
+++ b/src/skin-market-web/src/links.ts
@@ -1,2 +1,5 @@
+// Most visitors arrive from a shared appearance link without BitFun installed.
+// Keep the official website and download page in one place so every browse
+// surface funnels to the same URLs.
 export const BITFUN_HOME_URL = 'https://openbitfun.com/';
-export const BITFUN_RELEASES_URL = 'https://github.com/GCWing/BitFun/releases';
+export const BITFUN_DOWNLOAD_URL = 'https://openbitfun.com/download';

--- a/src/skin-market-web/src/styles.css
+++ b/src/skin-market-web/src/styles.css
@@ -439,42 +439,70 @@ img {
   line-height: 1.55;
 }
 
-.install-note {
+/* An appearance package only applies inside the desktop client, so the catalog
+   and every listing carry the same visible route to the download page. */
+.get-bitfun {
   display: grid;
   grid-template-columns: auto 1fr;
   gap: 14px;
-  padding: 20px 0 3px;
-  border-top: 1px solid var(--border-strong);
+  padding: 19px 20px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
   color: var(--text-soft);
-}
-
-.install-note > svg {
-  color: var(--accent);
-}
-
-.install-note > a {
-  color: inherit;
   text-decoration: none;
+  transition: border-color 150ms ease, background-color 150ms ease;
 }
 
-.install-note strong {
-  display: flex;
+.get-bitfun:hover {
+  border-color: var(--border-strong);
+  background: var(--surface-strong);
+}
+
+.get-bitfun__icon {
+  display: grid;
+  width: 38px;
+  height: 38px;
+  place-items: center;
+  border-radius: var(--control-radius);
+  background: var(--accent-soft);
+  color: var(--accent-text);
+}
+
+.get-bitfun__copy {
+  display: grid;
+  gap: 7px;
+  min-width: 0;
+}
+
+.get-bitfun__copy strong {
+  color: var(--text);
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.get-bitfun__copy > span {
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.get-bitfun__action {
+  display: inline-flex;
   width: fit-content;
   align-items: center;
   gap: 6px;
-  margin-bottom: 7px;
-  color: var(--text);
-  font-size: 15px;
-}
-
-.install-note > a:hover strong {
-  color: var(--accent-strong);
-}
-
-.install-note p {
-  margin: 0;
+  margin-top: 2px;
+  color: var(--accent-text);
   font-size: 14px;
-  line-height: 1.55;
+  font-weight: 720;
+}
+
+.get-bitfun__action svg {
+  transition: transform 150ms ease;
+}
+
+.get-bitfun:hover .get-bitfun__action svg {
+  transform: translateX(3px);
 }
 
 .catalog {
@@ -1046,41 +1074,23 @@ img {
   margin-top: 28px;
 }
 
-.desktop-guidance {
+.import-hint {
   display: grid;
   grid-template-columns: auto 1fr;
+  align-items: center;
   gap: 11px;
-  margin-top: 23px;
-  padding-top: 18px;
-  border-top: 1px solid var(--border);
+  margin: 20px 0 0;
   color: var(--text-faint);
+  font-size: 13px;
+  line-height: 1.5;
 }
 
-.desktop-guidance > svg {
+.import-hint > svg {
   color: var(--accent);
 }
 
-.desktop-guidance a {
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
-  color: inherit;
-  font-size: 12px;
-  line-height: 1.5;
-  text-decoration: none;
-}
-
-.desktop-guidance strong {
-  display: flex;
-  width: fit-content;
-  align-items: center;
-  gap: 5px;
-  color: var(--text);
-  font-size: 13px;
-}
-
-.desktop-guidance a:hover strong {
-  color: var(--accent-strong);
+.get-bitfun--listing {
+  margin-top: 22px;
 }
 
 .detail-fact-strip {
@@ -2091,7 +2101,7 @@ img {
     line-height: 1;
   }
 
-  .install-note {
+  .get-bitfun--catalog {
     max-width: 540px;
   }
 


### PR DESCRIPTION
## 问题

MiniApp 市场和 Skin 市场的网页上都没有「下载 BitFun 客户端」的入口。从分享链接进来的访客拿到的是一个 `.bfminiapp` 包或外观包 —— 没有桌面端就用不了，页面上却没有任何后续动作可做。

Skin 市场原本有一条安装提示，但它指向 GitHub releases 列表，这不是新用户该落地的地方。

## 改动

两个市场的目录页和详情页都加上同一个引流卡片，指向 `https://openbitfun.com/download`：

- **MiniApp 市场**：首页 hero 文案下方，以及详情页「下载 .bfminiapp / 收藏」按钮下方。
- **Skin 市场**：目录页 masthead 右栏（替换原来指向 GitHub releases 的安装提示），以及详情页下载按钮下方。详情页保留「设置 > 外观」的导入说明，改为一行普通提示，服务已经装了 BitFun 的用户。

两边各自新增 `GetBitfunCta.tsx` 和 `links.ts`（Skin 的 `links.ts` 用 `BITFUN_DOWNLOAD_URL` 取代不再使用的 `BITFUN_RELEASES_URL`）。文案按各自的语言集补齐：MiniApp 三语（en-US / zh-CN / zh-TW），Skin 双语（en-US / zh-CN）。

第三个 commit 是发布时发现的既有问题：`src/apps/skin-market-server/Dockerfile` 没有把 `patches/` 拷进构建上下文，`pnpm install --frozen-lockfile` 会在校验 patch 哈希时直接失败。和 55a7dc04c 给 MiniApp 镜像做的修复相同。

## 验证

- `pnpm run type-check:miniapp-market` / `test:miniapp-market` / `build:miniapp-market`
- `pnpm run type-check:skin-market` / `test:skin-market` / `build:skin-market`
- `pnpm run i18n:contract:test`、`pnpm run i18n:audit`
- 本地 Vite 代理生产 API，人工检查四个界面（两市场 × 目录/详情）、中英文、深浅色、桌面与移动宽度。

## 发布状态

已按 `deploy/miniapp-market/README.md` 和 `deploy/skin-market/README.md` 从本分支 commit 发布到生产（未走 main）：

- `bitfun-miniapp-market` → `000f16945`，healthy
- `bitfun-skin-market` → `f3fa4f92c`，healthy

合并后如果从 main 重新发布，需要确认 main 上已经包含这几个 commit，否则会把线上改动顶掉。