### PR TITLE
fix(harmonyos): show cross-workspace created sessions

### DIFF
--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/runtime/AppRootRuntime.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/runtime/AppRootRuntime.ets
@@ -1,4 +1,4 @@
-import { RemoteSession } from '../../model/RemoteModels';
+import { RemoteSession, SessionSummary } from '../../model/RemoteModels';
 import { RemoteI18n } from '../../i18n/RemoteI18n';
 import { ConnectionErrorPolicy } from '../../services/ConnectionErrorPolicy';
 import { CloudAccountDevice } from '../../services/CloudAccountClient';
@@ -346,6 +346,75 @@ export class AppRootRuntime extends AppRootRuntimeComposition {
       all.filter((item: RemoteSession) => item.workspacePath !== this.remotePageState.workspacePath),
       deviceId
     );
+    this.publishRemoteSessions(this.mergeSessions(current, extras), this.remotePageState.hasMoreSessions);
+  }
+
+  /**
+   * Reconciles the workspace row that owns a newly created remote session.
+   *
+   * Creating from the sidebar deliberately does not switch the desktop's
+   * active workspace. A normal session refresh therefore still lists the old
+   * active workspace and cannot discover the new row. Publish the confirmed
+   * create immediately, then refresh the workspace named by the response.
+   */
+  async reconcileCreatedRemoteSession(session: SessionSummary): Promise<void> {
+    const workspacePath = session.workspacePath.trim();
+    if (workspacePath.length === 0 || workspacePath === this.remotePageState.workspacePath) {
+      await this.remoteSessionViewModel.refreshSessions();
+      return;
+    }
+
+    const now = new Date().toISOString();
+    const created: RemoteSession = {
+      id: session.sessionId,
+      title: session.title,
+      agentType: session.agentType,
+      status: 'active',
+      updatedAt: now,
+      createdAt: now,
+      messageCount: session.initialTurnId ? 1 : 0,
+      workspacePath
+    };
+    this.remoteWorkspaceSessions = this.replaceWorkspaceSessions(
+      workspacePath,
+      this.mergeSessions([created], this.sessionsForWorkspace(workspacePath))
+    );
+    this.publishRemoteWorkspaceSessions();
+
+    try {
+      const refreshed = await this.sessionManager.listSessionsForWorkspace(workspacePath, 50);
+      const containsCreated = refreshed.some((item: RemoteSession): boolean => item.id === session.sessionId);
+      this.remoteWorkspaceSessions = this.replaceWorkspaceSessions(
+        workspacePath,
+        containsCreated ? refreshed : this.mergeSessions([created], refreshed)
+      );
+      this.publishRemoteWorkspaceSessions();
+    } catch (err) {
+      // The create already succeeded and is on screen. Keep that confirmed row
+      // instead of turning a follow-up list failure into a false create error.
+      RemoteLogger.warn(`created session workspace refresh failed path=${workspacePath}: ${String(err)}`);
+    }
+  }
+
+  private sessionsForWorkspace(path: string): RemoteSession[] {
+    return this.remotePageState.sessions.filter((item: RemoteSession): boolean => item.workspacePath === path);
+  }
+
+  private replaceWorkspaceSessions(path: string, replacement: RemoteSession[]): RemoteSession[] {
+    const preserved = this.remotePageState.sessions.filter((item: RemoteSession): boolean => {
+      return item.workspacePath !== path;
+    });
+    return replacement.concat(preserved);
+  }
+
+  private publishRemoteWorkspaceSessions(): void {
+    const currentPath = this.remotePageState.workspacePath;
+    const current = this.remotePageState.sessions.filter((item: RemoteSession): boolean => {
+      return (item.workspacePath || currentPath) === currentPath;
+    });
+    const extras = this.remoteWorkspaceSessions.filter((item: RemoteSession): boolean => {
+      return item.workspacePath !== currentPath;
+    });
     this.publishRemoteSessions(this.mergeSessions(current, extras), this.remotePageState.hasMoreSessions);
   }
 

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/runtime/AppRootRuntimeComposition.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/runtime/AppRootRuntimeComposition.ets
@@ -136,6 +136,7 @@ export abstract class AppRootRuntimeComposition {
   abstract openRemoteControlSettings(): void;
   abstract pickImages(): Promise<void>;
   abstract publishRemoteSessions(sessions: RemoteSession[], hasMore: boolean): void;
+  abstract reconcileCreatedRemoteSession(session: SessionSummary): Promise<void>;
   abstract reconnect(): Promise<void>;
   abstract reconnectActiveRemote(): Promise<void>;
   abstract selectAssistant(path: string): Promise<void>;
@@ -629,6 +630,9 @@ export abstract class AppRootRuntimeComposition {
         onKnownStateReset: (): void => this.conversationController.resetKnownRemoteState(),
         onLoadActiveMessages: async (): Promise<void> => {
           await this.conversationController.loadRemoteMessages();
+        },
+        onCreatedSession: async (session: SessionSummary): Promise<void> => {
+          await this.reconcileCreatedRemoteSession(session);
         },
         onRefreshSessions: async (): Promise<void> => {
           await this.remoteSessionController.refresh(

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/viewmodel/RemoteSessionViewModel.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/viewmodel/RemoteSessionViewModel.ets
@@ -22,6 +22,7 @@ export interface RemoteSessionViewModelHooks {
   readonly onClearRemoteFiles: () => void;
   readonly onKnownStateReset: () => void;
   readonly onLoadActiveMessages: () => Promise<void>;
+  readonly onCreatedSession: (session: SessionSummary) => Promise<void>;
   readonly onRefreshSessions: () => Promise<void>;
   readonly onSelectWorkspace: (path: string) => Promise<void>;
 }
@@ -136,7 +137,7 @@ export class RemoteSessionViewModel {
         // the poll started here carries the catalog back with it.
         await this.hooks.onLoadActiveMessages();
         this.hooks.onStartPolling();
-        await this.refreshSessions();
+        await this.hooks.onCreatedSession(session);
       },
       instruction,
       modelId,

--- a/src/apps/mobile/harmonyos/entry/src/test/RemoteControllersUnit.test.ets
+++ b/src/apps/mobile/harmonyos/entry/src/test/RemoteControllersUnit.test.ets
@@ -102,6 +102,7 @@ import { AppShellState } from '../main/ets/pages/state/AppShellState';
 import { GeneralChatPageState } from '../main/ets/pages/state/GeneralChatPageState';
 import { RemotePageState } from '../main/ets/pages/state/RemotePageState';
 import { RemoteCreateSessionState } from '../main/ets/pages/state/RemoteCreateSessionState';
+import { RemoteSessionViewModel } from '../main/ets/pages/viewmodel/RemoteSessionViewModel';
 import { ConversationViewState } from '../main/ets/pages/state/ConversationViewState';
 import {
   FilePreviewPhase,
@@ -1406,6 +1407,96 @@ export default function remoteControllersUnitTest() {
       expect(projection.sessions[0].id).assertEqual('session-2');
       expect(projection.sessions[1].id).assertEqual('session-3');
       expect(projection.hasMore).assertFalse();
+    });
+  });
+
+  describe('RemoteSessionViewModel', () => {
+    it('reconciles a created session with the workspace named by the response', 0, async () => {
+      const pageState = new RemotePageState();
+      pageState.workspacePath = '/current';
+      const sessionClient = new FakeRemoteSessionClient();
+      sessionClient.createdSession = {
+        sessionId: 'created-in-other',
+        title: 'Created in Other',
+        workspacePath: '/other',
+        agentType: 'code'
+      };
+      let busy = false;
+      const sessions = new RemoteSessionController(sessionClient, 8, {
+        onSessions: (_items: RemoteSession[], _hasMore: boolean) => {},
+        onActiveSession: (session: SessionSummary) => pageState.setActiveSession(session),
+        onStatusText: (_statusText: string) => {},
+        onBusy: (isBusy: boolean) => {
+          busy = isBusy;
+          pageState.setBusy(isBusy);
+        },
+        onLoading: (_isLoading: boolean) => {},
+        onSessionError: (_errorText: string) => {},
+        onReconnecting: () => {},
+        onConnected: () => {},
+        onConnectionFailed: (_err: Object) => {},
+        onStartHeartbeat: () => {}
+      });
+      const chat = new RemoteChatCommandController(new FakeRemoteChatCommandClient(), {
+        onMessagesLoaded: (_messages, _hasMoreMessages) => {},
+        onMessageCountKnown: (_pollVersion, _knownMessageCount) => {},
+        onTimelineReady: () => {},
+        onSendSucceeded: (_turnId, _pendingActiveId) => {},
+        onSendFailed: (_rawText, _images, _localMessageId, _pendingActiveId) => {},
+        onActiveSession: (_session) => {},
+        onSessionTitleChanged: (_sessionId, _title) => {},
+        onStatusText: (_statusText) => {},
+        onToast: (_message) => {},
+        onBusy: (_isBusy) => {},
+        onPollRequested: () => {}
+      }, inertRemoteChatCache());
+      const models = new RemoteModelController(
+        new FakeRemoteModelClient(),
+        new FakeRemoteModelPreferenceStore(),
+        (_catalog, _selectedModelId, _version) => {},
+        (_catalog, _selectedModelId, _version) => {},
+        (_statusText) => {},
+        (_isBusy) => {}
+      );
+      const files = new RemoteFileDownloadController(
+        new FakeRemoteFileDownloadClient(),
+        (_downloading, _downloaded, _status) => {},
+        () => {},
+        (_statusText) => {},
+        (_isBusy) => {},
+        2500,
+        new FakeRemoteFileDownloadScheduler(),
+        new FakeRemoteFileSaver()
+      );
+      const reconciled: SessionSummary[] = [];
+      const viewModel = new RemoteSessionViewModel(pageState, sessions, chat, models, files, {
+        remoteAvailable: (): boolean => true,
+        isConnected: (): boolean => true,
+        isBusy: (): boolean => busy,
+        onBusy: (isBusy: boolean): void => {
+          busy = isBusy;
+        },
+        onRouteChat: (_sessionId: string): void => {},
+        onRouteHome: (): void => {},
+        onStopPolling: (): void => {},
+        onStartPolling: (): void => {},
+        onResetTimeline: (_sessionId: string): void => {},
+        onClearRemoteFiles: (): void => {},
+        onKnownStateReset: (): void => {},
+        onLoadActiveMessages: async (): Promise<void> => {},
+        onCreatedSession: async (session: SessionSummary): Promise<void> => {
+          reconciled.push(session);
+        },
+        onRefreshSessions: async (): Promise<void> => {},
+        onSelectWorkspace: async (_path: string): Promise<void> => {}
+      });
+
+      await viewModel.createSessionInWorkspace('/other');
+
+      expect(reconciled.length).assertEqual(1);
+      expect(reconciled[0].sessionId).assertEqual('created-in-other');
+      expect(reconciled[0].workspacePath).assertEqual('/other');
+      expect(sessionClient.listRequests.length).assertEqual(0);
     });
   });
 


### PR DESCRIPTION
## Summary

- route successful remote session creation through a workspace-aware reconciliation hook
- optimistically publish the confirmed session under the workspace selected in the sidebar
- refresh that target workspace without switching the remote desktop active workspace
- preserve the created row when the follow-up workspace listing fails or has not observed it yet
- add a regression test proving cross-workspace creation no longer falls back to the current-workspace session list

## Root cause

`create_session` correctly carried the selected sidebar workspace path, but the post-create `refreshSessions()` call always listed `RemoteSessionManager.workspace`, which is the remote desktop current workspace. A session created in another workspace opened successfully while remaining absent from the sidebar.

## Verification

- `pnpm run harmony:architecture`
- `source scripts/ohos-env.sh && "$HVIGORW" --mode module -p module=entry@default -p ohos.test.type=LocalTest test --no-daemon`
- `source scripts/ohos-env.sh && "$HVIGORW" --mode module -p product=default -p module=entry@default assembleHap --no-daemon`
- `git diff --check`

The HarmonyOS compiler reports only the existing `READ_PASTEBOARD` permission warning.

## Remote scenarios

- Remote control: exercised through the HarmonyOS account-device RPC logs that reproduced the bug; the regression path is covered by a local HarmonyOS unit test.
- Remote workspace: path values remain opaque POSIX strings and are forwarded to the owning remote host; no controller-local fallback was added.
- Peer Device Mode and Detached Dispatch: not affected.

AI-assisted change; focused verification completed.