### PR TITLE
fix(web-ui): make pet context menu theme-aware

### DIFF
--- a/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.scss
+++ b/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.scss
@@ -95,7 +95,9 @@
     /* Intentionally no backdrop-filter: adding a blurred layer on right-click
        re-composites the other blurred surfaces and flashes the whole window.
        All remaining chrome still comes from FloatingSurface. */
-    color: var(--bitfun-agent-companion-bubble-fg);
+    /* The floating surface follows the active appearance, so its foreground
+       must do the same instead of inheriting the always-dark bubble copy. */
+    color: var(--bf-appearance-token-color-text-primary);
     pointer-events: auto;
 
     /* Context menus are placed at the cursor. */
@@ -119,7 +121,7 @@
     border: 0;
     border-radius: 6px;
     background: transparent;
-    color: inherit;
+    color: var(--bf-appearance-token-color-text-secondary);
     font: inherit;
     font-size: 11px;
     line-height: 1.3;
@@ -128,9 +130,17 @@
     white-space: normal;
     overflow-wrap: anywhere;
     cursor: pointer;
+    transition:
+      color var(--bf-appearance-token-motion-fast) var(--bf-appearance-token-easing-standard),
+      background var(--bf-appearance-token-motion-fast) var(--bf-appearance-token-easing-standard);
 
     &:hover {
-      background: var(--bf-appearance-token-color-overlay-slate-08);
+      color: var(--bf-appearance-token-color-text-primary);
+      background: var(--bf-appearance-token-element-bg-soft);
+    }
+
+    &:active {
+      background: var(--bf-appearance-token-element-bg-medium);
     }
 
     &:focus-visible {

--- a/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPetStyles.test.ts
+++ b/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPetStyles.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+function readStylesheet(): string {
+  return readFileSync(
+    fileURLToPath(new URL('./AgentCompanionDesktopPet.scss', import.meta.url)),
+    'utf8',
+  ).replace(/\r\n/g, '\n');
+}
+
+function extractBlock(stylesheet: string, selector: string): string {
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = stylesheet.match(
+    new RegExp(`^\\s*${escapedSelector}\\s*\\{(?<body>[\\s\\S]*?)\\n\\s*\\}`, 'm'),
+  );
+  return match?.groups?.body ?? '';
+}
+
+describe('AgentCompanionDesktopPet styles', () => {
+  it('keeps context-menu foregrounds and interaction states theme-aware', () => {
+    const stylesheet = readStylesheet();
+    const overlay = extractBlock(stylesheet, '&__overlay');
+    const menuItem = extractBlock(stylesheet, '&__menu-item');
+
+    expect(overlay).toContain('color: var(--bf-appearance-token-color-text-primary);');
+    expect(overlay).not.toContain('color: var(--bitfun-agent-companion-bubble-fg);');
+    expect(menuItem).toContain('color: var(--bf-appearance-token-color-text-secondary);');
+    expect(menuItem).toContain('color: var(--bf-appearance-token-color-text-primary);');
+    expect(menuItem).toContain('background: var(--bf-appearance-token-element-bg-soft);');
+    expect(stylesheet).toContain(
+      '&:active {\n      background: var(--bf-appearance-token-element-bg-medium);\n    }',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- stop the Agent companion context menu from inheriting the bubble-only fixed dark foreground
- use appearance-aware text, hover, and pressed tokens in both light and dark themes
- add a focused stylesheet regression test for the menu token contract

## Testing

- `pnpm --dir src/web-ui run test:run src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPetStyles.test.ts src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.test.tsx src/component-library/styles/overlay-surfaces.contract.test.ts` (47 passed)
- `pnpm run check:web`
- visual theme QA: dark contrast 7.91:1; light contrast 7.43:1 (previous dark combination was about 1.17:1)

## Remote scenarios

- this is a controller-local Desktop companion-window presentation fix
- remote workspace, remote control, Peer Device Mode, and Detached Dispatch behavior are unchanged