### PR TITLE
feat(session): add rename action to session control tool

### DIFF
--- a/src/crates/assembly/core/src/agentic/tools/implementations/session_control_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/session_control_tool.rs
@@ -18,15 +18,16 @@ use bitfun_agent_runtime::session_control::{
     session_control_agent_type_or_default, session_control_cancel_result_message,
     session_control_cancel_status, session_control_created_result_message,
     session_control_creator_marker, session_control_deleted_result_message,
-    session_control_session_name_or_default, validate_session_control_input, validate_session_id,
-    SessionControlAction, SessionControlCancelRoute, SessionControlInput,
-    SessionControlValidationContext, SessionControlValidationResult,
+    session_control_renamed_result_message, session_control_session_name_or_default,
+    validate_session_control_input, validate_session_id, SessionControlAction,
+    SessionControlCancelRoute, SessionControlInput, SessionControlValidationContext,
+    SessionControlValidationResult,
 };
 use bitfun_core_types::SessionExecutionTarget;
 use bitfun_runtime_ports::{
     AgentSessionCreateRequest, AgentSessionDeleteRequest, AgentSessionListRequest,
-    AgentSessionSummary, AgentSessionWorkspaceBinding, AgentSessionWorkspaceRequest,
-    AgentSubmissionSource, AgentTurnCancellationRequest,
+    AgentSessionRenameRequest, AgentSessionSummary, AgentSessionWorkspaceBinding,
+    AgentSessionWorkspaceRequest, AgentSubmissionSource, AgentTurnCancellationRequest,
 };
 use serde_json::{json, Value};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -101,7 +102,9 @@ impl SessionControlTool {
         runtime: &AgentRuntime,
     ) -> BitFunResult<SessionControlWorkspaceTarget> {
         match action {
-            SessionControlAction::Cancel | SessionControlAction::Delete => {
+            SessionControlAction::Cancel
+            | SessionControlAction::Delete
+            | SessionControlAction::Rename => {
                 let session_id = session_id.ok_or_else(|| {
                     BitFunError::tool(format!("session_id is required for {}", action.as_str()))
                 })?;
@@ -271,23 +274,24 @@ Actions:
 - "create": Create a new session. You may optionally provide session_name and agent_type.
 - "cancel": Cancel the target session's currently running dialog turn. This does not delete the session or clear any queued messages that may still run later.
 - "delete": Delete an existing session by session_id.
+- "rename": Rename an existing session by session_id using session_name as the new title.
 - "list": List all sessions.
 
 Arguments:
 - "workspace": Absolute workspace path. Required for create and list. Ignored for cancel and delete.
-- "session_name": Only used by create. Defaults to "New Session".
+- "session_name": Used by create (defaults to "New Session") and required as the new title for rename.
 - "agent_type": Only used by create. Defaults to "agentic".
   - "agentic": Coding-focused agent for implementation, debugging, and code changes.
   - "Plan": Planning agent for clarifying requirements and producing an implementation plan before coding.
   - "Cowork": Collaborative agent for office-style work such as research, documentation, presentations, etc.
   - "DeepResearch": Research agent for systematic investigation and evidence-driven reports.
-- "session_id": Required for cancel and delete."#
+- "session_id": Required for cancel, delete, and rename."#
                 .to_string(),
         )
     }
 
     fn short_description(&self) -> String {
-        "Create, list, cancel, and delete persisted agent sessions.".to_string()
+        "Create, list, rename, cancel, and delete persisted agent sessions.".to_string()
     }
 
     fn default_exposure(&self) -> ToolExposure {
@@ -300,7 +304,7 @@ Arguments:
             "properties": {
                 "action": {
                     "type": "string",
-                    "enum": ["create", "cancel", "delete", "list"],
+                    "enum": ["create", "cancel", "delete", "rename", "list"],
                     "description": "The session action to perform."
                 },
                 "workspace": {
@@ -309,11 +313,11 @@ Arguments:
                 },
                 "session_id": {
                     "type": "string",
-                    "description": "Required for cancel and delete."
+                    "description": "Required for cancel, delete, and rename."
                 },
                 "session_name": {
                     "type": "string",
-                    "description": "Optional display name when creating a session."
+                    "description": "Optional display name when creating a session; required as the new title when renaming."
                 },
                 "agent_type": {
                     "type": "string",
@@ -571,6 +575,73 @@ Arguments:
                     image_attachments: None,
                 }])
             }
+            SessionControlAction::Rename => {
+                let session_id = params.session_id.as_deref().ok_or_else(|| {
+                    BitFunError::tool("session_id is required for rename".to_string())
+                })?;
+                validate_session_id(session_id).map_err(BitFunError::tool)?;
+                let session_name = params
+                    .session_name
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .ok_or_else(|| {
+                        BitFunError::tool(
+                            "session_name is required and must not be empty for rename".to_string(),
+                        )
+                    })?;
+                let workspace = self
+                    .resolve_effective_workspace(
+                        SessionControlAction::Rename,
+                        Some(session_id),
+                        context,
+                        &runtime,
+                    )
+                    .await?;
+                if self.current_workspace_session(context, &workspace.display_workspace)
+                    == Some(session_id)
+                {
+                    return Err(BitFunError::tool(
+                        "cannot rename the current session from SessionControl".to_string(),
+                    ));
+                }
+
+                // Reuse the same rename channel as the frontend
+                // renameChatSessionTitle (AgentSessionManagementPort::rename_session)
+                // so the persisted title stays consistent with the desktop/frontend.
+                runtime
+                    .rename_session(AgentSessionRenameRequest {
+                        workspace_path: workspace.display_workspace.clone(),
+                        session_id: session_id.to_string(),
+                        session_name: session_name.to_string(),
+                        remote_connection_id: workspace.remote_connection_id.clone(),
+                        remote_ssh_host: workspace.remote_ssh_host.clone(),
+                    })
+                    .await
+                    .map_err(|error| {
+                        BitFunError::tool(format!(
+                            "cannot rename session '{session_id}': {}",
+                            CoreServiceAgentRuntime::runtime_error_message(error)
+                        ))
+                    })?;
+
+                let result_for_assistant = session_control_renamed_result_message(
+                    session_id,
+                    &workspace.display_workspace,
+                    session_name,
+                );
+                Ok(vec![ToolResult::Result {
+                    data: json!({
+                        "success": true,
+                        "action": "rename",
+                        "workspace": workspace.display_workspace.clone(),
+                        "session_id": session_id,
+                        "session_name": session_name,
+                    }),
+                    result_for_assistant: Some(result_for_assistant),
+                    image_attachments: None,
+                }])
+            }
             SessionControlAction::List => {
                 let workspace = self
                     .resolve_effective_workspace(
@@ -824,5 +895,65 @@ mod tests {
         );
 
         assert_eq!(message, "Cancel active turn for session worker_1");
+    }
+
+    #[tokio::test]
+    async fn validate_rename_requires_session_name() {
+        let tool = SessionControlTool::new();
+
+        let validation = tool
+            .validate_input(
+                &json!({
+                    "action": "rename",
+                    "session_id": "worker_1",
+                }),
+                Some(&empty_context()),
+            )
+            .await;
+
+        assert!(!validation.result);
+        assert_eq!(
+            validation.message.as_deref(),
+            Some("session_name is required for rename")
+        );
+    }
+
+    #[tokio::test]
+    async fn validate_rename_requires_session_id() {
+        let tool = SessionControlTool::new();
+
+        let validation = tool
+            .validate_input(
+                &json!({
+                    "action": "rename",
+                    "session_name": "new-title",
+                }),
+                Some(&empty_context()),
+            )
+            .await;
+
+        assert!(!validation.result);
+        assert_eq!(
+            validation.message.as_deref(),
+            Some("session_id is required for rename")
+        );
+    }
+
+    #[tokio::test]
+    async fn validate_rename_accepts_session_id_and_name() {
+        let tool = SessionControlTool::new();
+
+        let validation = tool
+            .validate_input(
+                &json!({
+                    "action": "rename",
+                    "session_id": "worker_1",
+                    "session_name": "new-title",
+                }),
+                Some(&empty_context()),
+            )
+            .await;
+
+        assert!(validation.result, "{:?}", validation.message);
     }
 }

--- a/src/crates/execution/agent-runtime/src/session_control.rs
+++ b/src/crates/execution/agent-runtime/src/session_control.rs
@@ -11,6 +11,7 @@ pub enum SessionControlAction {
     Cancel,
     Delete,
     List,
+    Rename,
 }
 
 impl SessionControlAction {
@@ -20,6 +21,7 @@ impl SessionControlAction {
             Self::Cancel => "cancel",
             Self::Delete => "delete",
             Self::List => "list",
+            Self::Rename => "rename",
         }
     }
 }
