### PR TITLE
feat(sdk): add image input and turn usage

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -14,6 +14,11 @@ The slice validates the intended public object model:
   Host process;
 - `Query` is an ordered async stream with idempotent cancellation, cached final
   `Result`, and explicit close semantics;
+- a prompt can be a string or ordered `text` / `local_image` parts; local image
+  paths are resolved against the Session workspace and reuse Runtime image
+  attachments;
+- a terminal `Result` reports aggregate token usage when the provider supplied
+  usage for that Turn;
 - the same stream reports safe Tool lifecycle facts and permission requests;
   `Query.respondPermission()` supports allow once, allow always, or reject;
 - protocol and process failures use `SdkError`, including outcome certainty.
@@ -65,7 +70,12 @@ await using client = await AgentClient.start({
   },
 });
 
-await using query = await client.query({ prompt: "Summarize this repository" });
+await using query = await client.query({
+  prompt: [
+    { type: "text", text: "Explain this screenshot in repository context" },
+    { type: "local_image", path: "screenshots/failure.png" },
+  ],
+});
 for await (const item of query) {
   switch (item.type) {
     case "assistant_text_delta":
@@ -80,7 +90,11 @@ for await (const item of query) {
   }
 }
 const result = await query.result();
+console.log(result.usage?.totalTokens);
 ```
+
+`local_image` accepts local PNG, JPEG, GIF, and WebP paths. Image bytes and
+remote URLs are intentionally outside this local Host protocol.
 
 Use an explicit Session when the application needs continuity across client or
 Host restarts. Here `options` is the same trusted `AgentClientOptions` value
@@ -112,8 +126,8 @@ separately. This PR does not publish the package. A future registry release
 still needs platform packages, signing, and release verification.
 
 Browser and mobile runtimes cannot launch the local native Host. Custom
-functions, general user-input callbacks, structured output, usage, Python
-support, platform package publication, signing, and downloads
+functions, general user-input callbacks, structured output, Python support,
+platform package publication, signing, and downloads
 remain deferred.
 
 ## Development

--- a/sdk/typescript/scripts/generate-wire.mjs
+++ b/sdk/typescript/scripts/generate-wire.mjs
@@ -57,6 +57,7 @@ const requiredTypes = [
   "QueryResultParams",
   "QueryStartParams",
   "QueryStartResult",
+  "QueryUsage",
   "SessionCloseParams",
   "SessionCloseResult",
   "SessionCreateParams",

--- a/sdk/typescript/scripts/generated-wire-runtime.test.mjs
+++ b/sdk/typescript/scripts/generated-wire-runtime.test.mjs
@@ -43,7 +43,7 @@ test("Rust wire export produces executable validators for every type", async () 
   }
 
   const initializeResult = {
-    protocolVersion: 4,
+    protocolVersion: 5,
     runtimeVersion: "0.1.0",
     stability: "not_delivered",
     capabilities: {
@@ -55,8 +55,9 @@ test("Rust wire export produces executable validators for every type", async () 
       sessionClose: true,
       eventStream: true,
       toolEvents: true,
+      imageInput: true,
       structuredOutput: false,
-      usage: false,
+      usage: true,
       customTools: false,
       permissionResponses: true,
       hooks: false,

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -1,6 +1,7 @@
 import type { InitializeResult, QueryStartParams, QueryStartResult } from "./internal/wire/index.js";
 import type { JsonRpcConnection } from "./internal/json-rpc.js";
 import { resolveHostPath } from "./internal/host-path.js";
+import { normalizeInput } from "./internal/input.js";
 import { SdkError } from "./errors.js";
 import { Query } from "./query.js";
 import { Session, Sessions } from "./session.js";
@@ -62,6 +63,7 @@ export class AgentClient {
       cancellation: initialized.capabilities.queryCancel,
       eventStream: initialized.capabilities.eventStream,
       toolEvents: initialized.capabilities.toolEvents,
+      imageInput: initialized.capabilities.imageInput,
       permissionResponses: initialized.capabilities.permissionResponses,
       structuredOutput: initialized.capabilities.structuredOutput,
       usage: initialized.capabilities.usage,
@@ -90,8 +92,10 @@ export class AgentClient {
 
   async query(input: QueryInput): Promise<Query> {
     this.#ensureOpen();
+    const normalized = normalizeInput(input.prompt);
     const params: QueryStartParams = {
-      prompt: input.prompt,
+      prompt: normalized.prompt,
+      images: normalized.images,
       sessionId: null,
       sessionName: null,
       agent: input.agent ?? null,

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -7,6 +7,7 @@ export type {
   AgentClientOptions,
   AgentModelOptions,
   AgentModelProvider,
+  Input,
   AssistantTextDelta,
   OutcomeCertainty,
   PermissionDecision,
@@ -27,4 +28,6 @@ export type {
   Turn,
   TurnInput,
   ToolEvent,
+  Usage,
+  UserInput,
 } from "./types.js";

--- a/sdk/typescript/src/internal/client.ts
+++ b/sdk/typescript/src/internal/client.ts
@@ -4,7 +4,7 @@ import { JsonRpcConnection } from "./json-rpc.js";
 import type { HostTransport } from "./transport.js";
 import type { InitializeParams, InitializeResult } from "./wire/index.js";
 
-const PROTOCOL_VERSION = 4;
+const PROTOCOL_VERSION = 5;
 const DEFAULT_INITIALIZE_TIMEOUT_MS = 30_000;
 
 export async function createAgentClient(

--- a/sdk/typescript/src/internal/input.ts
+++ b/sdk/typescript/src/internal/input.ts
@@ -1,0 +1,21 @@
+import type { Input } from "../types.js";
+
+export function normalizeInput(input: Input): {
+  prompt: string;
+  images: string[];
+} {
+  if (typeof input === "string") {
+    return { prompt: input, images: [] };
+  }
+
+  const promptParts: string[] = [];
+  const images: string[] = [];
+  for (const item of input) {
+    if (item.type === "text") {
+      promptParts.push(item.text);
+    } else if (item.type === "local_image") {
+      images.push(item.path);
+    }
+  }
+  return { prompt: promptParts.join("\n\n"), images };
+}

--- a/sdk/typescript/src/query.ts
+++ b/sdk/typescript/src/query.ts
@@ -17,6 +17,7 @@ import type {
   Result,
   ResultError,
   Turn,
+  Usage,
 } from "./types.js";
 import { isConnectionUnusableError, SdkError } from "./errors.js";
 
@@ -312,6 +313,7 @@ export class Query implements AsyncIterable<QueryStreamItem> {
       operationId: params.operationId,
       status: params.status,
       outputText: params.output.text,
+      ...(params.usage === undefined ? {} : { usage: mapUsage(params.usage) }),
       ...(params.error === undefined ? {} : { error: mapResultError(params.error) }),
     };
     if (!this.#push(result)) {
@@ -411,6 +413,19 @@ export class Query implements AsyncIterable<QueryStreamItem> {
     }
     this.#closedHandlers.clear();
   }
+}
+
+function mapUsage(usage: NonNullable<QueryResultParams["usage"]>): Usage {
+  return {
+    inputTokens: usage.inputTokens,
+    ...(usage.outputTokens === undefined
+      ? {}
+      : { outputTokens: usage.outputTokens }),
+    totalTokens: usage.totalTokens,
+    ...(usage.cachedTokens === undefined
+      ? {}
+      : { cachedTokens: usage.cachedTokens }),
+  };
 }
 
 function bufferedItemBytes(item: QueryStreamItem): number {

--- a/sdk/typescript/src/session.ts
+++ b/sdk/typescript/src/session.ts
@@ -7,6 +7,7 @@ import type {
   SessionResumeParams,
 } from "./internal/wire/index.js";
 import type { JsonRpcConnection } from "./internal/json-rpc.js";
+import { normalizeInput } from "./internal/input.js";
 import { withTimeout } from "./internal/deadline.js";
 import { isConnectionUnusableError, SdkError } from "./errors.js";
 import { Query } from "./query.js";
@@ -129,8 +130,10 @@ export class Session {
 
   async startTurn(input: TurnInput): Promise<Query> {
     this.#ensureOpen();
+    const normalized = normalizeInput(input.prompt);
     const params: QueryStartParams = {
-      prompt: input.prompt,
+      prompt: normalized.prompt,
+      images: normalized.images,
       sessionId: this.id,
     };
     const started = await this.#connection.request<QueryStartResult>(

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -27,6 +27,7 @@ export interface AgentCapabilities {
   cancellation: boolean;
   eventStream: boolean;
   toolEvents: boolean;
+  imageInput: boolean;
   permissionResponses: boolean;
   structuredOutput: boolean;
   usage: boolean;
@@ -86,8 +87,14 @@ export interface SdkErrorDetails {
 
 export type SessionLifetime = "connection" | "durable";
 
+export type UserInput =
+  | { type: "text"; text: string }
+  | { type: "local_image"; path: string };
+
+export type Input = string | readonly UserInput[];
+
 export interface QueryInput {
-  prompt: string;
+  prompt: Input;
   agent?: string;
 }
 
@@ -97,7 +104,7 @@ export interface SessionCreateInput {
 }
 
 export interface TurnInput {
-  prompt: string;
+  prompt: Input;
 }
 
 export interface Turn {
@@ -162,6 +169,13 @@ export interface ResultError extends SdkErrorDetails {
   message: string;
 }
 
+export interface Usage {
+  inputTokens: number;
+  outputTokens?: number;
+  totalTokens: number;
+  cachedTokens?: number;
+}
+
 export interface Result {
   type: "result";
   queryId: string;
@@ -170,6 +184,7 @@ export interface Result {
   operationId: string;
   status: ResultStatus;
   outputText: string;
+  usage?: Usage;
   error?: ResultError;
 }
 

--- a/sdk/typescript/test/client.test.ts
+++ b/sdk/typescript/test/client.test.ts
@@ -7,8 +7,10 @@ import { AgentClient, SdkError } from "../src/index.js";
 import { createAgentClient } from "../src/internal/client.js";
 import type {
   AgentClientOptions,
+  Input,
   QueryInput,
   SessionCreateInput,
+  UserInput,
 } from "../src/types.js";
 
 const clientOptions = {
@@ -35,6 +37,12 @@ void queryModelOverride;
 void sessionModelOverride;
 void packageHostOptions;
 
+const multimodalInput: Input = [
+  { type: "text", text: "hello" },
+  { type: "local_image", path: "screenshots/fixture.png" },
+] satisfies UserInput[];
+void multimodalInput;
+
 test("a Query streams tool and permission events before the terminal Result", async () => {
   const clientToHost = new PassThrough();
   const hostToClient = new PassThrough();
@@ -55,7 +63,7 @@ test("a Query streams tool and permission events before the terminal Result", as
   assert.ok(client instanceof AgentClient);
   assert.equal(initializeRequests.length, 1);
   assert.deepEqual(initializeRequests[0], {
-    protocolVersion: 4,
+    protocolVersion: 5,
     clientInfo: { name: "@bitfun/agent-sdk", version: "0.0.0" },
     capabilities: {
       serverNotifications: true,
@@ -69,7 +77,11 @@ test("a Query streams tool and permission events before the terminal Result", as
     },
   });
   const query = await client.query({
-    prompt: "hello",
+    prompt: [
+      { type: "text", text: "hello" },
+      { type: "local_image", path: "screenshots/fixture.png" },
+      { type: "text", text: "focus on the layout" },
+    ],
     model: "attempted-override",
   } as QueryInput);
   assert.equal(query.id, "query-1");
@@ -81,9 +93,10 @@ test("a Query streams tool and permission events before the terminal Result", as
     cancellation: true,
     eventStream: true,
     toolEvents: true,
+    imageInput: true,
     permissionResponses: true,
     structuredOutput: false,
-    usage: false,
+    usage: true,
     customTools: false,
     hooks: false,
     mcpConfiguration: false,
@@ -155,6 +168,12 @@ test("a Query streams tool and permission events before the terminal Result", as
       operationId: "operation-1",
       status: "completed",
       outputText: "fixture result",
+      usage: {
+        inputTokens: 100,
+        outputTokens: 25,
+        totalTokens: 125,
+        cachedTokens: 40,
+      },
     },
   ]);
   assert.equal((await query.result()).outputText, "fixture result");
@@ -189,7 +208,9 @@ test("an explicit Session starts Turns on the existing client connection", async
   assert.equal(session.agent, "agentic");
   assert.equal(session.lifetime, "durable");
 
-  const query = await session.startTurn({ prompt: "continue" });
+  const query = await session.startTurn({
+    prompt: [{ type: "local_image", path: "screenshots/continued.webp" }],
+  });
   assert.equal((await query.result()).outputText, "continued");
   await session.close();
   assert.equal(typeof session[Symbol.asyncDispose], "function");
@@ -562,7 +583,7 @@ async function runFixtureHost(
         jsonrpc: "2.0",
         id: request.id,
         result: {
-          protocolVersion: 4,
+          protocolVersion: 5,
           runtimeVersion: "0.2.17",
           stability: "not_delivered",
           capabilities: {
@@ -574,8 +595,9 @@ async function runFixtureHost(
             sessionClose: true,
             eventStream: true,
             toolEvents: true,
+            imageInput: true,
             structuredOutput: false,
-            usage: false,
+            usage: true,
             customTools: false,
             permissionResponses: true,
             hooks: false,
@@ -589,7 +611,8 @@ async function runFixtureHost(
     }
     if (request.method === "query/start") {
       assert.deepEqual(request.params, {
-        prompt: "hello",
+        prompt: "hello\n\nfocus on the layout",
+        images: ["screenshots/fixture.png"],
         sessionId: null,
         sessionName: null,
         agent: null,
@@ -702,6 +725,12 @@ async function runFixtureHost(
           operationId: "operation-1",
           status: "completed",
           output: { text: "fixture result" },
+          usage: {
+            inputTokens: 100,
+            outputTokens: 25,
+            totalTokens: 125,
+            cachedTokens: 40,
+          },
         },
       });
       continue;
@@ -765,7 +794,8 @@ async function runSessionFixtureHost(
     }
     if (request.method === "query/start") {
       assert.deepEqual(request.params, {
-        prompt: "continue",
+        prompt: "",
+        images: ["screenshots/continued.webp"],
         sessionId: "session-explicit",
       });
       write(responses, {
@@ -1313,7 +1343,7 @@ function initializeResponse(id: number): unknown {
     jsonrpc: "2.0",
     id,
     result: {
-      protocolVersion: 4,
+      protocolVersion: 5,
       runtimeVersion: "0.2.17",
       stability: "not_delivered",
       capabilities: {
@@ -1325,8 +1355,9 @@ function initializeResponse(id: number): unknown {
         sessionClose: true,
         eventStream: true,
         toolEvents: true,
+        imageInput: true,
         structuredOutput: false,
-        usage: false,
+        usage: true,
         customTools: false,
         permissionResponses: true,
         hooks: false,

--- a/sdk/typescript/test/fixtures/host.mjs
+++ b/sdk/typescript/test/fixtures/host.mjs
@@ -5,7 +5,7 @@ for await (const line of lines) {
   const request = JSON.parse(line);
   if (request.method === "initialize") {
     if (
-      request.params?.protocolVersion !== 4 ||
+      request.params?.protocolVersion !== 5 ||
       request.params?.model?.apiKey !== "fixture-secret"
     ) {
       throw new Error("Invalid initialize request");
@@ -14,7 +14,7 @@ for await (const line of lines) {
       jsonrpc: "2.0",
       id: request.id,
       result: {
-        protocolVersion: 4,
+        protocolVersion: 5,
         runtimeVersion: "fixture",
         stability: "not_delivered",
         capabilities: {
@@ -26,8 +26,9 @@ for await (const line of lines) {
           sessionClose: true,
           eventStream: true,
           toolEvents: true,
+          imageInput: true,
           structuredOutput: false,
-          usage: false,
+          usage: true,
           customTools: false,
           permissionResponses: true,
           hooks: false,

--- a/sdk/typescript/test/local-package-consumer.mjs
+++ b/sdk/typescript/test/local-package-consumer.mjs
@@ -57,6 +57,8 @@ const client = await AgentClient.start({
 try {
   assert.equal(client.capabilities.query, true);
   assert.equal(client.capabilities.toolEvents, true);
+  assert.equal(client.capabilities.imageInput, true);
+  assert.equal(client.capabilities.usage, true);
   assert.equal(client.capabilities.permissionResponses, true);
 } finally {
   await client.close();

--- a/src/apps/cli/src/modes/exec/lifecycle.rs
+++ b/src/apps/cli/src/modes/exec/lifecycle.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 
 use bitfun_agent_runtime::sdk::{
     PermissionReply, PermissionReplySource, PermissionRequest, PermissionRequestEvent,
-    PortErrorKind, RuntimeError,
+    PortErrorKind, RuntimeError, TurnTokenUsage,
 };
 use bitfun_agent_tools::effective_tool_invocation;
 use bitfun_events::{AgenticEvent, ToolEventIdentity};
@@ -53,65 +53,7 @@ pub(crate) enum ExecApprovalMode {
     Auto,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
-pub(super) struct ExecTokenUsage {
-    pub(super) input_tokens: usize,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub(super) output_tokens: Option<usize>,
-    pub(super) total_tokens: usize,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub(super) cached_tokens: Option<usize>,
-}
-
-impl ExecTokenUsage {
-    fn merge_round(&mut self, round: Self) {
-        self.input_tokens = self.input_tokens.saturating_add(round.input_tokens);
-        self.output_tokens = self
-            .output_tokens
-            .zip(round.output_tokens)
-            .map(|(current, next)| current.saturating_add(next));
-        self.total_tokens = self.total_tokens.saturating_add(round.total_tokens);
-        self.cached_tokens = self
-            .cached_tokens
-            .zip(round.cached_tokens)
-            .map(|(current, next)| current.saturating_add(next));
-    }
-
-    pub(super) fn accumulate_event<'a>(
-        aggregate: &mut Option<Self>,
-        event: &'a AgenticEvent,
-        expected_turn_id: &str,
-    ) -> Option<&'a str> {
-        let AgenticEvent::TokenUsageUpdated {
-            turn_id,
-            model_config_id,
-            input_tokens,
-            output_tokens,
-            total_tokens,
-            cached_tokens,
-            ..
-        } = event
-        else {
-            return None;
-        };
-        if turn_id != expected_turn_id {
-            return None;
-        }
-
-        let round = Self {
-            input_tokens: *input_tokens,
-            output_tokens: *output_tokens,
-            total_tokens: *total_tokens,
-            cached_tokens: *cached_tokens,
-        };
-        if let Some(total) = aggregate.as_mut() {
-            total.merge_round(round);
-        } else {
-            *aggregate = Some(round);
-        }
-        Some(model_config_id)
-    }
-}
+pub(super) type ExecTokenUsage = TurnTokenUsage;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub(super) struct ExecJsonResult {

--- a/src/apps/sdk-host/tests/stdio_process.rs
+++ b/src/apps/sdk-host/tests/stdio_process.rs
@@ -45,7 +45,7 @@ async fn standalone_sdk_host_negotiates_and_shuts_down_without_cli() {
         1,
         "initialize",
         json!({
-            "protocolVersion": 4,
+            "protocolVersion": 5,
             "clientInfo": { "name": "standalone-process-fixture", "version": "0.1.0" },
             "capabilities": {
                 "serverNotifications": true,
@@ -62,7 +62,7 @@ async fn standalone_sdk_host_negotiates_and_shuts_down_without_cli() {
     .await;
     let initialized = read_response(&mut stdout, "initialize").await;
     assert_eq!(initialized["id"], 1);
-    assert_eq!(initialized["result"]["protocolVersion"], 4);
+    assert_eq!(initialized["result"]["protocolVersion"], 5);
     assert!(initialized["result"]["modelId"]
         .as_str()
         .is_some_and(|model_id| model_id.starts_with("sdk:openai:")));

--- a/src/apps/sdk-host/tests/stdio_transport.rs
+++ b/src/apps/sdk-host/tests/stdio_transport.rs
@@ -236,7 +236,7 @@ async fn stdio_transport_serves_initialize_and_shutdown_without_non_protocol_std
     client_write
         .write_all(
             concat!(
-                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":4,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":5,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
                 "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"shutdown\",\"params\":{}}\n"
             )
             .as_bytes(),
@@ -252,7 +252,7 @@ async fn stdio_transport_serves_initialize_and_shutdown_without_non_protocol_std
         serde_json::from_str(&lines.next_line().await.unwrap().unwrap()).unwrap();
 
     assert_eq!(initialized["id"], 1);
-    assert_eq!(initialized["result"]["protocolVersion"], 4);
+    assert_eq!(initialized["result"]["protocolVersion"], 5);
     assert_eq!(initialized["result"]["modelId"], "sdk:openai:transport");
     assert_eq!(shutdown["id"], 2);
     assert_eq!(shutdown["result"]["accepted"], true);
@@ -286,7 +286,7 @@ async fn stdio_transport_executes_json_rpc_notifications_without_replying() {
     client_write
         .write_all(
             concat!(
-                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":4,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":5,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
                 "{\"jsonrpc\":\"2.0\",\"method\":\"shutdown\",\"params\":{}}\n"
             )
             .as_bytes(),
@@ -386,7 +386,7 @@ async fn transport_accepts_input_while_an_owner_call_is_pending_and_bounds_reque
     client_write
         .write_all(
             concat!(
-                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":4,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":5,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
                 "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"session/create\",\"params\":{}}\n",
                 "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"session/create\",\"params\":{}}\n"
             )
@@ -458,7 +458,7 @@ async fn shutdown_remains_available_when_the_data_request_budget_is_exhausted() 
     ));
     client_write
         .write_all(
-            b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":4,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
+            b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":5,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
         )
         .await
         .unwrap();
@@ -538,9 +538,9 @@ async fn duplicate_initialize_does_not_abort_an_in_flight_request() {
     client_write
         .write_all(
             concat!(
-                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":4,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":5,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
                 "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"session/create\",\"params\":{}}\n",
-                "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"initialize\",\"params\":{\"protocolVersion\":4,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n"
+                "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"initialize\",\"params\":{\"protocolVersion\":5,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n"
             )
             .as_bytes(),
         )
@@ -598,7 +598,7 @@ async fn connection_eof_cleans_a_session_created_after_its_request_is_aborted() 
     client_write
         .write_all(
             concat!(
-                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":4,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":5,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
                 "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"session/create\",\"params\":{}}\n"
             )
             .as_bytes(),
@@ -657,7 +657,7 @@ async fn explicit_shutdown_bounds_request_drain_and_session_cleanup_together() {
     client_write
         .write_all(
             concat!(
-                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":4,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":5,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
                 "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"session/create\",\"params\":{}}\n"
             )
             .as_bytes(),
@@ -715,7 +715,7 @@ async fn requests_before_a_successful_initialize_cannot_cross_the_handshake() {
             concat!(
                 "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":999,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
                 "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"session/create\",\"params\":{}}\n",
-                "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"initialize\",\"params\":{\"protocolVersion\":4,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n"
+                "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"initialize\",\"params\":{\"protocolVersion\":5,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n"
             )
             .as_bytes(),
         )
@@ -734,7 +734,7 @@ async fn requests_before_a_successful_initialize_cannot_cross_the_handshake() {
     assert_eq!(pre_initialize["id"], 2);
     assert_eq!(pre_initialize["error"]["data"]["code"], "not_initialized");
     assert_eq!(initialized["id"], 3);
-    assert_eq!(initialized["result"]["protocolVersion"], 4);
+    assert_eq!(initialized["result"]["protocolVersion"], 5);
     assert_eq!(initialized["result"]["modelId"], "sdk:openai:transport");
 
     client_write
@@ -775,7 +775,7 @@ async fn blocked_output_times_out_and_ends_the_connection() {
     ));
     client_write
         .write_all(
-            b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":4,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
+            b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":5,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
         )
         .await
         .unwrap();

--- a/src/crates/execution/agent-runtime/examples/sdk_minimal.rs
+++ b/src/crates/execution/agent-runtime/examples/sdk_minimal.rs
@@ -49,7 +49,7 @@ impl AgentSubmissionPort for ExampleAgentProvider {
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let compatibility = AgentRuntimeSdkCompatibility::current();
-    assert_eq!(compatibility.api_version, 8);
+    assert_eq!(compatibility.api_version, 9);
 
     let provider = Arc::new(ExampleAgentProvider::default());
     let events = AgentEventStream::new();

--- a/src/crates/execution/agent-runtime/src/dialog_turn.rs
+++ b/src/crates/execution/agent-runtime/src/dialog_turn.rs
@@ -10,6 +10,8 @@
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use bitfun_events::AgenticEvent;
+
 /// Generate a fresh turn id when callers do not supply one.
 pub fn new_turn_id(provided: Option<String>) -> String {
     provided.unwrap_or_else(|| Uuid::new_v4().to_string())
@@ -21,4 +23,136 @@ pub struct TurnStats {
     pub total_tools: usize,
     pub total_tokens: usize,
     pub duration_ms: u64,
+}
+
+/// Token usage aggregated across all model rounds in one dialog turn.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct TurnTokenUsage {
+    pub input_tokens: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_tokens: Option<usize>,
+    pub total_tokens: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cached_tokens: Option<usize>,
+}
+
+impl TurnTokenUsage {
+    fn merge_round(&mut self, round: Self) {
+        self.input_tokens = self.input_tokens.saturating_add(round.input_tokens);
+        self.output_tokens = self
+            .output_tokens
+            .zip(round.output_tokens)
+            .map(|(current, next)| current.saturating_add(next));
+        self.total_tokens = self.total_tokens.saturating_add(round.total_tokens);
+        self.cached_tokens = self
+            .cached_tokens
+            .zip(round.cached_tokens)
+            .map(|(current, next)| current.saturating_add(next));
+    }
+
+    pub fn accumulate_event<'a>(
+        aggregate: &mut Option<Self>,
+        event: &'a AgenticEvent,
+        expected_turn_id: &str,
+    ) -> Option<&'a str> {
+        let AgenticEvent::TokenUsageUpdated {
+            turn_id,
+            model_config_id,
+            input_tokens,
+            output_tokens,
+            total_tokens,
+            cached_tokens,
+            ..
+        } = event
+        else {
+            return None;
+        };
+        if turn_id != expected_turn_id {
+            return None;
+        }
+
+        let round = Self {
+            input_tokens: *input_tokens,
+            output_tokens: *output_tokens,
+            total_tokens: *total_tokens,
+            cached_tokens: *cached_tokens,
+        };
+        if let Some(total) = aggregate.as_mut() {
+            total.merge_round(round);
+        } else {
+            *aggregate = Some(round);
+        }
+        Some(model_config_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TurnTokenUsage;
+    use bitfun_events::AgenticEvent;
+
+    #[test]
+    fn turn_usage_accumulates_rounds_and_ignores_other_turns() {
+        let events = [
+            usage_event("turn-1", 100, Some(25), 125, Some(40)),
+            usage_event("turn-2", 900, Some(90), 990, Some(80)),
+            usage_event("turn-1", 200, Some(50), 250, Some(80)),
+        ];
+        let mut usage = None;
+
+        for event in &events {
+            TurnTokenUsage::accumulate_event(&mut usage, event, "turn-1");
+        }
+
+        assert_eq!(
+            usage,
+            Some(TurnTokenUsage {
+                input_tokens: 300,
+                output_tokens: Some(75),
+                total_tokens: 375,
+                cached_tokens: Some(120),
+            })
+        );
+    }
+
+    #[test]
+    fn turn_usage_keeps_optional_totals_unknown_if_any_round_omits_them() {
+        let events = [
+            usage_event("turn-1", 100, None, 100, Some(20)),
+            usage_event("turn-1", 50, Some(10), 60, None),
+        ];
+        let mut usage = None;
+
+        for event in &events {
+            TurnTokenUsage::accumulate_event(&mut usage, event, "turn-1");
+        }
+
+        let usage = usage.expect("matching usage");
+        assert_eq!(usage.input_tokens, 150);
+        assert_eq!(usage.output_tokens, None);
+        assert_eq!(usage.total_tokens, 160);
+        assert_eq!(usage.cached_tokens, None);
+    }
+
+    fn usage_event(
+        turn_id: &str,
+        input_tokens: usize,
+        output_tokens: Option<usize>,
+        total_tokens: usize,
+        cached_tokens: Option<usize>,
+    ) -> AgenticEvent {
+        AgenticEvent::TokenUsageUpdated {
+            session_id: "session-1".to_string(),
+            turn_id: turn_id.to_string(),
+            model_config_id: "model-config".to_string(),
+            effective_model_name: "provider-model".to_string(),
+            input_tokens,
+            output_tokens,
+            total_tokens,
+            max_context_tokens: Some(200_000),
+            is_subagent: false,
+            cached_tokens,
+            token_details: None,
+        }
+    }
 }

--- a/src/crates/execution/agent-runtime/src/sdk.rs
+++ b/src/crates/execution/agent-runtime/src/sdk.rs
@@ -8,7 +8,7 @@
 
 use std::sync::Arc;
 
-pub const AGENT_RUNTIME_SDK_API_VERSION: u32 = 8;
+pub const AGENT_RUNTIME_SDK_API_VERSION: u32 = 9;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
@@ -35,6 +35,7 @@ impl AgentRuntimeSdkCompatibility {
 }
 
 pub use crate::context_profile::{ContextProfile, ContextProfilePolicy, ModelCapabilityProfile};
+pub use crate::dialog_turn::TurnTokenUsage;
 pub use crate::event_source::{AgentEventReceiver, AgentEventSource, AgentSessionEventReceiver};
 pub use crate::permission::{
     PermissionReplyResolution, PermissionRequestEventReceiver, PermissionRequestManager,

--- a/src/crates/execution/agent-runtime/tests/agent_session_contracts/sdk_smoke.rs
+++ b/src/crates/execution/agent-runtime/tests/agent_session_contracts/sdk_smoke.rs
@@ -74,7 +74,7 @@ impl AgentModeCatalogPort for FakeModeCatalog {
 fn sdk_facade_exposes_versioned_preview_compatibility_contract() {
     let compatibility = AgentRuntimeSdkCompatibility::current();
 
-    assert_eq!(compatibility.api_version, 8);
+    assert_eq!(compatibility.api_version, 9);
     assert_eq!(compatibility.crate_version, env!("CARGO_PKG_VERSION"));
     assert_eq!(compatibility.stability, AgentRuntimeSdkStability::Preview);
 }

--- a/src/crates/interfaces/sdk-host/src/host.rs
+++ b/src/crates/interfaces/sdk-host/src/host.rs
@@ -1,18 +1,19 @@
 //! Connection-scoped SDK Host request and Query lifecycle.
 
 use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 
 use bitfun_agent_runtime::sdk::{
-    AgentDialogTurnRequest, AgentRuntime, AgentSessionCreateRequest, AgentSessionCreateResult,
-    AgentSessionDeleteRequest, AgentSessionModelUpdateRequest, AgentSessionReleaseRequest,
-    AgentSessionRestoreRequest, AgentSessionWorkspaceRequest, AgentSubmissionSource,
-    AgentTurnCancellationRequest, AgentTurnSettlementRequest, DialogSubmissionPolicy,
-    DialogSubmitOutcome, PermissionReply, PermissionReplySource, PermissionRequest,
-    PermissionRequestEvent, PermissionRequestSourceKind, PortError, PortErrorKind, RuntimeError,
-    AUTO_APPROVE_ASK_CONTEXT_KEY,
+    AgentDialogTurnRequest, AgentInputAttachment, AgentRuntime, AgentSessionCreateRequest,
+    AgentSessionCreateResult, AgentSessionDeleteRequest, AgentSessionModelUpdateRequest,
+    AgentSessionReleaseRequest, AgentSessionRestoreRequest, AgentSessionWorkspaceRequest,
+    AgentSubmissionSource, AgentTurnCancellationRequest, AgentTurnSettlementRequest,
+    DialogSubmissionPolicy, DialogSubmitOutcome, PermissionReply, PermissionReplySource,
+    PermissionRequest, PermissionRequestEvent, PermissionRequestSourceKind, PortError,
+    PortErrorKind, RuntimeError, TurnTokenUsage, AUTO_APPROVE_ASK_CONTEXT_KEY,
 };
 use bitfun_agent_runtime::user_questions::USER_INPUT_AVAILABLE_CONTEXT_KEY;
 use bitfun_core_types::ErrorCategory;
@@ -29,12 +30,12 @@ use crate::protocol::{
     PermissionDecision, PermissionRespondParams, PermissionRespondResult, PermissionSource,
     PermissionSourceKind, QueryCancelParams, QueryCancelResult, QueryEvent, QueryEventParams,
     QueryOutput, QueryResultError, QueryResultParams, QueryStartParams, QueryStartResult,
-    QueryTerminalStatus, RecoveryAction, RequestId, SessionCloseParams, SessionCloseResult,
-    SessionCreateParams, SessionCreateResult, SessionLifetime, SessionResumeParams, ShutdownParams,
-    ShutdownResult, TemporaryModelConfig, ToolEventStatus, JSON_RPC_VERSION, METHOD_INITIALIZE,
-    METHOD_PERMISSION_RESPOND, METHOD_QUERY_CANCEL, METHOD_QUERY_START, METHOD_SESSION_CLOSE,
-    METHOD_SESSION_CREATE, METHOD_SESSION_RESUME, METHOD_SHUTDOWN, NOTIFICATION_QUERY_EVENT,
-    NOTIFICATION_QUERY_RESULT, PROTOCOL_VERSION,
+    QueryTerminalStatus, QueryUsage, RecoveryAction, RequestId, SessionCloseParams,
+    SessionCloseResult, SessionCreateParams, SessionCreateResult, SessionLifetime,
+    SessionResumeParams, ShutdownParams, ShutdownResult, TemporaryModelConfig, ToolEventStatus,
+    JSON_RPC_VERSION, METHOD_INITIALIZE, METHOD_PERMISSION_RESPOND, METHOD_QUERY_CANCEL,
+    METHOD_QUERY_START, METHOD_SESSION_CLOSE, METHOD_SESSION_CREATE, METHOD_SESSION_RESUME,
+    METHOD_SHUTDOWN, NOTIFICATION_QUERY_EVENT, NOTIFICATION_QUERY_RESULT, PROTOCOL_VERSION,
 };
 
 const DEFAULT_SESSION_NAME: &str = "BitFun SDK query";
@@ -235,6 +236,7 @@ struct QueryLease {
     turn_id: String,
     operation_id: String,
     output: StdMutex<QueryOutputBuffer>,
+    usage: StdMutex<Option<TurnTokenUsage>>,
     terminal: AtomicBool,
     stop_forwarding: CancellationToken,
     emit_output: bool,
@@ -1107,11 +1109,20 @@ impl SdkHostConnection {
         else {
             return;
         };
-        if params.prompt.trim().is_empty() {
+        if params.prompt.trim().is_empty() && params.images.is_empty() {
             self.send_invalid_params(
                 request.id.clone(),
                 ErrorStage::Query,
-                "prompt must not be empty",
+                "prompt and images must not both be empty",
+            )
+            .await;
+            return;
+        }
+        if params.images.iter().any(|path| !is_local_image_path(path)) {
+            self.send_invalid_params(
+                request.id.clone(),
+                ErrorStage::Query,
+                "images must contain non-empty local paths with png, jpg, jpeg, gif, or webp extensions",
             )
             .await;
             return;
@@ -1299,6 +1310,11 @@ impl SdkHostConnection {
             AUTO_APPROVE_ASK_CONTEXT_KEY.to_string(),
             serde_json::Value::Bool(false),
         );
+        let attachments = params
+            .images
+            .iter()
+            .map(|image_path| local_image_attachment(image_path, &session.workspace_path))
+            .collect();
         let submitted = match self
             .inner
             .runtime
@@ -1315,7 +1331,7 @@ impl SdkHostConnection {
                 policy: DialogSubmissionPolicy::for_source(AgentSubmissionSource::SdkHost),
                 reply_route: None,
                 prepended_reminders: Vec::new(),
-                attachments: Vec::new(),
+                attachments,
                 metadata: submission_metadata,
             })
             .await
@@ -1351,6 +1367,7 @@ impl SdkHostConnection {
             turn_id: turn_id.clone(),
             operation_id: operation_id.clone(),
             output: StdMutex::new(QueryOutputBuffer::default()),
+            usage: StdMutex::new(None),
             terminal: AtomicBool::new(false),
             stop_forwarding: CancellationToken::new(),
             emit_output,
@@ -1544,6 +1561,14 @@ impl SdkHostConnection {
                 if event_turn_id(&envelope.event) != Some(lease.turn_id.as_str()) {
                     continue;
                 }
+                TurnTokenUsage::accumulate_event(
+                    &mut lease
+                        .usage
+                        .lock()
+                        .expect("SDK Host Query usage lock poisoned"),
+                    &envelope.event,
+                    &lease.turn_id,
+                );
                 let terminal = terminal_fact(&envelope.event, &lease.turn_id, &lease.query_id);
                 if lease.emit_output {
                     if let Some(projected) = project_query_event(&envelope.event) {
@@ -2590,6 +2615,17 @@ impl SdkHostConnection {
             .expect("SDK Host Query output lock poisoned")
             .text
             .clone();
+        let usage = lease
+            .usage
+            .lock()
+            .expect("SDK Host Query usage lock poisoned")
+            .as_ref()
+            .map(|usage| QueryUsage {
+                input_tokens: usage.input_tokens,
+                output_tokens: usage.output_tokens,
+                total_tokens: usage.total_tokens,
+                cached_tokens: usage.cached_tokens,
+            });
         self.send_notification(
             NOTIFICATION_QUERY_RESULT,
             QueryResultParams {
@@ -2599,6 +2635,7 @@ impl SdkHostConnection {
                 operation_id: lease.operation_id.clone(),
                 status,
                 output: QueryOutput { text: output_text },
+                usage,
                 error,
             },
         )
@@ -3034,8 +3071,47 @@ fn event_turn_id(event: &AgenticEvent) -> Option<&str> {
         AgenticEvent::DialogTurnCompleted { turn_id, .. }
         | AgenticEvent::DialogTurnCancelled { turn_id, .. }
         | AgenticEvent::DialogTurnFailed { turn_id, .. }
+        | AgenticEvent::TokenUsageUpdated { turn_id, .. }
         | AgenticEvent::TextChunk { turn_id, .. }
         | AgenticEvent::ToolEvent { turn_id, .. } => Some(turn_id),
+        _ => None,
+    }
+}
+
+fn is_local_image_path(path: &str) -> bool {
+    !path.trim().is_empty()
+        && !path.contains("://")
+        && local_image_mime_type(Path::new(path)).is_some()
+}
+
+fn local_image_attachment(image_path: &str, workspace_path: &str) -> AgentInputAttachment {
+    let image_path = PathBuf::from(image_path);
+    let image_path = if image_path.is_absolute() {
+        image_path
+    } else {
+        Path::new(workspace_path).join(image_path)
+    };
+    let mime_type = local_image_mime_type(&image_path).expect("validated local image extension");
+    AgentInputAttachment::image_context(
+        format!("sdk-image-{}", uuid::Uuid::new_v4()),
+        Some(image_path.to_string_lossy().into_owned()),
+        None,
+        mime_type,
+        None,
+    )
+}
+
+fn local_image_mime_type(path: &Path) -> Option<&'static str> {
+    match path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("png") => Some("image/png"),
+        Some("jpg" | "jpeg") => Some("image/jpeg"),
+        Some("gif") => Some("image/gif"),
+        Some("webp") => Some("image/webp"),
         _ => None,
     }
 }
@@ -3257,9 +3333,17 @@ fn runtime_error_kind(error: &RuntimeError) -> &'static str {
 
 #[cfg(test)]
 mod runtime_error_tests {
-    use super::{runtime_error_facts, runtime_error_kind};
+    use super::{is_local_image_path, runtime_error_facts, runtime_error_kind};
     use crate::protocol::{ErrorCode, RecoveryAction};
     use bitfun_agent_runtime::sdk::{PortError, PortErrorKind, RuntimeError};
+
+    #[test]
+    fn local_image_input_accepts_supported_paths_and_rejects_urls() {
+        assert!(is_local_image_path("screenshots/failure.PNG"));
+        assert!(!is_local_image_path("https://example.com/failure.png"));
+        assert!(!is_local_image_path("screenshots/failure.svg"));
+        assert!(!is_local_image_path("  "));
+    }
 
     #[test]
     fn session_writer_conflict_uses_existing_action_required_response() {

--- a/src/crates/interfaces/sdk-host/src/protocol.rs
+++ b/src/crates/interfaces/sdk-host/src/protocol.rs
@@ -6,7 +6,7 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
 pub const JSON_RPC_VERSION: &str = "2.0";
-pub const PROTOCOL_VERSION: u32 = 4;
+pub const PROTOCOL_VERSION: u32 = 5;
 
 pub const METHOD_INITIALIZE: &str = "initialize";
 pub const METHOD_SESSION_CREATE: &str = "session/create";
@@ -269,6 +269,7 @@ pub struct HostCapabilities {
     pub session_close: bool,
     pub event_stream: bool,
     pub tool_events: bool,
+    pub image_input: bool,
     pub structured_output: bool,
     pub usage: bool,
     pub custom_tools: bool,
@@ -289,8 +290,9 @@ impl HostCapabilities {
             session_close: true,
             event_stream: true,
             tool_events: true,
+            image_input: true,
             structured_output: false,
-            usage: false,
+            usage: true,
             custom_tools: false,
             permission_responses: true,
             hooks: false,
@@ -462,6 +464,8 @@ impl SessionCreateResult {
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct QueryStartParams {
     pub prompt: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub images: Vec<String>,
     #[cfg_attr(feature = "ts", ts(optional = nullable))]
     #[serde(default)]
     pub session_id: Option<String>,
@@ -670,7 +674,24 @@ pub struct QueryResultParams {
     pub output: QueryOutput,
     #[cfg_attr(feature = "ts", ts(optional))]
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage: Option<QueryUsage>,
+    #[cfg_attr(feature = "ts", ts(optional))]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<QueryResultError>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
+#[serde(rename_all = "camelCase")]
+pub struct QueryUsage {
+    pub input_tokens: usize,
+    #[cfg_attr(feature = "ts", ts(optional))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_tokens: Option<usize>,
+    pub total_tokens: usize,
+    #[cfg_attr(feature = "ts", ts(optional))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cached_tokens: Option<usize>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/crates/interfaces/sdk-host/tests/host_lifecycle.rs
+++ b/src/crates/interfaces/sdk-host/tests/host_lifecycle.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -44,6 +45,7 @@ struct FakeOwner {
     updated_models: Mutex<Vec<(String, String)>>,
     settlement_requests: Mutex<Vec<AgentTurnSettlementRequest>>,
     dialog_metadata: Mutex<Vec<serde_json::Map<String, serde_json::Value>>>,
+    dialog_requests: Mutex<Vec<AgentDialogTurnRequest>>,
     emit_terminal: bool,
     fail_dialog_submit: bool,
     fail_delete: bool,
@@ -393,6 +395,7 @@ impl AgentDialogTurnPort for FakeOwner {
         &self,
         request: AgentDialogTurnRequest,
     ) -> PortResult<DialogSubmitOutcome> {
+        self.dialog_requests.lock().unwrap().push(request.clone());
         self.dialog_metadata
             .lock()
             .unwrap()
@@ -1300,6 +1303,108 @@ async fn query_streams_existing_events_and_one_terminal_result() {
     assert_eq!(result["params"]["status"], "completed");
     assert_eq!(result["params"]["output"]["text"], "fixture result");
     assert!(output.try_recv().is_err(), "terminal result must be unique");
+}
+
+#[tokio::test]
+async fn query_maps_local_image_paths_to_existing_runtime_attachments() {
+    let (host, owner, mut output) = host().await;
+    initialize(&host, &mut output).await;
+
+    host.handle_request(request(serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": "query-image",
+        "method": "query/start",
+        "params": {
+            "prompt": "",
+            "images": ["screenshots/fixture.jpg"]
+        }
+    })))
+    .await;
+
+    let accepted = output.recv().await.unwrap();
+    assert_eq!(accepted["result"]["accepted"], true);
+    let requests = owner.dialog_requests.lock().unwrap();
+    let request = requests.last().expect("submitted dialog request");
+    assert!(request.message.is_empty());
+    let attachment = &request.attachments[0];
+    assert_eq!(attachment.kind, "remote_image");
+    assert_eq!(attachment.metadata["mimeType"], "image/jpeg");
+    assert_eq!(
+        PathBuf::from(
+            attachment.metadata["imagePath"]
+                .as_str()
+                .expect("local image path")
+        ),
+        PathBuf::from("D:/workspace/project").join("screenshots/fixture.jpg")
+    );
+}
+
+#[tokio::test]
+async fn query_result_aggregates_usage_for_its_turn() {
+    let (host, owner, mut output) = host_with_query_limit(1).await;
+    initialize(&host, &mut output).await;
+
+    host.handle_request(request(serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": "query-usage",
+        "method": "query/start",
+        "params": { "prompt": "hello" }
+    })))
+    .await;
+
+    let accepted = output.recv().await.unwrap();
+    assert_eq!(accepted["result"]["turnId"], "turn-fixture");
+    assert_eq!(output.recv().await.unwrap()["method"], "query/event");
+    let session_id = accepted["result"]["sessionId"].as_str().unwrap();
+    let queue = owner.queue.lock().unwrap().clone().unwrap();
+    for event in [
+        usage_event(session_id, "turn-fixture", 100, Some(25), 125, Some(40)),
+        usage_event(session_id, "another-turn", 900, Some(90), 990, Some(80)),
+        usage_event(session_id, "turn-fixture", 200, Some(50), 250, Some(80)),
+        AgenticEvent::DialogTurnCompleted {
+            session_id: session_id.to_string(),
+            turn_id: "turn-fixture".to_string(),
+            total_rounds: 2,
+            total_tools: 0,
+            duration_ms: 1,
+            partial_recovery_reason: None,
+            success: Some(true),
+            finish_reason: Some("stop".to_string()),
+            has_final_response: Some(true),
+        },
+    ] {
+        queue.enqueue(event, None).await.unwrap();
+    }
+
+    let result = output.recv().await.unwrap();
+    assert_eq!(result["method"], "query/result");
+    assert_eq!(result["params"]["usage"]["inputTokens"], 300);
+    assert_eq!(result["params"]["usage"]["outputTokens"], 75);
+    assert_eq!(result["params"]["usage"]["totalTokens"], 375);
+    assert_eq!(result["params"]["usage"]["cachedTokens"], 120);
+}
+
+fn usage_event(
+    session_id: &str,
+    turn_id: &str,
+    input_tokens: usize,
+    output_tokens: Option<usize>,
+    total_tokens: usize,
+    cached_tokens: Option<usize>,
+) -> AgenticEvent {
+    AgenticEvent::TokenUsageUpdated {
+        session_id: session_id.to_string(),
+        turn_id: turn_id.to_string(),
+        model_config_id: "model-config".to_string(),
+        effective_model_name: "provider-model".to_string(),
+        input_tokens,
+        output_tokens,
+        total_tokens,
+        max_context_tokens: Some(200_000),
+        is_subagent: false,
+        cached_tokens,
+        token_details: None,
+    }
 }
 
 #[tokio::test]

--- a/src/crates/interfaces/sdk-host/tests/protocol_contracts.rs
+++ b/src/crates/interfaces/sdk-host/tests/protocol_contracts.rs
@@ -2,9 +2,10 @@ use bitfun_sdk_host::protocol::{
     ErrorCode, ErrorData, ErrorStage, HostCapabilities, InitializeParams, InitializeResult,
     JsonRpcErrorResponse, JsonRpcRequest, JsonRpcSuccessResponse, OutcomeCertainty,
     PermissionDecision, PermissionRespondParams, PermissionSource, PermissionSourceKind,
-    QueryEvent, QueryOutput, QueryResultError, QueryResultParams, QueryTerminalStatus,
-    RecoveryAction, RequestId, SessionLifetime, SessionResumeParams, Stability,
-    TemporaryModelConfig, TemporaryModelProvider, ToolEventStatus, PROTOCOL_VERSION,
+    QueryEvent, QueryOutput, QueryResultError, QueryResultParams, QueryStartParams,
+    QueryTerminalStatus, QueryUsage, RecoveryAction, RequestId, SessionLifetime,
+    SessionResumeParams, Stability, TemporaryModelConfig, TemporaryModelProvider, ToolEventStatus,
+    PROTOCOL_VERSION,
 };
 
 #[test]
@@ -14,7 +15,7 @@ fn initialize_contract_is_versioned_and_binds_one_temporary_model() {
         "id": 1,
         "method": "initialize",
         "params": {
-            "protocolVersion": 4,
+            "protocolVersion": 5,
             "clientInfo": { "name": "fixture", "version": "0.1.0" },
             "capabilities": {
                 "serverNotifications": true,
@@ -32,7 +33,7 @@ fn initialize_contract_is_versioned_and_binds_one_temporary_model() {
     let params: InitializeParams = request.params_as().unwrap();
 
     assert_eq!(request.id, Some(RequestId::Number(1)));
-    assert_eq!(PROTOCOL_VERSION, 4);
+    assert_eq!(PROTOCOL_VERSION, 5);
     assert_eq!(params.protocol_version, PROTOCOL_VERSION);
     assert!(params.capabilities.server_notifications);
     assert!(params.capabilities.permission_responses);
@@ -79,8 +80,9 @@ fn initialize_contract_is_versioned_and_binds_one_temporary_model() {
             session_close: true,
             event_stream: true,
             tool_events: true,
+            image_input: true,
             structured_output: false,
-            usage: false,
+            usage: true,
             custom_tools: false,
             permission_responses: true,
             hooks: false,
@@ -103,18 +105,41 @@ fn current_host_capabilities_are_a_deliberate_subset_of_the_headless_cli_target(
     assert!(capabilities.session_close);
     assert!(capabilities.event_stream);
     assert!(capabilities.tool_events);
+    assert!(capabilities.image_input);
 
     assert_eq!(
         capabilities.session_create_lifetime,
         SessionLifetime::Durable
     );
     assert!(!capabilities.structured_output);
-    assert!(!capabilities.usage);
+    assert!(capabilities.usage);
     assert!(!capabilities.custom_tools);
     assert!(capabilities.permission_responses);
     assert!(!capabilities.hooks);
     assert!(!capabilities.mcp_configuration);
     assert!(!capabilities.prestarted_transport);
+}
+
+#[test]
+fn query_input_carries_only_text_and_local_image_paths() {
+    let params: QueryStartParams = serde_json::from_value(serde_json::json!({
+        "prompt": "describe these images",
+        "images": ["screenshots/one.png", "D:/captures/two.jpg"]
+    }))
+    .unwrap();
+
+    assert_eq!(params.prompt, "describe these images");
+    assert_eq!(
+        params.images,
+        vec!["screenshots/one.png", "D:/captures/two.jpg"]
+    );
+    assert!(
+        serde_json::from_value::<QueryStartParams>(serde_json::json!({
+            "prompt": "unsupported payload",
+            "imageUrl": "https://example.com/image.png"
+        }))
+        .is_err()
+    );
 }
 
 #[test]
@@ -201,6 +226,12 @@ fn query_events_and_terminal_errors_are_closed_protocol_values() {
         output: QueryOutput {
             text: "partial response".to_string(),
         },
+        usage: Some(QueryUsage {
+            input_tokens: 100,
+            output_tokens: Some(25),
+            total_tokens: 125,
+            cached_tokens: Some(40),
+        }),
         error: Some(QueryResultError {
             message: "Permission approval is required".to_string(),
             data: ErrorData {
@@ -220,6 +251,8 @@ fn query_events_and_terminal_errors_are_closed_protocol_values() {
     assert_eq!(result["error"]["data"]["stage"], "query");
     assert_eq!(result["operationId"], "operation-1");
     assert_eq!(result["output"]["text"], "partial response");
+    assert_eq!(result["usage"]["inputTokens"], 100);
+    assert_eq!(result["usage"]["cachedTokens"], 40);
     assert_eq!(result["error"]["data"]["outcomeCertainty"], "committed");
     assert_eq!(
         result["error"]["message"],


### PR DESCRIPTION
## 背景

上一阶段已经打通 Query、Session、流式事件、取消和权限响应。外部应用要完成一个最基础的多模态 Agent 调用，还缺少图片上下文和可计量的单轮结果。

本次参考 Codex TypeScript SDK 已验证的最小输入模型：调用方传字符串，或传有序的 `text` / `local_image` 数组；用量只作为完成结果的事实返回。功能继续走现有 Agent Runtime，没有增加第二套 Runtime、进程协议或图片处理实现。

## 变更

- TypeScript SDK 新增 `Input` / `UserInput`：支持字符串，以及 `text`、`local_image` 的有序组合；多段文字按顺序合并，图片路径单独传给 Host。
- SDK Host 协议升级到 v5，接收本地图片路径并映射到 Runtime 现有 `AgentInputAttachment`；相对路径按 Session workspace 解析。
- Runtime 提供单轮 `TurnTokenUsage`，聚合当前 turn 的多轮模型用量；CLI 复用同一实现，删除原有重复逻辑。
- `Result.usage` 返回 input/output/total/cached token；可选字段只在所有相关轮次均可确认时返回。
- 本地包示例、协议生成和消费者烟测同步更新。包仍为私有 `0.0.0`，本次不发布 npm 或 PyPI。

## 能力边界

- 图片仅支持本地 PNG、JPEG、GIF、WebP 路径。
- URL、base64、音频、通用附件、自定义 tool、hook、结构化输出和 Python SDK仍不在本次范围。
- 图片读取、格式检测、大小限制和模型多模态编码继续由现有 Runtime 链路负责。
- Host 只负责进程生命周期、协议校验和 DTO 映射；TypeScript SDK 只暴露稳定的外部对象。

## 兼容性

| 项目 | 变更 |
| --- | --- |
| SDK Host protocol | 4 → 5 |
| Agent Runtime preview API | 8 → 9 |
| npm package | 保持 private / 0.0.0，仅本地使用 |
| 代码规模 | 24 files，+557 / -126，1 commit |

## 验证

- `cargo test -p bitfun-agent-runtime --features agent-runtime dialog_turn --lib`
- `cargo test -p bitfun-sdk-host -p bitfun-sdk-host-app`
- `cargo test -p bitfun-cli json_usage -- --nocapture`
- `pnpm --dir sdk/typescript test`（65 passed，1 个 Unix-only 用例在 Windows 跳过）
- `pnpm --dir sdk/typescript smoke:consumer`
- `pnpm --dir sdk/typescript smoke:node`
- `git diff --check`

`cargo check --workspace` 在 Desktop build script 处因本地缺少预生成的 `src/mobile-web/dist` 资源而无法完成；受影响的 Runtime、CLI、SDK Host 和 TypeScript SDK 均已通过直接验证。