### PR TITLE
feat(sdk): add structured turn output

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -19,6 +19,8 @@ The slice validates the intended public object model:
   attachments;
 - a terminal `Result` reports aggregate token usage when the provider supplied
   usage for that Turn;
+- a Turn may request JSON output with `outputSchema`; its terminal `Result`
+  keeps the raw text and exposes the parsed value as `structuredOutput`;
 - the same stream reports safe Tool lifecycle facts and permission requests;
   `Query.respondPermission()` supports allow once, allow always, or reject;
 - protocol and process failures use `SdkError`, including outcome certainty.
@@ -93,6 +95,28 @@ const result = await query.result();
 console.log(result.usage?.totalTokens);
 ```
 
+Structured output is scoped to one Query or Session Turn:
+
+```typescript
+const result = await (
+  await client.query({
+    prompt: "Summarize the repository",
+    outputSchema: {
+      type: "object",
+      properties: { summary: { type: "string" } },
+      required: ["summary"],
+      additionalProperties: false,
+    },
+  })
+).result();
+
+console.log(result.structuredOutput);
+```
+
+The Host requires an object schema and maps it to the selected OpenAI Chat,
+OpenAI Responses, Anthropic, or Gemini protocol. It parses the final response
+as JSON; invalid JSON produces a failed Result while preserving `outputText`.
+
 `local_image` accepts local PNG, JPEG, GIF, and WebP paths. Image bytes and
 remote URLs are intentionally outside this local Host protocol.
 
@@ -126,8 +150,8 @@ separately. This PR does not publish the package. A future registry release
 still needs platform packages, signing, and release verification.
 
 Browser and mobile runtimes cannot launch the local native Host. Custom
-functions, general user-input callbacks, structured output, Python support,
-platform package publication, signing, and downloads
+functions, general user-input callbacks, Python support, platform package
+publication, signing, and downloads
 remain deferred.
 
 ## Development

--- a/sdk/typescript/scripts/generated-wire-runtime.test.mjs
+++ b/sdk/typescript/scripts/generated-wire-runtime.test.mjs
@@ -43,7 +43,7 @@ test("Rust wire export produces executable validators for every type", async () 
   }
 
   const initializeResult = {
-    protocolVersion: 5,
+    protocolVersion: 6,
     runtimeVersion: "0.1.0",
     stability: "not_delivered",
     capabilities: {
@@ -56,7 +56,7 @@ test("Rust wire export produces executable validators for every type", async () 
       eventStream: true,
       toolEvents: true,
       imageInput: true,
-      structuredOutput: false,
+      structuredOutput: true,
       usage: true,
       customTools: false,
       permissionResponses: true,

--- a/sdk/typescript/scripts/runtime-validator-generator.mjs
+++ b/sdk/typescript/scripts/runtime-validator-generator.mjs
@@ -36,6 +36,13 @@ export async function generateRuntimeValidators(
     '  return typeof value === "object" && value !== null && !Array.isArray(value);',
     "}",
     "",
+    "function isJsonValue(value: unknown): boolean {",
+    '  if (value === null || typeof value === "string" || typeof value === "boolean") return true;',
+    '  if (typeof value === "number") return Number.isFinite(value);',
+    "  if (Array.isArray(value)) return value.every(isJsonValue);",
+    "  return isRecord(value) && Object.values(value).every(isJsonValue);",
+    "}",
+    "",
     "function hasOnlyKeys(value: Record<string, unknown>, allowed: readonly string[]): boolean {",
     "  const keys = Object.keys(value);",
     "  return keys.length <= allowed.length && keys.every((key) => allowed.includes(key));",
@@ -148,6 +155,9 @@ function emitTypeCheck(node, value, aliases, owner) {
   if (node.kind === ts.SyntaxKind.BooleanKeyword) {
     return `typeof ${value} === "boolean"`;
   }
+  if (node.kind === ts.SyntaxKind.UnknownKeyword) {
+    return `isJsonValue(${value})`;
+  }
   if (ts.isArrayTypeNode(node)) {
     const item = emitTypeCheck(node.elementType, "item", aliases, owner);
     return `(Array.isArray(${value}) && ${value}.every((item: unknown) => ${item}))`;
@@ -175,6 +185,9 @@ function emitTypeCheck(node, value, aliases, owner) {
     }
     if (name === "Record" && isEmptyRecord(node)) {
       return `(isRecord(${value}) && Object.keys(${value}).length === 0)`;
+    }
+    if (name === "Record" && isJsonRecord(node)) {
+      return `(isRecord(${value}) && Object.values(${value}).every(isJsonValue))`;
     }
     throw new Error(
       `${owner}: unsupported type reference ${name}; runtime validator generation is fail-closed`,
@@ -225,6 +238,14 @@ function isEmptyRecord(node) {
   return (
     node.typeArguments[0].kind === ts.SyntaxKind.SymbolKeyword &&
     node.typeArguments[1].kind === ts.SyntaxKind.NeverKeyword
+  );
+}
+
+function isJsonRecord(node) {
+  return (
+    node.typeArguments?.length === 2 &&
+    node.typeArguments[0].kind === ts.SyntaxKind.StringKeyword &&
+    node.typeArguments[1].kind === ts.SyntaxKind.UnknownKeyword
   );
 }
 

--- a/sdk/typescript/scripts/runtime-validator-generator.test.mjs
+++ b/sdk/typescript/scripts/runtime-validator-generator.test.mjs
@@ -92,6 +92,31 @@ test("generated validators reject missing required fields", async () => {
   }
 });
 
+test("generated validators accept JSON values without accepting arbitrary runtime values", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "bitfun-wire-validator-"));
+  try {
+    await writeFile(
+      join(directory, "JsonPayload.ts"),
+      "export type JsonPayload = { schema: Record<string, unknown>, value: unknown };\n",
+    );
+
+    const validators = await loadValidators(directory);
+
+    assert.equal(
+      validators.isJsonPayload({
+        schema: { type: "object", properties: { summary: { type: "string" } } },
+        value: { summary: "ready", count: 1, tags: [true, null] },
+      }),
+      true,
+    );
+    assert.equal(validators.isJsonPayload({ schema: [], value: "ready" }), false);
+    assert.equal(validators.isJsonPayload({ schema: {}, value: undefined }), false);
+    assert.equal(validators.isJsonPayload({ schema: {}, value: () => true }), false);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 test("generation fails closed for unsupported type syntax", async () => {
   const directory = await mkdtemp(join(tmpdir(), "bitfun-wire-validator-"));
   try {

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -96,6 +96,7 @@ export class AgentClient {
     const params: QueryStartParams = {
       prompt: normalized.prompt,
       images: normalized.images,
+      outputSchema: input.outputSchema,
       sessionId: null,
       sessionName: null,
       agent: input.agent ?? null,

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -8,6 +8,7 @@ export type {
   AgentModelOptions,
   AgentModelProvider,
   Input,
+  JsonSchema,
   AssistantTextDelta,
   OutcomeCertainty,
   PermissionDecision,

--- a/sdk/typescript/src/internal/client.ts
+++ b/sdk/typescript/src/internal/client.ts
@@ -4,7 +4,7 @@ import { JsonRpcConnection } from "./json-rpc.js";
 import type { HostTransport } from "./transport.js";
 import type { InitializeParams, InitializeResult } from "./wire/index.js";
 
-const PROTOCOL_VERSION = 5;
+const PROTOCOL_VERSION = 6;
 const DEFAULT_INITIALIZE_TIMEOUT_MS = 30_000;
 
 export async function createAgentClient(

--- a/sdk/typescript/src/query.ts
+++ b/sdk/typescript/src/query.ts
@@ -313,6 +313,9 @@ export class Query implements AsyncIterable<QueryStreamItem> {
       operationId: params.operationId,
       status: params.status,
       outputText: params.output.text,
+      ...(params.output.structured === undefined
+        ? {}
+        : { structuredOutput: params.output.structured }),
       ...(params.usage === undefined ? {} : { usage: mapUsage(params.usage) }),
       ...(params.error === undefined ? {} : { error: mapResultError(params.error) }),
     };

--- a/sdk/typescript/src/session.ts
+++ b/sdk/typescript/src/session.ts
@@ -134,6 +134,7 @@ export class Session {
     const params: QueryStartParams = {
       prompt: normalized.prompt,
       images: normalized.images,
+      outputSchema: input.outputSchema,
       sessionId: this.id,
     };
     const started = await this.#connection.request<QueryStartResult>(

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -93,9 +93,12 @@ export type UserInput =
 
 export type Input = string | readonly UserInput[];
 
+export type JsonSchema = Record<string, unknown>;
+
 export interface QueryInput {
   prompt: Input;
   agent?: string;
+  outputSchema?: JsonSchema;
 }
 
 export interface SessionCreateInput {
@@ -105,6 +108,7 @@ export interface SessionCreateInput {
 
 export interface TurnInput {
   prompt: Input;
+  outputSchema?: JsonSchema;
 }
 
 export interface Turn {
@@ -184,6 +188,7 @@ export interface Result {
   operationId: string;
   status: ResultStatus;
   outputText: string;
+  structuredOutput?: unknown;
   usage?: Usage;
   error?: ResultError;
 }

--- a/sdk/typescript/test/client.test.ts
+++ b/sdk/typescript/test/client.test.ts
@@ -63,7 +63,7 @@ test("a Query streams tool and permission events before the terminal Result", as
   assert.ok(client instanceof AgentClient);
   assert.equal(initializeRequests.length, 1);
   assert.deepEqual(initializeRequests[0], {
-    protocolVersion: 5,
+    protocolVersion: 6,
     clientInfo: { name: "@bitfun/agent-sdk", version: "0.0.0" },
     capabilities: {
       serverNotifications: true,
@@ -82,6 +82,11 @@ test("a Query streams tool and permission events before the terminal Result", as
       { type: "local_image", path: "screenshots/fixture.png" },
       { type: "text", text: "focus on the layout" },
     ],
+    outputSchema: {
+      type: "object",
+      properties: { summary: { type: "string" } },
+      required: ["summary"],
+    },
     model: "attempted-override",
   } as QueryInput);
   assert.equal(query.id, "query-1");
@@ -95,7 +100,7 @@ test("a Query streams tool and permission events before the terminal Result", as
     toolEvents: true,
     imageInput: true,
     permissionResponses: true,
-    structuredOutput: false,
+    structuredOutput: true,
     usage: true,
     customTools: false,
     hooks: false,
@@ -168,6 +173,7 @@ test("a Query streams tool and permission events before the terminal Result", as
       operationId: "operation-1",
       status: "completed",
       outputText: "fixture result",
+      structuredOutput: { summary: "fixture result" },
       usage: {
         inputTokens: 100,
         outputTokens: 25,
@@ -210,6 +216,7 @@ test("an explicit Session starts Turns on the existing client connection", async
 
   const query = await session.startTurn({
     prompt: [{ type: "local_image", path: "screenshots/continued.webp" }],
+    outputSchema: { type: "object" },
   });
   assert.equal((await query.result()).outputText, "continued");
   await session.close();
@@ -583,7 +590,7 @@ async function runFixtureHost(
         jsonrpc: "2.0",
         id: request.id,
         result: {
-          protocolVersion: 5,
+          protocolVersion: 6,
           runtimeVersion: "0.2.17",
           stability: "not_delivered",
           capabilities: {
@@ -596,7 +603,7 @@ async function runFixtureHost(
             eventStream: true,
             toolEvents: true,
             imageInput: true,
-            structuredOutput: false,
+            structuredOutput: true,
             usage: true,
             customTools: false,
             permissionResponses: true,
@@ -613,6 +620,11 @@ async function runFixtureHost(
       assert.deepEqual(request.params, {
         prompt: "hello\n\nfocus on the layout",
         images: ["screenshots/fixture.png"],
+        outputSchema: {
+          type: "object",
+          properties: { summary: { type: "string" } },
+          required: ["summary"],
+        },
         sessionId: null,
         sessionName: null,
         agent: null,
@@ -724,7 +736,10 @@ async function runFixtureHost(
           turnId: "turn-1",
           operationId: "operation-1",
           status: "completed",
-          output: { text: "fixture result" },
+          output: {
+            text: "fixture result",
+            structured: { summary: "fixture result" },
+          },
           usage: {
             inputTokens: 100,
             outputTokens: 25,
@@ -796,6 +811,7 @@ async function runSessionFixtureHost(
       assert.deepEqual(request.params, {
         prompt: "",
         images: ["screenshots/continued.webp"],
+        outputSchema: { type: "object" },
         sessionId: "session-explicit",
       });
       write(responses, {
@@ -1343,7 +1359,7 @@ function initializeResponse(id: number): unknown {
     jsonrpc: "2.0",
     id,
     result: {
-      protocolVersion: 5,
+      protocolVersion: 6,
       runtimeVersion: "0.2.17",
       stability: "not_delivered",
       capabilities: {
@@ -1356,7 +1372,7 @@ function initializeResponse(id: number): unknown {
         eventStream: true,
         toolEvents: true,
         imageInput: true,
-        structuredOutput: false,
+        structuredOutput: true,
         usage: true,
         customTools: false,
         permissionResponses: true,

--- a/sdk/typescript/test/fixtures/host.mjs
+++ b/sdk/typescript/test/fixtures/host.mjs
@@ -5,7 +5,7 @@ for await (const line of lines) {
   const request = JSON.parse(line);
   if (request.method === "initialize") {
     if (
-      request.params?.protocolVersion !== 5 ||
+      request.params?.protocolVersion !== 6 ||
       request.params?.model?.apiKey !== "fixture-secret"
     ) {
       throw new Error("Invalid initialize request");
@@ -14,7 +14,7 @@ for await (const line of lines) {
       jsonrpc: "2.0",
       id: request.id,
       result: {
-        protocolVersion: 5,
+        protocolVersion: 6,
         runtimeVersion: "fixture",
         stability: "not_delivered",
         capabilities: {
@@ -27,7 +27,7 @@ for await (const line of lines) {
           eventStream: true,
           toolEvents: true,
           imageInput: true,
-          structuredOutput: false,
+          structuredOutput: true,
           usage: true,
           customTools: false,
           permissionResponses: true,

--- a/src/apps/cli/src/agent/runtime_client.rs
+++ b/src/apps/cli/src/agent/runtime_client.rs
@@ -1635,6 +1635,7 @@ impl CliAgentRuntimeClient {
         let request = AgentDialogTurnRequest {
             session_id: session_id.clone(),
             message: message.clone(),
+            output_schema: None,
             original_message,
             turn_id: Some(turn_id.clone()),
             execution,

--- a/src/apps/cli/src/dispatch/worker.rs
+++ b/src/apps/cli/src/dispatch/worker.rs
@@ -242,6 +242,7 @@ async fn run_inner(store: &DispatchStore, job_id: &str) -> Result<()> {
                 .submit_dialog_turn(AgentDialogTurnRequest {
                     session_id: job.request.session_id.clone(),
                     message: prompt,
+                    output_schema: None,
                     original_message: None,
                     turn_id: Some(turn_id.clone()),
                     execution: Default::default(),

--- a/src/apps/cli/src/peer_host/commands/dialog.rs
+++ b/src/apps/cli/src/peer_host/commands/dialog.rs
@@ -148,6 +148,7 @@ async fn submit_dialog_turn(state: &PeerHostState, args: &Value) -> Result<Value
         .submit_dialog_turn(AgentDialogTurnRequest {
             session_id: session_id.clone(),
             message: user_input,
+            output_schema: None,
             original_message: original_user_input,
             turn_id: Some(turn_id.clone()),
             execution: Default::default(),

--- a/src/apps/desktop/src/api/agentic_api.rs
+++ b/src/apps/desktop/src/api/agentic_api.rs
@@ -2329,6 +2329,7 @@ fn desktop_dialog_turn_request(
     Ok(AgentDialogTurnRequest {
         session_id,
         message: user_input,
+        output_schema: None,
         original_message: original_user_input,
         turn_id,
         execution,

--- a/src/apps/sdk-host/tests/stdio_process.rs
+++ b/src/apps/sdk-host/tests/stdio_process.rs
@@ -45,7 +45,7 @@ async fn standalone_sdk_host_negotiates_and_shuts_down_without_cli() {
         1,
         "initialize",
         json!({
-            "protocolVersion": 5,
+            "protocolVersion": 6,
             "clientInfo": { "name": "standalone-process-fixture", "version": "0.1.0" },
             "capabilities": {
                 "serverNotifications": true,
@@ -62,7 +62,7 @@ async fn standalone_sdk_host_negotiates_and_shuts_down_without_cli() {
     .await;
     let initialized = read_response(&mut stdout, "initialize").await;
     assert_eq!(initialized["id"], 1);
-    assert_eq!(initialized["result"]["protocolVersion"], 5);
+    assert_eq!(initialized["result"]["protocolVersion"], 6);
     assert!(initialized["result"]["modelId"]
         .as_str()
         .is_some_and(|model_id| model_id.starts_with("sdk:openai:")));

--- a/src/apps/sdk-host/tests/stdio_transport.rs
+++ b/src/apps/sdk-host/tests/stdio_transport.rs
@@ -236,7 +236,7 @@ async fn stdio_transport_serves_initialize_and_shutdown_without_non_protocol_std
     client_write
         .write_all(
             concat!(
-                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":5,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":6,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
                 "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"shutdown\",\"params\":{}}\n"
             )
             .as_bytes(),
@@ -252,7 +252,7 @@ async fn stdio_transport_serves_initialize_and_shutdown_without_non_protocol_std
         serde_json::from_str(&lines.next_line().await.unwrap().unwrap()).unwrap();
 
     assert_eq!(initialized["id"], 1);
-    assert_eq!(initialized["result"]["protocolVersion"], 5);
+    assert_eq!(initialized["result"]["protocolVersion"], 6);
     assert_eq!(initialized["result"]["modelId"], "sdk:openai:transport");
     assert_eq!(shutdown["id"], 2);
     assert_eq!(shutdown["result"]["accepted"], true);
@@ -286,7 +286,7 @@ async fn stdio_transport_executes_json_rpc_notifications_without_replying() {
     client_write
         .write_all(
             concat!(
-                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":5,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":6,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
                 "{\"jsonrpc\":\"2.0\",\"method\":\"shutdown\",\"params\":{}}\n"
             )
             .as_bytes(),
@@ -386,7 +386,7 @@ async fn transport_accepts_input_while_an_owner_call_is_pending_and_bounds_reque
     client_write
         .write_all(
             concat!(
-                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":5,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":6,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
                 "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"session/create\",\"params\":{}}\n",
                 "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"session/create\",\"params\":{}}\n"
             )
@@ -458,7 +458,7 @@ async fn shutdown_remains_available_when_the_data_request_budget_is_exhausted() 
     ));
     client_write
         .write_all(
-            b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":5,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
+            b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":6,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
         )
         .await
         .unwrap();
@@ -538,9 +538,9 @@ async fn duplicate_initialize_does_not_abort_an_in_flight_request() {
     client_write
         .write_all(
             concat!(
-                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":5,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":6,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
                 "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"session/create\",\"params\":{}}\n",
-                "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"initialize\",\"params\":{\"protocolVersion\":5,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n"
+                "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"initialize\",\"params\":{\"protocolVersion\":6,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n"
             )
             .as_bytes(),
         )
@@ -598,7 +598,7 @@ async fn connection_eof_cleans_a_session_created_after_its_request_is_aborted() 
     client_write
         .write_all(
             concat!(
-                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":5,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":6,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
                 "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"session/create\",\"params\":{}}\n"
             )
             .as_bytes(),
@@ -657,7 +657,7 @@ async fn explicit_shutdown_bounds_request_drain_and_session_cleanup_together() {
     client_write
         .write_all(
             concat!(
-                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":5,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":6,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
                 "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"session/create\",\"params\":{}}\n"
             )
             .as_bytes(),
@@ -715,7 +715,7 @@ async fn requests_before_a_successful_initialize_cannot_cross_the_handshake() {
             concat!(
                 "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":999,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
                 "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"session/create\",\"params\":{}}\n",
-                "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"initialize\",\"params\":{\"protocolVersion\":5,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n"
+                "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"initialize\",\"params\":{\"protocolVersion\":6,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n"
             )
             .as_bytes(),
         )
@@ -734,7 +734,7 @@ async fn requests_before_a_successful_initialize_cannot_cross_the_handshake() {
     assert_eq!(pre_initialize["id"], 2);
     assert_eq!(pre_initialize["error"]["data"]["code"], "not_initialized");
     assert_eq!(initialized["id"], 3);
-    assert_eq!(initialized["result"]["protocolVersion"], 5);
+    assert_eq!(initialized["result"]["protocolVersion"], 6);
     assert_eq!(initialized["result"]["modelId"], "sdk:openai:transport");
 
     client_write
@@ -775,7 +775,7 @@ async fn blocked_output_times_out_and_ends_the_connection() {
     ));
     client_write
         .write_all(
-            b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":5,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
+            b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":6,\"clientInfo\":{\"name\":\"fixture\",\"version\":\"0.1\"},\"capabilities\":{\"serverNotifications\":true,\"permissionResponses\":true},\"model\":{\"provider\":\"openai\",\"model\":\"fixture-model\",\"apiKey\":\"fixture-secret\"}}}\n",
         )
         .await
         .unwrap();

--- a/src/crates/adapters/agent-runtime-ipc/src/tests/protocol_contracts.rs
+++ b/src/crates/adapters/agent-runtime-ipc/src/tests/protocol_contracts.rs
@@ -586,6 +586,7 @@ fn submit_turn_accepts_the_existing_64_kib_tui_paste_contract() {
             request: AgentDialogTurnRequest {
                 session_id: "session-1".to_string(),
                 message: "x".repeat(64 * 1024),
+                output_schema: None,
                 original_message: None,
                 turn_id: Some("turn-1".to_string()),
                 execution: Default::default(),

--- a/src/crates/adapters/agent-runtime-ipc/src/tests/shared_controller.rs
+++ b/src/crates/adapters/agent-runtime-ipc/src/tests/shared_controller.rs
@@ -687,6 +687,7 @@ fn submit_operation(workspace: &Path, session_id: &str, turn_id: &str) -> Runtim
         request: AgentDialogTurnRequest {
             session_id: session_id.to_string(),
             message: "hello".to_string(),
+            output_schema: None,
             original_message: None,
             turn_id: Some(turn_id.to_string()),
             execution: Default::default(),

--- a/src/crates/adapters/ai-adapters/src/client.rs
+++ b/src/crates/adapters/ai-adapters/src/client.rs
@@ -282,7 +282,7 @@ impl AIClient {
             custom_body,
             1,
             trace,
-            None,
+            request_context,
         )
         .await
     }
@@ -439,7 +439,16 @@ impl AIClient {
     ) -> Result<StreamResponse> {
         match ApiFormat::parse(&self.config.format)? {
             ApiFormat::OpenAIChat => {
-                openai::chat::send_stream(self, messages, tools, extra_body, max_tries, trace).await
+                openai::chat::send_stream(
+                    self,
+                    messages,
+                    tools,
+                    extra_body,
+                    max_tries,
+                    trace,
+                    request_context,
+                )
+                .await
             }
             ApiFormat::OpenAIResponses => {
                 openai::responses::send_stream(
@@ -454,12 +463,28 @@ impl AIClient {
                 .await
             }
             ApiFormat::Anthropic => {
-                anthropic::request::send_stream(self, messages, tools, extra_body, max_tries, trace)
-                    .await
+                anthropic::request::send_stream(
+                    self,
+                    messages,
+                    tools,
+                    extra_body,
+                    max_tries,
+                    trace,
+                    request_context,
+                )
+                .await
             }
             ApiFormat::Gemini => {
-                gemini::request::send_stream(self, messages, tools, extra_body, max_tries, trace)
-                    .await
+                gemini::request::send_stream(
+                    self,
+                    messages,
+                    tools,
+                    extra_body,
+                    max_tries,
+                    trace,
+                    request_context,
+                )
+                .await
             }
             ApiFormat::GeminiCodeAssist => {
                 gemini::code_assist::send_stream(
@@ -610,7 +635,7 @@ fn gemini_response_to_trace(response: &GeminiResponse) -> ModelExchangeResponseT
 mod tests {
     use super::{send_message_retry_delay_ms, AIClient};
     use crate::providers::{anthropic, gemini, gemini::GeminiMessageConverter, openai};
-    use crate::types::{AIConfig, ToolDefinition};
+    use crate::types::{AIConfig, ModelRequestContext, ToolDefinition};
     use crate::types::{ReasoningPresetAction, ReasoningPresetDescriptor};
     use axum::extract::State;
     use axum::http::header::CONTENT_TYPE;
@@ -671,6 +696,69 @@ mod tests {
         let mut client = make_test_client(format, None);
         client.config.custom_request_body_mode = Some("trim".to_string());
         client
+    }
+
+    fn structured_output_context() -> ModelRequestContext {
+        ModelRequestContext {
+            prompt_cache_route_key: None,
+            output_schema: Some(json!({
+                "type": "object",
+                "properties": { "summary": { "type": "string" } }
+            })),
+        }
+    }
+
+    #[test]
+    fn provider_request_bodies_map_turn_output_schema() {
+        let context = structured_output_context();
+        let chat = openai::chat::build_request_body_with_context(
+            &make_test_client("openai", None),
+            "https://example.com/v1/chat/completions",
+            Vec::new(),
+            None,
+            Some(json!({ "response_format": { "type": "text" } })),
+            Some(&context),
+        );
+        assert_eq!(chat["response_format"]["type"], "json_schema");
+        assert_eq!(
+            chat["response_format"]["json_schema"]["schema"],
+            context.output_schema.clone().unwrap()
+        );
+
+        let anthropic = anthropic::request::build_request_body_with_context(
+            &make_test_client("anthropic", None),
+            "https://api.anthropic.com/v1/messages",
+            None,
+            Vec::new(),
+            None,
+            Some(json!({ "output_config": { "effort": "high" } })),
+            Some(&context),
+        );
+        assert_eq!(anthropic["output_config"]["effort"], "high");
+        assert_eq!(
+            anthropic["output_config"]["format"]["schema"],
+            context.output_schema.clone().unwrap()
+        );
+
+        let gemini = gemini::request::build_request_body_with_context(
+            &make_test_client("gemini", None),
+            None,
+            Vec::new(),
+            None,
+            Some(json!({
+                "responseMimeType": "text/plain",
+                "responseJsonSchema": { "type": "string" }
+            })),
+            Some(&context),
+        );
+        assert_eq!(
+            gemini["generationConfig"]["responseMimeType"],
+            "application/json"
+        );
+        assert_eq!(
+            gemini["generationConfig"]["responseJsonSchema"],
+            context.output_schema.unwrap()
+        );
     }
 
     fn reasoning_preset(

--- a/src/crates/adapters/ai-adapters/src/providers/anthropic/request.rs
+++ b/src/crates/adapters/ai-adapters/src/providers/anthropic/request.rs
@@ -9,7 +9,9 @@ use crate::client::{AIClient, StreamResponse};
 use crate::providers::shared;
 use crate::stream::handle_anthropic_stream;
 use crate::trace::ModelExchangeTraceConfig;
-use crate::types::{Message, ReasoningPresetAction, ReasoningPresetDescriptor, ToolDefinition};
+use crate::types::{
+    Message, ModelRequestContext, ReasoningPresetAction, ReasoningPresetDescriptor, ToolDefinition,
+};
 use anyhow::{anyhow, Result};
 use log::debug;
 use reqwest::RequestBuilder;
@@ -267,13 +269,14 @@ fn compile_reasoning_action(
     }
 }
 
-pub(crate) fn try_build_request_body(
+fn try_build_request_body_with_context(
     client: &AIClient,
     url: &str,
     system_message: Option<String>,
     anthropic_messages: Vec<serde_json::Value>,
     anthropic_tools: Option<Vec<serde_json::Value>>,
     extra_body: Option<serde_json::Value>,
+    request_context: Option<&ModelRequestContext>,
 ) -> Result<serde_json::Value> {
     let max_tokens = client.config.max_tokens.unwrap_or(32000);
 
@@ -357,6 +360,15 @@ pub(crate) fn try_build_request_body(
             },
         )?;
     }
+    if let Some(schema) = request_context.and_then(|context| context.output_schema.as_ref()) {
+        if !request_body["output_config"].is_object() {
+            request_body["output_config"] = serde_json::json!({});
+        }
+        request_body["output_config"]["format"] = serde_json::json!({
+            "type": "json_schema",
+            "schema": schema
+        });
+    }
 
     shared::log_request_body(
         "ai::anthropic_stream_request",
@@ -381,6 +393,25 @@ pub(crate) fn try_build_request_body(
     Ok(request_body)
 }
 
+pub(crate) fn try_build_request_body(
+    client: &AIClient,
+    url: &str,
+    system_message: Option<String>,
+    anthropic_messages: Vec<serde_json::Value>,
+    anthropic_tools: Option<Vec<serde_json::Value>>,
+    extra_body: Option<serde_json::Value>,
+) -> Result<serde_json::Value> {
+    try_build_request_body_with_context(
+        client,
+        url,
+        system_message,
+        anthropic_messages,
+        anthropic_tools,
+        extra_body,
+        None,
+    )
+}
+
 #[cfg(test)]
 pub(crate) fn build_request_body(
     client: &AIClient,
@@ -401,6 +432,28 @@ pub(crate) fn build_request_body(
     .expect("request body should compile")
 }
 
+#[cfg(test)]
+pub(crate) fn build_request_body_with_context(
+    client: &AIClient,
+    url: &str,
+    system_message: Option<String>,
+    anthropic_messages: Vec<serde_json::Value>,
+    anthropic_tools: Option<Vec<serde_json::Value>>,
+    extra_body: Option<serde_json::Value>,
+    request_context: Option<&ModelRequestContext>,
+) -> serde_json::Value {
+    try_build_request_body_with_context(
+        client,
+        url,
+        system_message,
+        anthropic_messages,
+        anthropic_tools,
+        extra_body,
+        request_context,
+    )
+    .expect("request body should compile")
+}
+
 pub(crate) async fn send_stream(
     client: &AIClient,
     messages: Vec<Message>,
@@ -408,6 +461,7 @@ pub(crate) async fn send_stream(
     extra_body: Option<serde_json::Value>,
     max_tries: usize,
     trace: Option<ModelExchangeTraceConfig>,
+    request_context: Option<ModelRequestContext>,
 ) -> Result<StreamResponse> {
     let url = client.config.request_url.clone();
     debug!(
@@ -418,13 +472,14 @@ pub(crate) async fn send_stream(
     let (system_message, anthropic_messages) =
         AnthropicMessageConverter::convert_messages(messages);
     let anthropic_tools = AnthropicMessageConverter::convert_tools(tools);
-    let request_body = try_build_request_body(
+    let request_body = try_build_request_body_with_context(
         client,
         &url,
         system_message,
         anthropic_messages,
         anthropic_tools,
         extra_body,
+        request_context.as_ref(),
     )?;
     let inline_think_in_text = client.config.inline_think_in_text;
     let idle_timeout = client.stream_options.idle_timeout;

--- a/src/crates/adapters/ai-adapters/src/providers/gemini/request.rs
+++ b/src/crates/adapters/ai-adapters/src/providers/gemini/request.rs
@@ -4,7 +4,9 @@ use crate::client::{AIClient, StreamResponse};
 use crate::providers::shared;
 use crate::stream::handle_gemini_stream;
 use crate::trace::ModelExchangeTraceConfig;
-use crate::types::{Message, ReasoningPresetAction, ReasoningPresetDescriptor, ToolDefinition};
+use crate::types::{
+    Message, ModelRequestContext, ReasoningPresetAction, ReasoningPresetDescriptor, ToolDefinition,
+};
 use anyhow::{anyhow, Result};
 use log::debug;
 use reqwest::RequestBuilder;
@@ -265,12 +267,13 @@ fn translate_extra_body(
     }
 }
 
-pub(crate) fn try_build_request_body(
+fn try_build_request_body_with_context(
     client: &AIClient,
     system_instruction: Option<serde_json::Value>,
     contents: Vec<serde_json::Value>,
     gemini_tools: Option<Vec<serde_json::Value>>,
     extra_body: Option<serde_json::Value>,
+    request_context: Option<&ModelRequestContext>,
 ) -> Result<serde_json::Value> {
     let mut request_body = serde_json::json!({
         "contents": contents,
@@ -398,6 +401,18 @@ pub(crate) fn try_build_request_body(
             },
         )?;
     }
+    if let Some(schema) = request_context.and_then(|context| context.output_schema.as_ref()) {
+        insert_generation_field(
+            &mut request_body,
+            "responseMimeType",
+            serde_json::json!("application/json"),
+        );
+        insert_generation_field(
+            &mut request_body,
+            "responseJsonSchema",
+            GeminiMessageConverter::sanitize_schema(schema.clone()),
+        );
+    }
 
     shared::log_request_body(
         "ai::gemini_stream_request",
@@ -406,6 +421,23 @@ pub(crate) fn try_build_request_body(
     );
 
     Ok(request_body)
+}
+
+pub(crate) fn try_build_request_body(
+    client: &AIClient,
+    system_instruction: Option<serde_json::Value>,
+    contents: Vec<serde_json::Value>,
+    gemini_tools: Option<Vec<serde_json::Value>>,
+    extra_body: Option<serde_json::Value>,
+) -> Result<serde_json::Value> {
+    try_build_request_body_with_context(
+        client,
+        system_instruction,
+        contents,
+        gemini_tools,
+        extra_body,
+        None,
+    )
 }
 
 #[cfg(test)]
@@ -426,6 +458,26 @@ pub(crate) fn build_request_body(
     .expect("request body should compile")
 }
 
+#[cfg(test)]
+pub(crate) fn build_request_body_with_context(
+    client: &AIClient,
+    system_instruction: Option<serde_json::Value>,
+    contents: Vec<serde_json::Value>,
+    gemini_tools: Option<Vec<serde_json::Value>>,
+    extra_body: Option<serde_json::Value>,
+    request_context: Option<&ModelRequestContext>,
+) -> serde_json::Value {
+    try_build_request_body_with_context(
+        client,
+        system_instruction,
+        contents,
+        gemini_tools,
+        extra_body,
+        request_context,
+    )
+    .expect("request body should compile")
+}
+
 pub(crate) async fn send_stream(
     client: &AIClient,
     messages: Vec<Message>,
@@ -433,6 +485,7 @@ pub(crate) async fn send_stream(
     extra_body: Option<serde_json::Value>,
     max_tries: usize,
     trace: Option<ModelExchangeTraceConfig>,
+    request_context: Option<ModelRequestContext>,
 ) -> Result<StreamResponse> {
     let url = resolve_request_url(&client.config.request_url, &client.config.model);
     debug!(
@@ -443,12 +496,13 @@ pub(crate) async fn send_stream(
     let (system_instruction, contents) =
         GeminiMessageConverter::convert_messages(messages, &client.config.model);
     let gemini_tools = GeminiMessageConverter::convert_tools(tools);
-    let request_body = try_build_request_body(
+    let request_body = try_build_request_body_with_context(
         client,
         system_instruction,
         contents,
         gemini_tools,
         extra_body,
+        request_context.as_ref(),
     )?;
     let idle_timeout = client.stream_options.idle_timeout;
     let ttft_timeout = client.stream_options.ttft_timeout;

--- a/src/crates/adapters/ai-adapters/src/providers/openai/chat.rs
+++ b/src/crates/adapters/ai-adapters/src/providers/openai/chat.rs
@@ -5,16 +5,17 @@ use crate::client::{AIClient, StreamResponse};
 use crate::providers::shared;
 use crate::stream::handle_openai_stream;
 use crate::trace::ModelExchangeTraceConfig;
-use crate::types::{Message, ToolDefinition};
+use crate::types::{Message, ModelRequestContext, ToolDefinition};
 use anyhow::Result;
 use log::{debug, warn};
 
-pub(crate) fn try_build_request_body(
+fn try_build_request_body_with_context(
     client: &AIClient,
     url: &str,
     openai_messages: Vec<serde_json::Value>,
     openai_tools: Option<Vec<serde_json::Value>>,
     extra_body: Option<serde_json::Value>,
+    request_context: Option<&ModelRequestContext>,
 ) -> Result<serde_json::Value> {
     let mut request_body = serde_json::json!({
         "model": client.config.model,
@@ -112,6 +113,16 @@ pub(crate) fn try_build_request_body(
             );
         }
     }
+    if let Some(schema) = request_context.and_then(|context| context.output_schema.as_ref()) {
+        request_body["response_format"] = serde_json::json!({
+            "type": "json_schema",
+            "json_schema": {
+                "name": "bitfun_output",
+                "strict": true,
+                "schema": schema
+            }
+        });
+    }
 
     shared::log_request_body(
         "ai::openai_stream_request",
@@ -122,6 +133,23 @@ pub(crate) fn try_build_request_body(
     common::attach_tools(&mut request_body, openai_tools, "ai::openai_stream_request");
 
     Ok(request_body)
+}
+
+pub(crate) fn try_build_request_body(
+    client: &AIClient,
+    url: &str,
+    openai_messages: Vec<serde_json::Value>,
+    openai_tools: Option<Vec<serde_json::Value>>,
+    extra_body: Option<serde_json::Value>,
+) -> Result<serde_json::Value> {
+    try_build_request_body_with_context(
+        client,
+        url,
+        openai_messages,
+        openai_tools,
+        extra_body,
+        None,
+    )
 }
 
 #[cfg(test)]
@@ -136,6 +164,26 @@ pub(crate) fn build_request_body(
         .expect("request body should compile")
 }
 
+#[cfg(test)]
+pub(crate) fn build_request_body_with_context(
+    client: &AIClient,
+    url: &str,
+    openai_messages: Vec<serde_json::Value>,
+    openai_tools: Option<Vec<serde_json::Value>>,
+    extra_body: Option<serde_json::Value>,
+    request_context: Option<&ModelRequestContext>,
+) -> serde_json::Value {
+    try_build_request_body_with_context(
+        client,
+        url,
+        openai_messages,
+        openai_tools,
+        extra_body,
+        request_context,
+    )
+    .expect("request body should compile")
+}
+
 pub(crate) async fn send_stream(
     client: &AIClient,
     messages: Vec<Message>,
@@ -143,6 +191,7 @@ pub(crate) async fn send_stream(
     extra_body: Option<serde_json::Value>,
     max_tries: usize,
     trace: Option<ModelExchangeTraceConfig>,
+    request_context: Option<ModelRequestContext>,
 ) -> Result<StreamResponse> {
     let url = client.config.request_url.clone();
     debug!(
@@ -152,8 +201,14 @@ pub(crate) async fn send_stream(
 
     let openai_messages = OpenAIMessageConverter::convert_messages(messages);
     let openai_tools = OpenAIMessageConverter::convert_tools(tools);
-    let request_body =
-        try_build_request_body(client, &url, openai_messages, openai_tools, extra_body)?;
+    let request_body = try_build_request_body_with_context(
+        client,
+        &url,
+        openai_messages,
+        openai_tools,
+        extra_body,
+        request_context.as_ref(),
+    )?;
     let inline_think_in_text = client.config.inline_think_in_text;
     let idle_timeout = client.stream_options.idle_timeout;
     let ttft_timeout = client.stream_options.ttft_timeout;

--- a/src/crates/adapters/ai-adapters/src/providers/openai/responses.rs
+++ b/src/crates/adapters/ai-adapters/src/providers/openai/responses.rs
@@ -177,6 +177,14 @@ fn try_build_request_body_with_context(
         shared::apply_reasoning_actions(preset, &mut request_body, protected_keys, &[], compile)?;
     }
     ensure_reasoning_summary_opt_in(&mut request_body);
+    if let Some(schema) = request_context.and_then(|context| context.output_schema.as_ref()) {
+        request_body["text"]["format"] = serde_json::json!({
+            "type": "json_schema",
+            "name": "bitfun_output",
+            "strict": true,
+            "schema": schema
+        });
+    }
 
     shared::log_request_body(
         TARGET,
@@ -436,6 +444,7 @@ mod tests {
         let client = test_client();
         let request_context = ModelRequestContext {
             prompt_cache_route_key: Some("lineage-1".to_string()),
+            output_schema: None,
         };
         let request_body = build_request_body_with_context(
             &client,
@@ -447,5 +456,28 @@ mod tests {
         );
 
         assert_eq!(request_body["prompt_cache_key"], json!("lineage-1"));
+    }
+
+    #[test]
+    fn attaches_turn_output_schema_after_custom_body_merge() {
+        let schema = json!({
+            "type": "object",
+            "properties": { "summary": { "type": "string" } }
+        });
+        let request_context = ModelRequestContext {
+            prompt_cache_route_key: None,
+            output_schema: Some(schema.clone()),
+        };
+        let request_body = build_request_body_with_context(
+            &test_client(),
+            None,
+            Vec::new(),
+            None,
+            Some(json!({ "text": { "format": { "type": "text" } } })),
+            Some(&request_context),
+        );
+
+        assert_eq!(request_body["text"]["format"]["type"], "json_schema");
+        assert_eq!(request_body["text"]["format"]["schema"], schema);
     }
 }

--- a/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/coordinator.rs
@@ -112,7 +112,7 @@ use bitfun_runtime_ports::{
     PermissionDelegationContext, PermissionMode, PermissionModeLayers, PermissionRuntimeCeiling,
     RemoteExecPort, ResolvedPermissionMode, SessionStoragePathRequest,
     SessionStoragePathResolution, SessionStorePort, SubagentContextMode, TerminalPort, ThreadGoal,
-    ThreadGoalContinuationPlan, ThreadGoalStatus,
+    ThreadGoalContinuationPlan, ThreadGoalStatus, OUTPUT_SCHEMA_CONTEXT_KEY,
 };
 use bitfun_services_core::filesystem::{FileSearchOptions, FileSystemService, FileTreeNode};
 use bitfun_services_core::workspace_text::{
@@ -1679,6 +1679,19 @@ impl ConversationCoordinator {
             Some(value) if value.is_object() => value,
             Some(value) => serde_json::json!({ "raw_metadata": value }),
             None => serde_json::json!({}),
+        }
+    }
+
+    fn copy_output_schema_context(
+        context: &mut HashMap<String, String>,
+        metadata: Option<&serde_json::Value>,
+    ) {
+        if let Some(schema) = metadata
+            .and_then(serde_json::Value::as_object)
+            .and_then(|metadata| metadata.get(OUTPUT_SCHEMA_CONTEXT_KEY))
+            .filter(|schema| schema.is_object())
+        {
+            context.insert(OUTPUT_SCHEMA_CONTEXT_KEY.to_string(), schema.to_string());
         }
     }
 
@@ -6415,6 +6428,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                 auto_approve_ask.to_string(),
             );
         }
+        Self::copy_output_schema_context(&mut context_vars, user_message_metadata.as_ref());
         if needs_computer_links_for_source(submission_policy.trigger_source) {
             context_vars.insert(
                 TOOL_CONTEXT_REMOTE_FILE_DELIVERY_KEY.to_string(),
@@ -6930,6 +6944,7 @@ Update the persona files and delete BOOTSTRAP.md as soon as bootstrap is complet
                 auto_approve_ask.to_string(),
             );
         }
+        Self::copy_output_schema_context(&mut context_vars, plan.user_message_metadata.as_ref());
 
         let execution_context = ExecutionContext {
             session_id: plan.session_id.clone(),

--- a/src/crates/assembly/core/src/agentic/coordination/scheduler.rs
+++ b/src/crates/assembly/core/src/agentic/coordination/scheduler.rs
@@ -2622,6 +2622,27 @@ fn agent_dialog_turn_prepended_messages(
         .collect()
 }
 
+fn agent_dialog_turn_metadata(
+    mut metadata: serde_json::Map<String, serde_json::Value>,
+    output_schema: Option<serde_json::Value>,
+) -> PortResult<Option<serde_json::Value>> {
+    metadata.remove(bitfun_runtime_ports::OUTPUT_SCHEMA_CONTEXT_KEY);
+    if let Some(output_schema) = output_schema {
+        if !output_schema.is_object() {
+            return Err(PortError::new(
+                PortErrorKind::InvalidRequest,
+                "Output schema must be a JSON object",
+            ));
+        }
+        metadata.insert(
+            bitfun_runtime_ports::OUTPUT_SCHEMA_CONTEXT_KEY.to_string(),
+            output_schema,
+        );
+    }
+
+    Ok((!metadata.is_empty()).then_some(serde_json::Value::Object(metadata)))
+}
+
 impl DialogScheduler {
     pub(crate) async fn submit_agent_dialog_turn_reject_if_busy(
         &self,
@@ -2674,11 +2695,8 @@ impl DialogScheduler {
         let image_contexts = agent_dialog_turn_image_contexts(&request.attachments)?;
         let prepended_messages =
             agent_dialog_turn_prepended_messages(&request.prepended_reminders)?;
-        let user_message_metadata = if request.metadata.is_empty() {
-            None
-        } else {
-            Some(serde_json::Value::Object(request.metadata))
-        };
+        let user_message_metadata =
+            agent_dialog_turn_metadata(request.metadata, request.output_schema)?;
         let resolved_turn_id = request
             .turn_id
             .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
@@ -3128,6 +3146,42 @@ mod tests {
         .into_port_error();
 
         assert_eq!(error.kind, PortErrorKind::SessionInUse);
+    }
+
+    #[test]
+    fn output_schema_field_owns_reserved_metadata_key() {
+        let mut metadata = serde_json::Map::new();
+        metadata.insert(
+            bitfun_runtime_ports::OUTPUT_SCHEMA_CONTEXT_KEY.to_string(),
+            serde_json::json!({ "type": "string" }),
+        );
+
+        assert_eq!(
+            agent_dialog_turn_metadata(metadata.clone(), None).unwrap(),
+            None
+        );
+
+        let schema = serde_json::json!({ "type": "object" });
+        let merged = agent_dialog_turn_metadata(metadata, Some(schema.clone())).unwrap();
+        assert_eq!(
+            merged
+                .and_then(|value| value.as_object().cloned())
+                .and_then(|metadata| metadata
+                    .get(bitfun_runtime_ports::OUTPUT_SCHEMA_CONTEXT_KEY)
+                    .cloned()),
+            Some(schema)
+        );
+    }
+
+    #[test]
+    fn output_schema_requires_an_object_root() {
+        let error = agent_dialog_turn_metadata(
+            serde_json::Map::new(),
+            Some(serde_json::json!(["not", "an", "object"])),
+        )
+        .expect_err("array schema root must be rejected");
+
+        assert_eq!(error.kind, PortErrorKind::InvalidRequest);
     }
 
     fn test_scheduler() -> (
@@ -3739,6 +3793,7 @@ mod tests {
             .submit_dialog_turn(AgentDialogTurnRequest {
                 session_id: "missing-session".to_string(),
                 message: "hello".to_string(),
+                output_schema: None,
                 original_message: None,
                 turn_id: Some("missing-turn".to_string()),
                 execution: Default::default(),
@@ -3804,6 +3859,7 @@ mod tests {
             .submit_dialog_turn(AgentDialogTurnRequest {
                 session_id: session_id.to_string(),
                 message: "queued prompt".to_string(),
+                output_schema: None,
                 original_message: None,
                 turn_id: Some(turn_id.to_string()),
                 execution: Default::default(),
@@ -3879,6 +3935,7 @@ mod tests {
             .submit_dialog_turn(AgentDialogTurnRequest {
                 session_id: session_id.to_string(),
                 message: "expanded command prompt".to_string(),
+                output_schema: None,
                 original_message: Some("/review".to_string()),
                 turn_id: Some("delegated-turn".to_string()),
                 execution: bitfun_runtime_ports::AgentDialogTurnExecution::FreshExternalSubagent {
@@ -3936,6 +3993,7 @@ mod tests {
             .submit_dialog_turn(AgentDialogTurnRequest {
                 session_id: session_id.to_string(),
                 message: "queued prompt".to_string(),
+                output_schema: None,
                 original_message: None,
                 turn_id: Some("queued-turn".to_string()),
                 execution: Default::default(),
@@ -3966,6 +4024,7 @@ mod tests {
             .submit_dialog_turn(AgentDialogTurnRequest {
                 session_id: session_id.to_string(),
                 message: "expanded command prompt".to_string(),
+                output_schema: None,
                 original_message: Some("/review".to_string()),
                 turn_id: Some("delegated-turn".to_string()),
                 execution: bitfun_runtime_ports::AgentDialogTurnExecution::FreshExternalSubagent {
@@ -4027,6 +4086,7 @@ mod tests {
             .submit_agent_dialog_turn_reject_if_busy(AgentDialogTurnRequest {
                 session_id: session_id.to_string(),
                 message: "second prompt".to_string(),
+                output_schema: None,
                 original_message: None,
                 turn_id: Some("rejected-turn".to_string()),
                 execution: Default::default(),
@@ -4099,6 +4159,7 @@ mod tests {
             .submit_dialog_turn(AgentDialogTurnRequest {
                 session_id: session_id.to_string(),
                 message: "duplicate".to_string(),
+                output_schema: None,
                 original_message: None,
                 turn_id: Some(turn_id.to_string()),
                 execution: Default::default(),
@@ -4143,6 +4204,7 @@ mod tests {
             .submit_dialog_turn(AgentDialogTurnRequest {
                 session_id: session_id.to_string(),
                 message: "wrong workspace".to_string(),
+                output_schema: None,
                 original_message: None,
                 turn_id: Some(turn_id.to_string()),
                 execution: Default::default(),
@@ -4193,6 +4255,7 @@ mod tests {
             .submit_dialog_turn(AgentDialogTurnRequest {
                 session_id: session_id.to_string(),
                 message: "invalid agent".to_string(),
+                output_schema: None,
                 original_message: None,
                 turn_id: Some(turn_id.to_string()),
                 execution: Default::default(),

--- a/src/crates/assembly/core/src/agentic/execution/execution_engine.rs
+++ b/src/crates/assembly/core/src/agentic/execution/execution_engine.rs
@@ -562,9 +562,15 @@ impl ExecutionEngine {
     const FINALIZE_USER_FOLLOWUP: &'static str =
         "Provide a final answer. You MUST not call any tools.";
 
-    fn model_request_context(prompt_cache_lineage_id: &str) -> ModelRequestContext {
+    fn model_request_context(
+        prompt_cache_lineage_id: &str,
+        context: &HashMap<String, String>,
+    ) -> ModelRequestContext {
         ModelRequestContext {
             prompt_cache_route_key: Some(prompt_cache_lineage_id.to_string()),
+            output_schema: context
+                .get(bitfun_runtime_ports::OUTPUT_SCHEMA_CONTEXT_KEY)
+                .and_then(|schema| serde_json::from_str(schema).ok()),
         }
     }
 
@@ -2608,8 +2614,10 @@ impl ExecutionEngine {
         };
         Self::validate_frozen_model_contract(context).await?;
         Self::validate_frozen_reasoning_contract(context, ai_client.as_ref())?;
-        let model_request_context =
-            Self::model_request_context(session.effective_prompt_cache_lineage_id());
+        let model_request_context = Self::model_request_context(
+            session.effective_prompt_cache_lineage_id(),
+            &context.context,
+        );
 
         let primary_model_facts = Self::resolve_primary_model_context(
             &model_id,
@@ -3530,8 +3538,10 @@ impl ExecutionEngine {
         };
         Self::validate_frozen_model_contract(&context).await?;
         Self::validate_frozen_reasoning_contract(&context, ai_client.as_ref())?;
-        let model_request_context =
-            Self::model_request_context(session.effective_prompt_cache_lineage_id());
+        let model_request_context = Self::model_request_context(
+            session.effective_prompt_cache_lineage_id(),
+            &context.context,
+        );
 
         // Primary model vision capability (tools + system prompt appendix; also used below for API message stripping).
         let primary_model_facts = Self::resolve_primary_model_context(
@@ -6555,9 +6565,10 @@ mod tests {
 
     #[test]
     fn provider_prompt_cache_route_key_depends_only_on_lineage() {
-        let first = ExecutionEngine::model_request_context("session-1");
-        let same_lineage = ExecutionEngine::model_request_context("session-1");
-        let changed_lineage = ExecutionEngine::model_request_context("session-2");
+        let context = HashMap::new();
+        let first = ExecutionEngine::model_request_context("session-1", &context);
+        let same_lineage = ExecutionEngine::model_request_context("session-1", &context);
+        let changed_lineage = ExecutionEngine::model_request_context("session-2", &context);
 
         assert_eq!(first.prompt_cache_route_key.as_deref(), Some("session-1"));
         assert_eq!(
@@ -6568,6 +6579,23 @@ mod tests {
             first.prompt_cache_route_key,
             changed_lineage.prompt_cache_route_key
         );
+    }
+
+    #[test]
+    fn model_request_context_reads_one_turn_output_schema() {
+        let schema = json!({
+            "type": "object",
+            "properties": { "summary": { "type": "string" } }
+        });
+        let mut context = HashMap::new();
+        context.insert(
+            bitfun_runtime_ports::OUTPUT_SCHEMA_CONTEXT_KEY.to_string(),
+            schema.to_string(),
+        );
+
+        let request_context = ExecutionEngine::model_request_context("session-1", &context);
+
+        assert_eq!(request_context.output_schema, Some(schema));
     }
 
     fn command_result(tool_name: &str, success: bool, exit_code: Option<i32>) -> Message {

--- a/src/crates/assembly/core/src/agentic/tools/implementations/session_message_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/session_message_tool.rs
@@ -695,6 +695,7 @@ Allowed agent types when creating a session:
             .submit_dialog_turn(AgentDialogTurnRequest {
                 session_id: target_session_id.clone(),
                 message: forwarded_message,
+                output_schema: None,
                 original_message: Some(params.message.clone()),
                 turn_id: None,
                 execution: Default::default(),

--- a/src/crates/assembly/core/src/service/cron/service.rs
+++ b/src/crates/assembly/core/src/service/cron/service.rs
@@ -564,6 +564,7 @@ impl CronService {
             .submit_dialog_turn(AgentDialogTurnRequest {
                 session_id: resolved.session_id,
                 message: enqueue_input.user_input.clone(),
+                output_schema: None,
                 original_message: Some(enqueue_input.user_input.clone()),
                 turn_id: Some(enqueue_input.turn_id.clone()),
                 execution: Default::default(),

--- a/src/crates/assembly/core/src/service_agent_runtime.rs
+++ b/src/crates/assembly/core/src/service_agent_runtime.rs
@@ -2156,6 +2156,7 @@ impl RemoteDialogRuntimeHost for CoreRemoteDialogRuntimeHost<'_> {
             .submit_dialog_turn(AgentDialogTurnRequest {
                 session_id: submission.session_id,
                 message: submission.content,
+                output_schema: None,
                 original_message: None,
                 turn_id: Some(submission.turn_id),
                 execution: Default::default(),

--- a/src/crates/contracts/core-types/src/ai.rs
+++ b/src/crates/contracts/core-types/src/ai.rs
@@ -653,6 +653,8 @@ pub struct AIConfig {
 pub struct ModelRequestContext {
     /// Stable, opaque routing identity for provider-side prompt-prefix caches.
     pub prompt_cache_route_key: Option<String>,
+    /// JSON Schema requested for this turn's final model output.
+    pub output_schema: Option<Value>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/crates/contracts/runtime-ports/src/agent_api.rs
+++ b/src/crates/contracts/runtime-ports/src/agent_api.rs
@@ -1,5 +1,9 @@
 use super::*;
 
+/// Reserved turn metadata/context key used to carry a provider-neutral JSON
+/// output schema through persistence and interrupted-turn recovery.
+pub const OUTPUT_SCHEMA_CONTEXT_KEY: &str = "bitfun_output_schema";
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 #[serde(rename_all = "camelCase")]
@@ -585,6 +589,8 @@ impl Default for AgentDialogTurnExecution {
 pub struct AgentDialogTurnRequest {
     pub session_id: String,
     pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_schema: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub original_message: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2957,6 +2963,7 @@ mod tests {
         let request = AgentDialogTurnRequest {
             session_id: "session_1".to_string(),
             message: "hello".to_string(),
+            output_schema: Some(serde_json::json!({ "type": "object" })),
             original_message: Some("raw hello".to_string()),
             turn_id: Some("turn_1".to_string()),
             execution: Default::default(),
@@ -2990,6 +2997,7 @@ mod tests {
 
         assert_eq!(json["sessionId"], "session_1");
         assert_eq!(json["message"], "hello");
+        assert_eq!(json["outputSchema"]["type"], "object");
         assert_eq!(json["originalMessage"], "raw hello");
         assert_eq!(json["turnId"], "turn_1");
         assert_eq!(json["agentType"], "agentic");

--- a/src/crates/execution/agent-runtime/src/runtime.rs
+++ b/src/crates/execution/agent-runtime/src/runtime.rs
@@ -3512,6 +3512,7 @@ mod tests {
             .submit_dialog_turn(AgentDialogTurnRequest {
                 session_id: "session_1".to_string(),
                 message: "hello".to_string(),
+                output_schema: None,
                 original_message: None,
                 turn_id: Some("turn_1".to_string()),
                 execution: Default::default(),
@@ -3567,6 +3568,7 @@ mod tests {
             .submit_dialog_turn(AgentDialogTurnRequest {
                 session_id: "session_1".to_string(),
                 message: "hello".to_string(),
+                output_schema: None,
                 original_message: Some("hello".to_string()),
                 turn_id: Some("turn_1".to_string()),
                 execution: Default::default(),
@@ -3686,6 +3688,7 @@ mod tests {
             .submit_dialog_turn(AgentDialogTurnRequest {
                 session_id: "requested-session".to_string(),
                 message: "hello".to_string(),
+                output_schema: None,
                 original_message: None,
                 turn_id: Some("turn-1".to_string()),
                 execution: Default::default(),

--- a/src/crates/interfaces/acp/src/runtime/prompt.rs
+++ b/src/crates/interfaces/acp/src/runtime/prompt.rs
@@ -104,6 +104,7 @@ fn dialog_turn_request(session: &AcpSessionState, prompt: ParsedPrompt) -> Agent
     AgentDialogTurnRequest {
         session_id: session.bitfun_session_id.clone(),
         message: prompt.user_message,
+        output_schema: None,
         original_message: prompt.original_user_message,
         turn_id: None,
         execution: Default::default(),

--- a/src/crates/interfaces/app-server-protocol/src/schemas/agent.rs
+++ b/src/crates/interfaces/app-server-protocol/src/schemas/agent.rs
@@ -150,6 +150,7 @@ impl SubmitDialogTurnBody {
         AgentDialogTurnRequest {
             session_id: self.session_id,
             message: self.message,
+            output_schema: None,
             original_message: self.original_message,
             turn_id: self.turn_id,
             execution: self.execution,

--- a/src/crates/interfaces/sdk-host/src/host.rs
+++ b/src/crates/interfaces/sdk-host/src/host.rs
@@ -236,6 +236,7 @@ struct QueryLease {
     turn_id: String,
     operation_id: String,
     output: StdMutex<QueryOutputBuffer>,
+    structured_output_requested: bool,
     usage: StdMutex<Option<TurnTokenUsage>>,
     terminal: AtomicBool,
     stop_forwarding: CancellationToken,
@@ -248,6 +249,34 @@ struct QueryLease {
 struct QueryOutputBuffer {
     text: String,
     wire_bytes: usize,
+    structured_attempt: Option<QueryOutputAttempt>,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+struct QueryOutputAttempt {
+    round_id: String,
+    attempt_id: Option<String>,
+    attempt_index: Option<u32>,
+}
+
+impl QueryOutputBuffer {
+    fn append(&mut self, text: &str, structured_attempt: Option<QueryOutputAttempt>) -> bool {
+        if let Some(attempt) = structured_attempt {
+            if self.structured_attempt.as_ref() != Some(&attempt) {
+                self.text.clear();
+                self.wire_bytes = 0;
+                self.structured_attempt = Some(attempt);
+            }
+        }
+
+        let encoded_bytes = json_string_content_bytes(text);
+        if encoded_bytes > MAX_QUERY_OUTPUT_WIRE_BYTES.saturating_sub(self.wire_bytes) {
+            return false;
+        }
+        self.text.push_str(text);
+        self.wire_bytes += encoded_bytes;
+        true
+    }
 }
 
 impl QueryLease {
@@ -1127,6 +1156,19 @@ impl SdkHostConnection {
             .await;
             return;
         }
+        if params
+            .output_schema
+            .as_ref()
+            .is_some_and(|schema| !schema.is_object())
+        {
+            self.send_invalid_params(
+                request.id.clone(),
+                ErrorStage::Query,
+                "outputSchema must be a JSON object",
+            )
+            .await;
+            return;
+        }
         if params.session_id.is_some()
             && (params.session_name.is_some()
                 || params.agent.is_some()
@@ -1321,6 +1363,7 @@ impl SdkHostConnection {
             .submit_dialog_turn(AgentDialogTurnRequest {
                 session_id: session_id.clone(),
                 message: params.prompt,
+                output_schema: params.output_schema.clone(),
                 original_message: None,
                 turn_id: None,
                 execution: Default::default(),
@@ -1367,6 +1410,7 @@ impl SdkHostConnection {
             turn_id: turn_id.clone(),
             operation_id: operation_id.clone(),
             output: StdMutex::new(QueryOutputBuffer::default()),
+            structured_output_requested: params.output_schema.is_some(),
             usage: StdMutex::new(None),
             terminal: AtomicBool::new(false),
             stop_forwarding: CancellationToken::new(),
@@ -1574,20 +1618,29 @@ impl SdkHostConnection {
                     if let Some(projected) = project_query_event(&envelope.event) {
                         if let QueryEvent::AssistantTextDelta { text } = &projected {
                             let output_exceeded = {
-                                let encoded_bytes = json_string_content_bytes(text);
                                 let mut output = lease
                                     .output
                                     .lock()
                                     .expect("SDK Host Query output lock poisoned");
-                                if encoded_bytes
-                                    > MAX_QUERY_OUTPUT_WIRE_BYTES.saturating_sub(output.wire_bytes)
-                                {
-                                    true
-                                } else {
-                                    output.text.push_str(text);
-                                    output.wire_bytes += encoded_bytes;
-                                    false
-                                }
+                                let structured_attempt =
+                                    lease.structured_output_requested.then(|| {
+                                        match &envelope.event {
+                                            AgenticEvent::TextChunk {
+                                                round_id,
+                                                attempt_id,
+                                                attempt_index,
+                                                ..
+                                            } => QueryOutputAttempt {
+                                                round_id: round_id.clone(),
+                                                attempt_id: attempt_id.clone(),
+                                                attempt_index: *attempt_index,
+                                            },
+                                            _ => unreachable!(
+                                                "assistant text projection requires TextChunk"
+                                            ),
+                                        }
+                                    });
+                                !output.append(text, structured_attempt)
                             };
                             if output_exceeded {
                                 connection
@@ -2600,14 +2653,11 @@ impl SdkHostConnection {
     async fn send_query_result(
         &self,
         lease: &QueryLease,
-        status: QueryTerminalStatus,
+        mut status: QueryTerminalStatus,
         mut error: Option<QueryResultError>,
     ) -> bool {
         if !lease.emit_output {
             return true;
-        }
-        if let Some(error) = error.as_mut() {
-            error.data.operation_id = Some(lease.operation_id.clone());
         }
         let output_text = lease
             .output
@@ -2615,6 +2665,25 @@ impl SdkHostConnection {
             .expect("SDK Host Query output lock poisoned")
             .text
             .clone();
+        let structured =
+            if lease.structured_output_requested && status == QueryTerminalStatus::Completed {
+                match serde_json::from_str(&output_text) {
+                    Ok(value) => Some(value),
+                    Err(_) => {
+                        status = QueryTerminalStatus::Failed;
+                        error = Some(QueryResultError::new(
+                            ErrorCode::Internal,
+                            false,
+                            None,
+                            &lease.query_id,
+                            "Model returned invalid JSON for the requested output schema",
+                        ));
+                        None
+                    }
+                }
+            } else {
+                None
+            };
         let usage = lease
             .usage
             .lock()
@@ -2626,6 +2695,9 @@ impl SdkHostConnection {
                 total_tokens: usage.total_tokens,
                 cached_tokens: usage.cached_tokens,
             });
+        if let Some(error) = error.as_mut() {
+            error.data.operation_id = Some(lease.operation_id.clone());
+        }
         self.send_notification(
             NOTIFICATION_QUERY_RESULT,
             QueryResultParams {
@@ -2634,7 +2706,10 @@ impl SdkHostConnection {
                 turn_id: lease.turn_id.clone(),
                 operation_id: lease.operation_id.clone(),
                 status,
-                output: QueryOutput { text: output_text },
+                output: QueryOutput {
+                    text: output_text,
+                    structured,
+                },
                 usage,
                 error,
             },
@@ -3333,7 +3408,10 @@ fn runtime_error_kind(error: &RuntimeError) -> &'static str {
 
 #[cfg(test)]
 mod runtime_error_tests {
-    use super::{is_local_image_path, runtime_error_facts, runtime_error_kind};
+    use super::{
+        is_local_image_path, runtime_error_facts, runtime_error_kind, QueryOutputAttempt,
+        QueryOutputBuffer,
+    };
     use crate::protocol::{ErrorCode, RecoveryAction};
     use bitfun_agent_runtime::sdk::{PortError, PortErrorKind, RuntimeError};
 
@@ -3343,6 +3421,31 @@ mod runtime_error_tests {
         assert!(!is_local_image_path("https://example.com/failure.png"));
         assert!(!is_local_image_path("screenshots/failure.svg"));
         assert!(!is_local_image_path("  "));
+    }
+
+    #[test]
+    fn structured_output_keeps_only_the_last_model_attempt() {
+        let attempt = |round_id: &str| QueryOutputAttempt {
+            round_id: round_id.to_string(),
+            attempt_id: Some(format!("{round_id}-attempt")),
+            attempt_index: Some(0),
+        };
+        let mut output = QueryOutputBuffer::default();
+
+        assert!(output.append(r#"{"draft":true}"#, Some(attempt("round-1"))));
+        assert!(output.append(r#"{"final":true}"#, Some(attempt("round-2"))));
+
+        assert_eq!(output.text, r#"{"final":true}"#);
+    }
+
+    #[test]
+    fn plain_output_still_aggregates_model_rounds() {
+        let mut output = QueryOutputBuffer::default();
+
+        assert!(output.append("first", None));
+        assert!(output.append("second", None));
+
+        assert_eq!(output.text, "firstsecond");
     }
 
     #[test]

--- a/src/crates/interfaces/sdk-host/src/protocol.rs
+++ b/src/crates/interfaces/sdk-host/src/protocol.rs
@@ -6,7 +6,7 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
 pub const JSON_RPC_VERSION: &str = "2.0";
-pub const PROTOCOL_VERSION: u32 = 5;
+pub const PROTOCOL_VERSION: u32 = 6;
 
 pub const METHOD_INITIALIZE: &str = "initialize";
 pub const METHOD_SESSION_CREATE: &str = "session/create";
@@ -291,7 +291,7 @@ impl HostCapabilities {
             event_stream: true,
             tool_events: true,
             image_input: true,
-            structured_output: false,
+            structured_output: true,
             usage: true,
             custom_tools: false,
             permission_responses: true,
@@ -466,6 +466,9 @@ pub struct QueryStartParams {
     pub prompt: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub images: Vec<String>,
+    #[cfg_attr(feature = "ts", ts(optional, type = "Record<string, unknown>"))]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_schema: Option<serde_json::Value>,
     #[cfg_attr(feature = "ts", ts(optional = nullable))]
     #[serde(default)]
     pub session_id: Option<String>,
@@ -698,6 +701,9 @@ pub struct QueryUsage {
 #[cfg_attr(feature = "ts", derive(ts_rs::TS), ts(export))]
 pub struct QueryOutput {
     pub text: String,
+    #[cfg_attr(feature = "ts", ts(optional, type = "unknown"))]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub structured: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/crates/interfaces/sdk-host/tests/host_lifecycle.rs
+++ b/src/crates/interfaces/sdk-host/tests/host_lifecycle.rs
@@ -823,6 +823,43 @@ async fn host_with_query_limit(
     )
 }
 
+async fn host_with_output(
+    output_text: &str,
+) -> (
+    SdkHostConnection,
+    Arc<FakeOwner>,
+    mpsc::Receiver<serde_json::Value>,
+) {
+    let queue = Arc::new(EventQueue::new(EventQueueConfig::default()));
+    let owner = Arc::new(FakeOwner::with_output(
+        queue.clone(),
+        output_text.to_string(),
+    ));
+    let runtime = AgentRuntimeBuilder::new()
+        .with_submission_port(owner.clone())
+        .with_dialog_turn_port(owner.clone())
+        .with_cancellation_port(owner.clone())
+        .with_turn_settlement_port(owner.clone())
+        .with_session_management_port(owner.clone())
+        .with_session_close_port(owner.clone())
+        .with_permission_request_manager(permission_manager())
+        .with_event_source(AgentEventSource::new(queue))
+        .build()
+        .unwrap();
+    let (output, receiver) = mpsc::channel(32);
+    (
+        SdkHostConnection::new(
+            runtime,
+            "D:/workspace/project",
+            output,
+            SdkHostConfig::default(),
+            fake_installer(),
+        ),
+        owner,
+        receiver,
+    )
+}
+
 #[async_trait]
 impl AgentTurnCancellationPort for FakeOwner {
     async fn cancel_turn(
@@ -1303,6 +1340,98 @@ async fn query_streams_existing_events_and_one_terminal_result() {
     assert_eq!(result["params"]["status"], "completed");
     assert_eq!(result["params"]["output"]["text"], "fixture result");
     assert!(output.try_recv().is_err(), "terminal result must be unique");
+}
+
+#[tokio::test]
+async fn query_passes_output_schema_to_runtime_and_returns_parsed_json() {
+    let (host, owner, mut output) = host_with_output(r#"{"summary":"ready"}"#).await;
+    initialize(&host, &mut output).await;
+    let schema = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "summary": { "type": "string" }
+        },
+        "required": ["summary"],
+        "additionalProperties": false
+    });
+
+    host.handle_request(request(serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": "query-structured",
+        "method": "query/start",
+        "params": {
+            "prompt": "summarize the repository",
+            "outputSchema": schema
+        }
+    })))
+    .await;
+
+    let accepted = output.recv().await.unwrap();
+    assert_eq!(accepted["result"]["accepted"], true);
+    let submitted = owner.dialog_requests.lock().unwrap();
+    assert_eq!(submitted.last().unwrap().output_schema, Some(schema));
+    drop(submitted);
+
+    assert_eq!(output.recv().await.unwrap()["method"], "query/event");
+    let result = output.recv().await.unwrap();
+    assert_eq!(result["method"], "query/result");
+    assert_eq!(result["params"]["status"], "completed");
+    assert_eq!(result["params"]["output"]["text"], r#"{"summary":"ready"}"#);
+    assert_eq!(
+        result["params"]["output"]["structured"],
+        serde_json::json!({ "summary": "ready" })
+    );
+}
+
+#[tokio::test]
+async fn query_rejects_a_non_object_output_schema_before_submission() {
+    let (host, owner, mut output) = host().await;
+    initialize(&host, &mut output).await;
+
+    host.handle_request(request(serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": "query-invalid-schema",
+        "method": "query/start",
+        "params": {
+            "prompt": "summarize the repository",
+            "outputSchema": ["not", "an", "object"]
+        }
+    })))
+    .await;
+
+    let rejected = output.recv().await.unwrap();
+    assert_eq!(rejected["error"]["data"]["code"], "invalid_request");
+    assert!(owner.dialog_requests.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn query_fails_when_structured_output_is_not_json() {
+    let (host, _, mut output) = host_with_output("not json").await;
+    initialize(&host, &mut output).await;
+
+    host.handle_request(request(serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": "query-invalid-output",
+        "method": "query/start",
+        "params": {
+            "prompt": "summarize the repository",
+            "outputSchema": { "type": "object" }
+        }
+    })))
+    .await;
+
+    let accepted = output.recv().await.unwrap();
+    assert_eq!(accepted["result"]["accepted"], true);
+    assert_eq!(output.recv().await.unwrap()["method"], "query/event");
+    let result = output.recv().await.unwrap();
+    assert_eq!(result["params"]["status"], "failed");
+    assert_eq!(result["params"]["output"]["text"], "not json");
+    assert!(result["params"]["output"].get("structured").is_none());
+    assert_eq!(result["params"]["error"]["data"]["code"], "internal");
+    assert_eq!(
+        result["params"]["error"]["data"]["operationId"],
+        result["params"]["operationId"]
+    );
 }
 
 #[tokio::test]

--- a/src/crates/interfaces/sdk-host/tests/protocol_contracts.rs
+++ b/src/crates/interfaces/sdk-host/tests/protocol_contracts.rs
@@ -15,7 +15,7 @@ fn initialize_contract_is_versioned_and_binds_one_temporary_model() {
         "id": 1,
         "method": "initialize",
         "params": {
-            "protocolVersion": 5,
+            "protocolVersion": 6,
             "clientInfo": { "name": "fixture", "version": "0.1.0" },
             "capabilities": {
                 "serverNotifications": true,
@@ -33,7 +33,7 @@ fn initialize_contract_is_versioned_and_binds_one_temporary_model() {
     let params: InitializeParams = request.params_as().unwrap();
 
     assert_eq!(request.id, Some(RequestId::Number(1)));
-    assert_eq!(PROTOCOL_VERSION, 5);
+    assert_eq!(PROTOCOL_VERSION, 6);
     assert_eq!(params.protocol_version, PROTOCOL_VERSION);
     assert!(params.capabilities.server_notifications);
     assert!(params.capabilities.permission_responses);
@@ -81,7 +81,7 @@ fn initialize_contract_is_versioned_and_binds_one_temporary_model() {
             event_stream: true,
             tool_events: true,
             image_input: true,
-            structured_output: false,
+            structured_output: true,
             usage: true,
             custom_tools: false,
             permission_responses: true,
@@ -111,7 +111,7 @@ fn current_host_capabilities_are_a_deliberate_subset_of_the_headless_cli_target(
         capabilities.session_create_lifetime,
         SessionLifetime::Durable
     );
-    assert!(!capabilities.structured_output);
+    assert!(capabilities.structured_output);
     assert!(capabilities.usage);
     assert!(!capabilities.custom_tools);
     assert!(capabilities.permission_responses);
@@ -139,6 +139,34 @@ fn query_input_carries_only_text_and_local_image_paths() {
             "imageUrl": "https://example.com/image.png"
         }))
         .is_err()
+    );
+}
+
+#[test]
+fn query_input_accepts_one_turn_scoped_output_schema() {
+    let params: QueryStartParams = serde_json::from_value(serde_json::json!({
+        "prompt": "summarize the repository",
+        "outputSchema": {
+            "type": "object",
+            "properties": {
+                "summary": { "type": "string" }
+            },
+            "required": ["summary"],
+            "additionalProperties": false
+        }
+    }))
+    .unwrap();
+
+    assert_eq!(
+        params.output_schema,
+        Some(serde_json::json!({
+            "type": "object",
+            "properties": {
+                "summary": { "type": "string" }
+            },
+            "required": ["summary"],
+            "additionalProperties": false
+        }))
     );
 }
 
@@ -225,6 +253,7 @@ fn query_events_and_terminal_errors_are_closed_protocol_values() {
         status: QueryTerminalStatus::Failed,
         output: QueryOutput {
             text: "partial response".to_string(),
+            structured: None,
         },
         usage: Some(QueryUsage {
             input_tokens: 100,


### PR DESCRIPTION
## 概要

将已合入 main 的 #2506 按语义迁移到 1.0.0-explore，让外部 TypeScript 应用可以为单次 Query 或 Session Turn 请求结构化 JSON 输出。

- TypeScript API 增加 outputSchema，Result 增加 structuredOutput
- SDK Host 协议升级到 v6，并声明 structuredOutput 能力
- Runtime 将单次 Turn 的 schema 传到模型请求
- OpenAI Chat、OpenAI Responses、Anthropic、Gemini 使用各自协议映射约束
- Host 只解析最后一次模型尝试；非法 JSON 返回 failed Result，同时保留 outputText

## 原因

当前 SDK 已具备启动 Host、创建会话、执行 Turn、事件流、取消与权限响应。外部应用仍需自行从自然语言文本中提取结果，难以稳定接入工作流、表单、自动化和其他软件。结构化输出补齐了最基础的机器可消费结果边界，调用方只需要提供 JSON Schema。

## 范围控制

- schema 只作用于单次 Turn
- 仅接受 JSON object 形式的 schema
- 保持普通 CLI、Desktop、ACP、定时任务等入口的现有行为
- 不增加自定义 tool、通用回调、Python SDK、npm/PyPI 发布或新的传输层
- 没有新增依赖或锁文件变化

## Explore 适配

- 基于 57da3221c 重新变基
- 保留 #2517 新增的 CLI peer cancel_tool 路由
- 保留 Explore 的 OpenAI Responses reasoning summary 保护，并让 JSON Schema 在自定义请求体合并后生效
- 保留 #2506 原作者、提交时间和单一 commit

## 验证

- pnpm --dir sdk/typescript test
- cargo test --locked -p bitfun-sdk-host
- cargo test --locked -p bitfun-ai-adapters
- cargo test --locked -p bitfun-agent-stream
- cargo test --locked -p bitfun-runtime-ports --no-default-features --features agent-api --lib
- cargo test --locked -p bitfun-agent-runtime --no-default-features --features agent-runtime --lib --tests
- cargo test --locked -p bitfun-sdk-host-app
- cargo check --locked -p bitfun-cli
- cargo check --locked -p bitfun-desktop
- git diff --check