### PR TITLE
fix(release): drop --offline from the workspace lockfile sync

### DIFF
--- a/scripts/set-build-version.mjs
+++ b/scripts/set-build-version.mjs
@@ -50,12 +50,15 @@ export function setBuildVersion(root, version) {
 // invocation. Cargo has to do the rewrite: a text substitution would also catch
 // third-party crates that happen to publish the same version string, and would
 // miss members that pin a version of their own.
+//
+// This cannot run with --offline: resolving the workspace walks every source,
+// and the git dependencies (tauri) are not in a cold CI cargo home yet.
 function syncCargoLock(root) {
   if (!existsSync(path.join(root, 'Cargo.lock'))) {
     return;
   }
 
-  const result = spawnSync('cargo', ['update', '--workspace', '--offline'], {
+  const result = spawnSync('cargo', ['update', '--workspace'], {
     cwd: root,
     encoding: 'utf8',
   });
@@ -64,7 +67,7 @@ function syncCargoLock(root) {
   }
   if (result.status !== 0) {
     throw new Error(
-      `cargo update --workspace --offline failed with exit code ${result.status}\n${result.stderr || ''}`,
+      `cargo update --workspace failed with exit code ${result.status}\n${result.stderr || ''}`,
     );
   }
 }


### PR DESCRIPTION
跟进 #2422。那个 PR 给 `set-build-version.mjs` 加的 lockfile 同步用了 `--offline`，在 CI 上跑不通。

## 问题

解析 workspace 时 cargo 会走一遍所有 source，而 `tauri-runtime` 是 git 依赖（`tauri-apps/tauri.git?rev=7cc68e74`），CI runner 的 cargo home 是冷的、还没有这个 checkout：

```
[build-version] cargo update --workspace --offline failed with exit code 101
error: failed to load source for dependency `tauri-runtime`

Caused by:
  unable to update https://github.com/tauri-apps/tauri.git?rev=7cc68e74ff6981f5c50a52a67d56c5eb2d227188#7cc68e74

Caused by:
  can't checkout from 'https://github.com/tauri-apps/tauri.git': you are in the offline mode (--offline)
```

`v0.2.19-beta.1` 的构建（[run 32476442233](https://github.com/GCWing/BitFun/actions/runs/32476442233)）五个平台都挂在 `Project beta build version` 这一步。

这个 flag 之所以没在本地被发现，是因为热 cargo home 里已经有那份 checkout —— 用热缓存验证了一个只在冷缓存下暴露的问题。

## 改动

去掉 `--offline`。`cargo update --workspace` 的语义不变，仍然只更新 workspace 成员，第三方依赖一行不动。

## 验证

这次用全新的 `CARGO_HOME` 验证（能复现 CI 的冷缓存状态）：

| 条件 | 结果 |
|---|---|
| 冷 `CARGO_HOME` + `--offline` | exit 101，逐字复现 CI 报错 |
| 冷 `CARGO_HOME`，无 `--offline` | **exit 0，耗时 26s** |
| `Cargo.toml` → `0.2.19-beta.1` | 是 |
| `Cargo.lock` 成员版本同步 | 43 / 43 |
| 第三方依赖改动 | 0 行 |
| `cargo metadata --locked`（#2422 要修的原始失败点） | exit 0 |
| `release-channel.test.mjs` | 5 pass / 0 fail |