### PR TITLE
fix(edit): search quote-normalized text with str::find

### DIFF
--- a/src/crates/execution/tool-execution/src/fs/edit_file.rs
+++ b/src/crates/execution/tool-execution/src/fs/edit_file.rs
@@ -135,34 +135,28 @@ fn find_actual_string(file_content: &str, search_string: &str) -> Option<String>
         return Some(search_string.to_string());
     }
 
-    let file_chars: Vec<char> = normalized_file.chars().collect();
-    let search_chars: Vec<char> = normalized_search.chars().collect();
-    if search_chars.is_empty() || file_chars.len() < search_chars.len() {
-        return None;
-    }
-
-    let normalized_search_chars: Vec<char> = search_chars
-        .iter()
-        .copied()
+    // Quote normalization maps one char to one char, so a match in the
+    // quote-normalized text starts at the same char offset in the original and
+    // spans the same number of chars.  Normalizing both sides once lets
+    // `str::find` locate it, instead of comparing every window by hand — that
+    // comparison is quadratic when the file holds long runs of one character.
+    let quoted_file: String = normalized_file.chars().map(normalize_quote_char).collect();
+    let quoted_search: String = normalized_search
+        .chars()
         .map(normalize_quote_char)
         .collect();
 
-    for start in 0..=file_chars.len() - search_chars.len() {
-        let window_matches = file_chars[start..start + search_chars.len()]
-            .iter()
-            .copied()
-            .map(normalize_quote_char)
-            .eq(normalized_search_chars.iter().copied());
-        if window_matches {
-            return Some(
-                file_chars[start..start + search_chars.len()]
-                    .iter()
-                    .collect(),
-            );
-        }
-    }
+    let match_start = quoted_file.find(&quoted_search)?;
+    let chars_before = quoted_file[..match_start].chars().count();
+    let match_chars = quoted_search.chars().count();
 
-    None
+    Some(
+        normalized_file
+            .chars()
+            .skip(chars_before)
+            .take(match_chars)
+            .collect(),
+    )
 }
 
 /// Replace every tab with `tab_width` spaces.
@@ -509,7 +503,7 @@ mod tests {
     };
     use std::fs;
     use std::path::PathBuf;
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
     fn write_temp_file(contents: &str) -> PathBuf {
         let unique = SystemTime::now()
@@ -796,6 +790,42 @@ mod tests {
         assert_eq!(
             result.new_content,
             "fn main() {\r\n    msg := \"hi\"\r\n}\r\n"
+        );
+    }
+
+    #[test]
+    fn apply_edit_matches_curly_quotes_after_multibyte_content() {
+        // Quote normalization maps one char to one char but changes byte
+        // length, so a match that sits behind multibyte text has to be located
+        // by char offset, not byte offset.
+        let content = "// \u{5909}\u{6570}\u{306e}\u{8aac}\u{660e} \u{2014} \u{3b1}\u{3b2}\u{3b3}\nmsg := \u{201c}hello\u{201d}\n";
+        let result = apply_edit_to_content(content, "msg := \"hello\"", "msg := \"hi\"", false)
+            .expect("curly-quote edit after multibyte content should succeed");
+
+        assert_eq!(
+            result.new_content,
+            "// \u{5909}\u{6570}\u{306e}\u{8aac}\u{660e} \u{2014} \u{3b1}\u{3b2}\u{3b3}\nmsg := \"hi\"\n"
+        );
+    }
+
+    #[test]
+    fn apply_edit_scans_long_repeated_runs_without_hanging() {
+        // A file that is one long run of a single character makes every
+        // candidate window share a long prefix with the search string, the
+        // worst case for comparing windows one at a time.  This input took
+        // over 20 seconds before find_actual_string searched with str::find.
+        let content = format!("\t{}\n", " ".repeat(256 * 1024));
+        let old_string = format!("\t{}X", " ".repeat(2000));
+
+        let started = Instant::now();
+        let error = apply_edit_to_content(&content, &old_string, "replacement", false)
+            .expect_err("old_string is not present in the file");
+
+        assert!(error.contains("old_string not found in file"));
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "scan took {:?}, expected the linear search path",
+            started.elapsed()
         );
     }
 }


### PR DESCRIPTION
## Summary

<!-- Briefly describe what changed. -->

`find_actual_string` in `edit_file.rs` compared every character window of the file against the search string by hand. The comparison short-circuits on the first mismatch, so ordinary source files stay fast, but a file holding long runs of one character (minified output, padded or aligned text, whitespace-heavy data) makes most windows share a deep prefix with the search string and the scan turns quadratic. Measured on this machine (debug build): 256KB of spaces with a 2KB `old_string` took 32s for one call, and `edit_string_candidates` can probe several candidates per failed edit, so a single failed Edit on such a file hangs for minutes.

Quote normalization maps one char to one char, so this change normalizes both sides once and searches with `str::find`, which finds the same leftmost match in linear time. The same 256KB input now completes in about 68ms, and a 512KB input went from 126s to 131ms. The returned slice is cut from the line-ending-normalized file by char offset, which byte offsets cannot do once multibyte text precedes the match; a new test covers exactly that case, and a second test guards against the scan regressing to quadratic on long repeated runs.

This addresses the hang half of #1650. The token-amplification half of that report is about how many times file content re-enters the model context after a failed edit, which lives in the read-state/`validate_input` flow, not in this function; I have left it alone.

References #1650

## Type and Areas

Type:

Bug fix (performance).

Areas:

Rust core (`tool-runtime`, `src/crates/execution/tool-execution`).

## Motivation / Impact

Editing large files with repetitive content could hang the Edit tool for minutes on a single failed match. After this change the fallback scan stays linear. No behavior change for edits that already matched: all existing candidates and fallbacks resolve to the same result, only faster.

## Verification

- `cargo test --locked -p tool-runtime --lib` - 132 passed, 0 failed (includes the two new tests)
- Red/green on the new regression test: with the old window scan spliced back in, `apply_edit_scans_long_repeated_runs_without_hanging` fails at 23.7s; with this change it passes in well under a second
- `cargo test --locked -p bitfun-core --lib` - 150 passed, 0 failed
- `cargo check --locked --workspace` - clean
- `cargo fmt -p tool-runtime -- --check` - clean

Note: CI's tool-runtime step only runs `--lib search::`, so the `fs::` tests here do not run in CI; the counts above are from local runs on Windows.

AI-assisted: fully tested (see verification above).

## Reviewer Notes

The subtle point is the byte/char offset distinction: `str::find` returns a byte offset into the quote-normalized string, while the returned slice must come from the pre-normalization string. Char offsets line up between the two because `normalize_quote_char` is a char-to-char map; byte offsets do not once any multibyte character precedes the match. `apply_edit_matches_curly_quotes_after_multibyte_content` fails if that is ever gotten wrong.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.
