### PR TITLE
fix(release): sync Cargo.lock when projecting build version

### DIFF
--- a/scripts/set-build-version.mjs
+++ b/scripts/set-build-version.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-import { readFileSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -40,6 +41,32 @@ export function setBuildVersion(root, version) {
     /^version = "[^"]+"$/m,
     `version = "${version}"`,
   );
+
+  syncCargoLock(root);
+}
+
+// Workspace members inherit the root version, so the lockfile carries a copy of
+// it for every member. Leaving those stale breaks any later `cargo --locked`
+// invocation. Cargo has to do the rewrite: a text substitution would also catch
+// third-party crates that happen to publish the same version string, and would
+// miss members that pin a version of their own.
+function syncCargoLock(root) {
+  if (!existsSync(path.join(root, 'Cargo.lock'))) {
+    return;
+  }
+
+  const result = spawnSync('cargo', ['update', '--workspace', '--offline'], {
+    cwd: root,
+    encoding: 'utf8',
+  });
+  if (result.error) {
+    throw new Error(`Failed to run cargo update: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `cargo update --workspace --offline failed with exit code ${result.status}\n${result.stderr || ''}`,
+    );
+  }
 }
 
 function replaceVersion(file, pattern, replacement) {


### PR DESCRIPTION
## 问题

`scripts/set-build-version.mjs` 改写各 manifest 的版本号，但漏掉了 `Cargo.lock`。workspace 成员都是 `version.workspace = true`，lockfile 里存了 43 份成员版本的副本，改完 `Cargo.toml` 后这些副本就失配了，随后任何 `cargo --locked` 调用都会拒绝执行：

```
error: cannot update the lock file /home/runner/work/BitFun/BitFun/Cargo.lock because --locked was passed to prevent this
```

## 影响范围

只影响**构建期改写版本号**的两条路径 —— beta 和 nightly。stable 发布的版本号在仓库里已经同步好（例如 #2417 的 bump 就一并改了 `Cargo.lock` 的 90 行），构建时不需要再改，所以一直没暴露。

回归引入点是 `6679a084a perf(app-server): move TypeScript schemas to protocol owner`（8/14），它把 `cargo test --locked --package bitfun-app-server-protocol` 放进了 `gen:types`，而 `gen:types` 在 desktop 构建路径上。

- **nightly** 自 8/14 起每一次都失败，报的正是上面这个错
- **`v0.2.19-beta.1`** 桌面构建五个平台全部失败（[run 32475285977](https://github.com/GCWing/BitFun/actions/runs/32475285977)）
- 最后一次成功的 beta 是 `v0.2.18-beta.1`（8/13），正好在回归引入之前

`nightly.yml` 里 Windows 那一步已经用 `cargo generate-lockfile` 临时绕过了同一个问题，但 `Build desktop app` 这条路径没有。

## 改动

版本改写完之后调用 `cargo update --workspace --offline` 同步 lockfile。

交给 cargo 而不是做文本替换，有两个原因：

1. 纯文本替换 `version = "0.2.19"` 会**误伤第三方 crate** —— 目前 `num-traits` 的版本恰好就是 `0.2.19`
2. 会**误改自己钉死版本的成员** —— `bitfun-page-function-runtime` 和 `bitfun-relay-service` 在各自 `Cargo.toml` 里硬编码了版本，脚本不改它们，lockfile 里也不该改，否则反而制造新的失配

`Cargo.lock` 不存在时直接跳过，这样 `release-channel.test.mjs` 的 fixture（不含 lockfile）不受影响。

## 验证

在 `4cd163856` 上：

| 项 | 修复前 | 修复后 |
|---|---|---|
| `cargo metadata --locked` | exit 101（复现 CI 报错） | exit 0 |
| `Cargo.lock` 成员版本同步 | 0 / 43 | 43 / 43 |
| 第三方依赖改动 | — | 0 行 |
| `release-channel.test.mjs` | 5 pass | 5 pass |
| `check-github-config.test.mjs` | 15 pass / 1 fail | 15 pass / 1 fail（`gates Rust and CLI validation` 在干净 main 上同样失败，与本改动无关） |

`cargo update --workspace --offline` 的实际输出确认只动 workspace 成员：43 行版本变更，第三方 0 行，`num-traits`、`bitfun-page-function-runtime`、`bitfun-relay-service` 都保持不变。