### PR TITLE
fix(agent): honor configured max rounds

### DIFF
--- a/src/apps/desktop/src/lib.rs
+++ b/src/apps/desktop/src/lib.rs
@@ -2074,29 +2074,14 @@ async fn init_agentic_system() -> anyhow::Result<(
         tool_pipeline.clone(),
     ));
 
-    // Get execution config from global settings
-    let exec_config = match bitfun_core::service::config::get_global_config_service().await {
-        Ok(config_service) => {
-            match config_service
-                .get_config::<bitfun_core::service::config::types::GlobalConfig>(None)
-                .await
-            {
-                Ok(global_config) => execution::ExecutionEngineConfig {
-                    max_rounds: global_config.ai.max_rounds,
-                    ..Default::default()
-                },
-                Err(_) => Default::default(),
-            }
-        }
-        Err(_) => Default::default(),
-    };
+    let execution_config = execution::execution_engine_config_from_global_config().await;
 
     let execution_engine = Arc::new(execution::ExecutionEngine::new(
         round_executor,
         event_queue.clone(),
         session_manager.clone(),
         context_compressor,
-        exec_config,
+        execution_config,
     ));
 
     let runtime_ownership = Arc::new(

--- a/src/apps/server/src/bootstrap.rs
+++ b/src/apps/server/src/bootstrap.rs
@@ -101,12 +101,13 @@ pub(crate) async fn initialize(workspace: Option<String>) -> anyhow::Result<Arc<
         tool_pipeline.clone(),
     ));
 
