### PR TITLE
fix(agent): hide type in control cards

### DIFF
--- a/src/web-ui/src/flow_chat/tool-cards/AgentControlToolCard.appearance.ts
+++ b/src/web-ui/src/flow_chat/tool-cards/AgentControlToolCard.appearance.ts
@@ -8,7 +8,6 @@ export const agentControlToolCardAppearanceDescriptor: AppearanceSurfaceDescript
     { id: 'agentPill' },
     { id: 'avatar' },
     { id: 'name' },
-    { id: 'type' },
     { id: 'status' },
     { id: 'expandIndicator' },
     { id: 'prompt' },

--- a/src/web-ui/src/flow_chat/tool-cards/AgentControlToolCard.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/AgentControlToolCard.scss
@@ -112,16 +112,6 @@
     white-space: nowrap;
   }
 
-  &__type {
-    min-width: 0;
-    overflow: hidden;
-    color: var(--bf-appearance-token-color-text-muted);
-    font-size: var(--bf-appearance-token-tool-card-action-font-size);
-    line-height: var(--bf-appearance-token-tool-card-action-line-height);
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
   &__status {
     min-width: 0;
     overflow: hidden;

--- a/src/web-ui/src/flow_chat/tool-cards/AgentControlToolCard.test.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/AgentControlToolCard.test.tsx
@@ -177,6 +177,8 @@ describeWithJsdom('AgentControlToolCard', () => {
       expect(pill?.textContent?.trim()).toBeTruthy();
       expect(pill?.textContent).toContain(toolName === 'AgentSpawn' ? 'parser-review' : 'agent-1');
       expect(pill?.querySelector('[data-bf-component="subagent-avatar"]')).not.toBeNull();
+      expect(container.querySelector('[data-bf-part="type"]')).toBeNull();
+      expect(container.textContent).not.toContain('SwarmWorker');
       expect(container.textContent).toContain('Running');
       expect(container.querySelector('[data-bf-part="expandIndicator"]')).not.toBeNull();
       expect(container.textContent).not.toContain(

--- a/src/web-ui/src/flow_chat/tool-cards/AgentControlToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/AgentControlToolCard.tsx
@@ -127,7 +127,6 @@ export const AgentControlToolCard: React.FC<ToolCardProps> = ({
     || linkedSession?.config?.agentType?.trim()
     || inputAgentType;
   const stableSubagentType = linkedSession?.subagentType?.trim() || inputAgentType;
-  const secondaryAgentType = stableSubagentType || stableAgentType;
   const isParameterStreaming = Boolean(toolItem.isParamsStreaming)
     || PARAMETER_STREAMING_STATUSES.has(status);
   const canExpand = Boolean(prompt) && !isParameterStreaming;
@@ -242,15 +241,6 @@ export const AgentControlToolCard: React.FC<ToolCardProps> = ({
           {agentPillContent}
         </span>
       )}
-      {secondaryAgentType && secondaryAgentType !== agentName ? (
-        <span
-          className="agent-control-tool-card__type"
-          data-bf-component="agent-control-tool-card"
-          data-bf-part="type"
-        >
-          {secondaryAgentType}
-        </span>
-      ) : null}
       <span
         className={`agent-control-tool-card__status agent-control-tool-card__status--${lifecycle}`}
         data-bf-component="agent-control-tool-card"


### PR DESCRIPTION
Remove the redundant agent type label from AgentControlToolCard while
preserving agent type metadata used to open child sessions.

Remove the associated styles and Appearance part, and cover the intended
avatar, name, and status-only layout in tests.
