### PR TITLE
feat(agent): let AgentWait yield to steering

### DIFF
--- a/src/crates/assembly/core/src/agentic/coordination/background_outcomes.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/background_outcomes.rs
@@ -42,6 +42,7 @@ impl BackgroundSubagentOutcome {
 pub(crate) enum BackgroundSubagentWaitStatus {
     Completed,
     TimedOut,
+    Steered,
     NoMatchingTasks,
 }
 
@@ -50,6 +51,7 @@ impl BackgroundSubagentWaitStatus {
         match self {
             Self::Completed => "completed",
             Self::TimedOut => "timed_out",
+            Self::Steered => "steered",
             Self::NoMatchingTasks => "no_matching_tasks",
         }
     }
@@ -207,6 +209,7 @@ impl BackgroundSubagentOutcomeStore {
         timeout: Duration,
         delivered_parent_dialog_turn_id: &str,
         cancellation_token: Option<&CancellationToken>,
+        round_injection_preemption_token: Option<&CancellationToken>,
     ) -> BitFunResult<BackgroundSubagentWaitResult> {
         self.reconcile_stale_running_tasks(parent_session_id)
             .await?;
@@ -229,10 +232,38 @@ impl BackgroundSubagentOutcomeStore {
         let mut debounce_deadline = None;
 
         loop {
+            if cancellation_token.is_some_and(CancellationToken::is_cancelled) {
+                return Err(BitFunError::cancelled(
+                    "AgentWait was cancelled".to_string(),
+                ));
+            }
+
             let notified = self.changes.notified();
             tokio::pin!(notified);
 
             let available = self.collect_available(&selected_task_pks).await?;
+            if round_injection_preemption_token.is_some_and(CancellationToken::is_cancelled) {
+                if available.outcomes.is_empty() {
+                    return Ok(wait_result(
+                        BackgroundSubagentWaitStatus::Steered,
+                        Vec::new(),
+                        available.pending_bg_task_ids,
+                    ));
+                }
+                if let Some(result) = self
+                    .claim_result(
+                        parent_session_id,
+                        delivered_parent_dialog_turn_id,
+                        BackgroundSubagentWaitStatus::Steered,
+                        available,
+                    )
+                    .await?
+                {
+                    return Ok(result);
+                }
+                debounce_deadline = None;
+                continue;
+            }
             if !available.outcomes.is_empty() && available.pending_bg_task_ids.is_empty() {
                 if let Some(result) = self
                     .claim_result(
@@ -283,22 +314,24 @@ impl BackgroundSubagentOutcomeStore {
                 continue;
             }
 
-            match cancellation_token {
-                Some(token) => {
-                    tokio::select! {
-                        _ = token.cancelled() => {
-                            return Err(BitFunError::cancelled("AgentWait was cancelled".to_string()));
-                        }
-                        _ = &mut notified => {}
-                        _ = sleep_until(wake_at) => {}
+            tokio::select! {
+                biased;
+                _ = async {
+                    match cancellation_token {
+                        Some(token) => token.cancelled().await,
+                        None => std::future::pending::<()>().await,
                     }
+                } => {
+                    return Err(BitFunError::cancelled("AgentWait was cancelled".to_string()));
                 }
-                None => {
-                    tokio::select! {
-                        _ = &mut notified => {}
-                        _ = sleep_until(wake_at) => {}
+                _ = async {
+                    match round_injection_preemption_token {
+                        Some(token) => token.cancelled().await,
+                        None => std::future::pending::<()>().await,
                     }
-                }
+                } => {}
+                _ = &mut notified => {}
+                _ = sleep_until(wake_at) => {}
             }
         }
     }
@@ -698,6 +731,7 @@ mod tests {
             BackgroundSubagentWaitMode::All,
             Duration::from_millis(50),
             "wait-turn",
+            None,
             None,
         )
         .await

--- a/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
@@ -11480,6 +11480,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         timeout: Duration,
         delivered_parent_dialog_turn_id: &str,
         cancellation_token: Option<&CancellationToken>,
+        round_injection_preemption_token: Option<&CancellationToken>,
     ) -> BitFunResult<BackgroundSubagentWaitResult> {
         self.background_subagent_outcomes
             .wait_for(
@@ -11489,6 +11490,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                 timeout,
                 delivered_parent_dialog_turn_id,
                 cancellation_token,
+                round_injection_preemption_token,
             )
             .await
     }
@@ -17432,6 +17434,7 @@ mod tests {
                 Duration::from_millis(10),
                 "wait-turn-1",
                 None,
+                None,
             )
             .await
             .expect("AgentWait should collect the completed outcome");
@@ -17450,6 +17453,7 @@ mod tests {
                 BackgroundSubagentWaitMode::All,
                 Duration::from_millis(10),
                 "wait-turn-2",
+                None,
                 None,
             )
             .await
@@ -17555,6 +17559,7 @@ mod tests {
                 Duration::from_millis(10),
                 "wait-turn",
                 None,
+                None,
             )
             .await
             .expect("AgentWait should collect a prior-turn outcome in the same session");
@@ -17596,6 +17601,7 @@ mod tests {
                 Duration::from_millis(1),
                 "wait-turn-1",
                 None,
+                None,
             )
             .await
             .expect("all selector timeout should return partial results");
@@ -17612,6 +17618,7 @@ mod tests {
                 BackgroundSubagentWaitMode::All,
                 Duration::from_millis(10),
                 "wait-turn-2",
+                None,
                 None,
             )
             .await
@@ -17649,6 +17656,7 @@ mod tests {
                 BackgroundSubagentWaitMode::Any,
                 Duration::from_secs(6),
                 "wait-turn",
+                None,
                 None,
             )
             .await
@@ -17697,6 +17705,7 @@ mod tests {
                 Duration::from_secs(10),
                 "cancelled-wait-turn",
                 Some(&cancellation),
+                None,
             )
             .await
             .expect_err("cancelled AgentWait should not return a partial result");
@@ -17709,6 +17718,7 @@ mod tests {
                 BackgroundSubagentWaitMode::All,
                 Duration::from_millis(10),
                 "retry-wait-turn",
+                None,
                 None,
             )
             .await
@@ -17737,6 +17747,7 @@ mod tests {
                 Duration::from_millis(1),
                 "wait-turn",
                 None,
+                None,
             )
             .await
             .expect("AgentWait timeout should be returned normally");
@@ -17744,6 +17755,95 @@ mod tests {
         assert_eq!(result.status.as_str(), "timed_out");
         assert!(result.outcomes.is_empty());
         assert_eq!(result.pending_bg_task_ids, vec![registered.bg_task_id]);
+    }
+
+    #[tokio::test]
+    async fn steered_agent_wait_returns_pending_tasks_without_cancelling_them() {
+        let (coordinator, _) = test_coordinator();
+        let registered = register_test_background_task(
+            &coordinator,
+            "parent-session",
+            "parent-turn",
+            "subagent-session",
+        )
+        .await;
+        let preemption = tokio_util::sync::CancellationToken::new();
+        preemption.cancel();
+
+        let result = coordinator
+            .wait_for_background_subagent_outcomes(
+                "parent-session",
+                std::slice::from_ref(&registered.bg_task_id),
+                BackgroundSubagentWaitMode::All,
+                Duration::from_secs(10),
+                "steered-wait-turn",
+                None,
+                Some(&preemption),
+            )
+            .await
+            .expect("steering should end AgentWait normally");
+
+        assert_eq!(result.status.as_str(), "steered");
+        assert!(result.outcomes.is_empty());
+        assert_eq!(result.pending_bg_task_ids, vec![registered.bg_task_id]);
+    }
+
+    #[tokio::test]
+    async fn steered_agent_wait_returns_and_consumes_available_partial_results() {
+        let (coordinator, _) = test_coordinator();
+        let completed_task = register_test_background_task(
+            &coordinator,
+            "parent-session",
+            "parent-turn",
+            "subagent-session-completed",
+        )
+        .await;
+        let pending_task = register_test_background_task(
+            &coordinator,
+            "parent-session",
+            "parent-turn",
+            "subagent-session-pending",
+        )
+        .await;
+        let completed = super::SubagentResult::completed("done".to_string());
+        coordinator
+            .background_subagent_outcomes
+            .complete(completed_task.task_pk, Ok(&completed))
+            .await;
+        let preemption = tokio_util::sync::CancellationToken::new();
+        preemption.cancel();
+
+        let result = coordinator
+            .wait_for_background_subagent_outcomes(
+                "parent-session",
+                &[],
+                BackgroundSubagentWaitMode::All,
+                Duration::from_secs(10),
+                "steered-wait-turn",
+                None,
+                Some(&preemption),
+            )
+            .await
+            .expect("steering should return collected outcomes");
+
+        assert_eq!(result.status.as_str(), "steered");
+        assert_eq!(result.outcomes.len(), 1);
+        assert_eq!(result.outcomes[0].bg_task_id, completed_task.bg_task_id);
+        assert_eq!(result.pending_bg_task_ids, vec![pending_task.bg_task_id]);
+
+        let retry = coordinator
+            .wait_for_background_subagent_outcomes(
+                "parent-session",
+                std::slice::from_ref(&completed_task.bg_task_id),
+                BackgroundSubagentWaitMode::All,
+                Duration::from_millis(10),
+                "retry-wait-turn",
+                None,
+                None,
+            )
+            .await
+            .expect("a steered wait should consume returned outcomes");
+        assert_eq!(retry.status.as_str(), "no_matching_tasks");
     }
 
     #[test]

--- a/src/crates/assembly/core/src/agentic/coordination/mod.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/mod.rs
@@ -17,7 +17,7 @@ pub use turn_outcome::*;
 
 pub(crate) use background_outcomes::{
     BackgroundSubagentOutcome, BackgroundSubagentOutcomeStore, BackgroundSubagentWaitMode,
-    BackgroundSubagentWaitResult,
+    BackgroundSubagentWaitResult, BackgroundSubagentWaitStatus,
 };
 pub(crate) use coordination_store::DirectChildAgentRecord;
 

--- a/src/crates/assembly/core/src/agentic/execution/round_executor.rs
+++ b/src/crates/assembly/core/src/agentic/execution/round_executor.rs
@@ -1129,6 +1129,7 @@ impl RoundExecutor {
                     Some(format!("round-budget-{}", round_id)),
                     self.computer_use_host(),
                     CancellationToken::new(),
+                    None,
                 );
 
             // Execute tools — convert pipeline-level Err into per-tool error results

--- a/src/crates/assembly/core/src/agentic/tools/framework.rs
+++ b/src/crates/assembly/core/src/agentic/tools/framework.rs
@@ -134,6 +134,12 @@ pub trait Tool: Send + Sync {
         false
     }
 
+    /// Whether a pending round injection may end this tool normally so the
+    /// current turn can advance without cancelling the underlying work.
+    fn round_injection_yieldable(&self) -> bool {
+        false
+    }
+
     /// Whether to support streaming output
     fn supports_streaming(&self) -> bool {
         false

--- a/src/crates/assembly/core/src/agentic/tools/implementations/agent_wait_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/agent_wait_tool.rs
@@ -1,6 +1,6 @@
 use crate::agentic::coordination::{
     get_global_coordinator, BackgroundSubagentOutcome, BackgroundSubagentWaitMode,
-    BackgroundSubagentWaitResult,
+    BackgroundSubagentWaitResult, BackgroundSubagentWaitStatus,
 };
 use crate::agentic::tools::framework::{
     PermissionIntent, Tool, ToolRenderOptions, ToolResult, ToolUseContext, ValidationResult,
@@ -93,15 +93,21 @@ impl AgentWaitTool {
     }
 
     fn assistant_result(result: &BackgroundSubagentWaitResult) -> String {
+        let finished = if result.status == BackgroundSubagentWaitStatus::Steered {
+            "AgentWait ended early because user steering arrived. Background agents continue running."
+                .to_string()
+        } else {
+            format!("AgentWait finished with status {}.", result.status.as_str())
+        };
         if result.outcomes.is_empty() {
             return format!(
-                "AgentWait finished with status {}. Pending background task IDs: {}.",
-                result.status.as_str(),
+                "{} Pending background task IDs: {}.",
+                finished,
                 result.pending_bg_task_ids.join(", ")
             );
         }
 
-        let mut message = format!("AgentWait finished with status {}.", result.status.as_str());
+        let mut message = finished;
         for outcome in &result.outcomes {
             message.push_str(&format!(
                 "\n<result bg_task_id=\"{}\" agent_id=\"{}\" status=\"{}\">",
@@ -135,6 +141,10 @@ impl Tool for AgentWaitTool {
     }
 
     fn manages_own_execution_timeout(&self) -> bool {
+        true
+    }
+
+    fn round_injection_yieldable(&self) -> bool {
         true
     }
 
@@ -230,6 +240,7 @@ Wait for every selected task to complete. The tool also returns when `timeout_se
                 Duration::from_secs(request.timeout_seconds),
                 dialog_turn_id,
                 context.cancellation_token(),
+                context.round_injection_preemption_token(),
             )
             .await?;
         let data = json!({
@@ -249,6 +260,13 @@ Wait for every selected task to complete. The tool also returns when `timeout_se
 mod tests {
     use super::{AgentWaitTool, DEFAULT_TIMEOUT_SECONDS, MAX_TIMEOUT_SECONDS, MIN_TIMEOUT_SECONDS};
     use crate::agentic::tools::framework::Tool;
+
+    #[test]
+    fn agent_wait_owns_timeout_and_yields_to_round_injection() {
+        let tool = AgentWaitTool::new();
+        assert!(tool.manages_own_execution_timeout());
+        assert!(tool.round_injection_yieldable());
+    }
 
     #[test]
     fn missing_or_empty_task_ids_are_tolerated_by_the_parser() {

--- a/src/crates/assembly/core/src/agentic/tools/pipeline/tool_pipeline.rs
+++ b/src/crates/assembly/core/src/agentic/tools/pipeline/tool_pipeline.rs
@@ -1266,21 +1266,33 @@ impl ToolPipeline {
         }
     }
 
-    async fn cancel_tools_for_round_injection(
+    async fn preempt_tools_for_round_injection(
         &self,
         task_ids: impl IntoIterator<Item = String>,
+        preemption: RoundInjectionToolPreemption,
     ) -> BitFunResult<()> {
         for task_id in task_ids {
-            self.cancel_tool(
-                &task_id,
-                ROUND_INJECTION_RUNNING_TOOL_CANCELLED_MESSAGE.to_string(),
-            )
-            .await?;
+            let Some(task) = self.state_manager.get_task(&task_id) else {
+                continue;
+            };
+            if tool_task_state_kind(&task.state).is_terminal() {
+                continue;
+            }
+
+            if let Some(token) = task.round_injection_preemption_token {
+                token.cancel();
+            } else if preemption.should_cancel_running_tools() {
+                self.cancel_tool(
+                    &task_id,
+                    ROUND_INJECTION_RUNNING_TOOL_CANCELLED_MESSAGE.to_string(),
+                )
+                .await?;
+            }
         }
         Ok(())
     }
 
-    fn spawn_round_injection_cancellation_watch(
+    fn spawn_round_injection_preemption_watch(
         &self,
         task_ids: Vec<String>,
         interrupt: Option<crate::agentic::round_preempt::DialogRoundInjectionInterrupt>,
@@ -1294,8 +1306,11 @@ impl ToolPipeline {
             };
 
             loop {
-                if interrupt.should_cancel_running_tools() {
-                    let _ = pipeline.cancel_tools_for_round_injection(task_ids).await;
+                let preemption = interrupt.pending_tool_preemption();
+                if preemption.should_interrupt_after_current_atomic_unit() {
+                    let _ = pipeline
+                        .preempt_tools_for_round_injection(task_ids, preemption)
+                        .await;
                     break;
                 }
                 tokio::time::sleep(Duration::from_millis(25)).await;
@@ -1340,41 +1355,53 @@ impl ToolPipeline {
             })
             .count();
 
-        // Determine concurrency safety for each tool call
-        let concurrency_flags: Vec<bool> = {
+        // Resolve execution traits before tasks are created so round-injection
+        // preemption can be routed without a second registry lookup.
+        let execution_traits: Vec<(bool, bool)> = {
             let registry = self.tool_registry.read().await;
             resolved_tool_calls
                 .iter()
                 .map(|(_, invocation, resolution_error)| {
                     if resolution_error.is_some() {
-                        return false;
+                        return (false, false);
                     }
-                    let tool_is_concurrency_safe = registry
-                        .get_tool(&invocation.effective_tool_name)
-                        .and_then(|tool| {
-                            resolve_contextual_tool(
-                                tool,
-                                context
-                                    .workspace
-                                    .as_ref()
-                                    .map(|workspace| workspace.root_path()),
-                                context
-                                    .workspace
-                                    .as_ref()
-                                    .is_some_and(|workspace| workspace.is_remote()),
-                            )
-                        })
+                    let tool =
+                        registry
+                            .get_tool(&invocation.effective_tool_name)
+                            .and_then(|tool| {
+                                resolve_contextual_tool(
+                                    tool,
+                                    context
+                                        .workspace
+                                        .as_ref()
+                                        .map(|workspace| workspace.root_path()),
+                                    context
+                                        .workspace
+                                        .as_ref()
+                                        .is_some_and(|workspace| workspace.is_remote()),
+                                )
+                            });
+                    let tool_is_concurrency_safe = tool
+                        .as_ref()
                         .map(|tool| tool.is_concurrency_safe(Some(&invocation.effective_arguments)))
                         .unwrap_or(false);
-                    tool_call_concurrency_safe_for_batch(
+                    let concurrency_safe = tool_call_concurrency_safe_for_batch(
                         &invocation.effective_tool_name,
                         tool_is_concurrency_safe,
                         subagent_call_count,
                         options.subagent_batch_execution_policy,
-                    )
+                    );
+                    let round_injection_yieldable = tool
+                        .as_ref()
+                        .is_some_and(|tool| tool.round_injection_yieldable());
+                    (concurrency_safe, round_injection_yieldable)
                 })
                 .collect()
         };
+        let concurrency_flags = execution_traits
+            .iter()
+            .map(|(concurrency_safe, _)| *concurrency_safe)
+            .collect::<Vec<_>>();
         let concurrency_safe_count = concurrency_flags.iter().filter(|&&flag| flag).count();
 
         // Create tasks for all tool calls
@@ -1390,6 +1417,9 @@ impl ToolPipeline {
                 options.clone(),
             );
             task.tool_call_order = tool_call_order as u32;
+            if execution_traits[tool_call_order].1 {
+                task.round_injection_preemption_token = Some(CancellationToken::new());
+            }
             let tool_id = self.state_manager.create_task(task).await;
             task_ids.push(tool_id);
         }
@@ -1488,7 +1518,7 @@ impl ToolPipeline {
             .and_then(|task_id| self.state_manager.get_task(task_id))
             .and_then(|task| task.context.steering_interrupt.clone());
         let watch_handle =
-            self.spawn_round_injection_cancellation_watch(task_ids.clone(), batch_interrupt);
+            self.spawn_round_injection_preemption_watch(task_ids.clone(), batch_interrupt);
 
         let futures: Vec<_> = task_ids
             .iter()
@@ -1535,7 +1565,7 @@ impl ToolPipeline {
 
             let interrupt = task.and_then(|task| task.context.steering_interrupt.clone());
             let watch_handle =
-                self.spawn_round_injection_cancellation_watch(vec![task_id.clone()], interrupt);
+                self.spawn_round_injection_preemption_watch(vec![task_id.clone()], interrupt);
             let result = self.execute_single_tool(task_id.clone()).await;
             if let Some(handle) = watch_handle {
                 handle.abort();
@@ -2482,6 +2512,7 @@ mod tests {
         response: serde_json::Value,
         delay_ms: u64,
         readonly: bool,
+        round_injection_yieldable: bool,
     }
 
     struct CapturingTestTool {
@@ -2728,6 +2759,10 @@ mod tests {
             self.readonly
         }
 
+        fn round_injection_yieldable(&self) -> bool {
+            self.round_injection_yieldable
+        }
+
         fn input_schema(&self) -> serde_json::Value {
             json!({ "type": "object" })
         }
@@ -2748,10 +2783,20 @@ mod tests {
         async fn call_impl(
             &self,
             _input: &serde_json::Value,
-            _context: &ToolUseContext,
+            context: &ToolUseContext,
         ) -> BitFunResult<Vec<ToolResult>> {
             if self.delay_ms > 0 {
-                sleep(Duration::from_millis(self.delay_ms)).await;
+                if let Some(token) = context
+                    .round_injection_preemption_token()
+                    .filter(|_| self.round_injection_yieldable)
+                {
+                    tokio::select! {
+                        _ = sleep(Duration::from_millis(self.delay_ms)) => {}
+                        _ = token.cancelled() => {}
+                    }
+                } else {
+                    sleep(Duration::from_millis(self.delay_ms)).await;
+                }
             }
             Ok(vec![ToolResult::Result {
                 data: self.response.clone(),
@@ -2874,6 +2919,25 @@ mod tests {
                 response,
                 delay_ms,
                 readonly: true,
+                round_injection_yieldable: false,
+            }));
+    }
+
+    async fn register_yieldable_test_tool(
+        pipeline: &ToolPipeline,
+        name: &str,
+        response: serde_json::Value,
+    ) {
+        pipeline
+            .tool_registry
+            .write()
+            .await
+            .register_tool(Arc::new(StaticTestTool {
+                name: name.to_string(),
+                response,
+                delay_ms: 30_000,
+                readonly: true,
+                round_injection_yieldable: true,
             }));
     }
 
@@ -2949,6 +3013,7 @@ mod tests {
                 response: json!({ "unexpected": true }),
                 delay_ms: 0,
                 readonly: false,
+                round_injection_yieldable: false,
             }));
         let mut options = ToolExecutionOptions::default();
         options.permission_policy = ResolvedPermissionPolicy::new(
@@ -4367,6 +4432,62 @@ mod tests {
         assert_eq!(results.len(), 1);
         assert!(results[0].result.is_error);
         assert_eq!(results[0].result.result["category"], json!("cancelled"));
+    }
+
+    #[tokio::test]
+    async fn yieldable_tools_end_normally_for_every_non_none_round_injection_policy() {
+        for policy in [
+            RoundInjectionToolPreemption::InterruptAfterCurrentAtomicUnit,
+            RoundInjectionToolPreemption::CancelRunningCooperatively,
+            RoundInjectionToolPreemption::CancelRunningForcefully,
+        ] {
+            let pipeline = test_tool_pipeline();
+            register_yieldable_test_tool(&pipeline, "AgentWait", json!({ "status": "steered" }))
+                .await;
+
+            let buffer = Arc::new(SessionRoundInjectionBuffer::default());
+            let buffer_for_injection = buffer.clone();
+            tokio::spawn(async move {
+                sleep(Duration::from_millis(50)).await;
+                buffer_for_injection.push(
+                    "session_1",
+                    test_round_injection(RoundInjectionKind::UserSteering, policy),
+                );
+            });
+
+            let mut context = test_tool_execution_context();
+            context.steering_interrupt = Some(DialogRoundInjectionInterrupt::new(
+                "session_1".to_string(),
+                "turn_1".to_string(),
+                buffer,
+            ));
+            let results = pipeline
+                .execute_tools(
+                    vec![test_tool_call("agent_wait", "AgentWait")],
+                    context,
+                    ToolExecutionOptions::default(),
+                )
+                .await
+                .expect("yieldable tool should finish normally");
+
+            assert_eq!(results.len(), 1, "policy: {policy:?}");
+            assert!(!results[0].result.is_error, "policy: {policy:?}");
+            assert_eq!(
+                results[0].result.result["status"],
+                json!("steered"),
+                "policy: {policy:?}"
+            );
+            assert!(
+                matches!(
+                    pipeline
+                        .state_manager
+                        .get_task("agent_wait")
+                        .map(|task| task.state),
+                    Some(ToolExecutionState::Completed { .. })
+                ),
+                "policy: {policy:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/crates/assembly/core/src/agentic/tools/pipeline/types.rs
+++ b/src/crates/assembly/core/src/agentic/tools/pipeline/types.rs
@@ -125,6 +125,9 @@ pub struct ToolTask {
     pub created_at: SystemTime,
     pub started_at: Option<SystemTime>,
     pub completed_at: Option<SystemTime>,
+    /// Tool-owned signal for ending a yieldable call at a round-injection
+    /// boundary. This is deliberately distinct from ordinary cancellation.
+    pub round_injection_preemption_token: Option<CancellationToken>,
 }
 
 impl ToolTask {
@@ -158,6 +161,7 @@ impl ToolTask {
             created_at: SystemTime::now(),
             started_at: None,
             completed_at: None,
+            round_injection_preemption_token: None,
         }
     }
 

--- a/src/crates/assembly/core/src/agentic/tools/tool_context_runtime.rs
+++ b/src/crates/assembly/core/src/agentic/tools/tool_context_runtime.rs
@@ -149,6 +149,10 @@ impl ToolUseContext {
         self.runtime_handles.cancellation_token()
     }
 
+    pub fn round_injection_preemption_token(&self) -> Option<&CancellationToken> {
+        self.runtime_handles.round_injection_preemption_token()
+    }
+
     pub fn workspace_services(&self) -> Option<&WorkspaceServices> {
         self.runtime_handles.workspace_services()
     }
@@ -191,6 +195,7 @@ impl ToolUseContext {
             runtime_tool_restrictions: ToolRuntimeRestrictions::default(),
             runtime_handles: core_tool_runtime_handles(
                 workspace_services,
+                None,
                 None,
                 None,
                 remote_exec_port,
@@ -250,6 +255,7 @@ pub(crate) fn build_tool_use_context_for_task(
         Some(task.tool_call.tool_id.clone()),
         computer_use_host,
         cancellation_token,
+        task.round_injection_preemption_token.clone(),
     )
 }
 
@@ -258,6 +264,7 @@ pub(crate) fn build_tool_use_context_for_execution_context(
     tool_call_id: Option<String>,
     computer_use_host: Option<ComputerUseHostRef>,
     cancellation_token: CancellationToken,
+    round_injection_preemption_token: Option<CancellationToken>,
 ) -> ToolUseContext {
     ToolUseContext {
         tool_call_id,
@@ -272,6 +279,7 @@ pub(crate) fn build_tool_use_context_for_execution_context(
         runtime_handles: core_tool_runtime_handles(
             context.workspace_services.clone(),
             Some(cancellation_token),
+            round_injection_preemption_token,
             context.terminal_port.clone(),
             context.remote_exec_port.clone(),
         ),
@@ -310,6 +318,7 @@ pub(crate) fn build_tool_description_context(
         runtime_handles: core_tool_runtime_handles(
             workspace_services.cloned(),
             None,
+            None,
             terminal_port.cloned(),
             remote_exec_port.cloned(),
         ),
@@ -327,10 +336,12 @@ fn canvas_storage_for_workspace(
 fn core_tool_runtime_handles(
     workspace_services: Option<WorkspaceServices>,
     cancellation_token: Option<CancellationToken>,
+    round_injection_preemption_token: Option<CancellationToken>,
     terminal_port: Option<Arc<dyn TerminalPort>>,
     remote_exec_port: Option<Arc<dyn RemoteExecPort>>,
 ) -> ToolRuntimeHandles {
     ToolRuntimeHandles::new(workspace_services, cancellation_token)
+        .with_round_injection_preemption_token(round_injection_preemption_token)
         .with_terminal_port(terminal_port)
         .with_remote_exec_port(remote_exec_port)
 }

--- a/src/crates/contracts/runtime-ports/src/tool_runtime_handles.rs
+++ b/src/crates/contracts/runtime-ports/src/tool_runtime_handles.rs
@@ -11,6 +11,7 @@ use tokio_util::sync::CancellationToken;
 pub struct ToolRuntimeHandles {
     workspace_services: Option<WorkspaceServices>,
     cancellation_token: Option<CancellationToken>,
+    round_injection_preemption_token: Option<CancellationToken>,
     terminal_port: Option<Arc<dyn TerminalPort>>,
     remote_exec_port: Option<Arc<dyn RemoteExecPort>>,
 }
@@ -23,6 +24,7 @@ impl ToolRuntimeHandles {
         Self {
             workspace_services,
             cancellation_token,
+            round_injection_preemption_token: None,
             terminal_port: None,
             remote_exec_port: None,
         }
@@ -30,6 +32,14 @@ impl ToolRuntimeHandles {
 
     pub fn with_terminal_port(mut self, terminal_port: Option<Arc<dyn TerminalPort>>) -> Self {
         self.terminal_port = terminal_port;
+        self
+    }
+
+    pub fn with_round_injection_preemption_token(
+        mut self,
+        round_injection_preemption_token: Option<CancellationToken>,
+    ) -> Self {
+        self.round_injection_preemption_token = round_injection_preemption_token;
         self
     }
 
@@ -47,6 +57,10 @@ impl ToolRuntimeHandles {
 
     pub fn cancellation_token(&self) -> Option<&CancellationToken> {
         self.cancellation_token.as_ref()
+    }
+
+    pub fn round_injection_preemption_token(&self) -> Option<&CancellationToken> {
+        self.round_injection_preemption_token.as_ref()
     }
 
     pub fn terminal_port(&self) -> Option<&Arc<dyn TerminalPort>> {
@@ -76,6 +90,13 @@ impl std::fmt::Debug for ToolRuntimeHandles {
                     .map(|_| "<CancellationToken>"),
             )
             .field(
+                "round_injection_preemption_token",
+                &self
+                    .round_injection_preemption_token
+                    .as_ref()
+                    .map(|_| "<CancellationToken>"),
+            )
+            .field(
                 "terminal_port",
                 &self.terminal_port.as_ref().map(|_| "<dyn TerminalPort>"),
             )
@@ -97,12 +118,17 @@ mod tests {
     #[test]
     fn tool_runtime_handles_keep_workspace_services_and_cancellation_contracts() {
         let cancellation_token = tokio_util::sync::CancellationToken::new();
+        let round_injection_preemption_token = tokio_util::sync::CancellationToken::new();
         let services = fake_workspace_services();
 
         let handles =
-            ToolRuntimeHandles::new(Some(services.clone()), Some(cancellation_token.clone()));
+            ToolRuntimeHandles::new(Some(services.clone()), Some(cancellation_token.clone()))
+                .with_round_injection_preemption_token(Some(
+                    round_injection_preemption_token.clone(),
+                ));
 
         assert!(handles.cancellation_token().is_some());
+        assert!(handles.round_injection_preemption_token().is_some());
         assert!(handles.workspace_services().is_some());
         assert!(std::sync::Arc::ptr_eq(
             &services.fs,
@@ -111,6 +137,12 @@ mod tests {
 
         let cloned = handles.clone();
         assert!(cloned.cancellation_token().is_some());
+        assert!(cloned.round_injection_preemption_token().is_some());
+        round_injection_preemption_token.cancel();
+        assert!(cloned
+            .round_injection_preemption_token()
+            .is_some_and(CancellationToken::is_cancelled));
+        assert!(!cancellation_token.is_cancelled());
         assert!(std::sync::Arc::ptr_eq(
             &services.shell,
             &cloned
@@ -120,7 +152,7 @@ mod tests {
         ));
         assert_eq!(
             format!("{:?}", handles),
-            "ToolRuntimeHandles { workspace_services: Some(\"<WorkspaceServices>\"), cancellation_token: Some(\"<CancellationToken>\"), terminal_port: None, remote_exec_port: None }"
+            "ToolRuntimeHandles { workspace_services: Some(\"<WorkspaceServices>\"), cancellation_token: Some(\"<CancellationToken>\"), round_injection_preemption_token: Some(\"<CancellationToken>\"), terminal_port: None, remote_exec_port: None }"
         );
     }
 }

--- a/src/web-ui/src/flow_chat/tool-cards/AgentWaitToolCard.appearance.ts
+++ b/src/web-ui/src/flow_chat/tool-cards/AgentWaitToolCard.appearance.ts
@@ -1,0 +1,11 @@
+import type { AppearanceSurfaceDescriptor } from '@/infrastructure/appearance';
+
+export const agentWaitToolCardAppearanceDescriptor: AppearanceSurfaceDescriptor = {
+  id: 'agent-wait-tool-card',
+  parts: [
+    { id: 'root' },
+  ],
+  states: [
+    { id: 'failed', selector: { kind: 'self', suffix: '[data-bf-state~="failed"]' } },
+  ],
+};

--- a/src/web-ui/src/flow_chat/tool-cards/AgentWaitToolCard.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/AgentWaitToolCard.scss
@@ -1,0 +1,13 @@
+.agent-wait-tool-card {
+  width: 100%;
+}
+
+.agent-wait-tool-card__steering-hint-inline {
+  display: block;
+  width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  color: inherit;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/src/web-ui/src/flow_chat/tool-cards/AgentWaitToolCard.test.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/AgentWaitToolCard.test.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { FlowToolItem, Session, ToolCardConfig } from '../types/flow-chat';
+import { AgentWaitToolCard, shouldShowAgentWaitSteeringHint } from './AgentWaitToolCard';
+
+const { getState } = vi.hoisted(() => ({ getState: vi.fn() }));
+
+vi.mock('../store/FlowChatStore', () => ({
+  flowChatStore: { getState },
+}));
+
+vi.mock('react-i18next', async () => {
+  const { createTestI18nT } = await import('@/test/i18nTestUtils');
+  return {
+    initReactI18next: {
+      type: '3rdParty',
+      init: vi.fn(),
+    },
+    useTranslation: () => ({ t: createTestI18nT('flow-chat') }),
+  };
+});
+
+const config: ToolCardConfig = {
+  toolName: 'AgentWait',
+  displayName: 'Wait for agents',
+  icon: 'WAIT',
+  requiresConfirmation: false,
+  resultDisplayType: 'summary',
+  displayMode: 'compact',
+};
+
+function session(overrides: Partial<Session> = {}): Session {
+  return {
+    sessionId: 'session-1',
+    dialogTurns: [],
+    status: 'active',
+    config: {},
+    createdAt: 1,
+    lastActiveAt: 1,
+    error: null,
+    sessionKind: 'normal',
+    ...overrides,
+  };
+}
+
+function item(status: FlowToolItem['status'] = 'running'): FlowToolItem {
+  return {
+    id: 'agent-wait-1',
+    type: 'tool',
+    toolName: 'AgentWait',
+    status,
+    timestamp: 1,
+    toolCall: { id: 'agent-wait-1', input: { bg_task_ids: ['a1_bg1'] } },
+  };
+}
+
+describe('AgentWaitToolCard', () => {
+  it('shows the steering hint only for a running top-level BitFun session', () => {
+    const topLevel = session();
+    expect(shouldShowAgentWaitSteeringHint('running', 'default', topLevel)).toBe(true);
+    expect(shouldShowAgentWaitSteeringHint('completed', 'default', topLevel)).toBe(false);
+    expect(
+      shouldShowAgentWaitSteeringHint('running', 'subagent-projection', topLevel),
+    ).toBe(false);
+    expect(
+      shouldShowAgentWaitSteeringHint('running', 'default', session({ sessionKind: 'subagent' })),
+    ).toBe(false);
+    expect(
+      shouldShowAgentWaitSteeringHint('running', 'default', session({ isHistorical: true })),
+    ).toBe(false);
+    expect(
+      shouldShowAgentWaitSteeringHint('running', 'default', session({ mode: 'acp:codex' })),
+    ).toBe(false);
+  });
+
+  it('renders the localized send-now steering guidance while waiting', () => {
+    getState.mockReturnValue({ sessions: new Map([['session-1', session()]]) });
+    const html = renderToStaticMarkup(
+      <AgentWaitToolCard toolItem={item()} config={config} sessionId="session-1" />,
+    );
+
+    expect(html).toContain('Wait for subagents to finish');
+    expect(html).toContain('Send a steering message to end the wait early');
+    expect(html).toContain('compact-card-content');
+    expect(html).toContain('agent-wait-tool-card__steering-hint-inline');
+    expect(html).not.toContain('data-bf-part="steeringHint"');
+  });
+
+  it('renders a normal steered result without the running hint', () => {
+    getState.mockReturnValue({ sessions: new Map([['session-1', session()]]) });
+    const completed = item('completed');
+    completed.toolResult = {
+      success: true,
+      result: { status: 'steered', results: [], pending_bg_task_ids: ['a1_bg1'] },
+    };
+    const html = renderToStaticMarkup(
+      <AgentWaitToolCard toolItem={completed} config={config} sessionId="session-1" />,
+    );
+
+    expect(html).toContain('Wait ended early');
+    expect(html).not.toContain('Send a steering message');
+  });
+
+  it('formats failures with an optional error detail', () => {
+    getState.mockReturnValue({ sessions: new Map([['session-1', session()]]) });
+    const failed = item('error');
+    failed.toolResult = { success: false, result: {}, error: 'database unavailable' };
+    const withDetail = renderToStaticMarkup(
+      <AgentWaitToolCard toolItem={failed} config={config} sessionId="session-1" />,
+    );
+    expect(withDetail).toContain('Execution failed: database unavailable');
+
+    failed.toolResult = { success: false, result: {} };
+    const withoutDetail = renderToStaticMarkup(
+      <AgentWaitToolCard toolItem={failed} config={config} sessionId="session-1" />,
+    );
+    expect(withoutDetail).toContain('Execution failed');
+  });
+});

--- a/src/web-ui/src/flow_chat/tool-cards/AgentWaitToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/AgentWaitToolCard.tsx
@@ -1,0 +1,125 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { Hourglass } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { Tooltip } from '@/component-library';
+import { flowChatStore } from '../store/FlowChatStore';
+import type { Session, ToolCardProps, ToolCardDisplayContext } from '../types/flow-chat';
+import { isAcpFlowSession } from '../utils/acpSession';
+import { CompactToolCard, CompactToolCardHeader } from './CompactToolCard';
+import { ToolCardStatusSlot } from './ToolCardStatusSlot';
+import './AgentWaitToolCard.scss';
+
+const RUNNING_STATUSES = new Set(['pending', 'preparing', 'running', 'streaming', 'receiving']);
+
+interface AgentWaitResult {
+  status?: string;
+  results?: unknown[];
+  pending_bg_task_ids?: string[];
+}
+
+const TruncatedSteeringHint: React.FC<{ text: string }> = ({ text }) => {
+  const hintRef = useRef<HTMLSpanElement>(null);
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  useEffect(() => {
+    const hint = hintRef.current;
+    if (!hint) return undefined;
+
+    const measure = () => setIsTruncated(hint.scrollWidth > hint.clientWidth + 1);
+    measure();
+
+    if (typeof ResizeObserver === 'undefined') return undefined;
+    const observer = new ResizeObserver(measure);
+    observer.observe(hint);
+    return () => observer.disconnect();
+  }, [text]);
+
+  return (
+    <Tooltip content={text} placement="top" delay={300} disabled={!isTruncated}>
+      <span ref={hintRef} className="agent-wait-tool-card__steering-hint-inline">
+        {text}
+      </span>
+    </Tooltip>
+  );
+};
+
+export function shouldShowAgentWaitSteeringHint(
+  status: ToolCardProps['toolItem']['status'],
+  displayContext: ToolCardDisplayContext | undefined,
+  session: Session | null | undefined,
+): boolean {
+  if (!RUNNING_STATUSES.has(status) || displayContext === 'subagent-projection' || !session) {
+    return false;
+  }
+
+  return session.sessionKind !== 'subagent'
+    && !session.parentToolCallId
+    && !session.isHistorical
+    && !isAcpFlowSession(session);
+}
+
+export const AgentWaitToolCard: React.FC<ToolCardProps> = ({
+  toolItem,
+  sessionId,
+  displayContext,
+}) => {
+  const { t } = useTranslation('flow-chat');
+  const { status, toolCall, toolResult } = toolItem;
+  const toolId = toolItem.id ?? toolCall?.id;
+  const result = toolResult?.result as AgentWaitResult | undefined;
+  const session = sessionId ? flowChatStore.getState().sessions.get(sessionId) : undefined;
+  const showSteeringHint = shouldShowAgentWaitSteeringHint(status, displayContext, session);
+  const steeringHint = t('toolCards.agentWait.steeringHint');
+
+  const summary = useMemo(() => {
+    if (RUNNING_STATUSES.has(status)) {
+      return null;
+    }
+    if (status === 'error') {
+      const error = toolResult?.error?.trim();
+      return error
+        ? t('toolCards.agentWait.failedWithError', { error })
+        : t('toolCards.agentWait.failed');
+    }
+    if (result?.status === 'steered') {
+      return t('toolCards.agentWait.steered');
+    }
+    if (result?.status === 'timed_out') {
+      return t('toolCards.agentWait.timedOut', {
+        count: result.pending_bg_task_ids?.length ?? 0,
+      });
+    }
+    if (status === 'completed') {
+      return t('toolCards.agentWait.completed', { count: result?.results?.length ?? 0 });
+    }
+    return t('toolCards.agentWait.title');
+  }, [result, status, t, toolResult?.error]);
+
+  const state = status === 'error' ? 'failed' : undefined;
+
+  return (
+    <div
+      data-bf-component="agent-wait-tool-card"
+      data-bf-part="root"
+      data-bf-state={state}
+      data-tool-card-id={toolId ?? ''}
+      className="agent-wait-tool-card"
+    >
+      <CompactToolCard
+        status={status}
+        className="agent-wait-tool-card__compact"
+        clickable={false}
+        header={(
+          <CompactToolCardHeader
+            icon={<ToolCardStatusSlot status={status} toolIcon={<Hourglass size={16} />} />}
+            action={t('toolCards.agentWait.title')}
+            content={showSteeringHint
+              ? <TruncatedSteeringHint text={steeringHint} />
+              : summary}
+          />
+        )}
+      />
+    </div>
+  );
+};

--- a/src/web-ui/src/flow_chat/tool-cards/index.ts
+++ b/src/web-ui/src/flow_chat/tool-cards/index.ts
@@ -29,6 +29,7 @@ import { GlobSearchDisplay } from './GlobSearchDisplay';
 import { LSDisplay } from './LSDisplay';
 import { TodoWriteDisplay } from './TodoWriteDisplay';
 import { TaskToolDisplay } from './TaskToolDisplay';
+import { AgentWaitToolCard } from './AgentWaitToolCard';
 import { CodeReviewToolCard } from './CodeReviewToolCard';
 import { FileOperationToolCard } from './FileOperationToolCard';
 import { DefaultToolCard } from './DefaultToolCard';
@@ -79,6 +80,7 @@ export const TOOL_CARD_COMPONENTS = {
   // Advanced tools
   'Task': TaskToolDisplay,
   'LaunchReviewAgent': TaskToolDisplay,
+  'AgentWait': AgentWaitToolCard,
   'TodoWrite': TodoWriteDisplay,
   
   'submit_code_review': CodeReviewToolCard,

--- a/src/web-ui/src/flow_chat/tool-cards/toolCardMetadata.ts
+++ b/src/web-ui/src/flow_chat/tool-cards/toolCardMetadata.ts
@@ -119,6 +119,16 @@ export const TOOL_CARD_CONFIGS: Record<string, ToolCardConfig> = {
     displayMode: 'detailed',
     primaryColor: APPEARANCE_DOMAIN_TOKENS.toolIdentity.assistantAction
   },
+  'AgentWait': {
+    toolName: 'AgentWait',
+    displayName: 'Wait for Agents',
+    icon: 'WAIT',
+    requiresConfirmation: false,
+    resultDisplayType: 'summary',
+    description: 'Wait for background agent results',
+    displayMode: 'compact',
+    primaryColor: APPEARANCE_DOMAIN_TOKENS.toolIdentity.assistantAction
+  },
   'TodoWrite': {
     toolName: 'TodoWrite',
     displayName: 'Task Manager',
@@ -530,6 +540,7 @@ export const DEDICATED_TOOL_CARD_NAMES = new Set([
   'WebFetch',
   'Task',
   'LaunchReviewAgent',
+  'AgentWait',
   'TodoWrite',
   'submit_code_review',
   'ContextCompression',

--- a/src/web-ui/src/infrastructure/appearance/registry/defaultAppearanceRegistry.ts
+++ b/src/web-ui/src/infrastructure/appearance/registry/defaultAppearanceRegistry.ts
@@ -257,6 +257,7 @@ import { toolCardHeaderActionsAppearanceDescriptor } from '@/flow_chat/tool-card
 import { acpPermissionActionsAppearanceDescriptor } from '@/flow_chat/tool-cards/AcpPermissionActions.appearance';
 import { contextCompressionDisplayAppearanceDescriptor } from '@/flow_chat/tool-cards/ContextCompressionDisplay.appearance';
 import { getToolSpecCardAppearanceDescriptor } from '@/flow_chat/tool-cards/GetToolSpecCard.appearance';
+import { agentWaitToolCardAppearanceDescriptor } from '@/flow_chat/tool-cards/AgentWaitToolCard.appearance';
 import { viewImageToolCardAppearanceDescriptor } from '@/flow_chat/tool-cards/ViewImageToolCard.appearance';
 import { runCodeToolCardAppearanceDescriptor } from '@/flow_chat/tool-cards/RunCodeToolCard.appearance';
 import { acpPlanPanelAppearanceDescriptor } from '@/flow_chat/components/AcpPlanPanel.appearance';
@@ -528,6 +529,7 @@ export function createDefaultAppearanceRegistry(): AppearanceRegistry {
     .registerComponent(acpPermissionActionsAppearanceDescriptor)
     .registerComponent(contextCompressionDisplayAppearanceDescriptor)
     .registerComponent(getToolSpecCardAppearanceDescriptor)
+    .registerComponent(agentWaitToolCardAppearanceDescriptor)
     .registerComponent(viewImageToolCardAppearanceDescriptor)
     .registerComponent(runCodeToolCardAppearanceDescriptor)
     .registerComponent(acpPlanPanelAppearanceDescriptor)

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -1935,6 +1935,15 @@
       "descriptionLabel": "Description",
       "schemaLabel": "Input schema"
     },
+    "agentWait": {
+      "title": "Wait for subagents to finish",
+      "completed": "Received {{count}} results",
+      "steered": "Wait ended early",
+      "timedOut": "Wait deadline reached; {{count}} tasks are still running",
+      "failed": "Execution failed",
+      "failedWithError": "Execution failed: {{error}}",
+      "steeringHint": "Send a steering message to end the wait early and let the agent handle new instructions"
+    },
     "todoWrite": {
       "tasksCount": "{{count}} tasks",
       "progress": "({{completed}}/{{total}} completed)",

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -1935,6 +1935,15 @@
       "descriptionLabel": "说明",
       "schemaLabel": "输入 Schema"
     },
+    "agentWait": {
+      "title": "等待子 Agent 完成",
+      "completed": "已收到 {{count}} 个结果",
+      "steered": "已提前结束等待",
+      "timedOut": "等待期限已到；仍有 {{count}} 个任务在运行",
+      "failed": "执行失败",
+      "failedWithError": "执行失败：{{error}}",
+      "steeringHint": "可以发送引导消息提前结束等待并让 Agent 处理新指示"
+    },
     "todoWrite": {
       "tasksCount": "{{count}} 项任务",
       "progress": "({{completed}}/{{total}} 完成)",

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -1935,6 +1935,15 @@
       "descriptionLabel": "說明",
       "schemaLabel": "輸入 Schema"
     },
+    "agentWait": {
+      "title": "等待子 Agent 完成",
+      "completed": "已收到 {{count}} 個結果",
+      "steered": "已提前結束等待",
+      "timedOut": "等待期限已到；仍有 {{count}} 個任務在執行",
+      "failed": "執行失敗",
+      "failedWithError": "執行失敗：{{error}}",
+      "steeringHint": "可以傳送引導訊息提前結束等待並讓 Agent 處理新指示"
+    },
     "todoWrite": {
       "tasksCount": "{{count}} 項任務",
       "progress": "({{completed}}/{{total}} 完成)",


### PR DESCRIPTION
Allow pending steering to end AgentWait normally while leaving
background agents running and returning any collected outcomes.

Add a dedicated compact AgentWait card that explains steering,
presents localized completion states, and truncates the inline hint
with a tooltip.
