### PR TITLE
fix(toolcard): preserve AskUserQuestion draft state

### DIFF
--- a/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
@@ -11,6 +11,10 @@ import { startupTrace } from '@/shared/utils/startupTrace';
 import { projectEffectiveToolItem } from '../utils/toolInvocationIdentity';
 import { dispatchJobStore } from '@/features/dispatch/dispatchJobStore';
 import { resetLiveSessionInteractionStoreForTest } from '../services/liveSessionInteractionStore';
+import {
+  askUserQuestionDraftKey,
+  askUserQuestionDraftStore,
+} from './askUserQuestionDraftStore';
 
 const apiMocks = vi.hoisted(() => ({
   listSessions: vi.fn(),
@@ -164,6 +168,7 @@ const resetStore = () => {
     activeSessionId: null,
   }));
   dispatchJobStore.getState().clear();
+  askUserQuestionDraftStore.setState({ drafts: {} });
   resetLiveSessionInteractionStoreForTest();
   flowChatStore.registerPersistUnreadCompletionCallback(() => {});
 };
@@ -1967,6 +1972,56 @@ describe('FlowChatStore historical session hydration state', () => {
       flowChatStore.getState().sessions.get('history-1')
         ?.dialogTurns[0].modelRounds[0].items,
     ).toEqual([]);
+  });
+
+  it('clears an unsubmitted question draft when an authoritative mailbox removes the tool', () => {
+    flowChatStore.setState(() => ({
+      sessions: new Map([[
+        'history-1',
+        createSession({
+          sessionId: 'history-1',
+          dialogTurns: [{
+            id: 'turn-live',
+            sessionId: 'history-1',
+            userMessage: { id: 'user-live', content: 'ask me', timestamp: 1 },
+            modelRounds: [],
+            status: 'processing',
+            startTime: 1,
+          }],
+        }),
+      ]]),
+      activeSessionId: 'history-1',
+    }));
+
+    const pendingQuestion = {
+      toolId: 'ask-tool-1',
+      sessionId: 'history-1',
+      dialogTurnId: 'turn-live',
+      modelRoundId: 'round-question',
+      questions: {
+        questions: [{
+          question: 'Which verification should run?',
+          header: 'Verification',
+          options: [{ label: 'Focused', description: 'Run focused checks.' }],
+        }],
+      },
+      registeredAtMs: 3,
+    };
+
+    expect(flowChatStore.reconcilePendingUserQuestions('history-1', {
+      revision: 1,
+      questions: [pendingQuestion],
+    })).toBe(true);
+
+    const draftKey = askUserQuestionDraftKey('history-1', 'ask-tool-1');
+    askUserQuestionDraftStore.getState().setSingleAnswer(draftKey, 0, 'Focused');
+    expect(askUserQuestionDraftStore.getState().drafts[draftKey]).toBeDefined();
+
+    expect(flowChatStore.reconcilePendingUserQuestions('history-1', {
+      revision: 2,
+      questions: [],
+    })).toBe(true);
+    expect(askUserQuestionDraftStore.getState().drafts[draftKey]).toBeUndefined();
   });
 
   it('acquires an empty current-Turn base for Runtime event replay before applying interactions', async () => {

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.ts
@@ -96,6 +96,7 @@ import { sessionMatchesWorkspace } from '../utils/workspaceScope';
 import { resolveThreadGoalUserMessageDisplay } from '../utils/threadGoalDisplay';
 import { cleanRemoteUserInput } from '../utils/userInputText';
 import { useBackgroundSubagentActivityStore } from './backgroundSubagentActivityStore';
+import { askUserQuestionDraftStore } from './askUserQuestionDraftStore';
 import { sessionComposerStore } from './sessionComposerStore';
 import { completeSessionMutationReconciliation } from './sessionMutationStore';
 import { recordHistorySessionDiagnosticEvent } from '../services/historySessionDiagnostics';
@@ -5085,6 +5086,7 @@ export class FlowChatStore {
 
     const removedSessionIds = this.removeSession(sessionId, options);
     sessionComposerStore.getState().removeDrafts(removedSessionIds);
+    askUserQuestionDraftStore.getState().removeSessionDrafts(removedSessionIds);
     this.pendingRemoveSessionOptions.delete(sessionId);
   }
 
@@ -5316,6 +5318,7 @@ export class FlowChatStore {
       : [];
     this.surfaceContainers.delete(surfaceId);
     sessionComposerStore.getState().removeSurfaceDrafts(surfaceId);
+    askUserQuestionDraftStore.getState().removeSurfaceDrafts(surfaceId);
     this.forgetSurfaceMetadataRequests(surfaceId);
 
     for (const [requestKey, request] of this.fullHistoryHydrationRequests) {
@@ -7534,6 +7537,7 @@ export class FlowChatStore {
         ? restored.interactionSnapshot.userQuestions
         : undefined;
     let applied = false;
+    let pendingQuestionSnapshotApplied = false;
 
     this.setState(prev => {
       if (
@@ -7627,6 +7631,7 @@ export class FlowChatStore {
           turnsChanged = true;
         }
         if (questionReconciliation.revisionApplied && pendingUserQuestions) {
+          pendingQuestionSnapshotApplied = true;
           this.userQuestionSnapshotRevisions.set(
             sessionId,
             pendingUserQuestions.revision,
@@ -7695,6 +7700,14 @@ export class FlowChatStore {
         sessions: newSessions,
       };
     });
+
+    if (pendingQuestionSnapshotApplied && pendingUserQuestions) {
+      askUserQuestionDraftStore.getState().reconcilePendingTools(
+        scope.surfaceId,
+        sessionId,
+        pendingUserQuestions.questions.map(question => question.toolId),
+      );
+    }
 
     if (applied) {
       this.seedSessionHistoryLoadedRanges(sessionId, 'initial-tail');
@@ -7851,7 +7864,9 @@ export class FlowChatStore {
     sessionId: string,
     pendingUserQuestions: PendingUserQuestionSnapshot | undefined,
   ): boolean {
+    const surfaceId = getActiveSurfaceId();
     let applied = false;
+    let pendingQuestionSnapshotApplied = false;
     this.setState(prev => {
       const session = prev.sessions.get(sessionId);
       if (!session) {
@@ -7864,6 +7879,7 @@ export class FlowChatStore {
         previousRevision,
       );
       if (reconciliation.revisionApplied && pendingUserQuestions) {
+        pendingQuestionSnapshotApplied = true;
         this.userQuestionSnapshotRevisions.set(sessionId, pendingUserQuestions.revision);
       }
       if (!reconciliation.changed) {
@@ -7878,6 +7894,13 @@ export class FlowChatStore {
       applied = true;
       return { ...prev, sessions };
     });
+    if (pendingQuestionSnapshotApplied && pendingUserQuestions) {
+      askUserQuestionDraftStore.getState().reconcilePendingTools(
+        surfaceId,
+        sessionId,
+        pendingUserQuestions.questions.map(question => question.toolId),
+      );
+    }
     return applied;
   }
 

--- a/src/web-ui/src/flow_chat/store/askUserQuestionDraftStore.test.ts
+++ b/src/web-ui/src/flow_chat/store/askUserQuestionDraftStore.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  LOCAL_SURFACE_ID,
+  activateSurface,
+} from '@/infrastructure/peer-device/deviceSurface';
+import {
+  askUserQuestionDraftKey,
+  askUserQuestionDraftStore,
+} from './askUserQuestionDraftStore';
+
+describe('askUserQuestionDraftStore', () => {
+  beforeEach(() => {
+    activateSurface(LOCAL_SURFACE_ID);
+    askUserQuestionDraftStore.setState({ drafts: {} });
+  });
+
+  it('keeps answers and custom input isolated by session and tool call', () => {
+    const sessionATool1 = askUserQuestionDraftKey('session-a', 'tool-1');
+    const sessionATool2 = askUserQuestionDraftKey('session-a', 'tool-2');
+    const sessionBTool1 = askUserQuestionDraftKey('session-b', 'tool-1');
+    const store = askUserQuestionDraftStore.getState();
+
+    store.setSingleAnswer(sessionATool1, 0, 'PostgreSQL');
+    store.setMultiAnswer(sessionATool1, 1, 'TypeScript', true);
+    store.setMultiAnswer(sessionATool1, 1, 'Rust', true);
+    store.setOtherInput(sessionATool1, 2, 'Custom answer');
+    store.setSingleAnswer(sessionATool2, 0, 'SQLite');
+    store.setSingleAnswer(sessionBTool1, 0, 'MySQL');
+
+    expect(askUserQuestionDraftStore.getState().drafts[sessionATool1]).toMatchObject({
+      answers: {
+        0: 'PostgreSQL',
+        1: ['TypeScript', 'Rust'],
+      },
+      otherInputs: { 2: 'Custom answer' },
+    });
+    expect(askUserQuestionDraftStore.getState().drafts[sessionATool2].answers[0]).toBe('SQLite');
+    expect(askUserQuestionDraftStore.getState().drafts[sessionBTool1].answers[0]).toBe('MySQL');
+  });
+
+  it('keeps equal session and tool ids isolated across device surfaces', () => {
+    const localKey = askUserQuestionDraftKey('same-session', 'same-tool');
+    askUserQuestionDraftStore.getState().setSingleAnswer(localKey, 0, 'Local answer');
+
+    activateSurface('peer-b');
+    const peerKey = askUserQuestionDraftKey('same-session', 'same-tool');
+    askUserQuestionDraftStore.getState().setSingleAnswer(peerKey, 0, 'Peer answer');
+
+    expect(peerKey).not.toBe(localKey);
+    expect(askUserQuestionDraftStore.getState().drafts[localKey].answers[0]).toBe('Local answer');
+    expect(askUserQuestionDraftStore.getState().drafts[peerKey].answers[0]).toBe('Peer answer');
+  });
+
+  it('preserves pending drafts and removes tools absent from an authoritative mailbox', () => {
+    const retainedKey = askUserQuestionDraftKey('session-a', 'tool-retained');
+    const removedKey = askUserQuestionDraftKey('session-a', 'tool-removed');
+    const otherSessionKey = askUserQuestionDraftKey('session-b', 'tool-removed');
+    const store = askUserQuestionDraftStore.getState();
+    store.setSingleAnswer(retainedKey, 0, 'Keep');
+    store.setSingleAnswer(removedKey, 0, 'Remove');
+    store.setSingleAnswer(otherSessionKey, 0, 'Other session');
+
+    store.reconcilePendingTools(LOCAL_SURFACE_ID, 'session-a', ['tool-retained']);
+
+    expect(askUserQuestionDraftStore.getState().drafts[retainedKey]).toBeDefined();
+    expect(askUserQuestionDraftStore.getState().drafts[removedKey]).toBeUndefined();
+    expect(askUserQuestionDraftStore.getState().drafts[otherSessionKey]).toBeDefined();
+  });
+
+  it('keeps submission phase across remounts without recreating a cleared draft', () => {
+    const key = askUserQuestionDraftKey('session-a', 'tool-1');
+    const store = askUserQuestionDraftStore.getState();
+    store.setSingleAnswer(key, 0, 'PostgreSQL');
+    store.setSubmissionPhase(key, 'submitting');
+    expect(askUserQuestionDraftStore.getState().drafts[key].submissionPhase).toBe('submitting');
+
+    store.clearDraft(key);
+    store.setSubmissionPhase(key, 'submitted');
+    expect(askUserQuestionDraftStore.getState().drafts[key]).toBeUndefined();
+  });
+
+  it('removes the Other marker when custom input becomes blank', () => {
+    const multiKey = askUserQuestionDraftKey('session-a', 'tool-multi');
+    const singleKey = askUserQuestionDraftKey('session-a', 'tool-single');
+    const store = askUserQuestionDraftStore.getState();
+
+    store.setMultiAnswer(multiKey, 0, 'PostgreSQL', true);
+    store.setMultiAnswer(multiKey, 0, 'Other', true);
+    store.setOtherInput(multiKey, 0, 'Custom database');
+    store.setOtherInput(multiKey, 0, '   ');
+
+    store.setSingleAnswer(singleKey, 0, 'Other');
+    store.setOtherInput(singleKey, 0, 'Custom database');
+    store.setOtherInput(singleKey, 0, '');
+
+    expect(askUserQuestionDraftStore.getState().drafts[multiKey]).toMatchObject({
+      answers: { 0: ['PostgreSQL'] },
+      otherInputs: { 0: '' },
+    });
+    expect(askUserQuestionDraftStore.getState().drafts[singleKey]).toMatchObject({
+      answers: {},
+      otherInputs: { 0: '' },
+    });
+  });
+
+  it('cleans up deleted sessions and discarded surfaces without disturbing others', () => {
+    const removedSessionKey = askUserQuestionDraftKey('session-a', 'tool-a');
+    const retainedSessionKey = askUserQuestionDraftKey('session-b', 'tool-b');
+    let store = askUserQuestionDraftStore.getState();
+    store.setSingleAnswer(removedSessionKey, 0, 'Remove session');
+    store.setSingleAnswer(retainedSessionKey, 0, 'Keep session');
+
+    activateSurface('peer-b');
+    const peerKey = askUserQuestionDraftKey('session-a', 'tool-a');
+    askUserQuestionDraftStore.getState().setSingleAnswer(peerKey, 0, 'Remove peer');
+
+    activateSurface(LOCAL_SURFACE_ID);
+    store = askUserQuestionDraftStore.getState();
+    store.removeSessionDrafts(['session-a']);
+    expect(askUserQuestionDraftStore.getState().drafts[removedSessionKey]).toBeUndefined();
+    expect(askUserQuestionDraftStore.getState().drafts[retainedSessionKey]).toBeDefined();
+    expect(askUserQuestionDraftStore.getState().drafts[peerKey]).toBeDefined();
+
+    store.removeSurfaceDrafts('peer-b');
+    expect(askUserQuestionDraftStore.getState().drafts[peerKey]).toBeUndefined();
+    expect(askUserQuestionDraftStore.getState().drafts[retainedSessionKey]).toBeDefined();
+  });
+});

--- a/src/web-ui/src/flow_chat/store/askUserQuestionDraftStore.ts
+++ b/src/web-ui/src/flow_chat/store/askUserQuestionDraftStore.ts
@@ -1,0 +1,228 @@
+import { create } from 'zustand';
+
+import {
+  getActiveSurfaceId,
+  surfaceScopedKey,
+  type DeviceSurfaceId,
+} from '@/infrastructure/peer-device/deviceSurface';
+
+export type AskUserQuestionAnswer = string | string[];
+export type AskUserQuestionSubmissionPhase = 'idle' | 'submitting' | 'submitted';
+
+export interface AskUserQuestionDraft {
+  answers: Record<number, AskUserQuestionAnswer>;
+  otherInputs: Record<number, string>;
+  submissionPhase: AskUserQuestionSubmissionPhase;
+  updatedAt: number;
+}
+
+interface AskUserQuestionDraftState {
+  drafts: Record<string, AskUserQuestionDraft>;
+  setSingleAnswer: (key: string, questionIndex: number, value: string) => void;
+  setMultiAnswer: (
+    key: string,
+    questionIndex: number,
+    value: string,
+    checked: boolean,
+  ) => void;
+  setOtherInput: (key: string, questionIndex: number, value: string) => void;
+  setSubmissionPhase: (key: string, phase: AskUserQuestionSubmissionPhase) => void;
+  clearDraft: (key: string) => void;
+  removeSessionDrafts: (sessionIds: Iterable<string>) => void;
+  removeSurfaceDrafts: (surfaceId: DeviceSurfaceId) => void;
+  reconcilePendingTools: (
+    surfaceId: DeviceSurfaceId,
+    sessionId: string,
+    pendingToolIds: Iterable<string>,
+  ) => void;
+}
+
+export function createEmptyAskUserQuestionDraft(): AskUserQuestionDraft {
+  return {
+    answers: {},
+    otherInputs: {},
+    submissionPhase: 'idle',
+    updatedAt: 0,
+  };
+}
+
+export function askUserQuestionDraftKey(
+  sessionId: string,
+  toolId: string,
+  surfaceId = getActiveSurfaceId(),
+): string {
+  return surfaceScopedKey(surfaceId, sessionId, toolId);
+}
+
+function parseDraftKey(key: string): [DeviceSurfaceId, string, string] | null {
+  try {
+    const parsed = JSON.parse(key) as unknown;
+    if (
+      !Array.isArray(parsed)
+      || parsed.length !== 3
+      || typeof parsed[0] !== 'string'
+      || typeof parsed[1] !== 'string'
+      || typeof parsed[2] !== 'string'
+    ) {
+      return null;
+    }
+    return [parsed[0], parsed[1], parsed[2]];
+  } catch {
+    return null;
+  }
+}
+
+function updateDraft(
+  state: AskUserQuestionDraftState,
+  key: string,
+  update: (draft: AskUserQuestionDraft) => AskUserQuestionDraft,
+): Pick<AskUserQuestionDraftState, 'drafts'> {
+  const current = state.drafts[key] ?? createEmptyAskUserQuestionDraft();
+  return {
+    drafts: {
+      ...state.drafts,
+      [key]: {
+        ...update(current),
+        updatedAt: Date.now(),
+      },
+    },
+  };
+}
+
+function removeOtherAnswer(
+  answers: Record<number, AskUserQuestionAnswer>,
+  questionIndex: number,
+): Record<number, AskUserQuestionAnswer> {
+  const current = answers[questionIndex];
+  if (Array.isArray(current)) {
+    if (!current.includes('Other')) {
+      return answers;
+    }
+    return {
+      ...answers,
+      [questionIndex]: current.filter(value => value !== 'Other'),
+    };
+  }
+  if (current !== 'Other') {
+    return answers;
+  }
+  const nextAnswers = { ...answers };
+  delete nextAnswers[questionIndex];
+  return nextAnswers;
+}
+
+function removeMatchingDrafts(
+  state: AskUserQuestionDraftState,
+  shouldRemove: (key: string) => boolean,
+): Pick<AskUserQuestionDraftState, 'drafts'> | AskUserQuestionDraftState {
+  const drafts = { ...state.drafts };
+  let changed = false;
+  for (const key of Object.keys(drafts)) {
+    if (shouldRemove(key)) {
+      delete drafts[key];
+      changed = true;
+    }
+  }
+  return changed ? { drafts } : state;
+}
+
+export const useAskUserQuestionDraftStore = create<AskUserQuestionDraftState>((set) => ({
+  drafts: {},
+
+  setSingleAnswer: (key, questionIndex, value) => {
+    set(state => updateDraft(state, key, draft => ({
+      ...draft,
+      answers: {
+        ...draft.answers,
+        [questionIndex]: value,
+      },
+    })));
+  },
+
+  setMultiAnswer: (key, questionIndex, value, checked) => {
+    set(state => updateDraft(state, key, draft => {
+      const current = draft.answers[questionIndex];
+      const currentValues = Array.isArray(current) ? current : [];
+      const nextValues = checked
+        ? (currentValues.includes(value) ? currentValues : [...currentValues, value])
+        : currentValues.filter(candidate => candidate !== value);
+      return {
+        ...draft,
+        answers: {
+          ...draft.answers,
+          [questionIndex]: nextValues,
+        },
+      };
+    }));
+  },
+
+  setOtherInput: (key, questionIndex, value) => {
+    set(state => updateDraft(state, key, draft => {
+      const isEmpty = value.trim().length === 0;
+      return {
+        ...draft,
+        answers: isEmpty
+          ? removeOtherAnswer(draft.answers, questionIndex)
+          : draft.answers,
+        otherInputs: {
+          ...draft.otherInputs,
+          [questionIndex]: isEmpty ? '' : value,
+        },
+      };
+    }));
+  },
+
+  setSubmissionPhase: (key, submissionPhase) => {
+    set(state => {
+      if (!(key in state.drafts)) {
+        return state;
+      }
+      return updateDraft(state, key, draft => ({
+        ...draft,
+        submissionPhase,
+      }));
+    });
+  },
+
+  clearDraft: (key) => {
+    set(state => {
+      if (!(key in state.drafts)) {
+        return state;
+      }
+      const drafts = { ...state.drafts };
+      delete drafts[key];
+      return { drafts };
+    });
+  },
+
+  removeSessionDrafts: (sessionIds) => {
+    const activeSurfaceId = getActiveSurfaceId();
+    const removedSessionIds = new Set(sessionIds);
+    if (removedSessionIds.size === 0) {
+      return;
+    }
+    set(state => removeMatchingDrafts(state, key => {
+      const parsed = parseDraftKey(key);
+      return parsed !== null
+        && parsed[0] === activeSurfaceId
+        && removedSessionIds.has(parsed[1]);
+    }));
+  },
+
+  removeSurfaceDrafts: (surfaceId) => {
+    set(state => removeMatchingDrafts(state, key => parseDraftKey(key)?.[0] === surfaceId));
+  },
+
+  reconcilePendingTools: (surfaceId, sessionId, pendingToolIds) => {
+    const retainedToolIds = new Set(pendingToolIds);
+    set(state => removeMatchingDrafts(state, key => {
+      const parsed = parseDraftKey(key);
+      return parsed !== null
+        && parsed[0] === surfaceId
+        && parsed[1] === sessionId
+        && !retainedToolIds.has(parsed[2]);
+    }));
+  },
+}));
+
+export const askUserQuestionDraftStore = useAskUserQuestionDraftStore;

--- a/src/web-ui/src/flow_chat/tool-cards/AskUserQuestionCard.test.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/AskUserQuestionCard.test.tsx
@@ -5,6 +5,11 @@ import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { FlowToolItem, ToolCardConfig } from '../types/flow-chat';
+import {
+  LOCAL_SURFACE_ID,
+  activateSurface,
+} from '@/infrastructure/peer-device/deviceSurface';
+import { askUserQuestionDraftStore } from '../store/askUserQuestionDraftStore';
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -31,6 +36,7 @@ vi.mock('@/infrastructure/api/service-api/ToolAPI', () => ({
   },
 }));
 
+import { toolAPI } from '@/infrastructure/api/service-api/ToolAPI';
 import { AskUserQuestionCard } from './AskUserQuestionCard';
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
@@ -43,7 +49,10 @@ const config: ToolCardConfig = {
   resultDisplayType: 'detailed',
 };
 
-function questionTool(status: FlowToolItem['status']): FlowToolItem {
+function questionTool(
+  status: FlowToolItem['status'],
+  multiSelect = false,
+): FlowToolItem {
   return {
     id: 'question-tool-1',
     type: 'tool',
@@ -56,7 +65,7 @@ function questionTool(status: FlowToolItem['status']): FlowToolItem {
         questions: [{
           header: 'Database',
           question: 'Which database?',
-          multiSelect: false,
+          multiSelect,
           options: [{
             label: 'PostgreSQL',
             description: 'Use PostgreSQL',
@@ -79,11 +88,24 @@ function questionTool(status: FlowToolItem['status']): FlowToolItem {
   };
 }
 
+function setInputValue(input: HTMLInputElement, value: string): void {
+  const valueSetter = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    'value',
+  )?.set;
+  valueSetter?.call(input, value);
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
 describe('AskUserQuestionCard', () => {
   let container: HTMLDivElement;
   let root: Root;
 
   beforeEach(() => {
+    activateSurface(LOCAL_SURFACE_ID);
+    askUserQuestionDraftStore.setState({ drafts: {} });
+    vi.mocked(toolAPI.submitUserAnswers).mockReset();
+    vi.mocked(toolAPI.submitUserAnswers).mockResolvedValue(undefined);
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
@@ -129,5 +151,127 @@ describe('AskUserQuestionCard', () => {
       );
     });
     expect(container.querySelector('.completed-summary')).not.toBeNull();
+  });
+
+  it('restores an unsubmitted answer after the session card is remounted', () => {
+    act(() => {
+      root.render(
+        <AskUserQuestionCard
+          toolItem={questionTool('pending_confirmation')}
+          config={config}
+          sessionId="session-a"
+          isLastItem
+        />,
+      );
+    });
+
+    const radio = container.querySelector<HTMLInputElement>('input[value="PostgreSQL"]');
+    expect(radio).not.toBeNull();
+    act(() => radio?.click());
+    expect(radio?.checked).toBe(true);
+
+    act(() => root.render(null));
+    act(() => {
+      root.render(
+        <AskUserQuestionCard
+          toolItem={questionTool('pending_confirmation')}
+          config={config}
+          sessionId="session-b"
+          isLastItem
+        />,
+      );
+    });
+    expect(
+      container.querySelector<HTMLInputElement>('input[value="PostgreSQL"]')?.checked,
+    ).toBe(false);
+
+    act(() => root.render(null));
+    act(() => {
+      root.render(
+        <AskUserQuestionCard
+          toolItem={questionTool('pending_confirmation')}
+          config={config}
+          sessionId="session-a"
+          isLastItem
+        />,
+      );
+    });
+    expect(
+      container.querySelector<HTMLInputElement>('input[value="PostgreSQL"]')?.checked,
+    ).toBe(true);
+  });
+
+  it('restores an unsubmitted custom input after the card is remounted', () => {
+    const renderCard = () => {
+      root.render(
+        <AskUserQuestionCard
+          toolItem={questionTool('pending_confirmation')}
+          config={config}
+          sessionId="session-a"
+          isLastItem
+        />,
+      );
+    };
+
+    act(renderCard);
+    const otherRadio = container.querySelector<HTMLInputElement>('input[value="Other"]');
+    expect(otherRadio).not.toBeNull();
+    act(() => otherRadio?.click());
+
+    const customInput = container.querySelector<HTMLInputElement>('.other-input-inline');
+    expect(customInput).not.toBeNull();
+    act(() => {
+      if (customInput) {
+        setInputValue(customInput, 'CockroachDB');
+      }
+    });
+    expect(customInput?.value).toBe('CockroachDB');
+
+    act(() => root.render(null));
+    act(renderCard);
+
+    expect(container.querySelector<HTMLInputElement>('input[value="Other"]')?.checked).toBe(true);
+    expect(container.querySelector<HTMLInputElement>('.other-input-inline')?.value).toBe('CockroachDB');
+  });
+
+  it('deselects a blank multi-select Other answer and omits it from submission', async () => {
+    act(() => {
+      root.render(
+        <AskUserQuestionCard
+          toolItem={questionTool('pending_confirmation', true)}
+          config={config}
+          sessionId="session-a"
+          isLastItem
+        />,
+      );
+    });
+
+    const databaseCheckbox = container.querySelector<HTMLInputElement>('input[value="PostgreSQL"]');
+    const otherCheckbox = container.querySelector<HTMLInputElement>('input[value="Other"]');
+    act(() => {
+      databaseCheckbox?.click();
+      otherCheckbox?.click();
+    });
+
+    const customInput = container.querySelector<HTMLInputElement>('.other-input-inline');
+    expect(customInput).not.toBeNull();
+    act(() => {
+      if (customInput) {
+        setInputValue(customInput, 'Custom database');
+        setInputValue(customInput, '');
+      }
+    });
+
+    expect(container.querySelector<HTMLInputElement>('input[value="Other"]')?.checked).toBe(false);
+    expect(container.querySelector<HTMLInputElement>('input[value="PostgreSQL"]')?.checked).toBe(true);
+
+    const submitButton = container.querySelector<HTMLButtonElement>('.submit-button');
+    expect(submitButton?.disabled).toBe(false);
+    await act(async () => submitButton?.click());
+
+    expect(toolAPI.submitUserAnswers).toHaveBeenCalledWith(
+      'question-tool-1',
+      { 0: ['PostgreSQL'] },
+    );
   });
 });

--- a/src/web-ui/src/flow_chat/tool-cards/AskUserQuestionCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/AskUserQuestionCard.tsx
@@ -3,7 +3,7 @@
  * Displays multiple questions, collects user answers and submits them
  */
 
-import React, { useState, useCallback, useMemo, useLayoutEffect, useRef } from 'react';
+import React, { useState, useCallback, useEffect, useMemo, useLayoutEffect, useRef } from 'react';
 import { Loader2, AlertCircle, ArrowUp, ChevronDown, ChevronRight } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { FlowToolItem, ToolCardProps } from '../types/flow-chat';
@@ -12,6 +12,14 @@ import { createLogger } from '@/shared/utils/logger';
 import { Button, Tooltip } from '@/component-library';
 import { useToolCardHeightContract } from './useToolCardHeightContract';
 import { SmoothHeightCollapse } from '../components/modern/SmoothHeightCollapse';
+import {
+  askUserQuestionDraftKey,
+  askUserQuestionDraftStore,
+  createEmptyAskUserQuestionDraft,
+  useAskUserQuestionDraftStore,
+  type AskUserQuestionSubmissionPhase,
+} from '../store/askUserQuestionDraftStore';
+import { getActiveSurfaceId } from '@/infrastructure/peer-device/deviceSurface';
 import './AskUserQuestionCard.scss';
 
 const log = createLogger('AskUserQuestionCard');
@@ -88,6 +96,7 @@ function isAwaitingQuestionPayload(
 export const AskUserQuestionCard: React.FC<ToolCardProps> = ({
   toolItem,
   isLastItem,
+  sessionId,
 }) => {
   const { t } = useTranslation('flow-chat');
   const { status, toolCall, toolResult, isParamsStreaming, partialParams } = toolItem;
@@ -104,13 +113,25 @@ export const AskUserQuestionCard: React.FC<ToolCardProps> = ({
     status
   );
   
-  const [answers, setAnswers] = useState<Record<number, string | string[]>>({});
-  const [otherInputs, setOtherInputs] = useState<Record<number, string>>({});
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [isSubmitted, setIsSubmitted] = useState(false);
+  const toolId = toolItem.id ?? toolCall?.id;
+  const draftToolId = toolCall?.id || toolId;
+  const activeSurfaceId = getActiveSurfaceId();
+  const draftKey = useMemo(
+    () => sessionId && draftToolId
+      ? askUserQuestionDraftKey(sessionId, draftToolId, activeSurfaceId)
+      : null,
+    [activeSurfaceId, draftToolId, sessionId],
+  );
+  const storedDraft = useAskUserQuestionDraftStore(state => (
+    draftKey ? state.drafts[draftKey] : undefined
+  ));
+  const [localDraft, setLocalDraft] = useState(createEmptyAskUserQuestionDraft);
+  const draft = storedDraft ?? localDraft;
+  const { answers, otherInputs, submissionPhase } = draft;
+  const isSubmitting = submissionPhase === 'submitting';
+  const isSubmitted = submissionPhase === 'submitted';
   const [isExpanded, setIsExpanded] = useState(false);
   const [showCompletedSummary, setShowCompletedSummary] = useState(status === 'completed');
-  const toolId = toolItem.id ?? toolCall?.id;
   const { cardRootRef, applyExpandedState } = useToolCardHeightContract({
     toolId,
     toolName: toolItem.toolName,
@@ -134,63 +155,144 @@ export const AskUserQuestionCard: React.FC<ToolCardProps> = ({
     }
   }, [applyExpandedState, isLastItem, showCompletedSummary, status]);
 
+  useEffect(() => {
+    if (
+      draftKey
+      && (
+        status === 'completed'
+        || status === 'cancelled'
+        || status === 'rejected'
+        || status === 'error'
+      )
+    ) {
+      askUserQuestionDraftStore.getState().clearDraft(draftKey);
+    }
+  }, [draftKey, status]);
+
+  const setSubmissionPhase = useCallback((phase: AskUserQuestionSubmissionPhase) => {
+    if (draftKey) {
+      askUserQuestionDraftStore.getState().setSubmissionPhase(draftKey, phase);
+      return;
+    }
+    setLocalDraft(current => ({
+      ...current,
+      submissionPhase: phase,
+      updatedAt: Date.now(),
+    }));
+  }, [draftKey]);
+
   const isAllAnswered = useCallback(() => {
     if (questions.length === 0) return false;
     
     for (let i = 0; i < questions.length; i++) {
       const answer = answers[i];
       if (!answer) return false;
-      if (Array.isArray(answer) && answer.length === 0) return false;
+      const otherInput = otherInputs[i]?.trim() || '';
+      if (
+        Array.isArray(answer)
+        && !answer.some(value => value !== 'Other' || otherInput.length > 0)
+      ) return false;
       if (typeof answer === 'string' && answer === '') return false;
+      if (answer === 'Other' && otherInput.length === 0) return false;
     }
     return true;
-  }, [answers, questions.length]);
+  }, [answers, otherInputs, questions.length]);
 
   const handleSingleChange = useCallback((questionIndex: number, value: string) => {
-    setAnswers(prev => ({
-      ...prev,
-      [questionIndex]: value
+    if (draftKey) {
+      askUserQuestionDraftStore.getState().setSingleAnswer(draftKey, questionIndex, value);
+      return;
+    }
+    setLocalDraft(current => ({
+      ...current,
+      answers: {
+        ...current.answers,
+        [questionIndex]: value,
+      },
+      updatedAt: Date.now(),
     }));
-  }, []);
+  }, [draftKey]);
 
   const handleMultiChange = useCallback((questionIndex: number, value: string, checked: boolean) => {
-    setAnswers(prev => {
-      const current = prev[questionIndex];
-      const currentArray = Array.isArray(current) ? current : [];
-      
-      if (checked) {
-        return { ...prev, [questionIndex]: [...currentArray, value] };
-      } else {
-        return { ...prev, [questionIndex]: currentArray.filter(v => v !== value) };
-      }
+    if (draftKey) {
+      askUserQuestionDraftStore.getState().setMultiAnswer(
+        draftKey,
+        questionIndex,
+        value,
+        checked,
+      );
+      return;
+    }
+    setLocalDraft(current => {
+      const currentAnswer = current.answers[questionIndex];
+      const currentValues = Array.isArray(currentAnswer) ? currentAnswer : [];
+      const nextValues = checked
+        ? (currentValues.includes(value) ? currentValues : [...currentValues, value])
+        : currentValues.filter(candidate => candidate !== value);
+      return {
+        ...current,
+        answers: {
+          ...current.answers,
+          [questionIndex]: nextValues,
+        },
+        updatedAt: Date.now(),
+      };
     });
-  }, []);
+  }, [draftKey]);
 
   const handleOtherInputChange = useCallback((questionIndex: number, value: string) => {
-    setOtherInputs(prev => ({
-      ...prev,
-      [questionIndex]: value
-    }));
-  }, []);
+    if (draftKey) {
+      askUserQuestionDraftStore.getState().setOtherInput(draftKey, questionIndex, value);
+      return;
+    }
+    setLocalDraft(current => {
+      const isEmpty = value.trim().length === 0;
+      const currentAnswer = current.answers[questionIndex];
+      let nextAnswers = current.answers;
+      if (isEmpty && Array.isArray(currentAnswer) && currentAnswer.includes('Other')) {
+        nextAnswers = {
+          ...current.answers,
+          [questionIndex]: currentAnswer.filter(answer => answer !== 'Other'),
+        };
+      } else if (isEmpty && currentAnswer === 'Other') {
+        nextAnswers = { ...current.answers };
+        delete nextAnswers[questionIndex];
+      }
+      return {
+        ...current,
+        answers: nextAnswers,
+        otherInputs: {
+          ...current.otherInputs,
+          [questionIndex]: isEmpty ? '' : value,
+        },
+        updatedAt: Date.now(),
+      };
+    });
+  }, [draftKey]);
 
   const handleSubmit = useCallback(async () => {
     if (!isAllAnswered() || isSubmitting || isSubmitted) return;
 
-    const toolId = toolItem.id;
-    setIsSubmitting(true);
+    setSubmissionPhase('submitting');
     try {
       const processedAnswers: Record<string, string | string[]> = {};
       
       for (let i = 0; i < questions.length; i++) {
         const answer = answers[i];
-        const otherInput = otherInputs[i] || '';
+        const otherInput = otherInputs[i]?.trim() || '';
         
         if (Array.isArray(answer)) {
-          processedAnswers[String(i)] = answer.map(v => 
-            v === 'Other' ? (otherInput || 'Other') : v
-          );
+          processedAnswers[String(i)] = answer.flatMap(value => (
+            value === 'Other'
+              ? (otherInput ? [otherInput] : [])
+              : [value]
+          ));
+        } else if (answer === 'Other') {
+          if (otherInput) {
+            processedAnswers[String(i)] = otherInput;
+          }
         } else {
-          processedAnswers[String(i)] = answer === 'Other' ? (otherInput || 'Other') : answer;
+          processedAnswers[String(i)] = answer;
         }
       }
 
@@ -198,13 +300,12 @@ export const AskUserQuestionCard: React.FC<ToolCardProps> = ({
       
       await toolAPI.submitUserAnswers(toolId, answersPayload);
       
-      setIsSubmitted(true);
+      setSubmissionPhase('submitted');
     } catch (error) {
       log.error('Failed to submit answers', { toolId, error });
-    } finally {
-      setIsSubmitting(false);
+      setSubmissionPhase('idle');
     }
-  }, [toolItem.id, answers, otherInputs, questions.length, isAllAnswered, isSubmitting, isSubmitted]);
+  }, [answers, isAllAnswered, isSubmitted, isSubmitting, otherInputs, questions.length, setSubmissionPhase, toolId]);
 
   const getStatusIcon = () => {
     if (status === 'completed') {
@@ -377,7 +478,7 @@ export const AskUserQuestionCard: React.FC<ToolCardProps> = ({
     
     if (!answer) return '';
     if (Array.isArray(answer)) {
-      return answer.map(v => v === 'Other' ? otherInput || 'Other' : v).join(', ');
+      return answer.map(value => value === 'Other' ? otherInput || 'Other' : value).join(', ');
     }
     return answer === 'Other' ? otherInput || 'Other' : String(answer);
   };
@@ -457,7 +558,7 @@ export const AskUserQuestionCard: React.FC<ToolCardProps> = ({
                 size="small"
                 className="submit-button"
                 onClick={handleSubmit}
-                disabled={!isAllAnswered() || isSubmitting || Boolean(isParamsStreaming)}
+                disabled={!isAllAnswered() || isSubmitting || isSubmitted || Boolean(isParamsStreaming)}
                 isLoading={isSubmitting}
                 title={!isAllAnswered() ? t('toolCards.askUser.answerAllBeforeSubmit') : ""}
               >


### PR DESCRIPTION
- Keep unsubmitted answers, custom input, and submission state scoped by
  device surface, session, and tool call across chat switches.
- Clear drafts when pending mailboxes, sessions, or device surfaces are
  removed to prevent stale interaction state.
- Deselect blank Other answers and filter empty custom values before
  submission so models receive only meaningful selections.
- Add regression coverage for remount restoration, cleanup, isolation,
  and multi-select payloads.
