### PR TITLE
fix(flowchat): hydrate opened subagent history

### DIFF
--- a/src/web-ui/src/flow_chat/services/btwSessionPane.ts
+++ b/src/web-ui/src/flow_chat/services/btwSessionPane.ts
@@ -4,6 +4,7 @@ import type { PanelContent } from '@/app/components/panels/base/types';
 import { useAgentCanvasStore } from '@/app/components/panels/content-canvas/stores';
 import type { CanvasTab } from '@/app/components/panels/content-canvas/types';
 import { flowChatStore } from '../store/FlowChatStore';
+import type { Session } from '../types/flow-chat';
 import { resolveSessionTitle } from '../utils/sessionTitle';
 import { flowChatManager } from './FlowChatManager';
 
@@ -163,7 +164,23 @@ export async function loadBtwSessionHistory(params: LoadBtwSessionHistoryParams)
   }
 }
 
-export function ensureBtwSessionAvailable(params: EnsureBtwSessionAvailableParams): void {
+interface EnsureBtwSessionAvailableResult {
+  historyLoadRequested: boolean;
+}
+
+const isSessionHistoryComplete = (session: Session | undefined): boolean =>
+  Boolean(
+    session &&
+    session.historyState === 'ready' &&
+    session.isPartial !== true &&
+    typeof session.loadedTurnCount === 'number' &&
+    typeof session.totalTurnCount === 'number' &&
+    session.loadedTurnCount >= session.totalTurnCount
+  );
+
+function ensureBtwSessionAvailableInternal(
+  params: EnsureBtwSessionAvailableParams,
+): EnsureBtwSessionAvailableResult {
   const existingSession = flowChatStore.getState().sessions.get(params.childSessionId);
   const parentSession = flowChatStore.getState().sessions.get(params.parentSessionId);
   const resolvedWorkspacePath = params.workspacePath || parentSession?.workspacePath;
@@ -220,7 +237,7 @@ export function ensureBtwSessionAvailable(params: EnsureBtwSessionAvailableParam
 
   const workspacePath = resolvedWorkspacePath || sessionToHydrate?.workspacePath;
   if (!shouldHydrate || !workspacePath) {
-    return;
+    return { historyLoadRequested: false };
   }
 
   void loadBtwSessionHistory({
@@ -233,6 +250,11 @@ export function ensureBtwSessionAvailable(params: EnsureBtwSessionAvailableParam
         }
       : {}),
   }).catch(() => undefined);
+  return { historyLoadRequested: true };
+}
+
+export function ensureBtwSessionAvailable(params: EnsureBtwSessionAvailableParams): void {
+  ensureBtwSessionAvailableInternal(params);
 }
 
 export function openBtwSessionInAuxPane(params: {
@@ -250,7 +272,35 @@ export function openBtwSessionInAuxPane(params: {
   includeInternal?: boolean;
   viewKind?: BtwSessionViewKind;
 }): void {
-  ensureBtwSessionAvailable(params);
+  const ensureResult = ensureBtwSessionAvailableInternal(params);
+  const childSession = flowChatStore.getState().sessions.get(params.childSessionId);
+  const isSubagentSession =
+    params.sessionKind === 'subagent' || childSession?.sessionKind === 'subagent';
+  if (
+    isSubagentSession &&
+    !ensureResult.historyLoadRequested &&
+    !isSessionHistoryComplete(childSession)
+  ) {
+    const parentSession = flowChatStore.getState().sessions.get(params.parentSessionId);
+    const workspacePath =
+      params.workspacePath || childSession?.workspacePath || parentSession?.workspacePath;
+    if (workspacePath) {
+      void loadBtwSessionHistory({
+        childSessionId: params.childSessionId,
+        ...(!childSession?.workspacePath
+          ? {
+              workspacePath,
+              remoteConnectionId:
+                params.remoteConnectionId ||
+                childSession?.remoteConnectionId ||
+                parentSession?.remoteConnectionId,
+              remoteSshHost:
+                params.remoteSshHost || childSession?.remoteSshHost || parentSession?.remoteSshHost,
+            }
+          : {}),
+      }).catch(() => undefined);
+    }
+  }
 
   const content = buildBtwSessionPanelContent(
     params.childSessionId,

--- a/src/web-ui/src/flow_chat/services/openBtwSession.test.ts
+++ b/src/web-ui/src/flow_chat/services/openBtwSession.test.ts
@@ -259,6 +259,70 @@ describe('openBtwSessionInAuxPane', () => {
     );
   });
 
+  it('hydrates incomplete live subagent history when explicitly opening the aux pane', () => {
+    sessions.set('parent-session', {
+      sessionId: 'parent-session',
+      workspacePath: 'D:\\workspace\\repo',
+      mode: 'agentic',
+    });
+    sessions.set('subagent-child', {
+      sessionId: 'subagent-child',
+      sessionKind: 'subagent',
+      isHistorical: false,
+      historyState: 'ready',
+      config: { agentType: 'Explore' },
+      workspacePath: 'D:\\workspace\\repo',
+      dialogTurns: [
+        {
+          id: 'post-restart-turn',
+          status: 'processing',
+          modelRounds: [],
+          userMessage: { id: 'user-1', type: 'user', content: 'continue', timestamp: 1 },
+          timestamp: 1,
+        },
+      ],
+    });
+
+    openBtwSessionInAuxPane({
+      childSessionId: 'subagent-child',
+      parentSessionId: 'parent-session',
+      sessionKind: 'subagent',
+      expand: false,
+    });
+
+    expect(mocks.hydrateSessionHistoryForDetail).toHaveBeenCalledTimes(1);
+    expect(mocks.hydrateSessionHistoryForDetail).toHaveBeenCalledWith('subagent-child');
+  });
+
+  it('does not rehydrate a subagent whose complete history is proven by counts', () => {
+    sessions.set('parent-session', {
+      sessionId: 'parent-session',
+      workspacePath: 'D:\\workspace\\repo',
+      mode: 'agentic',
+    });
+    sessions.set('subagent-child', {
+      sessionId: 'subagent-child',
+      sessionKind: 'subagent',
+      isHistorical: false,
+      historyState: 'ready',
+      isPartial: false,
+      loadedTurnCount: 2,
+      totalTurnCount: 2,
+      config: { agentType: 'Explore', modelName: 'model-1' },
+      workspacePath: 'D:\\workspace\\repo',
+      dialogTurns: [{ id: 'turn-1' }, { id: 'turn-2' }],
+    });
+
+    openBtwSessionInAuxPane({
+      childSessionId: 'subagent-child',
+      parentSessionId: 'parent-session',
+      sessionKind: 'subagent',
+      expand: false,
+    });
+
+    expect(mocks.hydrateSessionHistoryForDetail).not.toHaveBeenCalled();
+  });
+
   it('creates an on-demand subagent shell and hydrates it when the child session is missing', () => {
     sessions.set('parent-session', {
       sessionId: 'parent-session',


### PR DESCRIPTION
After restart, live AgentSendInput events can create a child session
shell that contains only new turns. Opening that shell previously skipped
persisted history hydration because in-memory turns were treated as
sufficient.

Hydrate explicitly opened subagents unless history state and turn counts
prove the session is complete, while keeping projection-only access lazy.
