### PR TITLE
fix(agent): restore subagents before reuse

### DIFF
--- a/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
@@ -10619,7 +10619,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
         Ok(turn_id)
     }
 
-    async fn ensure_subagent_session_loaded_for_reuse(
+    pub(crate) async fn ensure_subagent_session_loaded_for_reuse(
         &self,
         target_session_id: &str,
         parent_session_id: &str,
@@ -19211,7 +19211,7 @@ mod tests {
 
     #[tokio::test]
     async fn reused_subagent_send_input_updates_requested_and_inherited_model() {
-        let (coordinator, session_manager) = test_coordinator();
+        let (coordinator, session_manager) = test_persistent_coordinator();
         let workspace_path = std::env::temp_dir().join(format!(
             "bitfun-reused-subagent-model-test-{}",
             uuid::Uuid::new_v4()
@@ -19253,6 +19253,20 @@ mod tests {
             )
             .await
             .expect("subagent session should be created");
+
+        assert!(
+            session_manager
+                .unload_session_from_memory(&subagent_session.session_id)
+                .await
+                .expect("persisted subagent session should unload"),
+            "the restart regression requires the target subagent to be absent from memory"
+        );
+        assert!(
+            session_manager
+                .get_session(&subagent_session.session_id)
+                .is_none(),
+            "the send_input preparation must restore the persisted subagent on demand"
+        );
 
         let request = SubagentExecutionRequest {
             task_description: "Continue the investigation".to_string(),

--- a/src/crates/assembly/core/src/agentic/tools/implementations/task/execution.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/task/execution.rs
@@ -301,13 +301,18 @@ impl TaskTool {
             }
         }
         if let Some(target_session_id) = target_session_id.as_deref() {
-            let target_agent_type = coordinator
+            let target_agent_type = match coordinator
                 .get_session_manager()
                 .get_session(target_session_id)
-                .map(|session| session.agent_type)
-                .ok_or_else(|| {
-                    BitFunError::tool("Target agent session was not found".to_string())
-                })?;
+            {
+                Some(session) => session.agent_type,
+                None => {
+                    coordinator
+                        .ensure_subagent_session_loaded_for_reuse(target_session_id, &session_id)
+                        .await?
+                        .agent_type
+                }
+            };
             let target_is_swarm = is_swarm_delegate_agent_type(&target_agent_type);
             if parent_is_swarm_planner != target_is_swarm {
                 return Err(BitFunError::tool(


### PR DESCRIPTION
AgentSendInput previously checked Swarm scope against in-memory sessions, causing persisted reusable agents to fail after an app restart.

- Restore an unloaded subagent before scope validation
- Preserve continuation and parent ownership checks
- Cover send_input after unloading persisted session state
