### PR TITLE
feat(flowchat): add agent control tool cards

### DIFF
--- a/docs/interactive-capabilities/README.md
+++ b/docs/interactive-capabilities/README.md
@@ -27,9 +27,9 @@ BitFun Playbook currently contains **22 features**, **16 settings pages**, and *
 - Generated runtime catalog: `src/crates/contracts/product-domains/src/generated/product-control-catalog.json`
 - Generated per-item interaction audit: `docs/interactive-capabilities/technical/product-control-open-audit.json`
 
-说明书、网站、搜索和 Agent 只看“功能 + 设置 + 子能力”。每项子能力都必须引用已注册 Tauri Command 或可解析的源码标记；这些证据不会进入公开目录。当前 **651** 个 Tauri 命令，以及 **365** 个产品交互源码文件中的 **4408** 个交互候选，只用于实现覆盖审计。
+说明书、网站、搜索和 Agent 只看“功能 + 设置 + 子能力”。每项子能力都必须引用已注册 Tauri Command 或可解析的源码标记；这些证据不会进入公开目录。当前 **651** 个 Tauri 命令，以及 **366** 个产品交互源码文件中的 **4412** 个交互候选，只用于实现覆盖审计。
 
-Docs, website, search, and agents see only features, settings, and documented sub-capabilities. Every sub-capability must reference a registered Tauri command or a resolvable source marker; evidence is stripped from public projections. The **651** Tauri commands and **4408** interaction candidates across **365** product UI source files remain implementation-audit evidence only.
+Docs, website, search, and agents see only features, settings, and documented sub-capabilities. Every sub-capability must reference a registered Tauri command or a resolvable source marker; evidence is stripped from public projections. The **651** Tauri commands and **4412** interaction candidates across **366** product UI source files remain implementation-audit evidence only.
 
 ## 控制边界 / Control boundary
 

--- a/docs/interactive-capabilities/technical/ui-interaction-inventory.json
+++ b/docs/interactive-capabilities/technical/ui-interaction-inventory.json
@@ -5,9 +5,9 @@
   "roots": [
     "src/web-ui/src"
   ],
