### PR TITLE
fix(markdown): stabilize streaming images

### DIFF
--- a/src/web-ui/src/component-library/components/Markdown/Markdown.scss
+++ b/src/web-ui/src/component-library/components/Markdown/Markdown.scss
@@ -475,8 +475,22 @@
   opacity: 0.75;
 }
 
-.markdown-renderer .markdown-image--error {
-  outline: 1px dashed color-mix(in srgb, var(--bf-appearance-token-color-error) 35%, transparent);
+.markdown-renderer .markdown-image-fallback {
+  display: inline-flex;
+  align-items: center;
+  min-width: 1.25em;
+  min-height: 1.25em;
+  max-width: 100%;
+  box-sizing: border-box;
+  margin: 0.35rem 0.25rem;
+  padding: 0 0.3em;
+  border: 1px dashed color-mix(in srgb, var(--bf-appearance-token-color-text-muted) 35%, transparent);
+  border-radius: var(--bf-appearance-token-flowchat-card-radius);
+  color: var(--bf-appearance-token-color-text-muted);
+  font-size: var(--markdown-font-size-sm);
+  line-height: var(--markdown-support-line-height);
+  overflow-wrap: anywhere;
+  vertical-align: middle;
 }
 
 .markdown-renderer .katex-display {

--- a/src/web-ui/src/component-library/components/Markdown/Markdown.test.tsx
+++ b/src/web-ui/src/component-library/components/Markdown/Markdown.test.tsx
@@ -357,6 +357,144 @@ describe('Markdown file links', () => {
     expect(mocks.getCurrentWorkspacePath).not.toHaveBeenCalled();
   });
 
+  it('preserves existing markdown nodes while streaming content is appended', async () => {
+    const initialContent = [
+      'Before image',
+      '',
+      '![Stable diagram](stream-stable.png)',
+      '',
+      'After image',
+    ].join('\n');
+
+    await act(async () => {
+      root.render(
+        <Markdown
+          content={initialContent}
+          basePath={EXAMPLE_WORKSPACE}
+          isStreaming
+          onFileViewRequest={onFileViewRequest}
+        />,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const imageBefore = container.querySelector<HTMLImageElement>('img[alt="Stable diagram"]');
+    const paragraphsBefore = Array.from(container.querySelectorAll('p'));
+    expect(imageBefore).not.toBeNull();
+    expect(paragraphsBefore).toHaveLength(3);
+    expect(mocks.readFileContent).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      root.render(
+        <Markdown
+          content={`${initialContent}\n\nNew streamed paragraph`}
+          basePath={EXAMPLE_WORKSPACE}
+          isStreaming
+          onFileViewRequest={onFileViewRequest}
+        />,
+      );
+      await Promise.resolve();
+    });
+
+    const imageAfter = container.querySelector<HTMLImageElement>('img[alt="Stable diagram"]');
+    const paragraphsAfter = Array.from(container.querySelectorAll('p'));
+    expect(imageAfter).toBe(imageBefore);
+    expect(paragraphsAfter).toHaveLength(4);
+    expect(paragraphsAfter.slice(0, 3)).toEqual(paragraphsBefore);
+    expect(mocks.readFileContent).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders alt text instead of a broken image when a local image read fails', async () => {
+    mocks.readFileContent.mockRejectedValueOnce(new Error('missing image'));
+
+    await act(async () => {
+      root.render(
+        <Markdown
+          content={'![Missing diagram](missing-stream-image.png)'}
+          basePath={EXAMPLE_WORKSPACE}
+          isStreaming
+        />,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector('img[alt="Missing diagram"]')).toBeNull();
+    const fallback = container.querySelector('[data-bf-part="imageFallback"]');
+    expect(fallback?.textContent).toBe('Missing diagram');
+
+    await act(async () => {
+      root.render(
+        <Markdown
+          content={'![Missing diagram](missing-stream-image.png)\n\nLater streamed text'}
+          basePath={EXAMPLE_WORKSPACE}
+          isStreaming
+        />,
+      );
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector('[data-bf-part="imageFallback"]')).toBe(fallback);
+    expect(mocks.readFileContent).toHaveBeenCalledTimes(1);
+  });
+
+  it('replaces an externally hosted image after the browser reports an error', async () => {
+    await act(async () => {
+      root.render(<Markdown content={'![Unavailable chart](https://example.invalid/chart.png)'} />);
+      await Promise.resolve();
+    });
+
+    const image = container.querySelector<HTMLImageElement>('img[alt="Unavailable chart"]');
+    expect(image).not.toBeNull();
+
+    act(() => {
+      image?.dispatchEvent(new Event('error'));
+    });
+
+    expect(container.querySelector('img[alt="Unavailable chart"]')).toBeNull();
+    expect(container.querySelector('[data-bf-part="imageFallback"]')?.textContent)
+      .toBe('Unavailable chart');
+  });
+
+  it('uses the latest source text and callback without remounting a file link', async () => {
+    const firstHandler = vi.fn();
+    const secondHandler = vi.fn();
+    const firstPath = 'D:\\First\\README.md';
+    const secondPath = 'E:\\Second\\README.md';
+
+    await act(async () => {
+      root.render(
+        <Markdown
+          content={`[README.md](${firstPath})`}
+          onFileViewRequest={firstHandler}
+        />,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const linkBefore = container.querySelector<HTMLButtonElement>('button.file-link');
+    expect(linkBefore).not.toBeNull();
+
+    await act(async () => {
+      root.render(
+        <Markdown
+          content={`[README.md](${secondPath})`}
+          onFileViewRequest={secondHandler}
+        />,
+      );
+      await Promise.resolve();
+    });
+
+    const linkAfter = container.querySelector<HTMLButtonElement>('button.file-link');
+    expect(linkAfter).toBe(linkBefore);
+    act(() => linkAfter?.click());
+    expect(firstHandler).not.toHaveBeenCalled();
+    expect(secondHandler).toHaveBeenCalledWith(secondPath, 'README.md', undefined);
+  });
+
   it('routes remote markdown image reads through the session connection', async () => {
     await act(async () => {
       root.render(

--- a/src/web-ui/src/component-library/components/Markdown/Markdown.tsx
+++ b/src/web-ui/src/component-library/components/Markdown/Markdown.tsx
@@ -501,6 +501,8 @@ const MarkdownImage: React.FC<MarkdownImageProps> = ({
   className,
   basePath,
   remoteConnectionId,
+  onLoad,
+  onError,
   ...imgProps
 }) => {
   const rawSrc = typeof src === 'string' ? normalizeExternalImageSrc(src) : '';
@@ -515,31 +517,37 @@ const MarkdownImage: React.FC<MarkdownImageProps> = ({
     ? getLocalImageCacheKey(localPath, remoteConnectionId)
     : null;
   const [resolvedSrc, setResolvedSrc] = useState(() => {
+    if (!rawSrc) {
+      return '';
+    }
+
     if (!localPath || !cacheKey) {
       return rawSrc;
     }
 
     return localImageDataUrlCache.get(cacheKey) || LOCAL_IMAGE_PLACEHOLDER;
   });
-  const [loadState, setLoadState] = useState<'idle' | 'loading' | 'loaded' | 'error'>(() => {
-    if (!localPath || !cacheKey) {
-      return 'loaded';
-    }
-
-    return localImageDataUrlCache.has(cacheKey) ? 'loaded' : 'idle';
-  });
+  const [loadState, setLoadState] = useState<'loading' | 'loaded' | 'error'>(
+    rawSrc ? 'loading' : 'error',
+  );
 
   useEffect(() => {
+    if (!rawSrc) {
+      setResolvedSrc('');
+      setLoadState('error');
+      return;
+    }
+
     if (!localPath || !cacheKey) {
       setResolvedSrc(rawSrc);
-      setLoadState('loaded');
+      setLoadState('loading');
       return;
     }
 
     const cachedDataUrl = localImageDataUrlCache.get(cacheKey);
     if (cachedDataUrl) {
       setResolvedSrc(cachedDataUrl);
-      setLoadState('loaded');
+      setLoadState('loading');
       return;
     }
 
@@ -554,7 +562,10 @@ const MarkdownImage: React.FC<MarkdownImageProps> = ({
         }
 
         setResolvedSrc(dataUrl);
-        setLoadState('loaded');
+        // Wait for the browser's load event before considering the decoded
+        // image ready. A successful filesystem read does not prove the bytes
+        // are a displayable image.
+        setLoadState('loading');
       })
       .catch((error) => {
         if (cancelled) {
@@ -566,7 +577,10 @@ const MarkdownImage: React.FC<MarkdownImageProps> = ({
           remoteConnectionId,
           error,
         });
-        setResolvedSrc(rawSrc);
+        // Never hand a failed local path back to the browser. That produces a
+        // native broken-image glyph and retries the invalid source whenever
+        // the surrounding Markdown is reconciled.
+        setResolvedSrc('');
         setLoadState('error');
       });
 
@@ -575,6 +589,19 @@ const MarkdownImage: React.FC<MarkdownImageProps> = ({
     };
   }, [cacheKey, localPath, rawSrc, remoteConnectionId]);
 
+  if (loadState === 'error') {
+    return (
+      <span
+        className="markdown-image-fallback"
+        data-bf-component="markdown"
+        data-bf-part="imageFallback"
+        title={typeof alt === 'string' && alt ? alt : undefined}
+      >
+        {typeof alt === 'string' ? alt : null}
+      </span>
+    );
+  }
+
   return (
     <img
       {...imgProps}
@@ -582,10 +609,19 @@ const MarkdownImage: React.FC<MarkdownImageProps> = ({
       className={[
         className,
         loadState === 'loading' ? 'markdown-image markdown-image--loading' : '',
-        loadState === 'error' ? 'markdown-image markdown-image--error' : '',
       ].filter(Boolean).join(' ')}
       loading="lazy"
       src={resolvedSrc}
+      onLoad={(event) => {
+        if (resolvedSrc !== LOCAL_IMAGE_PLACEHOLDER) {
+          setLoadState('loaded');
+        }
+        onLoad?.(event);
+      }}
+      onError={(event) => {
+        setLoadState('error');
+        onError?.(event);
+      }}
     />
   );
 };
@@ -788,6 +824,12 @@ export interface MarkdownProps {
   traceContext?: MarkdownTraceContext;
 }
 
+function useLiveValueRef<T>(value: T): React.MutableRefObject<T> {
+  const ref = useRef(value);
+  ref.current = value;
+  return ref;
+}
+
 export const Markdown = React.memo<MarkdownProps>(({ 
   content, 
   basePath,
@@ -810,8 +852,19 @@ export const Markdown = React.memo<MarkdownProps>(({
   // looked like the chat pane refreshed when a turn finished).
   const isStreamingRef = useRef(isStreaming);
   isStreamingRef.current = isStreaming;
+  const basePathRef = useLiveValueRef(basePath);
+  const remoteConnectionIdRef = useLiveValueRef(remoteConnectionId);
+  const currentWorkspacePathRef = useLiveValueRef(currentWorkspacePath);
+  const expandDetailsByDefaultRef = useLiveValueRef(expandDetailsByDefault);
+  const onOpenVisualizationRef = useLiveValueRef(onOpenVisualization);
+  const onFileViewRequestRef = useLiveValueRef(onFileViewRequest);
+  const onTabOpenRef = useLiveValueRef(onTabOpen);
+  const onHttpLinkClickRef = useLiveValueRef(onHttpLinkClick);
+  const traceContextRef = useLiveValueRef(traceContext);
   
   const syntaxTheme = useMemo(() => buildMarkdownPrismStyle(isLight), [isLight]);
+  const syntaxThemeRef = useLiveValueRef(syntaxTheme);
+  const isLightRef = useLiveValueRef(isLight);
   
   const contentStr = typeof content === 'string' ? content : String(content || '');
   const renderTraceEnabled = isStartupRenderTraceEnabled();
@@ -846,6 +899,7 @@ export const Markdown = React.memo<MarkdownProps>(({
 
     return { markdownContent: body, reproductionSteps: steps };
   }, [contentStr, isStreaming]);
+  const markdownContentRef = useLiveValueRef(markdownContent);
 
   const needsWorkspacePathForLinks = useMemo(
     () => mayNeedWorkspacePathForMarkdownLinks(markdownContent),
@@ -906,30 +960,36 @@ export const Markdown = React.memo<MarkdownProps>(({
   }, []);
 
   const handleFileViewRequest = useCallback((filePath: string, fileName: string, lineRange?: LineRange) => {
-    onFileViewRequest?.(filePath, fileName, lineRange);
-  }, [onFileViewRequest]);
+    onFileViewRequestRef.current?.(filePath, fileName, lineRange);
+  }, [onFileViewRequestRef]);
 
   const handleOpenVisualization = useCallback((visualization: any) => {
-    onOpenVisualization?.(visualization);
-  }, [onOpenVisualization]);
+    onOpenVisualizationRef.current?.(visualization);
+  }, [onOpenVisualizationRef]);
 
   const handleTabOpen = useCallback((tabInfo: any) => {
-    onTabOpen?.(tabInfo);
-  }, [onTabOpen]);
+    onTabOpenRef.current?.(tabInfo);
+  }, [onTabOpenRef]);
 
   const handleRevealInExplorer = useCallback(async (filePath: string) => {
-    let targetPath = resolveDisplayFilePath(filePath, basePath, currentWorkspacePath);
+    const latestBasePath = basePathRef.current;
+    const latestWorkspacePath = currentWorkspacePathRef.current;
+    let targetPath = resolveDisplayFilePath(filePath, latestBasePath, latestWorkspacePath);
     try {
       if (!isAbsoluteFilesystemPath(targetPath)) {
         const workspacePath = await globalAPI.getCurrentWorkspacePath();
-        targetPath = resolveDisplayFilePath(filePath, basePath, workspacePath || currentWorkspacePath);
+        targetPath = resolveDisplayFilePath(
+          filePath,
+          latestBasePath,
+          workspacePath || latestWorkspacePath,
+        );
       }
 
       await workspaceAPI.revealInExplorer(targetPath);
     } catch (error) {
       log.error('Failed to reveal file in explorer', { filePath: targetPath, error });
     }
-  }, [basePath, currentWorkspacePath]);
+  }, [basePathRef, currentWorkspacePathRef]);
 
   const showLinkContextMenu = useCallback((
     event: React.MouseEvent<HTMLElement>,
@@ -1063,6 +1123,14 @@ export const Markdown = React.memo<MarkdownProps>(({
     showLinkContextMenu,
   ]);
   
+  /**
+   * Keep renderer component identities stable while Markdown content streams.
+   *
+   * React treats each function in this map as a component type. Rebuilding the
+   * map for every chunk remounts all existing custom-rendered nodes, including
+   * images and every paragraph below them. Values that must stay current are
+   * read from live refs when react-markdown invokes the stable renderers.
+   */
   const components = useMemo(() => ({
     code({ node: _node, className, children, ...props }: any) {
       const match = /language-(\w+)/.exec(className || '');
@@ -1101,7 +1169,7 @@ export const Markdown = React.memo<MarkdownProps>(({
       const codeTagStyle: React.CSSProperties = {
         fontFamily: 'var(--bf-appearance-token-font-family-mono)',
       };
-      const gutterColor = isLight
+      const gutterColor = isLightRef.current
         ? 'color-mix(in srgb, var(--bf-appearance-token-color-static-black) 40%, var(--bf-appearance-token-color-static-white))'
         : 'color-mix(in srgb, var(--bf-appearance-token-color-static-white) 40%, var(--bf-appearance-token-color-static-black))';
 
@@ -1120,7 +1188,7 @@ export const Markdown = React.memo<MarkdownProps>(({
             */}
             <AsyncPrismSyntaxHighlighter
               language={normalizedLang}
-              style={syntaxTheme}
+              style={syntaxThemeRef.current}
               showLineNumbers={true}
               customStyle={codeBodyStyle}
               codeTagProps={{ style: codeTagStyle }}
@@ -1140,7 +1208,7 @@ export const Markdown = React.memo<MarkdownProps>(({
                 codeTagStyle,
                 gutterColor,
               }}
-              traceContext={traceContext}
+              traceContext={traceContextRef.current}
             >
               {code}
             </AsyncPrismSyntaxHighlighter>
@@ -1151,7 +1219,7 @@ export const Markdown = React.memo<MarkdownProps>(({
     
     a({ node, href, children, ...props }: any) {
       const hrefValue = href || node?.properties?.href || extractMarkdownLinkHrefFromSource(
-        markdownContent,
+        markdownContentRef.current,
         node?.position,
       );
       const isHashLink = typeof hrefValue === 'string' && hrefValue.startsWith('#');
@@ -1188,8 +1256,12 @@ export const Markdown = React.memo<MarkdownProps>(({
           }
         }
 
-        filePath = resolveBaseRelativePath(filePath, basePath);
-        const displayFilePath = resolveDisplayFilePath(filePath, undefined, currentWorkspacePath);
+        filePath = resolveBaseRelativePath(filePath, basePathRef.current);
+        const displayFilePath = resolveDisplayFilePath(
+          filePath,
+          undefined,
+          currentWorkspacePathRef.current,
+        );
 
         const fileName = filePath.split(/[\\/]/).pop() || filePath;
 
@@ -1302,7 +1374,7 @@ export const Markdown = React.memo<MarkdownProps>(({
             onClick={async (e) => {
               e.preventDefault();
               e.stopPropagation();
-              if (onHttpLinkClick?.(hrefValue, e)) {
+              if (onHttpLinkClickRef.current?.(hrefValue, e)) {
                 return;
               }
               const hasExternalOpenModifier = e.metaKey || e.ctrlKey || e.shiftKey || e.altKey;
@@ -1356,7 +1428,7 @@ export const Markdown = React.memo<MarkdownProps>(({
 
     details({ children, open, ...props }: any) {
       return (
-        <details {...props} open={open ?? expandDetailsByDefault}>
+        <details {...props} open={open ?? expandDetailsByDefaultRef.current}>
           {children}
         </details>
       );
@@ -1366,8 +1438,8 @@ export const Markdown = React.memo<MarkdownProps>(({
       return (
         <MarkdownImage
           {...props}
-          basePath={basePath || currentWorkspacePath}
-          remoteConnectionId={remoteConnectionId}
+          basePath={basePathRef.current || currentWorkspacePathRef.current}
+          remoteConnectionId={remoteConnectionIdRef.current}
         />
       );
     },
@@ -1399,10 +1471,6 @@ export const Markdown = React.memo<MarkdownProps>(({
       );
     }
   }), [
-    basePath,
-    remoteConnectionId,
-    expandDetailsByDefault,
-    markdownContent,
     handleFileViewRequest,
     handleRevealInExplorer,
     handleLocalFileContextMenu,
@@ -1411,12 +1479,16 @@ export const Markdown = React.memo<MarkdownProps>(({
     handleOpenBuiltInBrowserLink,
     handleOpenVisualization,
     handleTabOpen,
-    onHttpLinkClick,
     parseLineRange,
-    syntaxTheme,
-    isLight,
-    currentWorkspacePath,
-    traceContext,
+    basePathRef,
+    currentWorkspacePathRef,
+    expandDetailsByDefaultRef,
+    isLightRef,
+    markdownContentRef,
+    onHttpLinkClickRef,
+    remoteConnectionIdRef,
+    syntaxThemeRef,
+    traceContextRef,
   ]);
   
   const wrapperClassName = `markdown-renderer ${className}`.trim();

--- a/src/web-ui/src/component-library/components/Markdown/appearance.ts
+++ b/src/web-ui/src/component-library/components/Markdown/appearance.ts
@@ -4,6 +4,7 @@ export const markdownAppearanceDescriptor: AppearanceSurfaceDescriptor = {
   id: 'markdown',
   parts: [
     { id: 'root', visualRole: 'content' }, { id: 'fallback', visualRole: 'content' },
+    { id: 'imageFallback', visualRole: 'content' },
     { id: 'codeBlock', visualRole: 'card' },
     { id: 'codeToolbar', propertyProfile: 'control', visualRole: 'toolbar' },
     { id: 'codeBody', visualRole: 'content' },


### PR DESCRIPTION
Keep Markdown renderer identities stable as streamed content grows.

Existing images and surrounding blocks now keep their React identity.

Failed local and remote images now use an alt-text fallback.

This avoids native broken-image glyphs and repeated reads.

Regression tests cover DOM identity, image failures, and current links.

Remote image routing remains covered.
