### PR TITLE
test(cli): stabilize macOS dispatch cancellation

### DIFF
--- a/src/apps/cli/src/dispatch/runner.rs
+++ b/src/apps/cli/src/dispatch/runner.rs
@@ -482,11 +482,13 @@ mod tests {
         let mut command = Command::new("/bin/sh");
         command
             .arg("-c")
+            // Keep the leader in the shell's `wait` builtin so TERM runs its
+            // trap immediately; an external `sleep` can defer trap handling.
             .arg(
                 "trap 'exit 0' TERM; trap '' HUP; \
                  sh -c 'trap \"\" TERM HUP; printf ready > \"$BITFUN_DISPATCH_TERM_TEST_READY\"; \
                  while :; do sleep 30; done' & \
-                 while :; do sleep 30; done",
+                 wait",
             )
             // These trailing arguments make the real process identity match
             // the hidden worker contract without launching BitFun Runtime.


### PR DESCRIPTION
## Summary

- keep the dispatch cancellation safety coverage that rejects SIGKILL after the verified process-group leader exits
- make the shell leader block in its built-in wait command so TERM traps run immediately
- remove the runner-dependent timing window caused by repeatedly launching external sleep processes

## Root cause

POSIX shells may defer a TERM trap while waiting for an external command. On slower macOS runners, the one-second process-group grace period could expire while the shell leader still appeared alive, so the production cancellation path correctly escalated and the test incorrectly failed. The shell built-in wait provides a deterministic handshake while the TERM-resistant child keeps the process group alive.

## Verification

- focused cancellation test passed 50 consecutive runs on macOS
- cargo test --locked -p bitfun-cli -p bitfun-acp
- pnpm run check:repo-hygiene
- git diff --check

## Remote scenarios

- Detached Dispatch: test-only fixture stabilization; production cancellation behavior is unchanged
- Remote workspace, Remote control, and Peer Device Mode are unchanged