-  "digest": "154fb37d1f29ab10e8f342c0de543258a8ca07584c08cfa659f4a161346eac58",
-  "fileCount": 365,
-  "interactionCount": 4408,
+  "digest": "b1e086d2457b5a3f9a2ac616be1a56f8108ce2c6f18906cff488cb388dcf2e14",
+  "fileCount": 366,
+  "interactionCount": 4412,
   "files": [
     {
       "sourceFile": "src/web-ui/src/app/components/AboutDialog/AboutDialog.tsx",
@@ -1088,6 +1088,11 @@
       "sourceFile": "src/web-ui/src/flow_chat/tool-cards/AcpPermissionActions.tsx",
       "interactionCount": 5,
       "digest": "7d26363dba5c7fedae5d477fefca660b93711f1d90e385753d7863e3f56d75d4"
+    },
+    {
+      "sourceFile": "src/web-ui/src/flow_chat/tool-cards/AgentControlToolCard.tsx",
+      "interactionCount": 4,
+      "digest": "0bfe02356ccc8a7ebbcf4ee243859b40e7d6e9d986e405841ba87d4c61319245"
     },
     {
       "sourceFile": "src/web-ui/src/flow_chat/tool-cards/AskUserQuestionCard.tsx",

--- a/src/web-ui/src/flow_chat/tool-cards/AgentControlToolCard.appearance.ts
+++ b/src/web-ui/src/flow_chat/tool-cards/AgentControlToolCard.appearance.ts
@@ -1,0 +1,25 @@
+import type { AppearanceSurfaceDescriptor } from '@/infrastructure/appearance';
+
+export const agentControlToolCardAppearanceDescriptor: AppearanceSurfaceDescriptor = {
+  id: 'agent-control-tool-card',
+  parts: [
+    { id: 'root' },
+    { id: 'header' },
+    { id: 'agentPill' },
+    { id: 'avatar' },
+    { id: 'name' },
+    { id: 'status' },
+    { id: 'expandIndicator' },
+    { id: 'prompt' },
+  ],
+  facets: [{
+    id: 'status',
+    attribute: 'data-bf-status',
+    values: ['running', 'finishing', 'waiting', 'completed', 'cancelled', 'error', 'idle'],
+  }],
+  states: [
+    { id: 'expanded', selector: { kind: 'self', suffix: '[data-bf-state~="expanded"]' } },
+    { id: 'streaming', selector: { kind: 'self', suffix: '[data-bf-state~="streaming"]' } },
+    { id: 'openable', selector: { kind: 'self', suffix: '[data-bf-state~="openable"]' } },
+  ],
+};

--- a/src/web-ui/src/flow_chat/tool-cards/AgentControlToolCard.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/AgentControlToolCard.scss
@@ -1,0 +1,191 @@
+.agent-control-tool-card {
+  width: 100%;
+
+  > .base-tool-card-wrapper.agent-control-tool-card__base {
+    margin: 0;
+    border: none !important;
+    background: transparent !important;
+    backdrop-filter: none !important;
+    box-shadow: none !important;
+
+    &:hover,
+    &:active {
+      border: none !important;
+      box-shadow: none !important;
+    }
+
+    > .base-tool-card {
+      cursor: default;
+    }
+
+    > .base-tool-card[data-testid='agent-control-tool-card-toggle'] {
+      cursor: pointer;
+    }
+
+    .base-tool-card-header {
+      gap: 0;
+      padding:
+        var(--bf-appearance-token-tool-card-header-pad-y)
+        var(--bf-appearance-token-tool-card-header-pad-right)
+        var(--bf-appearance-token-tool-card-header-pad-y)
+        8px;
+
+      &::before,
+      &::after {
+        display: none;
+      }
+    }
+
+    &:hover .agent-control-tool-card__expand-indicator {
+      opacity: 1;
+      visibility: visible;
+    }
+  }
+
+  &__header {
+    display: flex;
+    width: 100%;
+    min-width: 0;
+    align-items: center;
+    gap: 8px;
+  }
+
+  &__agent-pill {
+    display: inline-flex;
+    min-width: 0;
+    max-width: min(52%, 240px);
+    align-items: center;
+    gap: 6px;
+    padding: 2px 9px 2px 3px;
+    border: 1px solid var(--bf-appearance-token-border-base);
+    border-radius: 999px;
+    background: var(--bf-appearance-token-element-bg-soft);
+    color: var(--bf-appearance-token-color-text-primary);
+    font: inherit;
+    line-height: 1;
+    transition:
+      background-color 160ms ease,
+      border-color 160ms ease;
+
+    &:not(.agent-control-tool-card__agent-pill--static) {
+      cursor: pointer;
+    }
+
+    &:not(.agent-control-tool-card__agent-pill--static):hover {
+      border-color: var(--bf-appearance-token-border-medium);
+      background: var(--bf-appearance-token-element-bg-hover);
+    }
+
+    &:not(.agent-control-tool-card__agent-pill--static):focus-visible {
+      outline: 2px solid var(--bf-appearance-token-color-accent-500);
+      outline-offset: 1px;
+    }
+  }
+
+  &__avatar {
+    display: inline-flex;
+    width: 22px;
+    height: 22px;
+    flex: 0 0 22px;
+    align-items: center;
+    justify-content: center;
+  }
+
+  &__fallback-avatar {
+    display: inline-flex;
+    width: 22px;
+    height: 22px;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: var(--bf-appearance-token-element-bg-medium);
+    color: var(--bf-appearance-token-color-text-secondary);
+  }
+
+  &__name {
+    min-width: 0;
+    overflow: hidden;
+    font-size: var(--bf-appearance-token-tool-card-action-font-size);
+    font-weight: var(--bf-appearance-token-font-weight-medium);
+    line-height: var(--bf-appearance-token-tool-card-action-line-height);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__status {
+    min-width: 0;
+    overflow: hidden;
+    color: var(--bf-appearance-token-color-text-secondary);
+    font-size: var(--bf-appearance-token-tool-card-action-font-size);
+    line-height: var(--bf-appearance-token-tool-card-action-line-height);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    &--running,
+    &--finishing {
+      color: var(--bf-appearance-token-color-success);
+    }
+
+    &--waiting {
+      color: var(--bf-appearance-token-color-warning);
+    }
+
+    &--error,
+    &--cancelled {
+      color: var(--bf-appearance-token-color-error);
+    }
+  }
+
+  &__expand-indicator {
+    display: inline-flex;
+    width: 18px;
+    height: 18px;
+    margin-left: auto;
+    flex: 0 0 18px;
+    align-items: center;
+    justify-content: center;
+    color: var(--bf-appearance-token-color-text-muted);
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: opacity 140ms ease;
+
+    svg {
+      display: block;
+    }
+  }
+
+  &__prompt {
+    max-height: 240px;
+    box-sizing: border-box;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    padding: 10px 12px;
+    border: 1px solid var(--bf-appearance-token-border-base);
+    border-radius: var(--bf-appearance-token-flowchat-card-radius);
+    background: var(--bf-appearance-token-color-bg-scene);
+    color: var(--bf-appearance-token-color-text-secondary);
+    font-size: var(--bf-appearance-token-flowchat-font-size-base);
+    line-height: var(--bf-appearance-token-flowchat-text-line-height);
+  }
+
+  &__prompt-markdown.markdown-renderer {
+    font-size: inherit;
+    line-height: inherit;
+
+    > :first-child {
+      margin-top: 0;
+    }
+
+    > :last-child {
+      margin-bottom: 0;
+    }
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .agent-control-tool-card__agent-pill,
+  .agent-control-tool-card__expand-indicator {
+    transition: none;
+  }
+}

--- a/src/web-ui/src/flow_chat/tool-cards/AgentControlToolCard.test.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/AgentControlToolCard.test.tsx
@@ -1,0 +1,254 @@
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { FlowToolItem, ToolCardConfig } from '../types/flow-chat';
+import { useSubagentIdentityStore } from '../subagent-identity';
+import { AgentControlToolCard } from './AgentControlToolCard';
+
+const mocks = vi.hoisted(() => ({
+  openBtwSessionInAuxPane: vi.fn(),
+  listeners: new Set<() => void>(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => {
+      if (key === 'flowChatHeader.agentTreeStatus.running') return 'Running';
+      if (key === 'flowChatHeader.agentTreeStatus.completed') return 'Completed';
+      if (key === 'toolCards.taskTool.defaultAgentKind') return 'Agent';
+      if (typeof options?.defaultValue === 'string') return options.defaultValue;
+      return key;
+    },
+  }),
+}));
+
+vi.mock('@/component-library/components/Markdown/Markdown', () => ({
+  Markdown: ({ content }: { content: string }) => <div>{content}</div>,
+}));
+
+vi.mock('../services/btwSessionPane', () => ({
+  openBtwSessionInAuxPane: (...args: unknown[]) => mocks.openBtwSessionInAuxPane(...args),
+}));
+
+vi.mock('../store/FlowChatStore', () => ({
+  flowChatStore: {
+    subscribe: (listener: () => void) => {
+      mocks.listeners.add(listener);
+      return () => mocks.listeners.delete(listener);
+    },
+    getState: () => ({
+      sessions: new Map([
+        ['parent-session', {
+          sessionId: 'parent-session',
+          workspacePath: 'D:\\workspace\\repo',
+          remoteConnectionId: 'remote-1',
+          remoteSshHost: 'host-1',
+          config: { agentType: 'Ultra' },
+          dialogTurns: [],
+        }],
+        ['child-session', {
+          sessionId: 'child-session',
+          sessionKind: 'subagent',
+          parentSessionId: 'parent-session',
+          parentToolCallId: 'agent-call',
+          subagentType: 'SwarmWorker',
+          mode: 'SwarmWorker',
+          title: 'SwarmWorker: inspect parser',
+          createdAt: 1000,
+          status: 'active',
+          config: { agentType: 'SwarmWorker' },
+          dialogTurns: [{
+            id: 'child-turn',
+            status: 'processing',
+            modelRounds: [],
+          }],
+        }],
+      ]),
+    }),
+  },
+}));
+
+let JSDOMCtor: (new (
+  html?: string,
+  options?: { pretendToBeVisual?: boolean; url?: string }
+) => { window: Window & typeof globalThis }) | null = null;
+
+try {
+  const jsdom = await import('jsdom');
+  JSDOMCtor = jsdom.JSDOM as typeof JSDOMCtor;
+} catch {
+  JSDOMCtor = null;
+}
+
+const describeWithJsdom = JSDOMCtor ? describe : describe.skip;
+
+const config: ToolCardConfig = {
+  toolName: 'AgentSpawn',
+  displayName: 'Launch Agent',
+  icon: '',
+  requiresConfirmation: false,
+  resultDisplayType: 'detailed',
+};
+
+function agentToolItem(
+  toolName: 'AgentSpawn' | 'AgentSendInput',
+  overrides: Partial<FlowToolItem> = {},
+): FlowToolItem {
+  return {
+    id: 'agent-tool',
+    type: 'tool',
+    toolName,
+    timestamp: Date.now(),
+    status: 'completed',
+    subagentSessionId: 'child-session',
+    subagentDialogTurnId: 'child-turn',
+    toolCall: {
+      id: 'agent-call',
+      input: toolName === 'AgentSpawn'
+        ? {
+            agent_type: 'SwarmWorker',
+            description: 'Inspect parser',
+            prompt: 'Inspect the parser flow and report findings.',
+          }
+        : {
+            agent_id: 'agent-1',
+            description: 'Continue parser review',
+            prompt: 'Continue with the error recovery paths.',
+          },
+    },
+    ...overrides,
+  };
+}
+
+describeWithJsdom('AgentControlToolCard', () => {
+  let dom: { window: Window & typeof globalThis };
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    dom = new JSDOMCtor!('<!doctype html><html><body></body></html>', {
+      pretendToBeVisual: true,
+      url: 'http://localhost',
+    });
+    const { window } = dom;
+    vi.stubGlobal('window', window);
+    vi.stubGlobal('document', window.document);
+    vi.stubGlobal('navigator', window.navigator);
+    vi.stubGlobal('HTMLElement', window.HTMLElement);
+    vi.stubGlobal('CustomEvent', window.CustomEvent);
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+
+    useSubagentIdentityStore.getState().clear();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    dom.window.close();
+    mocks.listeners.clear();
+    useSubagentIdentityStore.getState().clear();
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it.each(['AgentSpawn', 'AgentSendInput'] as const)(
+    'shares the agent pill, status, and expandable prompt for %s',
+    async (toolName) => {
+      await act(async () => {
+        root.render(
+          <AgentControlToolCard
+            toolItem={agentToolItem(toolName)}
+            config={{ ...config, toolName }}
+            sessionId="parent-session"
+          />,
+        );
+      });
+
+      const pill = container.querySelector<HTMLButtonElement>('.agent-control-tool-card__agent-pill');
+      const toggle = container.querySelector<HTMLElement>('[data-testid="agent-control-tool-card-toggle"]');
+      expect(pill?.textContent?.trim()).toBeTruthy();
+      expect(pill?.querySelector('[data-bf-component="subagent-avatar"]')).not.toBeNull();
+      expect(container.textContent).toContain('Running');
+      expect(container.querySelector('[data-bf-part="expandIndicator"]')).not.toBeNull();
+      expect(container.textContent).not.toContain(
+        toolName === 'AgentSpawn'
+          ? 'Inspect the parser flow and report findings.'
+          : 'Continue with the error recovery paths.',
+      );
+
+      await act(async () => {
+        toggle!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+      });
+      expect(container.textContent).toContain(
+        toolName === 'AgentSpawn'
+          ? 'Inspect the parser flow and report findings.'
+          : 'Continue with the error recovery paths.',
+      );
+
+      await act(async () => {
+        pill!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+      });
+      expect(mocks.openBtwSessionInAuxPane).toHaveBeenCalledWith(expect.objectContaining({
+        childSessionId: 'child-session',
+        parentSessionId: 'parent-session',
+        parentToolCallId: 'agent-call',
+        sessionKind: 'subagent',
+        includeInternal: true,
+      }));
+      expect(container.textContent).toContain(
+        toolName === 'AgentSpawn'
+          ? 'Inspect the parser flow and report findings.'
+          : 'Continue with the error recovery paths.',
+      );
+    },
+  );
+
+  it('stays collapsed and disables expansion while parameters are streaming', async () => {
+    await act(async () => {
+      root.render(
+        <AgentControlToolCard
+          toolItem={agentToolItem('AgentSpawn')}
+          config={config}
+          sessionId="parent-session"
+        />,
+      );
+    });
+    await act(async () => {
+      container
+        .querySelector<HTMLElement>('[data-testid="agent-control-tool-card-toggle"]')!
+        .dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+    expect(container.textContent).toContain('Inspect the parser flow and report findings.');
+
+    const streamingItem = agentToolItem('AgentSpawn', {
+      status: 'streaming',
+      isParamsStreaming: true,
+      partialParams: {
+        agent_type: 'SwarmWorker',
+        description: 'Inspect parser',
+        prompt: 'Partial prompt that must stay collapsed.',
+      },
+    });
+
+    await act(async () => {
+      root.render(
+        <AgentControlToolCard
+          toolItem={streamingItem}
+          config={config}
+          sessionId="parent-session"
+        />,
+      );
+    });
+
+    expect(container.querySelector('[data-testid="agent-control-tool-card-toggle"]')).toBeNull();
+    expect(container.textContent).not.toContain('Inspect the parser flow and report findings.');
+    expect(
+      container.querySelector('.base-tool-card-expanded-collapse')?.getAttribute('aria-hidden'),
+    ).toBe('true');
+    expect(container.querySelector('[data-bf-state~="streaming"]')).not.toBeNull();
+  });
+});

--- a/src/web-ui/src/flow_chat/tool-cards/AgentControlToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/AgentControlToolCard.tsx
@@ -1,0 +1,321 @@
+import React, {
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+} from 'react';
+import { Bot, ChevronDown, ChevronRight } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { Markdown } from '@/component-library/components/Markdown/Markdown';
+import { flowChatStore } from '../store/FlowChatStore';
+import {
+  getSubagentNameDefinition,
+  SubagentAvatar,
+  useSubagentIdentity,
+} from '../subagent-identity';
+import type { FlowToolItem, ToolCardProps } from '../types/flow-chat';
+import {
+  sessionLineageLifecycleForSession,
+  type SessionLineageLifecycle,
+} from '../utils/sessionLineage';
+import { openBtwSessionInAuxPane } from '../services/btwSessionPane';
+import { BaseToolCard } from './BaseToolCard';
+import { useToolCardHeightContract } from './useToolCardHeightContract';
+import './AgentControlToolCard.scss';
+
+const PARAMETER_STREAMING_STATUSES = new Set<FlowToolItem['status']>([
+  'preparing',
+  'streaming',
+  'receiving',
+]);
+
+function readString(source: unknown, ...keys: string[]): string {
+  if (!source || typeof source !== 'object') {
+    return '';
+  }
+
+  const record = source as Record<string, unknown>;
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+  return '';
+}
+
+function fallbackLifecycle(status: FlowToolItem['status']): SessionLineageLifecycle {
+  switch (status) {
+    case 'completed':
+      return 'completed';
+    case 'cancelled':
+    case 'rejected':
+      return 'cancelled';
+    case 'error':
+      return 'error';
+    case 'waiting':
+      return 'waiting';
+    case 'pending':
+    case 'queued':
+      return 'idle';
+    default:
+      return 'running';
+  }
+}
+
+function subscribeToFlowChatStore(listener: () => void): () => void {
+  return flowChatStore.subscribe(() => listener());
+}
+
+function readLinkedAgentSnapshot(sessionId: string): string {
+  if (!sessionId) {
+    return '';
+  }
+
+  const session = flowChatStore.getState().sessions.get(sessionId);
+  const latestTurn = session?.dialogTurns?.[session.dialogTurns.length - 1];
+  return JSON.stringify([
+    session?.title ?? '',
+    session?.mode ?? '',
+    session?.subagentType ?? '',
+    session?.config?.agentType ?? '',
+    session?.needsUserAttention ?? false,
+    session?.status ?? '',
+    session?.persistedStatus ?? '',
+    session?.hasUnreadCompletion ?? '',
+    latestTurn?.id ?? '',
+    latestTurn?.status ?? '',
+    latestTurn?.modelRounds?.some(round => round.isStreaming) ?? false,
+  ]);
+}
+
+export const AgentControlToolCard: React.FC<ToolCardProps> = ({
+  toolItem,
+  sessionId,
+}) => {
+  const { t } = useTranslation('flow-chat');
+  const { toolCall, status } = toolItem;
+  const toolId = toolItem.id ?? toolCall?.id;
+  const params = toolItem.partialParams ?? toolCall?.input;
+  const prompt = readString(params, 'prompt');
+  const description = readString(params, 'description');
+  const inputAgentType = readString(params, 'agent_type', 'agentType');
+  const agentId = readString(params, 'agent_id', 'agentId')
+    || readString(toolItem.toolResult?.result, 'agent_id', 'agentId');
+  const linkedSubagentSessionId = toolItem.subagentSessionId ?? '';
+  const readSnapshot = useCallback(
+    () => readLinkedAgentSnapshot(linkedSubagentSessionId),
+    [linkedSubagentSessionId],
+  );
+
+  useSyncExternalStore(
+    subscribeToFlowChatStore,
+    readSnapshot,
+    readSnapshot,
+  );
+
+  const linkedSession = linkedSubagentSessionId
+    ? flowChatStore.getState().sessions.get(linkedSubagentSessionId)
+    : undefined;
+  const identity = useSubagentIdentity(linkedSubagentSessionId);
+  const identityName = useMemo(() => {
+    if (!identity) {
+      return '';
+    }
+    const definition = getSubagentNameDefinition(identity.nameId);
+    return t(definition.labelKey, { defaultValue: definition.fallback });
+  }, [identity, t]);
+  const lifecycle = linkedSession
+    ? sessionLineageLifecycleForSession(linkedSession)
+    : fallbackLifecycle(status);
+  const agentName = identityName
+    || linkedSession?.subagentType?.trim()
+    || linkedSession?.mode?.trim()
+    || inputAgentType
+    || agentId
+    || t('toolCards.taskTool.defaultAgentKind');
+  const stableAgentType = linkedSession?.mode?.trim()
+    || linkedSession?.config?.agentType?.trim()
+    || inputAgentType;
+  const stableSubagentType = linkedSession?.subagentType?.trim() || inputAgentType;
+  const isParameterStreaming = Boolean(toolItem.isParamsStreaming)
+    || PARAMETER_STREAMING_STATUSES.has(status);
+  const canExpand = Boolean(prompt) && !isParameterStreaming;
+  const canOpenSession = Boolean(linkedSubagentSessionId && sessionId);
+  const [isExpanded, setIsExpanded] = useState(false);
+  const { cardRootRef, applyExpandedState } = useToolCardHeightContract({
+    toolId,
+    toolName: toolItem.toolName,
+  });
+
+  const updateExpandedState = useCallback((nextExpanded: boolean) => {
+    applyExpandedState(isExpanded, nextExpanded, setIsExpanded);
+  }, [applyExpandedState, isExpanded]);
+
+  useLayoutEffect(() => {
+    if (isParameterStreaming && isExpanded) {
+      updateExpandedState(false);
+    }
+  }, [isExpanded, isParameterStreaming, updateExpandedState]);
+
+  const handleToggle = useCallback(() => {
+    if (!canExpand) {
+      return;
+    }
+    updateExpandedState(!isExpanded);
+  }, [canExpand, isExpanded, updateExpandedState]);
+
+  const handleOpenSession = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    if (!linkedSubagentSessionId || !sessionId) {
+      return;
+    }
+
+    const parentSession = flowChatStore.getState().sessions.get(sessionId);
+    openBtwSessionInAuxPane({
+      childSessionId: linkedSubagentSessionId,
+      parentSessionId: sessionId,
+      workspacePath: parentSession?.workspacePath,
+      sessionKind: 'subagent',
+      sessionTitle: description || agentName,
+      agentType: stableAgentType || undefined,
+      parentToolCallId: toolCall?.id || toolItem.id,
+      subagentType: stableSubagentType || undefined,
+      remoteConnectionId: parentSession?.remoteConnectionId,
+      remoteSshHost: parentSession?.remoteSshHost,
+      includeInternal: true,
+    });
+  }, [
+    agentName,
+    description,
+    linkedSubagentSessionId,
+    sessionId,
+    stableAgentType,
+    stableSubagentType,
+    toolCall?.id,
+    toolItem.id,
+  ]);
+
+  const agentPillContent = (
+    <>
+      <span
+        className="agent-control-tool-card__avatar"
+        data-bf-component="agent-control-tool-card"
+        data-bf-part="avatar"
+      >
+        {identity ? (
+          <SubagentAvatar
+            identity={identity}
+            name={identityName}
+            size={22}
+            status={lifecycle}
+          />
+        ) : (
+          <span className="agent-control-tool-card__fallback-avatar" aria-hidden="true">
+            <Bot size={14} strokeWidth={2} />
+          </span>
+        )}
+      </span>
+      <span
+        className="agent-control-tool-card__name"
+        data-bf-component="agent-control-tool-card"
+        data-bf-part="name"
+      >
+        {agentName}
+      </span>
+    </>
+  );
+
+  const header = (
+    <div
+      className="agent-control-tool-card__header"
+      data-bf-component="agent-control-tool-card"
+      data-bf-part="header"
+    >
+      {canOpenSession ? (
+        <button
+          type="button"
+          className="agent-control-tool-card__agent-pill"
+          data-bf-component="agent-control-tool-card"
+          data-bf-part="agentPill"
+          onClick={handleOpenSession}
+          aria-label={t('toolCards.taskTool.openInPanel')}
+          title={t('toolCards.taskTool.openInPanel')}
+        >
+          {agentPillContent}
+        </button>
+      ) : (
+        <span
+          className="agent-control-tool-card__agent-pill agent-control-tool-card__agent-pill--static"
+          data-bf-component="agent-control-tool-card"
+          data-bf-part="agentPill"
+        >
+          {agentPillContent}
+        </span>
+      )}
+      <span
+        className={`agent-control-tool-card__status agent-control-tool-card__status--${lifecycle}`}
+        data-bf-component="agent-control-tool-card"
+        data-bf-part="status"
+        data-bf-status={lifecycle}
+      >
+        {t(`flowChatHeader.agentTreeStatus.${lifecycle}`)}
+      </span>
+      {prompt ? (
+        <span
+          className="agent-control-tool-card__expand-indicator"
+          data-bf-component="agent-control-tool-card"
+          data-bf-part="expandIndicator"
+          aria-hidden="true"
+        >
+          {isExpanded ? (
+            <ChevronDown size={15} strokeWidth={2} />
+          ) : (
+            <ChevronRight size={15} strokeWidth={2} />
+          )}
+        </span>
+      ) : null}
+    </div>
+  );
+
+  return (
+    <div
+      ref={cardRootRef}
+      className="agent-control-tool-card"
+      data-bf-component="agent-control-tool-card"
+      data-bf-part="root"
+      data-bf-status={lifecycle}
+      data-bf-state={[
+        isExpanded && 'expanded',
+        isParameterStreaming && 'streaming',
+        canOpenSession && 'openable',
+      ].filter(Boolean).join(' ') || undefined}
+      data-tool-card-id={toolId ?? ''}
+    >
+      <BaseToolCard
+        status={status}
+        isExpanded={isExpanded}
+        onClick={canExpand ? handleToggle : undefined}
+        toggleTestId="agent-control-tool-card-toggle"
+        className="agent-control-tool-card__base"
+        header={header}
+        expandedContent={prompt ? (
+          <div
+            className="agent-control-tool-card__prompt"
+            data-bf-component="agent-control-tool-card"
+            data-bf-part="prompt"
+          >
+            <Markdown
+              content={prompt}
+              isStreaming={false}
+              className="agent-control-tool-card__prompt-markdown"
+            />
+          </div>
+        ) : null}
+        headerExpandAffordance={false}
+      />
+    </div>
+  );
+};

--- a/src/web-ui/src/flow_chat/tool-cards/index.test.ts
+++ b/src/web-ui/src/flow_chat/tool-cards/index.test.ts
@@ -10,10 +10,16 @@ import {
   usesDefaultToolCard,
 } from './index';
 import { TaskToolDisplay } from './TaskToolDisplay';
+import { AgentControlToolCard } from './AgentControlToolCard';
 
 describe('tool card registry', () => {
   it('projects managed Review workers through the unified coverage card', () => {
     expect(getToolCardComponent('LaunchReviewAgent')).toBe(TaskToolDisplay);
+  });
+
+  it('renders AgentSpawn and AgentSendInput with the shared agent control card', () => {
+    expect(getToolCardComponent('AgentSpawn')).toBe(AgentControlToolCard);
+    expect(getToolCardComponent('AgentSendInput')).toBe(AgentControlToolCard);
   });
 
   it('keeps lightweight dedicated-card classification aligned with the component registry', () => {

--- a/src/web-ui/src/flow_chat/tool-cards/index.ts
+++ b/src/web-ui/src/flow_chat/tool-cards/index.ts
@@ -29,6 +29,7 @@ import { GlobSearchDisplay } from './GlobSearchDisplay';
 import { LSDisplay } from './LSDisplay';
 import { TodoWriteDisplay } from './TodoWriteDisplay';
 import { TaskToolDisplay } from './TaskToolDisplay';
+import { AgentControlToolCard } from './AgentControlToolCard';
 import { AgentWaitToolCard } from './AgentWaitToolCard';
 import { CodeReviewToolCard } from './CodeReviewToolCard';
 import { FileOperationToolCard } from './FileOperationToolCard';
@@ -80,6 +81,8 @@ export const TOOL_CARD_COMPONENTS = {
   // Advanced tools
   'Task': TaskToolDisplay,
   'LaunchReviewAgent': TaskToolDisplay,
+  'AgentSpawn': AgentControlToolCard,
+  'AgentSendInput': AgentControlToolCard,
   'AgentWait': AgentWaitToolCard,
   'TodoWrite': TodoWriteDisplay,
   

--- a/src/web-ui/src/flow_chat/tool-cards/toolCardMetadata.ts
+++ b/src/web-ui/src/flow_chat/tool-cards/toolCardMetadata.ts
@@ -119,6 +119,26 @@ export const TOOL_CARD_CONFIGS: Record<string, ToolCardConfig> = {
     displayMode: 'detailed',
     primaryColor: APPEARANCE_DOMAIN_TOKENS.toolIdentity.assistantAction
   },
+  'AgentSpawn': {
+    toolName: 'AgentSpawn',
+    displayName: 'Launch Agent',
+    icon: '',
+    requiresConfirmation: false,
+    resultDisplayType: 'detailed',
+    description: 'Launch a background agent',
+    displayMode: 'detailed',
+    primaryColor: APPEARANCE_DOMAIN_TOKENS.toolIdentity.assistantAction
+  },
+  'AgentSendInput': {
+    toolName: 'AgentSendInput',
+    displayName: 'Send Agent Input',
+    icon: '',
+    requiresConfirmation: false,
+    resultDisplayType: 'detailed',
+    description: 'Send a follow-up instruction to an agent',
+    displayMode: 'detailed',
+    primaryColor: APPEARANCE_DOMAIN_TOKENS.toolIdentity.assistantAction
+  },
   'AgentWait': {
     toolName: 'AgentWait',
     displayName: 'Wait for Agents',
@@ -540,6 +560,8 @@ export const DEDICATED_TOOL_CARD_NAMES = new Set([
   'WebFetch',
   'Task',
   'LaunchReviewAgent',
+  'AgentSpawn',
+  'AgentSendInput',
   'AgentWait',
   'TodoWrite',
   'submit_code_review',

--- a/src/web-ui/src/infrastructure/appearance/registry/defaultAppearanceRegistry.ts
+++ b/src/web-ui/src/infrastructure/appearance/registry/defaultAppearanceRegistry.ts
@@ -48,6 +48,7 @@ import { codeReviewToolCardAppearanceDescriptor } from '@/flow_chat/tool-cards/C
 import { createAgentPageAppearanceDescriptor } from '@/app/scenes/agents/components/CreateAgentPage.appearance';
 import { keyboardShortcutsAppearanceDescriptor } from '@/app/scenes/settings/components/KeyboardShortcutsTab.appearance';
 import { taskToolDisplayAppearanceDescriptor } from '@/flow_chat/tool-cards/TaskToolDisplay.appearance';
+import { agentControlToolCardAppearanceDescriptor } from '@/flow_chat/tool-cards/AgentControlToolCard.appearance';
 import { applicationSettingsAppearanceDescriptor } from '@/infrastructure/config/components/ApplicationSettingsPages.appearance';
 import { markdownEditorAppearanceDescriptor } from '@/tools/editor/components/MarkdownEditor.appearance';
 import { planViewerAppearanceDescriptor } from '@/tools/editor/components/PlanViewer.appearance';
@@ -343,6 +344,7 @@ export function createDefaultAppearanceRegistry(): AppearanceRegistry {
     .registerComponent(createAgentPageAppearanceDescriptor)
     .registerComponent(keyboardShortcutsAppearanceDescriptor)
     .registerComponent(taskToolDisplayAppearanceDescriptor)
+    .registerComponent(agentControlToolCardAppearanceDescriptor)
     .registerComponent(applicationSettingsAppearanceDescriptor)
     .registerComponent(markdownEditorAppearanceDescriptor)
     .registerComponent(planViewerAppearanceDescriptor)


### PR DESCRIPTION
Render AgentSpawn and AgentSendInput through a shared card that:
- shows linked agent identity and lifecycle status
- opens the child session from the identity pill
- keeps streamed parameters collapsed
- displays bounded prompt details in a compact framed panel

Register the card with FlowChat and Appearance contracts, and add focused interaction and registry coverage.
