### PR TITLE
fix(usage): drop cache_write metric, keep hit-rate trend line continuous

### DIFF
--- a/src/crates/assembly/core/src/service/session_usage/service.rs
+++ b/src/crates/assembly/core/src/service/session_usage/service.rs
@@ -2919,7 +2919,6 @@ mod tests {
             output_tokens,
             cached_tokens,
             cached_tokens_available: false,
-            cache_write_tokens: 0,
             total_tokens: input_tokens + output_tokens,
             token_details: None,
             is_subagent: false,

--- a/src/crates/assembly/core/src/service/token_usage/statistics.rs
+++ b/src/crates/assembly/core/src/service/token_usage/statistics.rs
@@ -280,7 +280,6 @@ mod tests {
             output_tokens: 50,
             cached_tokens: 0,
             cached_tokens_available: false,
-            cache_write_tokens: 0,
             total_tokens: 150,
             token_details: None,
             is_subagent: false,

--- a/src/crates/services/services-core/src/token_usage/service.rs
+++ b/src/crates/services/services-core/src/token_usage/service.rs
@@ -147,12 +147,6 @@ impl TokenUsageService {
         let total_tokens = input_tokens + output_tokens;
         let cached_tokens_available = cached_tokens.is_some();
         let cached_tokens = cached_tokens.unwrap_or(0);
-        let cache_write_tokens: u32 = token_details
-            .as_ref()
-            .and_then(|details| details.get("cacheCreationTokenCount"))
-            .and_then(|value| value.as_u64())
-            .map(|value| value as u32)
-            .unwrap_or(0);
 
         let record = TokenUsageRecord {
             model_config_id: model_config_id.clone(),
@@ -164,7 +158,6 @@ impl TokenUsageService {
             output_tokens,
             cached_tokens,
             cached_tokens_available,
-            cache_write_tokens,
             total_tokens,
             token_details,
             is_subagent,
@@ -201,7 +194,6 @@ impl TokenUsageService {
         stats.total_input += record.input_tokens as u64;
         stats.total_output += record.output_tokens as u64;
         stats.total_cached += record.cached_tokens as u64;
-        stats.total_cache_write += record.cache_write_tokens as u64;
         if record.cached_tokens_available {
             stats.cache_reported_input_tokens += record.input_tokens as u64;
         }
@@ -232,7 +224,6 @@ impl TokenUsageService {
                 total_input: 0,
                 total_output: 0,
                 total_cached: 0,
-                total_cache_write: 0,
                 cache_reported_input_tokens: 0,
                 total_tokens: 0,
                 request_count: 0,
@@ -243,7 +234,6 @@ impl TokenUsageService {
         stats.total_input += record.input_tokens;
         stats.total_output += record.output_tokens;
         stats.total_cached += record.cached_tokens;
-        stats.total_cache_write += record.cache_write_tokens;
         if record.cached_tokens_available {
             stats.cache_reported_input_tokens += record.input_tokens;
         }
@@ -334,7 +324,6 @@ impl TokenUsageService {
             stats.total_input += record.input_tokens as u64;
             stats.total_output += record.output_tokens as u64;
             stats.total_cached += record.cached_tokens as u64;
-            stats.total_cache_write += record.cache_write_tokens as u64;
             if record.cached_tokens_available {
                 stats.cache_reported_input_tokens += record.input_tokens as u64;
             }
@@ -501,7 +490,6 @@ impl TokenUsageService {
         let mut total_input = 0u64;
         let mut total_output = 0u64;
         let mut total_cached = 0u64;
-        let mut total_cache_write = 0u64;
         let mut cache_reported_input_tokens = 0u64;
         let mut total_tokens = 0u64;
 
@@ -512,7 +500,6 @@ impl TokenUsageService {
             total_input += record.input_tokens as u64;
             total_output += record.output_tokens as u64;
             total_cached += record.cached_tokens as u64;
-            total_cache_write += record.cache_write_tokens as u64;
             if record.cached_tokens_available {
                 cache_reported_input_tokens += record.input_tokens as u64;
             }
@@ -528,7 +515,6 @@ impl TokenUsageService {
             model_stats.total_input += record.input_tokens as u64;
             model_stats.total_output += record.output_tokens as u64;
             model_stats.total_cached += record.cached_tokens as u64;
-            model_stats.total_cache_write += record.cache_write_tokens as u64;
             if record.cached_tokens_available {
                 model_stats.cache_reported_input_tokens += record.input_tokens as u64;
             }
@@ -551,7 +537,6 @@ impl TokenUsageService {
                     total_input: 0,
                     total_output: 0,
                     total_cached: 0,
-                    total_cache_write: 0,
                     cache_reported_input_tokens: 0,
                     total_tokens: 0,
                     request_count: 0,
@@ -562,7 +547,6 @@ impl TokenUsageService {
             session_stats.total_input += record.input_tokens;
             session_stats.total_output += record.output_tokens;
             session_stats.total_cached += record.cached_tokens;
-            session_stats.total_cache_write += record.cache_write_tokens;
             if record.cached_tokens_available {
                 session_stats.cache_reported_input_tokens += record.input_tokens;
             }
@@ -585,7 +569,6 @@ impl TokenUsageService {
             total_input,
             total_output,
             total_cached,
-            total_cache_write,
             cache_reported_input_tokens,
             total_tokens,
             by_model,
@@ -917,7 +900,6 @@ mod tests {
             output_tokens: 1,
             cached_tokens: 0,
             cached_tokens_available: false,
-            cache_write_tokens: 0,
             total_tokens: 2,
             token_details: None,
             is_subagent: false,

--- a/src/crates/services/services-core/src/token_usage/statistics.rs
+++ b/src/crates/services/services-core/src/token_usage/statistics.rs
@@ -115,8 +115,6 @@ pub struct UsageTrendPoint {
     pub output_tokens: u64,
     /// Tokens served from prefix cache (cache HIT).
     pub cache_read_tokens: u64,
-    /// Tokens written into the cache (Anthropic cache WRITE).
-    pub cache_write_tokens: u64,
     /// Cache hit ratio (0.0..=1.0) when the bucket contains cache telemetry,
     /// otherwise `None`.
     pub cache_hit_rate: Option<f64>,
@@ -131,7 +129,6 @@ pub struct UsageStatistics {
     pub total_input_tokens: u64,
     pub total_output_tokens: u64,
     pub total_cached_tokens: u64,
-    pub total_cache_write_tokens: u64,
     /// Prompt input tokens from requests that reported cache telemetry. Together
     /// with `total_cached_tokens` it yields the overall cache hit rate.
     pub total_cache_reported_input_tokens: u64,
@@ -179,7 +176,6 @@ where
     let mut total_input = 0u64;
     let mut total_output = 0u64;
     let mut total_cached = 0u64;
-    let mut total_cache_write = 0u64;
     let mut total_cache_reported_input = 0u64;
 
     let mut by_model: HashMap<String, UsageStatisticsEntry> = HashMap::new();
@@ -191,7 +187,6 @@ where
         total_input += record.input_tokens as u64;
         total_output += record.output_tokens as u64;
         total_cached += record.cached_tokens as u64;
-        total_cache_write += record.cache_write_tokens as u64;
         if record.cached_tokens_available {
             total_cache_reported_input += record.input_tokens as u64;
         }
@@ -211,7 +206,6 @@ where
         total_input_tokens: total_input,
         total_output_tokens: total_output,
         total_cached_tokens: total_cached,
-        total_cache_write_tokens: total_cache_write,
         total_cache_reported_input_tokens: total_cache_reported_input,
         by_model: finalize_entries(by_model),
         by_group: finalize_entries(by_group),
@@ -323,7 +317,6 @@ fn bucket_records(
         bucket.input_tokens += record.input_tokens as u64;
         bucket.output_tokens += record.output_tokens as u64;
         bucket.cached_tokens += record.cached_tokens as u64;
-        bucket.cache_write_tokens += record.cache_write_tokens as u64;
         if record.cached_tokens_available {
             bucket.reported_input_tokens += record.input_tokens as u64;
         }
@@ -385,7 +378,6 @@ struct TrendBucket {
     input_tokens: u64,
     output_tokens: u64,
     cached_tokens: u64,
-    cache_write_tokens: u64,
     reported_input_tokens: u64,
 }
 
@@ -398,7 +390,6 @@ impl TrendBucket {
             input_tokens: self.input_tokens,
             output_tokens: self.output_tokens,
             cache_read_tokens: self.cached_tokens,
-            cache_write_tokens: self.cache_write_tokens,
             cache_hit_rate,
         }
     }
@@ -415,7 +406,6 @@ mod tests {
         input: u32,
         output: u32,
         cached: u32,
-        cache_write: u32,
         cached_available: bool,
     ) -> TokenUsageRecord {
         TokenUsageRecord {
@@ -428,7 +418,6 @@ mod tests {
             output_tokens: output,
             cached_tokens: cached,
             cached_tokens_available: cached_available,
-            cache_write_tokens: cache_write,
             total_tokens: input + output,
             token_details: None,
             is_subagent: false,
@@ -472,17 +461,16 @@ mod tests {
     fn aggregates_totals_and_breakdowns() {
         let t0 = Utc.with_ymd_and_hms(2026, 8, 16, 10, 0, 0).unwrap();
         let records = vec![
-            record("model-a", t0, 1000, 200, 500, 0, true),
+            record("model-a", t0, 1000, 200, 500, true),
             record(
                 "model-a",
                 t0 + Duration::minutes(30),
                 2000,
                 300,
                 0,
-                100,
                 false,
             ),
-            record("model-b", t0 + Duration::hours(2), 500, 50, 0, 0, false),
+            record("model-b", t0 + Duration::hours(2), 500, 50, 0, false),
         ];
 
         let stats = aggregate_statistics(&records, UsageGranularity::Hour, attribution());
@@ -491,7 +479,6 @@ mod tests {
         assert_eq!(stats.total_input_tokens, 3500);
         assert_eq!(stats.total_output_tokens, 550);
         assert_eq!(stats.total_cached_tokens, 500);
-        assert_eq!(stats.total_cache_write_tokens, 100);
         assert_eq!(stats.total_tokens, 4050);
         assert_eq!(stats.total_cache_reported_input_tokens, 1000);
 
@@ -521,12 +508,11 @@ mod tests {
     #[test]
     fn same_named_models_with_different_keys_are_not_merged() {
         let t0 = Utc.with_ymd_and_hms(2026, 8, 16, 10, 0, 0).unwrap();
-        let first = record("shared-model", t0, 100, 0, 0, 0, false);
+        let first = record("shared-model", t0, 100, 0, 0, false);
         let mut second = record(
             "shared-model",
             t0 + Duration::minutes(1),
             200,
-            0,
             0,
             0,
             false,
@@ -546,7 +532,7 @@ mod tests {
     #[test]
     fn entry_without_cache_telemetry_has_no_hit_rate() {
         let t0 = Utc.with_ymd_and_hms(2026, 8, 16, 10, 0, 0).unwrap();
-        let records = vec![record("model-a", t0, 100, 100, 0, 0, false)];
+        let records = vec![record("model-a", t0, 100, 100, 0, false)];
         let stats = aggregate_statistics(&records, UsageGranularity::Hour, attribution());
         assert_eq!(stats.by_model[0].cache_hit_rate, None);
         assert_eq!(stats.total_cache_reported_input_tokens, 0);
@@ -556,7 +542,7 @@ mod tests {
     fn exact_full_cache_hit_is_reported_as_exactly_one() {
         let t0 = Utc.with_ymd_and_hms(2026, 8, 16, 10, 0, 0).unwrap();
         // cached == input on a single request: mathematically a 100% hit.
-        let records = vec![record("model-a", t0, 1000, 0, 1000, 0, true)];
+        let records = vec![record("model-a", t0, 1000, 0, 1000, true)];
         let stats = aggregate_statistics(&records, UsageGranularity::Hour, attribution());
         assert_eq!(stats.by_model[0].cache_hit_rate, Some(1.0));
         assert_eq!(
@@ -569,8 +555,8 @@ mod tests {
     fn trend_buckets_by_hour_and_fills_gaps() {
         let t0 = Utc.with_ymd_and_hms(2026, 8, 16, 10, 0, 0).unwrap();
         let records = vec![
-            record("model-a", t0, 100, 0, 0, 0, false),
-            record("model-a", t0 + Duration::hours(3), 200, 0, 0, 0, false),
+            record("model-a", t0, 100, 0, 0, false),
+            record("model-a", t0 + Duration::hours(3), 200, 0, 0, false),
         ];
         let stats = aggregate_statistics(&records, UsageGranularity::Hour, attribution());
         assert_eq!(stats.granularity, UsageGranularity::Hour);
@@ -588,8 +574,8 @@ mod tests {
     fn trend_cache_hit_rate_uses_reported_input() {
         let t0 = Utc.with_ymd_and_hms(2026, 8, 16, 10, 0, 0).unwrap();
         let records = vec![
-            record("model-a", t0, 1000, 0, 250, 0, true),
-            record("model-b", t0 + Duration::minutes(10), 100, 0, 0, 0, false),
+            record("model-a", t0, 1000, 0, 250, true),
+            record("model-b", t0 + Duration::minutes(10), 100, 0, 0, false),
         ];
         let stats = aggregate_statistics(&records, UsageGranularity::Hour, attribution());
         let point = &stats.trend[0];
@@ -603,8 +589,8 @@ mod tests {
     fn trend_coarsens_to_days_when_hourly_span_is_too_long() {
         let t0 = Utc.with_ymd_and_hms(2026, 8, 16, 0, 0, 0).unwrap();
         let records = vec![
-            record("model-a", t0, 100, 0, 0, 0, false),
-            record("model-a", t0 + Duration::days(60), 200, 0, 0, 0, false),
+            record("model-a", t0, 100, 0, 0, false),
+            record("model-a", t0 + Duration::days(60), 200, 0, 0, false),
         ];
         let stats = aggregate_statistics(&records, UsageGranularity::Hour, attribution());
         assert_eq!(stats.granularity, UsageGranularity::Day);
@@ -620,14 +606,12 @@ mod tests {
                 100,
                 0,
                 0,
-                0,
                 false,
             ),
             record(
                 "model-a",
                 Utc.with_ymd_and_hms(2026, 8, 16, 15, 30, 0).unwrap(),
                 200,
-                0,
                 0,
                 0,
                 false,
@@ -658,14 +642,12 @@ mod tests {
                 100,
                 0,
                 0,
-                0,
                 false,
             ),
             record(
                 "model-a",
                 Utc.with_ymd_and_hms(2026, 3, 9, 12, 0, 0).unwrap(),
                 200,
-                0,
                 0,
                 0,
                 false,

--- a/src/crates/services/services-core/src/token_usage/types.rs
+++ b/src/crates/services/services-core/src/token_usage/types.rs
@@ -20,11 +20,6 @@ pub struct TokenUsageRecord {
     /// Whether cached token count was explicitly reported by the provider/event.
     #[serde(default)]
     pub cached_tokens_available: bool,
-    /// Cache WRITE tokens (Anthropic only: `cache_creation_input_tokens`).
-    /// These are tokens written into the cache this call (billed at write price).
-    /// Extracted from `token_details.cacheCreationTokenCount` when present.
-    #[serde(default)]
-    pub cache_write_tokens: u32,
     pub total_tokens: u32,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub token_details: Option<serde_json::Value>,
@@ -41,9 +36,6 @@ pub struct ModelTokenStats {
     pub total_output: u64,
     /// Cumulative cache HIT tokens (served from cache, charged at cache-read price).
     pub total_cached: u64,
-    /// Cumulative cache WRITE tokens (Anthropic only; charged at cache-write price).
-    #[serde(default)]
-    pub total_cache_write: u64,
     /// Prompt input tokens from requests where the provider explicitly reported
     /// cache hit telemetry. Used as the cache hit ratio denominator.
     #[serde(default)]
@@ -90,9 +82,6 @@ pub struct SessionTokenStats {
     pub total_output: u32,
     /// Cumulative cache HIT tokens for this session.
     pub total_cached: u32,
-    /// Cumulative cache WRITE tokens for this session (Anthropic only).
-    #[serde(default)]
-    pub total_cache_write: u32,
     /// Prompt input tokens from requests where the provider explicitly reported
     /// cache hit telemetry. Used as the cache hit ratio denominator.
     #[serde(default)]
@@ -156,9 +145,6 @@ pub struct TokenUsageSummary {
     pub total_output: u64,
     /// Aggregate cache HIT tokens across all records in the query.
     pub total_cached: u64,
-    /// Aggregate cache WRITE tokens across all records in the query (Anthropic only).
-    #[serde(default)]
-    pub total_cache_write: u64,
     /// Aggregate prompt input tokens from requests where cache hit telemetry was reported.
     #[serde(default)]
     pub cache_reported_input_tokens: u64,

--- a/src/crates/services/services-core/tests/session_usage_contracts/token_usage_contracts.rs
+++ b/src/crates/services/services-core/tests/session_usage_contracts/token_usage_contracts.rs
@@ -71,7 +71,6 @@ fn session_cache_hit_ratio_uses_reported_input_denominator() {
         total_input: 300,
         total_output: 20,
         total_cached: 50,
-        total_cache_write: 0,
         cache_reported_input_tokens: 100,
         total_tokens: 320,
         request_count: 2,

--- a/src/crates/services/services-core/tests/storage_owner_contracts/storage_owner_contracts.rs
+++ b/src/crates/services/services-core/tests/storage_owner_contracts/storage_owner_contracts.rs
@@ -217,7 +217,6 @@ async fn token_usage_service_persists_records_and_filters_subagents_by_default()
     assert_eq!(summary.record_count, 1);
     assert_eq!(summary.total_input, 100);
     assert_eq!(summary.total_cached, 30);
-    assert_eq!(summary.total_cache_write, 12);
 
     let reloaded =
         bitfun_services_core::token_usage::TokenUsageService::new(temp.path().to_path_buf())
@@ -321,7 +320,7 @@ async fn token_usage_all_range_ignores_non_date_record_files() {
     let records_dir = temp.path().join("records");
     fs::write(
         records_dir.join("manual-backup.json"),
-        r#"{"records":[{"model_id":"model-b","session_id":"session-b","turn_id":"turn-b","timestamp":"2026-07-07T00:00:00Z","input_tokens":999,"output_tokens":1,"cached_tokens":0,"cached_tokens_available":false,"cache_write_tokens":0,"total_tokens":1000,"token_details":null,"is_subagent":false}]}"#,
+        r#"{"records":[{"model_id":"model-b","session_id":"session-b","turn_id":"turn-b","timestamp":"2026-07-07T00:00:00Z","input_tokens":999,"output_tokens":1,"cached_tokens":0,"cached_tokens_available":false,"total_tokens":1000,"token_details":null,"is_subagent":false}]}"#,
     )
     .expect("write stray record file");
 

--- a/src/web-ui/src/infrastructure/api/tokenUsageStatisticsApi.test.ts
+++ b/src/web-ui/src/infrastructure/api/tokenUsageStatisticsApi.test.ts
@@ -27,7 +27,6 @@ const STATISTICS: UsageStatistics = {
   totalInputTokens: 0,
   totalOutputTokens: 0,
   totalCachedTokens: 0,
-  totalCacheWriteTokens: 0,
   totalCacheReportedInputTokens: 0,
   byModel: [],
   byGroup: [],

--- a/src/web-ui/src/infrastructure/api/tokenUsageStatisticsApi.ts
+++ b/src/web-ui/src/infrastructure/api/tokenUsageStatisticsApi.ts
@@ -59,7 +59,6 @@ export interface UsageTrendPoint {
   inputTokens: number;
   outputTokens: number;
   cacheReadTokens: number;
-  cacheWriteTokens: number;
   /** 0.0..=1.0 when the bucket has cache telemetry. */
   cacheHitRate: number | null;
 }
@@ -70,7 +69,6 @@ export interface UsageStatistics {
   totalInputTokens: number;
   totalOutputTokens: number;
   totalCachedTokens: number;
-  totalCacheWriteTokens: number;
   /** Prompt input tokens from requests that reported cache telemetry. */
   totalCacheReportedInputTokens: number;
   byModel: UsageStatisticsEntry[];

--- a/src/web-ui/src/infrastructure/config/components/UsageStatisticsConfig.test.tsx
+++ b/src/web-ui/src/infrastructure/config/components/UsageStatisticsConfig.test.tsx
@@ -96,7 +96,6 @@ const SAMPLE_STATS: UsageStatistics = {
   totalInputTokens: 4_400_000,
   totalOutputTokens: 400_000,
   totalCachedTokens: 4_200_000,
-  totalCacheWriteTokens: 0,
   totalCacheReportedInputTokens: 4_400_000,
   byModel: [
     {
@@ -137,7 +136,6 @@ const SAMPLE_STATS: UsageStatistics = {
       inputTokens: 1_000_000,
       outputTokens: 100_000,
       cacheReadTokens: 900_000,
-      cacheWriteTokens: 0,
       cacheHitRate: 0.9,
     },
     {
@@ -145,7 +143,6 @@ const SAMPLE_STATS: UsageStatistics = {
       inputTokens: 2_000_000,
       outputTokens: 200_000,
       cacheReadTokens: 1_900_000,
-      cacheWriteTokens: 0,
       cacheHitRate: 0.95,
     },
   ],

--- a/src/web-ui/src/infrastructure/config/components/UsageStatisticsConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/UsageStatisticsConfig.tsx
@@ -413,8 +413,11 @@ const TrendChart: React.FC<TrendChartProps> = ({ points, granularity, timeZone }
   const yFor = (value: number): number => (
     PAD_TOP + plotHeight - (value / maxTokens) * plotHeight
   );
-  const rateFor = (value: number | null): number | null => (
-    value === null ? null : PAD_TOP + plotHeight - value * plotHeight
+  // Buckets without cache telemetry (idle hours, or the provider never
+  // reported cached tokens) plot at 0% so the dashed line stays continuous,
+  // matching the token series which also sit at zero for those buckets.
+  const rateFor = (value: number | null): number => (
+    PAD_TOP + plotHeight - (value ?? 0) * plotHeight
   );
 
   const xTickIndexes = useMemo(() => {
@@ -427,29 +430,6 @@ const TrendChart: React.FC<TrendChartProps> = ({ points, granularity, timeZone }
   if (points.length === 0) return null;
 
   const hovered = hoverIndex !== null ? points[hoverIndex] : null;
-
-  // The hit-rate series has real gaps: a bucket with no cache telemetry
-  // (no records, or the provider never reported cached tokens) carries
-  // `cacheHitRate: null`. Split the series into contiguous segments so the
-  // chart never draws a line ACROSS a gap — bridging e.g. a 97% bucket to a
-  // 100% bucket over an idle stretch made the chart look like cache hits
-  // continued while every token counter sat at zero.
-  const hitRateSegments: Array<Array<{ x: number; y: number }>> = [];
-  {
-    let current: Array<{ x: number; y: number }> = [];
-    for (let index = 0; index < points.length; index += 1) {
-      const y = rateFor(points[index].cacheHitRate);
-      if (y === null) {
-        if (current.length > 0) {
-          hitRateSegments.push(current);
-          current = [];
-        }
-        continue;
-      }
-      current.push({ x: xFor(index), y });
-    }
-    if (current.length > 0) hitRateSegments.push(current);
-  }
 
   return (
     <div className="bitfun-usage-stats__trend">
@@ -510,30 +490,19 @@ const TrendChart: React.FC<TrendChartProps> = ({ points, granularity, timeZone }
           />
         ))}
 
-        {/* Cache hit rate (right axis, dashed) — broken at buckets without
-            telemetry so gaps stay visible instead of being bridged. */}
-        {hitRateSegments.map((segment, segmentIndex) =>
-          segment.length === 1 ? (
-            <circle
-              key={`rate-gap-${segmentIndex}`}
-              cx={segment[0].x}
-              cy={segment[0].y}
-              r="2.5"
-              fill={SERIES_COLORS.cacheHitRate}
-            />
-          ) : (
-            <polyline
-              key={`rate-gap-${segmentIndex}`}
-              points={segment.map((p) => `${p.x},${p.y}`).join(' ')}
-              fill="none"
-              stroke={SERIES_COLORS.cacheHitRate}
-              strokeWidth="2"
-              strokeDasharray="4 4"
-              strokeLinejoin="round"
-              strokeLinecap="round"
-            />
-          ),
-        )}
+        {/* Cache hit rate (right axis, dashed). Buckets without telemetry
+            plot at 0% so the line stays continuous like the token series. */}
+        <polyline
+          points={points
+            .map((point, index) => `${xFor(index)},${rateFor(point.cacheHitRate)}`)
+            .join(' ')}
+          fill="none"
+          stroke={SERIES_COLORS.cacheHitRate}
+          strokeWidth="2"
+          strokeDasharray="4 4"
+          strokeLinejoin="round"
+          strokeLinecap="round"
+        />
 
         {/* Hover capture */}
         <rect
@@ -560,8 +529,7 @@ const TrendChart: React.FC<TrendChartProps> = ({ points, granularity, timeZone }
             />
             {/* Hover markers: one dot per series so small values stay visible
                 where a zero-baseline token axis would otherwise flatten them
-                (e.g. 276K next to a 20M peak). The rate dot only appears when
-                the bucket actually has cache telemetry. */}
+                (e.g. 276K next to a 20M peak). */}
             {TREND_SERIES.map((series) => (
               <circle
                 key={`hover-dot-${series.key}`}
@@ -573,16 +541,14 @@ const TrendChart: React.FC<TrendChartProps> = ({ points, granularity, timeZone }
                 strokeWidth="1"
               />
             ))}
-            {hovered.cacheHitRate !== null && (
-              <circle
-                cx={xFor(hoverIndex)}
-                cy={PAD_TOP + plotHeight - hovered.cacheHitRate * plotHeight}
-                r="3.5"
-                fill={SERIES_COLORS.cacheHitRate}
-                stroke="var(--bf-appearance-token-element-bg-soft)"
-                strokeWidth="1"
-              />
-            )}
+            <circle
+              cx={xFor(hoverIndex)}
+              cy={rateFor(hovered.cacheHitRate)}
+              r="3.5"
+              fill={SERIES_COLORS.cacheHitRate}
+              stroke="var(--bf-appearance-token-element-bg-soft)"
+              strokeWidth="1"
+            />
             <g className="bitfun-usage-stats__trend-tooltip">
               <rect
                 x={Math.min(Math.max(xFor(hoverIndex) - 92, PAD_LEFT), CHART_WIDTH - PAD_RIGHT - 184)}
@@ -604,7 +570,8 @@ const TrendChart: React.FC<TrendChartProps> = ({ points, granularity, timeZone }
                 { label: t('trend.legend.cacheRead'), value: hovered.cacheReadTokens, color: SERIES_COLORS.cacheRead },
                 {
                   label: t('trend.legend.cacheHitRate'),
-                  value: hovered.cacheHitRate,
+                  // Mirrors the line: buckets without telemetry are drawn at 0%.
+                  value: hovered.cacheHitRate ?? 0,
                   color: SERIES_COLORS.cacheHitRate,
                   isRate: true,
                 },

--- a/src/web-ui/src/infrastructure/config/components/UsageStatisticsConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/UsageStatisticsConfig.tsx
@@ -33,7 +33,6 @@ import './UsageStatisticsConfig.scss';
 const SERIES_COLORS = {
   input: 'var(--bf-appearance-token-color-accent-500)',
   output: 'var(--bf-appearance-token-color-success)',
-  cacheCreation: 'var(--bf-appearance-token-color-warning)',
   cacheRead: 'var(--bf-appearance-token-color-cyan-500)',
   cacheHitRate: 'var(--bf-appearance-token-color-purple-500)',
 } as const;
@@ -366,13 +365,12 @@ interface TrendChartProps {
 }
 
 const TREND_SERIES: {
-  key: 'inputTokens' | 'outputTokens' | 'cacheReadTokens' | 'cacheWriteTokens';
+  key: 'inputTokens' | 'outputTokens' | 'cacheReadTokens';
   color: string;
   legendKey: string;
 }[] = [
   { key: 'inputTokens', color: SERIES_COLORS.input, legendKey: 'trend.legend.input' },
   { key: 'outputTokens', color: SERIES_COLORS.output, legendKey: 'trend.legend.output' },
-  { key: 'cacheWriteTokens', color: SERIES_COLORS.cacheCreation, legendKey: 'trend.legend.cacheCreation' },
   { key: 'cacheReadTokens', color: SERIES_COLORS.cacheRead, legendKey: 'trend.legend.cacheRead' },
 ];
 
@@ -404,7 +402,6 @@ const TrendChart: React.FC<TrendChartProps> = ({ points, granularity, timeZone }
       point.inputTokens,
       point.outputTokens,
       point.cacheReadTokens,
-      point.cacheWriteTokens,
     ), 0),
   );
   const yTicks = 4;
@@ -548,7 +545,6 @@ const TrendChart: React.FC<TrendChartProps> = ({ points, granularity, timeZone }
               {[
                 { label: t('trend.legend.input'), value: hovered.inputTokens, color: SERIES_COLORS.input },
                 { label: t('trend.legend.output'), value: hovered.outputTokens, color: SERIES_COLORS.output },
-                { label: t('trend.legend.cacheCreation'), value: hovered.cacheWriteTokens, color: SERIES_COLORS.cacheCreation },
                 { label: t('trend.legend.cacheRead'), value: hovered.cacheReadTokens, color: SERIES_COLORS.cacheRead },
                 {
                   label: t('trend.legend.cacheHitRate'),

--- a/src/web-ui/src/infrastructure/config/components/UsageStatisticsConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/UsageStatisticsConfig.tsx
@@ -428,6 +428,29 @@ const TrendChart: React.FC<TrendChartProps> = ({ points, granularity, timeZone }
 
   const hovered = hoverIndex !== null ? points[hoverIndex] : null;
 
+  // The hit-rate series has real gaps: a bucket with no cache telemetry
+  // (no records, or the provider never reported cached tokens) carries
+  // `cacheHitRate: null`. Split the series into contiguous segments so the
+  // chart never draws a line ACROSS a gap — bridging e.g. a 97% bucket to a
+  // 100% bucket over an idle stretch made the chart look like cache hits
+  // continued while every token counter sat at zero.
+  const hitRateSegments: Array<Array<{ x: number; y: number }>> = [];
+  {
+    let current: Array<{ x: number; y: number }> = [];
+    for (let index = 0; index < points.length; index += 1) {
+      const y = rateFor(points[index].cacheHitRate);
+      if (y === null) {
+        if (current.length > 0) {
+          hitRateSegments.push(current);
+          current = [];
+        }
+        continue;
+      }
+      current.push({ x: xFor(index), y });
+    }
+    if (current.length > 0) hitRateSegments.push(current);
+  }
+
   return (
     <div className="bitfun-usage-stats__trend">
       <svg
@@ -487,22 +510,30 @@ const TrendChart: React.FC<TrendChartProps> = ({ points, granularity, timeZone }
           />
         ))}
 
-        {/* Cache hit rate (right axis, dashed) */}
-        <polyline
-          points={points
-            .map((point, index) => {
-              const y = rateFor(point.cacheHitRate);
-              return y === null ? '' : `${xFor(index)},${y}`;
-            })
-            .filter(Boolean)
-            .join(' ')}
-          fill="none"
-          stroke={SERIES_COLORS.cacheHitRate}
-          strokeWidth="2"
-          strokeDasharray="4 4"
-          strokeLinejoin="round"
-          strokeLinecap="round"
-        />
+        {/* Cache hit rate (right axis, dashed) — broken at buckets without
+            telemetry so gaps stay visible instead of being bridged. */}
+        {hitRateSegments.map((segment, segmentIndex) =>
+          segment.length === 1 ? (
+            <circle
+              key={`rate-gap-${segmentIndex}`}
+              cx={segment[0].x}
+              cy={segment[0].y}
+              r="2.5"
+              fill={SERIES_COLORS.cacheHitRate}
+            />
+          ) : (
+            <polyline
+              key={`rate-gap-${segmentIndex}`}
+              points={segment.map((p) => `${p.x},${p.y}`).join(' ')}
+              fill="none"
+              stroke={SERIES_COLORS.cacheHitRate}
+              strokeWidth="2"
+              strokeDasharray="4 4"
+              strokeLinejoin="round"
+              strokeLinecap="round"
+            />
+          ),
+        )}
 
         {/* Hover capture */}
         <rect
@@ -527,6 +558,31 @@ const TrendChart: React.FC<TrendChartProps> = ({ points, granularity, timeZone }
               y2={PAD_TOP + plotHeight}
               className="bitfun-usage-stats__trend-cursor"
             />
+            {/* Hover markers: one dot per series so small values stay visible
+                where a zero-baseline token axis would otherwise flatten them
+                (e.g. 276K next to a 20M peak). The rate dot only appears when
+                the bucket actually has cache telemetry. */}
+            {TREND_SERIES.map((series) => (
+              <circle
+                key={`hover-dot-${series.key}`}
+                cx={xFor(hoverIndex)}
+                cy={yFor(hovered[series.key])}
+                r="3.5"
+                fill={series.color}
+                stroke="var(--bf-appearance-token-element-bg-soft)"
+                strokeWidth="1"
+              />
+            ))}
+            {hovered.cacheHitRate !== null && (
+              <circle
+                cx={xFor(hoverIndex)}
+                cy={PAD_TOP + plotHeight - hovered.cacheHitRate * plotHeight}
+                r="3.5"
+                fill={SERIES_COLORS.cacheHitRate}
+                stroke="var(--bf-appearance-token-element-bg-soft)"
+                strokeWidth="1"
+              />
+            )}
             <g className="bitfun-usage-stats__trend-tooltip">
               <rect
                 x={Math.min(Math.max(xFor(hoverIndex) - 92, PAD_LEFT), CHART_WIDTH - PAD_RIGHT - 184)}
@@ -548,8 +604,9 @@ const TrendChart: React.FC<TrendChartProps> = ({ points, granularity, timeZone }
                 { label: t('trend.legend.cacheRead'), value: hovered.cacheReadTokens, color: SERIES_COLORS.cacheRead },
                 {
                   label: t('trend.legend.cacheHitRate'),
-                  value: hovered.cacheHitRate === null ? null : `${Math.round(hovered.cacheHitRate * 100)}%`,
+                  value: hovered.cacheHitRate,
                   color: SERIES_COLORS.cacheHitRate,
+                  isRate: true,
                 },
               ].map((row, index) => (
                 <text
@@ -559,7 +616,12 @@ const TrendChart: React.FC<TrendChartProps> = ({ points, granularity, timeZone }
                   className="bitfun-usage-stats__trend-tooltip-row"
                 >
                   <tspan fill={row.color}>● </tspan>
-                  {row.label}: {row.value === null ? '–' : formatTokens(row.value as number)}
+                  {row.label}:{' '}
+                  {row.isRate
+                    ? formatHitRate(row.value as number | null)
+                    : row.value === null
+                      ? '–'
+                      : formatTokens(row.value as number)}
                 </text>
               ))}
             </g>

--- a/src/web-ui/src/locales/en-US/settings/usage-statistics.json
+++ b/src/web-ui/src/locales/en-US/settings/usage-statistics.json
@@ -63,7 +63,6 @@
     "legend": {
       "input": "Input",
       "output": "Output",
-      "cacheCreation": "Cache Creation",
       "cacheRead": "Cache Read",
       "cacheHitRate": "Cache Hit Rate"
     }

--- a/src/web-ui/src/locales/zh-CN/settings/usage-statistics.json
+++ b/src/web-ui/src/locales/zh-CN/settings/usage-statistics.json
@@ -63,7 +63,6 @@
     "legend": {
       "input": "Input",
       "output": "Output",
-      "cacheCreation": "Cache Creation",
       "cacheRead": "Cache Read",
       "cacheHitRate": "缓存命中率"
     }

--- a/src/web-ui/src/locales/zh-TW/settings/usage-statistics.json
+++ b/src/web-ui/src/locales/zh-TW/settings/usage-statistics.json
@@ -63,7 +63,6 @@
     "legend": {
       "input": "Input",
       "output": "Output",
-      "cacheCreation": "Cache Creation",
       "cacheRead": "Cache Read",
       "cacheHitRate": "快取命中率"
     }


### PR DESCRIPTION
## Summary

Three follow-up fixes for the usage statistics page (continuation of the
review work in #2353, rebased onto current `main`):

1. **Drop the cache_write metric from the statistics pipeline** — cache
   creation/write counts are provider-internal telemetry that local
   clients generally never receive; the field was always 0 and only added
   noise. Removed end-to-end (Rust types + aggregation + integration
   tests + TS API mirror + chart series + legend i18n).
2. **Trend chart hover markers** — one dot per series under the cursor so
   small values stay visible on a zero-baseline token axis (e.g. 276K
   next to a 20M peak previously rendered as flat zero with no anchor).
3. **Cache hit-rate line plots gaps at 0%** — buckets without cache
   telemetry now sit at 0% like the token series do, keeping the dashed
   line continuous instead of breaking it into orphan dots and blank
   stretches. The tooltip mirrors the line with `0.00%`.

`formatHitRate` truncation semantics are preserved: no rounding up,
100% only for an exact full hit.

## Verification

```
cargo check -p bitfun-services-core --features local-storage        OK
cargo test -p bitfun-services-core --features local-storage         131 passed
cargo test -p bitfun-core service::token_usage                       10 passed
vitest (UsageStatisticsConfig + tokenUsageStatisticsApi)             10 passed
tsc --noEmit                                                         OK
```

Also validated end-to-end in a nightly desktop build against real
multi-provider data (智谱AI / OpenRouter): idle stretches now draw a
continuous hit-rate line through 0%, and small-value hover points are
visible.