### PR TITLE
Strengthen intent reduction safety across Agent Hook rewrites

### DIFF
--- a/docs/features/agent-hooks.md
+++ b/docs/features/agent-hooks.md
@@ -229,6 +229,10 @@ Everything not listed here behaves as the Codex documentation describes.
 - **A hook can narrow the permission policy, never widen it.** A `PreToolUse`
   `permissionDecision: "allow"` waives the interactive prompt, but a tool call
   denied by a permission rule stays denied.
+- `PreToolUse updatedInput` is final-validated before execution. It may repair
+  ordinary malformed input, but it cannot relax a non-relaxable internal
+  constraint (for example, a user-requested edit restriction) that rejected
+  the original input.
 - `suppressOutput` is parsed and currently ignored.
 - `continue: false` is honored for `PreToolUse` and `UserPromptSubmit`; for
   other events use `decision: "block"`.
@@ -245,6 +249,9 @@ every time its event fires. Treat `hooks.json` like a shell profile:
 - Review any hook you did not write before enabling it.
 - Keep project hooks off unless you trust everyone who can commit to the
   repository.
+- A hook command that writes files directly bypasses the tool pipeline and its
+  `validate_input` checks. Use `updatedInput` for tool rewrites; sandbox or
+  disable untrusted command hooks when direct process side effects are unsafe.
 - Payload values (prompts, tool arguments, file paths) are model- and
   user-supplied text. Parse them as JSON and never interpolate them into a
   shell command — that is why the examples above read fields with

--- a/docs/features/agent-hooks.zh-CN.md
+++ b/docs/features/agent-hooks.zh-CN.md
@@ -208,6 +208,9 @@ sys.exit(0)
 - **Hook 只能收紧权限策略，永远无法放宽。** `PreToolUse` 的
   `permissionDecision: "allow"` 只免去交互式确认；被权限规则拒绝的工具调用依然
   会被拒绝。
+- `PreToolUse updatedInput` 在执行前会用最终参数重新校验。它可以修复普通的
+  参数格式错误，但不能放宽已经拒绝原始参数的不可放宽内部约束（例如用户
+  明确提出的编辑限制）。
 - `suppressOutput` 会被解析，但当前被忽略。
 - `continue: false` 对 `PreToolUse` 和 `UserPromptSubmit` 生效；其他事件请使用
   `decision: "block"`。
@@ -223,6 +226,9 @@ Hook 是以你的用户权限运行的任意代码，且每次对应事件触发
 
 - 启用任何非你本人编写的 Hook 之前先审阅它。
 - 除非你信任所有能向仓库提交代码的人，否则保持项目级 Hooks 关闭。
+- Hook 命令如果直接写文件，会绕过工具管道及其 `validate_input` 检查。工具参数重写
+  应使用 `updatedInput`；无法接受外部进程副作用时，应禁用不可信命令 Hook 或将其
+  放入 sandbox。
 - 载荷中的值（提示词、工具参数、文件路径）是模型和用户提供的文本。请按 JSON 解析，
   不要拼接进 shell 命令 —— 上面的示例正是为此用 `jq` / `json.load` 读取字段。
 - 不要在 `SessionStart`、`UserPromptSubmit`、`SubagentStart` 中把密钥打印到

--- a/docs/plans/edit-constraint-guard-plan.md
+++ b/docs/plans/edit-constraint-guard-plan.md
@@ -124,8 +124,8 @@ turn 抽取与文件来源记录；旧格式中缺少 turn id 的来源记录不
 - matcher 规则和 operation scope；
 - 确定性抽取、模型解析失败、合法与非法撤销；
 - 新建测试辅助文件、已有测试文件和 delete-only 的差异；
-- `PreToolUse updatedInput` 修复普通无效参数、从受保护原始目标重写到新副本、从合法
-  原始目标重写到受保护目标，以及 hook allow 不能覆盖不可放宽拒绝；
+- `PreToolUse updatedInput` 修复仅含普通格式错误的参数、从同时带有普通格式错误的受保护
+  原始目标重写到新副本、从合法原始目标重写到受保护目标，以及 hook allow 不能覆盖不可放宽拒绝；
 - shell 重定向、`tee`、`cp`、`mv`、`rm`、in-place `sed/perl`、Python、Node、WriteStdin、
   Git pathspec 与无法解析目标的高风险命令；
 - 递归删除、符号链接、远程工作区检查失败；

--- a/docs/plans/edit-constraint-guard-plan.md
+++ b/docs/plans/edit-constraint-guard-plan.md
@@ -26,6 +26,11 @@ agent 返回可解释的拒绝原因。约束属于用户会话状态，必须�
 网络出口、仓库历史净化和评测审计属于评测管道。产品工具保持普通用户预期的 Web 与 Git
 能力，guard 代码不得出现 benchmark 名称或站点黑名单。
 
+`updatedInput` 依然通过 BitFun 工具管道执行，因此可由本设计守住。Native hook handler
+命令本身是一个外部进程；如果 handler 绕过 `updatedInput` 直接写文件，该副作用不会进入工具
+`validate_input`。这类 hook 的信任、启用和进程隔离属于 Native hook 安全边界；严格评测
+环境应禁用不可信 hook 或在外层 sandbox 中限制它，不应把外部进程副作用误认为工具守卫可见。
+
 ## 模块与职责
 
 | 模块 | 职责 |
@@ -71,8 +76,17 @@ turn 抽取与文件来源记录；旧格式中缺少 turn id 的来源记录不
    guard 状态，也不触发 metadata 重写。抽取失败单独记录，执行阶段 fail open。
 4. 文件工具在 `validate_input` 中调用统一检查；shell、WriteStdin 和 Git 工具先将可静态识别的
    变更目标解析为路径。存在 active constraint 时，无法解析目标的高风险变更命令 fail closed。
-5. 命中约束时返回 403 和结构化 `edit_constraint_guard` 元数据，不执行写入。
-6. 设置 `BITFUN_EDIT_CONSTRAINT_TELEMETRY=1` 后，guard 决策和成功的直接文件工具操作写入
+5. Native `PreToolUse` hook 是可扩展重写层，不是约束所有者。只要 hook 返回
+   `updatedInput`，pipeline 就对 hook 前的原始有效参数执行一次不可放宽约束检查，并对
+   hook 后的最终参数继续执行完整 `validate_input`。任一组参数命中不可放宽约束时都拒绝
+   执行；hook 的 allow 或路径重写不能洗掉用户约束。格式修复等未标记为不可放宽的普通
+   validation 失败仍可由 hook 修复。
+6. hook 重写不改变新建测试辅助文件豁免的语义：原始目标本来就是新测试文件时
+   可按现有 provenance 规则通过；从已受保护文件重写到一个新副本则仍因原始参数命中
+   约束而被拒绝。
+7. 命中约束时返回 403 和结构化 `edit_constraint_guard` 元数据，并标记该失败不可被
+   input rewrite 放宽，不执行写入。
+8. 设置 `BITFUN_EDIT_CONSTRAINT_TELEMETRY=1` 后，guard 决策和成功的直接文件工具操作写入
    session-scoped JSONL，用于产品诊断；默认不创建 JSONL。该开关不影响 AI provider 请求审计。
 
 撤销只接受当前 active constraint id，且只有真实用户提交的 turn 可以授权撤销。含糊表达、
@@ -96,6 +110,8 @@ turn 抽取与文件来源记录；旧格式中缺少 turn id 的来源记录不
 - 无 active constraint 时，guard 不改变普通编辑、Web 或 Git 行为，也不执行路径/远程存在性检查。
 - 同一 dialog turn 和消息 hash 不重复抽取。
 - 未知撤销 id 永远不删除约束。
+- Native hook 只能缩紧、修复或保持用户约束，不能通过 `updatedInput` 将原本受保护的
+  写入改到新路径后执行。
 - session restore 与 fork 后的 active constraints 与父会话一致。
 - rollback 后不能保留来自已删除 turn 的约束或 agent-created 豁免。
 - 拒绝发生在写入前，递归删除不会出现部分删除后才发现受保护文件。
@@ -108,6 +124,8 @@ turn 抽取与文件来源记录；旧格式中缺少 turn id 的来源记录不
 - matcher 规则和 operation scope；
 - 确定性抽取、模型解析失败、合法与非法撤销；
 - 新建测试辅助文件、已有测试文件和 delete-only 的差异；
+- `PreToolUse updatedInput` 修复普通无效参数、从受保护原始目标重写到新副本、从合法
+  原始目标重写到受保护目标，以及 hook allow 不能覆盖不可放宽拒绝；
 - shell 重定向、`tee`、`cp`、`mv`、`rm`、in-place `sed/perl`、Python、Node、WriteStdin、
   Git pathspec 与无法解析目标的高风险命令；
 - 递归删除、符号链接、远程工作区检查失败；

