### PR TITLE
fix(agent-runtime): persist evidence ledger

### DIFF
--- a/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
@@ -10062,14 +10062,31 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                         partial_result.text.len()
                     );
                     if let Some(parent_info) = subagent_parent_info.as_ref() {
-                        let event = self.session_manager.record_subagent_partial_timeout(
-                            &parent_info.session_id,
-                            &parent_info.dialog_turn_id,
-                            &logical_agent_type,
-                            &partial_result.text,
-                            Some("timeout"),
-                        );
-                        partial_result = partial_result.with_ledger_event_id(event.event_id);
+                        match self
+                            .session_manager
+                            .record_subagent_partial_timeout(
+                                &parent_info.session_id,
+                                &parent_info.dialog_turn_id,
+                                &logical_agent_type,
+                                &partial_result.text,
+                                Some("timeout"),
+                            )
+                            .await
+                        {
+                            Ok(event) => {
+                                partial_result =
+                                    partial_result.with_ledger_event_id(event.event_id);
+                            }
+                            Err(error) => {
+                                warn!(
+                                    "Failed to persist partial subagent evidence: parent_session_id={}, parent_turn_id={}, agent_type={}, error={}",
+                                    parent_info.session_id,
+                                    parent_info.dialog_turn_id,
+                                    logical_agent_type,
+                                    error
+                                );
+                            }
+                        }
                     }
                     if let Err(cleanup_err) = self.cleanup_subagent_resources(&session_id).await {
                         warn!(

--- a/src/crates/assembly/core/src/agentic/persistence/manager.rs
+++ b/src/crates/assembly/core/src/agentic/persistence/manager.rs
@@ -1690,6 +1690,42 @@ impl PersistenceManager {
         Ok(Some(retained))
     }
 
+    /// Write a complete evidence ledger sidecar for a session. Used by session
+    /// branching to copy inherited evidence into the fork target. The caller
+    /// must already hold the session write lock for `session_id`.
+    pub(crate) async fn save_evidence_ledger_events(
+        &self,
+        workspace_path: &Path,
+        session_id: &str,
+        events: Vec<EvidenceLedgerEvent>,
+    ) -> BitFunResult<()> {
+        Self::validate_session_id(session_id)?;
+        let persistence_lock = self
+            .get_session_persistence_lock(workspace_path, session_id)
+            .await;
+        let _persistence_guard = persistence_lock.lock().await;
+        self.ensure_session_dir(workspace_path, session_id).await?;
+        let path = self.evidence_ledger_path(workspace_path, session_id);
+        let _file_lock = JsonFileStore
+            .acquire_cross_process_lock(&path)
+            .await
+            .map_err(Self::json_store_error)?;
+        let file = PersistedEvidenceLedgerFile {
+            schema_version: EVIDENCE_LEDGER_SCHEMA_VERSION,
+            session_id: session_id.to_string(),
+            events,
+        };
+        // Validate before writing so a bad session_id on an event is caught.
+        file.clone()
+            .validated_events(session_id)
+            .map_err(|error| BitFunError::parse(error.to_string()))?;
+        JsonFileStore
+            .write_atomic_strict(&path, &file)
+            .await
+            .map_err(Self::json_store_error)?;
+        Ok(())
+    }
+
     pub async fn load_prompt_cache(
         &self,
         workspace_path: &Path,

--- a/src/crates/assembly/core/src/agentic/persistence/manager.rs
+++ b/src/crates/assembly/core/src/agentic/persistence/manager.rs
@@ -17,6 +17,9 @@ use crate::agentic::session::transcript_render::{
 use crate::agentic::session::{
     CoreSessionStorePort, SessionPromptCache, TokenAnchor, PROMPT_CACHE_SCHEMA_VERSION,
 };
+use crate::agentic::session::{
+    EvidenceLedgerEvent, PersistedEvidenceLedgerFile, EVIDENCE_LEDGER_SCHEMA_VERSION,
+};
 use crate::agentic::skill_agent_snapshot::TurnSkillAgentSnapshot;
 use crate::infrastructure::PathManager;
 use crate::service::config::get_global_config_service;
@@ -485,6 +488,8 @@ pub struct PersistenceManager {
     #[cfg(test)]
     fail_next_session_state_write: std::sync::Mutex<Option<String>>,
     #[cfg(test)]
+    fail_next_evidence_ledger_write: std::sync::Mutex<Option<String>>,
+    #[cfg(test)]
     fail_next_session_metadata_write: std::sync::Mutex<Option<String>>,
     #[cfg(test)]
     fail_next_session_metadata_rollback: std::sync::Mutex<Option<String>>,
@@ -499,6 +504,8 @@ impl PersistenceManager {
             path_manager,
             #[cfg(test)]
             fail_next_session_state_write: std::sync::Mutex::new(None),
+            #[cfg(test)]
+            fail_next_evidence_ledger_write: std::sync::Mutex::new(None),
             #[cfg(test)]
             fail_next_session_metadata_write: std::sync::Mutex::new(None),
             #[cfg(test)]
@@ -527,6 +534,14 @@ impl PersistenceManager {
             .fail_next_session_state_write
             .lock()
             .expect("session state fault lock") = Some(session_id.to_string());
+    }
+
+    #[cfg(test)]
+    pub(crate) fn fail_next_evidence_ledger_write_for_test(&self, session_id: &str) {
+        *self
+            .fail_next_evidence_ledger_write
+            .lock()
+            .expect("evidence ledger fault lock") = Some(session_id.to_string());
     }
 
     #[cfg(test)]
@@ -606,6 +621,12 @@ impl PersistenceManager {
 
     fn state_path(&self, workspace_path: &Path, session_id: &str) -> PathBuf {
         self.session_layout(workspace_path).state_path(session_id)
+    }
+
+    fn evidence_ledger_path(&self, workspace_path: &Path, session_id: &str) -> PathBuf {
+        self.session_layout(workspace_path)
+            .session_dir(session_id)
+            .join("evidence-ledger.json")
     }
 
     fn prompt_cache_path(&self, workspace_path: &Path, session_id: &str) -> PathBuf {
@@ -1557,6 +1578,74 @@ impl PersistenceManager {
         }
         self.write_json_atomic(&self.state_path(workspace_path, session_id), state)
             .await
+    }
+
+    pub(crate) async fn load_evidence_ledger_events(
+        &self,
+        workspace_path: &Path,
+        session_id: &str,
+    ) -> BitFunResult<Vec<EvidenceLedgerEvent>> {
+        Self::validate_session_id(session_id)?;
+        let path = self.evidence_ledger_path(workspace_path, session_id);
+        let file = JsonFileStore
+            .read_locked_optional::<PersistedEvidenceLedgerFile>(&path)
+            .await
+            .map_err(Self::json_store_error)?;
+        file.map(|file| {
+            file.validated_events(session_id)
+                .map_err(|error| BitFunError::parse(error.to_string()))
+        })
+        .transpose()
+        .map(Option::unwrap_or_default)
+    }
+
+    pub(crate) async fn append_evidence_ledger_event(
+        &self,
+        workspace_path: &Path,
+        event: &EvidenceLedgerEvent,
+    ) -> BitFunResult<Vec<EvidenceLedgerEvent>> {
+        Self::validate_session_id(&event.session_id)?;
+        let _session_write =
+            self.lock_session_write_operation(workspace_path, &event.session_id)?;
+        self.ensure_runtime_for_write(workspace_path).await?;
+        let persistence_lock = self
+            .get_session_persistence_lock(workspace_path, &event.session_id)
+            .await;
+        let _persistence_guard = persistence_lock.lock().await;
+        self.ensure_session_dir(workspace_path, &event.session_id)
+            .await?;
+
+        #[cfg(test)]
+        {
+            let mut fault = self
+                .fail_next_evidence_ledger_write
+                .lock()
+                .expect("evidence ledger fault lock");
+            if fault.as_deref() == Some(event.session_id.as_str()) {
+                *fault = None;
+                return Err(BitFunError::io("Injected evidence ledger write failure"));
+            }
+        }
+
+        let path = self.evidence_ledger_path(workspace_path, &event.session_id);
+        let _file_lock = JsonFileStore
+            .acquire_cross_process_lock(&path)
+            .await
+            .map_err(Self::json_store_error)?;
+        let mut file = JsonFileStore
+            .read_optional::<PersistedEvidenceLedgerFile>(&path)
+            .await
+            .map_err(Self::json_store_error)?
+            .unwrap_or_else(|| PersistedEvidenceLedgerFile::new(event.session_id.clone()));
+        file.append(event.clone())
+            .map_err(|error| BitFunError::parse(error.to_string()))?;
+        file.schema_version = EVIDENCE_LEDGER_SCHEMA_VERSION;
+        JsonFileStore
+            .write_atomic_strict(&path, &file)
+            .await
+            .map_err(Self::json_store_error)?;
+        file.validated_events(&event.session_id)
+            .map_err(|error| BitFunError::parse(error.to_string()))
     }
 
     pub async fn load_prompt_cache(

--- a/src/crates/assembly/core/src/agentic/persistence/manager.rs
+++ b/src/crates/assembly/core/src/agentic/persistence/manager.rs
@@ -1648,6 +1648,48 @@ impl PersistenceManager {
             .map_err(|error| BitFunError::parse(error.to_string()))
     }
 
+    pub(crate) async fn retain_evidence_ledger_events(
+        &self,
+        workspace_path: &Path,
+        session_id: &str,
+        surviving_turn_ids: &std::collections::HashSet<String>,
+    ) -> BitFunResult<Option<Vec<EvidenceLedgerEvent>>> {
+        Self::validate_session_id(session_id)?;
+        let _session_write = self.lock_session_write_operation(workspace_path, session_id)?;
+        let persistence_lock = self
+            .get_session_persistence_lock(workspace_path, session_id)
+            .await;
+        let _persistence_guard = persistence_lock.lock().await;
+
+        let path = self.evidence_ledger_path(workspace_path, session_id);
+        let _file_lock = JsonFileStore
+            .acquire_cross_process_lock(&path)
+            .await
+            .map_err(Self::json_store_error)?;
+        if !path.exists() {
+            return Ok(None);
+        }
+        let Some(mut file) = JsonFileStore
+            .read_optional::<PersistedEvidenceLedgerFile>(&path)
+            .await
+            .map_err(Self::json_store_error)?
+        else {
+            return Err(BitFunError::io(format!(
+                "Evidence ledger disappeared while retaining: {}",
+                path.display()
+            )));
+        };
+        let retained = file
+            .retain_turn_ids(session_id, surviving_turn_ids)
+            .map_err(|error| BitFunError::parse(error.to_string()))?;
+        file.schema_version = EVIDENCE_LEDGER_SCHEMA_VERSION;
+        JsonFileStore
+            .write_atomic_strict(&path, &file)
+            .await
+            .map_err(Self::json_store_error)?;
+        Ok(Some(retained))
+    }
+
     pub async fn load_prompt_cache(
         &self,
         workspace_path: &Path,

--- a/src/crates/assembly/core/src/agentic/persistence/session_branch.rs
+++ b/src/crates/assembly/core/src/agentic/persistence/session_branch.rs
@@ -176,6 +176,35 @@ impl PersistenceManager {
                 .await?;
             }
 
+            // Copy evidence ledger events for the branched turns, rewriting
+            // session_id to the target session so the fork inherits
+            // checkpoints, failed commands, and partial subagent results.
+            let source_evidence_events = self
+                .load_evidence_ledger_events(workspace_path, &request.source_session_id)
+                .await?;
+            if !source_evidence_events.is_empty() {
+                let copied_turn_ids: std::collections::HashSet<String> = branched_turns
+                    .iter()
+                    .map(|turn| turn.turn_id.clone())
+                    .collect();
+                let branched_evidence_events = source_evidence_events
+                    .into_iter()
+                    .filter(|event| copied_turn_ids.contains(&event.turn_id))
+                    .map(|mut event| {
+                        event.session_id = target_session_id.clone();
+                        event
+                    })
+                    .collect::<Vec<_>>();
+                if !branched_evidence_events.is_empty() {
+                    self.save_evidence_ledger_events(
+                        workspace_path,
+                        &target_session_id,
+                        branched_evidence_events,
+                    )
+                    .await?;
+                }
+            }
+
             let now_ms = SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .unwrap_or_default()

--- a/src/crates/assembly/core/src/agentic/session/session_manager.rs
+++ b/src/crates/assembly/core/src/agentic/session/session_manager.rs
@@ -2090,6 +2090,54 @@ impl SessionManager {
         Ok(event)
     }
 
+    /// Callers must hold the Session mutation boundary. The evidence operation
+    /// lock serializes this retention with evidence appends and restores.
+    ///
+    /// `force_prune_persisted_sidecar` covers explicit staged-revert history
+    /// mutations: a durable `session-revert.json` marker can exist even when
+    /// automatic Session persistence is disabled, and committing that marker
+    /// must prune the sidecar too. Legacy in-memory rollback keeps its existing
+    /// behavior unless automatic persistence is enabled.
+    async fn retain_evidence_events_locked(
+        &self,
+        session_storage_path: Option<&Path>,
+        session_id: &str,
+        surviving_turn_ids: &HashSet<String>,
+        force_prune_persisted_sidecar: bool,
+    ) -> BitFunResult<()> {
+        let _operation_guard = self.evidence_ledger_operation_locks.lock(session_id).await;
+        let durable_session = self
+            .sessions
+            .get(session_id)
+            .map(|session| self.should_persist_session(&session))
+            .unwrap_or(true);
+        let prune_persisted_sidecar =
+            durable_session && (self.config.enable_persistence || force_prune_persisted_sidecar);
+        if prune_persisted_sidecar {
+            let storage_path = session_storage_path.ok_or_else(|| {
+                BitFunError::session(format!(
+                    "Session storage path unavailable while retaining evidence: {}",
+                    session_id
+                ))
+            })?;
+            let retained = self
+                .persistence_manager
+                .retain_evidence_ledger_events(storage_path, session_id, surviving_turn_ids)
+                .await?;
+            if self.config.enable_persistence {
+                if let Some(retained) = retained {
+                    self.evidence_ledger
+                        .replace_session(session_id, retained)
+                        .map_err(|error| BitFunError::parse(error.to_string()))?;
+                    return Ok(());
+                }
+            }
+        }
+        self.evidence_ledger
+            .retain_turn_ids(session_id, surviving_turn_ids);
+        Ok(())
+    }
+
     pub async fn record_checkpoint_created(
         &self,
         session_id: &str,
@@ -5665,10 +5713,17 @@ impl SessionManager {
         if let Some(revert) = staged_revert.as_ref() {
             persisted_turns.retain(|turn| turn.turn_index < revert.boundary_turn);
         }
+        let surviving_turn_ids: HashSet<String> = persisted_turns
+            .iter()
+            .map(|turn| turn.turn_id.clone())
+            .collect();
         let restored_evidence_events = self
             .persistence_manager
             .load_evidence_ledger_events(session_storage_path, session_id)
-            .await?;
+            .await?
+            .into_iter()
+            .filter(|event| surviving_turn_ids.contains(&event.turn_id))
+            .collect::<Vec<_>>();
         debug!(
             "Session restore phase completed: session_id={}, phase=load_session_with_turns, turn_count={}, duration_ms={}",
             session_id,
@@ -6185,6 +6240,17 @@ impl SessionManager {
             session.updated_at = SystemTime::now();
             session.last_activity_at = SystemTime::now();
         }
+        let surviving_turn_ids = visible_turns
+            .iter()
+            .map(|turn| turn.turn_id.clone())
+            .collect::<HashSet<_>>();
+        self.retain_evidence_events_locked(
+            Some(session_storage_path),
+            session_id,
+            &surviving_turn_ids,
+            true,
+        )
+        .await?;
         Ok(())
     }
 
@@ -6244,6 +6310,13 @@ impl SessionManager {
             .unwrap_or_default();
         self.rollback_edit_constraint_state_to_turns(session_id, &surviving_turn_ids)
             .await;
+        self.retain_evidence_events_locked(
+            Some(session_storage_path),
+            session_id,
+            &surviving_turn_ids,
+            true,
+        )
+        .await?;
         let messages = self.context_store.get_context_messages(session_id);
         self.prune_token_anchors_to_messages(session_id, &messages)
             .await;
@@ -6393,6 +6466,13 @@ impl SessionManager {
             .remove_from(session_id, target_turn);
         self.rollback_edit_constraint_state_to_turns(session_id, &surviving_dialog_turn_ids)
             .await;
+        self.retain_evidence_events_locked(
+            Some(workspace_path),
+            session_id,
+            &surviving_dialog_turn_ids,
+            false,
+        )
+        .await?;
 
         Ok(())
     }
@@ -9974,7 +10054,7 @@ mod tests {
         let persistence_manager = Arc::new(
             PersistenceManager::new(workspace.path_manager()).expect("persistence manager"),
         );
-        let manager = test_manager(persistence_manager);
+        let manager = test_manager(persistence_manager.clone());
         let session = manager
             .create_session(
                 "Recovery permission".to_string(),
@@ -15708,7 +15788,7 @@ mod tests {
         let persistence_manager = Arc::new(
             PersistenceManager::new(workspace.path_manager()).expect("persistence manager"),
         );
-        let manager = test_manager(persistence_manager);
+        let manager = test_manager(persistence_manager.clone());
         let session = manager
             .create_session(
                 "Durable evidence".to_string(),
@@ -15724,6 +15804,26 @@ mod tests {
             .effective_session_storage_path(&session.session_id)
             .await
             .expect("storage path");
+        let turn = DialogTurnData::new(
+            "turn-a".to_string(),
+            0,
+            session.session_id.clone(),
+            UserMessageData {
+                id: "turn-a-user".to_string(),
+                content: "continue".to_string(),
+                timestamp: 1,
+                metadata: None,
+            },
+        );
+        persistence_manager
+            .save_dialog_turn(workspace.path(), &turn)
+            .await
+            .expect("turn should save");
+        manager
+            .sessions
+            .get_mut(&session.session_id)
+            .expect("session should be active")
+            .dialog_turn_ids = vec!["turn-a".to_string()];
         let event = manager
             .record_checkpoint_created(
                 &session.session_id,
@@ -15768,6 +15868,463 @@ mod tests {
         let summary = manager.evidence_summary_for_session(&session.session_id, 10);
         assert_eq!(summary.latest_checkpoints.len(), 1);
         assert_eq!(summary.latest_checkpoints[0].target, "src/lib.rs");
+    }
+
+    #[tokio::test]
+    async fn staged_revert_prunes_evidence_ledger_to_visible_turn_ids() {
+        use crate::agentic::session::revert::{
+            SessionRevertPhase, SessionRevertState, SESSION_REVERT_SCHEMA_VERSION,
+        };
+
+        let workspace = TestWorkspace::new();
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(workspace.path_manager()).expect("persistence manager"),
+        );
+        let manager = test_manager(persistence_manager.clone());
+        let session = manager
+            .create_session(
+                "Staged revert evidence".to_string(),
+                "agentic".to_string(),
+                SessionConfig {
+                    workspace_path: Some(workspace.path().to_string_lossy().to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("session should create");
+
+        for index in 0..3 {
+            let turn = DialogTurnData::new(
+                format!("turn-{index}"),
+                index,
+                session.session_id.clone(),
+                UserMessageData {
+                    id: format!("turn-{index}-user"),
+                    content: format!("prompt {index}"),
+                    timestamp: index as u64,
+                    metadata: None,
+                },
+            );
+            persistence_manager
+                .save_dialog_turn(workspace.path(), &turn)
+                .await
+                .expect("turn should save");
+            let messages = (0..=index)
+                .map(|message_index| {
+                    crate::agentic::core::Message::user(format!("prompt {message_index}"))
+                })
+                .collect::<Vec<_>>();
+            persistence_manager
+                .save_turn_context_snapshot(workspace.path(), &session.session_id, index, &messages)
+                .await
+                .expect("context snapshot should save");
+        }
+        manager
+            .sessions
+            .get_mut(&session.session_id)
+            .expect("session should be active")
+            .dialog_turn_ids = vec![
+            "turn-0".to_string(),
+            "turn-1".to_string(),
+            "turn-2".to_string(),
+        ];
+        let turn_0_event = manager
+            .record_subagent_partial_timeout(
+                &session.session_id,
+                "turn-0",
+                "ReviewSecurity",
+                "Partial turn 0",
+                Some("timeout"),
+            )
+            .await
+            .expect("turn-0 evidence should persist");
+        let turn_1_event = manager
+            .record_subagent_partial_timeout(
+                &session.session_id,
+                "turn-1",
+                "ReviewTests",
+                "Partial turn 1",
+                Some("timeout"),
+            )
+            .await
+            .expect("turn-1 evidence should persist");
+        let turn_2_event = manager
+            .record_subagent_partial_timeout(
+                &session.session_id,
+                "turn-2",
+                "Edit",
+                "Partial turn 2",
+                Some("timeout"),
+            )
+            .await
+            .expect("turn-2 evidence should persist");
+        let storage_path = manager
+            .effective_session_storage_path(&session.session_id)
+            .await
+            .expect("storage path");
+        let ledger_path = storage_path
+            .join(&session.session_id)
+            .join("evidence-ledger.json");
+        let stored_before: PersistedEvidenceLedgerFile = serde_json::from_slice(
+            &std::fs::read(&ledger_path).expect("ledger sidecar should exist"),
+        )
+        .expect("ledger sidecar should deserialize");
+        assert_eq!(
+            stored_before
+                .events
+                .iter()
+                .map(|event| event.event_id.clone())
+                .collect::<Vec<_>>(),
+            vec![
+                turn_0_event.event_id.clone(),
+                turn_1_event.event_id.clone(),
+                turn_2_event.event_id.clone(),
+            ]
+        );
+
+        let state = SessionRevertState {
+            schema_version: SESSION_REVERT_SCHEMA_VERSION,
+            boundary_turn: 2,
+            original_turn_end: 3,
+            phase: SessionRevertPhase::Staged,
+            workspace_checkpoint: Vec::new(),
+        };
+        persistence_manager
+            .save_session_revert_state(workspace.path(), &session.session_id, &state)
+            .await
+            .expect("staged revert should persist");
+
+        manager
+            .apply_staged_revert_context_locked(
+                workspace.path(),
+                &session.session_id,
+                state.boundary_turn,
+            )
+            .await
+            .expect("staged context should apply");
+
+        assert!(manager
+            .evidence_events_for_turn(&session.session_id, "turn-2")
+            .is_empty());
+        assert_eq!(
+            manager.evidence_events_for_turn(&session.session_id, "turn-1"),
+            vec![turn_1_event.clone()]
+        );
+        let stored_after: PersistedEvidenceLedgerFile = serde_json::from_slice(
+            &std::fs::read(&ledger_path).expect("ledger sidecar should still exist"),
+        )
+        .expect("ledger sidecar should deserialize");
+        assert_eq!(
+            stored_after.events,
+            vec![turn_0_event, turn_1_event.clone()]
+        );
+
+        assert!(manager
+            .unload_session_from_memory(&session.session_id)
+            .await
+            .expect("session should unload"));
+        let restored = manager
+            .restore_session(workspace.path(), &session.session_id)
+            .await
+            .expect("staged session should restore");
+        assert_eq!(
+            restored.dialog_turn_ids,
+            vec!["turn-0".to_string(), "turn-1".to_string()]
+        );
+        assert_eq!(
+            manager.evidence_events_for_turn(&session.session_id, "turn-1"),
+            vec![turn_1_event]
+        );
+        assert!(manager
+            .evidence_events_for_turn(&session.session_id, "turn-2")
+            .is_empty());
+        assert_eq!(
+            manager
+                .evidence_summary_for_session(&session.session_id, 10)
+                .partial_subagent_results
+                .len(),
+            2
+        );
+    }
+
+    #[tokio::test]
+    async fn staged_revert_prunes_evidence_sidecar_without_automatic_persistence() {
+        use crate::agentic::session::revert::{
+            SessionRevertPhase, SessionRevertState, SESSION_REVERT_SCHEMA_VERSION,
+        };
+
+        let workspace = TestWorkspace::new();
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(workspace.path_manager()).expect("persistence manager"),
+        );
+        let writer = test_manager(persistence_manager.clone());
+        let session = writer
+            .create_session(
+                "Staged revert explicit history evidence".to_string(),
+                "agentic".to_string(),
+                SessionConfig {
+                    workspace_path: Some(workspace.path().to_string_lossy().to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("session should create");
+
+        for index in 0..2 {
+            let turn = DialogTurnData::new(
+                format!("turn-{index}"),
+                index,
+                session.session_id.clone(),
+                UserMessageData {
+                    id: format!("turn-{index}-user"),
+                    content: format!("prompt {index}"),
+                    timestamp: index as u64,
+                    metadata: None,
+                },
+            );
+            persistence_manager
+                .save_dialog_turn(workspace.path(), &turn)
+                .await
+                .expect("turn should save");
+            let messages = (0..=index)
+                .map(|message_index| {
+                    crate::agentic::core::Message::user(format!("prompt {message_index}"))
+                })
+                .collect::<Vec<_>>();
+            persistence_manager
+                .save_turn_context_snapshot(workspace.path(), &session.session_id, index, &messages)
+                .await
+                .expect("context snapshot should save");
+        }
+        writer
+            .sessions
+            .get_mut(&session.session_id)
+            .expect("session should be active")
+            .dialog_turn_ids = vec!["turn-0".to_string(), "turn-1".to_string()];
+        let turn_0_event = writer
+            .record_subagent_partial_timeout(
+                &session.session_id,
+                "turn-0",
+                "ReviewSecurity",
+                "Partial turn 0",
+                Some("timeout"),
+            )
+            .await
+            .expect("turn-0 evidence should persist");
+        let _turn_1_event = writer
+            .record_subagent_partial_timeout(
+                &session.session_id,
+                "turn-1",
+                "ReviewTests",
+                "Partial turn 1",
+                Some("timeout"),
+            )
+            .await
+            .expect("turn-1 evidence should persist");
+        let storage_path = writer
+            .effective_session_storage_path(&session.session_id)
+            .await
+            .expect("storage path");
+        persistence_manager
+            .save_session_revert_state(
+                workspace.path(),
+                &session.session_id,
+                &SessionRevertState {
+                    schema_version: SESSION_REVERT_SCHEMA_VERSION,
+                    boundary_turn: 1,
+                    original_turn_end: 2,
+                    phase: SessionRevertPhase::Committing,
+                    workspace_checkpoint: Vec::new(),
+                },
+            )
+            .await
+            .expect("staged revert should persist");
+        assert!(writer
+            .unload_session_from_memory(&session.session_id)
+            .await
+            .expect("session should unload"));
+
+        let manager = test_manager_with_config(
+            persistence_manager.clone(),
+            SessionManagerConfig {
+                max_active_sessions: 100,
+                session_idle_timeout: Duration::from_secs(3600),
+                auto_save_interval: Duration::from_secs(300),
+                enable_persistence: false,
+                prompt_cache_policy: PromptCachePolicy::default(),
+            },
+        );
+        let restored = manager
+            .restore_session(workspace.path(), &session.session_id)
+            .await
+            .expect("explicit history should restore");
+        assert_eq!(restored.dialog_turn_ids, vec!["turn-0".to_string()]);
+        manager
+            .commit_staged_revert_context_locked(&storage_path, &session.session_id, 1)
+            .await
+            .expect("staged revert should commit without automatic persistence");
+
+        let stored: PersistedEvidenceLedgerFile = serde_json::from_slice(
+            &std::fs::read(
+                storage_path
+                    .join(&session.session_id)
+                    .join("evidence-ledger.json"),
+            )
+            .expect("ledger sidecar should still exist"),
+        )
+        .expect("ledger sidecar should deserialize");
+        assert_eq!(stored.events, vec![turn_0_event.clone()]);
+        assert_eq!(
+            manager.evidence_events_for_turn(&session.session_id, "turn-0"),
+            vec![turn_0_event]
+        );
+        assert!(manager
+            .evidence_events_for_turn(&session.session_id, "turn-1")
+            .is_empty());
+        assert_eq!(
+            manager
+                .evidence_summary_for_session(&session.session_id, 10)
+                .partial_subagent_results
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn legacy_rollback_prunes_evidence_ledger_to_surviving_turn_ids() {
+        let workspace = TestWorkspace::new();
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(workspace.path_manager()).expect("persistence manager"),
+        );
+        let manager = test_manager(persistence_manager.clone());
+        let session = manager
+            .create_session(
+                "Rollback evidence".to_string(),
+                "agentic".to_string(),
+                SessionConfig {
+                    workspace_path: Some(workspace.path().to_string_lossy().to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("session should create");
+
+        for index in 0..2 {
+            let turn = DialogTurnData::new(
+                format!("turn-{index}"),
+                index,
+                session.session_id.clone(),
+                UserMessageData {
+                    id: format!("turn-{index}-user"),
+                    content: format!("prompt {index}"),
+                    timestamp: index as u64,
+                    metadata: None,
+                },
+            );
+            persistence_manager
+                .save_dialog_turn(workspace.path(), &turn)
+                .await
+                .expect("turn should save");
+            let messages = (0..=index)
+                .map(|message_index| {
+                    crate::agentic::core::Message::user(format!("prompt {message_index}"))
+                })
+                .collect::<Vec<_>>();
+            persistence_manager
+                .save_turn_context_snapshot(workspace.path(), &session.session_id, index, &messages)
+                .await
+                .expect("context snapshot should save");
+        }
+        manager
+            .sessions
+            .get_mut(&session.session_id)
+            .expect("session should be active")
+            .dialog_turn_ids = vec!["turn-0".to_string(), "turn-1".to_string()];
+        let turn_0_event = manager
+            .record_subagent_partial_timeout(
+                &session.session_id,
+                "turn-0",
+                "ReviewSecurity",
+                "Partial turn 0",
+                Some("timeout"),
+            )
+            .await
+            .expect("turn-0 evidence should persist");
+        let _turn_1_event = manager
+            .record_subagent_partial_timeout(
+                &session.session_id,
+                "turn-1",
+                "ReviewTests",
+                "Partial turn 1",
+                Some("timeout"),
+            )
+            .await
+            .expect("turn-1 evidence should persist");
+
+        manager
+            .rollback_context_to_turn_start(workspace.path(), &session.session_id, 1)
+            .await
+            .expect("rollback should succeed");
+
+        assert!(manager
+            .evidence_events_for_turn(&session.session_id, "turn-1")
+            .is_empty());
+        assert_eq!(
+            manager.evidence_events_for_turn(&session.session_id, "turn-0"),
+            vec![turn_0_event.clone()]
+        );
+        let storage_path = manager
+            .effective_session_storage_path(&session.session_id)
+            .await
+            .expect("storage path");
+        let stored: PersistedEvidenceLedgerFile = serde_json::from_slice(
+            &std::fs::read(
+                storage_path
+                    .join(&session.session_id)
+                    .join("evidence-ledger.json"),
+            )
+            .expect("ledger sidecar should exist"),
+        )
+        .expect("ledger sidecar should deserialize");
+        assert_eq!(stored.events, vec![turn_0_event.clone()]);
+
+        assert!(manager
+            .unload_session_from_memory(&session.session_id)
+            .await
+            .expect("session should unload"));
+        let restored = manager
+            .restore_session(workspace.path(), &session.session_id)
+            .await
+            .expect("rolled-back session should restore");
+        assert_eq!(restored.dialog_turn_ids, vec!["turn-0".to_string()]);
+        assert_eq!(
+            manager.evidence_events_for_turn(&session.session_id, "turn-0"),
+            vec![turn_0_event]
+        );
+        assert!(manager
+            .evidence_events_for_turn(&session.session_id, "turn-1")
+            .is_empty());
+        let contract = manager
+            .compression_contract_for_session(&session.session_id, 10)
+            .expect("compression contract should be available");
+        assert!(
+            contract
+                .subagent_statuses
+                .iter()
+                .all(|item| item.target != "ReviewTests"),
+            "rolled-back turn evidence must not enter the compression contract"
+        );
+        assert!(contract
+            .subagent_statuses
+            .iter()
+            .any(|item| item.target == "ReviewSecurity"));
+        assert_eq!(
+            manager
+                .evidence_summary_for_session(&session.session_id, 10)
+                .partial_subagent_results
+                .len(),
+            1
+        );
     }
 
     #[tokio::test]
@@ -15929,6 +16486,44 @@ mod tests {
             .expect_err("corrupt evidence must not degrade to an empty ledger");
 
         assert!(manager.get_session(&session.session_id).is_none());
+        assert_eq!(
+            std::fs::read(&ledger_path).expect("corrupt sidecar should remain"),
+            corrupt_bytes
+        );
+    }
+
+    #[tokio::test]
+    async fn corrupt_evidence_ledger_blocks_retention_without_overwriting_original_bytes() {
+        let workspace = TestWorkspace::new();
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(workspace.path_manager()).expect("persistence manager"),
+        );
+        let manager = test_manager(persistence_manager.clone());
+        let session = manager
+            .create_session(
+                "Corrupt retention evidence".to_string(),
+                "agentic".to_string(),
+                SessionConfig {
+                    workspace_path: Some(workspace.path().to_string_lossy().to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("session should create");
+        let ledger_path = manager
+            .effective_session_storage_path(&session.session_id)
+            .await
+            .expect("storage path")
+            .join(&session.session_id)
+            .join("evidence-ledger.json");
+        let corrupt_bytes = b"{not valid evidence";
+        std::fs::write(&ledger_path, corrupt_bytes).expect("corrupt fixture should write");
+
+        persistence_manager
+            .retain_evidence_ledger_events(workspace.path(), &session.session_id, &HashSet::new())
+            .await
+            .expect_err("corrupt evidence must not degrade to an empty ledger");
+
         assert_eq!(
             std::fs::read(&ledger_path).expect("corrupt sidecar should remain"),
             corrupt_bytes

--- a/src/crates/assembly/core/src/agentic/session/session_manager.rs
+++ b/src/crates/assembly/core/src/agentic/session/session_manager.rs
@@ -2093,48 +2093,53 @@ impl SessionManager {
     /// Callers must hold the Session mutation boundary. The evidence operation
     /// lock serializes this retention with evidence appends and restores.
     ///
-    /// `force_prune_persisted_sidecar` covers explicit staged-revert history
-    /// mutations: a durable `session-revert.json` marker can exist even when
-    /// automatic Session persistence is disabled, and committing that marker
-    /// must prune the sidecar too. Legacy in-memory rollback keeps its existing
-    /// behavior unless automatic persistence is enabled.
+    /// `prune_persisted_sidecar` must only be true for permanent history
+    /// truncations. Staged undo/redo keeps the sidecar complete so a later
+    /// redo can restore hidden evidence; committing the revert or performing a
+    /// legacy rollback permanently discards the hidden suffix, so those paths
+    /// prune the sidecar as well.
     async fn retain_evidence_events_locked(
         &self,
         session_storage_path: Option<&Path>,
         session_id: &str,
         surviving_turn_ids: &HashSet<String>,
-        force_prune_persisted_sidecar: bool,
+        prune_persisted_sidecar: bool,
     ) -> BitFunResult<()> {
         let _operation_guard = self.evidence_ledger_operation_locks.lock(session_id).await;
-        let durable_session = self
-            .sessions
-            .get(session_id)
-            .map(|session| self.should_persist_session(&session))
-            .unwrap_or(true);
-        let prune_persisted_sidecar =
-            durable_session && (self.config.enable_persistence || force_prune_persisted_sidecar);
+        let storage_path = session_storage_path.ok_or_else(|| {
+            BitFunError::session(format!(
+                "Session storage path unavailable while retaining evidence: {}",
+                session_id
+            ))
+        })?;
         if prune_persisted_sidecar {
-            let storage_path = session_storage_path.ok_or_else(|| {
-                BitFunError::session(format!(
-                    "Session storage path unavailable while retaining evidence: {}",
-                    session_id
-                ))
-            })?;
-            let retained = self
+            let mut retained = Vec::new();
+            if let Some(events) = self
                 .persistence_manager
                 .retain_evidence_ledger_events(storage_path, session_id, surviving_turn_ids)
-                .await?;
-            if self.config.enable_persistence {
-                if let Some(retained) = retained {
-                    self.evidence_ledger
-                        .replace_session(session_id, retained)
-                        .map_err(|error| BitFunError::parse(error.to_string()))?;
-                    return Ok(());
-                }
+                .await?
+            {
+                retained = events;
             }
+            self.evidence_ledger
+                .replace_session(session_id, retained)
+                .map_err(|error| BitFunError::parse(error.to_string()))?;
+            return Ok(());
         }
+        // Staged undo/redo only changes what this runtime can see. Rebuild
+        // memory from the untouched sidecar so redo can reveal hidden evidence
+        // without losing it from disk.
+        let sidecar_events = self
+            .persistence_manager
+            .load_evidence_ledger_events(storage_path, session_id)
+            .await?;
+        let retained = sidecar_events
+            .into_iter()
+            .filter(|event| surviving_turn_ids.contains(&event.turn_id))
+            .collect::<Vec<_>>();
         self.evidence_ledger
-            .retain_turn_ids(session_id, surviving_turn_ids);
+            .replace_session(session_id, retained)
+            .map_err(|error| BitFunError::parse(error.to_string()))?;
         Ok(())
     }
 
@@ -6162,8 +6167,10 @@ impl SessionManager {
     }
 
     /// Move the loaded Session to a persisted staged-revert boundary without
-    /// deleting any turn, context snapshot, or compression artifact. The
-    /// durable `session-revert.json` remains the authoritative visibility fact.
+    /// deleting any turn, context snapshot, compression artifact, or evidence
+    /// sidecar. The durable `session-revert.json` remains the authoritative
+    /// visibility fact, and the complete sidecar lets a later redo restore the
+    /// hidden evidence.
     pub(crate) async fn apply_staged_revert_context_locked(
         &self,
         session_storage_path: &Path,
@@ -6248,7 +6255,7 @@ impl SessionManager {
             Some(session_storage_path),
             session_id,
             &surviving_turn_ids,
-            true,
+            false,
         )
         .await?;
         Ok(())
@@ -6274,12 +6281,8 @@ impl SessionManager {
                 .save_session(session_storage_path, &session)
                 .await?;
         }
-        // A durable revert marker means persisted Session artifacts exist even
-        // when automatic Session persistence is disabled for the current
-        // runtime (for example, an adapter restoring an explicitly selected
-        // history). Committing that marker must therefore always prune the
-        // persisted suffix; `enable_persistence` only controls automatic
-        // Session writes, not explicit history mutations.
+        // Committing the marker permanently discards the hidden suffix, so the
+        // evidence sidecar must be pruned to the surviving turns as well.
         self.persistence_manager
             .delete_dialog_turns_from(session_storage_path, session_id, boundary_turn)
             .await?;
@@ -6470,7 +6473,7 @@ impl SessionManager {
             Some(workspace_path),
             session_id,
             &surviving_dialog_turn_ids,
-            false,
+            true,
         )
         .await?;
 
@@ -15870,8 +15873,100 @@ mod tests {
         assert_eq!(summary.latest_checkpoints[0].target, "src/lib.rs");
     }
 
+    fn evidence_event_ids(ledger_path: &std::path::Path) -> Vec<String> {
+        let stored: PersistedEvidenceLedgerFile = serde_json::from_slice(
+            &std::fs::read(ledger_path).expect("ledger sidecar should exist"),
+        )
+        .expect("ledger sidecar should deserialize");
+        stored
+            .events
+            .iter()
+            .map(|event| event.event_id.clone())
+            .collect()
+    }
+
+    struct StagedEvidenceSession {
+        session_id: String,
+        ledger_path: PathBuf,
+    }
+
+    async fn create_staged_evidence_session(
+        manager: &SessionManager,
+        persistence_manager: &PersistenceManager,
+        workspace: &TestWorkspace,
+        turn_count: usize,
+    ) -> StagedEvidenceSession {
+        let session = manager
+            .create_session(
+                "Staged evidence".to_string(),
+                "agentic".to_string(),
+                SessionConfig {
+                    workspace_path: Some(workspace.path().to_string_lossy().to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("session should create");
+        for index in 0..turn_count {
+            let turn = DialogTurnData::new(
+                format!("turn-{index}"),
+                index,
+                session.session_id.clone(),
+                UserMessageData {
+                    id: format!("turn-{index}-user"),
+                    content: format!("prompt {index}"),
+                    timestamp: index as u64,
+                    metadata: None,
+                },
+            );
+            persistence_manager
+                .save_dialog_turn(workspace.path(), &turn)
+                .await
+                .expect("turn should save");
+            let messages = (0..=index)
+                .map(|message_index| {
+                    crate::agentic::core::Message::user(format!("prompt {message_index}"))
+                })
+                .collect::<Vec<_>>();
+            persistence_manager
+                .save_turn_context_snapshot(workspace.path(), &session.session_id, index, &messages)
+                .await
+                .expect("context snapshot should save");
+        }
+        manager
+            .sessions
+            .get_mut(&session.session_id)
+            .expect("session should be active")
+            .dialog_turn_ids = (0..turn_count)
+            .map(|index| format!("turn-{index}"))
+            .collect();
+        for index in 0..turn_count {
+            manager
+                .record_subagent_partial_timeout(
+                    &session.session_id,
+                    &format!("turn-{index}"),
+                    "ReviewSecurity",
+                    &format!("Partial turn {index}"),
+                    Some("timeout"),
+                )
+                .await
+                .expect("turn evidence should persist");
+        }
+        let storage_path = manager
+            .effective_session_storage_path(&session.session_id)
+            .await
+            .expect("storage path");
+        let ledger_path = storage_path
+            .join(&session.session_id)
+            .join("evidence-ledger.json");
+        StagedEvidenceSession {
+            session_id: session.session_id,
+            ledger_path,
+        }
+    }
+
     #[tokio::test]
-    async fn staged_revert_prunes_evidence_ledger_to_visible_turn_ids() {
+    async fn staged_revert_filters_memory_but_keeps_evidence_sidecar() {
         use crate::agentic::session::revert::{
             SessionRevertPhase, SessionRevertState, SESSION_REVERT_SCHEMA_VERSION,
         };
@@ -16016,7 +16111,11 @@ mod tests {
         .expect("ledger sidecar should deserialize");
         assert_eq!(
             stored_after.events,
-            vec![turn_0_event, turn_1_event.clone()]
+            vec![
+                turn_0_event.clone(),
+                turn_1_event.clone(),
+                turn_2_event.clone()
+            ]
         );
 
         assert!(manager
@@ -16033,17 +16132,281 @@ mod tests {
         );
         assert_eq!(
             manager.evidence_events_for_turn(&session.session_id, "turn-1"),
-            vec![turn_1_event]
+            vec![turn_1_event.clone()]
         );
         assert!(manager
             .evidence_events_for_turn(&session.session_id, "turn-2")
             .is_empty());
+        assert_eq!(
+            evidence_event_ids(&ledger_path),
+            vec![
+                turn_0_event.event_id.clone(),
+                turn_1_event.event_id.clone(),
+                turn_2_event.event_id.clone(),
+            ]
+        );
         assert_eq!(
             manager
                 .evidence_summary_for_session(&session.session_id, 10)
                 .partial_subagent_results
                 .len(),
             2
+        );
+    }
+
+    #[tokio::test]
+    async fn staged_undo_then_redo_restores_evidence_from_sidecar() {
+        use crate::agentic::session::revert::{
+            SessionRevertPhase, SessionRevertState, SESSION_REVERT_SCHEMA_VERSION,
+        };
+
+        let workspace = TestWorkspace::new();
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(workspace.path_manager()).expect("persistence manager"),
+        );
+        let manager = test_manager(persistence_manager.clone());
+        let staged =
+            create_staged_evidence_session(&manager, &persistence_manager, &workspace, 3).await;
+        let original_ledger = evidence_event_ids(&staged.ledger_path);
+        assert_eq!(original_ledger.len(), 3);
+
+        let state = SessionRevertState {
+            schema_version: SESSION_REVERT_SCHEMA_VERSION,
+            boundary_turn: 2,
+            original_turn_end: 3,
+            phase: SessionRevertPhase::Staged,
+            workspace_checkpoint: Vec::new(),
+        };
+        persistence_manager
+            .save_session_revert_state(workspace.path(), &staged.session_id, &state)
+            .await
+            .expect("staged undo should persist");
+        let _mutation = manager
+            .acquire_session_mutation(&staged.session_id)
+            .await
+            .expect("session mutation");
+        manager
+            .apply_staged_revert_context_locked(
+                workspace.path(),
+                &staged.session_id,
+                state.boundary_turn,
+            )
+            .await
+            .expect("staged undo should apply");
+        assert!(manager
+            .evidence_events_for_turn(&staged.session_id, "turn-2")
+            .is_empty());
+        assert_eq!(evidence_event_ids(&staged.ledger_path), original_ledger);
+
+        // Redo clears the staged boundary back to the original end. The intact
+        // sidecar must repopulate memory with the hidden turn evidence.
+        manager
+            .apply_staged_revert_context_locked(
+                workspace.path(),
+                &staged.session_id,
+                state.original_turn_end,
+            )
+            .await
+            .expect("redo should reapply the full boundary");
+        assert_eq!(
+            manager
+                .evidence_events_for_turn(&staged.session_id, "turn-2")
+                .len(),
+            1
+        );
+        persistence_manager
+            .delete_session_revert_state(workspace.path(), &staged.session_id)
+            .await
+            .expect("redo marker should clear");
+        assert_eq!(
+            manager
+                .get_session(&staged.session_id)
+                .expect("session should remain active")
+                .dialog_turn_ids,
+            vec![
+                "turn-0".to_string(),
+                "turn-1".to_string(),
+                "turn-2".to_string()
+            ]
+        );
+        assert_eq!(evidence_event_ids(&staged.ledger_path), original_ledger);
+        assert_eq!(
+            manager
+                .evidence_summary_for_session(&staged.session_id, 10)
+                .partial_subagent_results
+                .len(),
+            3
+        );
+    }
+
+    #[tokio::test]
+    async fn consecutive_staged_undo_and_redo_keep_sidecar_evidence() {
+        use crate::agentic::session::revert::{
+            SessionRevertPhase, SessionRevertState, SESSION_REVERT_SCHEMA_VERSION,
+        };
+
+        let workspace = TestWorkspace::new();
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(workspace.path_manager()).expect("persistence manager"),
+        );
+        let manager = test_manager(persistence_manager.clone());
+        let staged =
+            create_staged_evidence_session(&manager, &persistence_manager, &workspace, 3).await;
+        let original_ledger = evidence_event_ids(&staged.ledger_path);
+        assert_eq!(original_ledger.len(), 3);
+        let _mutation = manager
+            .acquire_session_mutation(&staged.session_id)
+            .await
+            .expect("session mutation");
+
+        for boundary in [2usize, 1, 0] {
+            let state = SessionRevertState {
+                schema_version: SESSION_REVERT_SCHEMA_VERSION,
+                boundary_turn: boundary,
+                original_turn_end: 3,
+                phase: SessionRevertPhase::Staged,
+                workspace_checkpoint: Vec::new(),
+            };
+            persistence_manager
+                .save_session_revert_state(workspace.path(), &staged.session_id, &state)
+                .await
+                .expect("staged undo should persist");
+            manager
+                .apply_staged_revert_context_locked(workspace.path(), &staged.session_id, boundary)
+                .await
+                .expect("staged undo should apply");
+        }
+        assert!(manager
+            .evidence_events_for_turn(&staged.session_id, "turn-2")
+            .is_empty());
+        assert!(manager
+            .evidence_events_for_turn(&staged.session_id, "turn-1")
+            .is_empty());
+        assert_eq!(evidence_event_ids(&staged.ledger_path), original_ledger);
+
+        for boundary in [1usize, 2, 3] {
+            let state = SessionRevertState {
+                schema_version: SESSION_REVERT_SCHEMA_VERSION,
+                boundary_turn: boundary,
+                original_turn_end: 3,
+                phase: SessionRevertPhase::Staged,
+                workspace_checkpoint: Vec::new(),
+            };
+            persistence_manager
+                .save_session_revert_state(workspace.path(), &staged.session_id, &state)
+                .await
+                .expect("staged redo should persist");
+            manager
+                .apply_staged_revert_context_locked(workspace.path(), &staged.session_id, boundary)
+                .await
+                .expect("staged redo should apply");
+        }
+        persistence_manager
+            .delete_session_revert_state(workspace.path(), &staged.session_id)
+            .await
+            .expect("redo marker should clear");
+        assert_eq!(
+            manager
+                .get_session(&staged.session_id)
+                .expect("session should remain active")
+                .dialog_turn_ids,
+            vec![
+                "turn-0".to_string(),
+                "turn-1".to_string(),
+                "turn-2".to_string()
+            ]
+        );
+        assert_eq!(evidence_event_ids(&staged.ledger_path), original_ledger);
+        assert_eq!(
+            manager
+                .evidence_events_for_turn(&staged.session_id, "turn-2")
+                .len(),
+            1
+        );
+        assert_eq!(
+            manager
+                .evidence_events_for_turn(&staged.session_id, "turn-1")
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn restoring_clearing_phase_keeps_redo_evidence_available() {
+        use crate::agentic::session::revert::{
+            SessionRevertPhase, SessionRevertState, SESSION_REVERT_SCHEMA_VERSION,
+        };
+
+        let workspace = TestWorkspace::new();
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(workspace.path_manager()).expect("persistence manager"),
+        );
+        let manager = test_manager(persistence_manager.clone());
+        let staged =
+            create_staged_evidence_session(&manager, &persistence_manager, &workspace, 3).await;
+        let original_ledger = evidence_event_ids(&staged.ledger_path);
+        assert_eq!(original_ledger.len(), 3);
+
+        let state = SessionRevertState {
+            schema_version: SESSION_REVERT_SCHEMA_VERSION,
+            boundary_turn: 3,
+            original_turn_end: 3,
+            phase: SessionRevertPhase::Clearing,
+            workspace_checkpoint: Vec::new(),
+        };
+        persistence_manager
+            .save_session_revert_state(workspace.path(), &staged.session_id, &state)
+            .await
+            .expect("clearing marker should persist");
+        assert!(manager
+            .unload_session_from_memory(&staged.session_id)
+            .await
+            .expect("session should unload"));
+
+        manager
+            .restore_session(workspace.path(), &staged.session_id)
+            .await
+            .expect("clearing session should restore");
+        let _mutation = manager
+            .acquire_session_mutation(&staged.session_id)
+            .await
+            .expect("session mutation");
+        manager
+            .apply_staged_revert_context_locked(
+                workspace.path(),
+                &staged.session_id,
+                state.boundary_turn,
+            )
+            .await
+            .expect("clearing boundary should reapply");
+        persistence_manager
+            .delete_session_revert_state(workspace.path(), &staged.session_id)
+            .await
+            .expect("clearing marker should clear");
+        assert_eq!(
+            manager
+                .get_session(&staged.session_id)
+                .expect("session should restore")
+                .dialog_turn_ids,
+            vec![
+                "turn-0".to_string(),
+                "turn-1".to_string(),
+                "turn-2".to_string()
+            ]
+        );
+        assert_eq!(
+            manager
+                .evidence_events_for_turn(&staged.session_id, "turn-2")
+                .len(),
+            1
+        );
+        assert_eq!(evidence_event_ids(&staged.ledger_path), original_ledger);
+        assert_eq!(
+            manager
+                .evidence_summary_for_session(&staged.session_id, 10)
+                .partial_subagent_results
+                .len(),
+            3
         );
     }
 

--- a/src/crates/assembly/core/src/agentic/session/session_manager.rs
+++ b/src/crates/assembly/core/src/agentic/session/session_manager.rs
@@ -348,6 +348,7 @@ pub struct SessionManager {
         Arc<DashMap<String, crate::agentic::execution::edit_constraint_guard::EditConstraintState>>,
     file_read_state_store: Arc<FileReadStateStore>,
     evidence_ledger: Arc<SessionEvidenceLedger>,
+    evidence_ledger_operation_locks: Arc<KeyedAsyncLock>,
     persistence_manager: Arc<PersistenceManager>,
     memory_database: Arc<MemoryDatabase>,
 
@@ -2027,6 +2028,7 @@ impl SessionManager {
             edit_constraints_store: Arc::new(DashMap::new()),
             file_read_state_store: Arc::new(FileReadStateStore::new()),
             evidence_ledger: Arc::new(SessionEvidenceLedger::new()),
+            evidence_ledger_operation_locks: Arc::new(KeyedAsyncLock::default()),
             persistence_manager,
             memory_database,
             config,
@@ -2046,21 +2048,60 @@ impl SessionManager {
         self.persistence_manager.clone()
     }
 
-    pub fn append_evidence_event(&self, event: EvidenceLedgerEvent) -> EvidenceLedgerEvent {
-        self.evidence_ledger.append(event)
+    pub async fn append_evidence_event(
+        &self,
+        event: EvidenceLedgerEvent,
+    ) -> BitFunResult<EvidenceLedgerEvent> {
+        let _mutation_guard = self.lock_session_mutation(&event.session_id).await;
+        let _operation_guard = self
+            .evidence_ledger_operation_locks
+            .lock(&event.session_id)
+            .await;
+        let should_persist = self.config.enable_persistence
+            && self
+                .sessions
+                .get(&event.session_id)
+                .is_some_and(|session| self.should_persist_session(&session));
+        if !should_persist {
+            return Ok(self.evidence_ledger.append(event));
+        }
+
+        let storage_path = self
+            .effective_session_storage_path(&event.session_id)
+            .await
+            .or_else(|| {
+                self.session_storage_path_index
+                    .get(&event.session_id)
+                    .map(|entry| entry.value().path.clone())
+            })
+            .ok_or_else(|| {
+                BitFunError::session(format!(
+                    "Session storage path unavailable while persisting evidence: {}",
+                    event.session_id
+                ))
+            })?;
+        let persisted_events = self
+            .persistence_manager
+            .append_evidence_ledger_event(&storage_path, &event)
+            .await?;
+        self.evidence_ledger
+            .replace_session(&event.session_id, persisted_events)
+            .map_err(|error| BitFunError::parse(error.to_string()))?;
+        Ok(event)
     }
 
-    pub fn record_checkpoint_created(
+    pub async fn record_checkpoint_created(
         &self,
         session_id: &str,
         turn_id: &str,
         tool_name: &str,
         target: &str,
         checkpoint: EvidenceLedgerCheckpoint,
-    ) -> EvidenceLedgerEvent {
+    ) -> BitFunResult<EvidenceLedgerEvent> {
         self.append_evidence_event(EvidenceLedgerEvent::checkpoint_created(
             session_id, turn_id, tool_name, target, checkpoint,
         ))
+        .await
     }
 
     pub fn evidence_events_for_turn(
@@ -2089,14 +2130,14 @@ impl SessionManager {
         (!contract.is_empty()).then_some(contract)
     }
 
-    pub fn record_subagent_partial_timeout(
+    pub async fn record_subagent_partial_timeout(
         &self,
         session_id: &str,
         turn_id: &str,
         subagent_type: &str,
         partial_output: &str,
         error_kind: Option<&str>,
-    ) -> EvidenceLedgerEvent {
+    ) -> BitFunResult<EvidenceLedgerEvent> {
         let summary = format!(
             "Subagent {} timed out after producing partial output.",
             subagent_type
@@ -2113,7 +2154,7 @@ impl SessionManager {
         .with_error_kind(error_kind.unwrap_or("timeout"))
         .with_partial_output(partial_output);
 
-        self.append_evidence_event(event)
+        self.append_evidence_event(event).await
     }
 
     /// Decide whether the given session model id is still usable.
@@ -2360,6 +2401,7 @@ impl SessionManager {
         let edit_constraints_store = self.edit_constraints_store.clone();
         let file_read_state_store = self.file_read_state_store.clone();
         let evidence_ledger = self.evidence_ledger.clone();
+        let evidence_ledger_operation_locks = self.evidence_ledger_operation_locks.clone();
         let persistence_manager = self.persistence_manager.clone();
         let memory_database = self.memory_database.clone();
         let manager_config = self.config.clone();
@@ -2393,6 +2435,7 @@ impl SessionManager {
                 edit_constraints_store,
                 file_read_state_store,
                 evidence_ledger,
+                evidence_ledger_operation_locks,
                 persistence_manager,
                 memory_database,
                 config: manager_config,
@@ -5519,6 +5562,7 @@ impl SessionManager {
         include_internal: bool,
     ) -> BitFunResult<(Session, Vec<DialogTurnData>)> {
         let _mutation_guard = self.lock_session_mutation(session_id).await;
+        let _evidence_ledger_guard = self.evidence_ledger_operation_locks.lock(session_id).await;
 
         if self.is_session_loaded_from_storage_path(session_storage_path, session_id)? {
             let session = self.get_session(session_id).ok_or_else(|| {
@@ -5621,6 +5665,10 @@ impl SessionManager {
         if let Some(revert) = staged_revert.as_ref() {
             persisted_turns.retain(|turn| turn.turn_index < revert.boundary_turn);
         }
+        let restored_evidence_events = self
+            .persistence_manager
+            .load_evidence_ledger_events(session_storage_path, session_id)
+            .await?;
         debug!(
             "Session restore phase completed: session_id={}, phase=load_session_with_turns, turn_count={}, duration_ms={}",
             session_id,
@@ -5992,6 +6040,9 @@ impl SessionManager {
                 self.evidence_ledger.as_ref(),
             );
         }
+        self.evidence_ledger
+            .replace_session(session_id, restored_evidence_events)
+            .map_err(|error| BitFunError::parse(error.to_string()))?;
 
         let context_replace_started_at = Instant::now();
         self.context_store
@@ -9378,9 +9429,11 @@ mod tests {
     use crate::agentic::persistence::PersistenceManager;
     use crate::agentic::session::{
         revert::{SessionRevertPhase, SessionRevertState, SESSION_REVERT_SCHEMA_VERSION},
-        PromptCachePolicy, PromptCacheScope, SessionContextStore, SystemPromptCacheIdentity,
-        UserContextCacheIdentity,
+        EvidenceLedgerCheckpoint, PersistedEvidenceLedgerFile, PromptCachePolicy, PromptCacheScope,
+        SessionContextStore, SystemPromptCacheIdentity, UserContextCacheIdentity,
     };
+    #[cfg(feature = "remote-workspace")]
+    use crate::agentic::session::{EvidenceLedgerEventStatus, EvidenceLedgerTargetKind};
     use crate::agentic::skill_agent_snapshot::{SkillSnapshotEntry, TurnSkillAgentSnapshot};
     use crate::infrastructure::ai::reasoning_catalog::{
         project_model_reasoning_catalog as project_test_model_reasoning_catalog,
@@ -15630,13 +15683,16 @@ mod tests {
             Arc::new(PersistenceManager::new(test_path_manager()).expect("persistence manager"));
         let manager = test_manager(persistence_manager);
 
-        let event = manager.record_subagent_partial_timeout(
-            "session-a",
-            "turn-a",
-            "ReviewSecurity",
-            "Found token logging before timeout.",
-            Some("timeout"),
-        );
+        let event = manager
+            .record_subagent_partial_timeout(
+                "session-a",
+                "turn-a",
+                "ReviewSecurity",
+                "Found token logging before timeout.",
+                Some("timeout"),
+            )
+            .await
+            .expect("in-memory evidence should record");
 
         assert!(!event.event_id.is_empty());
         let events = manager.evidence_events_for_turn("session-a", "turn-a");
@@ -15644,6 +15700,292 @@ mod tests {
         let summary = manager.evidence_summary_for_session("session-a", 10);
         assert_eq!(summary.partial_subagent_results.len(), 1);
         assert_eq!(summary.partial_subagent_results[0].event_id, event.event_id);
+    }
+
+    #[tokio::test]
+    async fn evidence_ledger_persists_across_session_unload_and_restore() {
+        let workspace = TestWorkspace::new();
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(workspace.path_manager()).expect("persistence manager"),
+        );
+        let manager = test_manager(persistence_manager);
+        let session = manager
+            .create_session(
+                "Durable evidence".to_string(),
+                "agentic".to_string(),
+                SessionConfig {
+                    workspace_path: Some(workspace.path().to_string_lossy().to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("session should create");
+        let storage_path = manager
+            .effective_session_storage_path(&session.session_id)
+            .await
+            .expect("storage path");
+        let event = manager
+            .record_checkpoint_created(
+                &session.session_id,
+                "turn-a",
+                "Edit",
+                "src/lib.rs",
+                EvidenceLedgerCheckpoint {
+                    current_branch: Some("feature/evidence".to_string()),
+                    dirty_state_summary: "staged=0, unstaged=1, untracked=0".to_string(),
+                    touched_files: vec!["src/lib.rs".to_string()],
+                    diff_hash: Some("abc123".to_string()),
+                },
+            )
+            .await
+            .expect("checkpoint should persist before mutation");
+        let ledger_path = storage_path
+            .join(&session.session_id)
+            .join("evidence-ledger.json");
+        let stored: PersistedEvidenceLedgerFile = serde_json::from_slice(
+            &std::fs::read(&ledger_path).expect("ledger sidecar should exist"),
+        )
+        .expect("ledger sidecar should deserialize");
+        assert_eq!(stored.session_id, session.session_id);
+        assert_eq!(stored.events, vec![event.clone()]);
+
+        assert!(manager
+            .unload_session_from_memory(&session.session_id)
+            .await
+            .expect("session should unload"));
+        assert!(manager
+            .evidence_events_for_turn(&session.session_id, "turn-a")
+            .is_empty());
+
+        manager
+            .restore_session_from_storage_path(&storage_path, &session.session_id)
+            .await
+            .expect("session should restore with evidence");
+        assert_eq!(
+            manager.evidence_events_for_turn(&session.session_id, "turn-a"),
+            vec![event]
+        );
+        let summary = manager.evidence_summary_for_session(&session.session_id, 10);
+        assert_eq!(summary.latest_checkpoints.len(), 1);
+        assert_eq!(summary.latest_checkpoints[0].target, "src/lib.rs");
+    }
+
+    #[tokio::test]
+    async fn evidence_ledger_write_failure_does_not_publish_memory_only_evidence() {
+        let workspace = TestWorkspace::new();
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(workspace.path_manager()).expect("persistence manager"),
+        );
+        let manager = test_manager(persistence_manager.clone());
+        let session = manager
+            .create_session(
+                "Evidence write failure".to_string(),
+                "agentic".to_string(),
+                SessionConfig {
+                    workspace_path: Some(workspace.path().to_string_lossy().to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("session should create");
+        persistence_manager.fail_next_evidence_ledger_write_for_test(&session.session_id);
+
+        manager
+            .record_subagent_partial_timeout(
+                &session.session_id,
+                "turn-a",
+                "ReviewSecurity",
+                "Partial result",
+                Some("timeout"),
+            )
+            .await
+            .expect_err("durable append failure must be visible");
+
+        assert!(manager
+            .evidence_events_for_turn(&session.session_id, "turn-a")
+            .is_empty());
+        assert!(manager
+            .evidence_summary_for_session(&session.session_id, 10)
+            .partial_subagent_results
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn concurrent_evidence_appends_keep_disk_and_memory_complete() {
+        let workspace = TestWorkspace::new();
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(workspace.path_manager()).expect("persistence manager"),
+        );
+        let manager = Arc::new(test_manager(persistence_manager));
+        let session = manager
+            .create_session(
+                "Concurrent evidence".to_string(),
+                "agentic".to_string(),
+                SessionConfig {
+                    workspace_path: Some(workspace.path().to_string_lossy().to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("session should create");
+        let storage_path = manager
+            .effective_session_storage_path(&session.session_id)
+            .await
+            .expect("storage path");
+
+        let first_manager = manager.clone();
+        let first_session_id = session.session_id.clone();
+        let first = tokio::spawn(async move {
+            first_manager
+                .record_subagent_partial_timeout(
+                    &first_session_id,
+                    "turn-a",
+                    "ReviewSecurity",
+                    "First partial result",
+                    Some("timeout"),
+                )
+                .await
+                .expect("first evidence append")
+        });
+        let second_manager = manager.clone();
+        let second_session_id = session.session_id.clone();
+        let second = tokio::spawn(async move {
+            second_manager
+                .record_subagent_partial_timeout(
+                    &second_session_id,
+                    "turn-b",
+                    "ReviewTests",
+                    "Second partial result",
+                    Some("timeout"),
+                )
+                .await
+                .expect("second evidence append")
+        });
+        let first = first.await.expect("first append task");
+        let second = second.await.expect("second append task");
+
+        let ledger_path = storage_path
+            .join(&session.session_id)
+            .join("evidence-ledger.json");
+        let stored: PersistedEvidenceLedgerFile = serde_json::from_slice(
+            &std::fs::read(ledger_path).expect("ledger sidecar should exist"),
+        )
+        .expect("ledger sidecar should deserialize");
+        let mut stored_ids = stored
+            .events
+            .into_iter()
+            .map(|event| event.event_id)
+            .collect::<Vec<_>>();
+        let mut memory_ids = manager
+            .evidence_ledger
+            .events_for_session(&session.session_id)
+            .into_iter()
+            .map(|event| event.event_id)
+            .collect::<Vec<_>>();
+        let mut expected_ids = vec![first.event_id, second.event_id];
+        stored_ids.sort();
+        memory_ids.sort();
+        expected_ids.sort();
+
+        assert_eq!(stored_ids, expected_ids);
+        assert_eq!(memory_ids, expected_ids);
+    }
+
+    #[tokio::test]
+    async fn corrupt_evidence_ledger_blocks_restore_without_overwriting_original_bytes() {
+        let workspace = TestWorkspace::new();
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(workspace.path_manager()).expect("persistence manager"),
+        );
+        let manager = test_manager(persistence_manager);
+        let session = manager
+            .create_session(
+                "Corrupt evidence".to_string(),
+                "agentic".to_string(),
+                SessionConfig {
+                    workspace_path: Some(workspace.path().to_string_lossy().to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("session should create");
+        let storage_path = manager
+            .effective_session_storage_path(&session.session_id)
+            .await
+            .expect("storage path");
+        let ledger_path = storage_path
+            .join(&session.session_id)
+            .join("evidence-ledger.json");
+        let corrupt_bytes = b"{not valid evidence";
+        std::fs::write(&ledger_path, corrupt_bytes).expect("corrupt fixture should write");
+        assert!(manager
+            .unload_session_from_memory(&session.session_id)
+            .await
+            .expect("session should unload"));
+
+        manager
+            .restore_session_from_storage_path(&storage_path, &session.session_id)
+            .await
+            .expect_err("corrupt evidence must not degrade to an empty ledger");
+
+        assert!(manager.get_session(&session.session_id).is_none());
+        assert_eq!(
+            std::fs::read(&ledger_path).expect("corrupt sidecar should remain"),
+            corrupt_bytes
+        );
+    }
+
+    #[cfg(feature = "remote-workspace")]
+    #[tokio::test]
+    async fn remote_workspace_evidence_uses_the_resolved_session_mirror() {
+        let workspace = TestWorkspace::new();
+        let path_manager = workspace.path_manager();
+        let persistence_manager =
+            Arc::new(PersistenceManager::new(path_manager.clone()).expect("persistence manager"));
+        let manager = test_manager(persistence_manager);
+        let session = manager
+            .create_session(
+                "Remote evidence".to_string(),
+                "agentic".to_string(),
+                SessionConfig {
+                    workspace_path: Some("/home/wsp/project".to_string()),
+                    remote_connection_id: Some("ssh-1".to_string()),
+                    remote_ssh_host: Some("dev-host".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("remote session should create");
+        let event = manager
+            .record_subagent_partial_timeout(
+                &session.session_id,
+                "turn-a",
+                "ReviewSecurity",
+                "Remote partial result",
+                Some("timeout"),
+            )
+            .await
+            .expect("remote evidence should persist");
+        let sessions_dir = crate::service::WorkspaceRuntimeService::new(path_manager)
+            .context_for_remote_workspace("dev-host", "/home/wsp/project")
+            .sessions_dir;
+        let ledger_path = sessions_dir
+            .join(&session.session_id)
+            .join("evidence-ledger.json");
+        let stored: PersistedEvidenceLedgerFile = serde_json::from_slice(
+            &std::fs::read(ledger_path).expect("remote ledger sidecar should exist"),
+        )
+        .expect("remote ledger sidecar should deserialize");
+
+        assert_eq!(stored.events, vec![event]);
+        assert_eq!(
+            stored.events[0].target_kind,
+            EvidenceLedgerTargetKind::Subagent
+        );
+        assert_eq!(
+            stored.events[0].status,
+            EvidenceLedgerEventStatus::PartialTimeout
+        );
     }
 
     #[tokio::test]

--- a/src/crates/assembly/core/src/agentic/session/session_manager.rs
+++ b/src/crates/assembly/core/src/agentic/session/session_manager.rs
@@ -2084,8 +2084,33 @@ impl SessionManager {
             .persistence_manager
             .append_evidence_ledger_event(&storage_path, &event)
             .await?;
+        // Project the persisted events to the session's currently visible
+        // turns before publishing to memory. This prevents stale evidence
+        // (from a sidecar that has not yet been converged, e.g. after an
+        // older build rewrote session history) from re-entering the runtime.
+        let visible_events = {
+            let visible_turn_ids = self
+                .sessions
+                .get(&event.session_id)
+                .map(|session| {
+                    session
+                        .dialog_turn_ids
+                        .iter()
+                        .cloned()
+                        .collect::<std::collections::HashSet<String>>()
+                })
+                .unwrap_or_default();
+            if visible_turn_ids.is_empty() {
+                persisted_events
+            } else {
+                persisted_events
+                    .into_iter()
+                    .filter(|e| visible_turn_ids.contains(&e.turn_id))
+                    .collect::<Vec<_>>()
+            }
+        };
         self.evidence_ledger
-            .replace_session(&event.session_id, persisted_events)
+            .replace_session(&event.session_id, visible_events)
             .map_err(|error| BitFunError::parse(error.to_string()))?;
         Ok(event)
     }
@@ -5722,13 +5747,33 @@ impl SessionManager {
             .iter()
             .map(|turn| turn.turn_id.clone())
             .collect();
-        let restored_evidence_events = self
+        let all_evidence_events = self
             .persistence_manager
             .load_evidence_ledger_events(session_storage_path, session_id)
-            .await?
-            .into_iter()
+            .await?;
+        let restored_evidence_events = all_evidence_events
+            .iter()
             .filter(|event| surviving_turn_ids.contains(&event.turn_id))
+            .cloned()
             .collect::<Vec<_>>();
+        // Converge the sidecar to surviving turns when there is no staged undo
+        // marker. A staged undo keeps the full sidecar on disk so a later redo
+        // can restore hidden evidence. Without this convergence, a stale event
+        // left by an older build (or a previous rollback) would re-enter memory
+        // on the next evidence append.
+        if staged_revert.is_none() && self.config.enable_persistence {
+            let should_converge = self
+                .sessions
+                .get(session_id)
+                .is_some_and(|session| self.should_persist_session(&session))
+                || !session_already_in_memory;
+            if should_converge {
+                let converged_events = restored_evidence_events.clone();
+                self.persistence_manager
+                    .save_evidence_ledger_events(session_storage_path, session_id, converged_events)
+                    .await?;
+            }
+        }
         debug!(
             "Session restore phase completed: session_id={}, phase=load_session_with_turns, turn_count={}, duration_ms={}",
             session_id,
@@ -9509,7 +9554,7 @@ mod tests {
         ProcessingPhase, Session, SessionAgentRouteOwner, SessionConfig, SessionModelBindingPolicy,
         SessionState, ToolCall, ToolResult, TurnStats,
     };
-    use crate::agentic::persistence::PersistenceManager;
+    use crate::agentic::persistence::{PersistenceManager, SessionBranchRequest};
     use crate::agentic::session::{
         revert::{SessionRevertPhase, SessionRevertState, SESSION_REVERT_SCHEMA_VERSION},
         EvidenceLedgerCheckpoint, PersistedEvidenceLedgerFile, PromptCachePolicy, PromptCacheScope,
@@ -9541,6 +9586,7 @@ mod tests {
         SessionExecutionTarget,
     };
     use bitfun_runtime_ports::SessionStoragePathRequest;
+    use bitfun_services_core::session::SessionBranchBoundary;
     use dashmap::{try_result::TryResult, DashMap};
     use serde_json::json;
     use std::collections::HashSet;
@@ -16944,6 +16990,247 @@ mod tests {
             stored.events[0].status,
             EvidenceLedgerEventStatus::PartialTimeout
         );
+    }
+
+    #[tokio::test]
+    async fn restore_converges_evidence_sidecar_to_surviving_turns() {
+        // P2 regression: after restore, the sidecar must be converged to the
+        // surviving turns so a subsequent evidence append does not resurrect
+        // stale events from a turn that no longer exists.
+        let workspace = TestWorkspace::new();
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(workspace.path_manager()).expect("persistence manager"),
+        );
+        let manager = test_manager(persistence_manager.clone());
+        let session = manager
+            .create_session(
+                "Converge evidence".to_string(),
+                "agentic".to_string(),
+                SessionConfig {
+                    workspace_path: Some(workspace.path().to_string_lossy().to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("session should create");
+        let storage_path = manager
+            .effective_session_storage_path(&session.session_id)
+            .await
+            .expect("storage path");
+
+        // Create two turns with evidence.
+        for index in 0..2 {
+            let turn = DialogTurnData::new(
+                format!("turn-{index}"),
+                index,
+                session.session_id.clone(),
+                UserMessageData {
+                    id: format!("turn-{index}-user"),
+                    content: format!("prompt {index}"),
+                    timestamp: index as u64,
+                    metadata: None,
+                },
+            );
+            persistence_manager
+                .save_dialog_turn(workspace.path(), &turn)
+                .await
+                .expect("turn should save");
+            let messages = (0..=index)
+                .map(|i| crate::agentic::core::Message::user(format!("prompt {i}")))
+                .collect::<Vec<_>>();
+            persistence_manager
+                .save_turn_context_snapshot(workspace.path(), &session.session_id, index, &messages)
+                .await
+                .expect("snapshot should save");
+        }
+        manager
+            .sessions
+            .get_mut(&session.session_id)
+            .expect("session should be active")
+            .dialog_turn_ids = vec!["turn-0".to_string(), "turn-1".to_string()];
+        for index in 0..2 {
+            manager
+                .record_subagent_partial_timeout(
+                    &session.session_id,
+                    &format!("turn-{index}"),
+                    "ReviewSecurity",
+                    &format!("Partial turn {index}"),
+                    Some("timeout"),
+                )
+                .await
+                .expect("evidence should persist");
+        }
+        let ledger_path = storage_path
+            .join(&session.session_id)
+            .join("evidence-ledger.json");
+        assert_eq!(evidence_event_ids(&ledger_path).len(), 2);
+
+        // Simulate an older build removing turn-1 from history but leaving
+        // the evidence sidecar untouched.
+        persistence_manager
+            .delete_dialog_turns_from(workspace.path(), &session.session_id, 1)
+            .await
+            .expect("turn-1 should be deleted");
+        persistence_manager
+            .delete_turn_context_snapshots_from(workspace.path(), &session.session_id, 1)
+            .await
+            .expect("snapshot-1 should be deleted");
+
+        // Unload and restore. The restore should converge the sidecar.
+        assert!(manager
+            .unload_session_from_memory(&session.session_id)
+            .await
+            .expect("session should unload"));
+        manager
+            .restore_session_from_storage_path(&storage_path, &session.session_id)
+            .await
+            .expect("session should restore");
+
+        // The sidecar should now only contain turn-0's evidence.
+        let sidecar_ids = evidence_event_ids(&ledger_path);
+        assert_eq!(sidecar_ids.len(), 1);
+        assert!(manager
+            .evidence_events_for_turn(&session.session_id, "turn-1")
+            .is_empty());
+
+        // Appending new evidence must not resurrect turn-1's event.
+        manager
+            .record_subagent_partial_timeout(
+                &session.session_id,
+                "turn-0",
+                "ReviewLogic",
+                "New partial result",
+                Some("timeout"),
+            )
+            .await
+            .expect("new evidence should persist");
+        let final_ids = evidence_event_ids(&ledger_path);
+        assert_eq!(final_ids.len(), 2);
+        assert!(manager
+            .evidence_events_for_turn(&session.session_id, "turn-1")
+            .is_empty());
+        let summary = manager.evidence_summary_for_session(&session.session_id, 10);
+        assert_eq!(summary.partial_subagent_results.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn branch_session_copies_evidence_ledger_for_inherited_turns() {
+        // P1 regression: forking a session must copy the evidence ledger,
+        // filtered to the copied turns and rewritten to the target session.
+        let workspace = TestWorkspace::new();
+        let persistence_manager = Arc::new(
+            PersistenceManager::new(workspace.path_manager()).expect("persistence manager"),
+        );
+        let manager = test_manager(persistence_manager.clone());
+        let session = manager
+            .create_session(
+                "Fork evidence".to_string(),
+                "agentic".to_string(),
+                SessionConfig {
+                    workspace_path: Some(workspace.path().to_string_lossy().to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("session should create");
+        let storage_path = manager
+            .effective_session_storage_path(&session.session_id)
+            .await
+            .expect("storage path");
+
+        // Create two turns with evidence.
+        for index in 0..2 {
+            let turn = DialogTurnData::new(
+                format!("turn-{index}"),
+                index,
+                session.session_id.clone(),
+                UserMessageData {
+                    id: format!("turn-{index}-user"),
+                    content: format!("prompt {index}"),
+                    timestamp: index as u64,
+                    metadata: None,
+                },
+            );
+            persistence_manager
+                .save_dialog_turn(workspace.path(), &turn)
+                .await
+                .expect("turn should save");
+            let messages = (0..=index)
+                .map(|i| crate::agentic::core::Message::user(format!("prompt {i}")))
+                .collect::<Vec<_>>();
+            persistence_manager
+                .save_turn_context_snapshot(workspace.path(), &session.session_id, index, &messages)
+                .await
+                .expect("snapshot should save");
+        }
+        manager
+            .sessions
+            .get_mut(&session.session_id)
+            .expect("session should be active")
+            .dialog_turn_ids = vec!["turn-0".to_string(), "turn-1".to_string()];
+        let turn_0_event = manager
+            .record_checkpoint_created(
+                &session.session_id,
+                "turn-0",
+                "Edit",
+                "src/lib.rs",
+                EvidenceLedgerCheckpoint {
+                    current_branch: Some("feature/evidence".to_string()),
+                    dirty_state_summary: "staged=0".to_string(),
+                    touched_files: vec!["src/lib.rs".to_string()],
+                    diff_hash: Some("abc".to_string()),
+                },
+            )
+            .await
+            .expect("turn-0 checkpoint should persist");
+        let turn_1_event = manager
+            .record_subagent_partial_timeout(
+                &session.session_id,
+                "turn-1",
+                "ReviewSecurity",
+                "Partial turn 1",
+                Some("timeout"),
+            )
+            .await
+            .expect("turn-1 evidence should persist");
+
+        // Branch through turn-0 only.
+        let branch_result = persistence_manager
+            .branch_session(
+                workspace.path(),
+                &SessionBranchRequest {
+                    source_session_id: session.session_id.clone(),
+                    source_turn_id: "turn-0".to_string(),
+                    boundary: SessionBranchBoundary::ThroughTurn,
+                },
+            )
+            .await
+            .expect("branch should succeed");
+
+        // The fork should have turn-0's evidence but not turn-1's.
+        let fork_ledger_path = storage_path
+            .join(&branch_result.session_id)
+            .join("evidence-ledger.json");
+        assert!(
+            fork_ledger_path.exists(),
+            "fork evidence sidecar should exist"
+        );
+        let fork_stored: PersistedEvidenceLedgerFile = serde_json::from_slice(
+            &std::fs::read(&fork_ledger_path).expect("fork ledger should read"),
+        )
+        .expect("fork ledger should deserialize");
+        assert_eq!(fork_stored.session_id, branch_result.session_id);
+        assert_eq!(fork_stored.events.len(), 1);
+        assert_eq!(fork_stored.events[0].turn_id, "turn-0");
+        assert_eq!(fork_stored.events[0].session_id, branch_result.session_id);
+        assert_eq!(fork_stored.events[0].event_id, turn_0_event.event_id);
+        // The checkpoint summary should be preserved.
+        assert!(fork_stored.events[0].checkpoint.is_some());
+        // turn-1's evidence must not be in the fork.
+        assert!(fork_stored
+            .events
+            .iter()
+            .all(|e| e.event_id != turn_1_event.event_id));
     }
 
     #[tokio::test]

--- a/src/crates/assembly/core/src/agentic/tools/implementations/bash_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/bash_tool.rs
@@ -605,7 +605,7 @@ Usage notes:
         if command_needs_light_checkpoint(command_str) {
             context
                 .record_light_checkpoint("Bash", command_str, Vec::new())
-                .await;
+                .await?;
         }
 
         // Remote workspace: execute via injected workspace shell

--- a/src/crates/assembly/core/src/agentic/tools/implementations/delete_file_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/delete_file_tool.rs
@@ -338,7 +338,7 @@ Important notes:
                 &resolved.logical_path,
                 vec![resolved.logical_path.clone()],
             )
-            .await;
+            .await?;
 
         // Remote workspace path: delete via shell command
         if resolved.uses_remote_workspace_backend() {

--- a/src/crates/assembly/core/src/agentic/tools/implementations/file_edit_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/file_edit_tool.rs
@@ -338,7 +338,7 @@ impl Tool for FileEditTool {
                 &resolved.logical_path,
                 vec![resolved.logical_path.clone()],
             )
-            .await;
+            .await?;
 
         // For remote workspace paths, use the abstract FS to read → edit in memory → write back.
         if resolved.uses_remote_workspace_backend() {

--- a/src/crates/assembly/core/src/agentic/tools/implementations/file_write_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/file_write_tool.rs
@@ -529,7 +529,7 @@ impl Tool for FileWriteTool {
                 &resolved.logical_path,
                 vec![resolved.logical_path.clone()],
             )
-            .await;
+            .await?;
 
         let file_already_exists = Self::file_exists(context, &resolved).await;
         if file_already_exists

--- a/src/crates/assembly/core/src/agentic/tools/implementations/git_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/git_tool.rs
@@ -1408,7 +1408,7 @@ When creating commits, use this format for the commit message:
                     &format!("git {} {}", operation, args.unwrap_or("").trim()),
                     Vec::new(),
                 )
-                .await;
+                .await?;
         }
 
         let start_time = std::time::Instant::now();

--- a/src/crates/assembly/core/src/agentic/tools/tool_context_runtime.rs
+++ b/src/crates/assembly/core/src/agentic/tools/tool_context_runtime.rs
@@ -396,21 +396,23 @@ impl ToolUseContext {
         tool_name: &str,
         target: &str,
         touched_files: Vec<String>,
-    ) {
+    ) -> BitFunResult<()> {
         let Some(session_id) = self.session_id.as_deref() else {
-            return;
+            return Ok(());
         };
         let Some(turn_id) = self.dialog_turn_id.as_deref() else {
-            return;
+            return Ok(());
         };
         let Some(coordinator) = get_global_coordinator() else {
-            return;
+            return Ok(());
         };
 
         let checkpoint = self.build_light_checkpoint(touched_files).await;
         coordinator
             .get_session_manager()
-            .record_checkpoint_created(session_id, turn_id, tool_name, target, checkpoint);
+            .record_checkpoint_created(session_id, turn_id, tool_name, target, checkpoint)
+            .await?;
+        Ok(())
     }
 
     async fn build_light_checkpoint(&self, touched_files: Vec<String>) -> EvidenceLedgerCheckpoint {

--- a/src/crates/execution/agent-runtime/src/evidence_ledger.rs
+++ b/src/crates/execution/agent-runtime/src/evidence_ledger.rs
@@ -2,7 +2,7 @@ use crate::checkpoint::LightCheckpoint;
 use bitfun_runtime_ports::{CompressionContract, CompressionContractItem};
 use dashmap::DashMap;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -262,6 +262,22 @@ impl PersistedEvidenceLedgerFile {
         Ok(true)
     }
 
+    /// Keep only events whose turn is still part of the session history.
+    pub fn retain_turn_ids(
+        &mut self,
+        expected_session_id: &str,
+        surviving_turn_ids: &HashSet<String>,
+    ) -> Result<Vec<EvidenceLedgerEvent>, EvidenceLedgerPersistenceError> {
+        self.validate_header(expected_session_id)?;
+        let retained = self
+            .validate_events()?
+            .into_iter()
+            .filter(|event| surviving_turn_ids.contains(&event.turn_id))
+            .collect::<Vec<_>>();
+        self.events = retained.clone();
+        Ok(retained)
+    }
+
     pub fn validated_events(
         self,
         expected_session_id: &str,
@@ -354,6 +370,25 @@ impl SessionEvidenceLedger {
         }
         events.push(event.clone());
         event
+    }
+
+    pub fn retain_turn_ids(
+        &self,
+        session_id: &str,
+        surviving_turn_ids: &HashSet<String>,
+    ) -> Vec<EvidenceLedgerEvent> {
+        let retained = self
+            .events_for_session(session_id)
+            .into_iter()
+            .filter(|event| surviving_turn_ids.contains(&event.turn_id))
+            .collect::<Vec<_>>();
+        if retained.is_empty() {
+            self.events_by_session.remove(session_id);
+        } else {
+            self.events_by_session
+                .insert(session_id.to_string(), retained.clone());
+        }
+        retained
     }
 
     pub fn replace_session(
@@ -558,6 +593,7 @@ mod tests {
         PersistedEvidenceLedgerFile, SessionEvidenceLedger, EVIDENCE_LEDGER_SCHEMA_VERSION,
     };
     use crate::checkpoint::LightCheckpoint;
+    use std::collections::HashSet;
 
     #[test]
     fn ledger_reads_events_scoped_by_session_and_turn() {
@@ -608,6 +644,74 @@ mod tests {
             Err(EvidenceLedgerPersistenceError::ConflictingEvent { .. })
         ));
         assert_eq!(file.events, vec![event]);
+    }
+
+    #[test]
+    fn persisted_ledger_retain_turn_ids_keeps_only_surviving_turn_evidence() {
+        let mut file = PersistedEvidenceLedgerFile::new("session-a");
+        let turn_a = EvidenceLedgerEvent::new(
+            "session-a",
+            "turn-a",
+            "Bash",
+            EvidenceLedgerTargetKind::Command,
+            "cargo test",
+            EvidenceLedgerEventStatus::Succeeded,
+            "Tests passed.",
+        );
+        let turn_b = EvidenceLedgerEvent::new(
+            "session-a",
+            "turn-b",
+            "Bash",
+            EvidenceLedgerTargetKind::Command,
+            "cargo check",
+            EvidenceLedgerEventStatus::Failed,
+            "Check failed.",
+        );
+        file.append(turn_a.clone()).expect("turn-a append");
+        file.append(turn_b.clone()).expect("turn-b append");
+
+        let retained = file
+            .retain_turn_ids("session-a", &HashSet::from(["turn-a".to_string()]))
+            .expect("retain should succeed");
+        assert_eq!(retained, vec![turn_a.clone()]);
+        assert_eq!(file.events, vec![turn_a.clone()]);
+
+        let retained = file
+            .retain_turn_ids("session-a", &HashSet::new())
+            .expect("retain should clear");
+        assert!(retained.is_empty());
+        assert!(file.events.is_empty());
+    }
+
+    #[test]
+    fn in_memory_ledger_retain_turn_ids_removes_empty_sessions() {
+        let ledger = SessionEvidenceLedger::new();
+        ledger.append(EvidenceLedgerEvent::new(
+            "session-a",
+            "turn-a",
+            "Task",
+            EvidenceLedgerTargetKind::Subagent,
+            "Review",
+            EvidenceLedgerEventStatus::Created,
+            "Started",
+        ));
+        ledger.append(EvidenceLedgerEvent::new(
+            "session-a",
+            "turn-b",
+            "Task",
+            EvidenceLedgerTargetKind::Subagent,
+            "Edit",
+            EvidenceLedgerEventStatus::Created,
+            "Started",
+        ));
+
+        let retained = ledger.retain_turn_ids("session-a", &HashSet::from(["turn-a".to_string()]));
+        assert_eq!(retained.len(), 1);
+        assert_eq!(retained[0].turn_id, "turn-a");
+
+        let retained = ledger.retain_turn_ids("session-a", &HashSet::new());
+        assert!(retained.is_empty());
+        assert!(ledger.events_for_session("session-a").is_empty());
     }
 
     #[test]

--- a/src/crates/execution/agent-runtime/src/evidence_ledger.rs
+++ b/src/crates/execution/agent-runtime/src/evidence_ledger.rs
@@ -2,10 +2,12 @@ use crate::checkpoint::LightCheckpoint;
 use bitfun_runtime_ports::{CompressionContract, CompressionContractItem};
 use dashmap::DashMap;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const MAX_PARTIAL_OUTPUT_BYTES: usize = 8_000;
+pub const EVIDENCE_LEDGER_SCHEMA_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum EvidenceLedgerTargetKind {
@@ -19,7 +21,7 @@ pub enum EvidenceLedgerTargetKind {
     Artifact,
     #[serde(rename = "checkpoint")]
     Checkpoint,
-    #[serde(rename = "unknown")]
+    #[serde(other, rename = "unknown")]
     Unknown,
 }
 
@@ -35,7 +37,7 @@ pub enum EvidenceLedgerEventStatus {
     PartialTimeout,
     #[serde(rename = "cancelled")]
     Cancelled,
-    #[serde(rename = "unknown")]
+    #[serde(other, rename = "unknown")]
     Unknown,
 }
 
@@ -59,14 +61,52 @@ pub struct EvidenceLedgerEvent {
     pub target_kind: EvidenceLedgerTargetKind,
     pub target: String,
     pub status: EvidenceLedgerEventStatus,
+    #[serde(default)]
     pub exit_code_or_error_kind: Option<String>,
+    #[serde(default)]
     pub touched_files: Vec<String>,
+    #[serde(default)]
     pub artifact_path: Option<String>,
     pub summary: String,
+    #[serde(default)]
     pub partial_output: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub checkpoint: Option<EvidenceLedgerCheckpoint>,
+    #[serde(default)]
     pub created_at_ms: u64,
+}
+
+/// Versioned sidecar owned by the runtime and written by product persistence.
+///
+/// Keeping evidence separate from mutable Session state lets older builds
+/// rewrite `state.json` without erasing evidence produced by a newer build.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PersistedEvidenceLedgerFile {
+    #[serde(default = "default_evidence_ledger_schema_version")]
+    pub schema_version: u32,
+    pub session_id: String,
+    #[serde(default)]
+    pub events: Vec<EvidenceLedgerEvent>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum EvidenceLedgerPersistenceError {
+    #[error(
+        "unsupported evidence ledger schema version {actual}; maximum supported is {supported}"
+    )]
+    UnsupportedSchema { actual: u32, supported: u32 },
+    #[error("evidence ledger session mismatch: expected {expected}, found {actual}")]
+    SessionMismatch { expected: String, actual: String },
+    #[error("evidence ledger event has an empty event_id")]
+    EmptyEventId,
+    #[error("evidence ledger event {event_id} belongs to session {actual}, expected {expected}")]
+    EventSessionMismatch {
+        event_id: String,
+        expected: String,
+        actual: String,
+    },
+    #[error("evidence ledger contains conflicting payloads for event {event_id}")]
+    ConflictingEvent { event_id: String },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -188,6 +228,110 @@ impl From<LightCheckpoint> for EvidenceLedgerCheckpoint {
     }
 }
 
+impl PersistedEvidenceLedgerFile {
+    pub fn new(session_id: impl Into<String>) -> Self {
+        Self {
+            schema_version: EVIDENCE_LEDGER_SCHEMA_VERSION,
+            session_id: session_id.into(),
+            events: Vec::new(),
+        }
+    }
+
+    pub fn append(
+        &mut self,
+        event: EvidenceLedgerEvent,
+    ) -> Result<bool, EvidenceLedgerPersistenceError> {
+        self.validate_header(&event.session_id)?;
+        self.validate_events()?;
+        validate_event(&event, &self.session_id)?;
+
+        if let Some(existing) = self
+            .events
+            .iter()
+            .find(|existing| existing.event_id == event.event_id)
+        {
+            if existing == &event {
+                return Ok(false);
+            }
+            return Err(EvidenceLedgerPersistenceError::ConflictingEvent {
+                event_id: event.event_id,
+            });
+        }
+
+        self.events.push(event);
+        Ok(true)
+    }
+
+    pub fn validated_events(
+        self,
+        expected_session_id: &str,
+    ) -> Result<Vec<EvidenceLedgerEvent>, EvidenceLedgerPersistenceError> {
+        self.validate_header(expected_session_id)?;
+        self.validate_events()
+    }
+
+    fn validate_events(&self) -> Result<Vec<EvidenceLedgerEvent>, EvidenceLedgerPersistenceError> {
+        let mut unique_events = Vec::with_capacity(self.events.len());
+        let mut event_indices = HashMap::<String, usize>::new();
+
+        for event in &self.events {
+            validate_event(event, &self.session_id)?;
+            if let Some(index) = event_indices.get(&event.event_id).copied() {
+                if unique_events[index] != *event {
+                    return Err(EvidenceLedgerPersistenceError::ConflictingEvent {
+                        event_id: event.event_id.clone(),
+                    });
+                }
+                continue;
+            }
+            event_indices.insert(event.event_id.clone(), unique_events.len());
+            unique_events.push(event.clone());
+        }
+
+        Ok(unique_events)
+    }
+
+    fn validate_header(
+        &self,
+        expected_session_id: &str,
+    ) -> Result<(), EvidenceLedgerPersistenceError> {
+        if self.schema_version > EVIDENCE_LEDGER_SCHEMA_VERSION {
+            return Err(EvidenceLedgerPersistenceError::UnsupportedSchema {
+                actual: self.schema_version,
+                supported: EVIDENCE_LEDGER_SCHEMA_VERSION,
+            });
+        }
+        if self.session_id != expected_session_id {
+            return Err(EvidenceLedgerPersistenceError::SessionMismatch {
+                expected: expected_session_id.to_string(),
+                actual: self.session_id.clone(),
+            });
+        }
+        Ok(())
+    }
+}
+
+fn default_evidence_ledger_schema_version() -> u32 {
+    EVIDENCE_LEDGER_SCHEMA_VERSION
+}
+
+fn validate_event(
+    event: &EvidenceLedgerEvent,
+    expected_session_id: &str,
+) -> Result<(), EvidenceLedgerPersistenceError> {
+    if event.event_id.is_empty() {
+        return Err(EvidenceLedgerPersistenceError::EmptyEventId);
+    }
+    if event.session_id != expected_session_id {
+        return Err(EvidenceLedgerPersistenceError::EventSessionMismatch {
+            event_id: event.event_id.clone(),
+            expected: expected_session_id.to_string(),
+            actual: event.session_id.clone(),
+        });
+    }
+    Ok(())
+}
+
 impl SessionEvidenceLedger {
     pub fn new() -> Self {
         Self::default()
@@ -198,11 +342,46 @@ impl SessionEvidenceLedger {
     }
 
     pub fn append(&self, event: EvidenceLedgerEvent) -> EvidenceLedgerEvent {
-        self.events_by_session
+        let mut events = self
+            .events_by_session
             .entry(event.session_id.clone())
-            .or_default()
-            .push(event.clone());
+            .or_default();
+        if let Some(existing) = events
+            .iter()
+            .find(|existing| existing.event_id == event.event_id)
+        {
+            return existing.clone();
+        }
+        events.push(event.clone());
         event
+    }
+
+    pub fn replace_session(
+        &self,
+        session_id: &str,
+        events: Vec<EvidenceLedgerEvent>,
+    ) -> Result<(), EvidenceLedgerPersistenceError> {
+        let events = PersistedEvidenceLedgerFile {
+            schema_version: EVIDENCE_LEDGER_SCHEMA_VERSION,
+            session_id: session_id.to_string(),
+            events,
+        }
+        .validated_events(session_id)?;
+
+        if events.is_empty() {
+            self.events_by_session.remove(session_id);
+        } else {
+            self.events_by_session
+                .insert(session_id.to_string(), events);
+        }
+        Ok(())
+    }
+
+    pub fn events_for_session(&self, session_id: &str) -> Vec<EvidenceLedgerEvent> {
+        self.events_by_session
+            .get(session_id)
+            .map(|events| events.clone())
+            .unwrap_or_default()
     }
 
     pub fn events_for_turn(&self, session_id: &str, turn_id: &str) -> Vec<EvidenceLedgerEvent> {
@@ -375,7 +554,8 @@ fn truncate_string_at_char_boundary(value: &str, max_bytes: usize) -> String {
 mod tests {
     use super::{
         CompressionContract, EvidenceLedgerCheckpoint, EvidenceLedgerEvent,
-        EvidenceLedgerEventStatus, EvidenceLedgerTargetKind, SessionEvidenceLedger,
+        EvidenceLedgerEventStatus, EvidenceLedgerPersistenceError, EvidenceLedgerTargetKind,
+        PersistedEvidenceLedgerFile, SessionEvidenceLedger, EVIDENCE_LEDGER_SCHEMA_VERSION,
     };
     use crate::checkpoint::LightCheckpoint;
 
@@ -403,6 +583,103 @@ mod tests {
         );
         assert!(ledger.events_for_turn("session-a", "other-turn").is_empty());
         assert!(ledger.events_for_turn("other-session", "turn-a").is_empty());
+    }
+
+    #[test]
+    fn persisted_ledger_append_is_idempotent_and_rejects_conflicting_replays() {
+        let event = EvidenceLedgerEvent::new(
+            "session-a",
+            "turn-a",
+            "Bash",
+            EvidenceLedgerTargetKind::Command,
+            "cargo test",
+            EvidenceLedgerEventStatus::Succeeded,
+            "Tests passed.",
+        );
+        let mut file = PersistedEvidenceLedgerFile::new("session-a");
+
+        assert!(file.append(event.clone()).expect("first append"));
+        assert!(!file.append(event.clone()).expect("idempotent replay"));
+
+        let mut conflicting = event.clone();
+        conflicting.summary = "Different payload.".to_string();
+        assert!(matches!(
+            file.append(conflicting),
+            Err(EvidenceLedgerPersistenceError::ConflictingEvent { .. })
+        ));
+        assert_eq!(file.events, vec![event]);
+    }
+
+    #[test]
+    fn persisted_ledger_rejects_newer_schema_and_cross_session_events() {
+        let newer = PersistedEvidenceLedgerFile {
+            schema_version: EVIDENCE_LEDGER_SCHEMA_VERSION + 1,
+            session_id: "session-a".to_string(),
+            events: Vec::new(),
+        };
+        assert!(matches!(
+            newer.validated_events("session-a"),
+            Err(EvidenceLedgerPersistenceError::UnsupportedSchema { .. })
+        ));
+
+        let mut mismatched = PersistedEvidenceLedgerFile::new("session-a");
+        mismatched.events.push(EvidenceLedgerEvent::new(
+            "session-b",
+            "turn-a",
+            "Bash",
+            EvidenceLedgerTargetKind::Command,
+            "cargo test",
+            EvidenceLedgerEventStatus::Succeeded,
+            "Tests passed.",
+        ));
+        assert!(matches!(
+            mismatched.validated_events("session-a"),
+            Err(EvidenceLedgerPersistenceError::EventSessionMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn legacy_evidence_event_payload_loads_with_additive_defaults() {
+        let file: PersistedEvidenceLedgerFile = serde_json::from_value(serde_json::json!({
+            "session_id": "session-a",
+            "events": [{
+                "event_id": "event-a",
+                "session_id": "session-a",
+                "turn_id": "turn-a",
+                "tool_name": "Bash",
+                "target_kind": "command",
+                "target": "cargo test",
+                "status": "succeeded",
+                "summary": "Tests passed."
+            }]
+        }))
+        .expect("legacy payload should deserialize");
+
+        assert_eq!(file.schema_version, EVIDENCE_LEDGER_SCHEMA_VERSION);
+        let events = file
+            .validated_events("session-a")
+            .expect("legacy payload should validate");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].created_at_ms, 0);
+        assert!(events[0].touched_files.is_empty());
+        assert!(events[0].partial_output.is_none());
+
+        let round_trip: PersistedEvidenceLedgerFile = serde_json::from_value(
+            serde_json::to_value(PersistedEvidenceLedgerFile {
+                schema_version: EVIDENCE_LEDGER_SCHEMA_VERSION,
+                session_id: "session-a".to_string(),
+                events,
+            })
+            .expect("upgraded payload should serialize"),
+        )
+        .expect("upgraded payload should deserialize");
+        assert_eq!(
+            round_trip
+                .validated_events("session-a")
+                .expect("round trip should validate")[0]
+                .event_id,
+            "event-a"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Persist `EvidenceLedger` events across session unloads, restarts, and restores to prevent long-running tasks from losing checkpoints, compression evidence, and partial subagent results.

The ledger is stored as a versioned `evidence-ledger.json` sidecar under the resolved session directory.

## Type and Areas

Type: Bug fix / reliability

Areas: Rust core, Agent Runtime, session persistence, remote workspace

## Motivation / Impact

Previously, `EvidenceLedger` existed only in process memory. When a session was unloaded or the host restarted, the ledger was lost. This could cause long-running tasks to lose important execution evidence and drift away from their original objective.

This change:

- Persists durable session evidence to a versioned JSON sidecar.
- Uses session-level serialization, cross-process file locking, and strict atomic replacement.
- Makes event appends idempotent by `event_id`.
- Rejects conflicting payloads for duplicate event IDs.
- Loads and validates the ledger before publishing restored runtime state.
- Preserves the original sidecar when the data is corrupt, from a newer schema, or belongs to another session.
- Keeps legacy payloads readable through additive defaults and unknown-enum fallbacks.
- Publishes evidence to in-memory state only after successful persistence.
- Makes checkpoint persistence fail closed for mutating Bash, file, and Git tools.
- Persists partial subagent timeout evidence while retaining already-produced partial results if persistence fails.
- Uses the resolved remote session mirror for remote workspaces instead of reusing controller-side paths.

No new user-facing strings, locale changes, or UI changes are required.

## Verification

- `cargo check --locked -p bitfun-agent-runtime --no-default-features --features agent-runtime` — passed.
- `cargo test --locked -p bitfun-agent-runtime --no-default-features --features agent-runtime --lib evidence_ledger` — 11 passed.
- `cargo test --locked -p bitfun-core --no-default-features --features agent-runtime --lib evidence_ledger` — 4 passed.
- `cargo test --locked -p bitfun-core --no-default-features --features agent-runtime --lib concurrent_evidence_appends_keep_disk_and_memory_complete` — passed.
- `cargo test --locked -p bitfun-core --no-default-features --features agent-runtime,remote-workspace --lib remote_workspace_evidence_uses_the_resolved_session_mirror` — passed.
- `cargo check --locked -p bitfun-core --no-default-features --features product-full` — passed.
- `pnpm run check:core-boundaries` — passed.
- `pnpm run fmt:rs` — passed.
- `git diff --check` — passed.

The remote workspace scenario was exercised. Remote control, Peer Device Mode, and Detached Dispatch protocols were not changed by this PR and were not modified in the tests.

## Reviewer Notes

- The persistence format is currently schema version `1`.
- The sidecar is created only for durable sessions; transient sessions retain their existing in-memory behavior.
- Restore is fail-closed for invalid or incompatible ledger data and does not delete or overwrite the original sidecar.
- Concurrent appends are serialized in-process and protected across processes by the JSON file lock.
- Existing repository feature-conditional warnings remain, but all targeted tests and checks pass.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above.
- [x] User-facing strings, docs, and locales are updated where applicable.