### PR TITLE
fix(agent-hooks): prevent input rewrites from relaxing edit guards

### DIFF
--- a/docs/features/agent-hooks.md
+++ b/docs/features/agent-hooks.md
@@ -229,6 +229,10 @@ Everything not listed here behaves as the Codex documentation describes.
 - **A hook can narrow the permission policy, never widen it.** A `PreToolUse`
   `permissionDecision: "allow"` waives the interactive prompt, but a tool call
   denied by a permission rule stays denied.
+- `PreToolUse updatedInput` is final-validated before execution. It may repair
+  ordinary malformed input, but it cannot relax a non-relaxable internal
+  constraint (for example, a user-requested edit restriction) that rejected
+  the original input.
 - `suppressOutput` is parsed and currently ignored.
 - `continue: false` is honored for `PreToolUse` and `UserPromptSubmit`; for
   other events use `decision: "block"`.
@@ -245,6 +249,9 @@ every time its event fires. Treat `hooks.json` like a shell profile:
 - Review any hook you did not write before enabling it.
 - Keep project hooks off unless you trust everyone who can commit to the
   repository.
+- A hook command that writes files directly bypasses the tool pipeline and its
+  `validate_input` checks. Use `updatedInput` for tool rewrites; sandbox or
+  disable untrusted command hooks when direct process side effects are unsafe.
 - Payload values (prompts, tool arguments, file paths) are model- and
   user-supplied text. Parse them as JSON and never interpolate them into a
   shell command — that is why the examples above read fields with

--- a/docs/features/agent-hooks.zh-CN.md
+++ b/docs/features/agent-hooks.zh-CN.md
@@ -208,6 +208,9 @@ sys.exit(0)
 - **Hook 只能收紧权限策略，永远无法放宽。** `PreToolUse` 的
   `permissionDecision: "allow"` 只免去交互式确认；被权限规则拒绝的工具调用依然
   会被拒绝。
+- `PreToolUse updatedInput` 在执行前会用最终参数重新校验。它可以修复普通的
+  参数格式错误，但不能放宽已经拒绝原始参数的不可放宽内部约束（例如用户
+  明确提出的编辑限制）。
 - `suppressOutput` 会被解析，但当前被忽略。
 - `continue: false` 对 `PreToolUse` 和 `UserPromptSubmit` 生效；其他事件请使用
   `decision: "block"`。
@@ -223,6 +226,9 @@ Hook 是以你的用户权限运行的任意代码，且每次对应事件触发
 
 - 启用任何非你本人编写的 Hook 之前先审阅它。
 - 除非你信任所有能向仓库提交代码的人，否则保持项目级 Hooks 关闭。
+- Hook 命令如果直接写文件，会绕过工具管道及其 `validate_input` 检查。工具参数重写
+  应使用 `updatedInput`；无法接受外部进程副作时，应禁用不可信命令 Hook 或将其
+  放入 sandbox。
 - 载荷中的值（提示词、工具参数、文件路径）是模型和用户提供的文本。请按 JSON 解析，
   不要拼接进 shell 命令 —— 上面的示例正是为此用 `jq` / `json.load` 读取字段。
 - 不要在 `SessionStart`、`UserPromptSubmit`、`SubagentStart` 中把密钥打印到

--- a/docs/plans/edit-constraint-guard-plan.md
+++ b/docs/plans/edit-constraint-guard-plan.md
@@ -26,6 +26,11 @@ agent 返回可解释的拒绝原因。约束属于用户会话状态，必须�
 网络出口、仓库历史净化和评测审计属于评测管道。产品工具保持普通用户预期的 Web 与 Git
 能力，guard 代码不得出现 benchmark 名称或站点黑名单。
 
+`updatedInput` 依然通过 BitFun 工具管道执行，因此可由本设计守住。Native hook handler
+命令本身是一个外部进程；如果 handler 绕过 `updatedInput` 直接写文件，该副作不会进入工具
+`validate_input`。这类 hook 的信任、启用和进程隔离属于 Native hook 安全边界；严格评测
+环境应禁用不可信 hook 或在外层 sandbox 中限制它，不应把外部进程副作误认为工具守卫可见。
+
 ## 模块与职责
 
 | 模块 | 职责 |
@@ -71,8 +76,17 @@ turn 抽取与文件来源记录；旧格式中缺少 turn id 的来源记录不
    guard 状态，也不触发 metadata 重写。抽取失败单独记录，执行阶段 fail open。
 4. 文件工具在 `validate_input` 中调用统一检查；shell、WriteStdin 和 Git 工具先将可静态识别的
    变更目标解析为路径。存在 active constraint 时，无法解析目标的高风险变更命令 fail closed。
