### PR TITLE
feat(sdk): resume durable agent sessions

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -9,8 +9,9 @@ The slice validates the intended public object model:
 - one application-level `AgentClient` owns one managed native
   `bitfun-sdk-host` process and one Host connection;
 - `client.query()` uses a Host-managed transient Session;
-- `client.sessions.create()` creates an explicit Session whose Turns reuse the
-  same connection and existing Agent Runtime owner;
+- `client.sessions.create()` creates a durable Session whose Turns reuse the
+  same connection, while `client.sessions.resume(id)` attaches it to a later
+  Host process;
 - `Query` is an ordered async stream with idempotent cancellation, cached final
   `Result`, and explicit close semantics;
 - the same stream reports safe Tool lifecycle facts and permission requests;
@@ -21,6 +22,12 @@ Lifecycle cleanup is bounded. The Windows Host contains descendants in a
 kill-on-close Job Object, while Unix managed Hosts run in an isolated process
 group. A cleanup result whose outcome is unknown makes the connection
 unusable and triggers Host reclamation.
+
+Durable Sessions are persisted by the existing Agent Runtime. Closing a
+Session or its client unloads it without deleting its history, so a later
+client using the same workspace can resume it by ID. Existing OS-level Session
+locks reject a second writer while another Host process owns that same Session;
+different Sessions remain independent.
 
 It does not start the CLI or the Node/Bun Plugin Host, and it does not implement
 another Agent Runtime. The managed native Host adapts this package to the
