### PR TITLE
refactor(web-ui): adopt design-system icon buttons

### DIFF
--- a/src/web-ui/src/app/scenes/todos/TodosScene.tsx
+++ b/src/web-ui/src/app/scenes/todos/TodosScene.tsx
@@ -11,7 +11,7 @@
  * broadcast on the shared change event so those views stay in step.
  */
 
-import { Button } from '@bitfun/ui';
+import { Button, IconButton } from '@bitfun/ui';
 import React, {
   useCallback,
   useEffect,
@@ -27,7 +27,7 @@ import {
   ChevronRight,
   Plus,
 } from 'lucide-react';
-import { IconButton, Modal, PresenceBoundary, confirmDanger } from '@/component-library';
+import { Modal, PresenceBoundary, Tooltip, confirmDanger } from '@/component-library';
 import { cronAPI, type CronJob, type CreateCronJobRequest, type UpdateCronJobRequest } from '@/infrastructure/api';
 import { useI18n } from '@/infrastructure/i18n';
 import { useWorkspaceContext } from '@/infrastructure/contexts/WorkspaceContext';
@@ -425,30 +425,30 @@ const TodosScene: React.FC = () => {
             data-bf-scene="todos"
             data-bf-part="monthNavigation"
           >
-            <IconButton
-              type="button"
-              size="xs"
-              aria-label={t('calendar.previousMonth')}
-              tooltip={t('calendar.previousMonth')}
-              onClick={() => shiftMonth(-1)}
-              data-testid="todos-calendar-prev"
-            >
-              <ChevronLeft size={16} />
-            </IconButton>
+            <Tooltip content={t('calendar.previousMonth')}>
+              <IconButton
+                type="button"
+                size="sm"
+                aria-label={t('calendar.previousMonth')}
+                icon={<ChevronLeft />}
+                onClick={() => shiftMonth(-1)}
+                data-testid="todos-calendar-prev"
+              />
+            </Tooltip>
             <span className="bf-todos__month-label" data-testid="todos-calendar-month">
               <CalendarDays size={14} aria-hidden="true" />
               <span>{monthLabel}</span>
             </span>
-            <IconButton
-              type="button"
-              size="xs"
-              aria-label={t('calendar.nextMonth')}
-              tooltip={t('calendar.nextMonth')}
-              onClick={() => shiftMonth(1)}
-              data-testid="todos-calendar-next"
-            >
-              <ChevronRight size={16} />
-            </IconButton>
+            <Tooltip content={t('calendar.nextMonth')}>
+              <IconButton
+                type="button"
+                size="sm"
+                aria-label={t('calendar.nextMonth')}
+                icon={<ChevronRight />}
+                onClick={() => shiftMonth(1)}
+                data-testid="todos-calendar-next"
+              />
+            </Tooltip>
           </div>
           <Button
             size="sm"

--- a/src/web-ui/src/app/scenes/todos/components/TodoItemRow.test.tsx
+++ b/src/web-ui/src/app/scenes/todos/components/TodoItemRow.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CronJob } from '@/infrastructure/api';
+import TodoItemRow from './TodoItemRow';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('@/infrastructure/i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+    formatDate: (date: Date) => date.toISOString(),
+  }),
+}));
+
+vi.mock('@/component-library', () => ({
+  Tooltip: ({ children }: { children: React.ReactElement }) => children,
+}));
+
+const job: CronJob = {
+  id: 'cron_test',
+  name: 'Review changes',
+  schedule: { kind: 'cron', expr: '0 9 * * *' },
+  payload: { text: 'Review the latest changes' },
+  enabled: true,
+  target: {
+    kind: 'workspace',
+    workspace: { workspacePath: '/workspace/bitfun' },
+    launch: { agentType: 'agentic' },
+  },
+  createdAtMs: 0,
+  configUpdatedAtMs: 0,
+  updatedAtMs: 0,
+  state: {
+    consecutiveFailures: 0,
+    coalescedRunCount: 0,
+  },
+};
+
+describe('TodoItemRow actions', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('uses accessible icon actions and keeps their callbacks isolated from the row', () => {
+    const onEdit = vi.fn();
+    const onDelete = vi.fn();
+
+    act(() => {
+      root.render(
+        <TodoItemRow
+          job={job}
+          atMs={null}
+          nowMs={0}
+          workspaces={[]}
+          statusLabel="Paused"
+          onEdit={onEdit}
+          onDelete={onDelete}
+          onToggleEnabled={vi.fn()}
+        />,
+      );
+    });
+
+    const editButton = container.querySelector<HTMLButtonElement>('button[aria-label="actions.edit"]');
+    const deleteButton = container.querySelector<HTMLButtonElement>('button[aria-label="actions.delete"]');
+
+    expect(editButton?.dataset.bfComponent).toBe('icon-button');
+    expect(editButton?.dataset.size).toBe('sm');
+    expect(deleteButton?.dataset.bfTone).toBe('danger');
+
+    act(() => editButton?.click());
+    expect(onEdit).toHaveBeenCalledTimes(1);
+
+    act(() => deleteButton?.click());
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/web-ui/src/app/scenes/todos/components/TodoItemRow.tsx
+++ b/src/web-ui/src/app/scenes/todos/components/TodoItemRow.tsx
@@ -5,10 +5,10 @@
  * several rows with different times.
  */
 
-import { Switch } from '@bitfun/ui';
+import { IconButton, Switch } from '@bitfun/ui';
 import React from 'react';
 import { CalendarClock, Pencil, Trash2 } from 'lucide-react';
-import { IconButton } from '@/component-library';
+import { Tooltip } from '@/component-library';
 import { useI18n } from '@/infrastructure/i18n';
 import type { CronJob } from '@/infrastructure/api';
 import type { WorkspaceInfo } from '@/shared/types';
@@ -153,25 +153,25 @@ const TodoItemRow: React.FC<TodoItemRowProps> = ({
           onChange={(event) => onToggleEnabled(job, event.currentTarget.checked)}
         />
         <div className="bf-todos__row-action-buttons">
-          <IconButton
-            type="button"
-            size="xs"
-            aria-label={t('actions.edit')}
-            tooltip={t('actions.edit')}
-            onClick={() => onEdit(job)}
-          >
-            <Pencil size={13} />
-          </IconButton>
-          <IconButton
-            type="button"
-            size="xs"
-            variant="danger"
-            aria-label={t('actions.delete')}
-            tooltip={t('actions.delete')}
-            onClick={() => onDelete(job)}
-          >
-            <Trash2 size={13} />
-          </IconButton>
+          <Tooltip content={t('actions.edit')}>
+            <IconButton
+              type="button"
+              size="sm"
+              aria-label={t('actions.edit')}
+              icon={<Pencil />}
+              onClick={() => onEdit(job)}
+            />
+          </Tooltip>
+          <Tooltip content={t('actions.delete')}>
+            <IconButton
+              type="button"
+              size="sm"
+              tone="danger"
+              aria-label={t('actions.delete')}
+              icon={<Trash2 />}
+              onClick={() => onDelete(job)}
+            />
+          </Tooltip>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Replace the legacy `IconButton` usages in the Todos scene with the shared `@bitfun/ui` implementation.
- Migrate the previous/next month controls and the todo edit/delete actions.
- Preserve tooltips and accessible labels, and map destructive actions to the design-system `danger` tone.
- Add a focused test covering action semantics, callbacks, and event isolation.

Fixes #

## Type and Areas

Type:

Refactor / UI/UX / test

Areas:

Web UI / design system

## Motivation / Impact

This continues the incremental migration away from the legacy component library and keeps icon-button behavior and styling consistent with the new design system.

Users receive consistent shared styling for calendar navigation and todo row actions. Existing behavior, labels, tooltips, and destructive-action semantics are preserved.

## Verification

- `pnpm --dir src/web-ui run test:run -- src/app/scenes/todos/components/TodoItemRow.test.tsx`
  - Passed: 1 test file, 1 test.
- `pnpm run check:web`
  - Passed appearance contracts, theme audits, visual contracts, and TypeScript checks.
  - Existing unrelated Appearance audit warnings remain unchanged.
- `pnpm --dir src/web-ui exec eslint src/app/scenes/todos/TodosScene.tsx src/app/scenes/todos/components/TodoItemRow.tsx src/app/scenes/todos/components/TodoItemRow.test.tsx`
  - Passed with no errors; the test file is excluded by the repository ESLint ignore configuration.
- `pnpm --dir src/web-ui run build:web`
  - Production build passed.
  - Existing unrelated Rollup chunking and bundle-size warnings remain unchanged.

## Reviewer Notes

- The migration is intentionally limited to four icon buttons in the Todos scene.
- The existing Tooltip component remains in use because it does not yet have a replacement in the new component library.
- Recommended manual checks:
  - Navigate between calendar months.
  - Open a todo through its edit action.
  - Trigger the delete action and confirm its destructive styling.
  - Verify tooltips appear for all four migrated controls.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.