-5. 命中约束时返回 403 和结构化 `edit_constraint_guard` 元数据，不执行写入。
-6. 设置 `BITFUN_EDIT_CONSTRAINT_TELEMETRY=1` 后，guard 决策和成功的直接文件工具操作写入
+5. Native `PreToolUse` hook 是可扩展重写层，不是约束所有者。只要 hook 返回
+   `updatedInput`，pipeline 就对 hook 前的原始有效参数执行一次不可放宽约束检查，并对
+   hook 后的最终参数继续执行完整 `validate_input`。任一组参数命中不可放宽约束时都拒绝
+   执行；hook 的 allow 或路径重写不能洗掉用户约束。格式修复等未标记为不可放宽的普通
+   validation 失败仍可由 hook 修复。
+6. hook 重写不改变新建测试辅助文件豁免的语义：原始目标本来就是新测试文件时
+   可按现有 provenance 规则通过；从已受保护文件重写到一个新副本则仍因原始参数命中
+   约束而被拒绝。
+7. 命中约束时返回 403 和结构化 `edit_constraint_guard` 元数据，并标记该失败不可被
+   input rewrite 放宽，不执行写入。
+8. 设置 `BITFUN_EDIT_CONSTRAINT_TELEMETRY=1` 后，guard 决策和成功的直接文件工具操作写入
    session-scoped JSONL，用于产品诊断；默认不创建 JSONL。该开关不影响 AI provider 请求审计。
 
 撤销只接受当前 active constraint id，且只有真实用户提交的 turn 可以授权撤销。含糊表达、
@@ -96,6 +110,8 @@ turn 抽取与文件来源记录；旧格式中缺少 turn id 的来源记录不
 - 无 active constraint 时，guard 不改变普通编辑、Web 或 Git 行为，也不执行路径/远程存在性检查。
 - 同一 dialog turn 和消息 hash 不重复抽取。
 - 未知撤销 id 永远不删除约束。
+- Native hook 只能缩紧、修复或保持用户约束，不能通过 `updatedInput` 将原本受保护的
+  写入改到新路径后执行。
 - session restore 与 fork 后的 active constraints 与父会话一致。
 - rollback 后不能保留来自已删除 turn 的约束或 agent-created 豁免。
 - 拒绝发生在写入前，递归删除不会出现部分删除后才发现受保护文件。
@@ -108,6 +124,8 @@ turn 抽取与文件来源记录；旧格式中缺少 turn id 的来源记录不
 - matcher 规则和 operation scope；
 - 确定性抽取、模型解析失败、合法与非法撤销；
 - 新建测试辅助文件、已有测试文件和 delete-only 的差异；
+- `PreToolUse updatedInput` 修复普通无效参数、从受保护原始目标重写到新副本、从合法
+  原始目标重写到受保护目标，以及 hook allow 不能覆盖不可放宽拒绝；
 - shell 重定向、`tee`、`cp`、`mv`、`rm`、in-place `sed/perl`、Python、Node、WriteStdin、
   Git pathspec 与无法解析目标的高风险命令；
 - 递归删除、符号链接、远程工作区检查失败；