@@ -159,8 +161,19 @@ fn validate_mutating_action_target(
     if input.agent_type.is_some() {
         return invalid("agent_type is only allowed for create");
     }
-    if input.session_name.is_some() {
+    // `rename` carries the new session title via session_name; every other
+    // mutating action rejects it (only `create` otherwise accepts session_name).
+    if input.session_name.is_some() && !matches!(action, SessionControlAction::Rename) {
         return invalid("session_name is only allowed for create");
+    }
+    // `rename` requires a non-empty new title.
+    if matches!(action, SessionControlAction::Rename) {
+        let Some(session_name) = input.session_name.as_deref() else {
+            return invalid("session_name is required for rename");
+        };
+        if session_name.trim().is_empty() {
+            return invalid("session_name must not be empty for rename");
+        }
     }
 
     let Some(session_id) = input.session_id.as_deref() else {
@@ -211,7 +224,9 @@ pub fn validate_session_control_input(
                 return invalid("create requires a creator session in tool context");
             }
         }
-        SessionControlAction::Cancel | SessionControlAction::Delete => {
+        SessionControlAction::Cancel
+        | SessionControlAction::Delete
+        | SessionControlAction::Rename => {
             return validate_mutating_action_target(&input.action, input, context);
         }
         SessionControlAction::List => {
@@ -251,6 +266,7 @@ pub fn render_session_control_tool_use_message(input: &Value) -> String {
         "create" => format!("Create session in {workspace}"),
         "cancel" => format!("Cancel active turn for session {session_id}"),
         "delete" => format!("Delete session {session_id}"),
+        "rename" => format!("Rename session {session_id}"),
         "list" => format!("List sessions in {workspace}"),
         _ => format!("Manage sessions in {workspace}"),
     }
@@ -290,4 +306,141 @@ pub fn session_control_cancel_result_message(
 
 pub fn session_control_deleted_result_message(session_id: &str, workspace: &str) -> String {
     format!("Deleted session '{session_id}' from workspace '{workspace}'.")
+}
+
+pub fn session_control_renamed_result_message(
+    session_id: &str,
+    workspace: &str,
+    session_name: &str,
+) -> String {
+    format!("Renamed session '{session_id}' to '{session_name}' in workspace '{workspace}'.")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn context(current: Option<&str>) -> SessionControlValidationContext<'_> {
+        SessionControlValidationContext {
+            current_session_id: current,
+            has_workspace_root: true,
+        }
+    }
+
+    #[test]
+    fn rename_action_parses_payload_session_id_and_name() {
+        let input: SessionControlInput = serde_json::from_value(json!({
+            "action": "rename",
+            "session_id": "worker_1",
+            "session_name": "new-title",
+        }))
+        .expect("rename payload must parse");
+        assert_eq!(input.action, SessionControlAction::Rename);
+        assert_eq!(input.session_id.as_deref(), Some("worker_1"));
+        assert_eq!(input.session_name.as_deref(), Some("new-title"));
+        assert_eq!(SessionControlAction::Rename.as_str(), "rename");
+    }
+
+    #[test]
+    fn rename_validation_requires_session_id() {
+        let input = SessionControlInput {
+            action: SessionControlAction::Rename,
+            workspace: None,
+            session_id: None,
+            session_name: Some("new-title".to_string()),
+            agent_type: None,
+        };
+        let result = validate_session_control_input(&input, context(None));
+        assert!(!result.result);
+        assert!(result
+            .message
+            .as_deref()
+            .unwrap_or_default()
+            .contains("session_id is required"));
+    }
+
+    #[test]
+    fn rename_validation_requires_session_name() {
+        let input = SessionControlInput {
+            action: SessionControlAction::Rename,
+            workspace: None,
+            session_id: Some("worker_1".to_string()),
+            session_name: None,
+            agent_type: None,
+        };
+        let result = validate_session_control_input(&input, context(None));
+        assert!(!result.result);
+        assert!(result
+            .message
+            .as_deref()
+            .unwrap_or_default()
+            .contains("session_name is required for rename"));
+    }
+
+    #[test]
+    fn rename_validation_rejects_blank_session_name() {
+        let input = SessionControlInput {
+            action: SessionControlAction::Rename,
+            workspace: None,
+            session_id: Some("worker_1".to_string()),
+            session_name: Some("   ".to_string()),
+            agent_type: None,
+        };
+        let result = validate_session_control_input(&input, context(None));
+        assert!(!result.result);
+        assert_eq!(
+            result.message.as_deref(),
+            Some("session_name must not be empty for rename")
+        );
+    }
+
+    #[test]
+    fn rename_validation_accepts_valid_input() {
+        let input = SessionControlInput {
+            action: SessionControlAction::Rename,
+            workspace: None,
+            session_id: Some("worker_1".to_string()),
+            session_name: Some("new-title".to_string()),
+            agent_type: None,
+        };
+        let result = validate_session_control_input(&input, context(None));
+        assert!(result.result, "{:?}", result.message);
+    }
+
+    #[test]
+    fn rename_validation_rejects_current_session() {
+        let input = SessionControlInput {
+            action: SessionControlAction::Rename,
+            workspace: None,
+            session_id: Some("self_1".to_string()),
+            session_name: Some("new-title".to_string()),
+            agent_type: None,
+        };
+        let result = validate_session_control_input(&input, context(Some("self_1")));
+        assert!(!result.result);
+        assert!(result
+            .message
+            .as_deref()
+            .unwrap_or_default()
+            .contains("cannot rename the current session"));
+    }
+
+    #[test]
+    fn rename_render_mentions_session() {
+        let rendered = render_session_control_tool_use_message(&json!({
+            "action": "rename",
+            "session_id": "worker_1",
+        }));
+        assert!(rendered.contains("Rename session"));
+        assert!(rendered.contains("worker_1"));
+    }
+
+    #[test]
+    fn renamed_result_message_mentions_id_and_new_name() {
+        let message = session_control_renamed_result_message("worker_1", "/ws", "new-title");
+        assert!(message.contains("worker_1"));
+        assert!(message.contains("new-title"));
+        assert!(message.contains("/ws"));
+    }
 }


### PR DESCRIPTION
## Summary

Extend the session control tool family with a `rename` action so a caller can rename a persisted session title through the same `AgentSessionManagementPort` channel used by the frontend `renameChatSessionTitle`.

## Changes

- Extend `SessionControlAction` with a `Rename` variant and its `as_str` mapping.
- Allow `session_name` as the required new title for `rename` (rejected for every other mutating action) and reject renaming the current session.
- Add `session_control_renamed_result_message` helper for the tool result text.
- Wire the `Rename` dispatch to reuse the upstream `AgentSessionRenameRequest`.
- Extend the tool input schema/description and add rename validation tests.

## Testing

AI-assisted output. Test extent: **已测 (tested)**.

- `cargo check -p bitfun-agent-runtime --jobs 4` EXIT 0.
- `cargo check -p bitfun-core --jobs 4` EXIT 0.
- `cargo test -p bitfun-agent-runtime --features agent-runtime rename --jobs 4` (7 tests pass).
- `cargo test -p bitfun-core --features agent-runtime session_control_tool --jobs 4` (11 tests pass, incl `validate_rename_*`).
- Verified by the project maintainer on a dev instance (real rename persistence through the full session chain).

Skipped: no full local CI — the complete build and broad test suite are covered by the repository CI against this PR. No UI change (backend tool), so no before/after screenshots; the low-risk manual verification path is to invoke the session control tool with the `rename` action against a persisted session on a dev instance.

## Commits

- `bc73ae388` feat(session): add rename action to session control tool — extend the session control tool with a rename action reusing the upstream rename channel.

Closes #2468