### PR TITLE
fix(harmonyos): preserve repeated chat messages

### DIFF
--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/viewmodel/GeneralChatConversationViewModel.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/viewmodel/GeneralChatConversationViewModel.ets
@@ -295,7 +295,7 @@ export class GeneralChatConversationViewModel {
 
   private localUserMessage(text: string, images: SelectedImageAttachment[]): ChatMessage {
     return {
-      id: Encoding.randomId('user'),
+      id: Encoding.randomId('optimistic-user'),
       turnId: '',
       role: 'user',
       text,

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/services/ChatTimelineProjector.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/services/ChatTimelineProjector.ets
@@ -1,4 +1,4 @@
-import { ChatMessage, ChatMessageItemResponse, ImageAttachment, RemoteToolStatusResponse } from '../model/RemoteModels';
+import { ChatMessage, ChatMessageItemResponse, RemoteToolStatusResponse } from '../model/RemoteModels';
 
 export type ChatTimelineItemType =
   | 'user_message'
@@ -171,7 +171,7 @@ export class ChatTimelineProjector {
   static pendingMessagesNotPersisted(pendingMessages: ChatMessage[], messages: ChatMessage[]): ChatMessage[] {
     return pendingMessages.filter((pending: ChatMessage) => {
       return !messages.some((message: ChatMessage) => {
-        return ChatTimelineProjector.isPersistedUserDuplicate(pending, message);
+        return pending.role === 'user' && message.role === 'user' && pending.id === message.id;
       });
     });
   }
@@ -212,9 +212,8 @@ export class ChatTimelineProjector {
     if (activeTurn.turnId && activeTurn.turnId.length > 0 && message.id === `${activeTurn.turnId}_assistant`) {
       return true;
     }
-    const activeText = (activeTurn.text || '').trim();
-    const messageText = (message.text || '').trim();
-    return activeText.length > 0 && activeText === messageText;
+    return activeTurn.turnId !== undefined && activeTurn.turnId.length > 0 &&
+      message.turnId !== undefined && message.turnId === activeTurn.turnId;
   }
 
   private static hasDisplayableAssistantFinal(message: ChatMessage): boolean {
@@ -289,27 +288,6 @@ export class ChatTimelineProjector {
       ].join(':'));
     });
     return parts.join(',');
-  }
-
-  private static isPersistedUserDuplicate(pending: ChatMessage, message: ChatMessage): boolean {
-    if (pending.role !== 'user' || message.role !== 'user') {
-      return false;
-    }
-    if (pending.id === message.id) {
-      return true;
-    }
-    const pendingText = (pending.text || '').trim();
-    const messageText = (message.text || '').trim();
-    if (pendingText.length === 0 || pendingText !== messageText) {
-      return false;
-    }
-    return ChatTimelineProjector.imageSignature(pending.images || []) === ChatTimelineProjector.imageSignature(message.images || []);
-  }
-
-  private static imageSignature(images: ImageAttachment[]): string {
-    return images.map((image: ImageAttachment) => {
-      return `${image.name || ''}:${image.data_url || ''}`;
-    }).sort().join('|');
   }
 
   private static stableTextHash(text: string): string {

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/services/ChatTimelineStore.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/services/ChatTimelineStore.ets
@@ -127,11 +127,19 @@ export class ChatTimelineStore {
 
   setPersistedMessages(messages: ChatMessage[]): void {
     const persistedMessages = ChatTimelineStore.realMessages(messages);
+    const previousIds = new Set<string>();
+    this.state.persistedMessages.forEach((message: ChatMessage) => previousIds.add(message.id));
+    const newlyPersistedMessages = persistedMessages.filter((message: ChatMessage) => !previousIds.has(message.id));
+    const activeTurnCovered = this.coveredByPersistedMessage(this.state.activeTurn, persistedMessages) ||
+      this.coveredByNewAssistantContent(this.state.activeTurn, newlyPersistedMessages);
     this.state = {
       sessionId: this.state.sessionId,
       persistedMessages,
-      optimisticMessages: ChatTimelineStore.optimisticMessagesNotPersisted(this.state.optimisticMessages, persistedMessages),
-      activeTurn: this.coveredByPersistedMessage(this.state.activeTurn, persistedMessages) ? undefined : this.state.activeTurn,
+      optimisticMessages: ChatTimelineStore.optimisticMessagesNotPersisted(
+        this.state.optimisticMessages,
+        newlyPersistedMessages
+      ),
+      activeTurn: activeTurnCovered ? undefined : this.state.activeTurn,
       syncPhase: this.state.syncPhase,
       cursor: this.state.cursor,
       modelCatalog: this.state.modelCatalog,
@@ -140,12 +148,23 @@ export class ChatTimelineStore {
   }
 
   mergePersistedMessages(messages: ChatMessage[]): void {
-    const persistedMessages = RemoteUiState.mergeMessages(this.state.persistedMessages, ChatTimelineStore.realMessages(messages));
+    const incomingMessages = ChatTimelineStore.realMessages(messages);
+    const previousIds = new Set<string>();
+    this.state.persistedMessages.forEach((message: ChatMessage) => previousIds.add(message.id));
+    // Only this delivery can acknowledge an optimistic message. Replayed
+    // history with the same text must not consume a message the user just sent.
+    const newlyPersistedMessages = incomingMessages.filter((message: ChatMessage) => !previousIds.has(message.id));
+    const persistedMessages = RemoteUiState.mergeMessages(this.state.persistedMessages, incomingMessages);
+    const activeTurnCovered = this.coveredByPersistedMessage(this.state.activeTurn, persistedMessages) ||
+      this.coveredByNewAssistantContent(this.state.activeTurn, newlyPersistedMessages);
     this.state = {
       sessionId: this.state.sessionId,
       persistedMessages,
-      optimisticMessages: ChatTimelineStore.optimisticMessagesNotPersisted(this.state.optimisticMessages, persistedMessages),
-      activeTurn: this.coveredByPersistedMessage(this.state.activeTurn, persistedMessages) ? undefined : this.state.activeTurn,
+      optimisticMessages: ChatTimelineStore.optimisticMessagesNotPersisted(
+        this.state.optimisticMessages,
+        newlyPersistedMessages
+      ),
+      activeTurn: activeTurnCovered ? undefined : this.state.activeTurn,
       syncPhase: this.state.syncPhase,
       cursor: this.state.cursor,
       modelCatalog: this.state.modelCatalog,
@@ -490,10 +509,19 @@ export class ChatTimelineStore {
   }
 
   static optimisticMessagesNotPersisted(optimisticMessages: ChatMessage[], persistedMessages: ChatMessage[]): ChatMessage[] {
+    // Consume acknowledgements one-to-one so two identical queued sends do not
+    // both disappear when the first persisted message arrives.
+    const acknowledgedPersistedIndexes = new Set<number>();
     return optimisticMessages.filter((pending: ChatMessage) => {
-      return !persistedMessages.some((message: ChatMessage) => {
-        return ChatTimelineStore.isPersistedUserDuplicate(pending, message);
+      const acknowledgedIndex = persistedMessages.findIndex((message: ChatMessage, index: number) => {
+        return !acknowledgedPersistedIndexes.has(index) &&
+          ChatTimelineStore.isPersistedUserDuplicate(pending, message);
       });
+      if (acknowledgedIndex < 0) {
+        return true;
+      }
+      acknowledgedPersistedIndexes.add(acknowledgedIndex);
+      return false;
     });
   }
 
@@ -511,6 +539,20 @@ export class ChatTimelineStore {
       return false;
     }
     return ChatTimelineStore.isActiveTurnCoveredByMessages(activeTurn, messages);
+  }
+
+  private coveredByNewAssistantContent(activeTurn: ChatMessage | undefined, messages: ChatMessage[]): boolean {
+    if (!activeTurn || activeTurn.id.length === 0) {
+      return false;
+    }
+    const activeText = (activeTurn.text || '').trim();
+    if (activeText.length === 0) {
+      return false;
+    }
+    return messages.some((message: ChatMessage) => {
+      return message.role === 'assistant' && ChatTimelineStore.hasDisplayableAssistantFinal(message) &&
+        (message.text || '').trim() === activeText;
+    });
   }
 
   private activeTurnForState(activeTurn: ChatMessage | undefined): ChatMessage | undefined {
@@ -765,9 +807,8 @@ export class ChatTimelineStore {
     if (activeTurn.turnId && activeTurn.turnId.length > 0 && message.id === `${activeTurn.turnId}_assistant`) {
       return true;
     }
-    const activeText = (activeTurn.text || '').trim();
-    const messageText = (message.text || '').trim();
-    return activeText.length > 0 && activeText === messageText;
+    return activeTurn.turnId !== undefined && activeTurn.turnId.length > 0 &&
+      message.turnId !== undefined && message.turnId === activeTurn.turnId;
   }
 
   private static shouldHoldCompletedTurn(activeTurn: ChatMessage): boolean {

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/services/RemoteUiState.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/services/RemoteUiState.ets
@@ -66,14 +66,7 @@ export class RemoteUiState {
       if (existingIndex >= 0) {
         merged[existingIndex] = RemoteUiState.mergeMessageSnapshot(merged[existingIndex], item);
       } else {
-        const optimisticIndex = merged.findIndex((existing: ChatMessage) => {
-          return RemoteUiState.isOptimisticDuplicate(existing, item);
-        });
-        if (optimisticIndex >= 0) {
-          merged[optimisticIndex] = item;
-        } else {
-          merged.push(item);
-        }
+        merged.push(item);
       }
     });
     return merged;
@@ -81,14 +74,17 @@ export class RemoteUiState {
 
   static mergeRemoteWithLocalOptimistic(remoteMessages: ChatMessage[], currentMessages: ChatMessage[]): ChatMessage[] {
     const merged = remoteMessages.slice();
+    const acknowledgedRemoteIndexes = new Set<number>();
     currentMessages.forEach((item: ChatMessage) => {
       if (!RemoteUiState.isLocalOptimisticMessage(item)) {
         return;
       }
-      const alreadySynced = merged.some((remote: ChatMessage) => {
-        return RemoteUiState.isOptimisticDuplicate(item, remote);
+      const acknowledgedIndex = merged.findIndex((remote: ChatMessage, index: number) => {
+        return !acknowledgedRemoteIndexes.has(index) && RemoteUiState.isOptimisticDuplicate(item, remote);
       });
-      if (!alreadySynced) {
+      if (acknowledgedIndex >= 0) {
+        acknowledgedRemoteIndexes.add(acknowledgedIndex);
+      } else {
         merged.push(item);
       }
     });
@@ -158,10 +154,11 @@ export class RemoteUiState {
 
   static localUserMessage(text: string, images?: ImageAttachment[]): ChatMessage {
     return {
-      id: `msg-${Date.now()}`,
+      id: `optimistic-user-${Date.now()}`,
       role: 'user',
       text,
       status: 'sent',
+      timestamp: new Date().toISOString(),
       images: images || []
     };
   }
@@ -210,14 +207,21 @@ export class RemoteUiState {
   }
 
   private static isLocalOptimisticMessage(item: ChatMessage): boolean {
-    return item.role === 'user' && item.id.indexOf('msg-') === 0;
+    return item.role === 'user' && item.id.indexOf('optimistic-user-') === 0;
   }
 
   private static isOptimisticDuplicate(local: ChatMessage, remote: ChatMessage): boolean {
     return RemoteUiState.isLocalOptimisticMessage(local) &&
       local.role === remote.role &&
       local.text.trim() === remote.text.trim() &&
-      local.text.trim().length > 0;
+      local.text.trim().length > 0 &&
+      RemoteUiState.imageSignature(local.images || []) === RemoteUiState.imageSignature(remote.images || []);
+  }
+
+  private static imageSignature(images: ImageAttachment[]): string {
+    return images.map((image: ImageAttachment) => {
+      return `${image.name || ''}:${image.data_url || ''}`;
+    }).sort().join('|');
   }
 
   private static mergeMessageSnapshot(previous: ChatMessage, incoming: ChatMessage): ChatMessage {

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/services/general-chat/GeneralChatRepository.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/services/general-chat/GeneralChatRepository.ets
@@ -265,13 +265,23 @@ export class GeneralChatRepository {
 
   async removeFailedUserMessage(sessionId: string, text: string): Promise<void> {
     const normalizedText = text.trim();
-    const messages = (await this.messages(sessionId)).filter((message: ChatMessage) => {
-      return !(message.role === 'user' && message.status === 'failed' &&
-        message.text.trim() === normalizedText);
-    });
-    this.messagesBySession.set(sessionId, messages);
-    await this.localStore.replaceMessages(sessionId, messages);
-    await this.bumpSession(sessionId, messages.length);
+    const messages = await this.messages(sessionId);
+    let removeIndex = -1;
+    for (let index = messages.length - 1; index >= 0; index--) {
+      const message = messages[index];
+      if (message.role === 'user' && message.status === 'failed' &&
+        message.text.trim() === normalizedText) {
+        removeIndex = index;
+        break;
+      }
+    }
+    if (removeIndex < 0) {
+      return;
+    }
+    const remaining = messages.slice(0, removeIndex).concat(messages.slice(removeIndex + 1));
+    this.messagesBySession.set(sessionId, remaining);
+    await this.localStore.replaceMessages(sessionId, remaining);
+    await this.bumpSession(sessionId, remaining.length);
   }
 
   private async replaceMessage(sessionId: string, message: ChatMessage): Promise<void> {

--- a/src/apps/mobile/harmonyos/entry/src/test/ConversationStateUnit.test.ets
+++ b/src/apps/mobile/harmonyos/entry/src/test/ConversationStateUnit.test.ets
@@ -179,16 +179,28 @@ export default function conversationStateUnitTest() {
       expect(items[0].type).assertEqual('empty_state');
     });
 
-    it('deduplicates optimistic user messages replaced by persisted messages', 0, () => {
+    it('deduplicates optimistic user messages confirmed with the same id', 0, () => {
       const items = ChatTimelineProjector.project([
-        chatMessage('remote-user-1', 'user', 'Explain this file')
+        chatMessage('message-user-1', 'user', 'Explain this file')
       ], [
-        chatMessage('msg-local-1', 'user', ' Explain this file ')
+        chatMessage('message-user-1', 'user', ' Explain this file ')
       ], chatMessage('', 'assistant', ''), false);
 
       expect(items.length).assertEqual(1);
-      expect(items[0].id).assertEqual('message-remote-user-1');
+      expect(items[0].id).assertEqual('message-message-user-1');
       expect(items[0].type).assertEqual('user_message');
+    });
+
+    it('keeps repeated user text when optimistic and historical ids differ', 0, () => {
+      const items = ChatTimelineProjector.project([
+        chatMessage('historical-user-1', 'user', '你是谁')
+      ], [
+        chatMessage('optimistic-user-2', 'user', '你是谁')
+      ], chatMessage('', 'assistant', ''), false);
+
+      expect(items.length).assertEqual(2);
+      expect(items[0].id).assertEqual('message-historical-user-1');
+      expect(items[1].id).assertEqual('pending-optimistic-user-2');
     });
 
     it('keeps optimistic image messages when persisted image payload differs', 0, () => {
@@ -205,20 +217,20 @@ export default function conversationStateUnitTest() {
     });
 
     it('keeps active turn until matching assistant message is persisted', 0, () => {
-      const activeTurn = chatMessage('active-turn-1', 'assistant', 'Done with the edit', 'completed');
+      const activeTurn = activeChatMessage('turn-1', 'Done with the edit', 'completed');
       const beforeFinal = ChatTimelineProjector.project([
         chatMessage('remote-user-1', 'user', 'Please edit')
       ], [], activeTurn, false);
       const afterFinal = ChatTimelineProjector.project([
         chatMessage('remote-user-1', 'user', 'Please edit'),
-        chatMessage('assistant-final-1', 'assistant', 'Done with the edit')
+        chatMessage('turn-1_assistant', 'assistant', 'Done with the edit')
       ], [], activeTurn, false);
 
       expect(beforeFinal.length).assertEqual(2);
       expect(beforeFinal[1].type).assertEqual('assistant_live_turn');
       expect(beforeFinal[1].isFinalizing).assertEqual(true);
       expect(afterFinal.length).assertEqual(2);
-      expect(afterFinal[1].id).assertEqual('message-assistant-final-1');
+      expect(afterFinal[1].id).assertEqual('message-turn-1_assistant');
       expect(afterFinal[1].type).assertEqual('assistant_message');
     });
 
@@ -278,6 +290,103 @@ export default function conversationStateUnitTest() {
   });
 
   describe('ChatTimelineStore', () => {
+    it('keeps persisted messages with different ids even when their text matches', 0, () => {
+      const merged = RemoteUiState.mergeMessages([
+        chatMessage('msg-historical-1', 'user', '你是谁')
+      ], [
+        chatMessage('msg-current-2', 'user', '你是谁')
+      ]);
+
+      expect(merged.length).assertEqual(2);
+      expect(merged[0].id).assertEqual('msg-historical-1');
+      expect(merged[1].id).assertEqual('msg-current-2');
+    });
+
+    it('appends a repeated user message and reconciles only its new acknowledgement', 0, () => {
+      const store = new ChatTimelineStore();
+      store.reset('session-repeat');
+      store.setPersistedMessages([
+        chatMessage('msg-historical-user', 'user', '你是谁'),
+        chatMessage('assistant-historical', 'assistant', '旧回复')
+      ]);
+      store.appendOptimisticMessage(chatMessage('optimistic-user-current', 'user', '你是谁'));
+
+      let items = store.project(false);
+      expect(items.length).assertEqual(3);
+      expect(items[2].id).assertEqual('pending-optimistic-user-current');
+
+      store.mergePersistedMessages([
+        chatMessage('msg-current-user', 'user', '你是谁')
+      ]);
+      const state = store.snapshot();
+      items = store.project(false);
+      expect(state.persistedMessages.length).assertEqual(3);
+      expect(state.optimisticMessages.length).assertEqual(0);
+      expect(items.length).assertEqual(3);
+      expect(items[0].id).assertEqual('message-msg-historical-user');
+      expect(items[2].id).assertEqual('message-msg-current-user');
+    });
+
+    it('reconciles identical queued user messages one acknowledgement at a time', 0, () => {
+      const remaining = ChatTimelineStore.optimisticMessagesNotPersisted([
+        chatMessage('optimistic-user-1', 'user', '继续'),
+        chatMessage('optimistic-user-2', 'user', '继续')
+      ], [
+        chatMessage('persisted-user-1', 'user', '继续')
+      ]);
+
+      expect(remaining.length).assertEqual(1);
+      expect(remaining[0].id).assertEqual('optimistic-user-2');
+    });
+
+    it('keeps one identical local message when one remote acknowledgement arrives', 0, () => {
+      const merged = RemoteUiState.mergeRemoteWithLocalOptimistic([
+        chatMessage('persisted-user-1', 'user', '继续')
+      ], [
+        chatMessage('optimistic-user-1', 'user', '继续'),
+        chatMessage('optimistic-user-2', 'user', '继续')
+      ]);
+
+      expect(merged.length).assertEqual(2);
+      expect(merged[0].id).assertEqual('persisted-user-1');
+      expect(merged[1].id).assertEqual('optimistic-user-2');
+    });
+
+    it('does not reconcile identical remote text when image payloads differ', 0, () => {
+      const merged = RemoteUiState.mergeRemoteWithLocalOptimistic([
+        chatMessageWithImage(
+          'persisted-user-image', 'user', '分析图片', 'remote.png', 'data:image/png;base64,remote'
+        )
+      ], [
+        chatMessageWithImage(
+          'optimistic-user-image', 'user', '分析图片', 'local.png', 'data:image/png;base64,local'
+        )
+      ]);
+
+      expect(merged.length).assertEqual(2);
+      expect(merged[1].id).assertEqual('optimistic-user-image');
+    });
+
+    it('does not hide an active reply that matches historical assistant text', 0, () => {
+      const store = new ChatTimelineStore();
+      store.reset('session-repeat-assistant');
+      store.setPersistedMessages([
+        chatMessage('assistant-historical', 'assistant', '相同回复')
+      ]);
+      store.setActiveTurn(activeChatMessage('turn-current', '相同回复'));
+
+      let state = store.snapshot();
+      expect(state.activeTurn ? state.activeTurn.id : '').assertEqual('active-turn-current');
+      expect(store.project(false).length).assertEqual(2);
+
+      store.mergePersistedMessages([
+        chatMessage('assistant-current', 'assistant', '相同回复')
+      ]);
+      state = store.snapshot();
+      expect(state.persistedMessages.length).assertEqual(2);
+      expect(state.activeTurn ? state.activeTurn.id : '').assertEqual('');
+    });
+
     it('updates same-id persisted messages when final content arrives later', 0, () => {
       const pendingFinal = chatMessage('assistant-final-same-id', 'assistant', '');
       pendingFinal.text = 'Still reasoning';

--- a/src/apps/mobile/harmonyos/entry/src/test/TransportAndGeneralChatUnit.test.ets
+++ b/src/apps/mobile/harmonyos/entry/src/test/TransportAndGeneralChatUnit.test.ets
@@ -724,6 +724,29 @@ export default function transportAndGeneralChatUnitTest() {
       expect(messages[0].status).assertEqual('sent');
     });
 
+    it('removes only the latest matching failed user message for retry', 0, async () => {
+      const localStore = new FakeGeneralChatLocalStore();
+      const session = remoteSession('chat-retry-repeat', '重复失败');
+      session.agentType = 'chat';
+      const first = chatMessage('failed-user-1', 'user', '再试一次', 'failed');
+      const second = chatMessage('failed-user-2', 'user', '再试一次', 'failed');
+      localStore.sessions = [session];
+      localStore.messagesBySession.set(session.id, [
+        first,
+        chatMessage('assistant-between', 'assistant', '中间回复'),
+        second
+      ]);
+      const repository = new GeneralChatRepository(new MockGeneralChatAdapter(), localStore);
+      await repository.restoreFromLocal();
+
+      await repository.removeFailedUserMessage(session.id, '再试一次');
+
+      const messages = await repository.messages(session.id);
+      expect(messages.length).assertEqual(2);
+      expect(messages[0].id).assertEqual('failed-user-1');
+      expect(messages[1].id).assertEqual('assistant-between');
+    });
+
     it('does not persist assistant retry detail after an interrupted turn', 0, async () => {
       const localStore = new FakeGeneralChatLocalStore();
       const repository = new GeneralChatRepository(new MockGeneralChatAdapter(), localStore);


### PR DESCRIPTION
## Summary

- preserve repeated user messages instead of merging them with historical messages by text
- reconcile optimistic user messages one-to-one and include image identity
- keep identical assistant replies distinct unless stable message or turn identity matches
- remove only the latest matching failed message when preparing a retry
- add regression coverage for ordinary and remote chat timelines

## Testing

- pnpm run harmony:architecture
- HarmonyOS LocalTest through hvigor
- signed HAP build
- installed and launched on HarmonyOS device 5ZU0226202001116

AI-assisted change; fully tested at the unit/build level. Real-device install and launch verified; repeated Remote send was not exercised end to end.