@@ -75,6 +82,23 @@ for await (const item of query) {
 const result = await query.result();
 ```
 
+Use an explicit Session when the application needs continuity across client or
+Host restarts. Here `options` is the same trusted `AgentClientOptions` value
+shown above:
+
+```typescript
+const firstClient = await AgentClient.start(options);
+const session = await firstClient.sessions.create({ sessionName: "review" });
+const sessionId = session.id;
+await (await session.startTurn({ prompt: "Inspect the current changes" })).result();
+await firstClient.close(); // unloads the Session and exits its managed Host
+
+const nextClient = await AgentClient.start(options);
+const resumed = await nextClient.sessions.resume(sessionId);
+await (await resumed.startTurn({ prompt: "Now summarize the risks" })).result();
+await nextClient.close();
+```
+
 An explicit absolute `hostPath` remains available as a development override.
 The SDK never searches `PATH` or an environment variable for the Host.
 
@@ -88,8 +112,8 @@ separately. This PR does not publish the package. A future registry release
 still needs platform packages, signing, and release verification.
 
 Browser and mobile runtimes cannot launch the local native Host. Custom
-functions, general user-input callbacks, structured output, usage, Session
-resume, Python support, platform package publication, signing, and downloads
+functions, general user-input callbacks, structured output, usage, Python
+support, platform package publication, signing, and downloads
 remain deferred.
 
 ## Development

--- a/sdk/typescript/scripts/generate-wire.mjs
+++ b/sdk/typescript/scripts/generate-wire.mjs
@@ -61,6 +61,7 @@ const requiredTypes = [
   "SessionCloseResult",
   "SessionCreateParams",
   "SessionCreateResult",
+  "SessionResumeParams",
   "ShutdownResult",
   "TemporaryModelConfig",
   "TemporaryModelProvider",

--- a/sdk/typescript/scripts/generated-wire-runtime.test.mjs
+++ b/sdk/typescript/scripts/generated-wire-runtime.test.mjs
@@ -43,12 +43,13 @@ test("Rust wire export produces executable validators for every type", async () 
   }
 
   const initializeResult = {
-    protocolVersion: 3,
+    protocolVersion: 4,
     runtimeVersion: "0.1.0",
     stability: "not_delivered",
     capabilities: {
       sessionCreate: true,
-      sessionCreateLifetime: "connection",
+      sessionCreateLifetime: "durable",
+      sessionResume: true,
       query: true,
       queryCancel: true,
       sessionClose: true,

--- a/sdk/typescript/src/internal/client.ts
+++ b/sdk/typescript/src/internal/client.ts
@@ -4,7 +4,7 @@ import { JsonRpcConnection } from "./json-rpc.js";
 import type { HostTransport } from "./transport.js";
 import type { InitializeParams, InitializeResult } from "./wire/index.js";
 
-const PROTOCOL_VERSION = 3;
+const PROTOCOL_VERSION = 4;
 const DEFAULT_INITIALIZE_TIMEOUT_MS = 30_000;
 
 export async function createAgentClient(

--- a/sdk/typescript/src/internal/wire-validation.ts
+++ b/sdk/typescript/src/internal/wire-validation.ts
@@ -36,6 +36,7 @@ export function validateResponseResult<T>(method: string, value: unknown): T {
     case "initialize":
       return validateInitializeResult(value) as T;
     case "session/create":
+    case "session/resume":
       return validateSessionCreateResult(value) as T;
     case "query/start":
       return validateQueryStartResult(value) as T;

--- a/sdk/typescript/src/session.ts
+++ b/sdk/typescript/src/session.ts
@@ -4,6 +4,7 @@ import type {
   SessionCloseParams,
   SessionCreateParams,
   SessionCreateResult,
+  SessionResumeParams,
 } from "./internal/wire/index.js";
 import type { JsonRpcConnection } from "./internal/json-rpc.js";
 import { withTimeout } from "./internal/deadline.js";
@@ -67,6 +68,21 @@ export class Sessions {
       params,
     );
     const session = Session.create(this.#connection, created, this.#onQuery);
+    this.#onSession(session);
+    return session;
+  }
+
+  async resume(sessionId: string): Promise<Session> {
+    this.#ensureClientOpen();
+    if (sessionId.trim().length === 0) {
+      throw new Error("sessionId must not be empty");
+    }
+    const params: SessionResumeParams = { sessionId };
+    const resumed = await this.#connection.request<SessionCreateResult>(
+      "session/resume",
+      params,
+    );
+    const session = Session.create(this.#connection, resumed, this.#onQuery);
     this.#onSession(session);
     return session;
   }

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -84,7 +84,7 @@ export interface SdkErrorDetails {
   recovery?: RecoveryAction;
 }
 
-export type SessionLifetime = "connection";
+export type SessionLifetime = "connection" | "durable";
 
 export interface QueryInput {
   prompt: string;

--- a/sdk/typescript/test/client.test.ts
+++ b/sdk/typescript/test/client.test.ts
@@ -55,7 +55,7 @@ test("a Query streams tool and permission events before the terminal Result", as
   assert.ok(client instanceof AgentClient);
   assert.equal(initializeRequests.length, 1);
   assert.deepEqual(initializeRequests[0], {
-    protocolVersion: 3,
+    protocolVersion: 4,
     clientInfo: { name: "@bitfun/agent-sdk", version: "0.0.0" },
     capabilities: {
       serverNotifications: true,
@@ -187,6 +187,7 @@ test("an explicit Session starts Turns on the existing client connection", async
   } as SessionCreateInput);
   assert.equal(session.id, "session-explicit");
   assert.equal(session.agent, "agentic");
+  assert.equal(session.lifetime, "durable");
 
   const query = await session.startTurn({ prompt: "continue" });
   assert.equal((await query.result()).outputText, "continued");
@@ -198,6 +199,37 @@ test("an explicit Session starts Turns on the existing client connection", async
     "initialize",
     "session/create",
     "query/start",
+    "session/close",
+    "shutdown",
+  ]);
+});
+
+test("a durable Session resumes on a new client connection", async () => {
+  const clientToHost = new PassThrough();
+  const hostToClient = new PassThrough();
+  const methods: string[] = [];
+  const host = runResumeFixtureHost(clientToHost, hostToClient, methods);
+  const client = await createAgentClient(
+    {
+      readable: hostToClient,
+      writable: clientToHost,
+      close: async () => {
+        clientToHost.end();
+        await host;
+      },
+    },
+    clientOptions,
+  );
+
+  const session = await client.sessions.resume("session-persisted");
+  assert.equal(session.id, "session-persisted");
+  assert.equal(session.lifetime, "durable");
+  await session.close();
+  await client.close();
+
+  assert.deepEqual(methods, [
+    "initialize",
+    "session/resume",
     "session/close",
     "shutdown",
   ]);
@@ -530,12 +562,13 @@ async function runFixtureHost(
         jsonrpc: "2.0",
         id: request.id,
         result: {
-          protocolVersion: 3,
+          protocolVersion: 4,
           runtimeVersion: "0.2.17",
           stability: "not_delivered",
           capabilities: {
             sessionCreate: true,
-            sessionCreateLifetime: "connection",
+            sessionCreateLifetime: "durable",
+            sessionResume: true,
             query: true,
             queryCancel: true,
             sessionClose: true,
@@ -725,7 +758,7 @@ async function runSessionFixtureHost(
           sessionId: "session-explicit",
           sessionName: "Explicit",
           agent: "agentic",
-          lifetime: "connection",
+          lifetime: "durable",
         },
       });
       continue;
@@ -770,6 +803,59 @@ async function runSessionFixtureHost(
         jsonrpc: "2.0",
         id: request.id,
         result: { sessionId: "session-explicit", unloaded: true },
+      });
+      continue;
+    }
+    if (request.method === "shutdown") {
+      write(responses, {
+        jsonrpc: "2.0",
+        id: request.id,
+        result: { accepted: true },
+      });
+      responses.end();
+      return;
+    }
+    throw new Error(`Unexpected fixture method: ${request.method}`);
+  }
+}
+
+async function runResumeFixtureHost(
+  requests: PassThrough,
+  responses: PassThrough,
+  methods: string[],
+): Promise<void> {
+  const lines = createInterface({ input: requests, crlfDelay: Infinity });
+  for await (const line of lines) {
+    const request = JSON.parse(line) as {
+      id: number;
+      method: string;
+      params: Record<string, unknown>;
+    };
+    methods.push(request.method);
+    if (request.method === "initialize") {
+      write(responses, initializeResponse(request.id));
+      continue;
+    }
+    if (request.method === "session/resume") {
+      assert.deepEqual(request.params, { sessionId: "session-persisted" });
+      write(responses, {
+        jsonrpc: "2.0",
+        id: request.id,
+        result: {
+          sessionId: "session-persisted",
+          sessionName: "Persisted",
+          agent: "agentic",
+          lifetime: "durable",
+          workspacePath: "D:/workspace/project",
+        },
+      });
+      continue;
+    }
+    if (request.method === "session/close") {
+      write(responses, {
+        jsonrpc: "2.0",
+        id: request.id,
+        result: { sessionId: "session-persisted", unloaded: true },
       });
       continue;
     }
@@ -1227,12 +1313,13 @@ function initializeResponse(id: number): unknown {
     jsonrpc: "2.0",
     id,
     result: {
-      protocolVersion: 3,
+      protocolVersion: 4,
       runtimeVersion: "0.2.17",
       stability: "not_delivered",
       capabilities: {
         sessionCreate: true,
-        sessionCreateLifetime: "connection",
+        sessionCreateLifetime: "durable",
+        sessionResume: true,
         query: true,
         queryCancel: true,
         sessionClose: true,

--- a/sdk/typescript/test/fixtures/host.mjs
+++ b/sdk/typescript/test/fixtures/host.mjs
@@ -5,7 +5,7 @@ for await (const line of lines) {
   const request = JSON.parse(line);
   if (request.method === "initialize") {
     if (
-      request.params?.protocolVersion !== 3 ||
+      request.params?.protocolVersion !== 4 ||
       request.params?.model?.apiKey !== "fixture-secret"
     ) {
       throw new Error("Invalid initialize request");
@@ -14,12 +14,13 @@ for await (const line of lines) {
       jsonrpc: "2.0",
       id: request.id,
       result: {
-        protocolVersion: 3,
+        protocolVersion: 4,
         runtimeVersion: "fixture",
         stability: "not_delivered",
         capabilities: {
           sessionCreate: true,
-          sessionCreateLifetime: "connection",
+          sessionCreateLifetime: "durable",
+          sessionResume: true,
           query: true,
           queryCancel: true,
           sessionClose: true,

--- a/sdk/typescript/test/lifecycle-timeouts.test.ts
+++ b/sdk/typescript/test/lifecycle-timeouts.test.ts
@@ -130,7 +130,7 @@ test("Session.close aborts an unresponsive Host after its cleanup deadline", asy
     sessionId: "session-timeout",
     sessionName: "timeout",
     agent: "agentic",
-    lifetime: "connection",
+    lifetime: "durable",
   };
   const createSession = Session.create as unknown as (
     owner: JsonRpcConnection,

--- a/src/apps/sdk-host/tests/stdio_process.rs
+++ b/src/apps/sdk-host/tests/stdio_process.rs
@@ -43,7 +43,7 @@ async fn standalone_sdk_host_negotiates_and_shuts_down_without_cli() {
         1,
         "initialize",
         json!({
-            "protocolVersion": 3,
+            "protocolVersion": 4,
             "clientInfo": { "name": "standalone-process-fixture", "version": "0.1.0" },
             "capabilities": {
                 "serverNotifications": true,
@@ -60,7 +60,7 @@ async fn standalone_sdk_host_negotiates_and_shuts_down_without_cli() {
     .await;
     let initialized = read_response(&mut stdout, "initialize").await;
     assert_eq!(initialized["id"], 1);
-    assert_eq!(initialized["result"]["protocolVersion"], 3);
+    assert_eq!(initialized["result"]["protocolVersion"], 4);
     assert!(initialized["result"]["modelId"]
         .as_str()
         .is_some_and(|model_id| model_id.starts_with("sdk:openai:")));

--- a/src/apps/sdk-host/tests/stdio_transport.rs
+++ b/src/apps/sdk-host/tests/stdio_transport.rs
@@ -118,6 +118,13 @@ impl AgentSessionClosePort for MinimalOwner {
     ) -> PortResult<bool> {
         Ok(false)
     }
+
+    async fn unload_persisted_session(
+        &self,
+        _request: AgentTransientSessionDiscardRequest,
+    ) -> PortResult<bool> {
+        Ok(false)
+    }
 }
 
 #[async_trait]
@@ -175,6 +182,13 @@ impl AgentSessionClosePort for BlockingCreateOwner {
         self.deleted.fetch_add(1, Ordering::AcqRel);
         Ok(true)
     }
+
+    async fn unload_persisted_session(
+        &self,
+        request: AgentTransientSessionDiscardRequest,
+    ) -> PortResult<bool> {
+        self.discard_transient_session(request).await
+    }
 }
 
 #[async_trait]
@@ -222,7 +236,7 @@ async fn stdio_transport_serves_initialize_and_shutdown_without_non_protocol_std
     client_write
         .write_all(
             concat!(
-                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":3,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":4,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
                 "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"shutdown\",\"params\":{}}\n"
             )
             .as_bytes(),
@@ -238,7 +252,7 @@ async fn stdio_transport_serves_initialize_and_shutdown_without_non_protocol_std
         serde_json::from_str(&lines.next_line().await.unwrap().unwrap()).unwrap();
 
     assert_eq!(initialized["id"], 1);
-    assert_eq!(initialized["result"]["protocolVersion"], 3);
+    assert_eq!(initialized["result"]["protocolVersion"], 4);
     assert_eq!(initialized["result"]["modelId"], "sdk:openai:transport");
     assert_eq!(shutdown["id"], 2);
     assert_eq!(shutdown["result"]["accepted"], true);
@@ -272,7 +286,7 @@ async fn stdio_transport_executes_json_rpc_notifications_without_replying() {
     client_write
         .write_all(
             concat!(
-                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":3,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":4,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
                 "{\"jsonrpc\":\"2.0\",\"method\":\"shutdown\",\"params\":{}}\n"
             )
             .as_bytes(),
@@ -372,7 +386,7 @@ async fn transport_accepts_input_while_an_owner_call_is_pending_and_bounds_reque
     client_write
         .write_all(
             concat!(
-                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":3,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":4,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
                 "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"session/create\",\"params\":{}}\n",
                 "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"session/create\",\"params\":{}}\n"
             )
@@ -444,7 +458,7 @@ async fn shutdown_remains_available_when_the_data_request_budget_is_exhausted() 
     ));
     client_write
         .write_all(
-            b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":3,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
+            b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":4,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
         )
         .await
         .unwrap();
@@ -524,9 +538,9 @@ async fn duplicate_initialize_does_not_abort_an_in_flight_request() {
     client_write
         .write_all(
             concat!(
-                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":3,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":4,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
                 "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"session/create\",\"params\":{}}\n",
-                "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"initialize\",\"params\":{\"protocolVersion\":3,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n"
+                "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"initialize\",\"params\":{\"protocolVersion\":4,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n"
             )
             .as_bytes(),
         )
@@ -584,7 +598,7 @@ async fn connection_eof_cleans_a_session_created_after_its_request_is_aborted() 
     client_write
         .write_all(
             concat!(
-                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":3,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":4,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
                 "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"session/create\",\"params\":{}}\n"
             )
             .as_bytes(),
@@ -606,7 +620,7 @@ async fn connection_eof_cleans_a_session_created_after_its_request_is_aborted() 
     client_write.shutdown().await.unwrap();
     timeout(Duration::from_secs(1), &mut task)
         .await
-        .expect("transient Session cleanup must stay within the Host deadline")
+        .expect("Session cleanup must stay within the Host deadline")
         .unwrap()
         .unwrap();
     assert_eq!(owner.deleted.load(Ordering::Acquire), 1);
@@ -618,7 +632,7 @@ async fn connection_eof_cleans_a_session_created_after_its_request_is_aborted() 
 }
 
 #[tokio::test]
-async fn explicit_shutdown_bounds_request_drain_and_transient_cleanup_together() {
+async fn explicit_shutdown_bounds_request_drain_and_session_cleanup_together() {
     let owner = Arc::new(BlockingCreateOwner::new());
     let runtime = AgentRuntimeBuilder::new()
         .with_submission_port(owner.clone())
@@ -643,7 +657,7 @@ async fn explicit_shutdown_bounds_request_drain_and_transient_cleanup_together()
     client_write
         .write_all(
             concat!(
-                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":3,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":4,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
                 "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"session/create\",\"params\":{}}\n"
             )
             .as_bytes(),
@@ -671,7 +685,7 @@ async fn explicit_shutdown_bounds_request_drain_and_transient_cleanup_together()
     assert_eq!(shutdown["id"], 3);
     timeout(Duration::from_secs(1), &mut task)
         .await
-        .expect("request drain and transient cleanup must share one total deadline")
+        .expect("request drain and Session cleanup must share one total deadline")
         .unwrap()
         .unwrap();
     assert_eq!(owner.deleted.load(Ordering::Acquire), 1);
@@ -701,7 +715,7 @@ async fn requests_before_a_successful_initialize_cannot_cross_the_handshake() {
             concat!(
                 "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":999,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
                 "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"session/create\",\"params\":{}}\n",
-                "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"initialize\",\"params\":{\"protocolVersion\":3,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n"
+                "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"initialize\",\"params\":{\"protocolVersion\":4,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n"
             )
             .as_bytes(),
         )
@@ -720,7 +734,7 @@ async fn requests_before_a_successful_initialize_cannot_cross_the_handshake() {
     assert_eq!(pre_initialize["id"], 2);
     assert_eq!(pre_initialize["error"]["data"]["code"], "not_initialized");
     assert_eq!(initialized["id"], 3);
-    assert_eq!(initialized["result"]["protocolVersion"], 3);
+    assert_eq!(initialized["result"]["protocolVersion"], 4);
     assert_eq!(initialized["result"]["modelId"], "sdk:openai:transport");
 
     client_write
@@ -761,7 +775,7 @@ async fn blocked_output_times_out_and_ends_the_connection() {
     ));
     client_write
         .write_all(
-            b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":3,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
+            b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":4,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
         )
         .await
         .unwrap();

--- a/src/crates/assembly/core/src/agentic/session/session_manager.rs
+++ b/src/crates/assembly/core/src/agentic/session/session_manager.rs
@@ -9720,6 +9720,14 @@ mod tests {
             [durable_id.as_str()]
         );
         assert!(sessions.contains_key(&transient_id));
+
+        assert!(SessionManager::collect_expired_session_candidates(
+            &sessions,
+            &transient_session_ids,
+            now,
+            Duration::MAX,
+        )
+        .is_empty());
     }
 
     #[test]

--- a/src/crates/assembly/core/src/agentic/system.rs
+++ b/src/crates/assembly/core/src/agentic/system.rs
@@ -1,6 +1,7 @@
 //! Agentic system assembly shared by CLI, ACP, and other hosts.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Result;
 use log::info;
@@ -17,6 +18,16 @@ use crate::infrastructure::try_get_path_manager_arc;
 use crate::runtime_ownership::CoreRuntimeOwnership;
 use crate::service::token_usage::{TokenUsageService, TokenUsageSubscriber};
 pub use bitfun_product_capabilities::DeliveryProfile;
+
+fn session_manager_config_for_profile(
+    delivery_profile: DeliveryProfile,
+) -> session::SessionManagerConfig {
+    let mut config = session::SessionManagerConfig::default();
+    if delivery_profile == DeliveryProfile::Sdk {
+        config.session_idle_timeout = Duration::MAX;
+    }
+    config
+}
 
 /// Agentic runtime state shared by host adapters.
 #[derive(Clone)]
@@ -86,7 +97,7 @@ pub async fn init_agentic_system_for_profile_with_runtime_ownership(
     let session_manager = Arc::new(session::SessionManager::new(
         context_store,
         persistence_manager,
-        Default::default(),
+        session_manager_config_for_profile(delivery_profile),
     ));
 
     event_router.subscribe_internal(
@@ -164,4 +175,22 @@ pub async fn init_agentic_system_for_profile_with_runtime_ownership(
         event_queue,
         token_usage_service,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{session_manager_config_for_profile, DeliveryProfile};
+    use std::time::Duration;
+
+    #[test]
+    fn sdk_profile_keeps_attached_sessions_loaded_until_the_host_releases_them() {
+        assert_eq!(
+            session_manager_config_for_profile(DeliveryProfile::Sdk).session_idle_timeout,
+            Duration::MAX
+        );
+        assert_eq!(
+            session_manager_config_for_profile(DeliveryProfile::ProductFull).session_idle_timeout,
+            Duration::from_secs(3600)
+        );
+    }
 }

--- a/src/crates/assembly/core/src/service_agent_runtime.rs
+++ b/src/crates/assembly/core/src/service_agent_runtime.rs
@@ -955,11 +955,17 @@ impl AgentSessionManagementPort for ScheduledSessionManagementPort {
     }
 }
 
-#[async_trait::async_trait]
-impl AgentSessionClosePort for ScheduledSessionManagementPort {
-    async fn discard_transient_session(
+#[derive(Clone, Copy)]
+enum SessionReleaseKind {
+    DiscardTransient,
+    UnloadPersisted,
+}
+
+impl ScheduledSessionManagementPort {
+    async fn release_session(
         &self,
-        request: bitfun_runtime_ports::AgentTransientSessionDiscardRequest,
+        request: bitfun_runtime_ports::AgentSessionReleaseRequest,
+        kind: SessionReleaseKind,
     ) -> bitfun_runtime_ports::PortResult<bool> {
         bitfun_core_types::validate_session_id(&request.session_id).map_err(|message| {
             bitfun_runtime_ports::PortError::new(
@@ -994,26 +1000,55 @@ impl AgentSessionClosePort for ScheduledSessionManagementPort {
         if cleanup_budget.is_zero() {
             return Err(bitfun_runtime_ports::PortError::new(
                 bitfun_runtime_ports::PortErrorKind::Timeout,
-                "Session close deadline was exhausted before transient resource cleanup",
+                "Session close deadline was exhausted before resource release",
             ));
         }
-        tokio::time::timeout(
-            cleanup_budget,
-            self.coordinator.discard_transient_session(
-                std::path::Path::new(&request.workspace_path),
-                request.remote_connection_id.as_deref(),
-                request.remote_ssh_host.as_deref(),
-                &request.session_id,
-            ),
-        )
+        tokio::time::timeout(cleanup_budget, async {
+            match kind {
+                SessionReleaseKind::DiscardTransient => {
+                    self.coordinator
+                        .discard_transient_session(
+                            std::path::Path::new(&request.workspace_path),
+                            request.remote_connection_id.as_deref(),
+                            request.remote_ssh_host.as_deref(),
+                            &request.session_id,
+                        )
+                        .await
+                }
+                SessionReleaseKind::UnloadPersisted => {
+                    session_manager
+                        .unload_session_from_memory(&request.session_id)
+                        .await
+                }
+            }
+        })
         .await
         .map_err(|_| {
             bitfun_runtime_ports::PortError::new(
                 bitfun_runtime_ports::PortErrorKind::Timeout,
-                "Transient Session resource cleanup exceeded the Session close deadline",
+                "Session resource release exceeded the Session close deadline",
             )
         })?
         .map_err(map_session_close_error)
+    }
+}
+
+#[async_trait::async_trait]
+impl AgentSessionClosePort for ScheduledSessionManagementPort {
+    async fn discard_transient_session(
+        &self,
+        request: bitfun_runtime_ports::AgentSessionReleaseRequest,
+    ) -> bitfun_runtime_ports::PortResult<bool> {
+        self.release_session(request, SessionReleaseKind::DiscardTransient)
+            .await
+    }
+
+    async fn unload_persisted_session(
+        &self,
+        request: bitfun_runtime_ports::AgentSessionReleaseRequest,
+    ) -> bitfun_runtime_ports::PortResult<bool> {
+        self.release_session(request, SessionReleaseKind::UnloadPersisted)
+            .await
     }
 }
 

--- a/src/crates/contracts/runtime-ports/src/agent_api.rs
+++ b/src/crates/contracts/runtime-ports/src/agent_api.rs
@@ -1500,11 +1500,10 @@ pub trait AgentWorkspaceReferencePort: Send + Sync {
     ) -> PortResult<Vec<AgentWorkspaceReference>>;
 }
 
-/// Deadline-bearing request for discarding a connection-scoped transient
-/// Session. This is separate from [`AgentSessionDeleteRequest`] so adding Host
-/// cleanup policy cannot break the established Rust Session-management API.
+/// Deadline-bearing request for releasing a loaded Session from one runtime.
+/// The lifecycle method decides whether persisted storage is preserved.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct AgentTransientSessionDiscardRequest {
+pub struct AgentSessionReleaseRequest {
     pub workspace_path: String,
     pub session_id: String,
     pub remote_connection_id: Option<String>,
@@ -1512,7 +1511,10 @@ pub struct AgentTransientSessionDiscardRequest {
     pub wait_timeout_ms: u64,
 }
 
-/// Runtime lifecycle owner for connection-scoped Session cleanup.
+/// Compatibility name for callers that only discard transient Sessions.
+pub type AgentTransientSessionDiscardRequest = AgentSessionReleaseRequest;
+
+/// Runtime lifecycle owner for releasing loaded Sessions.
 #[async_trait::async_trait]
 pub trait AgentSessionClosePort: Send + Sync {
     /// Quiesces and discards only a loaded transient Session owned by the
@@ -1520,12 +1522,25 @@ pub trait AgentSessionClosePort: Send + Sync {
     /// remove persisted Session storage through this operation.
     async fn discard_transient_session(
         &self,
-        request: AgentTransientSessionDiscardRequest,
+        request: AgentSessionReleaseRequest,
     ) -> PortResult<bool> {
         let _ = request;
         Err(PortError::new(
             PortErrorKind::NotAvailable,
             "transient session discard is not supported by this provider",
+        ))
+    }
+
+    /// Quiesces and unloads a durable Session while preserving its persisted
+    /// state so another runtime can restore it later.
+    async fn unload_persisted_session(
+        &self,
+        request: AgentSessionReleaseRequest,
+    ) -> PortResult<bool> {
+        let _ = request;
+        Err(PortError::new(
+            PortErrorKind::NotAvailable,
+            "persisted session unload is not supported by this provider",
         ))
     }
 }

--- a/src/crates/execution/agent-runtime/examples/sdk_minimal.rs
+++ b/src/crates/execution/agent-runtime/examples/sdk_minimal.rs
@@ -49,7 +49,7 @@ impl AgentSubmissionPort for ExampleAgentProvider {
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let compatibility = AgentRuntimeSdkCompatibility::current();
-    assert_eq!(compatibility.api_version, 6);
+    assert_eq!(compatibility.api_version, 7);
 
     let provider = Arc::new(ExampleAgentProvider::default());
     let events = AgentEventStream::new();

--- a/src/crates/execution/agent-runtime/src/runtime.rs
+++ b/src/crates/execution/agent-runtime/src/runtime.rs
@@ -25,11 +25,11 @@ use bitfun_runtime_ports::{
     AgentSessionLineageTranscriptRequest, AgentSessionListRequest, AgentSessionManagementPort,
     AgentSessionModePort, AgentSessionModeUpdateRequest, AgentSessionModelPort,
     AgentSessionModelSelectionUpdateRequest, AgentSessionModelUpdateRequest,
-    AgentSessionRenameRequest, AgentSessionRevertPort, AgentSessionRevertRequest,
-    AgentSessionRevertResult, AgentSessionRollbackToTurnOutcome, AgentSessionRollbackToTurnRequest,
-    AgentSessionSummary, AgentSessionUsagePort, AgentSessionUsageRequest,
-    AgentSessionWorkspaceBinding, AgentSessionWorkspaceRequest, AgentSubmissionPort,
-    AgentSubmissionRequest, AgentSubmissionResult, AgentSubmissionSource,
+    AgentSessionReleaseRequest, AgentSessionRenameRequest, AgentSessionRevertPort,
+    AgentSessionRevertRequest, AgentSessionRevertResult, AgentSessionRollbackToTurnOutcome,
+    AgentSessionRollbackToTurnRequest, AgentSessionSummary, AgentSessionUsagePort,
+    AgentSessionUsageRequest, AgentSessionWorkspaceBinding, AgentSessionWorkspaceRequest,
+    AgentSubmissionPort, AgentSubmissionRequest, AgentSubmissionResult, AgentSubmissionSource,
     AgentThreadGoalCreateRequest, AgentThreadGoalDeliveryRequest, AgentThreadGoalGetRequest,
     AgentThreadGoalManagementPort, AgentThreadGoalUpdateStatusRequest,
     AgentTransientSessionDiscardRequest, AgentTurnCancellationPort, AgentTurnCancellationRequest,
@@ -1172,6 +1172,23 @@ impl AgentRuntime {
                 ))
             })?
             .discard_transient_session(request)
+            .await
+            .map_err(RuntimeError::from)
+    }
+
+    pub async fn unload_persisted_session(
+        &self,
+        request: AgentSessionReleaseRequest,
+    ) -> Result<bool, RuntimeError> {
+        self.session_close
+            .as_ref()
+            .ok_or_else(|| {
+                RuntimeError::Port(PortError::new(
+                    PortErrorKind::NotAvailable,
+                    "agent session close port is not registered",
+                ))
+            })?
+            .unload_persisted_session(request)
             .await
             .map_err(RuntimeError::from)
     }

--- a/src/crates/execution/agent-runtime/src/sdk.rs
+++ b/src/crates/execution/agent-runtime/src/sdk.rs
@@ -8,7 +8,7 @@
 
 use std::sync::Arc;
 
-pub const AGENT_RUNTIME_SDK_API_VERSION: u32 = 6;
+pub const AGENT_RUNTIME_SDK_API_VERSION: u32 = 7;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
@@ -86,11 +86,11 @@ pub use bitfun_runtime_ports::{
     AgentSessionListRequest, AgentSessionManagementPort, AgentSessionModePort,
     AgentSessionModeUpdateRequest, AgentSessionModelPort, AgentSessionModelSelection,
     AgentSessionModelSelectionUpdateRequest, AgentSessionModelUpdateRequest,
-    AgentSessionRenameRequest, AgentSessionRevertPort, AgentSessionRevertRequest,
-    AgentSessionRevertResult, AgentSessionRollbackToTurnOutcome, AgentSessionRollbackToTurnRequest,
-    AgentSessionSummary, AgentSessionUsagePort, AgentSessionUsageRequest,
-    AgentSessionWorkspaceBinding, AgentSessionWorkspaceRequest, AgentSubmissionPort,
-    AgentSubmissionRequest, AgentSubmissionResult, AgentSubmissionSource,
+    AgentSessionReleaseRequest, AgentSessionRenameRequest, AgentSessionRevertPort,
+    AgentSessionRevertRequest, AgentSessionRevertResult, AgentSessionRollbackToTurnOutcome,
+    AgentSessionRollbackToTurnRequest, AgentSessionSummary, AgentSessionUsagePort,
+    AgentSessionUsageRequest, AgentSessionWorkspaceBinding, AgentSessionWorkspaceRequest,
+    AgentSubmissionPort, AgentSubmissionRequest, AgentSubmissionResult, AgentSubmissionSource,
     AgentThreadGoalCreateRequest, AgentThreadGoalDeliveryRequest, AgentThreadGoalGetRequest,
     AgentThreadGoalManagementPort, AgentThreadGoalUpdateStatusRequest,
     AgentTransientSessionDiscardRequest, AgentTurnCancellationPort, AgentTurnCancellationRequest,
@@ -489,6 +489,13 @@ impl AgentRuntime {
         request: AgentTransientSessionDiscardRequest,
     ) -> Result<bool, RuntimeError> {
         self.inner.discard_transient_session(request).await
+    }
+
+    pub async fn unload_persisted_session(
+        &self,
+        request: AgentSessionReleaseRequest,
+    ) -> Result<bool, RuntimeError> {
+        self.inner.unload_persisted_session(request).await
     }
 
     pub async fn list_sessions(

--- a/src/crates/execution/agent-runtime/tests/agent_session_contracts/sdk_smoke.rs
+++ b/src/crates/execution/agent-runtime/tests/agent_session_contracts/sdk_smoke.rs
@@ -48,6 +48,7 @@ struct FakeSdkRuntimeEventSink;
 #[derive(Debug, Default)]
 struct FakeSessionClosePort {
     requests: Mutex<Vec<AgentTransientSessionDiscardRequest>>,
+    persisted_requests: Mutex<Vec<AgentTransientSessionDiscardRequest>>,
 }
 
 #[derive(Debug, Default)]
@@ -75,7 +76,7 @@ impl AgentModeCatalogPort for FakeModeCatalog {
 fn sdk_facade_exposes_versioned_preview_compatibility_contract() {
     let compatibility = AgentRuntimeSdkCompatibility::current();
 
-    assert_eq!(compatibility.api_version, 6);
+    assert_eq!(compatibility.api_version, 7);
     assert_eq!(compatibility.crate_version, env!("CARGO_PKG_VERSION"));
     assert_eq!(compatibility.stability, AgentRuntimeSdkStability::Preview);
 }
@@ -140,6 +141,17 @@ impl AgentSessionClosePort for FakeSessionClosePort {
         request: AgentTransientSessionDiscardRequest,
     ) -> PortResult<bool> {
         self.requests.lock().unwrap().push(request.clone());
+        Ok(true)
+    }
+
+    async fn unload_persisted_session(
+        &self,
+        request: AgentTransientSessionDiscardRequest,
+    ) -> PortResult<bool> {
+        self.persisted_requests
+            .lock()
+            .unwrap()
+            .push(request.clone());
         Ok(true)
     }
 }
@@ -456,6 +468,35 @@ async fn sdk_facade_delegates_connection_scoped_session_discard() {
         .expect("discard transient session through SDK facade");
 
     assert_eq!(close_port.requests.lock().unwrap().as_slice(), &[request]);
+    assert!(result);
+}
+
+#[tokio::test]
+async fn sdk_facade_delegates_persisted_session_unload() {
+    let provider = Arc::new(FakeSdkAgentProvider::default());
+    let close_port = Arc::new(FakeSessionClosePort::default());
+    let runtime = AgentRuntimeBuilder::new()
+        .with_submission_port(provider)
+        .with_session_close_port(close_port.clone())
+        .build()
+        .expect("sdk runtime");
+    let request = AgentTransientSessionDiscardRequest {
+        workspace_path: "/workspace/project".to_string(),
+        session_id: "sdk-session-1".to_string(),
+        remote_connection_id: None,
+        remote_ssh_host: None,
+        wait_timeout_ms: 5_000,
+    };
+
+    let result = runtime
+        .unload_persisted_session(request.clone())
+        .await
+        .expect("unload persisted session through SDK facade");
+
+    assert_eq!(
+        close_port.persisted_requests.lock().unwrap().as_slice(),
+        &[request]
+    );
     assert!(result);
 }
 

--- a/src/crates/interfaces/sdk-host/src/host.rs
+++ b/src/crates/interfaces/sdk-host/src/host.rs
@@ -7,10 +7,12 @@ use std::time::Duration;
 
 use bitfun_agent_runtime::sdk::{
     AgentDialogTurnRequest, AgentRuntime, AgentSessionCreateRequest, AgentSessionCreateResult,
-    AgentSubmissionSource, AgentTransientSessionDiscardRequest, AgentTurnCancellationRequest,
-    AgentTurnSettlementRequest, DialogSubmissionPolicy, DialogSubmitOutcome, PermissionReply,
-    PermissionReplySource, PermissionRequest, PermissionRequestEvent, PermissionRequestSourceKind,
-    PortErrorKind, RuntimeError, AUTO_APPROVE_ASK_CONTEXT_KEY,
+    AgentSessionDeleteRequest, AgentSessionModelUpdateRequest, AgentSessionReleaseRequest,
+    AgentSessionRestoreRequest, AgentSessionWorkspaceRequest, AgentSubmissionSource,
+    AgentTurnCancellationRequest, AgentTurnSettlementRequest, DialogSubmissionPolicy,
+    DialogSubmitOutcome, PermissionReply, PermissionReplySource, PermissionRequest,
+    PermissionRequestEvent, PermissionRequestSourceKind, PortError, PortErrorKind, RuntimeError,
+    AUTO_APPROVE_ASK_CONTEXT_KEY,
 };
 use bitfun_agent_runtime::user_questions::USER_INPUT_AVAILABLE_CONTEXT_KEY;
 use bitfun_core_types::ErrorCategory;
@@ -28,11 +30,11 @@ use crate::protocol::{
     PermissionSourceKind, QueryCancelParams, QueryCancelResult, QueryEvent, QueryEventParams,
     QueryOutput, QueryResultError, QueryResultParams, QueryStartParams, QueryStartResult,
     QueryTerminalStatus, RecoveryAction, RequestId, SessionCloseParams, SessionCloseResult,
-    SessionCreateParams, SessionCreateResult, SessionLifetime, ShutdownParams, ShutdownResult,
-    TemporaryModelConfig, ToolEventStatus, JSON_RPC_VERSION, METHOD_INITIALIZE,
+    SessionCreateParams, SessionCreateResult, SessionLifetime, SessionResumeParams, ShutdownParams,
+    ShutdownResult, TemporaryModelConfig, ToolEventStatus, JSON_RPC_VERSION, METHOD_INITIALIZE,
     METHOD_PERMISSION_RESPOND, METHOD_QUERY_CANCEL, METHOD_QUERY_START, METHOD_SESSION_CLOSE,
-    METHOD_SESSION_CREATE, METHOD_SHUTDOWN, NOTIFICATION_QUERY_EVENT, NOTIFICATION_QUERY_RESULT,
-    PROTOCOL_VERSION,
+    METHOD_SESSION_CREATE, METHOD_SESSION_RESUME, METHOD_SHUTDOWN, NOTIFICATION_QUERY_EVENT,
+    NOTIFICATION_QUERY_RESULT, PROTOCOL_VERSION,
 };
 
 const DEFAULT_SESSION_NAME: &str = "BitFun SDK query";
@@ -42,6 +44,7 @@ const PERMISSION_REJECTION_TIMEOUT_MS: u64 = 2_000;
 const DEFAULT_PERMISSION_RESPONSE_TIMEOUT_MS: u64 = 120_000;
 const MAX_PERMISSION_FEEDBACK_BYTES: usize = 4 * 1024;
 const MAX_SESSION_CLOSE_TIMEOUT_MS: u64 = 30_000;
+const MAX_SESSION_PUBLICATION_WAIT_MS: u64 = 500;
 const MAX_QUERY_OUTPUT_WIRE_BYTES: usize = 768 * 1024;
 
 fn json_string_content_bytes(value: &str) -> usize {
@@ -140,12 +143,14 @@ struct ConnectionState {
     cleanup_failed: bool,
     sessions: HashMap<String, SessionLease>,
     queries: HashMap<String, Arc<QueryLease>>,
+    attaching_sessions: HashSet<String>,
+    publishing_sessions: HashSet<String>,
     starting_query_sessions: HashSet<String>,
     active_query_sessions: HashSet<String>,
     closing_sessions: HashSet<String>,
     poisoned_sessions: HashSet<String>,
     pending_session_tasks: Vec<PendingSessionTask>,
-    untracked_transient_cleanups: HashMap<String, TransientSessionCleanup>,
+    untracked_session_cleanups: HashMap<String, SessionCleanup>,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -168,18 +173,60 @@ struct SessionLease {
     remote_connection_id: Option<String>,
     remote_ssh_host: Option<String>,
     exposed: bool,
+    lifetime: SessionLifetime,
+    unexposed_release: SessionReleaseKind,
     _budget: Arc<OwnedSemaphorePermit>,
 }
 
 struct PendingSessionTask {
-    transient_cleanup: Option<TransientSessionCleanup>,
+    session_cleanup: Option<SessionCleanup>,
+    reservation: Option<SessionTaskReservation>,
     task: JoinHandle<()>,
 }
 
+enum SessionTaskReservation {
+    Attaching(String),
+    Publishing(String),
+}
+
+fn release_session_task_reservation(
+    state: &mut ConnectionState,
+    reservation: &SessionTaskReservation,
+) {
+    match reservation {
+        SessionTaskReservation::Attaching(session_id) => {
+            state.attaching_sessions.remove(session_id);
+        }
+        SessionTaskReservation::Publishing(session_id) => {
+            state.publishing_sessions.remove(session_id);
+        }
+    }
+}
+
 #[derive(Clone)]
-struct TransientSessionCleanup {
+struct SessionCleanup {
     session_id: String,
     workspace_path: String,
+    release_kind: SessionReleaseKind,
+}
+
+#[derive(Clone, Copy)]
+enum SessionReleaseKind {
+    DiscardTransient,
+    UnloadPersisted,
+    DeletePersisted,
+}
+
+impl SessionLease {
+    fn release_kind(&self) -> SessionReleaseKind {
+        if !self.exposed {
+            return self.unexposed_release;
+        }
+        match self.lifetime {
+            SessionLifetime::Connection => SessionReleaseKind::DiscardTransient,
+            SessionLifetime::Durable => SessionReleaseKind::UnloadPersisted,
+        }
+    }
 }
 
 struct QueryLease {
@@ -322,7 +369,7 @@ impl SdkHostConnection {
             (
                 state.initialization == InitializationState::Initialized,
                 state.shutting_down,
-                state.cleanup_failed || !state.untracked_transient_cleanups.is_empty(),
+                state.cleanup_failed || !state.untracked_session_cleanups.is_empty(),
             )
         };
         if !initialized {
@@ -364,6 +411,7 @@ impl SdkHostConnection {
 
         match request.method.as_str() {
             METHOD_SESSION_CREATE => self.handle_session_create(request).await,
+            METHOD_SESSION_RESUME => self.handle_session_resume(request).await,
             METHOD_QUERY_START => self.handle_query_start(request).await,
             METHOD_QUERY_CANCEL => self.handle_query_cancel(request).await,
             METHOD_PERMISSION_RESPOND => self.handle_permission_respond(request).await,
@@ -430,6 +478,9 @@ impl SdkHostConnection {
                 active.push(pending);
                 continue;
             }
+            if let Some(reservation) = &pending.reservation {
+                release_session_task_reservation(&mut state, reservation);
+            }
             match (&mut pending.task).now_or_never() {
                 Some(Ok(())) => {}
                 Some(Err(error)) => {
@@ -437,9 +488,9 @@ impl SdkHostConnection {
                         error = %error,
                         "SDK Host Session ownership task failed"
                     );
-                    if let Some(cleanup) = pending.transient_cleanup {
+                    if let Some(cleanup) = pending.session_cleanup {
                         state
-                            .untracked_transient_cleanups
+                            .untracked_session_cleanups
                             .insert(cleanup.session_id.clone(), cleanup);
                     }
                 }
@@ -453,7 +504,7 @@ impl SdkHostConnection {
         self.shutdown_connection_inner(None).await;
     }
 
-    /// Shuts down one connection without allowing a transient Session create
+    /// Shuts down one connection without allowing a Session ownership
     /// task to keep the Host process alive indefinitely.
     pub async fn shutdown_connection_bounded(&self, total_timeout: Duration) -> bool {
         self.shutdown_connection_inner(Some(total_timeout)).await
@@ -477,10 +528,7 @@ impl SdkHostConnection {
             self.settle_pending_session_task(pending, graceful_deadline)
                 .await;
         }
-        if !self
-            .compensate_registered_transient_sessions(deadline)
-            .await
-        {
+        if !self.compensate_registered_sessions(deadline).await {
             cleanup_complete = false;
         }
         let (queries, sessions) = {
@@ -546,7 +594,7 @@ impl SdkHostConnection {
         let mut cleanup = sessions
             .into_iter()
             .map(|(session_id, session)| {
-                let runtime = self.inner.runtime.clone();
+                let connection = self.clone();
                 let session_cleanup_timeout = deadline
                     .map(|deadline| {
                         deadline
@@ -556,18 +604,20 @@ impl SdkHostConnection {
                     .unwrap_or(Duration::from_millis(5_500));
                 async move {
                     let reported_session_id = session_id.clone();
+                    let release_kind = session.release_kind();
                     let cleanup = async move {
-                        runtime
-                            .discard_transient_session(AgentTransientSessionDiscardRequest {
-                                workspace_path: session.workspace_path,
-                                session_id: session_id.clone(),
-                                remote_connection_id: session.remote_connection_id,
-                                remote_ssh_host: session.remote_ssh_host,
-                                wait_timeout_ms: duration_ms(
+                        connection
+                            .release_runtime_session(
+                                session_id.clone(),
+                                session.workspace_path,
+                                session.remote_connection_id,
+                                session.remote_ssh_host,
+                                release_kind,
+                                duration_ms(
                                     session_cleanup_timeout
                                         .saturating_sub(Duration::from_millis(500)),
                                 ),
-                            })
+                            )
                             .await?;
                         Ok(())
                     };
@@ -618,7 +668,8 @@ impl SdkHostConnection {
         wait_deadline: Option<Instant>,
     ) {
         let PendingSessionTask {
-            transient_cleanup,
+            session_cleanup,
+            reservation,
             mut task,
         } = pending;
         let completed = if task.is_finished() {
@@ -640,39 +691,40 @@ impl SdkHostConnection {
                     error = %error,
                     "SDK Host Session ownership task failed"
                 );
-                if let Some(cleanup) = transient_cleanup {
-                    self.register_untracked_transient_cleanup(cleanup).await;
+                if let Some(cleanup) = session_cleanup {
+                    self.register_untracked_session_cleanup(cleanup).await;
                 }
             }
             None => {
                 task.abort();
                 let _ = task.await;
-                if let Some(cleanup) = transient_cleanup {
-                    self.register_untracked_transient_cleanup(cleanup).await;
+                if let Some(cleanup) = session_cleanup {
+                    self.register_untracked_session_cleanup(cleanup).await;
                 }
             }
         }
+        if let Some(reservation) = reservation {
+            let mut state = self.inner.state.lock().await;
+            release_session_task_reservation(&mut state, &reservation);
+        }
     }
 
-    async fn register_untracked_transient_cleanup(&self, cleanup: TransientSessionCleanup) {
+    async fn register_untracked_session_cleanup(&self, cleanup: SessionCleanup) {
         self.inner
             .state
             .lock()
             .await
-            .untracked_transient_cleanups
+            .untracked_session_cleanups
             .insert(cleanup.session_id.clone(), cleanup);
     }
 
-    async fn compensate_registered_transient_sessions(
-        &self,
-        cleanup_deadline: Option<Instant>,
-    ) -> bool {
+    async fn compensate_registered_sessions(&self, cleanup_deadline: Option<Instant>) -> bool {
         let cleanups = self
             .inner
             .state
             .lock()
             .await
-            .untracked_transient_cleanups
+            .untracked_session_cleanups
             .values()
             .cloned()
             .collect::<Vec<_>>();
@@ -683,7 +735,7 @@ impl SdkHostConnection {
                 async move {
                     let session_id = cleanup.session_id.clone();
                     let completed = connection
-                        .compensate_untracked_transient_session(cleanup, cleanup_deadline)
+                        .compensate_untracked_session(cleanup, cleanup_deadline)
                         .await;
                     (session_id, completed)
                 }
@@ -696,7 +748,7 @@ impl SdkHostConnection {
                     .state
                     .lock()
                     .await
-                    .untracked_transient_cleanups
+                    .untracked_session_cleanups
                     .remove(&session_id);
             } else {
                 cleanup_complete = false;
@@ -705,9 +757,9 @@ impl SdkHostConnection {
         cleanup_complete
     }
 
-    async fn compensate_untracked_transient_session(
+    async fn compensate_untracked_session(
         &self,
-        cleanup: TransientSessionCleanup,
+        cleanup: SessionCleanup,
         cleanup_deadline: Option<Instant>,
     ) -> bool {
         let cleanup_timeout = cleanup_deadline
@@ -715,17 +767,14 @@ impl SdkHostConnection {
             .unwrap_or(Duration::from_secs(5));
         let result = timeout(
             cleanup_timeout,
-            self.inner
-                .runtime
-                .discard_transient_session(AgentTransientSessionDiscardRequest {
-                    workspace_path: cleanup.workspace_path,
-                    session_id: cleanup.session_id.clone(),
-                    remote_connection_id: None,
-                    remote_ssh_host: None,
-                    wait_timeout_ms: duration_ms(
-                        cleanup_timeout.saturating_sub(Duration::from_millis(500)),
-                    ),
-                }),
+            self.release_runtime_session(
+                cleanup.session_id.clone(),
+                cleanup.workspace_path,
+                None,
+                None,
+                cleanup.release_kind,
+                duration_ms(cleanup_timeout.saturating_sub(Duration::from_millis(500))),
+            ),
         )
         .await;
         match result {
@@ -738,17 +787,65 @@ impl SdkHostConnection {
                 tracing::warn!(
                     session_id = %cleanup.session_id,
                     error_kind = runtime_error_kind(&error),
-                    "Failed to compensate an untracked transient SDK Host Session"
+                    "Failed to compensate an untracked SDK Host Session"
                 );
                 false
             }
             Err(_) => {
                 tracing::warn!(
                     session_id = %cleanup.session_id,
-                    "Transient SDK Host Session compensation timed out"
+                    "SDK Host Session compensation timed out"
                 );
                 false
             }
+        }
+    }
+
+    async fn release_runtime_session(
+        &self,
+        session_id: String,
+        workspace_path: String,
+        remote_connection_id: Option<String>,
+        remote_ssh_host: Option<String>,
+        release_kind: SessionReleaseKind,
+        wait_timeout_ms: u64,
+    ) -> Result<bool, RuntimeError> {
+        match release_kind {
+            SessionReleaseKind::DiscardTransient => {
+                self.inner
+                    .runtime
+                    .discard_transient_session(AgentSessionReleaseRequest {
+                        workspace_path,
+                        session_id,
+                        remote_connection_id,
+                        remote_ssh_host,
+                        wait_timeout_ms,
+                    })
+                    .await
+            }
+            SessionReleaseKind::UnloadPersisted => {
+                self.inner
+                    .runtime
+                    .unload_persisted_session(AgentSessionReleaseRequest {
+                        workspace_path,
+                        session_id,
+                        remote_connection_id,
+                        remote_ssh_host,
+                        wait_timeout_ms,
+                    })
+                    .await
+            }
+            SessionReleaseKind::DeletePersisted => self
+                .inner
+                .runtime
+                .delete_session(AgentSessionDeleteRequest {
+                    workspace_path,
+                    session_id,
+                    remote_connection_id,
+                    remote_ssh_host,
+                })
+                .await
+                .map(|_| true),
         }
     }
 
@@ -918,17 +1015,86 @@ impl SdkHostConnection {
                 },
                 workspace_path,
                 session_budget,
+                SessionLifetime::Durable,
             )
             .await;
         match result {
             Ok(created) => {
                 let session_id = created.session_id.clone();
-                self.deliver_session_create_response(request.id.clone(), created, session_id)
-                    .await;
+                self.deliver_session_create_response(
+                    request.id.clone(),
+                    created,
+                    session_id,
+                    SessionLifetime::Durable,
+                )
+                .await;
             }
             Err(error) => {
                 self.send_runtime_error(request.id.clone(), ErrorStage::Session, error)
                     .await
+            }
+        }
+    }
+
+    async fn handle_session_resume(&self, request: JsonRpcRequest) {
+        let Some(params) = self
+            .parse_params::<SessionResumeParams>(&request, ErrorStage::Session)
+            .await
+        else {
+            return;
+        };
+        if params.session_id.trim().is_empty() {
+            self.send_invalid_params(
+                request.id.clone(),
+                ErrorStage::Session,
+                "sessionId must not be empty",
+            )
+            .await;
+            return;
+        }
+        let Ok(session_budget) = self.inner.session_budget.clone().try_acquire_owned() else {
+            self.send_error(
+                request.id.clone(),
+                ErrorCode::Overloaded,
+                ErrorStage::Session,
+                true,
+                Some(RecoveryAction::Retry),
+                "SDK Host Session capacity is exhausted",
+            )
+            .await;
+            return;
+        };
+        let workspace_path = self.inner.default_cwd.clone();
+        let Some(model_id) = self.inner.state.lock().await.model_id.clone() else {
+            self.send_runtime_error(
+                request.id.clone(),
+                ErrorStage::Session,
+                PortError::new(
+                    PortErrorKind::NotAvailable,
+                    "SDK Host model is not initialized",
+                )
+                .into(),
+            )
+            .await;
+            return;
+        };
+        let session_id = params.session_id;
+        match self
+            .restore_leased_session(session_id.clone(), workspace_path, model_id, session_budget)
+            .await
+        {
+            Ok(restored) => {
+                self.deliver_session_create_response(
+                    request.id.clone(),
+                    restored,
+                    session_id,
+                    SessionLifetime::Durable,
+                )
+                .await;
+            }
+            Err(error) => {
+                self.send_runtime_error(request.id.clone(), ErrorStage::Session, error)
+                    .await;
             }
         }
     }
@@ -1045,6 +1211,7 @@ impl SdkHostConnection {
                         },
                         workspace_path,
                         session_budget,
+                        SessionLifetime::Connection,
                     )
                     .await
                 {
@@ -1064,7 +1231,7 @@ impl SdkHostConnection {
         let session = match self.reserve_query_session(&session_id).await {
             Ok(session) => session,
             Err(reservation_error) => {
-                if created_session && self.delete_unexposed_session(&session_id).await.is_err() {
+                if created_session && self.release_unexposed_session(&session_id).await.is_err() {
                     self.send_cleanup_required(request.id.clone(), ErrorStage::Query, &session_id)
                         .await;
                     return;
@@ -1093,13 +1260,13 @@ impl SdkHostConnection {
                 return;
             }
         };
-        let session_lifetime = SessionLifetime::Connection;
+        let session_lifetime = session.lifetime;
 
         let mut events = match self.inner.runtime.subscribe_session_events(&session_id) {
             Ok(events) => events,
             Err(error) => {
                 self.release_query_session(&session_id).await;
-                if created_session && self.delete_unexposed_session(&session_id).await.is_err() {
+                if created_session && self.release_unexposed_session(&session_id).await.is_err() {
                     self.send_cleanup_required(request.id.clone(), ErrorStage::Query, &session_id)
                         .await;
                     return;
@@ -1113,7 +1280,7 @@ impl SdkHostConnection {
             Ok(events) => events,
             Err(error) => {
                 self.release_query_session(&session_id).await;
-                if created_session && self.delete_unexposed_session(&session_id).await.is_err() {
+                if created_session && self.release_unexposed_session(&session_id).await.is_err() {
                     self.send_cleanup_required(request.id.clone(), ErrorStage::Query, &session_id)
                         .await;
                     return;
@@ -1156,7 +1323,7 @@ impl SdkHostConnection {
             Ok(outcome) => outcome,
             Err(error) => {
                 self.release_query_session(&session_id).await;
-                if created_session && self.delete_unexposed_session(&session_id).await.is_err() {
+                if created_session && self.release_unexposed_session(&session_id).await.is_err() {
                     self.send_cleanup_required(request.id.clone(), ErrorStage::Query, &session_id)
                         .await;
                     return;
@@ -1735,6 +1902,25 @@ impl SdkHostConnection {
             .await;
             return;
         }
+        let close_timeout_ms = params.wait_timeout_ms.unwrap_or(5_000);
+        if !self
+            .wait_for_session_publication(
+                &params.session_id,
+                Duration::from_millis(close_timeout_ms.min(MAX_SESSION_PUBLICATION_WAIT_MS)),
+            )
+            .await
+        {
+            self.send_error(
+                request.id.clone(),
+                ErrorCode::Timeout,
+                ErrorStage::Session,
+                true,
+                Some(RecoveryAction::Retry),
+                "Timed out waiting for Session creation or resume response to commit",
+            )
+            .await;
+            return;
+        }
         let session = {
             let mut state = self.inner.state.lock().await;
             if state.closing_sessions.contains(&params.session_id) {
@@ -1781,20 +1967,16 @@ impl SdkHostConnection {
             .await;
             return;
         };
-        let close_timeout_ms = params.wait_timeout_ms.unwrap_or(5_000);
         let session_id = params.session_id.clone();
-        let operation = async {
-            self.inner
-                .runtime
-                .discard_transient_session(AgentTransientSessionDiscardRequest {
-                    workspace_path: session.workspace_path,
-                    session_id: session_id.clone(),
-                    remote_connection_id: session.remote_connection_id,
-                    remote_ssh_host: session.remote_ssh_host,
-                    wait_timeout_ms: close_timeout_ms,
-                })
-                .await
-        };
+        let release_kind = session.release_kind();
+        let operation = self.release_runtime_session(
+            session_id,
+            session.workspace_path,
+            session.remote_connection_id,
+            session.remote_ssh_host,
+            release_kind,
+            close_timeout_ms,
+        );
         match timeout(Duration::from_millis(close_timeout_ms + 500), operation).await {
             Ok(Ok(unloaded)) => {
                 let queries = {
@@ -1874,6 +2056,27 @@ impl SdkHostConnection {
         state.cleanup_failed = true;
     }
 
+    async fn wait_for_session_publication(&self, session_id: &str, wait_timeout: Duration) -> bool {
+        timeout(wait_timeout, async {
+            loop {
+                self.reap_finished_pending_session_tasks().await;
+                if !self
+                    .inner
+                    .state
+                    .lock()
+                    .await
+                    .publishing_sessions
+                    .contains(session_id)
+                {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+        })
+        .await
+        .is_ok()
+    }
+
     async fn ensure_session_lease(&self, session_id: &str) -> Result<SessionLease, RuntimeError> {
         self.inner
             .state
@@ -1885,7 +2088,7 @@ impl SdkHostConnection {
             .ok_or_else(|| {
                 bitfun_runtime_ports::PortError::new(
                     PortErrorKind::NotAvailable,
-                    "sessionId must belong to the same SDK Host connection; durable Session resume is not available in this protocol version",
+                    "sessionId must be created or resumed on this SDK Host connection before starting a Query",
                 )
                 .into()
             })
@@ -1896,6 +2099,7 @@ impl SdkHostConnection {
         request: AgentSessionCreateRequest,
         workspace_path: String,
         session_budget: OwnedSemaphorePermit,
+        lifetime: SessionLifetime,
     ) -> Result<bitfun_agent_runtime::sdk::AgentSessionCreateResult, RuntimeError> {
         let session_id = uuid::Uuid::new_v4().to_string();
         let runtime = self.inner.runtime.clone();
@@ -1913,9 +2117,18 @@ impl SdkHostConnection {
         let task_session_id = session_id.clone();
         let cleanup_workspace_path = workspace_path.clone();
         let creation = tokio::spawn(async move {
-            let result = runtime
-                .create_transient_session_with_id(task_session_id, request)
-                .await;
+            let result = match lifetime {
+                SessionLifetime::Connection => {
+                    runtime
+                        .create_transient_session_with_id(task_session_id, request)
+                        .await
+                }
+                SessionLifetime::Durable => {
+                    runtime
+                        .create_session_with_id(task_session_id, request)
+                        .await
+                }
+            };
             if let Ok(created) = &result {
                 task_state.lock().await.sessions.insert(
                     created.session_id.clone(),
@@ -1924,6 +2137,11 @@ impl SdkHostConnection {
                         remote_connection_id: None,
                         remote_ssh_host: None,
                         exposed: false,
+                        lifetime,
+                        unexposed_release: match lifetime {
+                            SessionLifetime::Connection => SessionReleaseKind::DiscardTransient,
+                            SessionLifetime::Durable => SessionReleaseKind::DeletePersisted,
+                        },
                         _budget: Arc::new(session_budget),
                     },
                 );
@@ -1933,10 +2151,15 @@ impl SdkHostConnection {
         connection_state
             .pending_session_tasks
             .push(PendingSessionTask {
-                transient_cleanup: Some(TransientSessionCleanup {
+                session_cleanup: Some(SessionCleanup {
                     session_id,
                     workspace_path: cleanup_workspace_path,
+                    release_kind: match lifetime {
+                        SessionLifetime::Connection => SessionReleaseKind::DiscardTransient,
+                        SessionLifetime::Durable => SessionReleaseKind::DeletePersisted,
+                    },
                 }),
+                reservation: None,
                 task: creation,
             });
         drop(connection_state);
@@ -1948,11 +2171,157 @@ impl SdkHostConnection {
         })?
     }
 
+    async fn restore_leased_session(
+        &self,
+        session_id: String,
+        workspace_path: String,
+        model_id: String,
+        session_budget: OwnedSemaphorePermit,
+    ) -> Result<AgentSessionCreateResult, RuntimeError> {
+        let runtime = self.inner.runtime.clone();
+        let state = self.inner.state.clone();
+        let task_state = state.clone();
+        let (result_tx, result_rx) = oneshot::channel();
+        let mut connection_state = state.lock().await;
+        if connection_state.shutting_down {
+            return Err(PortError::new(
+                PortErrorKind::Cancelled,
+                "SDK Host connection is shutting down",
+            )
+            .into());
+        }
+        if connection_state.sessions.contains_key(&session_id)
+            || !connection_state
+                .attaching_sessions
+                .insert(session_id.clone())
+        {
+            return Err(PortError::new(
+                PortErrorKind::InvalidRequest,
+                "Session is already attached to this SDK Host connection",
+            )
+            .into());
+        }
+        let task_session_id = session_id.clone();
+        let task_workspace_path = workspace_path.clone();
+        let cleanup_workspace_path = workspace_path.clone();
+        let restoration = tokio::spawn(async move {
+            let restored = runtime
+                .restore_session(AgentSessionRestoreRequest {
+                    workspace_path: task_workspace_path.clone(),
+                    session_id: task_session_id.clone(),
+                    include_internal: false,
+                    remote_connection_id: None,
+                    remote_ssh_host: None,
+                })
+                .await;
+            let result = match restored {
+                Err(error) => Err(error),
+                Ok(restored) => {
+                    let prepared = async {
+                        runtime
+                            .update_session_model(AgentSessionModelUpdateRequest {
+                                session_id: task_session_id.clone(),
+                                model_id: model_id.clone(),
+                            })
+                            .await?;
+                        let binding = runtime
+                            .resolve_session_workspace_binding(AgentSessionWorkspaceRequest {
+                                session_id: task_session_id.clone(),
+                            })
+                            .await?;
+                        let mut result = AgentSessionCreateResult::new(
+                            restored.session.session_id,
+                            restored.session.session_name,
+                            restored.session.agent_type,
+                        );
+                        result.model_id = Some(model_id);
+                        if let Some(binding) = binding {
+                            result.workspace_path = Some(binding.workspace_path);
+                            result.workspace_id = binding.workspace_id;
+                            result.project_workspace_path = binding.project_workspace_path;
+                            result.execution_target = binding.execution_target;
+                        } else {
+                            result.workspace_path = Some(task_workspace_path.clone());
+                        }
+                        Ok(result)
+                    }
+                    .await;
+                    if prepared.is_err() {
+                        let release = runtime
+                            .unload_persisted_session(AgentSessionReleaseRequest {
+                                workspace_path: task_workspace_path.clone(),
+                                session_id: task_session_id.clone(),
+                                remote_connection_id: None,
+                                remote_ssh_host: None,
+                                wait_timeout_ms: 4_500,
+                            })
+                            .await;
+                        if release.is_err() {
+                            task_state.lock().await.untracked_session_cleanups.insert(
+                                task_session_id.clone(),
+                                SessionCleanup {
+                                    session_id: task_session_id.clone(),
+                                    workspace_path: task_workspace_path.clone(),
+                                    release_kind: SessionReleaseKind::UnloadPersisted,
+                                },
+                            );
+                            Err(PortError::new(
+                                PortErrorKind::CleanupRequired,
+                                "Restored Session could not be prepared or released",
+                            )
+                            .into())
+                        } else {
+                            prepared
+                        }
+                    } else {
+                        prepared
+                    }
+                }
+            };
+            let mut connection_state = task_state.lock().await;
+            if let Ok(restored) = &result {
+                connection_state.sessions.insert(
+                    restored.session_id.clone(),
+                    SessionLease {
+                        workspace_path,
+                        remote_connection_id: None,
+                        remote_ssh_host: None,
+                        exposed: false,
+                        lifetime: SessionLifetime::Durable,
+                        unexposed_release: SessionReleaseKind::UnloadPersisted,
+                        _budget: Arc::new(session_budget),
+                    },
+                );
+            }
+            drop(connection_state);
+            let _ = result_tx.send(result);
+        });
+        connection_state
+            .pending_session_tasks
+            .push(PendingSessionTask {
+                session_cleanup: Some(SessionCleanup {
+                    session_id: session_id.clone(),
+                    workspace_path: cleanup_workspace_path,
+                    release_kind: SessionReleaseKind::UnloadPersisted,
+                }),
+                reservation: Some(SessionTaskReservation::Attaching(session_id)),
+                task: restoration,
+            });
+        drop(connection_state);
+        result_rx.await.map_err(|_| {
+            RuntimeError::from(PortError::new(
+                PortErrorKind::Backend,
+                "SDK Host Session restore task ended without a result",
+            ))
+        })?
+    }
+
     async fn deliver_session_create_response(
         &self,
         request_id: Option<RequestId>,
         created: AgentSessionCreateResult,
         session_id: String,
+        lifetime: SessionLifetime,
     ) -> bool {
         let connection = self.clone();
         let (delivered_tx, delivered_rx) = oneshot::channel();
@@ -1960,11 +2329,13 @@ impl SdkHostConnection {
         if state.shutting_down {
             return false;
         }
+        state.publishing_sessions.insert(session_id.clone());
+        let publishing_session_id = session_id.clone();
         let delivery = tokio::spawn(async move {
             let delivered = connection
                 .send_success(
                     request_id,
-                    SessionCreateResult::from_runtime(created, SessionLifetime::Connection),
+                    SessionCreateResult::from_runtime(created, lifetime),
                 )
                 .await;
             if delivered {
@@ -1972,13 +2343,14 @@ impl SdkHostConnection {
             } else {
                 tokio::select! {
                     _ = connection.inner.shutdown_started.cancelled() => {}
-                    _ = connection.delete_unexposed_session(&session_id) => {}
+                    _ = connection.release_unexposed_session(&session_id) => {}
                 }
             }
             let _ = delivered_tx.send(delivered);
         });
         state.pending_session_tasks.push(PendingSessionTask {
-            transient_cleanup: None,
+            session_cleanup: None,
+            reservation: Some(SessionTaskReservation::Publishing(publishing_session_id)),
             task: delivery,
         });
         drop(state);
@@ -2020,7 +2392,9 @@ impl SdkHostConnection {
                         )
                         .await;
                     if created_session {
-                        let _ = connection.delete_unexposed_session(&lease.session_id).await;
+                        let _ = connection
+                            .release_unexposed_session(&lease.session_id)
+                            .await;
                     }
                 };
                 tokio::select! {
@@ -2031,7 +2405,8 @@ impl SdkHostConnection {
             let _ = delivered_tx.send(delivered);
         });
         state.pending_session_tasks.push(PendingSessionTask {
-            transient_cleanup: None,
+            session_cleanup: None,
+            reservation: None,
             task: delivery,
         });
         drop(state);
@@ -2069,12 +2444,13 @@ impl SdkHostConnection {
     }
 
     async fn mark_session_exposed(&self, session_id: &str) {
-        if let Some(session) = self.inner.state.lock().await.sessions.get_mut(session_id) {
+        let mut state = self.inner.state.lock().await;
+        if let Some(session) = state.sessions.get_mut(session_id) {
             session.exposed = true;
         }
     }
 
-    async fn delete_unexposed_session(&self, session_id: &str) -> Result<(), ()> {
+    async fn release_unexposed_session(&self, session_id: &str) -> Result<(), ()> {
         let lease = self
             .inner
             .state
@@ -2086,17 +2462,17 @@ impl SdkHostConnection {
         let Some(lease) = lease else {
             return Ok(());
         };
+        let release_kind = lease.release_kind();
         match timeout(
             Duration::from_millis(5_000),
-            self.inner
-                .runtime
-                .discard_transient_session(AgentTransientSessionDiscardRequest {
-                    workspace_path: lease.workspace_path,
-                    session_id: session_id.to_string(),
-                    remote_connection_id: lease.remote_connection_id,
-                    remote_ssh_host: lease.remote_ssh_host,
-                    wait_timeout_ms: 4_500,
-                }),
+            self.release_runtime_session(
+                session_id.to_string(),
+                lease.workspace_path,
+                lease.remote_connection_id,
+                lease.remote_ssh_host,
+                release_kind,
+                4_500,
+            ),
         )
         .await
         {
@@ -2108,7 +2484,7 @@ impl SdkHostConnection {
                 tracing::warn!(
                     session_id = %session_id,
                     error_kind = runtime_error_kind(&error),
-                    "Failed to delete an unexposed SDK Host Session"
+                    "Failed to release an unexposed SDK Host Session"
                 );
                 self.inner.state.lock().await.cleanup_failed = true;
                 Err(())
@@ -2116,7 +2492,7 @@ impl SdkHostConnection {
             Err(_) => {
                 tracing::warn!(
                     session_id = %session_id,
-                    "Timed out while deleting an unexposed SDK Host Session"
+                    "Timed out while releasing an unexposed SDK Host Session"
                 );
                 self.inner.state.lock().await.cleanup_failed = true;
                 Err(())

--- a/src/crates/interfaces/sdk-host/src/protocol.rs
+++ b/src/crates/interfaces/sdk-host/src/protocol.rs
@@ -6,10 +6,11 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
 pub const JSON_RPC_VERSION: &str = "2.0";
-pub const PROTOCOL_VERSION: u32 = 3;
+pub const PROTOCOL_VERSION: u32 = 4;
 
 pub const METHOD_INITIALIZE: &str = "initialize";
 pub const METHOD_SESSION_CREATE: &str = "session/create";
+pub const METHOD_SESSION_RESUME: &str = "session/resume";
 pub const METHOD_QUERY_START: &str = "query/start";
 pub const METHOD_QUERY_CANCEL: &str = "query/cancel";
 pub const METHOD_PERMISSION_RESPOND: &str = "permission/respond";
@@ -262,6 +263,7 @@ pub enum Stability {
 pub struct HostCapabilities {
     pub session_create: bool,
     pub session_create_lifetime: SessionLifetime,
+    pub session_resume: bool,
     pub query: bool,
     pub query_cancel: bool,
     pub session_close: bool,
@@ -280,7 +282,8 @@ impl HostCapabilities {
     pub const fn current() -> Self {
         Self {
             session_create: true,
-            session_create_lifetime: SessionLifetime::Connection,
+            session_create_lifetime: SessionLifetime::Durable,
+            session_resume: true,
             query: true,
             query_cancel: true,
             session_close: true,
@@ -304,6 +307,8 @@ impl HostCapabilities {
 pub enum SessionLifetime {
     /// Created and deleted by this Host connection.
     Connection,
+    /// Persisted by the Agent Runtime and resumable by a later Host process.
+    Durable,
 }
 
 fn deserialize_optional_request_id<'de, D>(deserializer: D) -> Result<Option<RequestId>, D::Error>
@@ -406,6 +411,13 @@ pub struct SessionCreateParams {
     #[cfg_attr(feature = "ts", ts(optional = nullable))]
     #[serde(default)]
     pub model: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct SessionResumeParams {
+    pub session_id: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/crates/interfaces/sdk-host/tests/host_lifecycle.rs
+++ b/src/crates/interfaces/sdk-host/tests/host_lifecycle.rs
@@ -8,12 +8,14 @@ use bitfun_agent_runtime::sdk::{
     AgentDialogTurnPort, AgentDialogTurnRequest, AgentEventSource, AgentRuntimeBuilder,
     AgentSessionClosePort, AgentSessionCreateRequest, AgentSessionCreateResult,
     AgentSessionDeleteRequest, AgentSessionListRequest, AgentSessionManagementPort,
-    AgentSessionSummary, AgentSessionWorkspaceBinding, AgentSessionWorkspaceRequest,
-    AgentSubmissionPort, AgentSubmissionRequest, AgentSubmissionResult,
-    AgentTransientSessionDiscardRequest, AgentTurnCancellationPort, AgentTurnCancellationRequest,
-    AgentTurnCancellationResult, AgentTurnSettlementPort, AgentTurnSettlementRequest,
-    DialogSubmitOutcome, PermissionRequest, PermissionRequestManager, PermissionRequestSource,
-    PermissionRequestSourceKind, PortError, PortErrorKind, PortResult,
+    AgentSessionModelPort, AgentSessionModelSelectionUpdateRequest, AgentSessionRestorePort,
+    AgentSessionRestoreRequest, AgentSessionRestoreResult, AgentSessionSummary,
+    AgentSessionWorkspaceBinding, AgentSessionWorkspaceRequest, AgentSubmissionPort,
+    AgentSubmissionRequest, AgentSubmissionResult, AgentTransientSessionDiscardRequest,
+    AgentTurnCancellationPort, AgentTurnCancellationRequest, AgentTurnCancellationResult,
+    AgentTurnSettlementPort, AgentTurnSettlementRequest, DialogSubmitOutcome, PermissionRequest,
+    PermissionRequestManager, PermissionRequestSource, PermissionRequestSourceKind, PortError,
+    PortErrorKind, PortResult, SessionState,
 };
 use bitfun_core_types::ErrorCategory;
 use bitfun_events::{AgenticEvent, ToolEventData, ToolEventIdentity};
@@ -36,6 +38,10 @@ struct FakeOwner {
     created_model_ids: Mutex<Vec<Option<String>>>,
     cancel_requests: Mutex<Vec<AgentTurnCancellationRequest>>,
     discard_requests: Mutex<Vec<AgentTransientSessionDiscardRequest>>,
+    unload_requests: Mutex<Vec<AgentTransientSessionDiscardRequest>>,
+    delete_requests: Mutex<Vec<AgentSessionDeleteRequest>>,
+    restored_session_ids: Mutex<Vec<String>>,
+    updated_models: Mutex<Vec<(String, String)>>,
     settlement_requests: Mutex<Vec<AgentTurnSettlementRequest>>,
     dialog_metadata: Mutex<Vec<serde_json::Map<String, serde_json::Value>>>,
     emit_terminal: bool,
@@ -51,7 +57,9 @@ struct FakeOwner {
     block_first_cancel: bool,
     block_delete: bool,
     block_session_create: bool,
+    block_first_session_restore: AtomicBool,
     panic_after_session_create: bool,
+    fail_model_update: bool,
     dialog_submit_started: Notify,
     release_dialog_submit: Notify,
     agent_resolution_started: Notify,
@@ -62,6 +70,8 @@ struct FakeOwner {
     release_delete: Notify,
     session_create_started: Notify,
     release_session_create: Notify,
+    session_restore_started: Notify,
+    release_session_restore: Notify,
 }
 
 impl FakeOwner {
@@ -74,6 +84,12 @@ impl FakeOwner {
                 .unwrap()
                 .iter()
                 .any(|created| created == session_id)
+            || self
+                .restored_session_ids
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|restored| restored == session_id)
     }
 
     fn last_created_session_id(&self) -> String {
@@ -196,6 +212,25 @@ impl FakeOwner {
         }
     }
 
+    fn blocking_first_session_restore(queue: Arc<EventQueue>) -> Self {
+        Self {
+            queue: Mutex::new(Some(queue)),
+            emit_terminal: true,
+            block_first_session_restore: AtomicBool::new(true),
+            ..Self::default()
+        }
+    }
+
+    fn failing_resume_preparation_and_unload(queue: Arc<EventQueue>) -> Self {
+        Self {
+            queue: Mutex::new(Some(queue)),
+            emit_terminal: true,
+            fail_delete: true,
+            fail_model_update: true,
+            ..Self::default()
+        }
+    }
+
     fn panicking_session_create(queue: Arc<EventQueue>, fail_delete: bool) -> Self {
         Self {
             queue: Mutex::new(Some(queue)),
@@ -310,7 +345,7 @@ impl AgentSubmissionPort for FakeOwner {
             .unwrap()
             .push(request.model_id.clone());
         if self.panic_after_session_create {
-            panic!("fixture panics after creating the transient Session");
+            panic!("fixture panics after creating the Session");
         }
         Ok(AgentSessionCreateResult::new(
             session_id,
@@ -520,7 +555,8 @@ impl AgentSessionManagementPort for FakeOwner {
         Ok(Vec::new())
     }
 
-    async fn delete_session(&self, _request: AgentSessionDeleteRequest) -> PortResult<()> {
+    async fn delete_session(&self, request: AgentSessionDeleteRequest) -> PortResult<()> {
+        self.delete_requests.lock().unwrap().push(request);
         if self.fail_delete {
             return Err(PortError::new(
                 PortErrorKind::CleanupRequired,
@@ -545,6 +581,61 @@ impl AgentSessionManagementPort for FakeOwner {
             remote_connection_id: None,
             remote_ssh_host: None,
         }))
+    }
+}
+
+#[async_trait]
+impl AgentSessionRestorePort for FakeOwner {
+    async fn restore_session(
+        &self,
+        request: AgentSessionRestoreRequest,
+    ) -> PortResult<AgentSessionRestoreResult> {
+        if self
+            .block_first_session_restore
+            .swap(false, Ordering::AcqRel)
+        {
+            self.session_restore_started.notify_one();
+            self.release_session_restore.notified().await;
+        }
+        self.restored_session_ids
+            .lock()
+            .unwrap()
+            .push(request.session_id.clone());
+        Ok(AgentSessionRestoreResult {
+            session: AgentSessionSummary {
+                session_id: request.session_id,
+                session_name: "Persisted".to_string(),
+                agent_type: "agentic".to_string(),
+                model_id: Some("sdk:openai:previous".to_string()),
+                reasoning_preset: None,
+                last_user_dialog_agent_type: None,
+                last_submitted_agent_type: None,
+                turn_count: 1,
+                created_at_ms: 1,
+                last_active_at_ms: 2,
+            },
+            state: SessionState::Idle,
+        })
+    }
+}
+
+#[async_trait]
+impl AgentSessionModelPort for FakeOwner {
+    async fn update_session_model_selection(
+        &self,
+        request: AgentSessionModelSelectionUpdateRequest,
+    ) -> PortResult<()> {
+        self.updated_models
+            .lock()
+            .unwrap()
+            .push((request.session_id, request.selection.model_id));
+        if self.fail_model_update {
+            return Err(PortError::new(
+                PortErrorKind::Backend,
+                "model update failed",
+            ));
+        }
+        Ok(())
     }
 }
 
@@ -779,14 +870,8 @@ struct BlockingSessionCreateOutput {
 #[async_trait]
 impl HostOutput for BlockingSessionCreateOutput {
     async fn send(&self, value: serde_json::Value) -> Result<(), ()> {
-        let is_session_create = value
-            .get("result")
-            .and_then(|result| result.get("sessionId"))
-            .is_some()
-            && value
-                .get("result")
-                .and_then(|result| result.get("queryId"))
-                .is_none();
+        let is_session_create =
+            value.get("id").and_then(serde_json::Value::as_str) == Some("visible-create");
         self.output.send(value).await.map_err(|_| ())?;
         if is_session_create {
             self.response_visible.notify_one();
@@ -814,6 +899,14 @@ impl AgentSessionClosePort for FakeOwner {
             ));
         }
         Ok(true)
+    }
+
+    async fn unload_persisted_session(
+        &self,
+        request: AgentTransientSessionDiscardRequest,
+    ) -> PortResult<bool> {
+        self.unload_requests.lock().unwrap().push(request.clone());
+        self.discard_transient_session(request).await
     }
 }
 
@@ -845,6 +938,8 @@ async fn host_with_temporary_model_installer(
         .with_turn_settlement_port(owner.clone())
         .with_session_management_port(owner.clone())
         .with_session_close_port(owner.clone())
+        .with_session_model_port(owner.clone())
+        .with_session_restore_port(owner.clone())
         .with_permission_request_manager(permission_manager())
         .with_event_source(AgentEventSource::new(queue))
         .build()
@@ -1125,7 +1220,7 @@ async fn resource_lifecycle_notifications_do_not_create_unaddressable_sessions()
     .await;
     let created = output.recv().await.unwrap();
     assert_eq!(created["id"], "create-after-notifications");
-    assert_eq!(created["result"]["lifetime"], "connection");
+    assert_eq!(created["result"]["lifetime"], "durable");
 
     host.shutdown_connection().await;
 }
@@ -1418,7 +1513,7 @@ async fn cancellation_timeout_reports_unknown_outcome_for_the_exact_operation() 
 }
 
 #[tokio::test]
-async fn query_on_created_transient_session_preserves_connection_lifetime() {
+async fn query_on_created_session_preserves_durable_lifetime() {
     let (host, _, mut output) = host().await;
     initialize(&host, &mut output).await;
 
@@ -1430,7 +1525,7 @@ async fn query_on_created_transient_session_preserves_connection_lifetime() {
     })))
     .await;
     let created = output.recv().await.unwrap();
-    assert_eq!(created["result"]["lifetime"], "connection");
+    assert_eq!(created["result"]["lifetime"], "durable");
     let session_id = created["result"]["sessionId"].as_str().unwrap();
 
     host.handle_request(request(serde_json::json!({
@@ -1447,9 +1542,160 @@ async fn query_on_created_transient_session_preserves_connection_lifetime() {
     let accepted = output.recv().await.unwrap();
     assert_eq!(accepted["id"], "query-1");
     assert_eq!(accepted["result"]["createdSession"], false);
-    assert_eq!(accepted["result"]["sessionLifetime"], "connection");
+    assert_eq!(accepted["result"]["sessionLifetime"], "durable");
 
     host.shutdown_connection().await;
+}
+
+#[tokio::test]
+async fn persisted_session_resume_rebinds_the_connection_model_and_unloads_on_close() {
+    let (host, owner, mut output) = host().await;
+    initialize(&host, &mut output).await;
+    let session_id = "00000000-0000-4000-8000-000000000001";
+
+    host.handle_request(request(serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": "resume-1",
+        "method": "session/resume",
+        "params": { "sessionId": session_id }
+    })))
+    .await;
+    let resumed = output.recv().await.unwrap();
+    assert_eq!(resumed["result"]["sessionId"], session_id);
+    assert_eq!(resumed["result"]["lifetime"], "durable");
+    assert_eq!(
+        owner.updated_models.lock().unwrap().as_slice(),
+        &[(session_id.to_string(), "sdk:openai:resolved".to_string())]
+    );
+
+    host.handle_request(request(serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": "close-resumed",
+        "method": "session/close",
+        "params": { "sessionId": session_id }
+    })))
+    .await;
+    assert_eq!(output.recv().await.unwrap()["result"]["unloaded"], true);
+    assert_eq!(owner.unload_requests.lock().unwrap().len(), 1);
+
+    host.shutdown_connection().await;
+}
+
+#[tokio::test]
+async fn concurrent_resume_of_the_same_session_is_rejected_while_attach_is_in_flight() {
+    let queue = Arc::new(EventQueue::new(EventQueueConfig::default()));
+    let owner = Arc::new(FakeOwner::blocking_first_session_restore(queue.clone()));
+    let runtime = AgentRuntimeBuilder::new()
+        .with_submission_port(owner.clone())
+        .with_dialog_turn_port(owner.clone())
+        .with_cancellation_port(owner.clone())
+        .with_turn_settlement_port(owner.clone())
+        .with_session_management_port(owner.clone())
+        .with_session_close_port(owner.clone())
+        .with_session_model_port(owner.clone())
+        .with_session_restore_port(owner.clone())
+        .with_permission_request_manager(permission_manager())
+        .with_event_source(AgentEventSource::new(queue))
+        .build()
+        .unwrap();
+    let (sender, mut output) = mpsc::channel(16);
+    let host = SdkHostConnection::new(
+        runtime,
+        "D:/workspace/project",
+        sender,
+        SdkHostConfig::default(),
+        fake_installer(),
+    );
+    initialize(&host, &mut output).await;
+    let session_id = "00000000-0000-4000-8000-000000000002";
+
+    let first_host = host.clone();
+    let first = tokio::spawn(async move {
+        first_host
+            .handle_request(request(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": "resume-first",
+                "method": "session/resume",
+                "params": { "sessionId": session_id }
+            })))
+            .await
+    });
+    owner.session_restore_started.notified().await;
+
+    host.handle_request(request(serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": "resume-second",
+        "method": "session/resume",
+        "params": { "sessionId": session_id }
+    })))
+    .await;
+    let rejected = output.recv().await.unwrap();
+    assert_eq!(rejected["id"], "resume-second");
+    assert_eq!(rejected["error"]["data"]["code"], "invalid_request");
+
+    owner.release_session_restore.notify_one();
+    assert_eq!(first.await.unwrap(), ConnectionControl::Continue);
+    let resumed = output.recv().await.unwrap();
+    assert_eq!(resumed["id"], "resume-first");
+    assert_eq!(resumed["result"]["sessionId"], session_id);
+    assert_eq!(owner.restored_session_ids.lock().unwrap().len(), 1);
+
+    host.shutdown_connection().await;
+}
+
+#[tokio::test]
+async fn failed_resume_compensation_blocks_new_work_and_retries_unload_on_shutdown() {
+    let queue = Arc::new(EventQueue::new(EventQueueConfig::default()));
+    let owner = Arc::new(FakeOwner::failing_resume_preparation_and_unload(
+        queue.clone(),
+    ));
+    let runtime = AgentRuntimeBuilder::new()
+        .with_submission_port(owner.clone())
+        .with_dialog_turn_port(owner.clone())
+        .with_cancellation_port(owner.clone())
+        .with_turn_settlement_port(owner.clone())
+        .with_session_management_port(owner.clone())
+        .with_session_close_port(owner.clone())
+        .with_session_model_port(owner.clone())
+        .with_session_restore_port(owner.clone())
+        .with_permission_request_manager(permission_manager())
+        .with_event_source(AgentEventSource::new(queue))
+        .build()
+        .unwrap();
+    let (sender, mut output) = mpsc::channel(16);
+    let host = SdkHostConnection::new(
+        runtime,
+        "D:/workspace/project",
+        sender,
+        SdkHostConfig::default(),
+        fake_installer(),
+    );
+    initialize(&host, &mut output).await;
+    let session_id = "00000000-0000-4000-8000-000000000003";
+
+    host.handle_request(request(serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": "resume-failed-cleanup",
+        "method": "session/resume",
+        "params": { "sessionId": session_id }
+    })))
+    .await;
+    let resume_error = output.recv().await.unwrap();
+    assert_eq!(resume_error["error"]["data"]["code"], "cleanup_required");
+    assert_eq!(owner.unload_requests.lock().unwrap().len(), 1);
+
+    host.handle_request(request(serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": "blocked-after-failed-cleanup",
+        "method": "session/create",
+        "params": {}
+    })))
+    .await;
+    let blocked = output.recv().await.unwrap();
+    assert_eq!(blocked["error"]["data"]["code"], "cleanup_required");
+
+    host.shutdown_connection().await;
+    assert_eq!(owner.unload_requests.lock().unwrap().len(), 2);
 }
 
 #[tokio::test]
@@ -1729,7 +1975,7 @@ async fn cancellation_remains_available_when_data_request_capacity_is_exhausted(
 }
 
 #[tokio::test]
-async fn connection_loss_discards_owned_transient_sessions_through_core_port() {
+async fn connection_loss_unloads_owned_durable_sessions_through_core_port() {
     let (host, owner, mut output) = host().await;
     initialize(&host, &mut output).await;
     host.handle_request(request(serde_json::json!({
@@ -1741,18 +1987,18 @@ async fn connection_loss_discards_owned_transient_sessions_through_core_port() {
     .await;
     let created = output.recv().await.unwrap();
     assert_eq!(created["id"], "create-1");
-    assert_eq!(created["result"]["lifetime"], "connection");
+    assert_eq!(created["result"]["lifetime"], "durable");
     let session_id = created["result"]["sessionId"].as_str().unwrap();
 
     host.shutdown_connection().await;
 
-    let requests = owner.discard_requests.lock().unwrap();
+    let requests = owner.unload_requests.lock().unwrap();
     assert_eq!(requests.len(), 1);
     assert_eq!(requests[0].session_id, session_id);
 }
 
 #[tokio::test]
-async fn existing_durable_session_is_not_adopted_without_cross_process_fencing() {
+async fn query_start_does_not_implicitly_resume_a_durable_session() {
     let (host, owner, mut output) = host().await;
     initialize(&host, &mut output).await;
     host.handle_request(request(serde_json::json!({
@@ -1776,7 +2022,7 @@ async fn existing_durable_session_is_not_adopted_without_cross_process_fencing()
 }
 
 #[tokio::test]
-async fn visible_session_create_response_is_exposed_before_shutdown_cleanup() {
+async fn visible_session_create_response_commits_before_immediate_close() {
     let queue = Arc::new(EventQueue::new(EventQueueConfig::default()));
     let owner = Arc::new(FakeOwner::with_queue(queue.clone()));
     let runtime = AgentRuntimeBuilder::new()
@@ -1818,21 +2064,37 @@ async fn visible_session_create_response_is_exposed_before_shutdown_cleanup() {
             .await
     });
     response_visible.notified().await;
-    assert_eq!(output.recv().await.unwrap()["id"], "visible-create");
+    let visible = output.recv().await.unwrap();
+    assert_eq!(visible["id"], "visible-create");
+    let session_id = visible["result"]["sessionId"].as_str().unwrap().to_string();
 
-    let shutdown_host = host.clone();
-    let mut shutdown = tokio::spawn(async move { shutdown_host.shutdown_connection().await });
+    let close_host = host.clone();
+    let close = tokio::spawn(async move {
+        close_host
+            .handle_request(request(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": "close-before-create-delivery-commits",
+                "method": "session/close",
+                "params": { "sessionId": session_id }
+            })))
+            .await
+    });
     assert!(
-        tokio::time::timeout(Duration::from_millis(50), &mut shutdown)
+        tokio::time::timeout(Duration::from_millis(50), output.recv())
             .await
             .is_err(),
-        "shutdown must wait until response visibility is committed"
+        "close must wait until response visibility is committed"
     );
     release_response.notify_one();
 
     assert_eq!(create.await.unwrap(), ConnectionControl::Continue);
-    shutdown.await.unwrap();
-    assert_eq!(owner.discard_requests.lock().unwrap().len(), 1);
+    assert_eq!(close.await.unwrap(), ConnectionControl::Continue);
+    let closed = output.recv().await.unwrap();
+    assert_eq!(closed["result"]["unloaded"], true);
+    assert_eq!(owner.unload_requests.lock().unwrap().len(), 1);
+    assert!(owner.delete_requests.lock().unwrap().is_empty());
+
+    host.shutdown_connection().await;
 }
 
 #[tokio::test]
@@ -1885,7 +2147,7 @@ async fn shutdown_waits_for_in_flight_session_creation_then_cleans_it() {
 
     assert_eq!(create.await.unwrap(), ConnectionControl::Continue);
     shutdown.await.unwrap();
-    let deleted = owner.discard_requests.lock().unwrap();
+    let deleted = owner.delete_requests.lock().unwrap();
     assert_eq!(deleted.len(), 1);
     assert_eq!(deleted[0].session_id, owner.last_created_session_id());
 }
@@ -1928,9 +2190,9 @@ async fn shutdown_compensates_a_session_creation_task_that_panics_after_creation
         host.shutdown_connection_bounded(Duration::from_secs(1))
             .await
     );
-    let discarded = owner.discard_requests.lock().unwrap();
-    assert_eq!(discarded.len(), 1);
-    assert_eq!(discarded[0].session_id, owner.last_created_session_id());
+    let deleted = owner.delete_requests.lock().unwrap();
+    assert_eq!(deleted.len(), 1);
+    assert_eq!(deleted[0].session_id, owner.last_created_session_id());
 }
 
 #[tokio::test]
@@ -1972,7 +2234,7 @@ async fn shutdown_reports_failure_when_post_panic_session_compensation_fails() {
             .shutdown_connection_bounded(Duration::from_secs(1))
             .await
     );
-    assert_eq!(owner.discard_requests.lock().unwrap().len(), 1);
+    assert_eq!(owner.delete_requests.lock().unwrap().len(), 1);
 }
 
 #[tokio::test]
@@ -2022,15 +2284,15 @@ async fn a_later_request_registers_panicked_session_cleanup_for_shutdown() {
         cleanup_required["error"]["data"]["code"],
         "cleanup_required"
     );
-    assert!(owner.discard_requests.lock().unwrap().is_empty());
+    assert!(owner.delete_requests.lock().unwrap().is_empty());
 
     assert!(
         host.shutdown_connection_bounded(Duration::from_secs(1))
             .await
     );
-    let discarded = owner.discard_requests.lock().unwrap();
-    assert_eq!(discarded.len(), 1);
-    assert_eq!(discarded[0].session_id, owner.last_created_session_id());
+    let deleted = owner.delete_requests.lock().unwrap();
+    assert_eq!(deleted.len(), 1);
+    assert_eq!(deleted[0].session_id, owner.last_created_session_id());
 }
 
 #[tokio::test]
@@ -2085,9 +2347,9 @@ async fn shutdown_does_not_forget_cleanup_registered_by_a_later_request() {
             .shutdown_connection_bounded(Duration::from_secs(1))
             .await
     );
-    let discarded = owner.discard_requests.lock().unwrap();
-    assert_eq!(discarded.len(), 1);
-    assert_eq!(discarded[0].session_id, owner.last_created_session_id());
+    let deleted = owner.delete_requests.lock().unwrap();
+    assert_eq!(deleted.len(), 1);
+    assert_eq!(deleted[0].session_id, owner.last_created_session_id());
 }
 
 #[tokio::test]
@@ -2133,7 +2395,7 @@ async fn existing_transient_session_cannot_be_adopted_as_durable() {
     assert_eq!(error["error"]["data"]["code"], "capability_unavailable");
     assert!(error["error"]["message"]
         .as_str()
-        .is_some_and(|message| message.contains("same SDK Host connection")));
+        .is_some_and(|message| message.contains("created or resumed")));
 }
 
 #[tokio::test]
@@ -2498,7 +2760,7 @@ async fn queued_query_is_accepted_and_tracked_by_its_exact_turn() {
     })))
     .await;
     let created = output.recv().await.unwrap();
-    assert_eq!(created["result"]["lifetime"], "connection");
+    assert_eq!(created["result"]["lifetime"], "durable");
     let session_id = created["result"]["sessionId"]
         .as_str()
         .expect("created Session id")

--- a/src/crates/interfaces/sdk-host/tests/protocol_contracts.rs
+++ b/src/crates/interfaces/sdk-host/tests/protocol_contracts.rs
@@ -3,8 +3,8 @@ use bitfun_sdk_host::protocol::{
     JsonRpcErrorResponse, JsonRpcRequest, JsonRpcSuccessResponse, OutcomeCertainty,
     PermissionDecision, PermissionRespondParams, PermissionSource, PermissionSourceKind,
     QueryEvent, QueryOutput, QueryResultError, QueryResultParams, QueryTerminalStatus,
-    RecoveryAction, RequestId, SessionLifetime, Stability, TemporaryModelConfig,
-    TemporaryModelProvider, ToolEventStatus, PROTOCOL_VERSION,
+    RecoveryAction, RequestId, SessionLifetime, SessionResumeParams, Stability,
+    TemporaryModelConfig, TemporaryModelProvider, ToolEventStatus, PROTOCOL_VERSION,
 };
 
 #[test]
@@ -14,7 +14,7 @@ fn initialize_contract_is_versioned_and_binds_one_temporary_model() {
         "id": 1,
         "method": "initialize",
         "params": {
-            "protocolVersion": 3,
+            "protocolVersion": 4,
             "clientInfo": { "name": "fixture", "version": "0.1.0" },
             "capabilities": {
                 "serverNotifications": true,
@@ -32,7 +32,7 @@ fn initialize_contract_is_versioned_and_binds_one_temporary_model() {
     let params: InitializeParams = request.params_as().unwrap();
 
     assert_eq!(request.id, Some(RequestId::Number(1)));
-    assert_eq!(PROTOCOL_VERSION, 3);
+    assert_eq!(PROTOCOL_VERSION, 4);
     assert_eq!(params.protocol_version, PROTOCOL_VERSION);
     assert!(params.capabilities.server_notifications);
     assert!(params.capabilities.permission_responses);
@@ -72,7 +72,8 @@ fn initialize_contract_is_versioned_and_binds_one_temporary_model() {
         result.capabilities,
         HostCapabilities {
             session_create: true,
-            session_create_lifetime: SessionLifetime::Connection,
+            session_create_lifetime: SessionLifetime::Durable,
+            session_resume: true,
             query: true,
             query_cancel: true,
             session_close: true,
@@ -105,7 +106,7 @@ fn current_host_capabilities_are_a_deliberate_subset_of_the_headless_cli_target(
 
     assert_eq!(
         capabilities.session_create_lifetime,
-        SessionLifetime::Connection
+        SessionLifetime::Durable
     );
     assert!(!capabilities.structured_output);
     assert!(!capabilities.usage);
@@ -114,6 +115,21 @@ fn current_host_capabilities_are_a_deliberate_subset_of_the_headless_cli_target(
     assert!(!capabilities.hooks);
     assert!(!capabilities.mcp_configuration);
     assert!(!capabilities.prestarted_transport);
+}
+
+#[test]
+fn durable_sessions_have_one_minimal_resume_contract() {
+    let params: SessionResumeParams = serde_json::from_value(serde_json::json!({
+        "sessionId": "session-1"
+    }))
+    .unwrap();
+
+    assert_eq!(params.session_id, "session-1");
+    assert_eq!(
+        serde_json::to_value(SessionLifetime::Durable).unwrap(),
+        serde_json::json!("durable")
+    );
+    assert!(HostCapabilities::current().session_resume);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- make explicit SDK sessions durable and resumable across managed Host restarts
- restore persisted history through the existing Agent Runtime and bind the resumed session to the new connection-scoped model
- unload durable sessions on `Session.close()` and Host shutdown without deleting history
- keep `client.query()` transient and continue using the existing per-session writer lock for same-session exclusion

## Why

The Host should be a replaceable process, not the owner of durable conversation state. An external application can now retain a session ID, restart its SDK client/Host, and resume that same session without introducing a machine-wide daemon or a second Agent Runtime.

| API | Lifetime | On Host close |
| --- | --- | --- |
| `client.query()` | transient | discarded |
| `client.sessions.create()` | durable | unloaded, history retained |
| `client.sessions.resume(id)` | durable | unloaded, history retained |

## Boundaries

- no daemon or shared socket service
- no Node-API, WASM/WASI, or custom tool surface
- no npm or PyPI publication; the TypeScript package remains local-only
- no changes to GUI, CLI, Server, or app-server routing

## Compatibility

- SDK Host protocol: v4
- Runtime SDK API: v7
- old clients fail closed through the existing version negotiation

## Validation

- `cargo test --locked -p bitfun-sdk-host --test host_lifecycle` (42 passed)
- `cargo test --locked -p bitfun-sdk-host --test protocol_contracts` (8 passed)
- `cargo test --locked -p bitfun-sdk-host-app --test stdio_transport` (10 passed)
- `cargo test --locked -p bitfun-sdk-host-app --test process_initialization` (6 passed)
- targeted Agent Runtime SDK tests (13 passed)
- targeted Core SDK-profile and idle-eviction tests passed
- `pnpm --dir sdk/typescript test` (65 passed, 1 platform skip)
- TypeScript type-check passed
- `cargo check --locked --workspace --exclude bitfun-desktop` passed
- package-scoped Rust formatting and `git diff --check` passed

`cargo test --locked --workspace --exclude bitfun-desktop` stopped on the unrelated existing app-server test `lightweight_client_negotiates_with_the_production_server` because `session/reloadContext` was not advertised. This PR does not modify app-server files. The full Desktop workspace check also remains blocked by the absent generated `src/mobile-web/dist` directory, so neither baseline limitation was expanded into this PR.