### PR TITLE
fix(web): make text inputs IME-safe

### DIFF
--- a/design-system/packages/ui/src/components/Input/Input.tsx
+++ b/design-system/packages/ui/src/components/Input/Input.tsx
@@ -1,10 +1,12 @@
 import {
   forwardRef,
+  useRef,
   type ChangeEventHandler,
   type InputHTMLAttributes,
   type ReactNode,
 } from "react";
 import { classNames } from "../../internal/classNames";
+import { isImeOwnedKeyboardEvent } from "../../internal/ime";
 import styles from "./Input.module.css";
 
 export interface InputProps
@@ -26,12 +28,16 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input({
   invalid = false,
   leading,
   onChange,
+  onCompositionEnd,
+  onCompositionStart,
+  onKeyDown,
   onValueChange,
   size = "sm",
   trailing,
   type = "text",
   ...props
 }, ref) {
+  const compositionActiveRef = useRef(false);
   const handleChange: ChangeEventHandler<HTMLInputElement> = (event) => {
     onChange?.(event);
     onValueChange?.(event.currentTarget.value);
@@ -58,6 +64,24 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input({
         className={classNames(styles.input, inputClassName)}
         disabled={disabled}
         onChange={handleChange}
+        onCompositionEnd={(event) => {
+          compositionActiveRef.current = false;
+          onCompositionEnd?.(event);
+        }}
+        onCompositionStart={(event) => {
+          compositionActiveRef.current = true;
+          onCompositionStart?.(event);
+        }}
+        onKeyDown={(event) => {
+          if (
+            (event.key === "Enter" || event.key === "Escape")
+            && isImeOwnedKeyboardEvent(event, compositionActiveRef.current)
+          ) {
+            event.stopPropagation();
+            return;
+          }
+          onKeyDown?.(event);
+        }}
         ref={ref}
         type={type}
       />

--- a/design-system/packages/ui/src/internal/ime.ts
+++ b/design-system/packages/ui/src/internal/ime.ts
@@ -1,0 +1,19 @@
+interface KeyboardEventWithNativeSignals {
+  isComposing?: boolean;
+  keyCode?: number;
+  nativeEvent?: {
+    isComposing?: boolean;
+    keyCode?: number;
+  };
+}
+
+export function isImeOwnedKeyboardEvent(
+  event: KeyboardEventWithNativeSignals,
+  compositionActive = false,
+): boolean {
+  return compositionActive
+    || event.isComposing === true
+    || event.keyCode === 229
+    || event.nativeEvent?.isComposing === true
+    || event.nativeEvent?.keyCode === 229;
+}

--- a/design-system/packages/ui/tests/input.test.mjs
+++ b/design-system/packages/ui/tests/input.test.mjs
@@ -5,6 +5,19 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 import { Input } from "../dist/index.js";
 
+test("Input keeps IME-owned Enter and Escape away from submit and cancel handlers", async () => {
+  const source = await readFile(
+    new URL("../src/components/Input/Input.tsx", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(source, /isImeOwnedKeyboardEvent/);
+  assert.match(source, /event\.key === "Enter" \|\| event\.key === "Escape"/);
+  assert.match(source, /event\.stopPropagation\(\)/);
+  assert.match(source, /onCompositionStart/);
+  assert.match(source, /onCompositionEnd/);
+});
+
 test("Input keeps native input semantics and independent content slots", () => {
   const markup = renderToStaticMarkup(
     createElement(Input, {

--- a/docs/interactive-capabilities/README.md
+++ b/docs/interactive-capabilities/README.md
@@ -27,9 +27,9 @@ BitFun Playbook currently contains **22 features**, **16 settings pages**, and *
 - Generated runtime catalog: `src/crates/contracts/product-domains/src/generated/product-control-catalog.json`
 - Generated per-item interaction audit: `docs/interactive-capabilities/technical/product-control-open-audit.json`
 
-说明书、网站、搜索和 Agent 只看“功能 + 设置 + 子能力”。每项子能力都必须引用已注册 Tauri Command 或可解析的源码标记；这些证据不会进入公开目录。当前 **651** 个 Tauri 命令，以及 **365** 个产品交互源码文件中的 **4421** 个交互候选，只用于实现覆盖审计。
+说明书、网站、搜索和 Agent 只看“功能 + 设置 + 子能力”。每项子能力都必须引用已注册 Tauri Command 或可解析的源码标记；这些证据不会进入公开目录。当前 **651** 个 Tauri 命令，以及 **365** 个产品交互源码文件中的 **4423** 个交互候选，只用于实现覆盖审计。
 
-Docs, website, search, and agents see only features, settings, and documented sub-capabilities. Every sub-capability must reference a registered Tauri command or a resolvable source marker; evidence is stripped from public projections. The **651** Tauri commands and **4421** interaction candidates across **365** product UI source files remain implementation-audit evidence only.
+Docs, website, search, and agents see only features, settings, and documented sub-capabilities. Every sub-capability must reference a registered Tauri command or a resolvable source marker; evidence is stripped from public projections. The **651** Tauri commands and **4423** interaction candidates across **365** product UI source files remain implementation-audit evidence only.
 
 ## 控制边界 / Control boundary
 

--- a/docs/interactive-capabilities/technical/ui-interaction-inventory.json
+++ b/docs/interactive-capabilities/technical/ui-interaction-inventory.json
@@ -5,9 +5,9 @@
   "roots": [
     "src/web-ui/src"
   ],
-  "digest": "b719c315ec5cd0e239cd76d60352781f297727d14bb8918d1768d2d582950fc5",
+  "digest": "58d766fcc65df497d6de40113bf8bbbc2cdc0b216df7355ee9e90c1a98c9e677",
   "fileCount": 365,
-  "interactionCount": 4421,
+  "interactionCount": 4423,
   "files": [
     {
       "sourceFile": "src/web-ui/src/app/components/AboutDialog/AboutDialog.tsx",
@@ -626,8 +626,8 @@
     },
     {
       "sourceFile": "src/web-ui/src/component-library/components/Input/Input.tsx",
-      "interactionCount": 1,
-      "digest": "37c2810a30e7352a856980ebc8ec6e1c2ee396fcaccb0d89e7b6da1f3b215742"
+      "interactionCount": 2,
+      "digest": "2e5b03618ea9b9e61264f32fd6d1d3359714c63d687aa900467275d0ad9b5dd9"
     },
     {
       "sourceFile": "src/web-ui/src/component-library/components/InputDialog/InputDialog.tsx",
@@ -681,8 +681,8 @@
     },
     {
       "sourceFile": "src/web-ui/src/component-library/components/Textarea/Textarea.tsx",
-      "interactionCount": 2,
-      "digest": "a6babb495854c3d0e7344818b3121bd142e382e828bc0b518f001aca74ffe6a8"
+      "interactionCount": 3,
+      "digest": "2616e59f775203d7f1c7ee62d150ab122b1e4c413d6880539fad8eb228d4c4b6"
     },
     {
       "sourceFile": "src/web-ui/src/component-library/components/WindowControls/WindowControls.tsx",
@@ -1092,7 +1092,7 @@
     {
       "sourceFile": "src/web-ui/src/flow_chat/tool-cards/AskUserQuestionCard.tsx",
       "interactionCount": 23,
-      "digest": "51d4a6e5c3c649963ab4b6c13624c135ffebfcd4db2db2a4a91c47530987e9f9"
+      "digest": "6a66aac2f6d2f544f1ac30b49daf8eac1112c4dadf1f1110307091f6d8e51389"
     },
     {
       "sourceFile": "src/web-ui/src/flow_chat/tool-cards/BaseToolCard.tsx",

--- a/scripts/ci/classify-build-impact.mjs
+++ b/scripts/ci/classify-build-impact.mjs
@@ -81,6 +81,7 @@ const DESKTOP_PACKAGE_PREFIXES = [
 // the Rust/CLI matrices on their own. Native mobile is intentionally filtered
 // as neutral below because it has no supported CI toolchain or producer here.
 const FRONTEND_ONLY_PREFIXES = [
+  'design-system/',
   'src/web-ui/',
   'src/mobile-web/',
 ];

--- a/scripts/ci/classify-build-impact.test.mjs
+++ b/scripts/ci/classify-build-impact.test.mjs
@@ -109,6 +109,10 @@ test('maps representative changes to the smallest predictive validation', () => 
       result: expected({ rustRequired: false, reason: 'frontend-only' }),
     },
     {
+      paths: ['design-system/packages/ui/src/components/Input/Input.tsx'],
+      result: expected({ rustRequired: false, reason: 'frontend-only' }),
+    },
+    {
       paths: [
         'src/apps/mobile/android/app/src/main/kotlin/com/bitfun/MainActivity.kt',
         'src/apps/mobile/shared/core-feature/src/commonMain/kotlin/Feature.kt',

--- a/src/mobile-web/src/pages/SessionListPage.tsx
+++ b/src/mobile-web/src/pages/SessionListPage.tsx
@@ -14,6 +14,11 @@ import logoIcon from '../assets/Logo-ICON.png';
 
 const PAGE_SIZE = 30;
 
+const isImeOwnedKey = (event: React.KeyboardEvent, compositionActive = false): boolean => {
+  const nativeEvent = event.nativeEvent as KeyboardEvent;
+  return compositionActive || nativeEvent.isComposing || nativeEvent.keyCode === 229;
+};
+
 type DisplayMode = 'pro' | 'assistant';
 
 interface SessionListPageProps {
@@ -175,6 +180,7 @@ const ThemeToggleIcon: React.FC<{ isDark: boolean }> = ({ isDark }) => (
 );
 
 const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectSession, onOpenWorkspace, onDisconnect, onOpenDevices }) => {
+  const renameInputCompositionActiveRef = useRef(false);
   const { t, formatDate } = useI18n();
   const {
     sessions,
@@ -1399,8 +1405,21 @@ const SessionListPage: React.FC<SessionListPageProps> = ({ sessionMgr, onSelectS
               placeholder={t('sessions.sessionNamePlaceholder')}
               autoFocus
               onKeyDown={(e) => {
+                if (
+                  (e.key === 'Enter' || e.key === 'Escape')
+                  && isImeOwnedKey(e, renameInputCompositionActiveRef.current)
+                ) {
+                  e.stopPropagation();
+                  return;
+                }
                 if (e.key === 'Enter') handleRename();
                 if (e.key === 'Escape') setRenameTarget(null);
+              }}
+              onCompositionStart={() => {
+                renameInputCompositionActiveRef.current = true;
+              }}
+              onCompositionEnd={() => {
+                renameInputCompositionActiveRef.current = false;
               }}
             />
             <div className="session-list__rename-actions">

--- a/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.tsx
+++ b/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.tsx
@@ -13,6 +13,7 @@ import type {
 } from '@/flow_chat/utils/agentCompanionActivity';
 import type { AgentCompanionPetCommand } from '@/app/services/agentCompanionPetCommands';
 import { createLogger } from '@/shared/utils/logger';
+import { isImeOwnedKeyboardEvent } from '@/shared/utils/ime';
 import './AgentCompanionDesktopPet.scss';
 
 const log = createLogger('AgentCompanionDesktopPet');
@@ -134,6 +135,7 @@ export const AgentCompanionDesktopPet: React.FC = () => {
   const bubblesRef = useRef<HTMLDivElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
   const composerInputRef = useRef<HTMLInputElement>(null);
+  const composerCompositionActiveRef = useRef(false);
   const outputRefs = useRef<Map<string, HTMLSpanElement>>(new Map());
   const lastActivitySequenceRef = useRef(0);
   const lastActivityEmittedAtRef = useRef(0);
@@ -679,6 +681,13 @@ export const AgentCompanionDesktopPet: React.FC = () => {
   }, [composerValue, isSendingComposer, overlay, sendPetCommand]);
 
   const onComposerKeyDown = useCallback((event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (
+      (event.key === 'Enter' || event.key === 'Escape')
+      && isImeOwnedKeyboardEvent(event, composerCompositionActiveRef.current)
+    ) {
+      event.stopPropagation();
+      return;
+    }
     if (event.key === 'Escape') {
       event.preventDefault();
       cancelBubbleComposer();
@@ -971,6 +980,12 @@ export const AgentCompanionDesktopPet: React.FC = () => {
                             aria-label={t('agentCompanion.composer.ariaLabel')}
                             onChange={event => setComposerValue(event.target.value)}
                             onKeyDown={onComposerKeyDown}
+                            onCompositionStart={() => {
+                              composerCompositionActiveRef.current = true;
+                            }}
+                            onCompositionEnd={() => {
+                              composerCompositionActiveRef.current = false;
+                            }}
                           />
                           <button
                             type="button"

--- a/src/web-ui/src/app/components/NavPanel/MainNav.tsx
+++ b/src/web-ui/src/app/components/NavPanel/MainNav.tsx
@@ -14,6 +14,7 @@ import React, { useCallback, useState, useMemo, useEffect, useRef, useSyncExtern
 import { createPortal } from 'react-dom';
 import { KeyHint } from '@bitfun/ui';
 import { getAppearanceOverlayHost } from '@/infrastructure/appearance/runtime/AppearanceOverlayHost';
+import { isImeOwnedKeyboardEvent } from '@/shared/utils/ime';
 import { Plus, FolderOpen, FolderPlus, History, Check, User, Users, Puzzle, ChevronDown, Network, Search, CalendarClock } from 'lucide-react';
 // import { PanelsTopLeft } from 'lucide-react'; // temporarily hidden: Pages nav entry
 import {
@@ -219,7 +220,7 @@ const MainNav: React.FC<MainNavProps> = ({
       closeWorkspaceMenu();
     };
     const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') closeWorkspaceMenu();
+      if (event.key === 'Escape' && !isImeOwnedKeyboardEvent(event)) closeWorkspaceMenu();
     };
     document.addEventListener('mousedown', handleClickOutside);
     document.addEventListener('keydown', handleEscape);

--- a/src/web-ui/src/app/components/NavPanel/components/AssistantSessionCreateMenu.tsx
+++ b/src/web-ui/src/app/components/NavPanel/components/AssistantSessionCreateMenu.tsx
@@ -6,6 +6,7 @@ import { getAppearanceOverlayHost } from '@/infrastructure/appearance/runtime/Ap
 import { useI18n } from '@/infrastructure/i18n/hooks/useI18n';
 import type { WorkspaceInfo } from '@/shared/types';
 import { useAnchoredPopoverPosition } from '@/shared/utils/useAnchoredPopoverPosition';
+import { isImeOwnedKeyboardEvent } from '@/shared/utils/ime';
 
 interface AssistantSessionCreateMenuProps {
   assistants: WorkspaceInfo[];
@@ -62,7 +63,7 @@ const AssistantSessionCreateMenu: React.FC<AssistantSessionCreateMenuProps> = ({
       closeMenu();
     };
     const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') closeMenu();
+      if (event.key === 'Escape' && !isImeOwnedKeyboardEvent(event)) closeMenu();
     };
 
     document.addEventListener('mousedown', handleMouseDown);

--- a/src/web-ui/src/app/components/NavPanel/components/BranchQuickSwitch.tsx
+++ b/src/web-ui/src/app/components/NavPanel/components/BranchQuickSwitch.tsx
@@ -12,6 +12,7 @@ import { gitService, gitEventService } from '../../../../tools/git/services';
 import { gitStateManager } from '../../../../tools/git/state/GitStateManager';
 import { notificationService } from '../../../../shared/notification-system/services/NotificationService';
 import { createLogger } from '@/shared/utils/logger';
+import { isImeOwnedKeyboardEvent } from '@/shared/utils/ime';
 import './BranchQuickSwitch.scss';
 
 const log = createLogger('BranchQuickSwitch');
@@ -43,6 +44,7 @@ export const BranchQuickSwitch: React.FC<BranchQuickSwitchProps> = ({
   const [position, setPosition] = useState<{ top: number; left: number }>({ top: 0, left: 0 });
 
   const inputRef = useRef<HTMLInputElement>(null);
+  const inputCompositionActiveRef = useRef(false);
   const panelRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
 
@@ -195,6 +197,13 @@ export const BranchQuickSwitch: React.FC<BranchQuickSwitchProps> = ({
   }, [repositoryPath, currentBranch, isSwitching, onSwitchSuccess, onClose, t]);
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (
+      (e.key === 'Enter' || e.key === 'Escape')
+      && isImeOwnedKeyboardEvent(e, inputCompositionActiveRef.current)
+    ) {
+      e.stopPropagation();
+      return;
+    }
     if (filteredBranches.length === 0) return;
     switch (e.key) {
       case 'ArrowDown':
@@ -238,6 +247,12 @@ export const BranchQuickSwitch: React.FC<BranchQuickSwitchProps> = ({
           placeholder={t('quickSwitch.searchPlaceholder')}
           value={searchTerm}
           onChange={(e) => setSearchTerm(e.target.value)}
+          onCompositionStart={() => {
+            inputCompositionActiveRef.current = true;
+          }}
+          onCompositionEnd={() => {
+            inputCompositionActiveRef.current = false;
+          }}
           className="branch-quick-switch__input"
           data-bf-component="branch-quick-switch"
           data-bf-part="input"

--- a/src/web-ui/src/app/components/panels/BranchSelectModal.tsx
+++ b/src/web-ui/src/app/components/panels/BranchSelectModal.tsx
@@ -9,6 +9,7 @@ import { createPortal } from 'react-dom';
 import { getAppearanceOverlayHost } from '@/infrastructure/appearance/runtime/AppearanceOverlayHost';
 import { GitBranch, Plus } from 'lucide-react';
 import { createLogger } from '@/shared/utils/logger';
+import { isImeOwnedKeyboardEvent } from '@/shared/utils/ime';
 import { Checkbox, PopupCloseButton, PresenceBoundary, PRESENCE_BOUNDARY_MIN_EXIT_MS } from '@/component-library';
 import { useI18n } from '@/infrastructure/i18n';
 import { gitAPI, type GitBranch as GitBranchType } from '../../../infrastructure/api/service-api/GitAPI';
@@ -99,7 +100,7 @@ export const BranchSelectModal: React.FC<BranchSelectModalProps> = ({
 
   useEffect(() => {
     const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && isOpen) {
+      if (e.key === 'Escape' && isOpen && !isImeOwnedKeyboardEvent(e)) {
         onClose();
       }
     };

--- a/src/web-ui/src/app/components/panels/DiffFullscreenViewer.tsx
+++ b/src/web-ui/src/app/components/panels/DiffFullscreenViewer.tsx
@@ -5,6 +5,7 @@ import { getAppearanceOverlayHost } from '@/infrastructure/appearance/runtime/Ap
 import { X, CheckCircle, XCircle } from 'lucide-react';
 import { PresenceBoundary, Tooltip } from '@/component-library';
 import { useI18n } from '@/infrastructure/i18n';
+import { isImeOwnedKeyboardEvent } from '@/shared/utils/ime';
 import { DiffEditor } from '../../../tools/editor';
 import './DiffFullscreenViewer.css';
 
@@ -54,7 +55,7 @@ export const DiffFullscreenViewer: React.FC<DiffFullscreenViewerProps> = ({
   // Close on Escape
   useEffect(() => {
     const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && isOpen) {
+      if (e.key === 'Escape' && isOpen && !isImeOwnedKeyboardEvent(e)) {
         onClose();
       }
     };

--- a/src/web-ui/src/app/components/panels/TerminalEditModal.tsx
+++ b/src/web-ui/src/app/components/panels/TerminalEditModal.tsx
@@ -7,6 +7,7 @@ import { Button } from '@bitfun/ui';
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Modal, Input } from '@/component-library';
 import { useI18n } from '@/infrastructure/i18n';
+import { isImeOwnedKeyboardEvent } from '@/shared/utils/ime';
 import './TerminalEditModal.scss';
 
 export interface TerminalEditModalProps {
@@ -50,7 +51,7 @@ export const TerminalEditModal: React.FC<TerminalEditModalProps> = ({
 
   useEffect(() => {
     const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && isOpen) {
+      if (e.key === 'Escape' && isOpen && !isImeOwnedKeyboardEvent(e)) {
         onClose();
       }
     };

--- a/src/web-ui/src/app/global-search/GlobalSearchRoot.tsx
+++ b/src/web-ui/src/app/global-search/GlobalSearchRoot.tsx
@@ -7,6 +7,7 @@ import React, {
   useState,
   useSyncExternalStore,
 } from 'react';
+import { isImeOwnedKeyboardEvent } from '@/shared/utils/ime';
 import { KeyHint } from '@bitfun/ui';
 import {
   BarChart3,
@@ -159,6 +160,7 @@ export const GlobalSearchContent: React.FC<GlobalSearchContentProps> = ({
   const [activeId, setActiveId] = useState<string | null>(null);
   const [drilldownGroup, setDrilldownGroup] = useState<GlobalSearchDrilldownGroupId | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const inputCompositionActiveRef = useRef(false);
   const listRef = useRef<HTMLDivElement>(null);
   const generatedId = useId().replace(/:/g, '');
   const instanceId = `global-search-${generatedId || 'content'}`;
@@ -275,6 +277,13 @@ export const GlobalSearchContent: React.FC<GlobalSearchContentProps> = ({
   }, [onBeforeActivate, openAssistant, selectAssistantWorkspace, setActiveWorkspace, tCommon]);
 
   const handleInputKeyDown = useCallback((event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (
+      (event.key === 'Enter' || event.key === 'Escape')
+      && isImeOwnedKeyboardEvent(event, inputCompositionActiveRef.current)
+    ) {
+      event.stopPropagation();
+      return;
+    }
     if (event.key === 'ArrowDown') {
       event.preventDefault();
       const nextIndex = Math.min(navigableItems.length - 1, Math.max(0, activeIndex + 1));
@@ -323,6 +332,7 @@ export const GlobalSearchContent: React.FC<GlobalSearchContentProps> = ({
   }, [focusSearchInput]);
 
   const handleRootKeyDownCapture = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (isImeOwnedKeyboardEvent(event, inputCompositionActiveRef.current)) return;
     if (event.key !== 'Escape' || !drilldownGroup) return;
     event.preventDefault();
     event.stopPropagation();
@@ -356,6 +366,12 @@ export const GlobalSearchContent: React.FC<GlobalSearchContentProps> = ({
                 setDrilldownGroup(null);
               }}
               onKeyDown={handleInputKeyDown}
+              onCompositionStart={() => {
+                inputCompositionActiveRef.current = true;
+              }}
+              onCompositionEnd={() => {
+                inputCompositionActiveRef.current = false;
+              }}
               placeholder={tCommon('nav.search.inputPlaceholder')}
               aria-label={tCommon('nav.search.inputLabel')}
               role="combobox"

--- a/src/web-ui/src/app/scenes/miniapps/views/MiniAppGalleryView.tsx
+++ b/src/web-ui/src/app/scenes/miniapps/views/MiniAppGalleryView.tsx
@@ -9,6 +9,7 @@ import {
 } from 'lucide-react';
 import { open } from '@tauri-apps/plugin-dialog';
 import { useSceneManager } from '@/app/hooks/useSceneManager';
+import { isImeOwnedKeyboardEvent } from '@/shared/utils/ime';
 import MiniAppCard from '../components/MiniAppCard';
 import MiniAppDetailModal from '../components/MiniAppDetailModal';
 import type { MiniAppMeta } from '@/infrastructure/api/service-api/MiniAppAPI';
@@ -99,7 +100,7 @@ const MiniAppGalleryView: React.FC = () => {
       closeImportMenu();
     };
     const handleEscape = (event: KeyboardEvent) => {
-      if (event.key !== 'Escape') return;
+      if (event.key !== 'Escape' || isImeOwnedKeyboardEvent(event)) return;
       closeImportMenu();
       requestAnimationFrame(() => importTriggerRef.current?.focus());
     };

--- a/src/web-ui/src/app/scenes/shell/hooks/useShellNavMenuState.ts
+++ b/src/web-ui/src/app/scenes/shell/hooks/useShellNavMenuState.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { computeFixedPopoverPosition } from '@/shared/utils/fixedPopoverViewport';
+import { isImeOwnedKeyboardEvent } from '@/shared/utils/ime';
 
 interface MenuPosition {
   top: number;
@@ -52,7 +53,7 @@ export function useShellNavMenuState(
     };
 
     const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
+      if (event.key === 'Escape' && !isImeOwnedKeyboardEvent(event)) {
         setMenuOpen(false);
         setWorkspaceMenuOpen(false);
       }

--- a/src/web-ui/src/component-library/components/CodeEditor/CodeEditor.tsx
+++ b/src/web-ui/src/component-library/components/CodeEditor/CodeEditor.tsx
@@ -9,6 +9,7 @@ import { requireMonaco } from '@/tools/editor/services/monacoRuntime';
 import { useI18n } from '@/infrastructure/i18n';
 import { MonacoEditorCore, type MonacoEditorCoreRef } from '@/tools/editor/core';
 import type { EditorConfigPartial } from '@/tools/editor/config';
+import { isImeOwnedKeyboardEvent } from '@/shared/utils/ime';
 import './CodeEditor.scss';
 
 export interface CodeEditorProps {
@@ -96,7 +97,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
   
   useEffect(() => {
     const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && isFullscreen) {
+      if (e.key === 'Escape' && isFullscreen && !isImeOwnedKeyboardEvent(e)) {
         setIsFullscreen(false);
       }
     };

--- a/src/web-ui/src/component-library/components/ImeSafeTextControls.test.tsx
+++ b/src/web-ui/src/component-library/components/ImeSafeTextControls.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { isImeOwnedKeyboardEvent } from '@/shared/utils/ime';
+import { Input } from './Input';
+import { Textarea } from './Textarea';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('IME-safe text controls', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it.each([
+    ['Input', <Input onKeyDown={vi.fn()} />],
+    ['Textarea', <Textarea onKeyDown={vi.fn()} />],
+  ])('does not submit, cancel, or bubble while %s is composing', (_name, control) => {
+    const onKeyDown = control.props.onKeyDown as ReturnType<typeof vi.fn>;
+    const bubbledKeyDown = vi.fn();
+    document.addEventListener('keydown', bubbledKeyDown);
+
+    act(() => root.render(control));
+    const textControl = container.querySelector('input, textarea');
+    expect(textControl).not.toBeNull();
+
+    act(() => {
+      textControl?.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+      textControl?.dispatchEvent(new KeyboardEvent('keydown', {
+        bubbles: true,
+        key: 'Enter',
+      }));
+      textControl?.dispatchEvent(new KeyboardEvent('keydown', {
+        bubbles: true,
+        key: 'Escape',
+      }));
+    });
+
+    expect(onKeyDown).not.toHaveBeenCalled();
+    expect(bubbledKeyDown).not.toHaveBeenCalled();
+
+    act(() => {
+      textControl?.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true }));
+      textControl?.dispatchEvent(new KeyboardEvent('keydown', {
+        bubbles: true,
+        key: 'Enter',
+      }));
+    });
+
+    expect(onKeyDown).toHaveBeenCalledTimes(1);
+    expect(bubbledKeyDown).toHaveBeenCalledTimes(1);
+    document.removeEventListener('keydown', bubbledKeyDown);
+  });
+
+  it('recognizes the WebKit keyCode 229 fallback', () => {
+    expect(isImeOwnedKeyboardEvent({ isComposing: true })).toBe(true);
+    expect(isImeOwnedKeyboardEvent({ keyCode: 229 })).toBe(true);
+    expect(isImeOwnedKeyboardEvent({ nativeEvent: { keyCode: 229 } })).toBe(true);
+    expect(isImeOwnedKeyboardEvent({ keyCode: 13 })).toBe(false);
+  });
+});

--- a/src/web-ui/src/component-library/components/Input/Input.tsx
+++ b/src/web-ui/src/component-library/components/Input/Input.tsx
@@ -2,7 +2,8 @@
  * Input component
  */
 
-import React, { forwardRef, useId } from 'react';
+import React, { forwardRef, useId, useRef } from 'react';
+import { isImeOwnedKeyboardEvent } from '@/shared/utils/ime';
 import './Input.scss';
 
 export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size' | 'prefix'> {
@@ -29,8 +30,12 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(({
   hint,
   className = '',
   disabled,
+  onKeyDown,
+  onCompositionStart,
+  onCompositionEnd,
   ...props
 }, ref) => {
+  const compositionActiveRef = useRef(false);
   const generatedId = useId();
   const inputId = props.id ?? `${generatedId}-input`;
   const supportId = `${generatedId}-support`;
@@ -67,6 +72,24 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(({
           data-bf-component="input"
           data-bf-part="control"
           disabled={disabled}
+          onKeyDown={(event) => {
+            if (
+              (event.key === 'Enter' || event.key === 'Escape')
+              && isImeOwnedKeyboardEvent(event, compositionActiveRef.current)
+            ) {
+              event.stopPropagation();
+              return;
+            }
+            onKeyDown?.(event);
+          }}
+          onCompositionStart={(event) => {
+            compositionActiveRef.current = true;
+            onCompositionStart?.(event);
+          }}
+          onCompositionEnd={(event) => {
+            compositionActiveRef.current = false;
+            onCompositionEnd?.(event);
+          }}
           aria-invalid={error || undefined}
           aria-describedby={(error && errorMessage) || (!error && hint) ? supportId : props['aria-describedby']}
         />

--- a/src/web-ui/src/component-library/components/Modal/Modal.tsx
+++ b/src/web-ui/src/component-library/components/Modal/Modal.tsx
@@ -6,6 +6,7 @@ import React, { useEffect, useState, useRef, useCallback, useId } from 'react';
 import { createPortal } from 'react-dom';
 import { useI18n } from '@/infrastructure/i18n';
 import { getAppearanceOverlayHost } from '@/infrastructure/appearance/runtime/AppearanceOverlayHost';
+import { isImeOwnedKeyboardEvent } from '@/shared/utils/ime';
 import { PopupCloseButton } from '../PopupCloseButton';
 import './Modal.scss';
 
@@ -126,7 +127,7 @@ export const Modal: React.FC<ModalProps> = ({
 
   useEffect(() => {
     const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && isOpen) {
+      if (e.key === 'Escape' && isOpen && !isImeOwnedKeyboardEvent(e)) {
         onClose();
       }
     };

--- a/src/web-ui/src/component-library/components/NumberInput/NumberInput.tsx
+++ b/src/web-ui/src/component-library/components/NumberInput/NumberInput.tsx
@@ -6,6 +6,7 @@
 import React, { forwardRef, useState, useCallback, useRef, useEffect } from 'react';
 import { ChevronUp, ChevronDown, Minus, Plus } from 'lucide-react';
 import { useI18n } from '@/infrastructure/i18n';
+import { isImeOwnedKeyboardEvent } from '@/shared/utils/ime';
 import './NumberInput.scss';
 
 export interface NumberInputProps {
@@ -54,6 +55,7 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
     const [isHovered, setIsHovered] = useState(false);
     const dragStartRef = useRef<{ y: number; value: number } | null>(null);
     const inputRef = useRef<HTMLInputElement>(null);
+    const compositionActiveRef = useRef(false);
     const containerRef = useRef<HTMLDivElement>(null);
 
     const formatValue = useCallback(
@@ -107,6 +109,13 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
 
     const handleKeyDown = useCallback(
       (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (
+          (e.key === 'Enter' || e.key === 'Escape')
+          && isImeOwnedKeyboardEvent(e, compositionActiveRef.current)
+        ) {
+          e.stopPropagation();
+          return;
+        }
         if (e.key === 'Enter') {
           handleInputBlur();
           inputRef.current?.blur();
@@ -225,6 +234,12 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
               onFocus={() => setIsEditing(true)}
               onBlur={handleInputBlur}
               onKeyDown={handleKeyDown}
+              onCompositionStart={() => {
+                compositionActiveRef.current = true;
+              }}
+              onCompositionEnd={() => {
+                compositionActiveRef.current = false;
+              }}
               disabled={disabled}
               data-bf-component="number-input"
               data-bf-part="input"

--- a/src/web-ui/src/component-library/components/Search/Search.tsx
+++ b/src/web-ui/src/component-library/components/Search/Search.tsx
@@ -4,6 +4,7 @@
 
 import React, { useState, useRef, useEffect, useCallback, forwardRef, useId } from 'react';
 import { useI18n } from '@/infrastructure/i18n';
+import { isImeOwnedKeyboardEvent } from '@/shared/utils/ime';
 import './Search.scss';
 
 function SearchGlyph() {
@@ -141,6 +142,7 @@ export const Search = forwardRef<HTMLInputElement, SearchProps>(({
   const [isHovered, setIsHovered] = useState(false);
   
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const compositionActiveRef = useRef(false);
 
   const setForwardedRef = useCallback((node: HTMLInputElement | null) => {
     if (typeof ref === 'function') {
@@ -185,6 +187,13 @@ export const Search = forwardRef<HTMLInputElement, SearchProps>(({
   }, [onChange, onClear]);
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (
+      (e.key === 'Enter' || e.key === 'Escape')
+      && isImeOwnedKeyboardEvent(e, compositionActiveRef.current)
+    ) {
+      e.stopPropagation();
+      return;
+    }
     onKeyDownProp?.(e);
     if (e.defaultPrevented) {
       return;
@@ -253,6 +262,12 @@ export const Search = forwardRef<HTMLInputElement, SearchProps>(({
           maxLength={maxLength}
           onChange={handleChange}
           onKeyDown={handleKeyDown}
+          onCompositionStart={() => {
+            compositionActiveRef.current = true;
+          }}
+          onCompositionEnd={() => {
+            compositionActiveRef.current = false;
+          }}
           onFocus={handleFocus}
           onBlur={handleBlur}
           aria-label={inputAriaLabel ?? t('search.placeholder')}

--- a/src/web-ui/src/component-library/components/Select/Select.tsx
+++ b/src/web-ui/src/component-library/components/Select/Select.tsx
@@ -17,6 +17,7 @@ import {
   useAnchoredPopoverPosition,
   type AnchoredPopoverLayout,
 } from '@/shared/utils/useAnchoredPopoverPosition';
+import { isImeOwnedKeyboardEvent } from '@/shared/utils/ime';
 import { PresenceBoundary } from '../PresenceBoundary/PresenceBoundary';
 import './Select.scss';
 
@@ -144,6 +145,7 @@ export const Select: React.FC<SelectProps> = ({
   const selectRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const searchCompositionActiveRef = useRef(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const isKeyboardNavigation = useRef(false);
 
@@ -655,6 +657,13 @@ export const Select: React.FC<SelectProps> = ({
             onChange={(e) => setSearchQuery(e.target.value)}
             onClick={(e) => e.stopPropagation()}
             onKeyDown={(e) => {
+              if (
+                (e.key === 'Enter' || e.key === 'Escape')
+                && isImeOwnedKeyboardEvent(e, searchCompositionActiveRef.current)
+              ) {
+                e.stopPropagation();
+                return;
+              }
               if (['Enter', 'Escape', 'ArrowDown', 'ArrowUp'].includes(e.key)) {
                 setKeyboardOpen(true);
               }
@@ -681,6 +690,12 @@ export const Select: React.FC<SelectProps> = ({
                   -1,
                 ));
               }
+            }}
+            onCompositionStart={() => {
+              searchCompositionActiveRef.current = true;
+            }}
+            onCompositionEnd={() => {
+              searchCompositionActiveRef.current = false;
             }}
             data-bf-component="select"
             data-bf-part="searchInput"

--- a/src/web-ui/src/component-library/components/Textarea/Textarea.tsx
+++ b/src/web-ui/src/component-library/components/Textarea/Textarea.tsx
@@ -1,4 +1,5 @@
 import React, { forwardRef, useRef, useImperativeHandle, useCallback, useId } from 'react';
+import { isImeOwnedKeyboardEvent } from '@/shared/utils/ime';
 import './Textarea.scss';
 
 export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
@@ -29,6 +30,9 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
       className = '',
       value,
       onChange,
+      onKeyDown,
+      onCompositionStart,
+      onCompositionEnd,
       style,
       'data-bf-component': rootAppearanceComponent = 'textarea',
       'data-bf-part': rootAppearancePart = 'root',
@@ -40,6 +44,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
     const textareaId = props.id ?? `${generatedId}-textarea`;
     const supportId = `${generatedId}-support`;
     const textareaRef = useRef<HTMLTextAreaElement>(null);
+    const compositionActiveRef = useRef(false);
     const [charCount, setCharCount] = React.useState(0);
 
     useImperativeHandle(ref, () => textareaRef.current!);
@@ -94,6 +99,24 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
             className="bitfun-textarea__field"
             value={value}
             onChange={handleChange}
+            onKeyDown={(event) => {
+              if (
+                (event.key === 'Enter' || event.key === 'Escape')
+                && isImeOwnedKeyboardEvent(event, compositionActiveRef.current)
+              ) {
+                event.stopPropagation();
+                return;
+              }
+              onKeyDown?.(event);
+            }}
+            onCompositionStart={(event) => {
+              compositionActiveRef.current = true;
+              onCompositionStart?.(event);
+            }}
+            onCompositionEnd={(event) => {
+              compositionActiveRef.current = false;
+              onCompositionEnd?.(event);
+            }}
             maxLength={maxLength}
             aria-invalid={error || undefined}
             aria-describedby={(error && errorMessage) || (!error && hint) || showCount

--- a/src/web-ui/src/features/market-account/MarketAccountControls.tsx
+++ b/src/web-ui/src/features/market-account/MarketAccountControls.tsx
@@ -11,6 +11,7 @@ import {
   useMarketAccount,
 } from '@/infrastructure/market-account';
 import { useNotification } from '@/shared/notification-system';
+import { isImeOwnedKeyboardEvent } from '@/shared/utils/ime';
 import {
   calculateMarketAccountMenuPosition,
   type MarketAccountMenuPosition,
@@ -97,7 +98,7 @@ export function MarketAccountControls({
       }
     };
     const closeOnEscape = (event: KeyboardEvent) => {
-      if (event.key !== 'Escape') return;
+      if (event.key !== 'Escape' || isImeOwnedKeyboardEvent(event)) return;
       setMenuOpen(false);
       menuTriggerRef.current?.focus();
     };

--- a/src/web-ui/src/features/ssh-remote/RemoteFileBrowser.tsx
+++ b/src/web-ui/src/features/ssh-remote/RemoteFileBrowser.tsx
@@ -12,6 +12,7 @@ import { PopupCloseButton } from '@/component-library';
 import { ConfirmDialog } from './ConfirmDialog';
 import type { RemoteFileEntry } from './types';
 import { sshApi } from './sshApi';
+import { isImeOwnedKeyboardEvent } from '@/shared/utils/ime';
 import {
   RefreshCw,
   Folder,
@@ -98,6 +99,7 @@ export const RemoteFileBrowser: React.FC<RemoteFileBrowserProps> = ({
   const [pathInputValue, setPathInputValue] = useState(initialPath);
   const [isEditingPath, setIsEditingPath] = useState(false);
   const pathInputRef = useRef<HTMLInputElement>(null);
+  const textInputCompositionActiveRef = useRef(false);
   const [entries, setEntries] = useState<RemoteFileEntry[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -175,6 +177,13 @@ export const RemoteFileBrowser: React.FC<RemoteFileBrowserProps> = ({
   };
 
   const handlePathInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (
+      (e.key === 'Enter' || e.key === 'Escape')
+      && isImeOwnedKeyboardEvent(e, textInputCompositionActiveRef.current)
+    ) {
+      e.stopPropagation();
+      return;
+    }
     if (e.key === 'Enter') {
       const val = pathInputValue.trim();
       if (val) {
@@ -415,6 +424,12 @@ export const RemoteFileBrowser: React.FC<RemoteFileBrowserProps> = ({
               value={pathInputValue}
               onChange={(e) => setPathInputValue(e.target.value)}
               onKeyDown={handlePathInputKeyDown}
+              onCompositionStart={() => {
+                textInputCompositionActiveRef.current = true;
+              }}
+              onCompositionEnd={() => {
+                textInputCompositionActiveRef.current = false;
+              }}
               onBlur={handlePathInputBlur}
               autoFocus
               spellCheck={false}
@@ -639,8 +654,21 @@ export const RemoteFileBrowser: React.FC<RemoteFileBrowserProps> = ({
                 className="remote-file-browser__dialog-input"
                 autoFocus
                 onKeyDown={(e) => {
+                  if (
+                    (e.key === 'Enter' || e.key === 'Escape')
+                    && isImeOwnedKeyboardEvent(e, textInputCompositionActiveRef.current)
+                  ) {
+                    e.stopPropagation();
+                    return;
+                  }
                   if (e.key === 'Enter') handleRename();
                   if (e.key === 'Escape') setRenameEntry(null);
+                }}
+                onCompositionStart={() => {
+                  textInputCompositionActiveRef.current = true;
+                }}
+                onCompositionEnd={() => {
+                  textInputCompositionActiveRef.current = false;
                 }}
               />
               <div className="remote-file-browser__dialog-actions">

--- a/src/web-ui/src/flow_chat/components/PendingQueuePanel.tsx
+++ b/src/web-ui/src/flow_chat/components/PendingQueuePanel.tsx
@@ -12,7 +12,7 @@
  *   deduped via `steeringId`.
  */
 
-import { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Pencil,
@@ -33,6 +33,7 @@ import { interruptedTurnRecoveryGate } from '../services/interruptedTurnRecovery
 import { insertSteeringItemIfAbsent } from '../services/flow-chat-manager/EventHandlerModule';
 import { notificationService } from '../../shared/notification-system';
 import { createLogger } from '@/shared/utils/logger';
+import { isImeOwnedKeyboardEvent } from '@/shared/utils/ime';
 import type { QueuedMessage, SteeringImage } from '../types/flow-chat';
 import { isAcpFlowSession } from '../utils/acpSession';
 import './PendingQueuePanel.scss';
@@ -47,6 +48,7 @@ interface PendingQueuePanelProps {
 
 export function PendingQueuePanel({ sessionId, className }: PendingQueuePanelProps): JSX.Element | null {
   const { t } = useTranslation('flow-chat');
+  const editorCompositionActiveRef = useRef(false);
   useSyncExternalStore(
     interruptedTurnRecoveryGate.subscribe,
     interruptedTurnRecoveryGate.getSnapshot,
@@ -256,6 +258,13 @@ export function PendingQueuePanel({ sessionId, className }: PendingQueuePanelPro
                       rows={Math.min(6, Math.max(2, editingDraft.split('\n').length))}
                       onChange={e => setEditingDraft(e.target.value)}
                       onKeyDown={e => {
+                        if (
+                          (e.key === 'Enter' || e.key === 'Escape')
+                          && isImeOwnedKeyboardEvent(e, editorCompositionActiveRef.current)
+                        ) {
+                          e.stopPropagation();
+                          return;
+                        }
                         if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
                           e.preventDefault();
                           handleEditSave(item);
@@ -263,6 +272,12 @@ export function PendingQueuePanel({ sessionId, className }: PendingQueuePanelPro
                           e.preventDefault();
                           handleEditCancel();
                         }
+                      }}
+                      onCompositionStart={() => {
+                        editorCompositionActiveRef.current = true;
+                      }}
+                      onCompositionEnd={() => {
+                        editorCompositionActiveRef.current = false;
                       }}
                     />
                     <div className="bitfun-pending-queue-panel__editor-hint">

--- a/src/web-ui/src/flow_chat/components/RichTextInput.tsx
+++ b/src/web-ui/src/flow_chat/components/RichTextInput.tsx
@@ -918,6 +918,7 @@ export const RichTextInput = React.forwardRef<HTMLDivElement, RichTextInputProps
     }
     
     if (composing && (e.key === 'Enter' || e.key === 'Escape')) {
+      e.stopPropagation();
       return;
     }
 

--- a/src/web-ui/src/flow_chat/hooks/useImeOwnedKeyGuard.ts
+++ b/src/web-ui/src/flow_chat/hooks/useImeOwnedKeyGuard.ts
@@ -7,6 +7,7 @@
  */
 
 import { useCallback, useRef } from 'react';
+import { isImeOwnedKeyboardEvent } from '@/shared/utils/ime';
 
 export interface ImeOwnedKeyGuard {
   isImeOwnedKey: (event: React.KeyboardEvent) => boolean;
@@ -26,10 +27,7 @@ export function useImeOwnedKeyGuard(): ImeOwnedKeyGuard {
   }, []);
 
   const isImeOwnedKey = useCallback((event: React.KeyboardEvent) => {
-    const nativeEvent = event.nativeEvent as KeyboardEvent | undefined;
-    return isImeComposingRef.current
-      || nativeEvent?.isComposing === true
-      || nativeEvent?.keyCode === 229;
+    return isImeOwnedKeyboardEvent(event, isImeComposingRef.current);
   }, []);
 
   return { isImeOwnedKey, handleCompositionStart, handleCompositionEnd };

--- a/src/web-ui/src/flow_chat/store/askUserQuestionDraftStore.test.ts
+++ b/src/web-ui/src/flow_chat/store/askUserQuestionDraftStore.test.ts
@@ -104,6 +104,19 @@ describe('askUserQuestionDraftStore', () => {
     });
   });
 
+  it('preserves the Other marker for transient blank IME composition values', () => {
+    const key = askUserQuestionDraftKey('session-a', 'tool-ime');
+    const store = askUserQuestionDraftStore.getState();
+
+    store.setSingleAnswer(key, 0, 'Other');
+    store.setOtherInput(key, 0, '', true);
+
+    expect(askUserQuestionDraftStore.getState().drafts[key]).toMatchObject({
+      answers: { 0: 'Other' },
+      otherInputs: { 0: '' },
+    });
+  });
+
   it('cleans up deleted sessions and discarded surfaces without disturbing others', () => {
     const removedSessionKey = askUserQuestionDraftKey('session-a', 'tool-a');
     const retainedSessionKey = askUserQuestionDraftKey('session-b', 'tool-b');

--- a/src/web-ui/src/flow_chat/store/askUserQuestionDraftStore.ts
+++ b/src/web-ui/src/flow_chat/store/askUserQuestionDraftStore.ts
@@ -25,7 +25,12 @@ interface AskUserQuestionDraftState {
     value: string,
     checked: boolean,
   ) => void;
-  setOtherInput: (key: string, questionIndex: number, value: string) => void;
+  setOtherInput: (
+    key: string,
+    questionIndex: number,
+    value: string,
+    preserveOtherSelection?: boolean,
+  ) => void;
   setSubmissionPhase: (key: string, phase: AskUserQuestionSubmissionPhase) => void;
   clearDraft: (key: string) => void;
   removeSessionDrafts: (sessionIds: Iterable<string>) => void;
@@ -156,12 +161,12 @@ export const useAskUserQuestionDraftStore = create<AskUserQuestionDraftState>((s
     }));
   },
 
-  setOtherInput: (key, questionIndex, value) => {
+  setOtherInput: (key, questionIndex, value, preserveOtherSelection = false) => {
     set(state => updateDraft(state, key, draft => {
       const isEmpty = value.trim().length === 0;
       return {
         ...draft,
-        answers: isEmpty
+        answers: isEmpty && !preserveOtherSelection
           ? removeOtherAnswer(draft.answers, questionIndex)
           : draft.answers,
         otherInputs: {

--- a/src/web-ui/src/flow_chat/tool-cards/AskUserQuestionCard.test.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/AskUserQuestionCard.test.tsx
@@ -234,6 +234,50 @@ describe('AskUserQuestionCard', () => {
     expect(container.querySelector<HTMLInputElement>('.other-input-inline')?.value).toBe('CockroachDB');
   });
 
+  it('keeps the custom input mounted and focused during Chinese IME composition', () => {
+    act(() => {
+      root.render(
+        <AskUserQuestionCard
+          toolItem={questionTool('pending_confirmation')}
+          config={config}
+          sessionId="session-a"
+          isLastItem
+        />,
+      );
+    });
+
+    const otherRadio = container.querySelector<HTMLInputElement>('input[value="Other"]');
+    act(() => otherRadio?.click());
+
+    const customInput = container.querySelector<HTMLInputElement>('.other-input-inline');
+    expect(customInput).not.toBeNull();
+    act(() => {
+      customInput?.focus();
+      customInput?.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+      if (customInput) {
+        setInputValue(customInput, 'n');
+        setInputValue(customInput, '');
+      }
+    });
+
+    expect(container.querySelector('.other-input-inline')).toBe(customInput);
+    expect(document.activeElement).toBe(customInput);
+    expect(container.querySelector<HTMLInputElement>('input[value="Other"]')?.checked).toBe(true);
+
+    act(() => {
+      if (customInput) {
+        setInputValue(customInput, '你');
+        customInput.dispatchEvent(new CompositionEvent('compositionend', {
+          bubbles: true,
+          data: '你',
+        }));
+      }
+    });
+
+    expect(container.querySelector<HTMLInputElement>('.other-input-inline')?.value).toBe('你');
+    expect(document.activeElement).toBe(customInput);
+  });
+
   it('deselects a blank multi-select Other answer and omits it from submission', async () => {
     act(() => {
       root.render(

--- a/src/web-ui/src/flow_chat/tool-cards/AskUserQuestionCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/AskUserQuestionCard.tsx
@@ -127,6 +127,7 @@ export const AskUserQuestionCard: React.FC<ToolCardProps> = ({
     draftKey ? state.drafts[draftKey] : undefined
   ));
   const [localDraft, setLocalDraft] = useState(createEmptyAskUserQuestionDraft);
+  const composingOtherInputsRef = useRef(new Set<number>());
   const draft = storedDraft ?? localDraft;
   const { answers, otherInputs, submissionPhase } = draft;
   const isSubmitting = submissionPhase === 'submitting';
@@ -241,21 +242,35 @@ export const AskUserQuestionCard: React.FC<ToolCardProps> = ({
     });
   }, [draftKey]);
 
-  const handleOtherInputChange = useCallback((questionIndex: number, value: string) => {
+  const handleOtherInputChange = useCallback((
+    questionIndex: number,
+    value: string,
+    preserveOtherSelection = false,
+  ) => {
     if (draftKey) {
-      askUserQuestionDraftStore.getState().setOtherInput(draftKey, questionIndex, value);
+      askUserQuestionDraftStore.getState().setOtherInput(
+        draftKey,
+        questionIndex,
+        value,
+        preserveOtherSelection,
+      );
       return;
     }
     setLocalDraft(current => {
       const isEmpty = value.trim().length === 0;
       const currentAnswer = current.answers[questionIndex];
       let nextAnswers = current.answers;
-      if (isEmpty && Array.isArray(currentAnswer) && currentAnswer.includes('Other')) {
+      if (
+        isEmpty
+        && !preserveOtherSelection
+        && Array.isArray(currentAnswer)
+        && currentAnswer.includes('Other')
+      ) {
         nextAnswers = {
           ...current.answers,
           [questionIndex]: currentAnswer.filter(answer => answer !== 'Other'),
         };
-      } else if (isEmpty && currentAnswer === 'Other') {
+      } else if (isEmpty && !preserveOtherSelection && currentAnswer === 'Other') {
         nextAnswers = { ...current.answers };
         delete nextAnswers[questionIndex];
       }
@@ -462,7 +477,24 @@ export const AskUserQuestionCard: React.FC<ToolCardProps> = ({
                 className="other-input-inline"
                 placeholder={t('toolCards.askUser.pleaseSpecify')}
                 value={otherInput}
-                onChange={(e) => handleOtherInputChange(questionIndex, e.target.value)}
+                onChange={(e) => handleOtherInputChange(
+                  questionIndex,
+                  e.target.value,
+                  composingOtherInputsRef.current.has(questionIndex)
+                    || (e.nativeEvent as InputEvent).isComposing,
+                )}
+                onCompositionStart={() => {
+                  composingOtherInputsRef.current.add(questionIndex);
+                }}
+                onCompositionEnd={(e) => {
+                  // WebKit can emit the final input event immediately after
+                  // compositionend. Keep Other selected through that event so
+                  // a transient empty IME value cannot unmount this input.
+                  handleOtherInputChange(questionIndex, e.currentTarget.value, true);
+                  queueMicrotask(() => {
+                    composingOtherInputsRef.current.delete(questionIndex);
+                  });
+                }}
                 disabled={isSubmitted || status === 'completed' || Boolean(isParamsStreaming)}
                 autoFocus
               />

--- a/src/web-ui/src/flow_chat/tool-cards/GenerativeWidgetToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/GenerativeWidgetToolCard.tsx
@@ -14,6 +14,7 @@ import { useGenerativeWidgetPromptMenu } from '@/tools/generative-widget/useGene
 import { useContextMenuStore } from '@/shared/context-menu-system/store/ContextMenuStore';
 import { captureElementToDownloadsPng } from '../utils/captureElementToDownloadsPng';
 import { createLogger } from '@/shared/utils/logger';
+import { isImeOwnedKeyboardEvent } from '@/shared/utils/ime';
 import { createTab } from '@/shared/utils/tabUtils';
 import { notificationService } from '@/shared/notification-system';
 import './GenerativeWidgetToolCard.scss';
@@ -183,7 +184,7 @@ export const GenerativeWidgetToolCard: React.FC<ToolCardProps> = ({ toolItem, se
     }
 
     const handleEscape = (event: KeyboardEvent) => {
-      if (event.key !== 'Escape') {
+      if (event.key !== 'Escape' || isImeOwnedKeyboardEvent(event)) {
         return;
       }
       setMenuSelectionActive(false);

--- a/src/web-ui/src/flow_chat/tool-cards/SnapshotFullscreenDiffViewer.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/SnapshotFullscreenDiffViewer.tsx
@@ -12,6 +12,7 @@ import { Tooltip } from '@/component-library';
 import { DiffEditor } from '../../tools/editor';
 import type { SnapshotFile } from '../../tools/snapshot_system/core/SnapshotStateManager';
 import { createLogger } from '@/shared/utils/logger';
+import { isImeOwnedKeyboardEvent } from '@/shared/utils/ime';
 import './SnapshotFullscreenDiffViewer.css';
 
 const log = createLogger('SnapshotFullscreenDiffViewer');
@@ -44,7 +45,7 @@ export const SnapshotFullscreenDiffViewer: React.FC<SnapshotFullscreenDiffViewer
   // Close on Escape key.
   useEffect(() => {
     const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && isOpen) {
+      if (e.key === 'Escape' && isOpen && !isImeOwnedKeyboardEvent(e)) {
         onClose();
       }
     };

--- a/src/web-ui/src/infrastructure/peer-device/PeerDirectoryBrowser.tsx
+++ b/src/web-ui/src/infrastructure/peer-device/PeerDirectoryBrowser.tsx
@@ -20,6 +20,7 @@ import { workspaceAPI } from '@/infrastructure/api';
 import { globalAPI } from '@/infrastructure/api/service-api/GlobalAPI';
 import { systemAPI } from '@/infrastructure/api/service-api/SystemAPI';
 import { createLogger } from '@/shared/utils/logger';
+import { isImeOwnedKeyboardEvent } from '@/shared/utils/ime';
 import {
   joinDirectoryPath,
   parentDirectoryPath,
@@ -83,6 +84,7 @@ export const PeerDirectoryBrowser: React.FC<PeerDirectoryBrowserProps> = ({
   const [error, setError] = useState<string | null>(null);
   const [selectedPath, setSelectedPath] = useState<string | null>(initialPath || null);
   const pathInputRef = useRef<HTMLInputElement>(null);
+  const pathInputCompositionActiveRef = useRef(false);
   const loadSeqRef = useRef(0);
 
   const parentPath = useMemo(() => parentDirectoryPath(currentPath), [currentPath]);
@@ -272,6 +274,13 @@ export const PeerDirectoryBrowser: React.FC<PeerDirectoryBrowserProps> = ({
                 data-bf-component="peer-device"
                 data-bf-part="pathInput"
                 onKeyDown={(event) => {
+                  if (
+                    (event.key === 'Enter' || event.key === 'Escape')
+                    && isImeOwnedKeyboardEvent(event, pathInputCompositionActiveRef.current)
+                  ) {
+                    event.stopPropagation();
+                    return;
+                  }
                   if (event.key === 'Enter') {
                     event.preventDefault();
                     handleCommitPathInput();
@@ -280,6 +289,12 @@ export const PeerDirectoryBrowser: React.FC<PeerDirectoryBrowserProps> = ({
                     setPathInputValue(currentPath);
                     setIsEditingPath(false);
                   }
+                }}
+                onCompositionStart={() => {
+                  pathInputCompositionActiveRef.current = true;
+                }}
+                onCompositionEnd={() => {
+                  pathInputCompositionActiveRef.current = false;
                 }}
               />
             ) : (

--- a/src/web-ui/src/infrastructure/services/ShortcutManager.ts
+++ b/src/web-ui/src/infrastructure/services/ShortcutManager.ts
@@ -2,6 +2,7 @@
 import type { ShortcutConfig, ShortcutScope } from '@/shared/types/shortcut';
 import { compareShortcutScope, NON_USER_CUSTOMIZABLE_SHORTCUT_IDS } from '@/shared/constants/shortcuts';
 import { createLogger } from '@/shared/utils/logger';
+import { isImeOwnedKeyboardEvent } from '@/shared/utils/ime';
 
 const log = createLogger('ShortcutManager');
 
@@ -342,7 +343,7 @@ export class ShortcutManager {
 
   private isImeOwnedKey(event: KeyboardEvent): boolean {
     return (event.key === 'Escape' || event.key === 'Enter')
-      && (event.isComposing || event.keyCode === 229);
+      && isImeOwnedKeyboardEvent(event);
   }
 
   /**

--- a/src/web-ui/src/shared/utils/ime.ts
+++ b/src/web-ui/src/shared/utils/ime.ts
@@ -1,0 +1,25 @@
+interface KeyboardEventWithNativeSignals {
+  isComposing?: boolean;
+  keyCode?: number;
+  nativeEvent?: {
+    isComposing?: boolean;
+    keyCode?: number;
+  };
+}
+
+/**
+ * Whether an IME still owns this keyboard event.
+ *
+ * `keyCode === 229` covers WebKit/older Chromium paths that do not reliably
+ * expose `isComposing` on the React synthetic event.
+ */
+export function isImeOwnedKeyboardEvent(
+  event: KeyboardEventWithNativeSignals,
+  compositionActive = false,
+): boolean {
+  return compositionActive
+    || event.isComposing === true
+    || event.keyCode === 229
+    || event.nativeEvent?.isComposing === true
+    || event.nativeEvent?.keyCode === 229;
+}


### PR DESCRIPTION
## Summary

- Preserve the AskUserQuestion custom-answer input during Chinese IME composition so transient composition values do not deselect “Other” and unmount the field.
- Add shared IME-owned keyboard-event detection based on composition lifecycle, native `isComposing`, and key code 229.
- Apply Enter/Escape guards consistently across the `@bitfun/ui` Input, legacy Web UI text controls, composite editors, raw text inputs, modal/global shortcuts, and mobile session rename.
- Add focused regression and source-contract tests.

## Type and Areas

Type:

Regression fix / UI/UX / test

Areas:

Web UI, design-system UI, mobile web

## Motivation / Impact

Chinese input methods could cause the AskUserQuestion custom text field to immediately lose focus because an intermediate empty composition value deselected the custom option and conditionally unmounted the input.

The audit also found text fields where Enter or Escape could submit, cancel, close, or switch context while an IME still owned the key event. Those paths now ignore IME-owned keyboard events while preserving normal keyboard behavior.

## Verification

- `pnpm --dir design-system/packages/ui test` — 49 tests passed.
- `pnpm --dir src/web-ui exec vitest run src/component-library/components/ImeSafeTextControls.test.tsx src/flow_chat/store/askUserQuestionDraftStore.test.ts src/flow_chat/tool-cards/AskUserQuestionCard.test.tsx` — 15 tests passed.
- `pnpm --dir src/mobile-web run type-check` — passed.
- `git diff --check` — passed.
- `pnpm run type-check:web` — still reports three unrelated generated API type errors in `websocket-adapter.ts`: missing `GitTrustReport`, `SearchSessionContentMessage`, and `SearchSessionContentResponse` exports.

Testing level: lightly tested. Focused automated coverage passed; no live Chinese IME/manual device test was performed.

## Reviewer Notes

- AI-assisted implementation and audit.
- Local/jsdom paths were exercised. Peer-device and remote-workspace input paths were code-audited, but remote workspace, remote control, Peer Device Mode, and Detached Dispatch were not exercised end-to-end.
- No user-facing strings, persisted schema, or protocol contracts changed.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.