### PR TITLE
fix(windows): hide remaining child consoles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,10 +152,12 @@ await api.invoke('your_command', { request: { ... } });
 - Desktop-only host adapters belong in `src/apps/desktop`, then flow through typed capability interfaces and, when event delivery is needed, the production transport adapter.
 - In shared core, avoid host-specific APIs such as `tauri::AppHandle`; use shared abstractions such as `bitfun_events::EventEmitter`.
 
-#### Child processes in GUI hosts
+#### Non-interactive child processes
 
-- GUI hosts such as Desktop and Installer must not spawn child processes with bare
-  `std::process::Command` or `tokio::process::Command`. Prefer
+- Any non-interactive child process that may run under a GUI, headless,
+  background, or redirected host must not use bare `std::process::Command` or
+  `tokio::process::Command`, including CLI modes that another host can invoke.
+  Prefer
   `bitfun_services_core::process_manager::{create_command, create_tokio_command}`
   or the existing facade for that layer. If a direct command is unavoidable,
   Windows code must explicitly apply `CREATE_NO_WINDOW`; Node child processes

--- a/src/apps/cli/src/dispatch/mod.rs
+++ b/src/apps/cli/src/dispatch/mod.rs
@@ -6,7 +6,6 @@ mod worker;
 mod workspace;
 
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 use anyhow::{anyhow, bail, Context, Result};
 use bitfun_core::infrastructure::ai::AIClientFactory;
