### PR TITLE
fix(session): keep long-running turns steerable

### DIFF
--- a/src/crates/assembly/core/src/agentic/session/session_manager.rs
+++ b/src/crates/assembly/core/src/agentic/session/session_manager.rs
@@ -985,7 +985,11 @@ impl SessionManager {
                 // Idle eviction is a restore optimization for durable Sessions.
                 // Non-persistent Sessions have an explicit lifecycle owner and
                 // no on-disk state from which they could be restored.
-                if !Self::should_persist_session_with_transient_ids(session, transient_session_ids)
+                if !matches!(session.state, SessionState::Idle)
+                    || !Self::should_persist_session_with_transient_ids(
+                        session,
+                        transient_session_ids,
+                    )
                     || !Self::is_session_expired(session, now, timeout)
                 {
                     return None;
@@ -1005,7 +1009,8 @@ impl SessionManager {
         now: SystemTime,
         timeout: Duration,
     ) -> bool {
-        Self::same_session_version(session, candidate.updated_at, candidate.last_activity_at)
+        matches!(session.state, SessionState::Idle)
+            && Self::same_session_version(session, candidate.updated_at, candidate.last_activity_at)
             && Self::is_session_expired(session, now, timeout)
     }
 
@@ -9682,7 +9687,7 @@ mod tests {
     }
 
     #[test]
-    fn idle_eviction_only_selects_sessions_that_can_be_restored() {
+    fn idle_eviction_only_selects_expired_idle_sessions_that_can_be_restored() {
         let now = SystemTime::now();
         let expired_at = now - Duration::from_secs(120);
         let mut durable = Session::new(
@@ -9697,11 +9702,23 @@ mod tests {
             SessionConfig::default(),
         );
         transient.last_activity_at = expired_at;
+        let mut processing = Session::new(
+            "Processing".to_string(),
+            "agentic".to_string(),
+            SessionConfig::default(),
+        );
+        processing.last_activity_at = expired_at;
+        processing.state = SessionState::Processing {
+            current_turn_id: "active-turn".to_string(),
+            phase: ProcessingPhase::Thinking,
+        };
         let durable_id = durable.session_id.clone();
         let transient_id = transient.session_id.clone();
+        let processing_id = processing.session_id.clone();
         let sessions = DashMap::new();
         sessions.insert(durable_id.clone(), durable);
         sessions.insert(transient_id.clone(), transient);
+        sessions.insert(processing_id.clone(), processing);
         let transient_session_ids = DashMap::new();
         transient_session_ids.insert(transient_id.clone(), ());
 
@@ -9720,6 +9737,7 @@ mod tests {
             [durable_id.as_str()]
         );
         assert!(sessions.contains_key(&transient_id));
+        assert!(sessions.contains_key(&processing_id));
 
         assert!(SessionManager::collect_expired_session_candidates(
             &sessions,
@@ -9728,6 +9746,64 @@ mod tests {
             Duration::MAX,
         )
         .is_empty());
+    }
+
+    #[test]
+    fn idle_eviction_rechecks_state_before_removing_candidate() {
+        let now = SystemTime::now();
+        let expired_at = now - Duration::from_secs(120);
+        let mut session = Session::new(
+            "Becomes active".to_string(),
+            "agentic".to_string(),
+            SessionConfig::default(),
+        );
+        session.last_activity_at = expired_at;
+        let session_id = session.session_id.clone();
+        let sessions = DashMap::new();
+        sessions.insert(session_id.clone(), session);
+        let transient_session_ids = DashMap::new();
+        let candidate = SessionManager::collect_expired_session_candidates(
+            &sessions,
+            &transient_session_ids,
+            now,
+            Duration::from_secs(60),
+        )
+        .into_iter()
+        .next()
+        .expect("expired Idle Session should be selected");
+
+        sessions
+            .get_mut(&session_id)
+            .expect("selected Session")
+            .state = SessionState::Processing {
+            current_turn_id: "active-turn".to_string(),
+            phase: ProcessingPhase::Thinking,
+        };
+
+        assert!(SessionManager::cleanup_snapshot_for_candidate(
+            &sessions,
+            &candidate,
+            now,
+            Duration::from_secs(60),
+        )
+        .is_none());
+        assert!(sessions
+            .remove_if(&session_id, |_, session| {
+                SessionManager::cleanup_candidate_matches_session(
+                    session,
+                    &candidate,
+                    now,
+                    Duration::from_secs(60),
+                )
+            })
+            .is_none());
+        assert!(matches!(
+            sessions
+                .get(&session_id)
+                .expect("active Session retained")
+                .state,
+            SessionState::Processing { .. }
+        ));
     }
 
     #[test]

--- a/src/web-ui/src/flow_chat/components/PendingQueuePanel.test.tsx
+++ b/src/web-ui/src/flow_chat/components/PendingQueuePanel.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { act, type ButtonHTMLAttributes, type ReactNode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { PendingQueuePanel } from './PendingQueuePanel';
+
+const mocks = vi.hoisted(() => ({
+  drainPendingQueueForSession: vi.fn(),
+  insertSteeringItemIfAbsent: vi.fn(),
+  promoteForExplicitDrain: vi.fn(() => true),
+  queueRemove: vi.fn(),
+  queueSetStatus: vi.fn(),
+  steerDialogTurn: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/component-library', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => children,
+  IconButton: ({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+vi.mock('@/infrastructure/api/service-api/AgentAPI', () => ({
+  agentAPI: { steerDialogTurn: mocks.steerDialogTurn },
+}));
+
+vi.mock('../state-machine', () => ({
+  stateMachineManager: {
+    get: () => ({
+      getContext: () => ({ currentDialogTurnId: 'turn-1' }),
+    }),
+  },
+}));
+
+vi.mock('../store/FlowChatStore', () => ({
+  FlowChatStore: {
+    getInstance: () => ({
+      getState: () => ({ sessions: new Map() }),
+      subscribe: () => () => undefined,
+    }),
+  },
+}));
+
+vi.mock('../services/flow-chat-manager/PendingQueueModule', () => ({
+  pendingQueueManager: {
+    list: () => [
+      {
+        id: 'queued-1',
+        sessionId: 'session-1',
+        content: 'steer this turn',
+        timestamp: 1,
+        status: 'queued',
+        retryCount: 0,
+      },
+    ],
+    subscribe: () => () => undefined,
+    setStatus: mocks.queueSetStatus,
+    remove: mocks.queueRemove,
+    promoteForExplicitDrain: mocks.promoteForExplicitDrain,
+  },
+}));
+
+vi.mock('../services/FlowChatManager', () => ({
+  FlowChatManager: {
+    getInstance: () => ({
+      drainPendingQueueForSession: mocks.drainPendingQueueForSession,
+    }),
+  },
+}));
+
+vi.mock('../services/interruptedTurnRecoveryGate', () => ({
+  interruptedTurnRecoveryGate: {
+    subscribe: () => () => undefined,
+    getSnapshot: () => 0,
+    isSessionInFlight: () => false,
+  },
+}));
+
+vi.mock('../services/flow-chat-manager/EventHandlerModule', () => ({
+  insertSteeringItemIfAbsent: mocks.insertSteeringItemIfAbsent,
+}));
+
+vi.mock('../../shared/notification-system', () => ({
+  notificationService: {
+    warning: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@/shared/utils/logger', () => ({
+  createLogger: () => ({
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+vi.mock('../utils/acpSession', () => ({
+  isAcpFlowSession: () => false,
+}));
+
+describe('PendingQueuePanel', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mocks.drainPendingQueueForSession.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it('submits only one steering request while send-now is in flight', async () => {
+    let resolveSteering: ((value: { steeringId: string }) => void) | undefined;
+    mocks.steerDialogTurn.mockImplementation(
+      () => new Promise(resolve => {
+        resolveSteering = resolve;
+      }),
+    );
+
+    await act(async () => {
+      root.render(<PendingQueuePanel sessionId="session-1" />);
+    });
+    const sendNowButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="pendingQueue.actions.sendNow"]',
+    );
+    expect(sendNowButton).not.toBeNull();
+
+    act(() => {
+      sendNowButton!.click();
+      sendNowButton!.click();
+    });
+
+    expect(mocks.steerDialogTurn).toHaveBeenCalledTimes(1);
+    expect(mocks.queueSetStatus).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveSteering?.({ steeringId: 'steering-1' });
+      await Promise.resolve();
+    });
+  });
+});

--- a/src/web-ui/src/flow_chat/components/PendingQueuePanel.tsx
+++ b/src/web-ui/src/flow_chat/components/PendingQueuePanel.tsx
@@ -12,7 +12,7 @@
  *   deduped via `steeringId`.
  */
 
-import { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Pencil,
@@ -46,6 +46,7 @@ interface PendingQueuePanelProps {
 
 export function PendingQueuePanel({ sessionId, className }: PendingQueuePanelProps): JSX.Element | null {
   const { t } = useTranslation('flow-chat');
+  const sendNowInFlightIdsRef = useRef(new Set<string>());
   useSyncExternalStore(
     interruptedTurnRecoveryGate.subscribe,
     interruptedTurnRecoveryGate.getSnapshot,
@@ -129,70 +130,77 @@ export function PendingQueuePanel({ sessionId, className }: PendingQueuePanelPro
   const handleSendNow = useCallback(
     async (item: QueuedMessage) => {
       if (!sessionId || recoveryInFlight) return;
-      const machine = stateMachineManager.get(sessionId);
-      const dialogTurnId = machine?.getContext().currentDialogTurnId ?? null;
+      if (sendNowInFlightIdsRef.current.has(item.id)) return;
+      sendNowInFlightIdsRef.current.add(item.id);
 
-      // A running turn takes the message through the steering channel, which
-      // carries the whole payload — text, attachments and metadata alike.
-      // ACP agents own their execution loop and expose no mid-turn injection
-      // point, so they take the drain path below instead.
-      if (dialogTurnId && !isAcpSession) {
-        pendingQueueManager.setStatus(sessionId, item.id, 'sending_now');
-        try {
-          const resp = await agentAPI.steerDialogTurn({
-            sessionId,
-            dialogTurnId,
-            content: item.content,
-            displayContent: item.displayMessage ?? item.content,
-            imageContexts: item.imageContexts,
-            userMessageMetadata: item.userMessageMetadata,
-          });
-          // Optimistically render the steering bubble in the running round so
-          // the user sees their message land immediately. The backend
-          // `UserSteeringInjected` event dedupes by the same `steeringId`.
-          if (resp?.steeringId) {
-            try {
-              insertSteeringItemIfAbsent({
-                sessionId,
-                turnId: dialogTurnId,
-                steeringId: resp.steeringId,
-                content: item.displayMessage ?? item.content,
-                images: item.imageDisplayData as SteeringImage[] | undefined,
-                status: 'pending',
-              });
-            } catch (renderErr) {
-              log.warn('Optimistic steering render failed', { renderErr });
-            }
-          }
-          pendingQueueManager.remove(sessionId, item.id);
-          return;
-        } catch (err) {
-          // Most often the turn finished between the click and the request.
-          // Fall through to the drain path rather than reporting a failure the
-          // user cannot act on.
-          log.warn('Steering rejected, falling back to the drain path', {
-            sessionId,
-            itemId: item.id,
-            err,
-          });
-          pendingQueueManager.setStatus(sessionId, item.id, 'queued');
-        }
-      }
-
-      // No turn to inject into. Move the item to the head and send it at the
-      // first opportunity: right now if the session is idle, otherwise the
-      // IDLE drain listener picks it up the moment the current turn ends.
       try {
-        if (!pendingQueueManager.promoteForExplicitDrain(sessionId, item.id)) {
-          log.warn('Send now item is no longer queued', { sessionId, itemId: item.id });
-          return;
+        const machine = stateMachineManager.get(sessionId);
+        const dialogTurnId = machine?.getContext().currentDialogTurnId ?? null;
+
+        // A running turn takes the message through the steering channel, which
+        // carries the whole payload — text, attachments and metadata alike.
+        // ACP agents own their execution loop and expose no mid-turn injection
+        // point, so they take the drain path below instead.
+        if (dialogTurnId && !isAcpSession) {
+          pendingQueueManager.setStatus(sessionId, item.id, 'sending_now');
+          try {
+            const resp = await agentAPI.steerDialogTurn({
+              sessionId,
+              dialogTurnId,
+              content: item.content,
+              displayContent: item.displayMessage ?? item.content,
+              imageContexts: item.imageContexts,
+              userMessageMetadata: item.userMessageMetadata,
+            });
+            // Optimistically render the steering bubble in the running round so
+            // the user sees their message land immediately. The backend
+            // `UserSteeringInjected` event dedupes by the same `steeringId`.
+            if (resp?.steeringId) {
+              try {
+                insertSteeringItemIfAbsent({
+                  sessionId,
+                  turnId: dialogTurnId,
+                  steeringId: resp.steeringId,
+                  content: item.displayMessage ?? item.content,
+                  images: item.imageDisplayData as SteeringImage[] | undefined,
+                  status: 'pending',
+                });
+              } catch (renderErr) {
+                log.warn('Optimistic steering render failed', { renderErr });
+              }
+            }
+            pendingQueueManager.remove(sessionId, item.id);
+            return;
+          } catch (err) {
+            // Most often the turn finished between the click and the request.
+            // Fall through to the drain path rather than reporting a failure the
+            // user cannot act on.
+            log.warn('Steering rejected, falling back to the drain path', {
+              sessionId,
+              itemId: item.id,
+              err,
+            });
+            pendingQueueManager.setStatus(sessionId, item.id, 'queued');
+          }
         }
-        await FlowChatManager.getInstance().drainPendingQueueForSession(sessionId, {
-          allowInterruptedRecoveryAbandon: true,
-        });
-      } catch (err) {
-        log.error('Send now fallback failed', { sessionId, itemId: item.id, err });
-        notificationService.error(t('pendingQueue.errors.sendNowFailed'), { duration: 4000 });
+
+        // No turn to inject into. Move the item to the head and send it at the
+        // first opportunity: right now if the session is idle, otherwise the
+        // IDLE drain listener picks it up the moment the current turn ends.
+        try {
+          if (!pendingQueueManager.promoteForExplicitDrain(sessionId, item.id)) {
+            log.warn('Send now item is no longer queued', { sessionId, itemId: item.id });
+            return;
+          }
+          await FlowChatManager.getInstance().drainPendingQueueForSession(sessionId, {
+            allowInterruptedRecoveryAbandon: true,
+          });
+        } catch (err) {
+          log.error('Send now fallback failed', { sessionId, itemId: item.id, err });
+          notificationService.error(t('pendingQueue.errors.sendNowFailed'), { duration: 4000 });
+        }
+      } finally {
+        sendNowInFlightIdsRef.current.delete(item.id);
       }
     },
     [isAcpSession, recoveryInFlight, sessionId, t],


### PR DESCRIPTION
Prevent idle cleanup from evicting durable sessions while a turn is
still processing, and recheck the state immediately before removal.

Add a synchronous per-message send-now guard so rapid clicks cannot
issue duplicate steering requests. Cover both cleanup races and UI
re-entry with regression tests.