+    let execution_config = execution::execution_engine_config_from_global_config().await;
     let execution_engine = Arc::new(execution::ExecutionEngine::new(
         round_executor,
         event_queue.clone(),
         session_manager.clone(),
         context_compressor,
-        execution::ExecutionEngineConfig::default(),
+        execution_config,
     ));
 
     let coordinator = Arc::new(coordination::ConversationCoordinator::new(

--- a/src/crates/assembly/core/src/agentic/execution/execution_engine.rs
+++ b/src/crates/assembly/core/src/agentic/execution/execution_engine.rs
@@ -101,11 +101,8 @@ fn skill_agent_listing_reminders(
     )
 }
 
-fn reached_fixed_model_round_limit(
-    max_model_rounds: Option<usize>,
-    completed_rounds: usize,
-) -> bool {
-    max_model_rounds.is_some_and(|limit| completed_rounds >= limit)
+fn reached_fixed_model_round_limit(max_rounds: usize, completed_rounds: usize) -> bool {
+    max_rounds > 0 && completed_rounds >= max_rounds
 }
 
 fn runtime_context_needs_for_manifest(manifest: &ResolvedToolManifest) -> RuntimeContextNeeds {
@@ -163,6 +160,15 @@ impl Default for ExecutionEngineConfig {
         Self {
             max_rounds: crate::service::config::types::DEFAULT_MAX_ROUNDS,
             max_consecutive_same_tool: 3,
+        }
+    }
+}
+
+impl ExecutionEngineConfig {
+    pub fn from_ai_config(ai_config: &crate::service::config::types::AIConfig) -> Self {
+        Self {
+            max_rounds: ai_config.max_rounds,
+            ..Self::default()
         }
     }
 }
@@ -3691,8 +3697,6 @@ impl ExecutionEngine {
             })
             .await?;
 
-        let max_model_rounds = (self.config.max_rounds > 0).then_some(self.config.max_rounds);
-
         // Add System Prompt to the beginning of message list (only for this execution, not persisted)
         let mut messages = vec![turn_prompt_scaffold.system_prompt_message.clone()];
         messages.extend(initial_messages);
@@ -3776,9 +3780,11 @@ impl ExecutionEngine {
 
         // Loop to execute model rounds
         loop {
-            if reached_fixed_model_round_limit(max_model_rounds, completed_rounds) {
-                let limit = max_model_rounds.expect("checked above");
-                warn!("Reached max rounds limit: {}, stopping execution", limit);
+            if reached_fixed_model_round_limit(self.config.max_rounds, completed_rounds) {
+                warn!(
+                    "Reached max rounds limit: {}, stopping execution",
+                    self.config.max_rounds
+                );
                 finalization_reason = Some("max_rounds");
                 break;
             }
@@ -5143,9 +5149,9 @@ impl ExecutionEngine {
 mod tests {
     use super::{
         activate_conditional_instructions_after_round, manual_compaction_terminal_error,
-        resolve_round_permission_mode, runtime_context_needs_for_manifest,
-        skill_agent_listing_reminders, ContextHealthSnapshot, ExecutionEngine, RoundResult,
-        TurnPromptScaffold,
+        reached_fixed_model_round_limit, resolve_round_permission_mode,
+        runtime_context_needs_for_manifest, skill_agent_listing_reminders, ContextHealthSnapshot,
+        ExecutionEngine, ExecutionEngineConfig, RoundResult, TurnPromptScaffold,
     };
     use crate::agentic::agents::{
         PrependedPromptReminders, PromptBuilderContext, ToolListingSections, UserContextPolicy,
@@ -5253,6 +5259,30 @@ mod tests {
 
         assert!(!runtime_context_needs_for_manifest(&base).exec_control);
         assert!(runtime_context_needs_for_manifest(&active).exec_control);
+    }
+
+    #[test]
+    fn zero_max_rounds_disables_the_fixed_round_limit() {
+        assert!(!reached_fixed_model_round_limit(0, 0));
+        assert!(!reached_fixed_model_round_limit(0, 10_000));
+    }
+
+    #[test]
+    fn positive_max_rounds_stops_at_the_configured_limit() {
+        assert!(!reached_fixed_model_round_limit(200, 199));
+        assert!(reached_fixed_model_round_limit(200, 200));
+        assert!(reached_fixed_model_round_limit(200, 201));
+    }
+
+    #[test]
+    fn max_rounds_execution_config_projects_the_global_ai_limit() {
+        let mut ai_config = AIConfig::default();
+        ai_config.max_rounds = 37;
+
+        assert_eq!(
+            ExecutionEngineConfig::from_ai_config(&ai_config).max_rounds,
+            37
+        );
     }
 
     #[test]
@@ -6556,10 +6586,4 @@ mod tests {
             image_attachments: None,
         })
     }
-}
-#[test]
-fn unlimited_profile_never_reaches_a_fixed_model_round_limit() {
-    assert!(!reached_fixed_model_round_limit(None, 0));
-    assert!(!reached_fixed_model_round_limit(None, 10_000));
-    assert!(reached_fixed_model_round_limit(Some(200), 200));
 }

--- a/src/crates/assembly/core/src/agentic/execution/mod.rs
+++ b/src/crates/assembly/core/src/agentic/execution/mod.rs
@@ -16,3 +16,20 @@ pub use execution_engine::*;
 pub use round_executor::*;
 pub use stream_processor::*;
 pub use types::{ExecutionContext, ExecutionResult, FinishReason, RoundContext, RoundResult};
+
+/// Load the product-wide model-round policy from the initialized global config.
+///
+/// Product hosts use this shared assembly path so Desktop, CLI, Server, ACP,
+/// SDK Host, and detached execution cannot silently drift to different limits.
+pub async fn execution_engine_config_from_global_config() -> ExecutionEngineConfig {
+    let Ok(config_service) = crate::service::config::get_global_config_service().await else {
+        return ExecutionEngineConfig::default();
+    };
+    let Ok(global_config) = config_service
+        .get_config::<crate::service::config::types::GlobalConfig>(None)
+        .await
+    else {
+        return ExecutionEngineConfig::default();
+    };
+    ExecutionEngineConfig::from_ai_config(&global_config.ai)
+}

--- a/src/crates/assembly/core/src/agentic/system.rs
+++ b/src/crates/assembly/core/src/agentic/system.rs
@@ -120,12 +120,13 @@ pub async fn init_agentic_system_for_profile_with_runtime_ownership(
         tool_pipeline.clone(),
     ));
 
+    let execution_config = execution::execution_engine_config_from_global_config().await;
     let execution_engine = Arc::new(execution::ExecutionEngine::new(
         round_executor,
         event_queue.clone(),
         session_manager.clone(),
         context_compressor,
-        execution::ExecutionEngineConfig::default(),
+        execution_config,
     ));
 
     let coordinator = Arc::new(coordination::ConversationCoordinator::new(

--- a/src/crates/assembly/core/src/service/config/manager.rs
+++ b/src/crates/assembly/core/src/service/config/manager.rs
@@ -149,6 +149,7 @@ fn config_value_for_persistence(config: &GlobalConfig) -> BitFunResult<Value> {
     let mut value = serde_json::to_value(config)
         .map_err(|e| BitFunError::config(format!("Failed to serialize config: {}", e)))?;
     prune_default_ai_tool_argument_json_repair(&mut value);
+    prune_default_ai_max_rounds(&mut value);
     prune_default_memories_config(&mut value)?;
     Ok(value)
 }
@@ -160,6 +161,18 @@ fn prune_default_ai_tool_argument_json_repair(config_value: &mut Value) {
 
     if ai_config.get("allow_tool_json_repair") == Some(&Value::Bool(true)) {
         ai_config.remove("allow_tool_json_repair");
+    }
+}
+
+fn prune_default_ai_max_rounds(config_value: &mut Value) {
+    let Some(ai_config) = config_value.get_mut("ai").and_then(Value::as_object_mut) else {
+        return;
+    };
+
+    if ai_config.get("max_rounds").and_then(Value::as_u64)
+        == Some(crate::service::config::types::DEFAULT_MAX_ROUNDS as u64)
+    {
+        ai_config.remove("max_rounds");
     }
 }
 
@@ -1150,7 +1163,19 @@ mod tests {
         assert!(value.get("memories").is_none());
         assert!(value["ai"].get("agent_models").is_none());
         assert!(value["ai"].get("allow_tool_json_repair").is_none());
+        assert!(value["ai"].get("max_rounds").is_none());
         assert!(value["ai"].get("task_models").is_none());
+    }
+
+    #[test]
+    fn persistence_keeps_explicit_max_rounds() {
+        let mut config = GlobalConfig::default();
+        config.ai.max_rounds = 37;
+
+        let value =
+            config_value_for_persistence(&config).expect("config should serialize for persistence");
+
+        assert_eq!(value["ai"].get("max_rounds"), Some(&serde_json::json!(37)));
     }
 
     #[test]

--- a/src/crates/assembly/core/src/service/config/types.rs
+++ b/src/crates/assembly/core/src/service/config/types.rs
@@ -2100,6 +2100,19 @@ mod tests {
     }
 
     #[test]
+    fn missing_max_rounds_defaults_to_unlimited_and_explicit_limits_survive() {
+        let defaulted: GlobalConfig = serde_json::from_value(serde_json::json!({}))
+            .expect("legacy global config should deserialize");
+        assert_eq!(defaulted.ai.max_rounds, 0);
+
+        let limited: GlobalConfig = serde_json::from_value(serde_json::json!({
+            "ai": { "max_rounds": 37 }
+        }))
+        .expect("explicit max rounds should deserialize");
+        assert_eq!(limited.ai.max_rounds, 37);
+    }
+
+    #[test]
     fn user_tool_groups_default_to_version_one_without_persisted_groups() {
         let config: GlobalConfig = serde_json::from_value(serde_json::json!({}))
             .expect("legacy global config should deserialize");


### PR DESCRIPTION
Use the global AI max-rounds setting across product runtimes.

Treat zero as unlimited and preserve config-load fallback behavior.

Omit the zero default from disk while keeping positive limits.
