### PR TITLE
test(cli): make dispatch cancellation handshake deterministic

### DIFF
--- a/src/apps/cli/src/dispatch/runner.rs
+++ b/src/apps/cli/src/dispatch/runner.rs
@@ -446,11 +446,13 @@ mod tests {
         let mut command = Command::new("/bin/sh");
         command
             .arg("-c")
+            // Keep the leader in the shell's `wait` builtin so TERM runs its
+            // trap immediately; an external `sleep` can defer trap handling.
             .arg(
                 "trap 'exit 0' TERM; trap '' HUP; \
                  sh -c 'trap \"\" TERM HUP; printf ready > \"$BITFUN_DISPATCH_TERM_TEST_READY\"; \
                  while :; do sleep 30; done' & \
-                 while :; do sleep 30; done",
+                 wait",
             )
             // These trailing arguments make the real process identity match
             // the hidden worker contract without launching BitFun Runtime.


### PR DESCRIPTION
## Summary

- keep the test leader blocked in the shell builtin `wait`
- let SIGTERM run the exit trap immediately instead of waiting on an external `sleep`
- preserve the TERM-resistant child that verifies SIGKILL is not sent after leader exit

## Why

The macOS CLI job in #2495 intermittently failed `cancellation_does_not_escalate_after_term_exits_the_verified_leader`. Under load, `/bin/sh` can defer a trapped signal while waiting for an external foreground command, so the test leader sometimes survived the one-second TERM grace window and was legitimately escalated.

## Verification

- target test: 50/50 repeated passes on macOS
- all 6 `dispatch::runner` tests pass
- `cargo check -p bitfun-cli`
- `cargo test -p bitfun-cli` (685 unit tests plus CLI integration suites)

Only the test fixture changes; production cancellation behavior is unchanged.