### PR TITLE
fix(config): preserve primary fallback for unset fast model

### DIFF
--- a/src/crates/assembly/core/src/service/config/normalization.rs
+++ b/src/crates/assembly/core/src/service/config/normalization.rs
@@ -214,6 +214,12 @@ fn diagnose_reference_repair(
     });
 }
 
+#[derive(Clone, Copy)]
+enum MissingSlotPolicy {
+    FillFromFirstCapableModel,
+    Preserve,
+}
+
 /// Reconciles every product model reference against both enablement and the
 /// capability required by its consumer.
 pub fn reconcile_model_references(config: &mut GlobalConfig) -> ModelReferenceReconcileResult {
@@ -361,12 +367,12 @@ pub fn reconcile_model_references(config: &mut GlobalConfig) -> ModelReferenceRe
     let mut reconcile_slot = |slot: &mut Option<String>,
                               path: &str,
                               capability: ModelCapability,
-                              fill_when_missing: bool| {
+                              missing_policy: MissingSlotPolicy| {
         let previous = slot.clone();
         let valid = previous
             .as_deref()
             .is_some_and(|id| enabled_model_with_capability(&snapshot, id, capability.clone()));
-        if valid || (previous.is_none() && !fill_when_missing) {
+        if valid || (previous.is_none() && matches!(missing_policy, MissingSlotPolicy::Preserve)) {
             return;
         }
         let replacement = first_enabled_model_with_capability(&snapshot, capability);
@@ -390,37 +396,37 @@ pub fn reconcile_model_references(config: &mut GlobalConfig) -> ModelReferenceRe
         &mut config.ai.default_models.primary,
         "ai.default_models.primary",
         ModelCapability::TextChat,
-        true,
+        MissingSlotPolicy::FillFromFirstCapableModel,
     );
     reconcile_slot(
         &mut config.ai.default_models.fast,
         "ai.default_models.fast",
         ModelCapability::TextChat,
-        true,
+        MissingSlotPolicy::Preserve,
     );
     reconcile_slot(
         &mut config.ai.default_models.image_understanding,
         "ai.default_models.image_understanding",
         ModelCapability::ImageUnderstanding,
-        false,
+        MissingSlotPolicy::Preserve,
     );
     reconcile_slot(
         &mut config.ai.default_models.image_generation,
         "ai.default_models.image_generation",
         ModelCapability::ImageGeneration,
-        false,
+        MissingSlotPolicy::Preserve,
     );
     reconcile_slot(
         &mut config.ai.default_models.search,
         "ai.default_models.search",
         ModelCapability::Search,
-        false,
+        MissingSlotPolicy::Preserve,
     );
     reconcile_slot(
         &mut config.ai.default_models.speech_recognition,
         "ai.default_models.speech_recognition",
         ModelCapability::SpeechRecognition,
-        false,
+        MissingSlotPolicy::Preserve,
     );
 
     result.invalidated_model_ids = invalidated.into_iter().collect();
@@ -509,6 +515,38 @@ mod tests {
             Some("speech")
         );
         assert!(result.default_models_changed);
+    }
+
+    #[test]
+    fn missing_fast_slot_is_preserved_and_resolves_to_primary() {
+        let mut config = GlobalConfig::default();
+        config.ai.models = vec![
+            AIModelConfig {
+                id: "first-text".to_string(),
+                enabled: true,
+                category: ModelCategory::GeneralChat,
+                capabilities: vec![ModelCapability::TextChat],
+                ..AIModelConfig::default()
+            },
+            AIModelConfig {
+                id: "primary-text".to_string(),
+                enabled: true,
+                category: ModelCategory::GeneralChat,
+                capabilities: vec![ModelCapability::TextChat],
+                ..AIModelConfig::default()
+            },
+        ];
+        config.ai.default_models.primary = Some("primary-text".to_string());
+        config.ai.default_models.fast = None;
+
+        let result = reconcile_model_references(&mut config);
+
+        assert_eq!(config.ai.default_models.fast, None);
+        assert_eq!(
+            config.ai.resolve_model_selection("fast").as_deref(),
+            Some("primary-text")
+        );
+        assert!(!result.default_models_changed);
     }
 
     #[test]

--- a/src/crates/assembly/core/src/service/config/service.rs
+++ b/src/crates/assembly/core/src/service/config/service.rs
@@ -841,10 +841,7 @@ mod tests {
             before.ai.default_models.primary.as_deref(),
             Some("reused-model")
         );
-        assert_eq!(
-            before.ai.default_models.fast.as_deref(),
-            Some("reused-model")
-        );
+        assert_eq!(before.ai.default_models.fast, None);
 
         let result = service
             .save_cloud_speech_config(SaveCloudSpeechConfigRequest {
@@ -875,6 +872,49 @@ mod tests {
             after.ai.task_models.git_commit.fixed_model_id(),
             Some("reused-model")
         );
+    }
+
+    #[tokio::test]
+    async fn clearing_fast_model_persists_unset_and_resolves_to_primary() {
+        let test_name = "clear-fast-model";
+        let (service, dir) = test_service(test_name).await;
+        service
+            .set_config(
+                "ai.models",
+                vec![
+                    model("first-text", true, ModelCategory::GeneralChat),
+                    model("primary-text", true, ModelCategory::GeneralChat),
+                ],
+            )
+            .await
+            .expect("models should save");
+        service
+            .set_config(
+                "ai.default_models",
+                &DefaultModelsConfig {
+                    primary: Some("primary-text".to_string()),
+                    fast: None,
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("defaults should save");
+
+        let current: GlobalConfig = service.get_config(None).await.expect("current config");
+        assert_eq!(current.ai.default_models.fast, None);
+        assert_eq!(
+            current.ai.resolve_model_selection("fast").as_deref(),
+            Some("primary-text")
+        );
+
+        let path_manager = PathManager::with_user_root_for_tests(dir.path().join(test_name));
+        let persisted: GlobalConfig = serde_json::from_slice(
+            &tokio::fs::read(path_manager.app_config_file())
+                .await
+                .expect("persisted config"),
+        )
+        .expect("valid persisted config");
+        assert_eq!(persisted.ai.default_models.fast, None);
     }
 
     #[tokio::test]

--- a/src/crates/assembly/core/src/service/config/types.rs
+++ b/src/crates/assembly/core/src/service/config/types.rs
@@ -593,7 +593,7 @@ pub enum ModelCategory {
 pub struct DefaultModelsConfig {
     /// Primary model ID (for complex tasks).
     pub primary: Option<String>,
-    /// Fast model ID (for simple tasks).
+    /// Fast model ID (for simple tasks). When unset, selection falls back to primary.
     pub fast: Option<String>,
     /// Search model.
     pub search: Option<String>,

--- a/src/web-ui/src/infrastructure/config/components/DefaultModelConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/DefaultModelConfig.tsx
@@ -125,11 +125,19 @@ export const DefaultModelConfig: React.FC = () => {
       }));
 
       const modelName = getModelName(modelIdStr);
-      notificationService.success(
-        t('messages.modelUpdated', {
+      let successMessage: string;
+      if (modelIdStr) {
+        successMessage = t('messages.modelUpdated', {
           slot: slotLabel(slot),
           name: modelName || modelIdStr,
-        }),
+        });
+      } else if (slot === 'fast') {
+        successMessage = t('messages.fastModelCleared');
+      } else {
+        successMessage = t('messages.modelCleared', { slot: slotLabel(slot) });
+      }
+      notificationService.success(
+        successMessage,
         { duration: 2000 }
       );
     } catch (error) {

--- a/src/web-ui/src/locales/en-US/settings/default-model.json
+++ b/src/web-ui/src/locales/en-US/settings/default-model.json
@@ -59,6 +59,8 @@
     "loadFailed": "Failed to load configuration",
     "updateFailed": "Update failed",
     "modelUpdated": "{{slot}} set to {{name}}",
+    "modelCleared": "{{slot}} is no longer set",
+    "fastModelCleared": "Fast model cleared; the primary model will be used",
     "capabilityUpdated": "Capability model updated"
   }
 }

--- a/src/web-ui/src/locales/zh-CN/settings/default-model.json
+++ b/src/web-ui/src/locales/zh-CN/settings/default-model.json
@@ -59,6 +59,8 @@
     "loadFailed": "加载配置失败",
     "updateFailed": "更新失败",
     "modelUpdated": "{{slot}}已设置为 {{name}}",
+    "modelCleared": "{{slot}}已取消设置",
+    "fastModelCleared": "快速模型已取消设置，将使用主力模型",
     "capabilityUpdated": "能力模型已更新"
   }
 }

--- a/src/web-ui/src/locales/zh-TW/settings/default-model.json
+++ b/src/web-ui/src/locales/zh-TW/settings/default-model.json
@@ -59,6 +59,8 @@
     "loadFailed": "載入設定失敗",
     "updateFailed": "更新失敗",
     "modelUpdated": "{{slot}}已設置為 {{name}}",
+    "modelCleared": "{{slot}}已取消設定",
+    "fastModelCleared": "快速模型已取消設定，將使用主力模型",
     "capabilityUpdated": "能力模型已更新"
   }
 }


### PR DESCRIPTION
Previously, clearing the fast model selected the first enabled text
model and left the settings success message without a value.

- Distinguish required and optional model slots with an explicit
  missing-value policy.
- Preserve an unset fast slot so runtime selection falls back to the
  configured primary model.
- Show localized clear confirmations instead of interpolating a null
  model name.
- Cover normalization, runtime resolution, and persisted config behavior.