@@ -853,7 +852,7 @@ fn classify_repository_probe(result: Result<GitProbeOutput, GitProbeOutput>) -> 
 /// below matches Git's English prose, and a localized host would otherwise make
 /// an ownership rejection unrecognizable.
 fn git_probe(workspace: &Path, args: &[&str]) -> Result<GitProbeOutput, GitProbeOutput> {
-    let output = Command::new("git")
+    let output = bitfun_services_core::process_manager::create_command("git")
         .env("LC_ALL", "C")
         .arg("-C")
         .arg(workspace)

--- a/src/apps/cli/src/dispatch/store.rs
+++ b/src/apps/cli/src/dispatch/store.rs
@@ -2916,14 +2916,14 @@ mod tests {
         let executable = std::env::current_exe().expect("test executable");
         let test_name =
             "dispatch::store::tests::cross_process_reader_and_writer_remain_consistent_during_rotation";
-        let mut reader = std::process::Command::new(&executable)
+        let mut reader = bitfun_services_core::process_manager::create_command(&executable)
             .args(["--exact", test_name, "--nocapture"])
             .env(MODE_ENV, "reader")
             .env(ROOT_ENV, &root)
             .env(DONE_ENV, &done)
             .spawn()
             .expect("spawn stress reader");
-        let writer = std::process::Command::new(&executable)
+        let writer = bitfun_services_core::process_manager::create_command(&executable)
             .args(["--exact", test_name, "--nocapture"])
             .env(MODE_ENV, "writer")
             .env(ROOT_ENV, &root)
@@ -3076,20 +3076,22 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let bitfun_home = dir.path().join("bitfun-home");
         let user_root = dir.path().join("user-root");
-        let output = std::process::Command::new(std::env::current_exe().expect("test executable"))
-            .args([
-                "--exact",
-                "dispatch::store::tests::default_store_honors_path_manager_storage_overrides",
-                "--nocapture",
-            ])
-            .env(CHILD_ENV, &bitfun_home)
-            .env("BITFUN_HOME", &bitfun_home)
-            .env("BITFUN_USER_ROOT", &user_root)
-            .env("BITFUN_E2E_STORAGE_GUARD", "1")
-            .env_remove("BITFUN_E2E_HOME")
-            .env_remove("BITFUN_E2E_USER_ROOT")
-            .output()
-            .expect("run isolated path test");
+        let output = bitfun_services_core::process_manager::create_command(
+            std::env::current_exe().expect("test executable"),
+        )
+        .args([
+            "--exact",
+            "dispatch::store::tests::default_store_honors_path_manager_storage_overrides",
+            "--nocapture",
+        ])
+        .env(CHILD_ENV, &bitfun_home)
+        .env("BITFUN_HOME", &bitfun_home)
+        .env("BITFUN_USER_ROOT", &user_root)
+        .env("BITFUN_E2E_STORAGE_GUARD", "1")
+        .env_remove("BITFUN_E2E_HOME")
+        .env_remove("BITFUN_E2E_USER_ROOT")
+        .output()
+        .expect("run isolated path test");
         assert!(
             output.status.success(),
             "isolated child failed:\nstdout:\n{}\nstderr:\n{}",

--- a/src/apps/cli/src/dispatch/workspace.rs
+++ b/src/apps/cli/src/dispatch/workspace.rs
@@ -1573,7 +1573,7 @@ fn commit_exists(repo: &Path, commit: &str) -> Result<bool> {
 }
 
 fn git_command(dir: &Path) -> Command {
-    let mut command = Command::new("git");
+    let mut command = bitfun_services_core::process_manager::create_command("git");
     command
         .current_dir(dir)
         // A detached dispatch worker has nobody to answer a credential or
@@ -2419,20 +2419,22 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let bitfun_home = dir.path().join("bitfun-home");
         let user_root = dir.path().join("user-root");
-        let output = std::process::Command::new(std::env::current_exe().expect("test executable"))
-            .args([
-                "--exact",
-                "dispatch::workspace::tests::completed_clean_sync_poll_returns_the_durable_result",
-                "--nocapture",
-            ])
-            .env(CHILD_ENV, &bitfun_home)
-            .env("BITFUN_HOME", &bitfun_home)
-            .env("BITFUN_USER_ROOT", &user_root)
-            .env("BITFUN_E2E_STORAGE_GUARD", "1")
-            .env_remove("BITFUN_E2E_HOME")
-            .env_remove("BITFUN_E2E_USER_ROOT")
-            .output()
-            .expect("run isolated clean-sync poll test");
+        let output = bitfun_services_core::process_manager::create_command(
+            std::env::current_exe().expect("test executable"),
+        )
+        .args([
+            "--exact",
+            "dispatch::workspace::tests::completed_clean_sync_poll_returns_the_durable_result",
+            "--nocapture",
+        ])
+        .env(CHILD_ENV, &bitfun_home)
+        .env("BITFUN_HOME", &bitfun_home)
+        .env("BITFUN_USER_ROOT", &user_root)
+        .env("BITFUN_E2E_STORAGE_GUARD", "1")
+        .env_remove("BITFUN_E2E_HOME")
+        .env_remove("BITFUN_E2E_USER_ROOT")
+        .output()
+        .expect("run isolated clean-sync poll test");
         assert!(
             output.status.success(),
             "isolated child failed:\nstdout:\n{}\nstderr:\n{}",

--- a/src/apps/cli/src/modes/exec/tests.rs
+++ b/src/apps/cli/src/modes/exec/tests.rs
@@ -1,5 +1,3 @@
-use std::process::Command;
-
 use super::lifecycle::{
     completed_turn_failure, drain_interrupted_turn_events, effective_event_invocation,
     event_belongs_to_exec_turn, event_turn_id, is_exec_terminal,
@@ -103,7 +101,7 @@ fn git_patch_includes_staged_and_untracked_files_from_a_repo_subdirectory() {
     let temp = tempfile::tempdir().expect("tempdir");
     let repo = temp.path();
     let run_git = |args: &[&str]| {
-        let output = Command::new("git")
+        let output = bitfun_core::util::process_manager::create_command("git")
             .args(args)
             .current_dir(repo)
             .output()
@@ -141,7 +139,7 @@ fn git_patch_excludes_a_preexisting_output_artifact_inside_the_repository() {
     let temp = tempfile::tempdir().expect("tempdir");
     let repo = temp.path();
     let run_git = |args: &[&str]| {
-        let output = Command::new("git")
+        let output = bitfun_core::util::process_manager::create_command("git")
             .args(args)
             .current_dir(repo)
             .output()
@@ -181,7 +179,7 @@ fn git_patch_excludes_a_tracked_output_artifact_inside_the_repository() {
     let temp = tempfile::tempdir().expect("tempdir");
     let repo = temp.path();
     let run_git = |args: &[&str]| {
-        let output = Command::new("git")
+        let output = bitfun_core::util::process_manager::create_command("git")
             .args(args)
             .current_dir(repo)
             .output()
@@ -702,7 +700,7 @@ fn deferred_exec_event_projects_effective_name_and_input() {
 }
 
 fn run_git(workspace: &std::path::Path, args: &[&str]) {
-    let output = Command::new("git")
+    let output = bitfun_core::util::process_manager::create_command("git")
         .args(args)
         .current_dir(workspace)
         .output()

--- a/src/apps/cli/src/modes/exec/verification.rs
+++ b/src/apps/cli/src/modes/exec/verification.rs
@@ -63,11 +63,11 @@ pub(super) async fn run_verifier(
     retries_used: u32,
 ) -> VerifyOutcome {
     let mut process = if cfg!(windows) {
-        let mut process = tokio::process::Command::new("cmd");
+        let mut process = bitfun_core::util::process_manager::create_tokio_command("cmd");
         process.arg("/C").arg(command);
         process
     } else {
-        let mut process = tokio::process::Command::new("sh");
+        let mut process = bitfun_core::util::process_manager::create_tokio_command("sh");
         process.arg("-c").arg(command);
         process
     };

--- a/src/apps/cli/tests/acp_stdio_cli.rs
+++ b/src/apps/cli/tests/acp_stdio_cli.rs
@@ -16,7 +16,9 @@ struct AcpProcess {
 
 impl AcpProcess {
     async fn spawn(environment: &CliTestEnvironment) -> Self {
-        let mut command = tokio::process::Command::new(env!("CARGO_BIN_EXE_bitfun"));
+        let mut command = bitfun_services_core::process_manager::create_tokio_command(env!(
+            "CARGO_BIN_EXE_bitfun"
+        ));
         command
             .arg("acp")
             .stdin(Stdio::piped())

--- a/src/apps/cli/tests/cli_command_contracts/compat_entrypoint.rs
+++ b/src/apps/cli/tests/cli_command_contracts/compat_entrypoint.rs
@@ -27,14 +27,16 @@ fn run_freshly_written(command: &mut Command) -> std::io::Result<Output> {
 
 #[test]
 fn legacy_version_matches_primary_and_warns_only_on_stderr() {
-    let primary = Command::new(env!("CARGO_BIN_EXE_bitfun"))
-        .arg("--version")
-        .output()
-        .expect("run bitfun --version");
-    let legacy = Command::new(env!("CARGO_BIN_EXE_bitfun-cli"))
-        .arg("--version")
-        .output()
-        .expect("run deprecated bitfun-cli --version");
+    let primary =
+        bitfun_services_core::process_manager::create_command(env!("CARGO_BIN_EXE_bitfun"))
+            .arg("--version")
+            .output()
+            .expect("run bitfun --version");
+    let legacy =
+        bitfun_services_core::process_manager::create_command(env!("CARGO_BIN_EXE_bitfun-cli"))
+            .arg("--version")
+            .output()
+            .expect("run deprecated bitfun-cli --version");
 
     assert!(primary.status.success());
     assert!(legacy.status.success());
@@ -45,14 +47,16 @@ fn legacy_version_matches_primary_and_warns_only_on_stderr() {
 
 #[test]
 fn legacy_forwards_clap_failure_exit_code() {
-    let primary = Command::new(env!("CARGO_BIN_EXE_bitfun"))
-        .arg("--not-a-real-option")
-        .output()
-        .expect("run invalid primary command");
-    let legacy = Command::new(env!("CARGO_BIN_EXE_bitfun-cli"))
-        .arg("--not-a-real-option")
-        .output()
-        .expect("run invalid legacy command");
+    let primary =
+        bitfun_services_core::process_manager::create_command(env!("CARGO_BIN_EXE_bitfun"))
+            .arg("--not-a-real-option")
+            .output()
+            .expect("run invalid primary command");
+    let legacy =
+        bitfun_services_core::process_manager::create_command(env!("CARGO_BIN_EXE_bitfun-cli"))
+            .arg("--not-a-real-option")
+            .output()
+            .expect("run invalid legacy command");
 
     assert_eq!(legacy.status.code(), primary.status.code());
     assert!(String::from_utf8_lossy(&legacy.stderr).starts_with(DEPRECATION));
@@ -69,8 +73,10 @@ fn legacy_reports_a_missing_primary_without_recursing() {
     let copied = temp.path().join(file_name);
     std::fs::copy(env!("CARGO_BIN_EXE_bitfun-cli"), &copied)
         .expect("copy deprecated launcher without primary sibling");
-    let output = run_freshly_written(Command::new(copied).arg("--version"))
-        .expect("run isolated deprecated launcher");
+    let output = run_freshly_written(
+        bitfun_services_core::process_manager::create_command(copied).arg("--version"),
+    )
+    .expect("run isolated deprecated launcher");
     let stderr = String::from_utf8_lossy(&output.stderr);
 
     assert!(!output.status.success());

--- a/src/apps/cli/tests/cli_command_contracts/exec_cli_contracts.rs
+++ b/src/apps/cli/tests/cli_command_contracts/exec_cli_contracts.rs
@@ -1,14 +1,14 @@
 #[path = "../support/mod.rs"]
 mod support;
 
-use std::process::{Command, Output};
+use std::process::Output;
 use support::{
     command_output_with_timeout, CliTestEnvironment, MockOpenAiServer, STREAM_COMPLETED_MARKER,
     STREAM_START_MARKER,
 };
 
 fn run_cli(args: &[&str]) -> Output {
-    Command::new(env!("CARGO_BIN_EXE_bitfun"))
+    bitfun_services_core::process_manager::create_command(env!("CARGO_BIN_EXE_bitfun"))
         .args(args)
         .output()
         .expect("run bitfun")
@@ -43,13 +43,13 @@ fn is_terminal_event(value: &serde_json::Value) -> bool {
 fn command_timeout_helper_returns_within_its_failure_budget() {
     #[cfg(windows)]
     let mut command = {
-        let mut command = Command::new("powershell.exe");
+        let mut command = bitfun_services_core::process_manager::create_command("powershell.exe");
         command.args(["-NoProfile", "-Command", "Start-Sleep -Seconds 30"]);
         command
     };
     #[cfg(not(windows))]
     let mut command = {
-        let mut command = Command::new("sh");
+        let mut command = bitfun_services_core::process_manager::create_command("sh");
         command.args(["-c", "exec sleep 30"]);
         command
     };

--- a/src/apps/cli/tests/cli_command_contracts/mcp_add_cli.rs
+++ b/src/apps/cli/tests/cli_command_contracts/mcp_add_cli.rs
@@ -1,9 +1,9 @@
 use std::path::Path;
-use std::process::{Command, Output};
+use std::process::Output;
 
 fn run_cli(workspace: &Path, user_root: &Path, home_root: &Path, args: &[&str]) -> Output {
     let config_root = user_root.join("host-config");
-    Command::new(env!("CARGO_BIN_EXE_bitfun"))
+    bitfun_services_core::process_manager::create_command(env!("CARGO_BIN_EXE_bitfun"))
         .args(args)
         .current_dir(workspace)
         .env_remove("BITFUN_USER_ROOT")

--- a/src/apps/cli/tests/cli_command_contracts/plugin_source_cli.rs
+++ b/src/apps/cli/tests/cli_command_contracts/plugin_source_cli.rs
@@ -1,6 +1,6 @@
 use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Output};
+use std::process::Output;
 
 const PLUGIN_SOURCE: &[u8] = br#"
 import { type Plugin, tool } from "@opencode-ai/plugin"
@@ -42,7 +42,7 @@ fn write_package(workspace: &Path, source: &[u8], declared_hash: &str) {
 
 fn run_cli(workspace: &Path, user_root: &Path, home_root: &Path, args: &[&str]) -> Output {
     let config_root = user_root.join("host-config");
-    Command::new(env!("CARGO_BIN_EXE_bitfun"))
+    bitfun_services_core::process_manager::create_command(env!("CARGO_BIN_EXE_bitfun"))
         .args(args)
         .current_dir(workspace)
         .env_remove("BITFUN_USER_ROOT")
@@ -120,18 +120,19 @@ fn plugin_source_cli_rejects_unavailable_product_paths() {
     let config_root = temp.path().join("host-config");
     std::fs::create_dir_all(&workspace).expect("create workspace");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_bitfun"))
-        .args(["plugins", "list"])
-        .current_dir(&workspace)
-        .env_remove("BITFUN_USER_ROOT")
-        .env_remove("BITFUN_HOME")
-        .env_remove("BITFUN_E2E_USER_ROOT")
-        .env_remove("BITFUN_E2E_HOME")
-        .env("BITFUN_E2E_STORAGE_GUARD", "1")
-        .env("APPDATA", &config_root)
-        .env("XDG_CONFIG_HOME", &config_root)
-        .output()
-        .expect("run bitfun");
+    let output =
+        bitfun_services_core::process_manager::create_command(env!("CARGO_BIN_EXE_bitfun"))
+            .args(["plugins", "list"])
+            .current_dir(&workspace)
+            .env_remove("BITFUN_USER_ROOT")
+            .env_remove("BITFUN_HOME")
+            .env_remove("BITFUN_E2E_USER_ROOT")
+            .env_remove("BITFUN_E2E_HOME")
+            .env("BITFUN_E2E_STORAGE_GUARD", "1")
+            .env("APPDATA", &config_root)
+            .env("XDG_CONFIG_HOME", &config_root)
+            .output()
+            .expect("run bitfun");
 
     assert!(!output.status.success());
     assert!(stderr(&output).contains("Configuration error"));

--- a/src/apps/cli/tests/cli_command_contracts/product_assembly_cli.rs
+++ b/src/apps/cli/tests/cli_command_contracts/product_assembly_cli.rs
@@ -1,5 +1,3 @@
-use std::process::Command;
-
 #[test]
 fn doctor_reports_the_validated_cli_runtime_assembly() {
     let temp = tempfile::tempdir().expect("tempdir");
@@ -9,19 +7,20 @@ fn doctor_reports_the_validated_cli_runtime_assembly() {
     let config_root = temp.path().join("host-config");
     std::fs::create_dir_all(&workspace).expect("create workspace");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_bitfun"))
-        .arg("doctor")
-        .current_dir(&workspace)
-        .env_remove("BITFUN_USER_ROOT")
-        .env_remove("BITFUN_HOME")
-        .env("BITFUN_E2E_STORAGE_GUARD", "1")
-        .env("BITFUN_E2E_USER_ROOT", &user_root)
-        .env("BITFUN_E2E_HOME", &home_root)
-        .env("APPDATA", &config_root)
-        .env("XDG_CONFIG_HOME", &config_root)
-        .env("HOME", &home_root)
-        .output()
-        .expect("run bitfun doctor");
+    let output =
+        bitfun_services_core::process_manager::create_command(env!("CARGO_BIN_EXE_bitfun"))
+            .arg("doctor")
+            .current_dir(&workspace)
+            .env_remove("BITFUN_USER_ROOT")
+            .env_remove("BITFUN_HOME")
+            .env("BITFUN_E2E_STORAGE_GUARD", "1")
+            .env("BITFUN_E2E_USER_ROOT", &user_root)
+            .env("BITFUN_E2E_HOME", &home_root)
+            .env("APPDATA", &config_root)
+            .env("XDG_CONFIG_HOME", &config_root)
+            .env("HOME", &home_root)
+            .output()
+            .expect("run bitfun doctor");
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -57,19 +56,20 @@ fn health_reports_assembly_and_compatibility_boundaries() {
     let config_root = temp.path().join("host-config");
     std::fs::create_dir_all(&workspace).expect("create workspace");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_bitfun"))
-        .arg("health")
-        .current_dir(&workspace)
-        .env_remove("BITFUN_USER_ROOT")
-        .env_remove("BITFUN_HOME")
-        .env("BITFUN_E2E_STORAGE_GUARD", "1")
-        .env("BITFUN_E2E_USER_ROOT", &user_root)
-        .env("BITFUN_E2E_HOME", &home_root)
-        .env("APPDATA", &config_root)
-        .env("XDG_CONFIG_HOME", &config_root)
-        .env("HOME", &home_root)
-        .output()
-        .expect("run bitfun health");
+    let output =
+        bitfun_services_core::process_manager::create_command(env!("CARGO_BIN_EXE_bitfun"))
+            .arg("health")
+            .current_dir(&workspace)
+            .env_remove("BITFUN_USER_ROOT")
+            .env_remove("BITFUN_HOME")
+            .env("BITFUN_E2E_STORAGE_GUARD", "1")
+            .env("BITFUN_E2E_USER_ROOT", &user_root)
+            .env("BITFUN_E2E_HOME", &home_root)
+            .env("APPDATA", &config_root)
+            .env("XDG_CONFIG_HOME", &config_root)
+            .env("HOME", &home_root)
+            .output()
+            .expect("run bitfun health");
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -104,7 +104,8 @@ fn doctor_rejects_incomplete_e2e_storage_roots() {
         let config_root = temp.path().join("host-config");
         std::fs::create_dir_all(&workspace).expect("create workspace");
 
-        let mut command = Command::new(env!("CARGO_BIN_EXE_bitfun"));
+        let mut command =
+            bitfun_services_core::process_manager::create_command(env!("CARGO_BIN_EXE_bitfun"));
         command
             .arg("doctor")
             .current_dir(&workspace)

--- a/src/apps/cli/tests/support/mod.rs
+++ b/src/apps/cli/tests/support/mod.rs
@@ -238,7 +238,8 @@ impl CliTestEnvironment {
     }
 
     pub(crate) fn std_command(&self) -> Command {
-        let mut command = Command::new(env!("CARGO_BIN_EXE_bitfun"));
+        let mut command =
+            bitfun_services_core::process_manager::create_command(env!("CARGO_BIN_EXE_bitfun"));
         command.current_dir(&self.workspace);
         self.apply_std_environment(&mut command);
         command
@@ -298,7 +299,7 @@ impl CliTestEnvironment {
     }
 
     fn run_git(&self, args: &[&str]) {
-        let output = Command::new("git")
+        let output = bitfun_services_core::process_manager::create_command("git")
             .args(args)
             .current_dir(&self.workspace)
             .output()

--- a/src/apps/sdk-host/tests/process_initialization.rs
+++ b/src/apps/sdk-host/tests/process_initialization.rs
@@ -22,11 +22,13 @@ fn sdk_host_process_job_reclaims_descendants_when_host_exits() {
         Ok("owner") => {
             bitfun_sdk_host_app::initialize_process_runtime()
                 .expect("initialize owned SDK Host process");
-            let descendant = std::process::Command::new(std::env::current_exe().unwrap())
-                .args(["--exact", TEST_NAME, "--nocapture"])
-                .env(MODE_ENV, "descendant")
-                .spawn()
-                .expect("spawn owned descendant");
+            let descendant = bitfun_services_core::process_manager::create_command(
+                std::env::current_exe().unwrap(),
+            )
+            .args(["--exact", TEST_NAME, "--nocapture"])
+            .env(MODE_ENV, "descendant")
+            .spawn()
+            .expect("spawn owned descendant");
             std::fs::write(
                 std::env::var(PID_FILE_ENV).expect("PID file path"),
                 descendant.id().to_string(),
@@ -40,12 +42,13 @@ fn sdk_host_process_job_reclaims_descendants_when_host_exits() {
 
     let directory = tempfile::tempdir().expect("create job test directory");
     let pid_file = directory.path().join("descendant.pid");
-    let status = std::process::Command::new(std::env::current_exe().unwrap())
-        .args(["--exact", TEST_NAME, "--nocapture"])
-        .env(MODE_ENV, "owner")
-        .env(PID_FILE_ENV, &pid_file)
-        .status()
-        .expect("run process-tree owner fixture");
+    let status =
+        bitfun_services_core::process_manager::create_command(std::env::current_exe().unwrap())
+            .args(["--exact", TEST_NAME, "--nocapture"])
+            .env(MODE_ENV, "owner")
+            .env(PID_FILE_ENV, &pid_file)
+            .status()
+            .expect("run process-tree owner fixture");
     assert!(status.success(), "process-tree owner fixture failed");
     let descendant_pid = std::fs::read_to_string(pid_file)
         .expect("read descendant PID")
@@ -53,7 +56,7 @@ fn sdk_host_process_job_reclaims_descendants_when_host_exits() {
         .to_string();
     std::thread::sleep(std::time::Duration::from_millis(200));
 
-    let cleanup = std::process::Command::new("taskkill.exe")
+    let cleanup = bitfun_services_core::process_manager::create_command("taskkill.exe")
         .args(["/pid", &descendant_pid, "/t", "/f"])
         .output()
         .expect("probe descendant process");

--- a/src/apps/sdk-host/tests/stdio_process.rs
+++ b/src/apps/sdk-host/tests/stdio_process.rs
@@ -15,23 +15,25 @@ async fn standalone_sdk_host_negotiates_and_shuts_down_without_cli() {
         std::fs::create_dir_all(path).expect("SDK Host fixture directory");
     }
 
-    let mut child = tokio::process::Command::new(env!("CARGO_BIN_EXE_bitfun-sdk-host"))
-        .current_dir(&workspace)
-        .env_remove("BITFUN_USER_ROOT")
-        .env_remove("BITFUN_HOME")
-        .env("BITFUN_E2E_STORAGE_GUARD", "1")
-        .env("BITFUN_E2E_USER_ROOT", &user_root)
-        .env("BITFUN_E2E_HOME", &home_root)
-        .env("APPDATA", &config_root)
-        .env("XDG_CONFIG_HOME", &config_root)
-        .env("HOME", &home_root)
-        .env("USERPROFILE", &home_root)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .kill_on_drop(true)
-        .spawn()
-        .expect("start standalone Agent SDK Host");
+    let mut child = bitfun_services_core::process_manager::create_tokio_command(env!(
+        "CARGO_BIN_EXE_bitfun-sdk-host"
+    ))
+    .current_dir(&workspace)
+    .env_remove("BITFUN_USER_ROOT")
+    .env_remove("BITFUN_HOME")
+    .env("BITFUN_E2E_STORAGE_GUARD", "1")
+    .env("BITFUN_E2E_USER_ROOT", &user_root)
+    .env("BITFUN_E2E_HOME", &home_root)
+    .env("APPDATA", &config_root)
+    .env("XDG_CONFIG_HOME", &config_root)
+    .env("HOME", &home_root)
+    .env("USERPROFILE", &home_root)
+    .stdin(Stdio::piped())
+    .stdout(Stdio::piped())
+    .stderr(Stdio::piped())
+    .kill_on_drop(true)
+    .spawn()
+    .expect("start standalone Agent SDK Host");
 
     let mut stdin = child.stdin.take().expect("SDK Host stdin");
     let mut stdout = BufReader::new(child.stdout.take().expect("SDK Host stdout"));

--- a/src/crates/adapters/ai-adapters/src/subscription_auth/mod.rs
+++ b/src/crates/adapters/ai-adapters/src/subscription_auth/mod.rs
@@ -1398,16 +1398,17 @@ mod tests {
         let loaded_path = parent.join("child-loaded");
         let resume_path = parent.join("child-resume");
         let outcome_path = parent.join("child-outcome");
-        let mut child = std::process::Command::new(std::env::current_exe().unwrap())
-            .arg("--exact")
-            .arg("subscription_auth::tests::cross_process_stale_login_cas_child")
-            .arg("--nocapture")
-            .env(STALE_LOGIN_CHILD_METADATA_ENV, &path)
-            .env(STALE_LOGIN_CHILD_LOADED_ENV, &loaded_path)
-            .env(STALE_LOGIN_CHILD_RESUME_ENV, &resume_path)
-            .env(STALE_LOGIN_CHILD_OUTCOME_ENV, &outcome_path)
-            .spawn()
-            .expect("spawn stale-login child process");
+        let mut child =
+            bitfun_services_core::process_manager::create_command(std::env::current_exe().unwrap())
+                .arg("--exact")
+                .arg("subscription_auth::tests::cross_process_stale_login_cas_child")
+                .arg("--nocapture")
+                .env(STALE_LOGIN_CHILD_METADATA_ENV, &path)
+                .env(STALE_LOGIN_CHILD_LOADED_ENV, &loaded_path)
+                .env(STALE_LOGIN_CHILD_RESUME_ENV, &resume_path)
+                .env(STALE_LOGIN_CHILD_OUTCOME_ENV, &outcome_path)
+                .spawn()
+                .expect("spawn stale-login child process");
 
         tokio::time::timeout(Duration::from_secs(5), async {
             while !loaded_path.exists() {

--- a/src/crates/adapters/ai-adapters/src/subscription_auth/store.rs
+++ b/src/crates/adapters/ai-adapters/src/subscription_auth/store.rs
@@ -1867,15 +1867,17 @@ mod file_lock_tests {
         )
         .await
         .expect("stage cleanup intent before vault write and metadata commit");
-        let mut child = std::process::Command::new(std::env::current_exe().expect("test binary"))
-            .arg("--exact")
-            .arg("subscription_auth::store::file_lock_tests::cross_process_lock_child")
-            .arg("--nocapture")
-            .env(LOCK_CHILD_METADATA_ENV, &metadata_path)
-            .env(LOCK_CHILD_STARTED_ENV, &started_path)
-            .env(LOCK_CHILD_OBSERVED_ENV, &observed_path)
-            .spawn()
-            .expect("spawn lock-contending child process");
+        let mut child = bitfun_services_core::process_manager::create_command(
+            std::env::current_exe().expect("test binary"),
+        )
+        .arg("--exact")
+        .arg("subscription_auth::store::file_lock_tests::cross_process_lock_child")
+        .arg("--nocapture")
+        .env(LOCK_CHILD_METADATA_ENV, &metadata_path)
+        .env(LOCK_CHILD_STARTED_ENV, &started_path)
+        .env(LOCK_CHILD_OBSERVED_ENV, &observed_path)
+        .spawn()
+        .expect("spawn lock-contending child process");
 
         tokio::time::timeout(Duration::from_secs(2), async {
             while !started_path.exists() {

--- a/src/crates/adapters/opencode-adapter/tests/opencode_mcp_adapter.rs
+++ b/src/crates/adapters/opencode-adapter/tests/opencode_mcp_adapter.rs
@@ -13,6 +13,20 @@ use std::path::PathBuf;
 use std::process::Command;
 use tempfile::TempDir;
 
+fn create_test_command(program: impl AsRef<std::ffi::OsStr>) -> Command {
+    let command = Command::new(program);
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+
+        let mut command = command;
+        command.creation_flags(0x0800_0000);
+        command
+    }
+    #[cfg(not(windows))]
+    command
+}
+
 fn context(workspace_root: PathBuf) -> ExternalSourceContext {
     ExternalSourceContext {
         workspace_root: Some(workspace_root),
@@ -67,7 +81,7 @@ fn opencode_config_dir_keeps_xdg_user_config_when_read_from_environment() {
     let temp = TempDir::new().unwrap();
     let xdg = temp.path().join("xdg");
     let explicit = temp.path().join("explicit");
-    let output = Command::new(std::env::current_exe().expect("current test executable"))
+    let output = create_test_command(std::env::current_exe().expect("current test executable"))
         .arg("--exact")
         .arg("opencode_config_dir_keeps_xdg_user_config_when_read_from_environment")
         .arg("--nocapture")

--- a/src/crates/assembly/core/builtin_skills/writing-skills/render-graphs.js
+++ b/src/crates/assembly/core/builtin_skills/writing-skills/render-graphs.js
@@ -72,7 +72,8 @@ function renderToSvg(dotContent) {
     return execSync('dot -Tsvg', {
       input: dotContent,
       encoding: 'utf-8',
-      maxBuffer: 10 * 1024 * 1024
+      maxBuffer: 10 * 1024 * 1024,
+      windowsHide: true
     });
   } catch (err) {
     console.error('Error running dot:', err.message);

--- a/src/crates/assembly/core/src/agentic/tools/implementations/get_file_diff_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/get_file_diff_tool.rs
@@ -1836,7 +1836,7 @@ Usage:
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{process::Command, sync::Mutex};
+    use std::sync::Mutex;
 
     #[derive(Default)]
     struct RecordingProviderDiffService {
@@ -1870,7 +1870,7 @@ mod tests {
     }
 
     fn git(root: &Path, args: &[&str]) {
-        let output = Command::new("git")
+        let output = crate::util::create_test_command("git")
             .current_dir(root)
             .args(args)
             .output()
@@ -1884,7 +1884,7 @@ mod tests {
     }
 
     fn git_stdout(root: &Path, args: &[&str]) -> String {
-        let output = Command::new("git")
+        let output = crate::util::create_test_command("git")
             .current_dir(root)
             .args(args)
             .output()

--- a/src/crates/assembly/core/src/agentic/tools/implementations/git_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/git_tool.rs
@@ -1487,10 +1487,10 @@ mod tests {
 
     use super::{git_operation_needs_light_checkpoint, CheckoutPlan, GitTool, ParsedDiffArgs};
     use serde_json::json;
-    use std::{fs, path::Path, process::Command};
+    use std::{fs, path::Path};
 
     fn git(root: &Path, args: &[&str], commit_date: Option<&str>) {
-        let mut command = Command::new("git");
+        let mut command = crate::util::create_test_command("git");
         command.current_dir(root).args(args);
         if let Some(commit_date) = commit_date {
             command

--- a/src/crates/assembly/core/src/function_agents/port_adapters.rs
+++ b/src/crates/assembly/core/src/function_agents/port_adapters.rs
@@ -142,7 +142,6 @@ mod tests {
     use bitfun_product_domains::function_agents::ports::FunctionAgentGitPort;
     use std::fs;
     use std::path::{Path, PathBuf};
-    use std::process::Command;
     use std::sync::Arc;
 
     use crate::function_agents::common::AgentErrorType;
@@ -301,7 +300,7 @@ mod tests {
     }
 
     fn git(repo: &std::path::Path, args: &[&str]) {
-        let output = Command::new("git")
+        let output = crate::util::create_test_command("git")
             .args(args)
             .current_dir(repo)
             .output()

--- a/src/crates/assembly/core/src/service/dispatch/baseline.rs
+++ b/src/crates/assembly/core/src/service/dispatch/baseline.rs
@@ -564,7 +564,7 @@ mod tests {
     use super::*;
 
     fn git(path: &Path, args: &[&str]) -> String {
-        let output = std::process::Command::new("git")
+        let output = crate::util::create_test_command("git")
             .arg("-C")
             .arg(path)
             .args(args)

--- a/src/crates/assembly/core/src/service/dispatch/controller.rs
+++ b/src/crates/assembly/core/src/service/dispatch/controller.rs
@@ -1867,7 +1867,7 @@ mod tests {
         let temp = tempfile::tempdir().expect("tempdir");
         let repository = temp.path().join("baseline");
         std::fs::create_dir_all(&repository).expect("repository");
-        let init = std::process::Command::new("git")
+        let init = crate::util::create_test_command("git")
             .arg("-C")
             .arg(&repository)
             .args(["init", "--quiet", "--initial-branch=main"])

--- a/src/crates/assembly/core/src/service/workspace/worktree_topology.rs
+++ b/src/crates/assembly/core/src/service/workspace/worktree_topology.rs
@@ -254,10 +254,9 @@ fn hash_metadata_path(path: &Path, hasher: &mut DefaultHasher, remaining_depth: 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::process::Command;
 
     fn git(root: &Path, args: &[&str]) {
-        let output = Command::new("git")
+        let output = crate::util::create_test_command("git")
             .current_dir(root)
             .args(args)
             .output()

--- a/src/crates/assembly/core/src/util/mod.rs
+++ b/src/crates/assembly/core/src/util/mod.rs
@@ -36,6 +36,21 @@ pub fn truncate_at_char_boundary(s: &str, max_bytes: usize) -> &str {
 }
 
 #[cfg(test)]
+pub(crate) fn create_test_command(program: impl AsRef<std::ffi::OsStr>) -> std::process::Command {
+    let command = std::process::Command::new(program);
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+
+        let mut command = command;
+        command.creation_flags(0x0800_0000);
+        command
+    }
+    #[cfg(not(windows))]
+    command
+}
+
+#[cfg(test)]
 mod tests {
     use super::truncate_at_char_boundary;
 

--- a/src/crates/services/services-core/src/process_tree.rs
+++ b/src/crates/services/services-core/src/process_tree.rs
@@ -492,7 +492,7 @@ mod tests {
 
     #[cfg(windows)]
     fn process_is_alive(pid: u32) -> bool {
-        std::process::Command::new("powershell.exe")
+        crate::process_manager::create_command("powershell.exe")
             .arg("-NoProfile")
             .arg("-NonInteractive")
             .arg("-Command")

--- a/src/crates/services/services-core/src/session/metadata_store.rs
+++ b/src/crates/services/services-core/src/session/metadata_store.rs
@@ -553,7 +553,13 @@ mod tests {
         let dir = tempdir().expect("tempdir");
         let ready_path = dir.path().join("child-ready");
         let release_path = dir.path().join("child-release");
-        let mut child = Command::new(std::env::current_exe().expect("test executable"))
+        let mut command = Command::new(std::env::current_exe().expect("test executable"));
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            command.creation_flags(0x0800_0000);
+        }
+        let mut child = command
             .arg("--exact")
             .arg("session::metadata_store::tests::index_lock_child_holds_the_cross_process_guard")
             .arg("--nocapture")

--- a/src/crates/services/services-core/tests/session_write_lock_contracts.rs
+++ b/src/crates/services/services-core/tests/session_write_lock_contracts.rs
@@ -140,7 +140,13 @@ fn abnormal_process_exit_releases_the_writer() {
     let project_root = tempdir().expect("project runtime root");
     let storage_root = project_root.path().join("sessions");
     let ready_path = project_root.path().join("child-ready");
-    let mut child = Command::new(std::env::current_exe().expect("current test executable"))
+    let mut command = Command::new(std::env::current_exe().expect("current test executable"));
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        command.creation_flags(0x0800_0000);
+    }
+    let mut child = command
         .arg("--exact")
         .arg("abnormal_exit_child_holds_writer")
         .arg("--nocapture")

--- a/src/crates/services/services-integrations/src/git/managed_worktree.rs
+++ b/src/crates/services/services-integrations/src/git/managed_worktree.rs
@@ -478,11 +478,10 @@ mod tests {
     use super::GitService;
     use std::fs;
     use std::path::Path;
-    use std::process::Command;
     use tempfile::TempDir;
 
     fn git(path: &Path, args: &[&str]) -> String {
-        let output = Command::new("git")
+        let output = bitfun_services_core::process_manager::create_command("git")
             .current_dir(path)
             .env("GIT_TERMINAL_PROMPT", "0")
             .args(args)

--- a/src/crates/services/services-integrations/src/git/service.rs
+++ b/src/crates/services/services-integrations/src/git/service.rs
@@ -1531,10 +1531,10 @@ fn ensure_worktree_directory_excluded(common_git_dir: &Path) -> Result<(), GitEr
 #[cfg(test)]
 mod review_path_tests {
     use super::{review_path_has_parent_traversal, GitLogParams, GitService};
-    use std::{fs, path::Path, process::Command};
+    use std::{fs, path::Path};
 
     fn git(root: &Path, args: &[&str], commit_date: Option<&str>) {
-        let mut command = Command::new("git");
+        let mut command = bitfun_services_core::process_manager::create_command("git");
         command.current_dir(root).args(args);
         if let Some(commit_date) = commit_date {
             command

--- a/src/crates/services/services-integrations/src/hook_import.rs
+++ b/src/crates/services/services-integrations/src/hook_import.rs
@@ -558,14 +558,14 @@ async fn publish_bundle(
         && validate_bundle_content(root, final_path, content_digest)
             .await
             .is_ok()
-        {
-            return Ok(BundlePublication {
-                root: root.to_path_buf(),
-                final_path: final_path.to_path_buf(),
-                retired_path: None,
-                changed: false,
-            });
-        }
+    {
+        return Ok(BundlePublication {
+            root: root.to_path_buf(),
+            final_path: final_path.to_path_buf(),
+            retired_path: None,
+            changed: false,
+        });
+    }
     let staging = root
         .join(".staging")
         .join(format!("import-{}", uuid::Uuid::new_v4()));
@@ -1489,14 +1489,19 @@ mod tests {
         #[cfg(unix)]
         std::os::unix::fs::symlink(&outside, root.join("bundles")).unwrap();
         #[cfg(windows)]
-        assert!(std::process::Command::new("cmd")
-            .args(["/c", "mklink", "/J"])
-            .arg(root.join("bundles"))
-            .arg(&outside)
-            .output()
-            .expect("create junction")
-            .status
-            .success());
+        {
+            use std::os::windows::process::CommandExt;
+
+            assert!(std::process::Command::new("cmd")
+                .args(["/c", "mklink", "/J"])
+                .arg(root.join("bundles"))
+                .arg(&outside)
+                .creation_flags(0x0800_0000)
+                .output()
+                .expect("create junction")
+                .status
+                .success());
+        }
         let store = HookImportStore::open(root, ExternalSourceScope::UserGlobal)
             .await
             .unwrap();

--- a/src/crates/services/services-integrations/src/mcp/server/connection.rs
+++ b/src/crates/services/services-integrations/src/mcp/server/connection.rs
@@ -659,16 +659,18 @@ mod tests {
 
     #[tokio::test]
     async fn local_catalog_and_execution_timeouts_remove_pending_requests() {
-        let mut child = tokio::process::Command::new(std::env::current_exe().unwrap())
-            .arg("--exact")
-            .arg("mcp::server::connection::tests::mcp_connection_timeout_child")
-            .arg("--nocapture")
-            .env("BITFUN_MCP_CONNECTION_TIMEOUT_CHILD", "1")
-            .stdin(std::process::Stdio::piped())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .spawn()
-            .expect("spawn silent test child");
+        let mut child = bitfun_services_core::process_manager::create_tokio_command(
+            std::env::current_exe().unwrap(),
+        )
+        .arg("--exact")
+        .arg("mcp::server::connection::tests::mcp_connection_timeout_child")
+        .arg("--nocapture")
+        .env("BITFUN_MCP_CONNECTION_TIMEOUT_CHILD", "1")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("spawn silent test child");
         let stdin = child.stdin.take().expect("capture child stdin");
         let (_tx, rx) = mpsc::unbounded_channel();
         let connection = MCPConnection::new_local_with_timeouts(

--- a/src/crates/services/services-integrations/tests/function_agent_contracts.rs
+++ b/src/crates/services/services-integrations/tests/function_agent_contracts.rs
@@ -2,7 +2,6 @@
 
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use bitfun_services_integrations::function_agents::FunctionAgentGitService;
@@ -74,7 +73,7 @@ fn git(repo: &Path, args: &[&str]) {
 }
 
 fn git_with_env(repo: &Path, args: &[&str], envs: &[(&str, &str)]) {
-    let mut command = Command::new("git");
+    let mut command = bitfun_services_core::process_manager::create_command("git");
     command.args(args).current_dir(repo);
     for (key, value) in envs {
         command.env(key, value);

--- a/src/crates/services/services-integrations/tests/git_contracts.rs
+++ b/src/crates/services/services-integrations/tests/git_contracts.rs
@@ -8,7 +8,6 @@ use bitfun_services_integrations::git::{
     GitService, GitStatus, GitWorkspaceDiffPort, GitWorktreeInfo, GraphNode, GraphRef,
 };
 use std::fs;
-use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 #[test]
@@ -737,7 +736,7 @@ impl Drop for TempRepoDir {
 }
 
 fn run_git(repo_dir: &std::path::Path, args: &[&str]) {
-    let output = Command::new("git")
+    let output = bitfun_services_core::process_manager::create_command("git")
         .current_dir(repo_dir)
         .args(args)
         .output()
@@ -752,7 +751,7 @@ fn run_git(repo_dir: &std::path::Path, args: &[&str]) {
 }
 
 fn run_git_expect_failure(repo_dir: &std::path::Path, args: &[&str]) {
-    let output = Command::new("git")
+    let output = bitfun_services_core::process_manager::create_command("git")
         .current_dir(repo_dir)
         .args(args)
         .output()

--- a/src/crates/services/services-integrations/tests/workspace_search_contracts.rs
+++ b/src/crates/services/services-integrations/tests/workspace_search_contracts.rs
@@ -1,7 +1,6 @@
 #![cfg(feature = "workspace-search")]
 
 use std::path::Path;
-use std::process::Command;
 use std::time::{Duration, Instant};
 
 use bitfun_services_integrations::workspace_search::{
@@ -127,7 +126,7 @@ async fn content_search_hydrates_real_line_text_and_previews() {
 
 #[cfg(test)]
 fn git(repo_root: &Path, args: &[&str]) {
-    let output = Command::new("git")
+    let output = bitfun_services_core::process_manager::create_command("git")
         .current_dir(repo_root)
         .args(args)
         .output()


### PR DESCRIPTION
Route non-interactive CLI, dispatch, service, adapter, and test
processes through the shared process factories so Windows release and
headless hosts do not flash console windows.

Apply explicit CREATE_NO_WINDOW where lower-level test helpers cannot
depend on process-runtime, and set windowsHide for the built-in Graphviz
renderer. Document the repository-wide rule for future call sites.
