### PR TITLE
fix(web-ui): make the device status footer scale with attached devices

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/NavPanel.scss
+++ b/src/web-ui/src/app/components/NavPanel/NavPanel.scss
@@ -1709,8 +1709,8 @@ $_section-header-height: 24px;
   width: 100%;
   min-width: 0;
   max-width: none;
-  height: 42px;
-  padding: 4px 6px;
+  height: 30px;
+  padding: 0 6px;
   border: none;
   border-radius: $size-radius-sm;
   background: transparent;
@@ -1738,19 +1738,8 @@ $_section-header-height: 24px;
   }
 }
 
-.bitfun-nav-panel__footer-device-status-copy {
-  display: flex;
-  flex: 1 1 auto;
-  min-width: 0;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 1px;
-  text-align: left;
-}
-
 .bitfun-nav-panel__footer-device-status-label {
-  display: block;
-  width: 100%;
+  flex: 0 1 auto;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1761,16 +1750,36 @@ $_section-header-height: 24px;
   line-height: 1.25;
 }
 
-.bitfun-nav-panel__footer-device-status-meta {
-  display: block;
-  width: 100%;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  color: var(--bf-appearance-token-color-text-muted);
-  font-size: 10px;
-  line-height: 1.25;
+// Attached remote parties are shown as one badge per device kind in the
+// connection-live green the workspace list already teaches in this panel. The
+// number lives inside a badge, so twenty attached hosts occupy the same width
+// as one and no state sentence sits in permanent navigation chrome.
+.bitfun-nav-panel__footer-device-status-attached {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 6px;
+  margin-left: 2px;
+  color: var(--bf-appearance-token-color-success);
+}
+
+.bitfun-nav-panel__footer-device-status-attached-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 1px;
+  line-height: 1;
+}
+
+.bitfun-nav-panel__footer-device-status-attached-count {
+  font-size: 9px;
+  font-weight: 650;
+  line-height: 1;
+}
+
+.bitfun-nav-panel__footer-device-status-tip {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
 
 // Footer notification: yellow only when there are unread messages (BellDot)
@@ -2372,6 +2381,19 @@ $_section-header-height: 24px;
     font-weight: 550;
     text-overflow: ellipsis;
     white-space: nowrap;
+
+    // Same live-state dot the footer trigger uses, so the summary and the
+    // expanded list read as one status language.
+    &:not(:empty)::before {
+      content: '';
+      display: inline-block;
+      width: 5px;
+      height: 5px;
+      margin-right: 5px;
+      border-radius: $size-radius-full;
+      background: var(--bf-appearance-token-color-success);
+      vertical-align: 1px;
+    }
   }
 }
 

--- a/src/web-ui/src/app/components/NavPanel/components/DeviceStatusControl.tsx
+++ b/src/web-ui/src/app/components/NavPanel/components/DeviceStatusControl.tsx
@@ -16,9 +16,13 @@ import { getAppearanceOverlayHost } from '@/infrastructure/appearance/runtime/Ap
 import { useAnchoredPopoverPosition } from '@/shared/utils/useAnchoredPopoverPosition';
 import { usePeerDeviceModeOptional } from '@/infrastructure/peer-device/peerDeviceContextState';
 import { useNotification } from '@/shared/notification-system';
