### PR TITLE
fix(flow-chat): shorten visible turn rail bars

### DIFF
--- a/src/web-ui/src/flow_chat/components/modern/FlowChatTurnRail.scss
+++ b/src/web-ui/src/flow_chat/components/modern/FlowChatTurnRail.scss
@@ -64,7 +64,7 @@
   }
 
   &__item--visible &__bar {
-    width: 16px;
+    width: 10px;
     height: 2px;
     background: var(--bf-appearance-token-color-text-primary);
     opacity: 1;


### PR DESCRIPTION
Keep in-viewport turn markers at the same compact width as inactive
markers while preserving their emphasized color. Hover and focus states
remain expanded.
