### PR TITLE
chore(deps): upgrade h2 to 0.4.19 (RUSTSEC-2026-0258)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4348,9 +4348,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## Summary

Upgrade the transitive `h2` dependency from 0.4.15 to 0.4.19 to address RUSTSEC-2026-0258. Version 0.4.16 is the minimum patched release, while 0.4.19 also includes the follow-up fixes that prevent the new DATA-frame protection from rejecting legitimate small-frame traffic.

Only `Cargo.lock` changes; no application source or dependency-graph changes are included.

Fixes #2459

Supersedes #2461. Thanks to @1688mengdie for identifying the advisory and preparing the original dependency update.

## Type and Areas

Type: dependency

Areas: Rust core dependency

## Motivation / Impact

RUSTSEC-2026-0258 affects `h2` 0.4.15: an HTTP/2 peer can send unbounded empty DATA frames, leading to unbounded memory use or a panic when streams are not actively drained.

Upgrading directly to 0.4.19 closes the advisory while also including the 0.4.17-0.4.19 follow-up corrections for legitimate concurrent and streaming small-frame workloads. There is no direct user-facing change.

## Verification

- `cargo check --locked -p bitfun-core` — passed.
- `cargo tree --locked -i h2 --depth 1` — resolved `h2 v0.4.19` through `hyper v1.11.0` and `reqwest v0.13.4`.
- `git diff --check` — passed.
- Full workspace, runtime HTTP/2, remote scenarios, and UI checks were not run locally; repository CI remains the cross-platform verification source.
- This is an AI-assisted change.

## Reviewer Notes

- `h2` 0.4.19 keeps the same 0.4.x compatibility line, Rust 1.63 minimum, dependency list, and Cargo features as 0.4.16.
- No UI change, screenshots, migration, or persisted-shape compatibility work is applicable.
- Rollback is the inverse lockfile-only version/checksum change.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable. (Not applicable: no user-facing change.)
