### PR TITLE
fix(web-ui): align remote workspace title with icon

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSection.scss
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSection.scss
@@ -257,6 +257,17 @@
     }
   }
 
+  /**
+   * Remote metadata makes the row taller than its primary title line. Keep the
+   * 30px collapse hit target, but pin it to the top and align its 16px icon with
+   * the remote title's 16px line instead of centring it across both text rows.
+   */
+  &__workspace-item[data-bf-state~='remote'] &__workspace-item-collapse-btn {
+    align-self: flex-start;
+    align-items: flex-start;
+    padding-top: 2px;
+  }
+
   &__workspace-item-name-cluster {
     display: inline-flex;
     align-items: stretch;

--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSectionLayout.test.ts
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSectionLayout.test.ts
@@ -188,6 +188,22 @@ describe('WorkspaceListSection layout styles', () => {
       .toBeLessThan(remoteMetaMarkup.indexOf('workspace-item-status-dot'));
   });
 
+  it('anchors remote workspace icons to the primary title line', () => {
+    const stylesheet = readWorkspaceListStylesheet();
+    const workspaceCard = extractBlock(stylesheet, '&__workspace-item-card');
+    const collapseButton = extractBlock(stylesheet, '&__workspace-item-collapse-btn');
+    const remoteCollapseButton = extractBlock(
+      stylesheet,
+      "&__workspace-item[data-bf-state~='remote'] &__workspace-item-collapse-btn",
+    );
+
+    expect(workspaceCard).toContain('align-items: center;');
+    expect(collapseButton).toContain('min-height: 30px;');
+    expect(remoteCollapseButton).toContain('align-self: flex-start;');
+    expect(remoteCollapseButton).toContain('align-items: flex-start;');
+    expect(remoteCollapseButton).toContain('padding-top: 2px;');
+  });
+
   it('uses stable BitFun semantics for grouped entries without a redundant aggregate header', () => {
     const itemSource = readWorkspaceItemSource();
     const listSource = readWorkspaceListSource();


### PR DESCRIPTION
## Summary

- anchor the remote workspace collapse icon to the primary title line
- keep the remote server metadata on the second line and preserve the 30px hit target
- add a focused layout regression contract for remote rows

## Testing

- `pnpm --dir src/web-ui run test:run src/app/components/NavPanel/sections/workspaces/WorkspaceListSectionLayout.test.ts` (9 passed)
- `pnpm run check:web`
- production stylesheet visual QA: icon/title center delta 0.5px

## Remote scenarios

- exercised the connected remote-workspace presentation state in the local Web UI
- remote transport and SSH behavior are unchanged; no SSH end-to-end test was required for this presentation-only change