-import type {
-  DeviceOverviewConnectionService,
-  DeviceOverviewDevice,
+import {
+  selectActivityFacts,
+  selectAttachedGroups,
+  type DeviceOverviewActivityFact,
+  type DeviceOverviewConnectionService,
+  type DeviceOverviewDevice,
+  type DeviceOverviewDeviceKind,
 } from '../deviceInterconnectionOverview';
 import { useDeviceInterconnectionOverview } from './useDeviceInterconnectionOverview';
 
@@ -28,16 +32,16 @@ interface DeviceStatusControlProps {
   onManageDevices: () => void;
 }
 
-function DeviceIcon({ device }: { device: DeviceOverviewDevice }) {
-  switch (device.kind) {
+function DeviceIcon({ kind, size = 17 }: { kind: DeviceOverviewDeviceKind; size?: number }) {
+  switch (kind) {
     case 'mobile':
-      return <Smartphone size={17} aria-hidden="true" />;
+      return <Smartphone size={size} aria-hidden="true" />;
     case 'execution-host':
-      return <Server size={17} aria-hidden="true" />;
+      return <Server size={size} aria-hidden="true" />;
     case 'message-app':
-      return <MessageCircle size={17} aria-hidden="true" />;
+      return <MessageCircle size={size} aria-hidden="true" />;
     default:
-      return <Monitor size={17} aria-hidden="true" />;
+      return <Monitor size={size} aria-hidden="true" />;
   }
 }
 
@@ -116,21 +120,58 @@ const DeviceStatusControl: React.FC<DeviceStatusControlProps> = ({
     onManageDevices();
   }, [onManageDevices, onOpenChange]);
 
-  const controller = overview.devices.find(device => (
-    !device.local && device.activities.includes('controlling')
-  ));
-  const footerSubtitle = overview.mode === 'local'
-    ? t('deviceOverview.footerLocalSimple')
-    : overview.peerActive
-      ? t('deviceOverview.footerControlledFromHere')
-      : controller
-        ? t('deviceOverview.footerControlledBy', { device: controller.name })
-        : t('deviceOverview.footerDistributedExecution', {
-            count: overview.connectedDevices.filter(device => (
-              device.activities.includes('background-execution')
-            )).length,
-          });
-  const tooltip = `${overview.currentWorkDeviceName} · ${footerSubtitle}`;
+  const activityFactSentence = useCallback((fact: DeviceOverviewActivityFact) => {
+    switch (fact.kind) {
+      case 'local':
+        return t('deviceOverview.footerLocalSimple');
+      case 'controlled-from-here':
+        return t('deviceOverview.footerControlledFromHere');
+      case 'controlled-by':
+        return t('deviceOverview.footerControlledBy', { device: fact.device });
+      case 'controllers':
+        return t('deviceOverview.footerControllers', { count: fact.count });
+      default:
+        return t('deviceOverview.footerDistributedExecution', { count: fact.count });
+    }
+  }, [t]);
+  const activityLines = useMemo(
+    () => selectActivityFacts(overview).map(activityFactSentence),
+    [activityFactSentence, overview],
+  );
+  const attachedGroups = useMemo(() => selectAttachedGroups(overview), [overview]);
+  const accessibleSummary = [overview.currentWorkDeviceName, ...activityLines].join(' · ');
+
+  const labelRef = useRef<HTMLSpanElement>(null);
+  const [labelClipped, setLabelClipped] = useState(false);
+
+  useEffect(() => {
+    const label = labelRef.current;
+    if (!label) return undefined;
+    const measure = () => setLabelClipped(label.scrollWidth > label.clientWidth + 1);
+
+    measure();
+    if (typeof ResizeObserver === 'undefined') return undefined;
+    const observer = new ResizeObserver(measure);
+    observer.observe(label);
+    return () => observer.disconnect();
+  }, [overview.currentWorkDeviceName]);
+
+  // Hover is where the detail belongs: the trigger itself stays glanceable, so
+  // the tooltip carries the name the layout had to clip and the sentence the
+  // device-kind badges only imply.
+  const hoverDetail = useMemo(() => {
+    const lines = [
+      ...(labelClipped ? [overview.currentWorkDeviceName] : []),
+      ...(overview.mode === 'local' ? [] : activityLines),
+    ];
+    if (lines.length === 0) return null;
+    if (lines.length === 1) return lines[0];
+    return (
+      <span className="bitfun-nav-panel__footer-device-status-tip">
+        {lines.map(line => <span key={line}>{line}</span>)}
+      </span>
+    );
+  }, [activityLines, labelClipped, overview.currentWorkDeviceName, overview.mode]);
 
   const deviceActivity = useCallback((device: DeviceOverviewDevice) => {
     const parts: string[] = [];
@@ -172,12 +213,16 @@ const DeviceStatusControl: React.FC<DeviceStatusControlProps> = ({
 
   return (
     <>
-      <Tooltip content={tooltip} placement="right" followCursor disabled={open}>
+      <Tooltip
+        content={hoverDetail}
+        placement="top"
+        disabled={open || hoverDetail === null}
+      >
         <button
           ref={triggerRef}
           type="button"
           className={`bitfun-nav-panel__footer-device-status${open ? ' is-open' : ''}`}
-          aria-label={tooltip}
+          aria-label={accessibleSummary}
           aria-expanded={open}
           aria-haspopup="dialog"
           onClick={() => onOpenChange(!open)}
@@ -186,15 +231,33 @@ const DeviceStatusControl: React.FC<DeviceStatusControlProps> = ({
           data-bf-part="deviceStatus"
           data-bf-state={overview.mode}
         >
-          <Monitor size={16} aria-hidden="true" />
-          <span className="bitfun-nav-panel__footer-device-status-copy">
-            <span className="bitfun-nav-panel__footer-device-status-label">
-              {overview.currentWorkDeviceName}
-            </span>
-            <span className="bitfun-nav-panel__footer-device-status-meta">
-              {footerSubtitle}
-            </span>
+          <DeviceIcon kind={overview.primaryDevice.kind} size={15} />
+          <span
+            ref={labelRef}
+            className="bitfun-nav-panel__footer-device-status-label"
+          >
+            {overview.currentWorkDeviceName}
           </span>
+          {attachedGroups.length > 0 && (
+            <span
+              className="bitfun-nav-panel__footer-device-status-attached"
+              aria-hidden="true"
+            >
+              {attachedGroups.map(group => (
+                <span
+                  className="bitfun-nav-panel__footer-device-status-attached-group"
+                  key={group.kind}
+                >
+                  <DeviceIcon kind={group.kind} size={13} />
+                  {group.count > 1 && (
+                    <span className="bitfun-nav-panel__footer-device-status-attached-count">
+                      {group.count}
+                    </span>
+                  )}
+                </span>
+              ))}
+            </span>
+          )}
         </button>
       </Tooltip>
 
@@ -229,7 +292,7 @@ const DeviceStatusControl: React.FC<DeviceStatusControlProps> = ({
                 className="bitfun-device-overview__local-device"
                 data-testid="nav-device-status-summary"
               >
-                <Monitor size={19} aria-hidden="true" />
+                <DeviceIcon kind={overview.primaryDevice.kind} size={19} />
                 <strong>{overview.currentWorkDeviceName}</strong>
               </div>
             ) : (
@@ -237,7 +300,7 @@ const DeviceStatusControl: React.FC<DeviceStatusControlProps> = ({
                 <section className="bitfun-device-overview__device-group is-primary">
                   <h3>{t('deviceOverview.currentUse')}</h3>
                   <div className="bitfun-device-overview__device-row">
-                    <DeviceIcon device={overview.primaryDevice} />
+                    <DeviceIcon kind={overview.primaryDevice.kind} />
                     <strong>{overview.primaryDevice.name}</strong>
                     {overview.primaryDevice.activities.includes('background-execution') && (
                       <span>{deviceActivity(overview.primaryDevice)}</span>
@@ -257,7 +320,7 @@ const DeviceStatusControl: React.FC<DeviceStatusControlProps> = ({
                         data-bf-device-kind={device.kind}
                         data-bf-activities={device.activities.join(' ')}
                       >
-                        <DeviceIcon device={device} />
+                        <DeviceIcon kind={device.kind} />
                         <strong>{device.name}</strong>
                         <span>{deviceActivity(device)}</span>
                       </div>

--- a/src/web-ui/src/app/components/NavPanel/deviceInterconnectionOverview.test.ts
+++ b/src/web-ui/src/app/components/NavPanel/deviceInterconnectionOverview.test.ts
@@ -3,7 +3,10 @@ import type { RemoteConnectStatus } from '@/infrastructure/api/service-api/Remot
 import {
   classifyAccountRelayUrl,
   connectionServiceFromRelayUrl,
+  formatDeviceDisplayName,
   projectDeviceInterconnectionOverview,
+  selectActivityFacts,
+  selectAttachedGroups,
   type DeviceInterconnectionOverviewInput,
 } from './deviceInterconnectionOverview';
 
@@ -149,6 +152,178 @@ describe('projectDeviceInterconnectionOverview', () => {
       'background-execution',
     ]);
     expect(overview.primaryDevice.backgroundTaskCount).toBe(1);
+  });
+});
+
+describe('selectActivityFacts', () => {
+  const connectedPhone = {
+    ...disconnectedStatus,
+    is_connected: true,
+    pairing_state: 'connected' as const,
+    active_method: 'BitfunServer',
+    peer_device_name: 'My iPhone',
+    peer_user_id: 'mobile-user',
+  };
+
+  it('reports nothing beyond the local host when no device is attached', () => {
+    expect(selectActivityFacts(projectDeviceInterconnectionOverview(baseInput())))
+      .toEqual([{ kind: 'local' }]);
+  });
+
+  it('names the single remote party that holds this host', () => {
+    const overview = projectDeviceInterconnectionOverview(baseInput({
+      remoteStatus: connectedPhone,
+    }));
+
+    expect(selectActivityFacts(overview)).toEqual([
+      { kind: 'controlled-by', device: 'My iPhone' },
+    ]);
+  });
+
+  it('counts controllers instead of naming only the first when several hold this host', () => {
+    const overview = projectDeviceInterconnectionOverview(baseInput({
+      remoteStatus: { ...connectedPhone, bot_connected: 'Weixin (group)' },
+    }));
+
+    expect(selectActivityFacts(overview)).toEqual([{ kind: 'controllers', count: 2 }]);
+  });
+
+  it('states that this device drives the work when peer mode is active', () => {
+    const overview = projectDeviceInterconnectionOverview(baseInput({
+      peer: { deviceId: 'linux-1', deviceName: 'Linux Workstation' },
+      remoteStatus: connectedPhone,
+    }));
+
+    expect(selectActivityFacts(overview)).toEqual([{ kind: 'controlled-from-here' }]);
+  });
+
+  it('reports distributed execution when devices only run background work', () => {
+    const overview = projectDeviceInterconnectionOverview(baseInput({
+      dispatchJobs: [
+        {
+          id: 'job-device',
+          state: 'running',
+          target: { kind: 'device', id: 'linux-2', name: 'Build Server' },
+        },
+      ],
+    }));
+
+    expect(selectActivityFacts(overview)).toEqual([
+      { kind: 'distributed-execution', count: 1 },
+    ]);
+  });
+
+  it('keeps control and distributed execution as separate facts when both hold', () => {
+    const overview = projectDeviceInterconnectionOverview(baseInput({
+      remoteStatus: connectedPhone,
+      dispatchJobs: [
+        { id: 'a', state: 'running', target: { kind: 'device', id: 'host-1', name: 'Host 1' } },
+        { id: 'b', state: 'queued', target: { kind: 'device', id: 'host-2', name: 'Host 2' } },
+      ],
+    }));
+
+    expect(selectActivityFacts(overview)).toEqual([
+      { kind: 'controlled-by', device: 'My iPhone' },
+      { kind: 'distributed-execution', count: 2 },
+    ]);
+  });
+});
+
+describe('selectAttachedGroups', () => {
+  it('shows nothing while no other device is attached', () => {
+    expect(selectAttachedGroups(projectDeviceInterconnectionOverview(baseInput())))
+      .toEqual([]);
+  });
+
+  it('keeps one group per device kind so the footer width never grows with device count', () => {
+    const overview = projectDeviceInterconnectionOverview(baseInput({
+      remoteStatus: {
+        ...disconnectedStatus,
+        is_connected: true,
+        pairing_state: 'connected',
+        active_method: 'BitfunServer',
+        peer_device_name: 'My iPhone',
+        peer_user_id: 'mobile-user',
+        bot_connected: 'Weixin (family group)',
+      },
+      dispatchJobs: [
+        { id: 'a', state: 'running', target: { kind: 'device', id: 'host-1', name: 'Host 1' } },
+        { id: 'b', state: 'queued', target: { kind: 'device', id: 'host-2', name: 'Host 2' } },
+        { id: 'c', state: 'running', target: { kind: 'device', id: 'host-3', name: 'Host 3' } },
+      ],
+    }));
+
+    expect(selectAttachedGroups(overview)).toEqual([
+      { kind: 'mobile', count: 1 },
+      { kind: 'message-app', count: 1 },
+      { kind: 'execution-host', count: 3 },
+    ]);
+  });
+
+  it('counts the controlling desktop when this device drives a peer', () => {
+    const overview = projectDeviceInterconnectionOverview(baseInput({
+      peer: { deviceId: 'linux-1', deviceName: 'Linux Workstation' },
+    }));
+
+    expect(selectAttachedGroups(overview)).toEqual([{ kind: 'desktop', count: 1 }]);
+  });
+
+  it('leaves the current device out of the attached groups', () => {
+    const overview = projectDeviceInterconnectionOverview(baseInput({
+      peer: { deviceId: 'linux-1', deviceName: 'Linux Workstation' },
+      dispatchJobs: [
+        {
+          id: 'job-1',
+          state: 'running',
+          target: { kind: 'device', id: 'linux-1', name: 'Linux Workstation' },
+        },
+      ],
+    }));
+
+    expect(overview.primaryDevice.activities).toContain('background-execution');
+    expect(selectAttachedGroups(overview)).toEqual([{ kind: 'desktop', count: 1 }]);
+  });
+});
+
+describe('device display names', () => {
+  it('drops the discovery zone suffix that no person uses to name a machine', () => {
+    expect(formatDeviceDisplayName('yuyuqingqingdeMacBook-Pro.local')).toBe('yuyuqingqingdeMacBook-Pro');
+    expect(formatDeviceDisplayName('build-box.LAN')).toBe('build-box');
+    expect(formatDeviceDisplayName('nas.internal.')).toBe('nas');
+  });
+
+  it('keeps names that only look like a zone suffix', () => {
+    expect(formatDeviceDisplayName('.local')).toBe('.local');
+    expect(formatDeviceDisplayName('  My iPhone  ')).toBe('My iPhone');
+    expect(formatDeviceDisplayName(null)).toBe('');
+  });
+
+  it('normalizes every device name the overview projects', () => {
+    const overview = projectDeviceInterconnectionOverview(baseInput({
+      localDeviceName: 'Studio-Mac.local',
+      remoteStatus: {
+        ...disconnectedStatus,
+        is_connected: true,
+        pairing_state: 'connected',
+        active_method: 'BitfunServer',
+        peer_device_name: 'Pixel.lan',
+        peer_user_id: 'mobile-user',
+      },
+      dispatchJobs: [
+        {
+          id: 'job-device',
+          state: 'running',
+          target: { kind: 'device', id: 'linux-2', name: 'Build-Server.local' },
+        },
+      ],
+    }));
+
+    expect(overview.localDeviceName).toBe('Studio-Mac');
+    expect(overview.devices.map(device => device.name)).toEqual([
+      'Studio-Mac',
+      'Pixel',
+      'Build-Server',
+    ]);
   });
 });
 

--- a/src/web-ui/src/app/components/NavPanel/deviceInterconnectionOverview.ts
+++ b/src/web-ui/src/app/components/NavPanel/deviceInterconnectionOverview.ts
@@ -47,6 +47,87 @@ export interface DeviceInterconnectionOverview {
   topologyUnavailable: boolean;
 }
 
+/**
+ * What the device status has to state, as facts rather than phrases, so the
+ * selection stays testable and the surface owns only the wording.
+ */
+export type DeviceOverviewActivityFact =
+  | { kind: 'local' }
+  | { kind: 'controlled-from-here' }
+  | { kind: 'controlled-by'; device: string }
+  | { kind: 'controllers'; count: number }
+  | { kind: 'distributed-execution'; count: number };
+
+/**
+ * Control and distributed execution are separate facts that can hold at the
+ * same time. Collapsing them into a single phrase would silently drop whichever
+ * one lost, and these sentences are now the only place the detail is spelled
+ * out, so they have to be complete.
+ */
+export function selectActivityFacts(
+  overview: DeviceInterconnectionOverview,
+): DeviceOverviewActivityFact[] {
+  if (overview.mode === 'local') return [{ kind: 'local' }];
+
+  const facts: DeviceOverviewActivityFact[] = [];
+  if (overview.peerActive) {
+    facts.push({ kind: 'controlled-from-here' });
+  } else {
+    // Every remote party holding this host counts. Naming only the first one
+    // would claim a single controller while several are attached.
+    const controllers = overview.devices.filter(device => (
+      !device.local && device.activities.includes('controlling')
+    ));
+    if (controllers.length === 1) {
+      facts.push({ kind: 'controlled-by', device: controllers[0].name });
+    } else if (controllers.length > 1) {
+      facts.push({ kind: 'controllers', count: controllers.length });
+    }
+  }
+
+  const executingDeviceCount = overview.connectedDevices.filter(device => (
+    device.activities.includes('background-execution')
+  )).length;
+  if (executingDeviceCount > 0) {
+    facts.push({ kind: 'distributed-execution', count: executingDeviceCount });
+  }
+
+  return facts;
+}
+
+export interface DeviceOverviewAttachedGroup {
+  kind: DeviceOverviewDeviceKind;
+  count: number;
+}
+
+const ATTACHED_GROUP_ORDER: DeviceOverviewDeviceKind[] = [
+  'desktop',
+  'mobile',
+  'message-app',
+  'execution-host',
+];
+
+/**
+ * Attached devices collapsed to one group per device kind. The footer trigger
+ * lives in fixed navigation chrome, so it has to stay the same size whether one
+ * phone or twenty hosts are attached: the number belongs inside a group, never
+ * in the layout, and the names belong in the overview a click away.
+ */
+export function selectAttachedGroups(
+  overview: DeviceInterconnectionOverview,
+): DeviceOverviewAttachedGroup[] {
+  const counts = new Map<DeviceOverviewDeviceKind, number>();
+  for (const device of overview.connectedDevices) {
+    const attached = device.activities.includes('controlling')
+      || device.activities.includes('background-execution');
+    if (!attached) continue;
+    counts.set(device.kind, (counts.get(device.kind) ?? 0) + 1);
+  }
+  return ATTACHED_GROUP_ORDER
+    .filter(kind => counts.has(kind))
+    .map(kind => ({ kind, count: counts.get(kind) as number }));
+}
+
 export interface DeviceOverviewDispatchJob {
   id: string;
   state: 'submitting' | 'submission_unknown' | 'queued' | 'running' | 'succeeded' | 'failed' | 'cancelled';
@@ -73,6 +154,22 @@ const ACTIVE_DISPATCH_STATES = new Set<DeviceOverviewDispatchJob['state']>([
 ]);
 
 const OFFICIAL_RELAY_HOST = 'remote.openbitfun.com';
+
+// Device names reach us as discovery host names, so macOS reports
+// `<name>.local` and LAN hosts add their own zone. That suffix identifies a
+// network zone, not a machine, and it spends the scarce width the footer has
+// for the part a person actually recognizes.
+const NETWORK_ZONE_SUFFIXES = ['.local', '.lan', '.home', '.internal'];
+
+export function formatDeviceDisplayName(rawName: string | null | undefined): string {
+  const trimmed = rawName?.trim() ?? '';
+  const withoutRoot = trimmed.replace(/\.+$/, '');
+  const lowered = withoutRoot.toLowerCase();
+  const suffix = NETWORK_ZONE_SUFFIXES.find(candidate => (
+    lowered.endsWith(candidate) && withoutRoot.length > candidate.length
+  ));
+  return (suffix ? withoutRoot.slice(0, -suffix.length) : withoutRoot) || trimmed;
+}
 
 export function connectionServiceFromRelayUrl(
   relayUrl: string | null | undefined,
@@ -159,8 +256,8 @@ function addOrMergeDevice(
 export function projectDeviceInterconnectionOverview(
   input: DeviceInterconnectionOverviewInput,
 ): DeviceInterconnectionOverview {
-  const localDeviceName = input.localDeviceName.trim();
-  const currentWorkDeviceName = input.peer?.deviceName.trim() || localDeviceName;
+  const localDeviceName = formatDeviceDisplayName(input.localDeviceName);
+  const currentWorkDeviceName = formatDeviceDisplayName(input.peer?.deviceName) || localDeviceName;
   const devices: DeviceOverviewDevice[] = [];
 
   const primaryDevice = addOrMergeDevice(devices, {
@@ -188,7 +285,7 @@ export function projectDeviceInterconnectionOverview(
   if (input.remoteStatus?.is_connected) {
     addOrMergeDevice(devices, {
       id: `mobile:${input.remoteStatus.peer_user_id ?? input.remoteStatus.peer_device_name ?? 'connected'}`,
-      name: input.remoteStatus.peer_device_name?.trim() || 'Mobile device',
+      name: formatDeviceDisplayName(input.remoteStatus.peer_device_name) || 'Mobile device',
       kind: 'mobile',
       local: false,
       activities: ['controlling'],
@@ -225,7 +322,7 @@ export function projectDeviceInterconnectionOverview(
     backgroundTaskCount += 1;
     const device = addOrMergeDevice(devices, {
       id: `device:${job.target.id}`,
-      name: job.target.name,
+      name: formatDeviceDisplayName(job.target.name) || job.target.name,
       kind: 'execution-host',
       local: false,
       activities: ['background-execution'],


### PR DESCRIPTION
## Summary

The nav panel footer spelled the remote-control state out as a sentence (`Weixin 正在控制`) and then repeated the very same text in a cursor-following tooltip. One controller already filled the row, a second one had nowhere to go, and the tooltip covered the neighbouring footer buttons while adding no information.

- State is now carried by **one badge per attached device kind**, with the count inside the badge, so the trigger keeps the same width and height whether one phone or twenty execution hosts are attached. The bound is the number of device kinds (4), not the number of devices.
- Names and sentences move to hover and to the overview popover. The trigger stays glanceable; `aria-label` keeps the full summary for screen readers.
- Device names drop discovery zone suffixes (`.local`, `.lan`, `.home`, `.internal`), which identify a network zone rather than a machine and were spending the footer's scarce width.
- The footer trigger collapses to a single 30px row, matching the 28px icon buttons next to it, instead of a 42px two-line block whose second line repeated "this device" in the idle case.
- Badges use the connection-live green the workspace list already teaches in this panel, and the overview popover gets the same dot so both read as one status language.

Model changes behind it:

- `selectAttachedGroups()` collapses attached devices to one group per kind, excluding the current device.
- `selectActivityFacts()` replaces the previous single-fact selection. Control and distributed execution can hold at the same time, and the old code silently dropped whichever lost; these sentences are now the only place the detail is spelled out, so they have to be complete.
- Several controllers no longer get reported as just the first one; the existing `footerControllers` string is finally used.

## Test plan

- [x] `pnpm run type-check:web`
- [x] `pnpm --dir src/web-ui run test:run src/app/components/NavPanel/deviceInterconnectionOverview.test.ts` — 20 passing, including new coverage for badge grouping by kind, counting within a kind, excluding the current device, peer mode, name normalization, and control plus execution holding together
- [x] `pnpm run theme:color-audit:all`
- [x] `node scripts/audit-appearance-contracts.mjs`
- [x] `pnpm run i18n:audit` (no new locale keys)
- [x] `pnpm run motion:audit`
- [x] Real-browser verification against the live data path (stubbed backend responses) for four states: idle local, one message-app controller, phone + message app + 7 execution hosts, and the hover detail. Trigger geometry stayed 148x30 across all of them.

Remote scenarios: exercised locally. The `controlled-from-here` (Peer Device Mode) and `distributed-execution` (Detached Dispatch) branches are covered by pure model tests but were not run against two real hosts.