### PR TITLE
fix(ai): sync subscription auth with OpenCode 1.18.23

### DIFF
--- a/docs/interactive-capabilities/README.md
+++ b/docs/interactive-capabilities/README.md
@@ -27,9 +27,9 @@ BitFun Playbook currently contains **22 features**, **16 settings pages**, and *
 - Generated runtime catalog: `src/crates/contracts/product-domains/src/generated/product-control-catalog.json`
 - Generated per-item interaction audit: `docs/interactive-capabilities/technical/product-control-open-audit.json`
 
-说明书、网站、搜索和 Agent 只看“功能 + 设置 + 子能力”。每项子能力都必须引用已注册 Tauri Command 或可解析的源码标记；这些证据不会进入公开目录。当前 **651** 个 Tauri 命令，以及 **365** 个产品交互源码文件中的 **4423** 个交互候选，只用于实现覆盖审计。
+说明书、网站、搜索和 Agent 只看“功能 + 设置 + 子能力”。每项子能力都必须引用已注册 Tauri Command 或可解析的源码标记；这些证据不会进入公开目录。当前 **651** 个 Tauri 命令，以及 **365** 个产品交互源码文件中的 **4421** 个交互候选，只用于实现覆盖审计。
 
-Docs, website, search, and agents see only features, settings, and documented sub-capabilities. Every sub-capability must reference a registered Tauri command or a resolvable source marker; evidence is stripped from public projections. The **651** Tauri commands and **4423** interaction candidates across **365** product UI source files remain implementation-audit evidence only.
+Docs, website, search, and agents see only features, settings, and documented sub-capabilities. Every sub-capability must reference a registered Tauri command or a resolvable source marker; evidence is stripped from public projections. The **651** Tauri commands and **4421** interaction candidates across **365** product UI source files remain implementation-audit evidence only.
 
 ## 控制边界 / Control boundary
 

--- a/docs/interactive-capabilities/technical/ui-interaction-inventory.json
+++ b/docs/interactive-capabilities/technical/ui-interaction-inventory.json
@@ -5,9 +5,9 @@
   "roots": [
     "src/web-ui/src"
   ],
-  "digest": "58d766fcc65df497d6de40113bf8bbbc2cdc0b216df7355ee9e90c1a98c9e677",
+  "digest": "981019f2d18ab8ca85a2247122aab358ec6618c69ca8a693b480f28e480555eb",
   "fileCount": 365,
