### PR TITLE
fix(web-ui): stop repeating a paired bot as its own connection service

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/NavPanel.scss
+++ b/src/web-ui/src/app/components/NavPanel/NavPanel.scss
@@ -2376,14 +2376,15 @@ $_section-header-height: 24px;
   > span {
     max-width: 128px;
     overflow: hidden;
-    color: var(--bf-appearance-token-color-accent-500);
+    color: var(--bf-appearance-token-color-text-muted);
     font-size: 10px;
     font-weight: 550;
     text-overflow: ellipsis;
     white-space: nowrap;
 
-    // Same live-state dot the footer trigger uses, so the summary and the
-    // expanded list read as one status language.
+    // Green dot plus muted label, the live-state pairing the workspace list
+    // already teaches in this panel. Colouring the text as well would make one
+    // fact speak in two different status hues.
     &:not(:empty)::before {
       content: '';
       display: inline-block;

--- a/src/web-ui/src/app/components/NavPanel/components/DeviceStatusControl.tsx
+++ b/src/web-ui/src/app/components/NavPanel/components/DeviceStatusControl.tsx
@@ -204,8 +204,6 @@ const DeviceStatusControl: React.FC<DeviceStatusControlProps> = ({
         return { label: t('deviceOverview.sameNetwork'), detail: null };
       case 'public-tunnel':
         return { label: t('deviceOverview.publicConnection'), detail: null };
-      case 'message-app':
-        return { label: t('deviceOverview.messageAppControl'), detail: service.host };
       default:
         return { label: t('deviceOverview.deviceService'), detail: service.host };
     }

--- a/src/web-ui/src/app/components/NavPanel/deviceInterconnectionOverview.test.ts
+++ b/src/web-ui/src/app/components/NavPanel/deviceInterconnectionOverview.test.ts
@@ -82,6 +82,38 @@ describe('projectDeviceInterconnectionOverview', () => {
     expect(overview.connectionService?.kind).toBe('official');
   });
 
+  it('names a paired bot once, as a controller rather than a second connection service', () => {
+    const overview = projectDeviceInterconnectionOverview(baseInput({
+      remoteStatus: { ...disconnectedStatus, bot_connected: 'Weixin(wxid_9f3a)' },
+    }));
+
+    expect(overview.mode).toBe('connected');
+    expect(overview.connectedDevices).toEqual([
+      expect.objectContaining({
+        name: 'Weixin',
+        kind: 'message-app',
+        activities: ['controlling'],
+      }),
+    ]);
+    expect(overview.connectionService).toBeNull();
+  });
+
+  it('reports the relay that carries dispatch work even while a bot is paired', () => {
+    const overview = projectDeviceInterconnectionOverview(baseInput({
+      accountService: connectionServiceFromRelayUrl('https://relay.example.com'),
+      remoteStatus: { ...disconnectedStatus, bot_connected: 'Telegram(7096812005)' },
+      dispatchJobs: [
+        {
+          id: 'job-device',
+          state: 'running',
+          target: { kind: 'device', id: 'linux-2', name: 'Build Server' },
+        },
+      ],
+    }));
+
+    expect(overview.connectionService?.kind).toBe('self-hosted');
+  });
+
   it('makes the peer the current device and the local desktop its controller', () => {
     const overview = projectDeviceInterconnectionOverview(baseInput({
       peer: { deviceId: 'linux-1', deviceName: 'Linux Workstation' },

--- a/src/web-ui/src/app/components/NavPanel/deviceInterconnectionOverview.ts
+++ b/src/web-ui/src/app/components/NavPanel/deviceInterconnectionOverview.ts
@@ -10,13 +10,18 @@ export type DeviceOverviewActivity =
   | 'current-use'
   | 'controlling'
   | 'background-execution';
+/**
+ * A connection service answers "which relay or network carries this link", a
+ * fact no device row can state. A message app is not one of those: it is the
+ * controller itself, already listed as a device, so reporting it here would only
+ * repeat that row's icon and name.
+ */
 export type DeviceOverviewConnectionServiceKind =
   | 'official'
   | 'self-hosted'
   | 'local-network'
   | 'public-tunnel'
-  | 'device-service'
-  | 'message-app';
+  | 'device-service';
 
 export interface DeviceOverviewDevice {
   id: string;
@@ -294,6 +299,9 @@ export function projectDeviceInterconnectionOverview(
     connectionService ??= connectionServiceFromActiveMethod(input.remoteStatus.active_method);
   }
 
+  // A paired bot contributes a controller and nothing else. It does not claim
+  // the connection service, so a link that also carries dispatch or peer traffic
+  // can still report the relay that actually carries it.
   if (input.remoteStatus?.bot_connected) {
     const applicationName = messageApplicationName(input.remoteStatus.bot_connected);
     addOrMergeDevice(devices, {
@@ -304,11 +312,6 @@ export function projectDeviceInterconnectionOverview(
       activities: ['controlling'],
       backgroundTaskCount: 0,
     });
-    connectionService ??= {
-      kind: 'message-app',
-      url: null,
-      host: applicationName ?? null,
-    };
   }
 
   let backgroundTaskCount = 0;

--- a/src/web-ui/src/locales/en-US/common.json
+++ b/src/web-ui/src/locales/en-US/common.json
@@ -725,8 +725,6 @@
     "deviceService": "Device connection service",
     "connectControlDevices": "Connects control devices",
     "connectedTo": "Connected to {{target}}",
-    "messageAppControl": "Messaging app",
-    "messageAppDetail": "Control through a messaging app",
     "mobileDevice": "Mobile device",
     "backupSyncing": "Encrypted backup · Syncing",
     "backupSynced": "Encrypted backup · Synced",

--- a/src/web-ui/src/locales/zh-CN/common.json
+++ b/src/web-ui/src/locales/zh-CN/common.json
@@ -725,8 +725,6 @@
     "deviceService": "设备连接服务",
     "connectControlDevices": "连接控制设备",
     "connectedTo": "连接 {{target}}",
-    "messageAppControl": "消息应用",
-    "messageAppDetail": "通过消息应用操作",
     "mobileDevice": "移动设备",
     "backupSyncing": "加密备份 · 同步中",
     "backupSynced": "加密备份 · 已同步",

--- a/src/web-ui/src/locales/zh-TW/common.json
+++ b/src/web-ui/src/locales/zh-TW/common.json
@@ -725,8 +725,6 @@
     "deviceService": "裝置連線服務",
     "connectControlDevices": "連線控制裝置",
     "connectedTo": "連線 {{target}}",
-    "messageAppControl": "訊息應用程式",
-    "messageAppDetail": "透過訊息應用程式操作",
     "mobileDevice": "行動裝置",
     "backupSyncing": "加密備份 · 同步中",
     "backupSynced": "加密備份 · 已同步",


### PR DESCRIPTION
## Summary

A paired message app reached the device overview through a single backend field (`bot_connected = "Weixin(wxid_...)"`) and left two rows behind, so the popover printed the same name twice:

1. a controller row — messaging icon, `Weixin`, `Controlling`
2. a connection service card — cloud icon, `Connection service`, `Messaging app`, `Weixin`

Every element of that card was already on screen: the label repeated the row's icon, the detail repeated the row's name, and the cloud icon was simply wrong, because a WeChat/Telegram/Feishu bot does not go through a BitFun relay at all.

A connection service answers *which relay or network carries this link* — official relay, self-hosted host, same network, public tunnel — a fact no device row can state. A message app is the controller itself, so it is now listed once as a device and no longer claims that slot. `'message-app'` is gone from `DeviceOverviewConnectionServiceKind`, and the retired `messageAppControl` / `messageAppDetail` strings are removed from all three locales.

This also fixes an ordering bug the duplication was hiding: because the bot claimed `connectionService` first via `??=`, a link that was *also* carrying dispatch work reported nothing about the relay actually carrying it. With the bot out of that slot, the account relay is reported again.

Last, the activity label loses its accent colour and keeps the green live dot. That green-dot-plus-muted-label pairing is what the workspace list in the same panel already teaches; colouring the text as well made one fact speak in two status hues.

## Test plan

- [x] `pnpm --dir src/web-ui run test:run src/app/components/NavPanel/deviceInterconnectionOverview.test.ts` — 22 passing, including two new cases: a bot-only connection lists the app once as a controller with `connectionService === null`, and a bot paired alongside dispatch work still reports the relay carrying that work
- [x] `pnpm run type-check:web`
- [x] `pnpm run i18n:audit` — 0 warnings after removing the two retired keys
- [x] `pnpm run theme:color-audit:all`
- [x] `node scripts/audit-appearance-contracts.mjs`
- [x] `eslint` on the changed sources
- [x] Real-browser check with the live projection driving the markup and real appearance tokens: the bot-only popover now contains `Weixin` exactly once and zero `.bitfun-device-overview__service` nodes, while a phone + bot + execution host still renders `Account service / Official service`. Measured the activity label at `rgb(133, 133, 133)` with a `#34d399` dot.

Remote scenarios: this is projection and presentation over the existing `remote_connect` status, so remote control (IM bot and mobile relay), Peer Device Mode, and Detached Dispatch inputs are covered by the model tests above. No wire, command, or persisted shape changed.