--- a/src/crates/assembly/core/src/agentic/execution/edit_constraint_guard.rs
+++ b/src/crates/assembly/core/src/agentic/execution/edit_constraint_guard.rs
@@ -862,6 +862,7 @@ fn decision_result(
         error_code,
         meta: Some(json!({
             "failure_kind": "edit_constraint_guard",
+            "blocks_input_rewrite": true,
             "guard_decision_id": decision_id,
             "guard_decision": decision,
             "constraint_id": violation.map(|constraint| constraint.id.as_str()),

--- a/src/crates/assembly/core/src/agentic/execution/edit_constraint_guard.rs
+++ b/src/crates/assembly/core/src/agentic/execution/edit_constraint_guard.rs
@@ -36,6 +36,8 @@ use shell_targets::ShellMutationOperation;
 use shell_targets::{explicit_bash_mutation_targets, has_unresolved_bash_mutation};
 
 pub const EDIT_CONSTRAINT_METADATA_KEY: &str = "editConstraintGuard";
+#[cfg(test)]
+pub(crate) const TEST_EDIT_CONSTRAINT_STATE_KEY: &str = "__bitfun_test_edit_constraint_state";
 const EDIT_CONSTRAINT_SCHEMA_VERSION: u32 = 6;
 const MAX_PROMPT_CHARS: usize = 8_000;
 const MAX_RESPONSE_TELEMETRY_CHARS: usize = 4_000;
@@ -812,6 +814,24 @@ fn resolved_path(context: &ToolUseContext, file_path: &str) -> Option<String> {
         .map(|resolved| resolved.resolved_path)
 }
 
+fn current_edit_constraint_state(context: Option<&ToolUseContext>) -> Option<EditConstraintState> {
+    #[cfg(test)]
+    if let Some(state) = context
+        .and_then(|value| value.custom_data.get(TEST_EDIT_CONSTRAINT_STATE_KEY))
+        .and_then(|value| serde_json::from_value(value.clone()).ok())
+    {
+        return Some(state);
+    }
+
+    context
+        .and_then(|value| value.session_id.as_deref())
+        .and_then(|session_id| {
+            get_global_coordinator()?
+                .get_session_manager()
+                .edit_constraint_state(session_id)
+        })
+}
+
 fn decision_result(
     context: Option<&ToolUseContext>,
     tool_name: &str,
@@ -883,27 +903,33 @@ pub fn check(
     file_path: &str,
     force_requested: bool,
 ) -> Option<ValidationResult> {
-    let state = context
-        .and_then(|value| value.session_id.as_deref())
-        .and_then(|session_id| {
-            get_global_coordinator()?
-                .get_session_manager()
-                .edit_constraint_state(session_id)
-        });
+    let state = current_edit_constraint_state(context);
 
+    check_with_state(
+        context,
+        tool_name,
+        operation,
+        file_path,
+        force_requested,
+        state.as_ref(),
+    )
+}
+
+fn check_with_state(
+    context: Option<&ToolUseContext>,
+    tool_name: &str,
+    operation: &str,
+    file_path: &str,
+    force_requested: bool,
+    state: Option<&EditConstraintState>,
+) -> Option<ValidationResult> {
     if !force_requested
         && !edit_constraint_telemetry_enabled()
-        && state
-            .as_ref()
-            .is_none_or(|state| !state.has_enforceable_constraints())
+        && state.is_none_or(|state| !state.has_enforceable_constraints())
     {
         return None;
     }
-    if !force_requested
-        && state
-            .as_ref()
-            .is_none_or(|state| !state.has_enforceable_constraints())
-    {
+    if !force_requested && state.is_none_or(|state| !state.has_enforceable_constraints()) {
         if edit_constraint_telemetry_enabled() {
             decision_result(
                 context,
@@ -912,7 +938,7 @@ pub fn check(
                 file_path,
                 "allow_no_active_constraint",
                 false,
-                state.as_ref(),
+                state,
                 None,
                 None,
                 None,
@@ -929,7 +955,7 @@ pub fn check(
             file_path,
             "force_denied",
             true,
-            state.as_ref(),
+            state,
             None,
             Some(
                 "`force` cannot override constraints stated by the user. Reconsider the source-code approach without modifying the protected file."
@@ -940,7 +966,7 @@ pub fn check(
     }
 
     let paths = candidate_paths(context, file_path);
-    let violation = state.as_ref().and_then(|state| {
+    let violation = state.and_then(|state| {
         paths
             .iter()
             .find_map(|path| find_violation_for_operation(&state.constraints, path, operation))
@@ -953,28 +979,19 @@ pub fn check(
             file_path,
             "deny",
             false,
-            state.as_ref(),
+            state,
             Some(violation),
             Some(violation_message(file_path, violation)),
             Some(403),
         );
     }
 
-    let decision = match state.as_ref().and_then(EditConstraintState::latest_status) {
+    let decision = match state.and_then(EditConstraintState::latest_status) {
         Some(ExtractionStatus::Failed) | None => "allow_extraction_unavailable",
         _ => "allow",
     };
     decision_result(
-        context,
-        tool_name,
-        operation,
-        file_path,
-        decision,
-        false,
-        state.as_ref(),
-        None,
-        None,
-        None,
+        context, tool_name, operation, file_path, decision, false, state, None, None, None,
     );
     None
 }
@@ -1155,44 +1172,61 @@ pub fn check_delete(
 /// remain dynamic or implicit are rejected before execution; ordinary build,
 /// test, and read-only commands retain the normal shell path.
 pub fn check_bash_command(context: &ToolUseContext, command: &str) -> Option<ValidationResult> {
-    let has_active_constraints = context.session_id.as_deref().is_some_and(|session_id| {
-        get_global_coordinator()
-            .and_then(|coordinator| {
-                coordinator
-                    .get_session_manager()
-                    .edit_constraint_state(session_id)
-            })
-            .is_some_and(|state| state.has_enforceable_constraints())
-    });
-    if !has_active_constraints {
-        return None;
-    }
+    check_bash_command_in_directory(context, command, None)
+}
+
+pub fn check_bash_command_in_directory(
+    context: &ToolUseContext,
+    command: &str,
+    working_directory: Option<&str>,
+) -> Option<ValidationResult> {
+    let state = current_edit_constraint_state(Some(context));
+    check_bash_command_with_state(context, command, working_directory, state.as_ref())
+}
+
+fn command_target_path(
+    context: &ToolUseContext,
+    target: &str,
+    working_directory: Option<&str>,
+) -> String {
+    let Some(working_directory) = working_directory else {
+        return target.to_string();
+    };
+    bitfun_agent_tools::resolve_workspace_tool_path(
+        target,
+        Some(working_directory),
+        context.is_remote(),
+    )
+    .unwrap_or_else(|_| target.to_string())
+}
+
+fn check_bash_command_with_state(
+    context: &ToolUseContext,
+    command: &str,
+    working_directory: Option<&str>,
+    state: Option<&EditConstraintState>,
+) -> Option<ValidationResult> {
+    let state = state.filter(|state| state.has_enforceable_constraints())?;
     let targets = explicit_bash_mutation_targets(command);
     for target in &targets {
-        if let Some(rejection) = check(
+        let target_path = command_target_path(context, &target.path, working_directory);
+        if let Some(rejection) = check_with_state(
             Some(context),
             "Bash",
             target.operation.guard_operation(),
-            &target.path,
+            &target_path,
             false,
+            Some(state),
         ) {
             return Some(rejection);
         }
     }
     if has_unresolved_bash_mutation(command, &targets) {
-        let state = context.session_id.as_deref().and_then(|session_id| {
-            get_global_coordinator()?
-                .get_session_manager()
-                .edit_constraint_state(session_id)
-        });
-        if let Some((state, constraint)) = state.and_then(|state| {
-            let constraint = state
-                .constraints
-                .iter()
-                .find(|constraint| constraint.matcher.enforceable())?
-                .clone();
-            Some((state, constraint))
-        }) {
+        if let Some(constraint) = state
+            .constraints
+            .iter()
+            .find(|constraint| constraint.matcher.enforceable())
+        {
             return decision_result(
                 Some(context),
                 "Bash",
@@ -1200,8 +1234,8 @@ pub fn check_bash_command(context: &ToolUseContext, command: &str) -> Option<Val
                 "<dynamic shell target>",
                 "deny_unresolved_target",
                 false,
-                Some(&state),
-                Some(&constraint),
+                Some(state),
+                Some(constraint),
                 Some(
                     "This command may modify files through a dynamic or implicit target while an edit constraint is active. Use a direct file tool or a command with explicit literal paths so the protected scope can be checked before execution."
                         .to_string(),
@@ -1218,12 +1252,21 @@ pub fn check_git_command(
     operation: &str,
     arguments: &str,
 ) -> Option<ValidationResult> {
+    check_git_command_in_directory(context, operation, arguments, None)
+}
+
+pub fn check_git_command_in_directory(
+    context: &ToolUseContext,
+    operation: &str,
+    arguments: &str,
+    working_directory: Option<&str>,
+) -> Option<ValidationResult> {
     let command = if arguments.trim().is_empty() {
         format!("git {operation}")
     } else {
         format!("git {operation} {}", arguments.trim())
     };
-    check_bash_command(context, &command)
+    check_bash_command_in_directory(context, &command, working_directory)
 }
 
 /// Checks the target and every non-symlink descendant before recursive delete.

--- a/src/crates/assembly/core/src/agentic/execution/edit_constraint_guard/tests.rs
+++ b/src/crates/assembly/core/src/agentic/execution/edit_constraint_guard/tests.rs
@@ -522,6 +522,48 @@ fn guard_rejections_are_non_relaxable_by_input_rewrites() {
 }
 
 #[test]
+fn command_guard_resolves_relative_targets_from_actual_working_directory() {
+    let context = ToolUseContext {
+        tool_call_id: Some("tool-call-cwd".to_string()),
+        agent_type: Some("agentic".to_string()),
+        session_id: None,
+        dialog_turn_id: Some("turn-cwd".to_string()),
+        workspace: Some(WorkspaceBinding::new(None, "/workspace".into())),
+        loaded_deferred_tool_specs: Vec::new(),
+        primary_model_facts: tool_runtime::context::PrimaryModelFacts::default(),
+        custom_data: HashMap::new(),
+        computer_use_host: None,
+        runtime_tool_restrictions: ToolRuntimeRestrictions::default(),
+        runtime_handles: bitfun_runtime_ports::ToolRuntimeHandles::default(),
+    };
+    let state = EditConstraintState {
+        constraints: vec![constraint(
+            "don't touch tests",
+            ConstraintMatcher::TestFiles,
+        )],
+        ..Default::default()
+    };
+
+    assert!(check_bash_command_with_state(
+        &context,
+        "touch helper.rs",
+        Some("/workspace"),
+        Some(&state),
+    )
+    .is_none());
+    let rejection = check_bash_command_with_state(
+        &context,
+        "touch helper.rs",
+        Some("/workspace/tests"),
+        Some(&state),
+    )
+    .expect("the same command in tests must be rejected");
+
+    assert!(rejection.blocks_input_rewrite());
+    assert_eq!(rejection.error_code, Some(403));
+}
+
+#[test]
 fn new_files_are_exempt_only_from_test_file_constraints() {
     let test_only = EditConstraintState {
         constraints: vec![constraint(

--- a/src/crates/assembly/core/src/agentic/execution/edit_constraint_guard/tests.rs
+++ b/src/crates/assembly/core/src/agentic/execution/edit_constraint_guard/tests.rs
@@ -501,6 +501,27 @@ fn find_violation_returns_first_match() {
 }
 
 #[test]
+fn guard_rejections_are_non_relaxable_by_input_rewrites() {
+    let protected = constraint("don't touch tests", ConstraintMatcher::TestFiles);
+    let rejection = decision_result(
+        None,
+        "Write",
+        "write",
+        "tests/existing_test.rs",
+        "deny",
+        false,
+        None,
+        Some(&protected),
+        Some("protected test file".to_string()),
+        Some(403),
+    )
+    .expect("guard rejection");
+
+    assert!(rejection.blocks_input_rewrite());
+    assert_eq!(rejection.error_code, Some(403));
+}
+
+#[test]
 fn new_files_are_exempt_only_from_test_file_constraints() {
     let test_only = EditConstraintState {
         constraints: vec![constraint(

--- a/src/crates/assembly/core/src/agentic/tools/framework.rs
+++ b/src/crates/assembly/core/src/agentic/tools/framework.rs
@@ -153,6 +153,22 @@ pub trait Tool: Send + Sync {
         }
     }
 
+    /// Validate invariants from the original input that a PreToolUse rewrite
+    /// must not relax.
+    ///
+    /// The default preserves existing tools that mark a normal validation
+    /// rejection with `blocks_input_rewrite`. Tools whose ordinary validator
+    /// can return a repairable shape error before reaching an invariant should
+    /// override this method and run the invariant independently.
+    async fn validate_non_relaxable_input(
+        &self,
+        input: &Value,
+        context: Option<&ToolUseContext>,
+    ) -> Option<ValidationResult> {
+        let validation = self.validate_input(input, context).await;
+        validation.blocks_input_rewrite().then_some(validation)
+    }
+
     /// Render result for assistant
     fn render_result_for_assistant(&self, _output: &Value) -> String {
         "Tool result".to_string()

--- a/src/crates/assembly/core/src/agentic/tools/implementations/bash_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/bash_tool.rs
@@ -138,6 +138,40 @@ impl BashTool {
         context.resolve_workspace_tool_path(trimmed).map(Some)
     }
 
+    async fn guard_working_directory(
+        input: &Value,
+        context: &ToolUseContext,
+    ) -> BitFunResult<String> {
+        if let Some(requested) = Self::resolve_working_directory(input, context)? {
+            return Ok(requested);
+        }
+
+        let workspace_path = context
+            .workspace
+            .as_ref()
+            .map(|workspace| workspace.root_path_string())
+            .ok_or_else(|| BitFunError::tool("workspace_path is required for Bash tool"))?;
+        if context.is_remote() {
+            return Ok(workspace_path);
+        }
+
+        let Some(chat_session_id) = context.session_id.as_deref() else {
+            return Ok(workspace_path);
+        };
+        let Ok(terminal_api) = TerminalApi::from_singleton() else {
+            return Ok(workspace_path);
+        };
+        let binding = terminal_api.session_manager().binding();
+        let Some(primary_session_id) = binding.get(chat_session_id) else {
+            return Ok(workspace_path);
+        };
+        Ok(terminal_api
+            .get_session(&primary_session_id)
+            .await
+            .map(|session| session.cwd)
+            .unwrap_or(workspace_path))
+    }
+
     async fn is_existing_workspace_directory(
         context: &ToolUseContext,
         resolved_dir: &str,
@@ -371,7 +405,7 @@ Usage notes:
     fn permission_intents(
         &self,
         input: &Value,
-        _context: &ToolUseContext,
+        context: &ToolUseContext,
     ) -> BitFunResult<Vec<PermissionIntent>> {
         let command = input
             .get("command")
@@ -379,10 +413,29 @@ Usage notes:
             .map(str::trim)
             .filter(|command| !command.is_empty())
             .ok_or_else(|| BitFunError::validation("command is required".to_string()))?;
+        let working_directory = Self::resolve_working_directory(input, context)?;
         Ok(vec![PermissionIntent::new(
             "bash",
-            vec![command.to_string()],
+            vec![command_for_working_directory(
+                command,
+                working_directory.as_deref(),
+            )],
         )])
+    }
+
+    async fn validate_non_relaxable_input(
+        &self,
+        input: &Value,
+        context: Option<&ToolUseContext>,
+    ) -> Option<ValidationResult> {
+        let context = context?;
+        let command = input.get("command").and_then(Value::as_str)?;
+        let working_directory = Self::guard_working_directory(input, context).await.ok();
+        crate::agentic::execution::edit_constraint_guard::check_bash_command_in_directory(
+            context,
+            command,
+            working_directory.as_deref(),
+        )
     }
 
     async fn validate_input(
@@ -497,10 +550,12 @@ Usage notes:
             };
         }
 
+        let guard_working_directory = Self::guard_working_directory(input, context).await.ok();
         if let Some(rejection) =
-            crate::agentic::execution::edit_constraint_guard::check_bash_command(
+            crate::agentic::execution::edit_constraint_guard::check_bash_command_in_directory(
                 context,
                 command.unwrap_or_default(),
+                guard_working_directory.as_deref(),
             )
         {
             return rejection;
@@ -1406,6 +1461,109 @@ impl BashTool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agentic::execution::edit_constraint_guard::{
+        ConstraintMatcher, ConstraintOperationScope, ConstraintSource, EditConstraintState,
+        ExtractedConstraint, TEST_EDIT_CONSTRAINT_STATE_KEY,
+    };
+    use crate::agentic::tools::ToolRuntimeRestrictions;
+    use crate::agentic::WorkspaceBinding;
+    use std::collections::HashMap;
+
+    fn local_tool_context(workspace: &Path) -> ToolUseContext {
+        ToolUseContext {
+            tool_call_id: Some("bash-cwd-test".to_string()),
+            agent_type: Some("agentic".to_string()),
+            session_id: Some("bash-cwd-session".to_string()),
+            dialog_turn_id: Some("bash-cwd-turn".to_string()),
+            workspace: Some(WorkspaceBinding::new(None, workspace.to_path_buf())),
+            loaded_deferred_tool_specs: Vec::new(),
+            primary_model_facts: tool_runtime::context::PrimaryModelFacts::default(),
+            custom_data: HashMap::new(),
+            computer_use_host: None,
+            runtime_tool_restrictions: ToolRuntimeRestrictions::default(),
+            runtime_handles: bitfun_runtime_ports::ToolRuntimeHandles::default(),
+        }
+    }
+
+    fn protect_tests(context: &mut ToolUseContext) {
+        let state = EditConstraintState {
+            constraints: vec![ExtractedConstraint {
+                id: "test:no-tests".to_string(),
+                description: "don't touch tests".to_string(),
+                operation_scope: ConstraintOperationScope::All,
+                matcher: ConstraintMatcher::TestFiles,
+                source: ConstraintSource::Legacy,
+                source_text: None,
+            }],
+            ..Default::default()
+        };
+        context.custom_data.insert(
+            TEST_EDIT_CONSTRAINT_STATE_KEY.to_string(),
+            serde_json::to_value(state).expect("test constraint state"),
+        );
+    }
+
+    #[test]
+    fn permission_intent_includes_requested_working_directory() {
+        let workspace = tempfile::tempdir().expect("temporary workspace");
+        let tests_dir = workspace.path().join("tests");
+        std::fs::create_dir(&tests_dir).expect("tests directory");
+        let context = local_tool_context(workspace.path());
+        let tests_dir_text = tests_dir.to_string_lossy().to_string();
+
+        let intents = BashTool::new()
+            .permission_intents(
+                &json!({
+                    "command": "touch helper.rs",
+                    "working_directory": "tests"
+                }),
+                &context,
+            )
+            .expect("permission intent");
+
+        assert_eq!(
+            intents[0].resources,
+            vec![command_for_working_directory(
+                "touch helper.rs",
+                Some(&tests_dir_text),
+            )]
+        );
+    }
+
+    #[tokio::test]
+    async fn command_guard_rejects_when_only_bash_working_directory_changes() {
+        let workspace = tempfile::tempdir().expect("temporary workspace");
+        std::fs::create_dir(workspace.path().join("tests")).expect("tests directory");
+        let mut context = local_tool_context(workspace.path());
+        protect_tests(&mut context);
+
+        assert!(
+            BashTool::new()
+                .validate_non_relaxable_input(
+                    &json!({
+                        "command": "touch helper.rs",
+                        "working_directory": "."
+                    }),
+                    Some(&context),
+                )
+                .await
+                .is_none(),
+            "the command is allowed from the workspace root"
+        );
+
+        let rejection = BashTool::new()
+            .validate_non_relaxable_input(
+                &json!({
+                    "command": "touch helper.rs",
+                    "working_directory": "tests"
+                }),
+                Some(&context),
+            )
+            .await
+            .expect("Bash command in tests must be rejected");
+
+        assert!(rejection.blocks_input_rewrite());
+    }
 
     #[test]
     fn checkpoint_detection_flags_mutating_bash_commands() {

--- a/src/crates/assembly/core/src/agentic/tools/implementations/delete_file_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/delete_file_tool.rs
@@ -128,6 +128,32 @@ Important notes:
         file_permission_intents("edit", [path], context)
     }
 
+    async fn validate_non_relaxable_input(
+        &self,
+        input: &Value,
+        context: Option<&ToolUseContext>,
+    ) -> Option<ValidationResult> {
+        let path = input
+            .get("path")
+            .and_then(Value::as_str)
+            .filter(|path| !path.is_empty())?;
+        let force = input.get("force").and_then(Value::as_bool).unwrap_or(false);
+        if input
+            .get("recursive")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+        {
+            crate::agentic::execution::edit_constraint_guard::check_recursive_delete(
+                context, path, force,
+            )
+            .await
+        } else {
+            crate::agentic::execution::edit_constraint_guard::check_delete(
+                context, "Delete", "delete", path, force,
+            )
+        }
+    }
+
     async fn validate_input(
         &self,
         input: &Value,

--- a/src/crates/assembly/core/src/agentic/tools/implementations/exec_command/command.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/exec_command/command.rs
@@ -40,6 +40,7 @@ use tool_runtime::exec_command::{
     ExecCommandLifecycleStatus, ExecCommandResultData, ExecCommandResultFields,
     ExecCommandShellMetadata, REMOTE_EXEC_SHELL_PROBE_TIMEOUT_MS,
 };
+use tool_runtime::shell::command_for_working_directory;
 
 #[derive(Debug, Clone)]
 struct RemoteShell {
@@ -114,6 +115,22 @@ impl ExecCommandTool {
             )));
         }
         Ok(path)
+    }
+
+    fn guard_workdir(input: &Value, context: &ToolUseContext) -> Option<String> {
+        let raw = input
+            .get("workdir")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|workdir| !workdir.is_empty())
+            .map(str::to_string)
+            .or_else(|| {
+                context
+                    .workspace
+                    .as_ref()
+                    .map(|workspace| workspace.root_path_string())
+            })?;
+        context.resolve_workspace_tool_path(&raw).ok()
     }
 
     async fn resolve_remote_workdir(
@@ -617,17 +634,39 @@ Output:
     fn permission_intents(
         &self,
         input: &Value,
-        _context: &ToolUseContext,
+        context: &ToolUseContext,
     ) -> BitFunResult<Vec<PermissionIntent>> {
         let command = exec_command_run_input_from_input(input)
             .map(|parsed| parsed.cmd.trim().to_string())
             .filter(|command| !command.is_empty())
             .ok_or_else(|| BitFunError::validation("cmd is required".to_string()))?;
-        Ok(vec![PermissionIntent::new("bash", vec![command])])
+        let working_directory = Self::guard_workdir(input, context);
+        Ok(vec![PermissionIntent::new(
+            "bash",
+            vec![command_for_working_directory(
+                &command,
+                working_directory.as_deref(),
+            )],
+        )])
     }
 
     fn manages_own_execution_timeout(&self) -> bool {
         true
+    }
+
+    async fn validate_non_relaxable_input(
+        &self,
+        input: &Value,
+        context: Option<&ToolUseContext>,
+    ) -> Option<ValidationResult> {
+        let context = context?;
+        let parsed = exec_command_run_input_from_input(input)?;
+        let working_directory = Self::guard_workdir(input, context);
+        crate::agentic::execution::edit_constraint_guard::check_bash_command_in_directory(
+            context,
+            parsed.cmd,
+            working_directory.as_deref(),
+        )
     }
 
     async fn validate_input(
@@ -644,9 +683,12 @@ Output:
             };
         }
         if let (Some(context), Some(parsed)) = (context, exec_command_run_input_from_input(input)) {
+            let working_directory = Self::guard_workdir(input, context);
             if let Some(rejection) =
-                crate::agentic::execution::edit_constraint_guard::check_bash_command(
-                    context, parsed.cmd,
+                crate::agentic::execution::edit_constraint_guard::check_bash_command_in_directory(
+                    context,
+                    parsed.cmd,
+                    working_directory.as_deref(),
                 )
             {
                 return rejection;
@@ -779,6 +821,10 @@ mod tests {
     use super::super::env_snapshot::RemoteEnvSnapshot;
     use super::ExecCommandTool;
     use super::{parse_remote_shell_probe_output, RemoteShell};
+    use crate::agentic::execution::edit_constraint_guard::{
+        ConstraintMatcher, ConstraintOperationScope, ConstraintSource, EditConstraintState,
+        ExtractedConstraint, TEST_EDIT_CONSTRAINT_STATE_KEY,
+    };
     use crate::agentic::tools::framework::{Tool, ToolUseContext};
     use crate::agentic::tools::ToolRuntimeRestrictions;
     use crate::agentic::workspace::WorkspaceBinding;
@@ -792,6 +838,103 @@ mod tests {
     use tool_runtime::exec_command::{
         remote_exec_shell_login_args, EXEC_COMMAND_POWERSHELL_UTF8_OUTPUT_PREFIX,
     };
+
+    fn local_tool_context(workspace: &Path) -> ToolUseContext {
+        ToolUseContext {
+            tool_call_id: Some("exec-cwd-test".to_string()),
+            agent_type: Some("agentic".to_string()),
+            session_id: Some("exec-cwd-session".to_string()),
+            dialog_turn_id: Some("exec-cwd-turn".to_string()),
+            workspace: Some(WorkspaceBinding::new(None, workspace.to_path_buf())),
+            loaded_deferred_tool_specs: Vec::new(),
+            primary_model_facts: tool_runtime::context::PrimaryModelFacts::default(),
+            custom_data: HashMap::new(),
+            computer_use_host: None,
+            runtime_tool_restrictions: ToolRuntimeRestrictions::default(),
+            runtime_handles: bitfun_runtime_ports::ToolRuntimeHandles::default(),
+        }
+    }
+
+    fn protect_tests(context: &mut ToolUseContext) {
+        let state = EditConstraintState {
+            constraints: vec![ExtractedConstraint {
+                id: "test:no-tests".to_string(),
+                description: "don't touch tests".to_string(),
+                operation_scope: ConstraintOperationScope::All,
+                matcher: ConstraintMatcher::TestFiles,
+                source: ConstraintSource::Legacy,
+                source_text: None,
+            }],
+            ..Default::default()
+        };
+        context.custom_data.insert(
+            TEST_EDIT_CONSTRAINT_STATE_KEY.to_string(),
+            serde_json::to_value(state).expect("test constraint state"),
+        );
+    }
+
+    #[test]
+    fn permission_intent_includes_exec_workdir() {
+        let workspace = tempfile::tempdir().expect("temporary workspace");
+        let tests_dir = workspace.path().join("tests");
+        std::fs::create_dir(&tests_dir).expect("tests directory");
+        let context = local_tool_context(workspace.path());
+        let tests_dir_text = tests_dir.to_string_lossy().to_string();
+
+        let intents = ExecCommandTool::new()
+            .permission_intents(
+                &json!({
+                    "cmd": "touch helper.rs",
+                    "workdir": tests_dir.to_string_lossy().to_string()
+                }),
+                &context,
+            )
+            .expect("permission intent");
+
+        assert_eq!(
+            intents[0].resources,
+            vec![tool_runtime::shell::command_for_working_directory(
+                "touch helper.rs",
+                Some(&tests_dir_text),
+            )]
+        );
+    }
+
+    #[tokio::test]
+    async fn command_guard_rejects_when_only_exec_workdir_changes() {
+        let workspace = tempfile::tempdir().expect("temporary workspace");
+        let tests_dir = workspace.path().join("tests");
+        std::fs::create_dir(&tests_dir).expect("tests directory");
+        let mut context = local_tool_context(workspace.path());
+        protect_tests(&mut context);
+
+        assert!(
+            ExecCommandTool::new()
+                .validate_non_relaxable_input(
+                    &json!({
+                        "cmd": "touch helper.rs",
+                        "workdir": workspace.path().to_string_lossy().to_string()
+                    }),
+                    Some(&context),
+                )
+                .await
+                .is_none(),
+            "the command is allowed from the workspace root"
+        );
+
+        let rejection = ExecCommandTool::new()
+            .validate_non_relaxable_input(
+                &json!({
+                    "cmd": "touch helper.rs",
+                    "workdir": tests_dir.to_string_lossy().to_string()
+                }),
+                Some(&context),
+            )
+            .await
+            .expect("ExecCommand in tests must be rejected");
+
+        assert!(rejection.blocks_input_rewrite());
+    }
 
     #[derive(Debug)]
     struct ShellProbeRemoteExecPort {

--- a/src/crates/assembly/core/src/agentic/tools/implementations/exec_command/stdin.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/exec_command/stdin.rs
@@ -159,6 +159,16 @@ Output is only what was produced during this tool call's wait window."#
         true
     }
 
+    async fn validate_non_relaxable_input(
+        &self,
+        input: &Value,
+        context: Option<&ToolUseContext>,
+    ) -> Option<ValidationResult> {
+        let context = context?;
+        let chars = input.get("chars").and_then(Value::as_str)?;
+        crate::agentic::execution::edit_constraint_guard::check_bash_command(context, chars)
+    }
+
     async fn validate_input(
         &self,
         input: &Value,

--- a/src/crates/assembly/core/src/agentic/tools/implementations/file_edit_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/file_edit_tool.rs
@@ -170,6 +170,21 @@ impl Tool for FileEditTool {
         file_permission_intents_allowing_managed_plan_edits("edit", [file_path], context)
     }
 
+    async fn validate_non_relaxable_input(
+        &self,
+        input: &Value,
+        context: Option<&ToolUseContext>,
+    ) -> Option<ValidationResult> {
+        let file_path = input
+            .get("file_path")
+            .and_then(Value::as_str)
+            .filter(|path| !path.is_empty())?;
+        let force = input.get("force").and_then(Value::as_bool).unwrap_or(false);
+        crate::agentic::execution::edit_constraint_guard::check_edit(
+            context, "Edit", "edit", file_path, force,
+        )
+    }
+
     async fn validate_input(
         &self,
         input: &Value,
@@ -456,7 +471,7 @@ impl Tool for FileEditTool {
 mod tests {
     use super::{FileEditTool, EDIT_TOOL_PROMPT};
     use crate::agentic::tools::framework::Tool;
-    use serde_json::Value;
+    use serde_json::{json, Value};
 
     #[tokio::test]
     async fn edit_tool_prompt_matches_claude_style() {
@@ -520,5 +535,26 @@ mod tests {
             FileEditTool::new().short_description(),
             "A tool for editing files"
         );
+    }
+
+    #[tokio::test]
+    async fn rewrite_invariant_is_not_hidden_by_a_later_shape_error() {
+        let tool = FileEditTool::new();
+        let input = json!({
+            "file_path": "tests/existing.rs",
+            "old_string": "old",
+            "force": true
+        });
+
+        let ordinary = tool.validate_input(&input, None).await;
+        assert!(!ordinary.result);
+        assert_eq!(ordinary.message.as_deref(), Some("new_string is required"));
+        assert!(!ordinary.blocks_input_rewrite());
+
+        let invariant = tool
+            .validate_non_relaxable_input(&input, None)
+            .await
+            .expect("force is a non-relaxable edit-guard rejection");
+        assert!(invariant.blocks_input_rewrite());
     }
 }

--- a/src/crates/assembly/core/src/agentic/tools/implementations/file_write_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/file_write_tool.rs
@@ -391,6 +391,25 @@ impl Tool for FileWriteTool {
         file_permission_intents_allowing_managed_plan_edits("edit", [file_path.as_str()], context)
     }
 
+    async fn validate_non_relaxable_input(
+        &self,
+        input: &Value,
+        context: Option<&ToolUseContext>,
+    ) -> Option<ValidationResult> {
+        let ParsedWritePayload::Target { file_path, .. } = Self::parse_payload(input).ok()? else {
+            return None;
+        };
+        let force_requested = input.get("force").and_then(Value::as_bool).unwrap_or(false);
+        crate::agentic::execution::edit_constraint_guard::check_write(
+            context,
+            "Write",
+            "write",
+            file_path,
+            force_requested,
+        )
+        .await
+    }
+
     async fn validate_input(
         &self,
         input: &Value,

--- a/src/crates/assembly/core/src/agentic/tools/implementations/git_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/git_tool.rs
@@ -1199,7 +1199,7 @@ When creating commits, use this format for the commit message:
     fn permission_intents(
         &self,
         input: &Value,
-        _context: &ToolUseContext,
+        context: &ToolUseContext,
     ) -> BitFunResult<Vec<PermissionIntent>> {
         let normalized = Self::normalize_git_input(input.clone());
         let operation = normalized
@@ -1211,11 +1211,32 @@ When creating commits, use this format for the commit message:
             .and_then(Value::as_str)
             .map(str::trim)
             .filter(|args| !args.is_empty());
+        let working_directory = normalized.get("working_directory").and_then(Value::as_str);
+        let repo_path = Self::get_repo_path(working_directory, context)?;
         let resource = match args {
-            Some(args) => format!("git {operation} {args}"),
-            None => format!("git {operation}"),
+            Some(args) => format!("git -C {} {operation} {args}", Self::sh_quote(&repo_path)),
+            None => format!("git -C {} {operation}", Self::sh_quote(&repo_path)),
         };
         Ok(vec![PermissionIntent::new("git", vec![resource])])
+    }
+
+    async fn validate_non_relaxable_input(
+        &self,
+        input: &Value,
+        context: Option<&ToolUseContext>,
+    ) -> Option<ValidationResult> {
+        let context = context?;
+        let input = Self::normalize_git_input(input.clone());
+        let operation = input.get("operation").and_then(Value::as_str)?;
+        let args = input.get("args").and_then(Value::as_str).unwrap_or("");
+        let working_directory = input.get("working_directory").and_then(Value::as_str);
+        let repo_path = Self::get_repo_path(working_directory, context).ok();
+        crate::agentic::execution::edit_constraint_guard::check_git_command_in_directory(
+            context,
+            operation,
+            args,
+            repo_path.as_deref(),
+        )
     }
 
     async fn validate_input(
@@ -1259,9 +1280,14 @@ When creating commits, use this format for the commit message:
         let args = input.get("args").and_then(|v| v.as_str()).unwrap_or("");
 
         if let Some(context) = context {
+            let working_directory = input.get("working_directory").and_then(Value::as_str);
+            let repo_path = Self::get_repo_path(working_directory, context).ok();
             if let Some(rejection) =
-                crate::agentic::execution::edit_constraint_guard::check_git_command(
-                    context, operation, args,
+                crate::agentic::execution::edit_constraint_guard::check_git_command_in_directory(
+                    context,
+                    operation,
+                    args,
+                    repo_path.as_deref(),
                 )
             {
                 return rejection;
@@ -1483,11 +1509,116 @@ impl Default for GitTool {
 
 #[cfg(test)]
 mod tests {
-    use crate::agentic::tools::framework::Tool;
+    use crate::agentic::execution::edit_constraint_guard::{
+        ConstraintMatcher, ConstraintOperationScope, ConstraintSource, EditConstraintState,
+        ExtractedConstraint, TEST_EDIT_CONSTRAINT_STATE_KEY,
+    };
+    use crate::agentic::tools::framework::{Tool, ToolUseContext};
+    use crate::agentic::tools::ToolRuntimeRestrictions;
+    use crate::agentic::WorkspaceBinding;
 
     use super::{git_operation_needs_light_checkpoint, CheckoutPlan, GitTool, ParsedDiffArgs};
     use serde_json::json;
+    use std::collections::HashMap;
     use std::{fs, path::Path};
+
+    fn local_tool_context(workspace: &Path) -> ToolUseContext {
+        ToolUseContext {
+            tool_call_id: Some("git-cwd-test".to_string()),
+            agent_type: Some("agentic".to_string()),
+            session_id: Some("git-cwd-session".to_string()),
+            dialog_turn_id: Some("git-cwd-turn".to_string()),
+            workspace: Some(WorkspaceBinding::new(None, workspace.to_path_buf())),
+            loaded_deferred_tool_specs: Vec::new(),
+            primary_model_facts: tool_runtime::context::PrimaryModelFacts::default(),
+            custom_data: HashMap::new(),
+            computer_use_host: None,
+            runtime_tool_restrictions: ToolRuntimeRestrictions::default(),
+            runtime_handles: bitfun_runtime_ports::ToolRuntimeHandles::default(),
+        }
+    }
+
+    fn protect_tests(context: &mut ToolUseContext) {
+        let state = EditConstraintState {
+            constraints: vec![ExtractedConstraint {
+                id: "test:no-tests".to_string(),
+                description: "don't touch tests".to_string(),
+                operation_scope: ConstraintOperationScope::All,
+                matcher: ConstraintMatcher::TestFiles,
+                source: ConstraintSource::Legacy,
+                source_text: None,
+            }],
+            ..Default::default()
+        };
+        context.custom_data.insert(
+            TEST_EDIT_CONSTRAINT_STATE_KEY.to_string(),
+            serde_json::to_value(state).expect("test constraint state"),
+        );
+    }
+
+    #[test]
+    fn permission_intent_includes_git_working_directory() {
+        let workspace = tempfile::tempdir().expect("temporary workspace");
+        let tests_dir = workspace.path().join("tests");
+        fs::create_dir(&tests_dir).expect("tests directory");
+        let context = local_tool_context(workspace.path());
+
+        let intents = GitTool::new()
+            .permission_intents(
+                &json!({
+                    "operation": "add",
+                    "args": "helper.rs",
+                    "working_directory": "tests"
+                }),
+                &context,
+            )
+            .expect("permission intent");
+
+        assert_eq!(
+            intents[0].resources,
+            vec![format!(
+                "git -C {} add helper.rs",
+                GitTool::sh_quote(&tests_dir.to_string_lossy())
+            )]
+        );
+    }
+
+    #[tokio::test]
+    async fn command_guard_rejects_when_only_git_working_directory_changes() {
+        let workspace = tempfile::tempdir().expect("temporary workspace");
+        fs::create_dir(workspace.path().join("tests")).expect("tests directory");
+        let mut context = local_tool_context(workspace.path());
+        protect_tests(&mut context);
+
+        assert!(
+            GitTool::new()
+                .validate_non_relaxable_input(
+                    &json!({
+                        "operation": "restore",
+                        "args": "helper.rs",
+                        "working_directory": "."
+                    }),
+                    Some(&context),
+                )
+                .await
+                .is_none(),
+            "the command is allowed from the workspace root"
+        );
+
+        let rejection = GitTool::new()
+            .validate_non_relaxable_input(
+                &json!({
+                    "operation": "restore",
+                    "args": "helper.rs",
+                    "working_directory": "tests"
+                }),
+                Some(&context),
+            )
+            .await
+            .expect("Git command in tests must be rejected");
+
+        assert!(rejection.blocks_input_rewrite());
+    }
 
     fn git(root: &Path, args: &[&str], commit_date: Option<&str>) {
         let mut command = crate::util::create_test_command("git");

--- a/src/crates/assembly/core/src/agentic/tools/pipeline/state_manager.rs
+++ b/src/crates/assembly/core/src/agentic/tools/pipeline/state_manager.rs
@@ -101,7 +101,7 @@ impl ToolStateManager {
         rejection: Option<ValidationResult>,
     ) -> bool {
         if let Some(mut task) = self.tasks.get_mut(tool_id) {
-            task.invocation.effective_arguments = arguments;
+            task.invocation.replace_effective_arguments(arguments);
             task.input_rewrite_rejection = rejection;
             true
         } else {
@@ -435,6 +435,96 @@ mod tests {
         );
         assert_eq!(identity.effective_name(), "CreatePlan");
         assert_eq!(params, &wire_arguments);
+    }
+
+    #[tokio::test]
+    async fn direct_started_event_uses_hook_rewritten_arguments() {
+        let mut task = test_task("tool-direct-rewrite");
+        task.tool_call.arguments = serde_json::json!({ "command": "old" });
+        task.invocation = bitfun_agent_tools::ResolvedToolInvocation::direct(
+            "Bash",
+            task.tool_call.arguments.clone(),
+        );
+        task.original_effective_arguments = task.invocation.effective_arguments.clone();
+
+        let sink = Arc::new(CapturingEventSink::default());
+        let manager = ToolStateManager::new(sink.clone());
+        let tool_id = manager.create_task(task).await;
+        assert!(manager.apply_hook_input_rewrite(
+            &tool_id,
+            serde_json::json!({ "command": "new" }),
+            None,
+        ));
+        manager
+            .update_state(
+                &tool_id,
+                ToolExecutionState::Running {
+                    started_at: std::time::SystemTime::now(),
+                    progress: None,
+                },
+            )
+            .await;
+
+        let events = sink.events.lock().await;
+        let AgenticEvent::ToolEvent {
+            tool_event: bitfun_events::ToolEventData::Started { params, .. },
+            ..
+        } = &events[0]
+        else {
+            panic!("expected started event");
+        };
+        assert_eq!(params, &serde_json::json!({ "command": "new" }));
+    }
+
+    #[tokio::test]
+    async fn deferred_started_event_uses_hook_rewritten_inner_arguments() {
+        let wire_arguments = serde_json::json!({
+            "tool_name": "CreatePlan",
+            "args": { "name": "old" }
+        });
+        let mut task = test_task("tool-deferred-rewrite");
+        task.tool_call.tool_name = bitfun_agent_tools::CALL_DEFERRED_TOOL_NAME.to_string();
+        task.tool_call.arguments = wire_arguments.clone();
+        task.invocation = bitfun_agent_tools::ResolvedToolInvocation::from_wire_call(
+            bitfun_agent_tools::CALL_DEFERRED_TOOL_NAME,
+            wire_arguments,
+        )
+        .expect("valid deferred invocation");
+        task.original_effective_arguments = task.invocation.effective_arguments.clone();
+
+        let sink = Arc::new(CapturingEventSink::default());
+        let manager = ToolStateManager::new(sink.clone());
+        let tool_id = manager.create_task(task).await;
+        assert!(manager.apply_hook_input_rewrite(
+            &tool_id,
+            serde_json::json!({ "name": "new" }),
+            None,
+        ));
+        manager
+            .update_state(
+                &tool_id,
+                ToolExecutionState::Running {
+                    started_at: std::time::SystemTime::now(),
+                    progress: None,
+                },
+            )
+            .await;
+
+        let events = sink.events.lock().await;
+        let AgenticEvent::ToolEvent {
+            tool_event: bitfun_events::ToolEventData::Started { params, .. },
+            ..
+        } = &events[0]
+        else {
+            panic!("expected started event");
+        };
+        assert_eq!(
+            params,
+            &serde_json::json!({
+                "tool_name": "CreatePlan",
+                "args": { "name": "new" }
+            })
+        );
     }
 }
 

--- a/src/crates/assembly/core/src/agentic/tools/pipeline/state_manager.rs
+++ b/src/crates/assembly/core/src/agentic/tools/pipeline/state_manager.rs
@@ -6,6 +6,7 @@ use super::types::ToolTask;
 use crate::agentic::core::ToolExecutionState;
 use crate::agentic::events::AgenticEvent;
 use bitfun_agent_stream::StreamEventSink;
+use bitfun_agent_tools::ValidationResult;
 use dashmap::DashMap;
 use log::debug;
 use std::sync::Arc;
@@ -91,12 +92,17 @@ impl ToolStateManager {
         self.tasks.get(tool_id).map(|t| t.clone())
     }
 
-    /// Replace a task's effective tool arguments before execution.
-    /// Used by PreToolUse hook `updatedInput` rewrites; later readers
-    /// (validation, permission planning, execution) observe the new value.
-    pub fn update_task_arguments(&self, tool_id: &str, arguments: serde_json::Value) -> bool {
+    /// Apply a PreToolUse `updatedInput` proposal and preserve any rejection
+    /// raised by non-relaxable validation of the original effective input.
+    pub fn apply_hook_input_rewrite(
+        &self,
+        tool_id: &str,
+        arguments: serde_json::Value,
+        rejection: Option<ValidationResult>,
+    ) -> bool {
         if let Some(mut task) = self.tasks.get_mut(tool_id) {
             task.invocation.effective_arguments = arguments;
+            task.input_rewrite_rejection = rejection;
             true
         } else {
             false

--- a/src/crates/assembly/core/src/agentic/tools/pipeline/tool_pipeline.rs
+++ b/src/crates/assembly/core/src/agentic/tools/pipeline/tool_pipeline.rs
@@ -824,10 +824,9 @@ impl ToolPipeline {
                 })
         }?;
         let tool_context = self.build_tool_use_context(task, CancellationToken::new());
-        let validation = tool
-            .validate_input(&task.original_effective_arguments, Some(&tool_context))
-            .await;
-        validation.blocks_input_rewrite().then_some(validation)
+        tool.validate_non_relaxable_input(&task.original_effective_arguments, Some(&tool_context))
+            .await
+            .filter(bitfun_agent_tools::ValidationResult::blocks_input_rewrite)
     }
 
     async fn apply_hook_input_rewrite(
@@ -2784,6 +2783,19 @@ mod tests {
             input: &serde_json::Value,
             _context: Option<&ToolUseContext>,
         ) -> ValidationResult {
+            let valid = input
+                .get("city")
+                .and_then(serde_json::Value::as_str)
+                .is_some()
+                && input.as_object().is_some_and(|object| object.len() == 1);
+            if !valid {
+                return ValidationResult {
+                    result: false,
+                    message: Some("city must be the only target argument".to_string()),
+                    error_code: Some(400),
+                    meta: None,
+                };
+            }
             if input.get("city").and_then(serde_json::Value::as_str) == Some("protected") {
                 return ValidationResult {
                     result: false,
@@ -2792,17 +2804,27 @@ mod tests {
                     meta: Some(json!({ "blocks_input_rewrite": true })),
                 };
             }
-            let valid = input
-                .get("city")
-                .and_then(serde_json::Value::as_str)
-                .is_some()
-                && input.as_object().is_some_and(|object| object.len() == 1);
             ValidationResult {
-                result: valid,
-                message: (!valid).then(|| "city must be the only target argument".to_string()),
-                error_code: (!valid).then_some(400),
+                result: true,
+                message: None,
+                error_code: None,
                 meta: None,
             }
+        }
+
+        async fn validate_non_relaxable_input(
+            &self,
+            input: &serde_json::Value,
+            _context: Option<&ToolUseContext>,
+        ) -> Option<ValidationResult> {
+            (input.get("city").and_then(serde_json::Value::as_str) == Some("protected")).then(
+                || ValidationResult {
+                    result: false,
+                    message: Some("the original target is protected".to_string()),
+                    error_code: Some(403),
+                    meta: Some(json!({ "blocks_input_rewrite": true })),
+                },
+            )
         }
 
         async fn call_impl(
@@ -3287,7 +3309,7 @@ mod tests {
         let task = test_tool_task_with_arguments(
             "rewrite-protected-original",
             "get_weather",
-            json!({ "city": "protected" }),
+            json!({ "city": "protected", "legacy_shape_error": true }),
         );
         let tool_id = pipeline.state_manager.create_task(task.clone()).await;
 
@@ -3302,7 +3324,7 @@ mod tests {
             .expect("rewritten task");
         assert_eq!(
             persisted.original_effective_arguments,
-            json!({ "city": "protected" })
+            json!({ "city": "protected", "legacy_shape_error": true })
         );
         assert_eq!(persisted.effective_arguments(), &json!({ "city": "copy" }));
         assert!(persisted

--- a/src/crates/assembly/core/src/agentic/tools/pipeline/tool_pipeline.rs
+++ b/src/crates/assembly/core/src/agentic/tools/pipeline/tool_pipeline.rs
@@ -796,9 +796,67 @@ impl ToolPipeline {
         Ok(receivers)
     }
 
+    async fn non_relaxable_original_input_rejection(
+        &self,
+        task: &ToolTask,
+        updated_input: &serde_json::Value,
+    ) -> Option<bitfun_agent_tools::ValidationResult> {
+        if updated_input == &task.original_effective_arguments {
+            return None;
+        }
+
+        let tool = {
+            let registry = self.tool_registry.read().await;
+            registry
+                .get_tool(task.effective_tool_name())
+                .and_then(|tool| {
+                    resolve_contextual_tool(
+                        tool,
+                        task.context
+                            .workspace
+                            .as_ref()
+                            .map(|workspace| workspace.root_path()),
+                        task.context
+                            .workspace
+                            .as_ref()
+                            .is_some_and(|workspace| workspace.is_remote()),
+                    )
+                })
+        }?;
+        let tool_context = self.build_tool_use_context(task, CancellationToken::new());
+        let validation = tool
+            .validate_input(&task.original_effective_arguments, Some(&tool_context))
+            .await;
+        validation.blocks_input_rewrite().then_some(validation)
+    }
+
+    async fn apply_hook_input_rewrite(
+        &self,
+        task: &ToolTask,
+        updated_input: serde_json::Value,
+    ) -> bool {
+        let rejection = self
+            .non_relaxable_original_input_rejection(task, &updated_input)
+            .await;
+        let blocked = rejection.is_some();
+        if self.state_manager.apply_hook_input_rewrite(
+            &task.tool_call.tool_id,
+            updated_input,
+            rejection,
+        ) {
+            info!(
+                "PreToolUse hook rewrote tool arguments: tool_name={}, tool_id={}, blocked_by_original_input={}",
+                task.effective_tool_name(),
+                task.tool_call.tool_id,
+                blocked
+            );
+        }
+        blocked
+    }
+
     /// Run PreToolUse hooks for every valid task and record their decisions
-    /// as pre-seeded permission plans. `updatedInput` rewrites the stored
-    /// task arguments before validation and permission planning observe them.
+    /// as pre-seeded permission plans. `updatedInput` becomes the final input,
+    /// but cannot relax non-relaxable validation of the original input.
     async fn apply_pre_tool_use_hooks(&self, task_ids: &[String]) {
         for task_id in task_ids {
             let Some(task) = self.state_manager.get_task(task_id) else {
@@ -819,14 +877,15 @@ impl ToolPipeline {
             )
             .await;
             if let Some(updated_input) = decision.updated_input {
-                if self
-                    .state_manager
-                    .update_task_arguments(task_id, updated_input)
-                {
+                if self.apply_hook_input_rewrite(&task, updated_input).await {
                     info!(
-                        "PreToolUse hook rewrote tool arguments: tool_name={}, tool_id={}",
+                        "PreToolUse hook rewrite was rejected by original-input constraints: tool_name={}, tool_id={}",
                         tool_name, task_id
                     );
+                    // A hook allow decision cannot override this internal
+                    // rejection. Execution reports the stored validation
+                    // reason without invoking the tool.
+                    continue;
                 }
             }
             if let Some(reason) = decision.deny_reason {
@@ -851,6 +910,49 @@ impl ToolPipeline {
                 self.hook_preapprovals.lock().await.insert(task_id.clone());
             }
         }
+    }
+
+    async fn concurrency_flags_for_final_inputs(
+        &self,
+        task_ids: &[String],
+        subagent_call_count: usize,
+        subagent_batch_execution_policy: SubagentBatchExecutionPolicy,
+    ) -> Vec<bool> {
+        let registry = self.tool_registry.read().await;
+        task_ids
+            .iter()
+            .map(|task_id| {
+                let Some(task) = self.state_manager.get_task(task_id) else {
+                    return false;
+                };
+                if task.invocation_resolution_error.is_some() {
+                    return false;
+                }
+                let tool_is_concurrency_safe = registry
+                    .get_tool(task.effective_tool_name())
+                    .and_then(|tool| {
+                        resolve_contextual_tool(
+                            tool,
+                            task.context
+                                .workspace
+                                .as_ref()
+                                .map(|workspace| workspace.root_path()),
+                            task.context
+                                .workspace
+                                .as_ref()
+                                .is_some_and(|workspace| workspace.is_remote()),
+                        )
+                    })
+                    .map(|tool| tool.is_concurrency_safe(Some(task.effective_arguments())))
+                    .unwrap_or(false);
+                tool_call_concurrency_safe_for_batch(
+                    task.effective_tool_name(),
+                    tool_is_concurrency_safe,
+                    subagent_call_count,
+                    subagent_batch_execution_policy,
+                )
+            })
+            .collect()
     }
 
     /// Run PostToolUse hooks for a completed tool call and fold blocking
@@ -913,6 +1015,9 @@ impl ToolPipeline {
             let Some(task) = self.state_manager.get_task(task_id) else {
                 continue;
             };
+            if task.input_rewrite_rejection.is_some() {
+                continue;
+            }
             let tool_name = task.invocation.effective_tool_name.clone();
             if task.invocation_resolution_error.is_some()
                 || task.tool_call.tool_name.is_empty()
@@ -1334,43 +1439,6 @@ impl ToolPipeline {
             })
             .count();
 
-        // Determine concurrency safety for each tool call
-        let concurrency_flags: Vec<bool> = {
-            let registry = self.tool_registry.read().await;
-            resolved_tool_calls
-                .iter()
-                .map(|(_, invocation, resolution_error)| {
-                    if resolution_error.is_some() {
-                        return false;
-                    }
-                    let tool_is_concurrency_safe = registry
-                        .get_tool(&invocation.effective_tool_name)
-                        .and_then(|tool| {
-                            resolve_contextual_tool(
-                                tool,
-                                context
-                                    .workspace
-                                    .as_ref()
-                                    .map(|workspace| workspace.root_path()),
-                                context
-                                    .workspace
-                                    .as_ref()
-                                    .is_some_and(|workspace| workspace.is_remote()),
-                            )
-                        })
-                        .map(|tool| tool.is_concurrency_safe(Some(&invocation.effective_arguments)))
-                        .unwrap_or(false);
-                    tool_call_concurrency_safe_for_batch(
-                        &invocation.effective_tool_name,
-                        tool_is_concurrency_safe,
-                        subagent_call_count,
-                        options.subagent_batch_execution_policy,
-                    )
-                })
-                .collect()
-        };
-        let concurrency_safe_count = concurrency_flags.iter().filter(|&&flag| flag).count();
-
         // Create tasks for all tool calls
         let mut task_ids = Vec::with_capacity(resolved_tool_calls.len());
         for (tool_call_order, (tool_call, invocation, resolution_error)) in
@@ -1392,6 +1460,17 @@ impl ToolPipeline {
         // (deny / pre-approve / rewritten input) is visible to the planner
         // and no permission prompt is raised for calls a hook already decided.
         self.apply_pre_tool_use_hooks(&task_ids).await;
+
+        // Hook rewrites can change whether a command is concurrency-safe.
+        // Resolve scheduling from the final arguments.
+        let concurrency_flags = self
+            .concurrency_flags_for_final_inputs(
+                &task_ids,
+                subagent_call_count,
+                options.subagent_batch_execution_policy,
+            )
+            .await;
+        let concurrency_safe_count = concurrency_flags.iter().filter(|&&flag| flag).count();
 
         if let Err(error) = self.prepare_permission_plans(&task_ids).await {
             self.cleanup_permission_plans(&task_ids, "Permission planning failed".to_string())
@@ -1607,6 +1686,30 @@ impl ToolPipeline {
                 )
                 .await;
 
+            return Err(BitFunError::Validation(error_msg));
+        }
+
+        if let Some(rejection) = task.input_rewrite_rejection.as_ref() {
+            let error_msg = rejection.message.clone().unwrap_or_else(|| {
+                format!(
+                    "PreToolUse input rewrite cannot relax validation constraints for tool '{}'",
+                    tool_name
+                )
+            });
+            self.state_manager
+                .update_state(
+                    &tool_id,
+                    ToolExecutionState::Failed {
+                        error: error_msg.clone(),
+                        is_retryable: false,
+                        duration_ms: None,
+                        queue_wait_ms: None,
+                        preflight_ms: None,
+                        confirmation_wait_ms: None,
+                        execution_ms: None,
+                    },
+                )
+                .await;
             return Err(BitFunError::Validation(error_msg));
         }
 
@@ -2658,6 +2761,13 @@ mod tests {
             true
         }
 
+        fn is_concurrency_safe(&self, input: Option<&serde_json::Value>) -> bool {
+            input
+                .and_then(|input| input.get("city"))
+                .and_then(serde_json::Value::as_str)
+                != Some("unsafe")
+        }
+
         fn input_schema(&self) -> serde_json::Value {
             json!({
                 "type": "object",
@@ -2674,6 +2784,14 @@ mod tests {
             input: &serde_json::Value,
             _context: Option<&ToolUseContext>,
         ) -> ValidationResult {
+            if input.get("city").and_then(serde_json::Value::as_str) == Some("protected") {
+                return ValidationResult {
+                    result: false,
+                    message: Some("the original target is protected".to_string()),
+                    error_code: Some(403),
+                    meta: Some(json!({ "blocks_input_rewrite": true })),
+                };
+            }
             let valid = input
                 .get("city")
                 .and_then(serde_json::Value::as_str)
@@ -2806,6 +2924,20 @@ mod tests {
     fn test_tool_task(tool_id: &str, tool_name: &str) -> ToolTask {
         ToolTask::new(
             test_tool_call(tool_id, tool_name),
+            test_tool_execution_context(),
+            ToolExecutionOptions::default(),
+        )
+    }
+
+    fn test_tool_task_with_arguments(
+        tool_id: &str,
+        tool_name: &str,
+        arguments: serde_json::Value,
+    ) -> ToolTask {
+        let mut tool_call = test_tool_call(tool_id, tool_name);
+        tool_call.arguments = arguments;
+        ToolTask::new(
+            tool_call,
             test_tool_execution_context(),
             ToolExecutionOptions::default(),
         )
@@ -3144,6 +3276,162 @@ mod tests {
                 Some(ToolExecutionState::Rejected { .. })
             ));
         }
+    }
+
+    #[tokio::test]
+    async fn hook_rewrite_cannot_hide_a_non_relaxable_original_input_rejection() {
+        let pipeline = test_tool_pipeline();
+        let received_arguments = Arc::new(Mutex::new(None));
+        register_capturing_test_tool(&pipeline, "get_weather", Arc::clone(&received_arguments))
+            .await;
+        let task = test_tool_task_with_arguments(
+            "rewrite-protected-original",
+            "get_weather",
+            json!({ "city": "protected" }),
+        );
+        let tool_id = pipeline.state_manager.create_task(task.clone()).await;
+
+        assert!(
+            pipeline
+                .apply_hook_input_rewrite(&task, json!({ "city": "copy" }))
+                .await
+        );
+        let persisted = pipeline
+            .state_manager
+            .get_task(&tool_id)
+            .expect("rewritten task");
+        assert_eq!(
+            persisted.original_effective_arguments,
+            json!({ "city": "protected" })
+        );
+        assert_eq!(persisted.effective_arguments(), &json!({ "city": "copy" }));
+        assert!(persisted
+            .input_rewrite_rejection
+            .as_ref()
+            .is_some_and(ValidationResult::blocks_input_rewrite));
+
+        let error = pipeline
+            .execute_single_tool(tool_id)
+            .await
+            .expect_err("protected original input must block execution");
+        assert!(matches!(error, BitFunError::Validation(_)));
+        assert!(received_arguments
+            .lock()
+            .expect("capturing tool argument lock")
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn hook_rewrite_can_repair_an_ordinary_validation_failure() {
+        let pipeline = test_tool_pipeline();
+        let received_arguments = Arc::new(Mutex::new(None));
+        register_capturing_test_tool(&pipeline, "get_weather", Arc::clone(&received_arguments))
+            .await;
+        let task = test_tool_task_with_arguments(
+            "rewrite-repairable-original",
+            "get_weather",
+            json!({ "legacy_city": "Paris" }),
+        );
+        let tool_id = pipeline.state_manager.create_task(task.clone()).await;
+
+        assert!(
+            !pipeline
+                .apply_hook_input_rewrite(&task, json!({ "city": "Paris" }))
+                .await
+        );
+        let persisted = pipeline
+            .state_manager
+            .get_task(&tool_id)
+            .expect("rewritten task");
+        assert_eq!(
+            persisted.original_effective_arguments,
+            json!({ "legacy_city": "Paris" })
+        );
+        assert_eq!(persisted.effective_arguments(), &json!({ "city": "Paris" }));
+        assert!(persisted.input_rewrite_rejection.is_none());
+
+        pipeline
+            .execute_single_tool(tool_id)
+            .await
+            .expect("repaired input should execute");
+        assert_eq!(
+            *received_arguments
+                .lock()
+                .expect("capturing tool argument lock"),
+            Some(json!({ "city": "Paris" }))
+        );
+    }
+
+    #[tokio::test]
+    async fn final_validation_rejects_a_hook_rewrite_into_a_protected_input() {
+        let pipeline = test_tool_pipeline();
+        let received_arguments = Arc::new(Mutex::new(None));
+        register_capturing_test_tool(&pipeline, "get_weather", Arc::clone(&received_arguments))
+            .await;
+        let task = test_tool_task_with_arguments(
+            "rewrite-protected-final",
+            "get_weather",
+            json!({ "city": "Paris" }),
+        );
+        let tool_id = pipeline.state_manager.create_task(task.clone()).await;
+
+        assert!(
+            !pipeline
+                .apply_hook_input_rewrite(&task, json!({ "city": "protected" }))
+                .await
+        );
+        assert!(pipeline
+            .state_manager
+            .get_task(&tool_id)
+            .expect("rewritten task")
+            .input_rewrite_rejection
+            .is_none());
+
+        let error = pipeline
+            .execute_single_tool(tool_id)
+            .await
+            .expect_err("protected final input must fail final validation");
+        assert!(matches!(error, BitFunError::Validation(_)));
+        assert!(received_arguments
+            .lock()
+            .expect("capturing tool argument lock")
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn hook_rewrite_recomputes_concurrency_from_final_input() {
+        let pipeline = test_tool_pipeline();
+        register_capturing_test_tool(&pipeline, "get_weather", Arc::new(Mutex::new(None))).await;
+        let task = test_tool_task_with_arguments(
+            "rewrite-concurrency",
+            "get_weather",
+            json!({ "city": "Paris" }),
+        );
+        let tool_id = pipeline.state_manager.create_task(task.clone()).await;
+
+        assert!(
+            pipeline
+                .concurrency_flags_for_final_inputs(
+                    std::slice::from_ref(&tool_id),
+                    0,
+                    SubagentBatchExecutionPolicy::SafeOnly,
+                )
+                .await[0]
+        );
+        assert!(
+            !pipeline
+                .apply_hook_input_rewrite(&task, json!({ "city": "unsafe" }))
+                .await
+        );
+        assert!(
+            !pipeline
+                .concurrency_flags_for_final_inputs(
+                    std::slice::from_ref(&tool_id),
+                    0,
+                    SubagentBatchExecutionPolicy::SafeOnly,
+                )
+                .await[0]
+        );
     }
 
     /// A PreToolUse hook approval waives the interactive permission prompt.

--- a/src/crates/assembly/core/src/agentic/tools/pipeline/types.rs
+++ b/src/crates/assembly/core/src/agentic/tools/pipeline/types.rs
@@ -6,7 +6,7 @@ use crate::agentic::round_preempt::DialogRoundInjectionInterrupt;
 use crate::agentic::tools::ToolRuntimeRestrictions;
 use crate::agentic::workspace::WorkspaceServices;
 use crate::agentic::WorkspaceBinding;
-use bitfun_agent_tools::ResolvedToolInvocation;
+use bitfun_agent_tools::{ResolvedToolInvocation, ValidationResult};
 use bitfun_runtime_ports::{
     DelegationPolicy, PermissionDelegationContext, RemoteExecPort, ResolvedPermissionPolicy,
     TerminalPort,
@@ -118,6 +118,12 @@ pub struct ToolTask {
     /// round. Permission requests inherit this value as their order key.
     pub tool_call_order: u32,
     pub invocation: ResolvedToolInvocation,
+    /// Effective arguments before any Native PreToolUse hook rewrite. This
+    /// remains immutable so validation and audit can compare both inputs.
+    pub original_effective_arguments: serde_json::Value,
+    /// A non-relaxable validation rejection found on the original input while
+    /// applying a hook rewrite. Final validation still checks rewritten input.
+    pub input_rewrite_rejection: Option<ValidationResult>,
     pub invocation_resolution_error: Option<String>,
     pub context: ToolExecutionContext,
     pub options: ToolExecutionOptions,
@@ -147,10 +153,13 @@ impl ToolTask {
         context: ToolExecutionContext,
         options: ToolExecutionOptions,
     ) -> Self {
+        let original_effective_arguments = invocation.effective_arguments.clone();
         Self {
             tool_call,
             tool_call_order: 0,
             invocation,
+            original_effective_arguments,
+            input_rewrite_rejection: None,
             invocation_resolution_error,
             context,
             options,

--- a/src/crates/assembly/core/src/agentic/tools/registry.rs
+++ b/src/crates/assembly/core/src/agentic/tools/registry.rs
@@ -711,6 +711,31 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn product_registered_edit_preserves_non_relaxable_validation() {
+        let registry = ProductToolRuntime::default()
+            .create_registry()
+            .expect("the default runtime plan must materialize");
+        let edit = registry
+            .get_tool("Edit")
+            .expect("Edit tool should be registered");
+        let input = json!({
+            "file_path": "tests/existing.rs",
+            "old_string": "old",
+            "force": true
+        });
+
+        let ordinary = edit.validate_input(&input, None).await;
+        assert_eq!(ordinary.message.as_deref(), Some("new_string is required"));
+        assert!(!ordinary.blocks_input_rewrite());
+
+        let invariant = edit
+            .validate_non_relaxable_input(&input, None)
+            .await
+            .expect("snapshot-wrapped Edit must forward its non-relaxable guard");
+        assert!(invariant.blocks_input_rewrite());
+    }
+
     #[test]
     fn product_tool_runtime_owner_preserves_registry_contract() {
         let runtime = ProductToolRuntime::default();

--- a/src/crates/assembly/core/src/native_hooks.rs
+++ b/src/crates/assembly/core/src/native_hooks.rs
@@ -134,8 +134,10 @@ pub async fn dispatch_user_prompt_submit(
     decision
 }
 
-/// PreToolUse hooks run after tool-input validation and before permission
-/// evaluation. They may deny the call, pre-approve it, or rewrite its input.
+/// PreToolUse hooks run before final tool-input validation and permission
+/// evaluation. They may deny the call, pre-approve it, or propose rewritten
+/// input. The tool pipeline independently prevents a rewrite from relaxing
+/// non-relaxable validation constraints.
 pub async fn dispatch_pre_tool_use(
     facts: NativeHookSessionFacts<'_>,
     tool_name: &str,

--- a/src/crates/assembly/core/src/service/snapshot/manager.rs
+++ b/src/crates/assembly/core/src/service/snapshot/manager.rs
@@ -690,6 +690,16 @@ impl Tool for WrappedTool {
         original_validation
     }
 
+    async fn validate_non_relaxable_input(
+        &self,
+        input: &Value,
+        context: Option<&ToolUseContext>,
+    ) -> Option<crate::agentic::tools::framework::ValidationResult> {
+        self.original_tool
+            .validate_non_relaxable_input(input, context)
+            .await
+    }
+
     fn render_result_for_assistant(&self, output: &Value) -> String {
         let original_render = self.original_tool.render_result_for_assistant(output);
         format!(

--- a/src/crates/execution/tool-contracts/src/framework.rs
+++ b/src/crates/execution/tool-contracts/src/framework.rs
@@ -2449,6 +2449,21 @@ pub struct ValidationResult {
     pub meta: Option<Value>,
 }
 
+impl ValidationResult {
+    /// Whether this rejection represents an invariant that an input rewrite
+    /// must not relax. Ordinary schema or formatting failures intentionally
+    /// remain repairable by a PreToolUse hook.
+    pub fn blocks_input_rewrite(&self) -> bool {
+        !self.result
+            && self
+                .meta
+                .as_ref()
+                .and_then(|meta| meta.get("blocks_input_rewrite"))
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+    }
+}
+
 impl Default for ValidationResult {
     fn default() -> Self {
         Self {
@@ -2523,6 +2538,26 @@ impl ToolResult {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn validation_result_only_blocks_rewrites_when_explicitly_marked() {
+        let repairable = ValidationResult {
+            result: false,
+            message: Some("repairable".to_string()),
+            error_code: Some(400),
+            meta: None,
+        };
+        let non_relaxable = ValidationResult {
+            result: false,
+            message: Some("protected".to_string()),
+            error_code: Some(403),
+            meta: Some(json!({ "blocks_input_rewrite": true })),
+        };
+
+        assert!(!repairable.blocks_input_rewrite());
+        assert!(non_relaxable.blocks_input_rewrite());
+        assert!(!ValidationResult::default().blocks_input_rewrite());
+    }
 
     struct TestTool {
         name: &'static str,


### PR DESCRIPTION
## Summary

Further strengthens intent reduction when PreToolUse Hooks participate in tool argument rewriting.

- Preserve original tool arguments for user edit-scope checks and other explicitly non-relaxable restrictions.
- Fully validate Hook-rewritten final arguments, then recompute permission intents, concurrency classification, and telemetry from the arguments that will actually execute.
- Resolve Bash, ExecCommand, and Git mutation targets against their actual original and final working directories.
- Forward non-relaxable validation through the snapshot-wrapped Edit tool used by the default product registry.
- Keep direct and deferred tool-start events aligned with the effective execution arguments while retaining the original arguments separately for audit.
- Document the exact protection boundary and expected Hook interaction.

Fixes: N/A (no linked issue)

## Type and Areas

Type:

Regression fix / security hardening / docs / test.

Areas:

Rust core, Agent tool pipeline, Hook integration, Edit Guard, tool contracts, and docs.

## Motivation / Impact

This is a further strengthening of the intent-reduction feature and its coordination with the Hook mechanism.

PreToolUse Hooks may legitimately repair ordinary invalid inputs, but they must not broaden a user-defined edit scope or bypass restrictions that tools explicitly mark as non-relaxable. The pipeline now evaluates both the original request and the rewritten final request at the correct boundaries, while permissions, concurrency decisions, telemetry, execution events, and actual execution consistently use the final arguments.

This prevents snapshot wrappers, working-directory-only rewrites, and stale event payloads from creating a mismatch between the protected intent, the permission prompt, the UI or audit trail, and the operation that actually runs.

## Verification

- `cargo test --locked -p bitfun-core --no-default-features --features agent-runtime,tools-git --lib agentic::execution::edit_constraint_guard` — passed, 33 tests.
- `cargo test --locked -p bitfun-core --no-default-features --features agent-runtime,tools-git --lib hook_rewrite` — passed, 4 tests.
- `cargo test --locked -p bitfun-core --no-default-features --features agent-runtime,tools-git --lib working_directory` — passed.
- `cargo test --locked -p bitfun-core --no-default-features --features agent-runtime,tools-git --lib started_event` — passed.
- `cargo test --locked -p bitfun-core --no-default-features --features agent-runtime,tools-git --lib product_registered_edit` — passed.
- `cargo test --locked -p bitfun-agent-tools --no-default-features` — passed, 16 library tests and 103 contract tests.
- `git diff --check cb0c692a029bb797cc42a01739cf5348b7d4ce85..HEAD` — passed.

The focused Core test build emitted existing unused-import and dead-code warnings; there were no test failures.

## Reviewer Notes

- Original arguments remain available as a separate audit fact. Effective arguments are the source of truth for final validation, permissions, concurrency, telemetry, started events, and execution.
- The boundary is intentionally scoped: user-configured edit restrictions and tool rejections explicitly marked as non-relaxable cannot be rewritten away. Ordinary validation failures may still be repaired by a Hook.
- Regression coverage includes the default snapshot-wrapped Edit registration, Bash/ExecCommand/Git working-directory-only rewrites, and direct/deferred started-event arguments.
- No migration is required.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.