-  "interactionCount": 4423,
+  "interactionCount": 4421,
   "files": [
     {
       "sourceFile": "src/web-ui/src/app/components/AboutDialog/AboutDialog.tsx",
@@ -1381,8 +1381,8 @@
     },
     {
       "sourceFile": "src/web-ui/src/infrastructure/config/components/ModelSettingsPage.tsx",
-      "interactionCount": 152,
-      "digest": "32726de1185e90e8949c2eefe6491f2ae9e0b39fd4b2a148d24649a37cc0ac13"
+      "interactionCount": 150,
+      "digest": "3ea0b2ee92bfbd4b6ad40f3fed55fa73b5756a9fd55d1b05b209a0638d4e15e6"
     },
     {
       "sourceFile": "src/web-ui/src/infrastructure/config/components/QuickActionsConfig.tsx",

--- a/src/crates/adapters/ai-adapters/src/providers/gemini/code_assist.rs
+++ b/src/crates/adapters/ai-adapters/src/providers/gemini/code_assist.rs
@@ -101,6 +101,244 @@ fn is_antigravity(client: &AIClient) -> bool {
         .is_some_and(|value| value.contains("ANTIGRAVITY"))
 }
 
+#[derive(Debug, PartialEq, Eq)]
+struct AntigravityModelRoute {
+    model: String,
+    thinking_level: Option<String>,
+    thinking_budget: Option<i64>,
+}
+
+fn configured_thinking_level(request: &serde_json::Value) -> Option<String> {
+    request
+        .get("generationConfig")
+        .and_then(|value| value.get("thinkingConfig"))
+        .and_then(|value| value.get("thinkingLevel"))
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_ascii_lowercase)
+}
+
+fn configured_thinking_budget(request: &serde_json::Value) -> Option<i64> {
+    request
+        .get("generationConfig")
+        .and_then(|value| value.get("thinkingConfig"))
+        .and_then(|value| {
+            value
+                .get("thinking_budget")
+                .or_else(|| value.get("thinkingBudget"))
+        })
+        .and_then(serde_json::Value::as_i64)
+        .filter(|value| *value > 0)
+}
+
+fn strip_thinking_tier(model: &str) -> (&str, Option<&str>) {
+    for tier in ["minimal", "low", "medium", "high", "max"] {
+        let suffix = format!("-{tier}");
+        if let Some(base) = model.strip_suffix(suffix.as_str()) {
+            return (base, Some(tier));
+        }
+    }
+    (model, None)
+}
+
+/// Resolves current Antigravity wire ids and keeps old Gemini CLI preview ids
+/// working for model configurations persisted by earlier BitFun releases.
+fn resolve_antigravity_model(
+    configured_model: &str,
+    request: &serde_json::Value,
+) -> AntigravityModelRoute {
+    let normalized = configured_model.trim().to_ascii_lowercase();
+    let normalized = normalized
+        .strip_prefix("antigravity-")
+        .unwrap_or(&normalized)
+        .to_string();
+    let normalized = normalized
+        .strip_suffix("-preview-customtools")
+        .or_else(|| normalized.strip_suffix("-preview"))
+        .unwrap_or(&normalized)
+        .to_string();
+    let (base, requested_tier) = strip_thinking_tier(&normalized);
+    let configured_level = configured_thinking_level(request);
+
+    if base.starts_with("gemini-3") && base.contains("-pro") && !base.contains("image") {
+        let level = match requested_tier.or(configured_level.as_deref()) {
+            Some("high") => "high",
+            _ => "low",
+        };
+        return AntigravityModelRoute {
+            model: format!("{base}-{level}"),
+            thinking_level: Some(level.to_string()),
+            thinking_budget: None,
+        };
+    }
+
+    if base.starts_with("gemini-3") && base.contains("-flash") {
+        let level = match requested_tier.or(configured_level.as_deref()) {
+            Some(level @ ("minimal" | "low" | "medium" | "high")) => level,
+            _ => "low",
+        };
+        return AntigravityModelRoute {
+            model: base.to_string(),
+            thinking_level: Some(level.to_string()),
+            thinking_budget: None,
+        };
+    }
+
+    if base.starts_with("claude-") && base.contains("-thinking") {
+        let thinking_budget = match requested_tier {
+            Some("low") => 8_192,
+            Some("medium") => 16_384,
+            Some("high" | "max") => 32_768,
+            _ => configured_thinking_budget(request).unwrap_or(32_768),
+        };
+        return AntigravityModelRoute {
+            model: base.to_string(),
+            thinking_level: None,
+            thinking_budget: Some(thinking_budget),
+        };
+    }
+
+    AntigravityModelRoute {
+        model: normalized,
+        thinking_level: None,
+        thinking_budget: None,
+    }
+}
+
+fn configure_antigravity_claude_tools(request: &mut serde_json::Value) {
+    let request = request
+        .as_object_mut()
+        .expect("Gemini request body must be an object");
+    let tool_config = request
+        .entry("toolConfig")
+        .or_insert_with(|| serde_json::json!({}));
+    if !tool_config.is_object() {
+        *tool_config = serde_json::json!({});
+    }
+    let tool_config = tool_config
+        .as_object_mut()
+        .expect("toolConfig must be an object");
+    let function_calling = tool_config
+        .entry("functionCallingConfig")
+        .or_insert_with(|| serde_json::json!({}));
+    if !function_calling.is_object() {
+        *function_calling = serde_json::json!({});
+    }
+    function_calling
+        .as_object_mut()
+        .expect("functionCallingConfig must be an object")
+        .insert(
+            "mode".to_string(),
+            serde_json::Value::String("VALIDATED".to_string()),
+        );
+
+    let Some(tools) = request
+        .get_mut("tools")
+        .and_then(serde_json::Value::as_array_mut)
+    else {
+        return;
+    };
+    for declarations in tools.iter_mut().filter_map(|tool| {
+        tool.get_mut("functionDeclarations")
+            .and_then(serde_json::Value::as_array_mut)
+    }) {
+        for declaration in declarations {
+            let Some(declaration) = declaration.as_object_mut() else {
+                continue;
+            };
+            let parameters = declaration
+                .entry("parameters")
+                .or_insert_with(|| serde_json::json!({ "type": "object" }));
+            if !parameters.is_object() {
+                *parameters = serde_json::json!({ "type": "object" });
+            }
+            let parameters = parameters
+                .as_object_mut()
+                .expect("tool parameters must be an object");
+            let has_properties = parameters
+                .get("properties")
+                .and_then(serde_json::Value::as_object)
+                .is_some_and(|properties| !properties.is_empty());
+            if has_properties {
+                continue;
+            }
+            parameters.insert("type".to_string(), serde_json::json!("object"));
+            parameters.insert(
+                "properties".to_string(),
+                serde_json::json!({
+                    "_placeholder": {
+                        "type": "boolean",
+                        "description": "Placeholder. Always pass true."
+                    }
+                }),
+            );
+            parameters.insert("required".to_string(), serde_json::json!(["_placeholder"]));
+        }
+    }
+}
+
+fn apply_antigravity_thinking(request: &mut serde_json::Value, route: &AntigravityModelRoute) {
+    if route.model.starts_with("claude-") {
+        configure_antigravity_claude_tools(request);
+    }
+    if route.thinking_level.is_none() && route.thinking_budget.is_none() {
+        return;
+    }
+    if !request
+        .get("generationConfig")
+        .is_some_and(serde_json::Value::is_object)
+    {
+        request["generationConfig"] = serde_json::json!({});
+    }
+    let generation = request["generationConfig"]
+        .as_object_mut()
+        .expect("generationConfig must be an object");
+    let thinking = generation
+        .entry("thinkingConfig")
+        .or_insert_with(|| serde_json::json!({}));
+    if !thinking.is_object() {
+        *thinking = serde_json::json!({});
+    }
+    let thinking = thinking
+        .as_object_mut()
+        .expect("thinkingConfig must be an object");
+
+    if let Some(level) = &route.thinking_level {
+        thinking.remove("thinkingBudget");
+        thinking.remove("thinking_budget");
+        thinking.insert("includeThoughts".to_string(), serde_json::Value::Bool(true));
+        thinking.insert(
+            "thinkingLevel".to_string(),
+            serde_json::Value::String(level.clone()),
+        );
+    } else if let Some(budget) = route.thinking_budget {
+        let include_thoughts = thinking
+            .remove("includeThoughts")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(true);
+        thinking.remove("thinkingLevel");
+        thinking.remove("thinkingBudget");
+        thinking.insert(
+            "include_thoughts".to_string(),
+            serde_json::Value::Bool(include_thoughts),
+        );
+        thinking.insert(
+            "thinking_budget".to_string(),
+            serde_json::Value::Number(budget.into()),
+        );
+        let max_output_tokens = generation
+            .get("maxOutputTokens")
+            .and_then(serde_json::Value::as_i64);
+        if max_output_tokens.is_none_or(|limit| limit <= budget) {
+            generation.insert(
+                "maxOutputTokens".to_string(),
+                serde_json::Value::Number(64_000.into()),
+            );
+        }
+    }
+}
+
 fn antigravity_platform(client: &AIClient) -> &'static str {
     let metadata = client
         .config
@@ -319,7 +557,7 @@ pub(crate) async fn send_stream(
     let (system_instruction, contents) =
         GeminiMessageConverter::convert_messages(messages, &client.config.model);
     let gemini_tools = GeminiMessageConverter::convert_tools(tools);
-    let inner = gemini_request::try_build_request_body(
+    let mut inner = gemini_request::try_build_request_body(
         client,
         system_instruction,
         contents,
@@ -328,8 +566,15 @@ pub(crate) async fn send_stream(
     )?;
 
     let antigravity = is_antigravity(client);
+    let model = if antigravity {
+        let route = resolve_antigravity_model(&client.config.model, &inner);
+        apply_antigravity_thinking(&mut inner, &route);
+        route.model
+    } else {
+        client.config.model.clone()
+    };
     let mut request_body = serde_json::json!({
-        "model": client.config.model,
+        "model": model,
         "project": project,
         "request": inner,
     });
@@ -338,6 +583,15 @@ pub(crate) async fn send_stream(
             obj.insert(
                 "userAgent".to_string(),
                 serde_json::Value::String("antigravity".to_string()),
+            );
+            obj.insert(
+                "requestType".to_string(),
+                serde_json::Value::String("agent".to_string()),
+            );
+            #[cfg(feature = "subscription-auth")]
+            obj.insert(
+                "requestId".to_string(),
+                serde_json::Value::String(format!("agent-{}", uuid::Uuid::new_v4())),
             );
         }
     }
@@ -358,8 +612,8 @@ pub(crate) async fn send_stream(
     };
 
     debug!(
-        "Gemini Code Assist config: model={}, request_url={}, project={}, max_tries={}",
-        client.config.model, urls[0], project, max_tries
+        "Gemini Code Assist config: model={}, configured_model={}, request_url={}, project={}, max_tries={}",
+        model, client.config.model, urls[0], project, max_tries
     );
 
     let idle_timeout = client.stream_options.idle_timeout;
@@ -417,6 +671,16 @@ const DEFAULT_CODE_ASSIST_MODELS: &[(&str, &str)] = &[
     ("gemini-2.5-pro", "Gemini 2.5 Pro"),
     ("gemini-2.5-flash", "Gemini 2.5 Flash"),
     ("gemini-2.5-flash-lite", "Gemini 2.5 Flash-Lite"),
+];
+
+const DEFAULT_ANTIGRAVITY_MODELS: &[(&str, &str)] = &[
+    ("gemini-3.1-pro-high", "Gemini 3.1 Pro (High)"),
+    ("gemini-3.1-pro-low", "Gemini 3.1 Pro (Low)"),
+    ("gemini-3-pro-high", "Gemini 3 Pro (High)"),
+    ("gemini-3-pro-low", "Gemini 3 Pro (Low)"),
+    ("gemini-3-flash", "Gemini 3 Flash"),
+    ("claude-sonnet-4-6", "Claude Sonnet 4.6"),
+    ("claude-opus-4-6-thinking", "Claude Opus 4.6 Thinking"),
 ];
 
 fn gemini_home_dir() -> Option<PathBuf> {
@@ -490,7 +754,17 @@ fn read_gemini_env_model(gemini_home: &Path) -> Option<String> {
 /// endpoint; the upstream `gemini-cli` ships a hard-coded `VALID_GEMINI_MODELS`
 /// set in `packages/core/src/config/models.ts`. We mirror its stable entries and
 /// preserve the user's local configured model when present.
-pub(crate) async fn list_models(_client: &AIClient) -> Result<Vec<RemoteModelInfo>> {
+pub(crate) async fn list_models(client: &AIClient) -> Result<Vec<RemoteModelInfo>> {
+    if is_antigravity(client) {
+        return Ok(DEFAULT_ANTIGRAVITY_MODELS
+            .iter()
+            .map(|(id, display_name)| RemoteModelInfo {
+                id: (*id).to_string(),
+                display_name: Some((*display_name).to_string()),
+            })
+            .collect());
+    }
+
     let mut models = Vec::new();
 
     if let Some(gemini_home) = gemini_home_dir() {
@@ -517,8 +791,9 @@ pub(crate) async fn list_models(_client: &AIClient) -> Result<Vec<RemoteModelInf
 #[cfg(test)]
 mod tests {
     use super::{
-        antigravity_metadata, default_tier, extract_project, should_try_next_antigravity_endpoint,
-        AiProviderError, CodeAssistTier, LoadCodeAssistResponse, ANTIGRAVITY_DEFAULT_PROJECT,
+        antigravity_metadata, apply_antigravity_thinking, default_tier, extract_project,
+        resolve_antigravity_model, should_try_next_antigravity_endpoint, AiProviderError,
+        CodeAssistTier, LoadCodeAssistResponse, ANTIGRAVITY_DEFAULT_PROJECT,
     };
 
     #[test]
@@ -581,5 +856,72 @@ mod tests {
         assert!(should_try_next_antigravity_endpoint(&anyhow::anyhow!(
             "transport error"
         )));
+    }
+
+    #[test]
+    fn maps_legacy_and_current_antigravity_models_to_subscription_wire_ids() {
+        let empty_request = serde_json::json!({});
+        let cases = [
+            ("gemini-3-pro-preview", "gemini-3-pro-low"),
+            ("gemini-3.1-pro-preview-customtools", "gemini-3.1-pro-low"),
+            ("antigravity-gemini-3-pro-high", "gemini-3-pro-high"),
+            ("gemini-3-flash-preview", "gemini-3-flash"),
+            ("claude-opus-4-6-thinking-high", "claude-opus-4-6-thinking"),
+            ("claude-sonnet-4-6", "claude-sonnet-4-6"),
+        ];
+
+        for (configured, expected) in cases {
+            assert_eq!(
+                resolve_antigravity_model(configured, &empty_request).model,
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn writes_provider_specific_antigravity_thinking_fields() {
+        let mut gemini_request = serde_json::json!({});
+        let gemini_route = resolve_antigravity_model("gemini-3.1-pro-high", &gemini_request);
+        apply_antigravity_thinking(&mut gemini_request, &gemini_route);
+        assert_eq!(
+            gemini_request["generationConfig"]["thinkingConfig"]["thinkingLevel"],
+            "high"
+        );
+
+        let mut claude_request = serde_json::json!({});
+        let claude_route =
+            resolve_antigravity_model("claude-opus-4-6-thinking-low", &claude_request);
+        apply_antigravity_thinking(&mut claude_request, &claude_route);
+        assert_eq!(
+            claude_request["generationConfig"]["thinkingConfig"]["thinking_budget"],
+            8_192
+        );
+        assert_eq!(
+            claude_request["generationConfig"]["maxOutputTokens"],
+            64_000
+        );
+    }
+
+    #[test]
+    fn configures_validated_claude_tool_calls_and_nonempty_schemas() {
+        let mut request = serde_json::json!({
+            "tools": [{
+                "functionDeclarations": [{
+                    "name": "empty_tool",
+                    "parameters": { "type": "object", "properties": {} }
+                }]
+            }]
+        });
+        let route = resolve_antigravity_model("claude-sonnet-4-6", &request);
+        apply_antigravity_thinking(&mut request, &route);
+
+        assert_eq!(
+            request["toolConfig"]["functionCallingConfig"]["mode"],
+            "VALIDATED"
+        );
+        assert_eq!(
+            request["tools"][0]["functionDeclarations"][0]["parameters"]["required"],
+            serde_json::json!(["_placeholder"])
+        );
     }
 }

--- a/src/crates/adapters/ai-adapters/src/providers/openai/common.rs
+++ b/src/crates/adapters/ai-adapters/src/providers/openai/common.rs
@@ -185,27 +185,36 @@ struct CodexBackendModelEntry {
     priority: Option<i64>,
 }
 
-const DEFAULT_CODEX_MODELS: &[&str] = &[
-    "gpt-5.5",
-    "gpt-5.4-mini",
-    "gpt-5.4",
-    "gpt-5.3-codex",
-    "gpt-5.2-codex",
-    "gpt-5.1-codex-max",
-    "gpt-5.1-codex-mini",
-];
+const DEFAULT_CODEX_MODELS: &[&str] =
+    &["gpt-5.5", "gpt-5.3-codex-spark", "gpt-5.4", "gpt-5.4-mini"];
+
+fn parsed_gpt_version(model_id: &str) -> Option<(u32, u32)> {
+    let version = model_id.strip_prefix("gpt-")?.split('-').next()?;
+    let (major, minor) = version.split_once('.')?;
+    if minor.contains('.') {
+        return None;
+    }
+    Some((major.parse().ok()?, minor.parse().ok()?))
+}
+
+/// Mirrors OpenCode's ChatGPT subscription allowlist while keeping future
+/// versioned variants visible. Exact `gpt-5.6` and the Pro entitlement remain
+/// excluded because the subscription endpoint does not offer those products.
+fn codex_subscription_model_allowed(model_id: &str) -> bool {
+    let model_id = model_id.trim().to_ascii_lowercase();
+    if DEFAULT_CODEX_MODELS.contains(&model_id.as_str()) {
+        return true;
+    }
+    if matches!(model_id.as_str(), "gpt-5.5-pro" | "gpt-5.6") {
+        return false;
+    }
+    parsed_gpt_version(&model_id).is_some_and(|version| version > (5, 4))
+}
 
 pub(crate) fn is_known_codex_reasoning_model(model_id: &str) -> bool {
     let model_id = model_id.trim().to_ascii_lowercase();
-    model_id == "gpt-5-codex" || DEFAULT_CODEX_MODELS.contains(&model_id.as_str())
+    model_id == "gpt-5-codex" || codex_subscription_model_allowed(&model_id)
 }
-
-const FORWARD_COMPAT_CODEX_MODELS: &[(&str, &[&str])] = &[
-    ("gpt-5.5", &["gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex"]),
-    ("gpt-5.4-mini", &["gpt-5.3-codex", "gpt-5.2-codex"]),
-    ("gpt-5.4", &["gpt-5.3-codex", "gpt-5.2-codex"]),
-    ("gpt-5.3-codex", &["gpt-5.2-codex"]),
-];
 
 fn codex_home_dir() -> PathBuf {
     std::env::var("CODEX_HOME")
@@ -220,20 +229,6 @@ fn codex_home_dir() -> PathBuf {
 fn add_unique_model_id(ordered: &mut Vec<String>, id: String) {
     if !id.trim().is_empty() && !ordered.iter().any(|existing| existing == &id) {
         ordered.push(id);
-    }
-}
-
-fn add_forward_compat_codex_models(ordered: &mut Vec<String>) {
-    for (synthetic, templates) in FORWARD_COMPAT_CODEX_MODELS {
-        if ordered.iter().any(|model| model == synthetic) {
-            continue;
-        }
-        if templates
-            .iter()
-            .any(|template| ordered.iter().any(|model| model == template))
-        {
-            ordered.push((*synthetic).to_string());
-        }
     }
 }
 
@@ -312,6 +307,9 @@ fn codex_models_from_entries(entries: Vec<CodexBackendModelEntry>) -> Vec<String
         {
             continue;
         }
+        if !codex_subscription_model_allowed(&model.slug) {
+            continue;
+        }
         sortable.push((model.priority.unwrap_or(10_000), model.slug));
     }
     sortable.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
@@ -327,7 +325,9 @@ fn codex_fallback_model_ids() -> Vec<String> {
     let codex_home = codex_home_dir();
     let mut ordered = Vec::new();
     if let Some(model) = read_codex_config_model(&codex_home) {
-        add_unique_model_id(&mut ordered, model);
+        if codex_subscription_model_allowed(&model) {
+            add_unique_model_id(&mut ordered, model);
+        }
     }
     for model in read_codex_cached_models(&codex_home) {
         add_unique_model_id(&mut ordered, model);
@@ -335,7 +335,6 @@ fn codex_fallback_model_ids() -> Vec<String> {
     for model in DEFAULT_CODEX_MODELS {
         add_unique_model_id(&mut ordered, (*model).to_string());
     }
-    add_forward_compat_codex_models(&mut ordered);
     ordered
 }
 
@@ -382,7 +381,7 @@ async fn list_codex_chatgpt_models(
     }
     .await;
 
-    let mut model_ids = match live_models {
+    let model_ids = match live_models {
         Ok(models) if !models.is_empty() => models,
         Ok(_) => {
             log::warn!(
@@ -399,7 +398,6 @@ async fn list_codex_chatgpt_models(
         }
     };
 
-    add_forward_compat_codex_models(&mut model_ids);
     Ok(codex_model_infos(model_ids))
 }
 
@@ -464,7 +462,7 @@ pub(crate) fn convert_tools_flat(
 
 #[cfg(test)]
 mod tests {
-    use super::{attach_tools, is_known_codex_reasoning_model};
+    use super::{attach_tools, codex_subscription_model_allowed, is_known_codex_reasoning_model};
     use serde_json::json;
 
     #[test]
@@ -483,11 +481,25 @@ mod tests {
     }
 
     #[test]
-    fn codex_reasoning_model_table_is_exact_and_case_insensitive() {
+    fn codex_subscription_models_match_opencode_and_allow_future_variants() {
+        for model in [
+            "gpt-5.5",
+            "gpt-5.3-codex-spark",
+            "gpt-5.4",
+            "gpt-5.4-mini",
+            "gpt-5.6-sol",
+            "gpt-6.0-codex",
+        ] {
+            assert!(codex_subscription_model_allowed(model), "{model}");
+        }
+        for model in ["gpt-5.5-pro", "gpt-5.6", "gpt-5.4-pro", "o3"] {
+            assert!(!codex_subscription_model_allowed(model), "{model}");
+        }
+
         assert!(is_known_codex_reasoning_model("GPT-5.5"));
         assert!(is_known_codex_reasoning_model("gpt-5-codex"));
-        assert!(!is_known_codex_reasoning_model("gpt-9-unknown"));
-        assert!(!is_known_codex_reasoning_model("gpt-5.5-proxy"));
+        assert!(is_known_codex_reasoning_model("gpt-5.5-proxy"));
+        assert!(!is_known_codex_reasoning_model("gpt-5.5-pro"));
     }
 
     #[test]

--- a/src/crates/adapters/ai-adapters/src/subscription_auth/codex.rs
+++ b/src/crates/adapters/ai-adapters/src/subscription_auth/codex.rs
@@ -28,7 +28,6 @@ const SCOPE: &str = "openid profile email offline_access";
 const CHATGPT_BASE_URL: &str = "https://chatgpt.com/backend-api/codex";
 const CHATGPT_REQUEST_URL: &str = "https://chatgpt.com/backend-api/codex/responses";
 const DEFAULT_MODEL: &str = "gpt-5.5";
-const OPENCODE_VERSION: &str = "1.18.21";
 const REFRESH_LEEWAY_MS: i64 = 5 * 60 * 1000;
 const STORE_KEY: &str = "codex";
 
@@ -63,7 +62,8 @@ struct DeviceAuthorizationResponse {
 
 fn opencode_user_agent() -> String {
     format!(
-        "opencode/{OPENCODE_VERSION} ({}; {})",
+        "opencode/{} ({}; {})",
+        super::OPENCODE_COMPAT_VERSION,
         std::env::consts::OS,
         std::env::consts::ARCH
     )
@@ -484,7 +484,7 @@ pub(crate) fn suggested() -> (&'static str, &'static str, &'static str) {
 mod tests {
     use super::{
         build_authorize_url, device_poll_interval, opencode_user_agent, redirect_uri,
-        CALLBACK_PORT, DEFAULT_MODEL, OPENCODE_VERSION,
+        CALLBACK_PORT, DEFAULT_MODEL,
     };
     use crate::subscription_auth::pkce::Pkce;
 
@@ -505,7 +505,7 @@ mod tests {
         assert_eq!(device_poll_interval(&serde_json::json!(2)), 2);
         assert_eq!(device_poll_interval(&serde_json::json!(0)), 5);
         assert_eq!(DEFAULT_MODEL, "gpt-5.5");
-        assert_eq!(OPENCODE_VERSION, "1.18.21");
-        assert!(opencode_user_agent().starts_with("opencode/1.18.21 ("));
+        assert_eq!(super::super::OPENCODE_COMPAT_VERSION, "1.18.23");
+        assert!(opencode_user_agent().starts_with("opencode/1.18.23 ("));
     }
 }

--- a/src/crates/adapters/ai-adapters/src/subscription_auth/grok.rs
+++ b/src/crates/adapters/ai-adapters/src/subscription_auth/grok.rs
@@ -21,13 +21,12 @@ const SCOPE: &str = "openid profile email offline_access grok-cli:access api:acc
 const XAI_BASE_URL: &str = "https://api.x.ai/v1";
 const XAI_REQUEST_URL: &str = "https://api.x.ai/v1/responses";
 const DEFAULT_MODEL: &str = "grok-4.5";
-const OPENCODE_VERSION: &str = "1.18.21";
 const STORE_KEY: &str = "grok";
 const DEFAULT_TOKEN_LIFETIME_SECS: i64 = 60 * 60;
 const DEFAULT_DEVICE_LIFETIME_SECS: i64 = 5 * 60;
 const DEFAULT_POLL_INTERVAL_SECS: i64 = 5;
 const SLOW_DOWN_INCREMENT_SECS: i64 = 5;
-const REFRESH_LEEWAY_MS: i64 = 5 * 60 * 1000;
+const REFRESH_LEEWAY_MS: i64 = 2 * 60 * 1000;
 
 #[derive(Debug, Deserialize)]
 struct DeviceCodeResponse {
@@ -92,7 +91,7 @@ fn expires_at_ms(expires_in: Option<i64>) -> i64 {
 }
 
 fn opencode_user_agent() -> String {
-    format!("opencode/{OPENCODE_VERSION}")
+    format!("opencode/{}", super::OPENCODE_COMPAT_VERSION)
 }
 
 fn oauth_request(builder: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
@@ -377,7 +376,10 @@ async fn ensure_fresh(options: &SubscriptionHttpOptions) -> Result<(String, i64)
         return Err(anyhow!("xAI credential is not an OAuth login"));
     };
 
-    if expires > now_ms() + REFRESH_LEEWAY_MS {
+    let now = now_ms();
+    if expires > now + REFRESH_LEEWAY_MS
+        && !super::jwt::expires_within(&access, now, REFRESH_LEEWAY_MS)
+    {
         return Ok((access, expires));
     }
 
@@ -472,7 +474,7 @@ mod tests {
     use super::{
         classify_device_poll_error, inference_headers, suggested, validate_user_code,
         validate_verification_url, DeviceCodeResponse, DevicePoll, TokenErrorResponse,
-        TokenResponse, DEFAULT_MODEL, OPENCODE_VERSION, XAI_BASE_URL, XAI_REQUEST_URL,
+        TokenResponse, DEFAULT_MODEL, XAI_BASE_URL, XAI_REQUEST_URL,
     };
 
     #[test]
@@ -520,9 +522,9 @@ mod tests {
         let headers = inference_headers();
         assert_eq!(
             headers.get("User-Agent").map(String::as_str),
-            Some(concat!("opencode/", "1.18.21"))
+            Some(concat!("opencode/", "1.18.23"))
         );
-        assert_eq!(OPENCODE_VERSION, "1.18.21");
+        assert_eq!(super::super::OPENCODE_COMPAT_VERSION, "1.18.23");
         assert!(!headers.contains_key("X-XAI-Token-Auth"));
         assert!(!headers.contains_key("x-grok-model-override"));
     }

--- a/src/crates/adapters/ai-adapters/src/subscription_auth/jwt.rs
+++ b/src/crates/adapters/ai-adapters/src/subscription_auth/jwt.rs
@@ -32,6 +32,14 @@ pub(crate) fn subject(token: &str) -> Option<String> {
         .map(str::to_string)
 }
 
+/// Checks the unverified JWT `exp` claim for proactive refresh only. Opaque
+/// access tokens return false and continue using the provider's stored expiry.
+pub(crate) fn expires_within(token: &str, now_ms: i64, skew_ms: i64) -> bool {
+    decode_claims(token)
+        .and_then(|claims| claims.get("exp").and_then(Value::as_i64))
+        .is_some_and(|expires| expires.saturating_mul(1000) <= now_ms.saturating_add(skew_ms))
+}
+
 /// Extracts the ChatGPT account id from a Codex id/access token, mirroring
 /// OpenCode's `extractAccountIdFromClaims`.
 pub(crate) fn chatgpt_account_id(token: &str) -> Option<String> {
@@ -114,5 +122,13 @@ mod tests {
     #[test]
     fn returns_none_for_malformed_token() {
         assert_eq!(decode_claims("not-a-jwt"), None);
+    }
+
+    #[test]
+    fn checks_jwt_expiry_without_treating_opaque_tokens_as_expired() {
+        let token = make_token(serde_json::json!({ "exp": 1_800_000_000i64 }));
+        assert!(expires_within(&token, 1_799_999_900_000, 120_000));
+        assert!(!expires_within(&token, 1_799_999_000_000, 120_000));
+        assert!(!expires_within("opaque-token", 1_799_999_900_000, 120_000));
     }
 }

--- a/src/crates/adapters/ai-adapters/src/subscription_auth/mod.rs
+++ b/src/crates/adapters/ai-adapters/src/subscription_auth/mod.rs
@@ -32,6 +32,9 @@ use tokio_util::sync::CancellationToken;
 /// Maximum lifetime of a pending login session (matches OpenCode).
 const LOGIN_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 
+/// OpenCode release whose built-in subscription protocols these adapters mirror.
+pub(crate) const OPENCODE_COMPAT_VERSION: &str = "1.18.23";
+
 /// One of the subscription providers BitFun can sign in to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/src/crates/adapters/ai-adapters/src/subscription_auth/opencode.rs
+++ b/src/crates/adapters/ai-adapters/src/subscription_auth/opencode.rs
@@ -32,6 +32,12 @@ const STORE_KEY: &str = "opencode";
 const OFFERINGS_METADATA_KEY: &str = "api_offerings";
 const SUPPORTED_FORMATS: [&str; 3] = ["openai", "responses", "anthropic"];
 
+struct FreshCredential {
+    access: String,
+    expires_at_ms: Option<i64>,
+    metadata: Option<serde_json::Value>,
+}
+
 #[derive(Debug, Deserialize)]
 struct DeviceCodeResponse {
     device_code: String,
@@ -650,13 +656,17 @@ pub(crate) async fn begin_login(
     })
 }
 
-async fn ensure_fresh(options: &SubscriptionHttpOptions) -> Result<String> {
+async fn ensure_fresh(options: &SubscriptionHttpOptions) -> Result<FreshCredential> {
     let snapshot = store::load_entry_with_revision(STORE_KEY).await?;
     let entry = snapshot
         .credential
         .ok_or_else(|| anyhow!("OpenCode is not connected; sign in first"))?;
     match entry {
-        StoredCredential::Api { key, .. } => Ok(key),
+        StoredCredential::Api { key, metadata } => Ok(FreshCredential {
+            access: key,
+            expires_at_ms: None,
+            metadata,
+        }),
         StoredCredential::Oauth {
             refresh: refresh_token,
             access,
@@ -665,16 +675,22 @@ async fn ensure_fresh(options: &SubscriptionHttpOptions) -> Result<String> {
             metadata,
         } => {
             if expires > now_ms() + REFRESH_LEEWAY_MS {
-                return Ok(access);
+                return Ok(FreshCredential {
+                    access,
+                    expires_at_ms: Some(expires),
+                    metadata,
+                });
             }
             let refreshed = refresh(&refresh_token, options).await?;
             let new_expires = now_ms() + refreshed.expires_in * 1000;
+            let refreshed_access = refreshed.access_token.clone();
+            let refreshed_metadata = metadata.clone();
             let outcome = store::upsert_if_revision(
                 STORE_KEY,
                 snapshot.revision,
                 StoredCredential::Oauth {
                     refresh: refreshed.refresh_token,
-                    access: refreshed.access_token.clone(),
+                    access: refreshed_access.clone(),
                     expires: new_expires,
                     account_id,
                     metadata,
@@ -684,7 +700,11 @@ async fn ensure_fresh(options: &SubscriptionHttpOptions) -> Result<String> {
             match outcome {
                 store::ConditionalCommitOutcome::Committed { .. } => {
                     log::info!("opencode subscription tokens refreshed");
-                    Ok(refreshed.access_token)
+                    Ok(FreshCredential {
+                        access: refreshed_access,
+                        expires_at_ms: Some(new_expires),
+                        metadata: refreshed_metadata,
+                    })
                 }
                 store::ConditionalCommitOutcome::Conflict { current_revision } => {
                     let current = super::load_current_store_after_conflict(
@@ -693,19 +713,30 @@ async fn ensure_fresh(options: &SubscriptionHttpOptions) -> Result<String> {
                     )
                     .await?;
                     match current.credential {
-                        Some(StoredCredential::Api { key, .. }) => {
+                        Some(StoredCredential::Api { key, metadata }) => {
                             log::info!(
                                 "opencode refresh reused the current API credential after a concurrent update"
                             );
-                            Ok(key)
+                            Ok(FreshCredential {
+                                access: key,
+                                expires_at_ms: None,
+                                metadata,
+                            })
                         }
                         Some(StoredCredential::Oauth {
-                            access, expires, ..
+                            access,
+                            expires,
+                            metadata,
+                            ..
                         }) if expires > now_ms() => {
                             log::info!(
                                 "opencode refresh reused tokens committed by a concurrent refresh"
                             );
-                            Ok(access)
+                            Ok(FreshCredential {
+                                access,
+                                expires_at_ms: Some(expires),
+                                metadata,
+                            })
                         }
                         _ => Err(super::store_revision_conflict(
                             super::SubscriptionProvider::Opencode,
@@ -720,7 +751,7 @@ async fn ensure_fresh(options: &SubscriptionHttpOptions) -> Result<String> {
 
 /// Refreshes account/org/catalog metadata using a fresh credential.
 pub(crate) async fn refresh_profile(options: &SubscriptionHttpOptions) -> Result<()> {
-    let access = ensure_fresh(options).await?;
+    let access = ensure_fresh(options).await?.access;
     let snapshot = store::load_entry_with_revision(STORE_KEY).await?;
     let entry = snapshot
         .credential
@@ -760,18 +791,32 @@ pub(crate) async fn refresh_profile(options: &SubscriptionHttpOptions) -> Result
     Ok(())
 }
 
+fn inference_headers(metadata: Option<&serde_json::Value>) -> HashMap<String, String> {
+    let org_id = metadata
+        .and_then(serde_json::Value::as_object)
+        .and_then(|metadata| metadata.get("org_id").or_else(|| metadata.get("orgID")))
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+
+    org_id
+        .map(|org_id| HashMap::from([("x-org-id".to_string(), org_id.to_string())]))
+        .unwrap_or_default()
+}
+
 async fn resolve_route(
     route: OpenCodeRoute,
     options: &SubscriptionHttpOptions,
 ) -> Result<ResolvedCredential> {
-    let api_key = ensure_fresh(options).await?;
+    let credential = ensure_fresh(options).await?;
+    let extra_headers = inference_headers(credential.metadata.as_ref());
     Ok(ResolvedCredential {
-        api_key,
+        api_key: credential.access,
         base_url: Some(route.base_url.to_string()),
         request_url: Some(route.request_url.to_string()),
         format: Some(route.format.to_string()),
-        extra_headers: HashMap::new(),
-        expires_at: None,
+        extra_headers,
+        expires_at: credential.expires_at_ms.map(|expires| expires / 1000),
     })
 }
 
@@ -798,10 +843,10 @@ pub(crate) fn suggested() -> (&'static str, &'static str, &'static str) {
 #[cfg(test)]
 mod tests {
     use super::{
-        absolute_verification_url, offerings_from_metadata, offerings_from_remote_config,
-        route_for, OpenCodePlan, RemoteConfig, RemoteModel, RemoteModelProvider, RemoteProvider,
-        GO_MESSAGES_URL, GO_REQUEST_URL, GO_RESPONSES_URL, ZEN_MESSAGES_URL, ZEN_REQUEST_URL,
-        ZEN_RESPONSES_URL,
+        absolute_verification_url, inference_headers, offerings_from_metadata,
+        offerings_from_remote_config, route_for, OpenCodePlan, RemoteConfig, RemoteModel,
+        RemoteModelProvider, RemoteProvider, GO_MESSAGES_URL, GO_REQUEST_URL, GO_RESPONSES_URL,
+        ZEN_MESSAGES_URL, ZEN_REQUEST_URL, ZEN_RESPONSES_URL,
     };
     use std::collections::HashMap;
 
@@ -949,5 +994,21 @@ mod tests {
         assert_eq!(offerings.len(), 6);
         assert!(offerings.iter().any(|item| item.plan == OpenCodePlan::Zen));
         assert!(offerings.iter().any(|item| item.plan == OpenCodePlan::Go));
+    }
+
+    #[test]
+    fn forwards_current_and_legacy_org_ids_to_subscription_inference() {
+        for metadata in [
+            serde_json::json!({ "org_id": "org-current" }),
+            serde_json::json!({ "orgID": "org-legacy" }),
+        ] {
+            let headers = inference_headers(Some(&metadata));
+            assert_eq!(headers.len(), 1);
+            assert!(headers
+                .get("x-org-id")
+                .is_some_and(|value| value.starts_with("org-")));
+        }
+        assert!(inference_headers(Some(&serde_json::json!({ "org_id": " " }))).is_empty());
+        assert!(inference_headers(None).is_empty());
     }
 }

--- a/src/web-ui/src/infrastructure/config/components/ModelSettingsPage.tsx
+++ b/src/web-ui/src/infrastructure/config/components/ModelSettingsPage.tsx
@@ -41,9 +41,13 @@ import ReasoningConfigPanel, { type ReasoningConfigApplyResult } from './Reasoni
 import { createLogger } from '@/shared/utils/logger';
 import { translateConnectionTestMessage } from '@/shared/utils/aiConnectionTestMessages';
 import { i18nService } from '@/infrastructure/i18n';
+import { isTauriRuntime } from '@/infrastructure/runtime';
+import { isPeerDeviceModeActive } from '@/infrastructure/peer-device/peerModeFlag';
 import { LONG_CONTEXT_WARNING_THRESHOLD_TOKENS } from '@/shared/constants/modelContext';
 import {
+  preferredSubscriptionLoginMethod,
   settleSubscriptionLoginStart,
+  subscriptionLoginRequiresLocalDevice,
   SubscriptionLoginCoordinator,
   type SubscriptionLoginOperation,
 } from './subscriptionLoginCoordinator';
@@ -84,7 +88,7 @@ interface ProviderGroup {
 
 interface SubscriptionLoginPanelState {
   provider: SubscriptionProvider;
-  method: SubscriptionLoginMethod;
+  method?: SubscriptionLoginMethod;
   authorizationUrl: string;
   userCode?: string | null;
   deadlineMs?: number;
@@ -99,21 +103,6 @@ interface SubscriptionLogoutRequest {
 
 const SUBSCRIPTION_LOGIN_TIMEOUT_MS = 5 * 60 * 1000;
 const SUBSCRIPTION_MIGRATION_NOTICE_KEY = 'bitfun.subscription-auth.secure-store-notice.v1';
-const DEFAULT_SUBSCRIPTION_LOGIN_METHODS: Record<SubscriptionProvider, SubscriptionLoginMethod[]> = {
-  codex: ['browser', 'device'],
-  antigravity: ['browser'],
-  opencode: ['device'],
-  grok: ['device'],
-};
-
-function subscriptionLoginMethods(account: SubscriptionAccount): SubscriptionLoginMethod[] {
-  const supportedMethods = account.login_methods?.filter(
-    (method): method is SubscriptionLoginMethod => method === 'browser' || method === 'device',
-  );
-  return supportedMethods?.length
-    ? supportedMethods
-    : DEFAULT_SUBSCRIPTION_LOGIN_METHODS[account.provider];
-}
 
 function subscriptionLoginCancelledError(): Error {
   const error = new Error('Login cancelled');
@@ -1108,24 +1097,33 @@ const ModelSettingsPage: React.FC = () => {
     };
   }, []);
 
-  const handleSubscriptionLogin = useCallback(async (
-    provider: SubscriptionProvider,
-    method: SubscriptionLoginMethod,
-  ) => {
+  const handleSubscriptionLogin = useCallback(async (provider: SubscriptionProvider) => {
+    if (isPeerDeviceModeActive() && subscriptionLoginRequiresLocalDevice(provider)) {
+      notification.error(t('subscriptionAuth.peerLoginRequiresLocalDevice'));
+      return;
+    }
     // The settings surface intentionally permits one authorization flow at a
     // time. This prevents a stale provider poll/finally block from clearing a
     // newer provider's state or leaving an undiscoverable backend session.
     const operation = loginCoordinatorRef.current.begin(provider);
     if (!operation) return;
+    const requestedMethod = preferredSubscriptionLoginMethod(
+      provider,
+      isTauriRuntime() && !isPeerDeviceModeActive(),
+    );
     setLoggingInProvider(provider);
     setSubscriptionLoginPanel({
       provider,
-      method,
+      method: requestedMethod,
       authorizationUrl: '',
       status: 'starting',
     });
     try {
-      const started = await aiApi.startSubscriptionLogin(provider, operation.sessionId, method);
+      const started = await aiApi.startSubscriptionLogin(
+        provider,
+        operation.sessionId,
+        requestedMethod,
+      );
       const settlement = await settleSubscriptionLoginStart(
         loginCoordinatorRef.current,
         operation,
@@ -1259,7 +1257,7 @@ const ModelSettingsPage: React.FC = () => {
         ) {
           setSubscriptionLoginPanel({
             provider,
-            method,
+            method: requestedMethod,
             authorizationUrl: '',
             userCode: undefined,
             status: 'failed',
@@ -3244,7 +3242,6 @@ const ModelSettingsPage: React.FC = () => {
               }
               const isLoggingIn = loggingInProvider === account.provider;
               const anyLoginInProgress = loggingInProvider !== null;
-              const availableLoginMethods = subscriptionLoginMethods(account);
               const loginPanel = subscriptionLoginPanel?.provider === account.provider
                 ? subscriptionLoginPanel
                 : null;
@@ -3322,20 +3319,17 @@ const ModelSettingsPage: React.FC = () => {
                           {t('subscriptionAuth.retryVault')}
                         </Button>
                       ) : (
-                        availableLoginMethods.map((method) => (
-                          <Button
-                            key={method}
-                            size="sm"
-                            variant="fill"
-                            loading={isLoggingIn && loginPanel?.method === method}
-                            disabled={anyLoginInProgress}
-                            onClick={() => void handleSubscriptionLogin(account.provider, method)}
-                          >
-                            {t(method === 'browser'
-                              ? 'subscriptionAuth.browserLogin'
-                              : 'subscriptionAuth.deviceLogin')}
-                          </Button>
-                        ))
+                        <Button
+                          size="sm"
+                          variant="fill"
+                          loading={isLoggingIn}
+                          disabled={anyLoginInProgress}
+                          onClick={() => void handleSubscriptionLogin(account.provider)}
+                        >
+                          {t(loginPanel?.status === 'failed'
+                            ? 'subscriptionAuth.retryLogin'
+                            : 'subscriptionAuth.login')}
+                        </Button>
                       )}
                       {isLoggingIn && (
                         <Button
@@ -3421,9 +3415,9 @@ const ModelSettingsPage: React.FC = () => {
                         </div>
                       )}
 
-                      {(loginPanel.status === 'pending' || loginPanel.status === 'failed') && (
+                      {loginPanel.status === 'pending' && (
                         <div className="bitfun-model-settings__subscription-login-actions" data-bf-component="model-settings" data-bf-part="subscriptionActions">
-                          {loginPanel.status === 'pending' && loginPanel.userCode && (
+                          {loginPanel.userCode && (
                             <Button
                               size="sm"
                               variant="outline"
@@ -3432,24 +3426,14 @@ const ModelSettingsPage: React.FC = () => {
                               {t('subscriptionAuth.copyCode')}
                             </Button>
                           )}
-                          {loginPanel.status === 'pending' && loginPanel.authorizationUrl && (
+                          {loginPanel.authorizationUrl && (
                             <Button
                               size="sm"
                               variant="outline"
                               onClick={() => void handleOpenSubscriptionAuthorization(loginPanel.authorizationUrl)}
                               leadingIcon={<ExternalLink size={14} aria-hidden="true" />}
                             >
-
                               {t('subscriptionAuth.openAuthorization')}
-                            </Button>
-                          )}
-                          {loginPanel.status === 'failed' && (
-                            <Button
-                              size="sm"
-                              variant="fill"
-                              onClick={() => void handleSubscriptionLogin(account.provider, loginPanel.method)}
-                            >
-                              {t('subscriptionAuth.retryLogin')}
                             </Button>
                           )}
                         </div>

--- a/src/web-ui/src/infrastructure/config/components/subscriptionLoginCoordinator.test.ts
+++ b/src/web-ui/src/infrastructure/config/components/subscriptionLoginCoordinator.test.ts
@@ -1,8 +1,30 @@
 import { describe, expect, it } from 'vitest';
 import {
+  preferredSubscriptionLoginMethod,
   settleSubscriptionLoginStart,
+  subscriptionLoginRequiresLocalDevice,
   SubscriptionLoginCoordinator,
 } from './subscriptionLoginCoordinator';
+
+describe('preferredSubscriptionLoginMethod', () => {
+  it('uses Codex device authorization when the callback browser is not local', () => {
+    expect(preferredSubscriptionLoginMethod('codex', false)).toBe('device');
+    expect(preferredSubscriptionLoginMethod('codex', true)).toBeUndefined();
+  });
+
+  it('lets single-method providers choose their backend default', () => {
+    expect(preferredSubscriptionLoginMethod('antigravity', false)).toBeUndefined();
+    expect(preferredSubscriptionLoginMethod('opencode', false)).toBeUndefined();
+    expect(preferredSubscriptionLoginMethod('grok', false)).toBeUndefined();
+  });
+
+  it('identifies the browser-only provider that cannot sign in through a peer', () => {
+    expect(subscriptionLoginRequiresLocalDevice('antigravity')).toBe(true);
+    expect(subscriptionLoginRequiresLocalDevice('codex')).toBe(false);
+    expect(subscriptionLoginRequiresLocalDevice('opencode')).toBe(false);
+    expect(subscriptionLoginRequiresLocalDevice('grok')).toBe(false);
+  });
+});
 
 describe('SubscriptionLoginCoordinator', () => {
   it('assigns an immutable session id to each operation', () => {

--- a/src/web-ui/src/infrastructure/config/components/subscriptionLoginCoordinator.ts
+++ b/src/web-ui/src/infrastructure/config/components/subscriptionLoginCoordinator.ts
@@ -1,5 +1,21 @@
 import type { SubscriptionProvider } from '../types';
 
+/**
+ * Keeps the settings UI to one sign-in action while selecting the Codex flow
+ * that can actually return to the host running authorization.
+ */
+export function preferredSubscriptionLoginMethod(
+  provider: SubscriptionProvider,
+  localBrowserCallbackReachable: boolean,
+): 'device' | undefined {
+  return provider === 'codex' && !localBrowserCallbackReachable ? 'device' : undefined;
+}
+
+/** Antigravity currently exposes only a callback bound on the execution host. */
+export function subscriptionLoginRequiresLocalDevice(provider: SubscriptionProvider): boolean {
+  return provider === 'antigravity';
+}
+
 export interface SubscriptionLoginOperation {
   id: number;
   sessionId: string;

--- a/src/web-ui/src/locales/en-US/settings/models.json
+++ b/src/web-ui/src/locales/en-US/settings/models.json
@@ -44,6 +44,7 @@
     "refreshFailed": "Refresh failed: {{error}}",
     "loginSuccess": "Signed in",
     "loginFailed": "Sign-in failed: {{error}}",
+    "peerLoginRequiresLocalDevice": "Antigravity sign-in must be completed on the device running BitFun. Switch to that device and sign in there.",
     "logoutSuccess": "Signed out",
     "logoutCleanupPending": "Signed out. Credential cleanup is pending and will retry automatically.",
     "logoutFailed": "Sign-out failed: {{error}}",

--- a/src/web-ui/src/locales/zh-CN/settings/models.json
+++ b/src/web-ui/src/locales/zh-CN/settings/models.json
@@ -44,6 +44,7 @@
     "refreshFailed": "刷新失败：{{error}}",
     "loginSuccess": "登录成功",
     "loginFailed": "登录失败：{{error}}",
+    "peerLoginRequiresLocalDevice": "Antigravity 登录必须在运行 BitFun 的设备上完成，请切换到该设备后再登录。",
     "logoutSuccess": "已退出登录",
     "logoutCleanupPending": "已退出登录，凭据清理仍在等待中，稍后会自动重试。",
     "logoutFailed": "退出登录失败：{{error}}",

--- a/src/web-ui/src/locales/zh-TW/settings/models.json
+++ b/src/web-ui/src/locales/zh-TW/settings/models.json
@@ -44,6 +44,7 @@
     "refreshFailed": "重新整理失敗：{{error}}",
     "loginSuccess": "登入成功",
     "loginFailed": "登入失敗：{{error}}",
+    "peerLoginRequiresLocalDevice": "Antigravity 登入必須在執行 BitFun 的裝置上完成，請切換到該裝置後再登入。",
     "logoutSuccess": "已登出",
     "logoutCleanupPending": "已登出，憑據清理仍在等待中，稍後會自動重試。",
     "logoutFailed": "登出失敗：{{error}}",


### PR DESCRIPTION
## Summary

- Sync Codex and xAI subscription compatibility with OpenCode 1.18.23, including current model filtering and token-expiry handling.
- Forward OpenCode Console organization routing and expiry metadata, and align Antigravity model aliases, routing, thinking payloads, tool compatibility, request metadata, and catalog entries.
- Replace separate browser and device-code actions with one adaptive login button. Codex selects browser login locally and device authorization remotely; Antigravity reports its local-device requirement explicitly.

## Upstream references

- OpenCode dev commit: https://github.com/anomalyco/opencode/commit/6568a824553200254e30e5a49c2831d1fb5f62e2
- OpenCode Antigravity auth commit: https://github.com/NoeFabris/opencode-antigravity-auth/commit/9a2cf7e5c05f103a809a8302715d28a2722c8c4a

## Verification

- cargo test -q -p bitfun-ai-adapters --features subscription-auth
- pnpm run check:web
- pnpm run i18n:audit
- pnpm --dir src/web-ui test:run src/infrastructure/config/components/subscriptionLoginCoordinator.test.ts

Rust results: 314 unit tests, 6 protocol tests, and 23 stream tests passed. Login coordinator: 9 tests passed.

## Remote scenarios

- Unit coverage verifies remote Codex chooses device authorization and Antigravity fails clearly when local browser login is unavailable.
- No live Remote Workspace, Remote Control, Peer Device Mode, Detached Dispatch, or real-account billing E2E was run because external subscription credentials were not available.