--- a/src/crates/assembly/core/src/agentic/execution/edit_constraint_guard.rs
+++ b/src/crates/assembly/core/src/agentic/execution/edit_constraint_guard.rs
@@ -862,6 +862,7 @@ fn decision_result(
         error_code,
         meta: Some(json!({
             "failure_kind": "edit_constraint_guard",
+            "blocks_input_rewrite": true,
             "guard_decision_id": decision_id,
             "guard_decision": decision,
             "constraint_id": violation.map(|constraint| constraint.id.as_str()),

--- a/src/crates/assembly/core/src/agentic/execution/edit_constraint_guard/tests.rs
+++ b/src/crates/assembly/core/src/agentic/execution/edit_constraint_guard/tests.rs
@@ -501,6 +501,27 @@ fn find_violation_returns_first_match() {
 }
 
 #[test]
+fn guard_rejections_are_non_relaxable_by_input_rewrites() {
+    let protected = constraint("don't touch tests", ConstraintMatcher::TestFiles);
+    let rejection = decision_result(
+        None,
+        "Write",
+        "write",
+        "tests/existing_test.rs",
+        "deny",
+        false,
+        None,
+        Some(&protected),
+        Some("protected test file".to_string()),
+        Some(403),
+    )
+    .expect("guard rejection");
+
+    assert!(rejection.blocks_input_rewrite());
+    assert_eq!(rejection.error_code, Some(403));
+}
+
+#[test]
 fn new_files_are_exempt_only_from_test_file_constraints() {
     let test_only = EditConstraintState {
         constraints: vec![constraint(

--- a/src/crates/assembly/core/src/agentic/tools/pipeline/state_manager.rs
+++ b/src/crates/assembly/core/src/agentic/tools/pipeline/state_manager.rs
@@ -6,6 +6,7 @@ use super::types::ToolTask;
 use crate::agentic::core::ToolExecutionState;
 use crate::agentic::events::AgenticEvent;
 use bitfun_agent_stream::StreamEventSink;
+use bitfun_agent_tools::ValidationResult;
 use dashmap::DashMap;
 use log::debug;
 use std::sync::Arc;
@@ -91,12 +92,32 @@ impl ToolStateManager {
         self.tasks.get(tool_id).map(|t| t.clone())
     }
 
-    /// Replace a task's effective tool arguments before execution.
-    /// Used by PreToolUse hook `updatedInput` rewrites; later readers
-    /// (validation, permission planning, execution) observe the new value.
-    pub fn update_task_arguments(&self, tool_id: &str, arguments: serde_json::Value) -> bool {
+    /// Apply a PreToolUse `updatedInput` proposal and preserve any rejection
+    /// raised by non-relaxable validation of the original effective input.
+    pub fn apply_hook_input_rewrite(
+        &self,
+        tool_id: &str,
+        arguments: serde_json::Value,
+        rejection: Option<ValidationResult>,
+    ) -> bool {
         if let Some(mut task) = self.tasks.get_mut(tool_id) {
             task.invocation.effective_arguments = arguments;
+            task.input_rewrite_rejection = rejection;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Update the tool-owned cooperative preemption token after final hook
+    /// arguments have determined the execution traits.
+    pub fn set_round_injection_preemption_token(
+        &self,
+        tool_id: &str,
+        token: Option<tokio_util::sync::CancellationToken>,
+    ) -> bool {
+        if let Some(mut task) = self.tasks.get_mut(tool_id) {
+            task.round_injection_preemption_token = token;
             true
         } else {
             false

--- a/src/crates/assembly/core/src/agentic/tools/pipeline/tool_pipeline.rs
+++ b/src/crates/assembly/core/src/agentic/tools/pipeline/tool_pipeline.rs
@@ -802,9 +802,67 @@ impl ToolPipeline {
         Ok(receivers)
     }
 
+    async fn non_relaxable_original_input_rejection(
+        &self,
+        task: &ToolTask,
+        updated_input: &serde_json::Value,
+    ) -> Option<bitfun_agent_tools::ValidationResult> {
+        if updated_input == &task.original_effective_arguments {
+            return None;
+        }
+
+        let tool = {
+            let registry = self.tool_registry.read().await;
+            registry
+                .get_tool(task.effective_tool_name())
+                .and_then(|tool| {
+                    resolve_contextual_tool(
+                        tool,
+                        task.context
+                            .workspace
+                            .as_ref()
+                            .map(|workspace| workspace.root_path()),
+                        task.context
+                            .workspace
+                            .as_ref()
+                            .is_some_and(|workspace| workspace.is_remote()),
+                    )
+                })
+        }?;
+        let tool_context = self.build_tool_use_context(task, CancellationToken::new());
+        let validation = tool
+            .validate_input(&task.original_effective_arguments, Some(&tool_context))
+            .await;
+        validation.blocks_input_rewrite().then_some(validation)
+    }
+
+    async fn apply_hook_input_rewrite(
+        &self,
+        task: &ToolTask,
+        updated_input: serde_json::Value,
+    ) -> bool {
+        let rejection = self
+            .non_relaxable_original_input_rejection(task, &updated_input)
+            .await;
+        let blocked = rejection.is_some();
+        if self.state_manager.apply_hook_input_rewrite(
+            &task.tool_call.tool_id,
+            updated_input,
+            rejection,
+        ) {
+            info!(
+                "PreToolUse hook rewrote tool arguments: tool_name={}, tool_id={}, blocked_by_original_input={}",
+                task.effective_tool_name(),
+                task.tool_call.tool_id,
+                blocked
+            );
+        }
+        blocked
+    }
+
     /// Run PreToolUse hooks for every valid task and record their decisions
-    /// as pre-seeded permission plans. `updatedInput` rewrites the stored
-    /// task arguments before validation and permission planning observe them.
+    /// as pre-seeded permission plans. `updatedInput` becomes the final input,
+    /// but cannot relax non-relaxable validation of the original input.
     async fn apply_pre_tool_use_hooks(&self, task_ids: &[String]) {
         for task_id in task_ids {
             let Some(task) = self.state_manager.get_task(task_id) else {
@@ -825,14 +883,15 @@ impl ToolPipeline {
             )
             .await;
             if let Some(updated_input) = decision.updated_input {
-                if self
-                    .state_manager
-                    .update_task_arguments(task_id, updated_input)
-                {
+                if self.apply_hook_input_rewrite(&task, updated_input).await {
                     info!(
-                        "PreToolUse hook rewrote tool arguments: tool_name={}, tool_id={}",
+                        "PreToolUse hook rewrite was rejected by original-input constraints: tool_name={}, tool_id={}",
                         tool_name, task_id
                     );
+                    // A hook allow decision cannot override this internal
+                    // rejection. Execution reports the stored validation
+                    // reason without invoking the tool.
+                    continue;
                 }
             }
             if let Some(reason) = decision.deny_reason {
@@ -857,6 +916,55 @@ impl ToolPipeline {
                 self.hook_preapprovals.lock().await.insert(task_id.clone());
             }
         }
+    }
+
+    async fn execution_traits_for_final_inputs(
+        &self,
+        task_ids: &[String],
+        subagent_call_count: usize,
+        subagent_batch_execution_policy: SubagentBatchExecutionPolicy,
+    ) -> Vec<(bool, bool)> {
+        let registry = self.tool_registry.read().await;
+        task_ids
+            .iter()
+            .map(|task_id| {
+                let Some(task) = self.state_manager.get_task(task_id) else {
+                    return (false, false);
+                };
+                if task.invocation_resolution_error.is_some() {
+                    return (false, false);
+                }
+                let tool = registry
+                    .get_tool(task.effective_tool_name())
+                    .and_then(|tool| {
+                        resolve_contextual_tool(
+                            tool,
+                            task.context
+                                .workspace
+                                .as_ref()
+                                .map(|workspace| workspace.root_path()),
+                            task.context
+                                .workspace
+                                .as_ref()
+                                .is_some_and(|workspace| workspace.is_remote()),
+                        )
+                    });
+                let tool_is_concurrency_safe = tool
+                    .as_ref()
+                    .map(|tool| tool.is_concurrency_safe(Some(task.effective_arguments())))
+                    .unwrap_or(false);
+                let concurrency_safe = tool_call_concurrency_safe_for_batch(
+                    task.effective_tool_name(),
+                    tool_is_concurrency_safe,
+                    subagent_call_count,
+                    subagent_batch_execution_policy,
+                );
+                let round_injection_yieldable = tool
+                    .as_ref()
+                    .is_some_and(|tool| tool.round_injection_yieldable());
+                (concurrency_safe, round_injection_yieldable)
+            })
+            .collect()
     }
 
     /// Run PostToolUse hooks for a completed tool call and fold blocking
@@ -919,6 +1027,9 @@ impl ToolPipeline {
             let Some(task) = self.state_manager.get_task(task_id) else {
                 continue;
             };
+            if task.input_rewrite_rejection.is_some() {
+                continue;
+            }
             let tool_name = task.invocation.effective_tool_name.clone();
             if task.invocation_resolution_error.is_some()
                 || task.tool_call.tool_name.is_empty()
@@ -1355,55 +1466,6 @@ impl ToolPipeline {
             })
             .count();
 
-        // Resolve execution traits before tasks are created so round-injection
-        // preemption can be routed without a second registry lookup.
-        let execution_traits: Vec<(bool, bool)> = {
-            let registry = self.tool_registry.read().await;
-            resolved_tool_calls
-                .iter()
-                .map(|(_, invocation, resolution_error)| {
-                    if resolution_error.is_some() {
-                        return (false, false);
-                    }
-                    let tool =
-                        registry
-                            .get_tool(&invocation.effective_tool_name)
-                            .and_then(|tool| {
-                                resolve_contextual_tool(
-                                    tool,
-                                    context
-                                        .workspace
-                                        .as_ref()
-                                        .map(|workspace| workspace.root_path()),
-                                    context
-                                        .workspace
-                                        .as_ref()
-                                        .is_some_and(|workspace| workspace.is_remote()),
-                                )
-                            });
-                    let tool_is_concurrency_safe = tool
-                        .as_ref()
-                        .map(|tool| tool.is_concurrency_safe(Some(&invocation.effective_arguments)))
-                        .unwrap_or(false);
-                    let concurrency_safe = tool_call_concurrency_safe_for_batch(
-                        &invocation.effective_tool_name,
-                        tool_is_concurrency_safe,
-                        subagent_call_count,
-                        options.subagent_batch_execution_policy,
-                    );
-                    let round_injection_yieldable = tool
-                        .as_ref()
-                        .is_some_and(|tool| tool.round_injection_yieldable());
-                    (concurrency_safe, round_injection_yieldable)
-                })
-                .collect()
-        };
-        let concurrency_flags = execution_traits
-            .iter()
-            .map(|(concurrency_safe, _)| *concurrency_safe)
-            .collect::<Vec<_>>();
-        let concurrency_safe_count = concurrency_flags.iter().filter(|&&flag| flag).count();
-
         // Create tasks for all tool calls
         let mut task_ids = Vec::with_capacity(resolved_tool_calls.len());
         for (tool_call_order, (tool_call, invocation, resolution_error)) in
@@ -1417,9 +1479,6 @@ impl ToolPipeline {
                 options.clone(),
             );
             task.tool_call_order = tool_call_order as u32;
-            if execution_traits[tool_call_order].1 {
-                task.round_injection_preemption_token = Some(CancellationToken::new());
-            }
             let tool_id = self.state_manager.create_task(task).await;
             task_ids.push(tool_id);
         }
@@ -1428,6 +1487,30 @@ impl ToolPipeline {
         // (deny / pre-approve / rewritten input) is visible to the planner
         // and no permission prompt is raised for calls a hook already decided.
         self.apply_pre_tool_use_hooks(&task_ids).await;
+
+        // Hook rewrites can change whether a command is concurrency-safe.
+        // Resolve all execution traits from the final arguments, then attach
+        // cooperative preemption tokens before scheduling starts.
+        let execution_traits = self
+            .execution_traits_for_final_inputs(
+                &task_ids,
+                subagent_call_count,
+                options.subagent_batch_execution_policy,
+            )
+            .await;
+        for (task_id, (_, round_injection_yieldable)) in
+            task_ids.iter().zip(execution_traits.iter())
+        {
+            if *round_injection_yieldable {
+                self.state_manager
+                    .set_round_injection_preemption_token(task_id, Some(CancellationToken::new()));
+            }
+        }
+        let concurrency_flags = execution_traits
+            .iter()
+            .map(|(concurrency_safe, _)| *concurrency_safe)
+            .collect::<Vec<_>>();
+        let concurrency_safe_count = concurrency_flags.iter().filter(|&&flag| flag).count();
 
         if let Err(error) = self.prepare_permission_plans(&task_ids).await {
             self.cleanup_permission_plans(&task_ids, "Permission planning failed".to_string())
@@ -1643,6 +1726,30 @@ impl ToolPipeline {
                 )
                 .await;
 
+            return Err(BitFunError::Validation(error_msg));
+        }
+
+        if let Some(rejection) = task.input_rewrite_rejection.as_ref() {
+            let error_msg = rejection.message.clone().unwrap_or_else(|| {
+                format!(
+                    "PreToolUse input rewrite cannot relax validation constraints for tool '{}'",
+                    tool_name
+                )
+            });
+            self.state_manager
+                .update_state(
+                    &tool_id,
+                    ToolExecutionState::Failed {
+                        error: error_msg.clone(),
+                        is_retryable: false,
+                        duration_ms: None,
+                        queue_wait_ms: None,
+                        preflight_ms: None,
+                        confirmation_wait_ms: None,
+                        execution_ms: None,
+                    },
+                )
+                .await;
             return Err(BitFunError::Validation(error_msg));
         }
 
@@ -2695,6 +2802,13 @@ mod tests {
             true
         }
 
+        fn is_concurrency_safe(&self, input: Option<&serde_json::Value>) -> bool {
+            input
+                .and_then(|input| input.get("city"))
+                .and_then(serde_json::Value::as_str)
+                != Some("unsafe")
+        }
+
         fn input_schema(&self) -> serde_json::Value {
             json!({
                 "type": "object",
@@ -2711,6 +2825,14 @@ mod tests {
             input: &serde_json::Value,
             _context: Option<&ToolUseContext>,
         ) -> ValidationResult {
+            if input.get("city").and_then(serde_json::Value::as_str) == Some("protected") {
+                return ValidationResult {
+                    result: false,
+                    message: Some("the original target is protected".to_string()),
+                    error_code: Some(403),
+                    meta: Some(json!({ "blocks_input_rewrite": true })),
+                };
+            }
             let valid = input
                 .get("city")
                 .and_then(serde_json::Value::as_str)
@@ -2857,6 +2979,20 @@ mod tests {
     fn test_tool_task(tool_id: &str, tool_name: &str) -> ToolTask {
         ToolTask::new(
             test_tool_call(tool_id, tool_name),
+            test_tool_execution_context(),
+            ToolExecutionOptions::default(),
+        )
+    }
+
+    fn test_tool_task_with_arguments(
+        tool_id: &str,
+        tool_name: &str,
+        arguments: serde_json::Value,
+    ) -> ToolTask {
+        let mut tool_call = test_tool_call(tool_id, tool_name);
+        tool_call.arguments = arguments;
+        ToolTask::new(
+            tool_call,
             test_tool_execution_context(),
             ToolExecutionOptions::default(),
         )
@@ -3271,6 +3407,164 @@ mod tests {
             calls.load(Ordering::SeqCst),
             0,
             "a denied tool must not execute even when a hook approved it"
+        );
+    }
+
+    #[tokio::test]
+    async fn hook_rewrite_cannot_hide_a_non_relaxable_original_input_rejection() {
+        let pipeline = test_tool_pipeline();
+        let received_arguments = Arc::new(Mutex::new(None));
+        register_capturing_test_tool(&pipeline, "get_weather", Arc::clone(&received_arguments))
+            .await;
+        let task = test_tool_task_with_arguments(
+            "rewrite-protected-original",
+            "get_weather",
+            json!({ "city": "protected" }),
+        );
+        let tool_id = pipeline.state_manager.create_task(task.clone()).await;
+
+        assert!(
+            pipeline
+                .apply_hook_input_rewrite(&task, json!({ "city": "copy" }))
+                .await
+        );
+        let persisted = pipeline
+            .state_manager
+            .get_task(&tool_id)
+            .expect("rewritten task");
+        assert_eq!(
+            persisted.original_effective_arguments,
+            json!({ "city": "protected" })
+        );
+        assert_eq!(persisted.effective_arguments(), &json!({ "city": "copy" }));
+        assert!(persisted
+            .input_rewrite_rejection
+            .as_ref()
+            .is_some_and(ValidationResult::blocks_input_rewrite));
+
+        let error = pipeline
+            .execute_single_tool(tool_id)
+            .await
+            .expect_err("protected original input must block execution");
+        assert!(matches!(error, BitFunError::Validation(_)));
+        assert!(received_arguments
+            .lock()
+            .expect("capturing tool argument lock")
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn hook_rewrite_can_repair_an_ordinary_validation_failure() {
+        let pipeline = test_tool_pipeline();
+        let received_arguments = Arc::new(Mutex::new(None));
+        register_capturing_test_tool(&pipeline, "get_weather", Arc::clone(&received_arguments))
+            .await;
+        let task = test_tool_task_with_arguments(
+            "rewrite-repairable-original",
+            "get_weather",
+            json!({ "legacy_city": "Paris" }),
+        );
+        let tool_id = pipeline.state_manager.create_task(task.clone()).await;
+
+        assert!(
+            !pipeline
+                .apply_hook_input_rewrite(&task, json!({ "city": "Paris" }))
+                .await
+        );
+        let persisted = pipeline
+            .state_manager
+            .get_task(&tool_id)
+            .expect("rewritten task");
+        assert_eq!(
+            persisted.original_effective_arguments,
+            json!({ "legacy_city": "Paris" })
+        );
+        assert_eq!(persisted.effective_arguments(), &json!({ "city": "Paris" }));
+        assert!(persisted.input_rewrite_rejection.is_none());
+
+        pipeline
+            .execute_single_tool(tool_id)
+            .await
+            .expect("repaired input should execute");
+        assert_eq!(
+            *received_arguments
+                .lock()
+                .expect("capturing tool argument lock"),
+            Some(json!({ "city": "Paris" }))
+        );
+    }
+
+    #[tokio::test]
+    async fn final_validation_rejects_a_hook_rewrite_into_a_protected_input() {
+        let pipeline = test_tool_pipeline();
+        let received_arguments = Arc::new(Mutex::new(None));
+        register_capturing_test_tool(&pipeline, "get_weather", Arc::clone(&received_arguments))
+            .await;
+        let task = test_tool_task_with_arguments(
+            "rewrite-protected-final",
+            "get_weather",
+            json!({ "city": "Paris" }),
+        );
+        let tool_id = pipeline.state_manager.create_task(task.clone()).await;
+
+        assert!(
+            !pipeline
+                .apply_hook_input_rewrite(&task, json!({ "city": "protected" }))
+                .await
+        );
+        assert!(pipeline
+            .state_manager
+            .get_task(&tool_id)
+            .expect("rewritten task")
+            .input_rewrite_rejection
+            .is_none());
+
+        let error = pipeline
+            .execute_single_tool(tool_id)
+            .await
+            .expect_err("protected final input must fail final validation");
+        assert!(matches!(error, BitFunError::Validation(_)));
+        assert!(received_arguments
+            .lock()
+            .expect("capturing tool argument lock")
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn hook_rewrite_recomputes_concurrency_from_final_input() {
+        let pipeline = test_tool_pipeline();
+        register_capturing_test_tool(&pipeline, "get_weather", Arc::new(Mutex::new(None))).await;
+        let task = test_tool_task_with_arguments(
+            "rewrite-concurrency",
+            "get_weather",
+            json!({ "city": "Paris" }),
+        );
+        let tool_id = pipeline.state_manager.create_task(task.clone()).await;
+
+        assert!(
+            pipeline
+                .execution_traits_for_final_inputs(
+                    std::slice::from_ref(&tool_id),
+                    0,
+                    SubagentBatchExecutionPolicy::SafeOnly,
+                )
+                .await[0]
+                .0
+        );
+        assert!(
+            !pipeline
+                .apply_hook_input_rewrite(&task, json!({ "city": "unsafe" }))
+                .await
+        );
+        assert!(
+            !pipeline
+                .execution_traits_for_final_inputs(
+                    std::slice::from_ref(&tool_id),
+                    0,
+                    SubagentBatchExecutionPolicy::SafeOnly,
+                )
+                .await[0]
+                .0
         );
     }
 

--- a/src/crates/assembly/core/src/agentic/tools/pipeline/types.rs
+++ b/src/crates/assembly/core/src/agentic/tools/pipeline/types.rs
@@ -6,7 +6,7 @@ use crate::agentic::round_preempt::DialogRoundInjectionInterrupt;
 use crate::agentic::tools::ToolRuntimeRestrictions;
 use crate::agentic::workspace::WorkspaceServices;
 use crate::agentic::WorkspaceBinding;
-use bitfun_agent_tools::ResolvedToolInvocation;
+use bitfun_agent_tools::{ResolvedToolInvocation, ValidationResult};
 use bitfun_runtime_ports::{
     DelegationPolicy, PermissionDelegationContext, RemoteExecPort, ResolvedPermissionPolicy,
     TerminalPort,
@@ -118,6 +118,12 @@ pub struct ToolTask {
     /// round. Permission requests inherit this value as their order key.
     pub tool_call_order: u32,
     pub invocation: ResolvedToolInvocation,
+    /// Effective arguments before any Native PreToolUse hook rewrite. This
+    /// remains immutable so validation and audit can compare both inputs.
+    pub original_effective_arguments: serde_json::Value,
+    /// A non-relaxable validation rejection found on the original input while
+    /// applying a hook rewrite. Final validation still checks rewritten input.
+    pub input_rewrite_rejection: Option<ValidationResult>,
     pub invocation_resolution_error: Option<String>,
     pub context: ToolExecutionContext,
     pub options: ToolExecutionOptions,
@@ -150,10 +156,13 @@ impl ToolTask {
         context: ToolExecutionContext,
         options: ToolExecutionOptions,
     ) -> Self {
+        let original_effective_arguments = invocation.effective_arguments.clone();
         Self {
             tool_call,
             tool_call_order: 0,
             invocation,
+            original_effective_arguments,
+            input_rewrite_rejection: None,
             invocation_resolution_error,
             context,
             options,

--- a/src/crates/assembly/core/src/native_hooks.rs
+++ b/src/crates/assembly/core/src/native_hooks.rs
@@ -134,8 +134,10 @@ pub async fn dispatch_user_prompt_submit(
     decision
 }
 
-/// PreToolUse hooks run after tool-input validation and before permission
-/// evaluation. They may deny the call, pre-approve it, or rewrite its input.
+/// PreToolUse hooks run before final tool-input validation and permission
+/// evaluation. They may deny the call, pre-approve it, or propose rewritten
+/// input. The tool pipeline independently prevents a rewrite from relaxing
+/// non-relaxable validation constraints.
 pub async fn dispatch_pre_tool_use(
     facts: NativeHookSessionFacts<'_>,
     tool_name: &str,

--- a/src/crates/execution/tool-contracts/src/framework.rs
+++ b/src/crates/execution/tool-contracts/src/framework.rs
@@ -2451,6 +2451,21 @@ pub struct ValidationResult {
     pub meta: Option<Value>,
 }
 
+impl ValidationResult {
+    /// Whether this rejection represents an invariant that an input rewrite
+    /// must not relax. Ordinary schema or formatting failures intentionally
+    /// remain repairable by a PreToolUse hook.
+    pub fn blocks_input_rewrite(&self) -> bool {
+        !self.result
+            && self
+                .meta
+                .as_ref()
+                .and_then(|meta| meta.get("blocks_input_rewrite"))
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+    }
+}
+
 impl Default for ValidationResult {
     fn default() -> Self {
         Self {
@@ -2525,6 +2540,26 @@ impl ToolResult {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn validation_result_only_blocks_rewrites_when_explicitly_marked() {
+        let repairable = ValidationResult {
+            result: false,
+            message: Some("repairable".to_string()),
+            error_code: Some(400),
+            meta: None,
+        };
+        let non_relaxable = ValidationResult {
+            result: false,
+            message: Some("protected".to_string()),
+            error_code: Some(403),
+            meta: Some(json!({ "blocks_input_rewrite": true })),
+        };
+
+        assert!(!repairable.blocks_input_rewrite());
+        assert!(non_relaxable.blocks_input_rewrite());
+        assert!(!ValidationResult::default().blocks_input_rewrite());
+    }
 
     struct TestTool {
         name: &'static str,


### PR DESCRIPTION
## Summary

- Preserve the original effective tool input before Native `PreToolUse` hooks run.
- Prevent `updatedInput` from relaxing an explicitly non-relaxable validation rejection such as Edit Constraint Guard, while still allowing hooks to repair ordinary malformed input.
- Continue full validation and permission planning on the final rewritten input, and recompute argument-sensitive execution traits after hooks.
- Preserve the existing exemption for genuinely new agent-created test helpers and document the direct hook-process side-effect boundary.

Fixes: N/A

## Type and Areas

Type:

Regression fix / test / docs.

Areas:

Rust core Agent hooks and tool pipeline, Edit Constraint Guard, tool contracts, Agent Hooks documentation.

## Motivation / Impact

`PreToolUse updatedInput` previously replaced the task effective arguments before tool validation. A hook could therefore rewrite an existing protected test-file target to a new copy; final validation saw only the copy and could allow the write, even though the original model request violated the user edit constraint. Argument-sensitive concurrency planning was also calculated from the pre-hook input.

This PR makes the ordering explicit:

1. `ToolTask` retains immutable pre-hook effective arguments together with the final effective arguments for in-process audit.
2. A tool rejection can opt into the provider-neutral `blocks_input_rewrite` invariant. Edit Constraint Guard marks its 403 rejections this way.
3. Only when `updatedInput` actually changes the input, the pipeline validates the original input and preserves any non-relaxable rejection. Hook `allow` cannot override it, and execution fails before tool side effects.
4. The rewritten input still passes the existing complete `validate_input` and permission flow, so rewriting a legal target into a protected target is also rejected.
5. Ordinary validation failures without the invariant remain repairable by hooks.
6. Concurrency safety and round-injection execution traits are resolved from final arguments after hooks.

The extra original-input validation runs only for actual input rewrites; ordinary tool calls and hooks that do not return a changed `updatedInput` do not pay this cost.

A genuinely new test helper remains allowed by the existing provenance rule. Rewriting an existing protected test to a new copy remains blocked because the original input is checked independently.

## Verification

- `cargo test -p bitfun-agent-tools --lib` — 16 passed.
- `cargo test -p bitfun-core --no-default-features --features agent-runtime,git --lib agentic::tools::pipeline::tool_pipeline::tests` — 44 passed.
- `cargo test -p bitfun-core --no-default-features --features agent-runtime,git --lib agentic::execution::edit_constraint_guard::tests` — 32 passed.
- `git diff --check upstream/1.0.0-explore...HEAD` — passed.

The focused test coverage includes:

- protected original input rewritten to a new target remains rejected;
- ordinary invalid input can be repaired;
- valid original input rewritten to a protected final input is rejected;
- hook approval cannot widen permission or guard policy;
- concurrency safety is recomputed from final input;
- new agent-created test helpers remain exempt only under the existing test-file rule.

## Reviewer Notes

- Compatibility: no persisted config, session schema, or event schema changes; the new validation marker is additive metadata and the original-input state is internal to `ToolTask`.
- Security boundary: this protects `updatedInput` because the resulting write still runs through the BitFun tool pipeline. A Native command hook is arbitrary external code; if that command writes files directly, it bypasses tool `validate_input` and must be trusted, disabled, or sandboxed separately. The English and Chinese Hook docs now state this explicitly.
- Remote scenarios: Native hooks are skipped for remote workspaces by existing policy. The changed local execution path was covered by focused tests; remote workspace, remote control, Peer Device Mode, and Detached Dispatch were not exercised.
- Rollback: revert the two commits in this PR; no data migration is required.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.