### PR TITLE
feat(web-ui): merge session header into scene top bar

### DIFF
--- a/src/web-ui/src/app/appearance.ts
+++ b/src/web-ui/src/app/appearance.ts
@@ -9,6 +9,8 @@ export const workbenchAppearanceDescriptor: AppearanceSurfaceDescriptor = {
     { id: 'navDivider' },
     { id: 'sceneArea' },
     { id: 'sceneSurface' },
+    { id: 'topBar' },
+    { id: 'sceneActions' },
     { id: 'viewport' },
     { id: 'viewportClip' },
     { id: 'scene' },

--- a/src/web-ui/src/app/components/SceneBar/SceneBar.scss
+++ b/src/web-ui/src/app/components/SceneBar/SceneBar.scss
@@ -6,9 +6,9 @@
 .bitfun-scene-bar {
   display: flex;
   align-items: center;
-  height: var(--bf-control-tab-group-item-height);
-  min-height: var(--bf-control-tab-group-item-height);
-  flex-shrink: 0;
+  flex: 1 1 240px;
+  min-width: calc(var(--bf-control-height-sm) * 4);
+  height: 100%;
   overflow: hidden;
   background: transparent;
   user-select: none;
@@ -139,15 +139,6 @@
       outline: var(--bf-focus-width) solid var(--bf-color-focus-ring);
       outline-offset: var(--bf-focus-offset);
     }
-  }
-
-  &__controls {
-    display: flex;
-    align-items: center;
-    flex-shrink: 0;
-    height: 100%;
-    margin-left: auto;
-    padding-left: var(--bf-space-2);
   }
 
   &__tab-label {

--- a/src/web-ui/src/app/components/SceneBar/SceneBar.tsx
+++ b/src/web-ui/src/app/components/SceneBar/SceneBar.tsx
@@ -5,29 +5,16 @@
  * AI Agent tab shows the current session title as a subtitle.
  */
 
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback } from 'react';
 import { ChevronLeft, ChevronRight, X } from 'lucide-react';
 import { TabGroup, type TabGroupItem } from '@bitfun/ui';
 import { useSceneTabNavigation } from './useSceneTabNavigation';
-import { WindowControls } from '@/component-library';
 import { useSceneManager } from '../../hooks/useSceneManager';
 import { useCurrentSessionTitle } from '../../hooks/useCurrentSessionTitle';
 import { useCurrentSettingsPageTitle } from '../../hooks/useCurrentSettingsPageTitle';
 import { useI18n } from '@/infrastructure/i18n/hooks/useI18n';
-import { createLogger } from '@/shared/utils/logger';
-import { supportsNativeWindowDragging } from '@/infrastructure/runtime';
 import type { SceneTabId } from './types';
 import './SceneBar.scss';
-
-const log = createLogger('SceneBar');
-
-const INTERACTIVE_SELECTOR =
-  'button, input, textarea, select, a, [role="button"], [contenteditable="true"], .window-controls';
-
-function blocksWindowChromeInteraction(target: HTMLElement): boolean {
-  const interactive = target.closest<HTMLElement>(INTERACTIVE_SELECTOR);
-  return interactive !== null && interactive.getAttribute('role') !== 'tab';
-}
 
 function getSceneIdFromTabTarget(target: EventTarget | null): SceneTabId | undefined {
   if (!(target instanceof HTMLElement)) return undefined;
@@ -38,18 +25,10 @@ function getSceneIdFromTabTarget(target: EventTarget | null): SceneTabId | undef
 
 interface SceneBarProps {
   className?: string;
-  onMinimize?: () => void;
-  onMaximize?: () => void;
-  onClose?: () => void;
-  isMaximized?: boolean;
 }
 
 const SceneBar: React.FC<SceneBarProps> = ({
   className = '',
-  onMinimize,
-  onMaximize,
-  onClose,
-  isMaximized = false,
 }) => {
   const {
     openTabs,
@@ -62,11 +41,7 @@ const SceneBar: React.FC<SceneBarProps> = ({
   const sessionTitle = useCurrentSessionTitle();
   const settingsPageTitle = useCurrentSettingsPageTitle();
   const { t } = useI18n('common');
-  const hasWindowControls = !!(onMinimize && onMaximize && onClose);
-  const sceneBarClassName = `bitfun-scene-bar ${!hasWindowControls ? 'bitfun-scene-bar--no-controls' : ''} ${className}`.trim();
-  const isSingleTab = openTabs.length <= 1;
-  const canDragWindow = supportsNativeWindowDragging();
-  const lastMouseDownTimeRef = useRef<number>(0);
+  const sceneBarClassName = `bitfun-scene-bar ${className}`.trim();
   const {
     tabRegionRef,
     tabsRef,
@@ -101,38 +76,6 @@ const SceneBar: React.FC<SceneBarProps> = ({
     e.stopPropagation();
     closeScene(sceneId);
   }, [closeScene, tabDefs]);
-
-  const handleBarMouseDown = useCallback((e: React.MouseEvent) => {
-    if (!canDragWindow) return;
-    if (!isSingleTab) return;
-
-    const now = Date.now();
-    const timeSinceLastMouseDown = now - lastMouseDownTimeRef.current;
-    lastMouseDownTimeRef.current = now;
-
-    if (e.button !== 0) return;
-    const target = e.target as HTMLElement | null;
-    if (!target) return;
-    if (blocksWindowChromeInteraction(target)) return;
-    if (timeSinceLastMouseDown < 500 && timeSinceLastMouseDown > 50) return;
-
-    void (async () => {
-      try {
-        const { getCurrentWindow } = await import('@tauri-apps/api/window');
-        await getCurrentWindow().startDragging();
-      } catch (error) {
-        log.debug('startDragging failed', error);
-      }
-    })();
-  }, [canDragWindow, isSingleTab]);
-
-  const handleBarDoubleClick = useCallback((e: React.MouseEvent) => {
-    if (!isSingleTab) return;
-    const target = e.target as HTMLElement | null;
-    if (!target) return;
-    if (blocksWindowChromeInteraction(target)) return;
-    onMaximize?.();
-  }, [isSingleTab, onMaximize]);
 
   const tabItems = openTabs.reduce<TabGroupItem[]>((items, tab) => {
     const def = tabDefs.find(candidate => candidate.id === tab.id);
@@ -181,8 +124,6 @@ const SceneBar: React.FC<SceneBarProps> = ({
   return (
     <div data-bf-component="scene-bar" data-bf-part="root"
       className={sceneBarClassName}
-      onMouseDown={handleBarMouseDown}
-      onDoubleClick={handleBarDoubleClick}
     >
       <div
         ref={tabRegionRef}
@@ -236,16 +177,6 @@ const SceneBar: React.FC<SceneBarProps> = ({
         )}
       </div>
 
-      {hasWindowControls && (
-        <div className="bitfun-scene-bar__controls" data-bf-component="scene-bar" data-bf-part="controls">
-          <WindowControls
-            onMinimize={onMinimize!}
-            onMaximize={onMaximize!}
-            onClose={onClose!}
-            isMaximized={isMaximized}
-          />
-        </div>
-      )}
     </div>
   );
 };

--- a/src/web-ui/src/app/components/SceneTopBar/SceneChrome.test.tsx
+++ b/src/web-ui/src/app/components/SceneTopBar/SceneChrome.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  SceneChromeContribution,
+  SceneChromeHost,
+  SceneChromeProvider,
+} from './SceneChrome';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('SceneChrome', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('mounts only the active scene contribution in the registered host', () => {
+    const renderScene = (activeSceneId: 'session' | 'settings') => {
+      root.render(
+        <SceneChromeProvider activeSceneId={activeSceneId}>
+          <SceneChromeHost data-testid="scene-chrome-host" />
+          <SceneChromeContribution sceneId="session">
+            <button type="button" data-testid="session-action">Session action</button>
+          </SceneChromeContribution>
+          <SceneChromeContribution sceneId="settings">
+            <button type="button" data-testid="settings-action">Settings action</button>
+          </SceneChromeContribution>
+        </SceneChromeProvider>,
+      );
+    };
+
+    act(() => renderScene('session'));
+    const host = container.querySelector('[data-testid="scene-chrome-host"]');
+    expect(host?.querySelector('[data-testid="session-action"]')).not.toBeNull();
+    expect(host?.querySelector('[data-testid="settings-action"]')).toBeNull();
+
+    act(() => renderScene('settings'));
+    expect(host?.querySelector('[data-testid="session-action"]')).toBeNull();
+    expect(host?.querySelector('[data-testid="settings-action"]')).not.toBeNull();
+  });
+});

--- a/src/web-ui/src/app/components/SceneTopBar/SceneChrome.tsx
+++ b/src/web-ui/src/app/components/SceneTopBar/SceneChrome.tsx
@@ -1,0 +1,121 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type HTMLAttributes,
+  type ReactNode,
+} from 'react';
+import type { SceneTabId } from '../SceneBar/types';
+
+interface SceneChromeContributionRecord {
+  owner: symbol;
+  content: ReactNode;
+}
+
+interface SceneChromeContextValue {
+  activeSceneId: SceneTabId;
+  setContribution: (
+    sceneId: SceneTabId,
+    owner: symbol,
+    content: ReactNode,
+  ) => void;
+  removeContribution: (sceneId: SceneTabId, owner: symbol) => void;
+}
+
+const SceneChromeContext = createContext<SceneChromeContextValue | null>(null);
+const SceneChromeContentContext = createContext<ReactNode>(null);
+
+interface SceneChromeProviderProps {
+  activeSceneId: SceneTabId;
+  children: ReactNode;
+}
+
+export const SceneChromeProvider: React.FC<SceneChromeProviderProps> = ({
+  activeSceneId,
+  children,
+}) => {
+  const [contributions, setContributions] = useState(
+    () => new Map<SceneTabId, SceneChromeContributionRecord>(),
+  );
+  const setContribution = useCallback((
+    sceneId: SceneTabId,
+    owner: symbol,
+    content: ReactNode,
+  ) => {
+    setContributions(current => {
+      const existing = current.get(sceneId);
+      if (existing?.owner === owner && existing.content === content) {
+        return current;
+      }
+
+      const next = new Map(current);
+      next.set(sceneId, { owner, content });
+      return next;
+    });
+  }, []);
+  const removeContribution = useCallback((sceneId: SceneTabId, owner: symbol) => {
+    setContributions(current => {
+      if (current.get(sceneId)?.owner !== owner) {
+        return current;
+      }
+
+      const next = new Map(current);
+      next.delete(sceneId);
+      return next;
+    });
+  }, []);
+  const registrationValue = useMemo<SceneChromeContextValue>(() => ({
+    activeSceneId,
+    setContribution,
+    removeContribution,
+  }), [activeSceneId, removeContribution, setContribution]);
+  const activeContent = contributions.get(activeSceneId)?.content ?? null;
+
+  return (
+    <SceneChromeContext.Provider value={registrationValue}>
+      <SceneChromeContentContext.Provider value={activeContent}>
+        {children}
+      </SceneChromeContentContext.Provider>
+    </SceneChromeContext.Provider>
+  );
+};
+
+type SceneChromeHostProps = Omit<HTMLAttributes<HTMLDivElement>, 'children'>;
+
+export const SceneChromeHost: React.FC<SceneChromeHostProps> = (props) => {
+  const activeContent = useContext(SceneChromeContentContext);
+  return <div {...props}>{activeContent}</div>;
+};
+
+interface SceneChromeContributionProps {
+  sceneId: SceneTabId;
+  children: ReactNode;
+}
+
+export const SceneChromeContribution: React.FC<SceneChromeContributionProps> = ({
+  sceneId,
+  children,
+}) => {
+  const sceneChrome = useContext(SceneChromeContext);
+  const ownerRef = useRef(Symbol('scene-chrome-contribution'));
+  const setContribution = sceneChrome?.setContribution;
+  const removeContribution = sceneChrome?.removeContribution;
+
+  useLayoutEffect(() => {
+    setContribution?.(sceneId, ownerRef.current, children);
+  }, [children, sceneId, setContribution]);
+
+  useLayoutEffect(() => () => {
+    removeContribution?.(sceneId, ownerRef.current);
+  }, [removeContribution, sceneId]);
+
+  return null;
+};
+
+export function useSceneChromeContext(): SceneChromeContextValue | null {
+  return useContext(SceneChromeContext);
+}

--- a/src/web-ui/src/app/components/SceneTopBar/SceneTopBar.scss
+++ b/src/web-ui/src/app/components/SceneTopBar/SceneTopBar.scss
@@ -1,0 +1,36 @@
+.bitfun-scene-top-bar {
+  position: relative;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  flex: 0 0 var(--bf-control-tab-group-item-height);
+  width: 100%;
+  min-width: 0;
+  height: var(--bf-control-tab-group-item-height);
+  overflow: visible;
+  background: var(--bf-appearance-token-color-bg-scene);
+  container-name: scene-top-bar;
+  container-type: inline-size;
+  user-select: none;
+
+  &__actions {
+    display: flex;
+    align-items: center;
+    flex: 0 1 auto;
+    min-width: 0;
+    height: 100%;
+    margin-inline-start: var(--bf-space-2);
+
+    &:empty {
+      display: none;
+    }
+  }
+
+  &__window-controls {
+    display: flex;
+    align-items: center;
+    flex: 0 0 auto;
+    height: 100%;
+    margin-inline-start: var(--bf-space-2);
+  }
+}

--- a/src/web-ui/src/app/components/SceneTopBar/SceneTopBar.tsx
+++ b/src/web-ui/src/app/components/SceneTopBar/SceneTopBar.tsx
@@ -1,0 +1,99 @@
+import React, { useCallback, useRef } from 'react';
+import { WindowControls } from '@/component-library';
+import { supportsNativeWindowDragging } from '@/infrastructure/runtime';
+import { createLogger } from '@/shared/utils/logger';
+import { useSceneStore } from '../../stores/sceneStore';
+import SceneBar from '../SceneBar/SceneBar';
+import { SceneChromeHost } from './SceneChrome';
+import './SceneTopBar.scss';
+
+const log = createLogger('SceneTopBar');
+
+const INTERACTIVE_SELECTOR =
+  'button, input, textarea, select, a, [role="button"], [contenteditable="true"], .window-controls';
+
+function blocksWindowChromeInteraction(target: HTMLElement): boolean {
+  const interactive = target.closest<HTMLElement>(INTERACTIVE_SELECTOR);
+  return interactive !== null && interactive.getAttribute('role') !== 'tab';
+}
+
+interface SceneTopBarProps {
+  className?: string;
+  onMinimize?: () => void;
+  onMaximize?: () => void;
+  onClose?: () => void;
+  isMaximized?: boolean;
+}
+
+const SceneTopBar: React.FC<SceneTopBarProps> = ({
+  className = '',
+  onMinimize,
+  onMaximize,
+  onClose,
+  isMaximized = false,
+}) => {
+  const isSingleTab = useSceneStore(state => state.openTabs.length <= 1);
+  const canDragWindow = supportsNativeWindowDragging();
+  const lastMouseDownTimeRef = useRef(0);
+  const hasWindowControls = Boolean(onMinimize && onMaximize && onClose);
+
+  const handleMouseDown = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    if (!canDragWindow || !isSingleTab || event.button !== 0) return;
+    const target = event.target as HTMLElement | null;
+    if (!target || blocksWindowChromeInteraction(target)) return;
+
+    const now = Date.now();
+    const timeSinceLastMouseDown = now - lastMouseDownTimeRef.current;
+    lastMouseDownTimeRef.current = now;
+    if (timeSinceLastMouseDown < 500 && timeSinceLastMouseDown > 50) return;
+
+    void (async () => {
+      try {
+        const { getCurrentWindow } = await import('@tauri-apps/api/window');
+        await getCurrentWindow().startDragging();
+      } catch (error) {
+        log.debug('startDragging failed', error);
+      }
+    })();
+  }, [canDragWindow, isSingleTab]);
+
+  const handleDoubleClick = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    if (!isSingleTab) return;
+    const target = event.target as HTMLElement | null;
+    if (!target || blocksWindowChromeInteraction(target)) return;
+    onMaximize?.();
+  }, [isSingleTab, onMaximize]);
+
+  return (
+    <div
+      className={`bitfun-scene-top-bar ${className}`.trim()}
+      onMouseDown={handleMouseDown}
+      onDoubleClick={handleDoubleClick}
+      data-bf-scene="workbench"
+      data-bf-part="topBar"
+    >
+      <SceneBar />
+      <SceneChromeHost
+        className="bitfun-scene-top-bar__actions"
+        data-bf-scene="workbench"
+        data-bf-part="sceneActions"
+      />
+      {hasWindowControls ? (
+        <div
+          className="bitfun-scene-top-bar__window-controls"
+          data-bf-component="scene-bar"
+          data-bf-part="controls"
+        >
+          <WindowControls
+            onMinimize={onMinimize!}
+            onMaximize={onMaximize!}
+            onClose={onClose!}
+            isMaximized={isMaximized}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export default SceneTopBar;

--- a/src/web-ui/src/app/components/SceneTopBar/index.ts
+++ b/src/web-ui/src/app/components/SceneTopBar/index.ts
@@ -1,0 +1,7 @@
+export { default as SceneTopBar } from './SceneTopBar';
+export {
+  SceneChromeContribution,
+  SceneChromeHost,
+  SceneChromeProvider,
+  useSceneChromeContext,
+} from './SceneChrome';

--- a/src/web-ui/src/app/layout/WorkspaceBody.scss
+++ b/src/web-ui/src/app/layout/WorkspaceBody.scss
@@ -93,7 +93,7 @@ $_resize-target-width: 6px;
   display: flex;
   flex: 1 1 auto;
   flex-direction: column;
-  gap: $size-gap-5;
+  gap: 0;
   min-width: 0;
   min-height: 0;
   padding: $size-gap-4 $size-gap-4 0;
@@ -141,7 +141,7 @@ $_resize-target-width: 6px;
 
 // The compact toolbar remains reachable when the navigation panel is hidden.
 .bitfun-workspace-body__nav-area.is-collapsed + .bitfun-workspace-body__scene-area {
-  .bitfun-workspace-body__scene-surface .bitfun-scene-bar {
+  .bitfun-workspace-body__scene-surface .bitfun-scene-top-bar {
     padding-left: calc(#{$_nav-collapsed-width} + #{$size-gap-1});
   }
 }
@@ -151,7 +151,7 @@ $_resize-target-width: 6px;
 }
 
 .bitfun-app-layout--macos .bitfun-workspace-body__nav-area.is-collapsed + .bitfun-workspace-body__scene-area {
-  .bitfun-workspace-body__scene-surface .bitfun-scene-bar {
+  .bitfun-workspace-body__scene-surface .bitfun-scene-top-bar {
     padding-left: calc(#{$_nav-collapsed-width} + #{$size-gap-1} + 72px);
   }
 }

--- a/src/web-ui/src/app/layout/WorkspaceBody.tsx
+++ b/src/web-ui/src/app/layout/WorkspaceBody.tsx
@@ -6,7 +6,7 @@
  *     NavBar        (35px — back/forward + drag + WindowControls)
  *     NavPanel      (flex:1 — navigation sidebar)
  *   .scene-area (flex:1, flex-column)
- *     SceneBar      (scene tab strip inside the scene surface)
+ *     SceneTopBar   (scene tabs + active-scene chrome + WindowControls)
  *     SceneViewport (flex:1 — active scene content)
  */
 
@@ -14,10 +14,11 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useCurrentWorkspace } from '../../infrastructure/contexts/WorkspaceContext';
 import { NavBar } from '../components/NavBar';
 import NavPanel from '../components/NavPanel/NavPanel';
-import { SceneBar } from '../components/SceneBar';
+import { SceneChromeProvider, SceneTopBar } from '../components/SceneTopBar';
 import { SceneViewport } from '../scenes';
 import TerminalActionBridge from '../scenes/terminal/TerminalActionBridge';
 import { useApp } from '../hooks/useApp';
+import { useSceneStore } from '../stores/sceneStore';
 import './WorkspaceBody.scss';
 
 const NAV_DEFAULT_WIDTH = 300;
@@ -48,6 +49,7 @@ const WorkspaceBody: React.FC<WorkspaceBodyProps> = ({
 }) => {
   const { workspace: currentWorkspace } = useCurrentWorkspace();
   const { state, toggleLeftPanel } = useApp();
+  const activeSceneId = useSceneStore(sceneState => sceneState.activeTabId);
   const isNavCollapsed = state.layout.leftPanelCollapsed;
   const [navWidth, setNavWidth] = useState(NAV_DEFAULT_WIDTH);
   const navAreaRef = useRef<HTMLDivElement>(null);
@@ -180,16 +182,18 @@ const WorkspaceBody: React.FC<WorkspaceBodyProps> = ({
           data-bf-scene="workbench"
           data-bf-part="sceneSurface"
         >
-          <SceneBar
-            onMinimize={onMinimize}
-            onMaximize={onMaximize}
-            onClose={onClose}
-            isMaximized={isMaximized}
-          />
-          <SceneViewport
-            workspacePath={currentWorkspace?.rootPath}
-            isEntering={isEntering}
-          />
+          <SceneChromeProvider activeSceneId={activeSceneId}>
+            <SceneTopBar
+              onMinimize={onMinimize}
+              onMaximize={onMaximize}
+              onClose={onClose}
+              isMaximized={isMaximized}
+            />
+            <SceneViewport
+              workspacePath={currentWorkspace?.rootPath}
+              isEntering={isEntering}
+            />
+          </SceneChromeProvider>
         </div>
         {sceneOverlay}
       </div>

--- a/src/web-ui/src/flow_chat/components/modern/FlowChatHeader.appearance.ts
+++ b/src/web-ui/src/flow_chat/components/modern/FlowChatHeader.appearance.ts
@@ -5,8 +5,6 @@ export const flowChatHeaderAppearanceDescriptor: AppearanceSurfaceDescriptor = {
   parts: [
     { id: 'root' },
     { id: 'leftActions' },
-    { id: 'message' },
-    { id: 'turnBadge' },
     { id: 'actions' },
     { id: 'sessionOverview' },
     { id: 'sessionOverviewTrigger' },

--- a/src/web-ui/src/flow_chat/components/modern/FlowChatHeader.scss
+++ b/src/web-ui/src/flow_chat/components/modern/FlowChatHeader.scss
@@ -10,20 +10,40 @@
   justify-content: space-between;
   gap: $size-gap-1;
   padding: 0 $size-gap-3;
-  border-bottom: 1px solid var(--bf-appearance-token-border-base);
 
-  // Opaque bar stacked above the message list, so message geometry stays
+  // Opaque bar stacked above the transcript, so transcript geometry stays
   // independent of the header.
   background: var(--bf-appearance-token-color-bg-scene);
 
   height: 36px;
   min-height: 36px;
   flex-shrink: 0;
-  transition:
-    background-color $motion-base $easing-standard,
-    border-color $motion-base $easing-standard;
+  transition: background-color $motion-base $easing-standard;
   position: relative;
   z-index: 10;
+
+  &__chrome-actions {
+    min-width: 0;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    gap: $size-gap-1;
+    max-width: 100%;
+  }
+
+  &__chrome-actions &__actions {
+    min-width: 0;
+
+    &--left {
+      margin-right: $size-gap-1;
+    }
+  }
+
+  &__chrome-actions &__search {
+    width: clamp(180px, 30cqi, 420px);
+    min-width: 0;
+    max-width: 420px;
+  }
 
   &__btw-back {
     flex: 0 0 auto;
@@ -602,57 +622,6 @@
     text-overflow: ellipsis;
   }
 
-  // ==================== Center message ====================
-  &__message {
-    position: absolute;
-    left: calc(var(--bf-appearance-token-flowchat-header-side-width) + #{$size-gap-5});
-    right: calc(var(--bf-appearance-token-flowchat-header-side-width) + #{$size-gap-5});
-    min-width: 0;
-    padding: 0 $size-gap-3;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: $size-gap-2;
-    overflow: hidden;
-    cursor: pointer;
-    border-radius: $size-radius-base;
-    transition: background $motion-base $easing-standard;
-
-    &:hover {
-      background: color-mix(in srgb, var(--bf-appearance-token-element-bg-soft) 70%, transparent);
-    }
-
-    &:focus-visible {
-      outline: none;
-      background: color-mix(in srgb, var(--bf-appearance-token-element-bg-soft) 82%, transparent);
-      box-shadow: 0 0 0 1.5px var(--bf-appearance-token-border-strong);
-    }
-  }
-
-  &__turn-badge {
-    display: inline-flex;
-    align-items: center;
-    flex: 0 0 auto;
-    max-width: 100%;
-    padding: 2px 8px;
-    border-radius: 999px;
-    background: color-mix(in srgb, var(--bf-appearance-token-element-bg-soft) 82%, transparent);
-    color: var(--bf-appearance-token-color-text-secondary);
-    font-size: flow-type.$support-size;
-    line-height: 1;
-    white-space: nowrap;
-  }
-
-  &__message-text {
-    min-width: 0;
-    font-size: flow-type.$control-size;
-    color: var(--bf-appearance-token-color-text-primary);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    text-align: center;
-  }
-
   // ==================== Actions ====================
   &__actions {
     position: relative;
@@ -673,5 +642,23 @@
       min-width: min(220px, 52vw);
       max-width: min(300px, 56vw);
     }
+  }
+}
+
+@container scene-top-bar (max-width: 820px) {
+  .flowchat-header__chrome-actions {
+    &:has(.flowchat-header__search) .flowchat-header__actions--left {
+      display: none;
+    }
+
+    .flowchat-header__search {
+      width: min(220px, 30cqi);
+    }
+  }
+}
+
+@container scene-top-bar (max-width: 680px) {
+  .flowchat-header__chrome-actions .flowchat-header__search {
+    width: min(180px, 27cqi);
   }
 }

--- a/src/web-ui/src/flow_chat/components/modern/FlowChatHeader.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/FlowChatHeader.test.tsx
@@ -3,6 +3,10 @@
 import React, { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  SceneChromeHost,
+  SceneChromeProvider,
+} from '@/app/components/SceneTopBar/SceneChrome';
 import { FlowChatHeader, type FlowChatHeaderProps } from './FlowChatHeader';
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
@@ -21,12 +25,7 @@ const {
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string, values?: Record<string, unknown>) => {
-      if (key === 'flowChatHeader.turnBadge') {
-        return `Turn ${values?.current ?? ''}`;
-      }
-      return key;
-    },
+    t: (key: string) => key,
   }),
 }));
 
@@ -91,9 +90,6 @@ vi.mock('./SessionTreePopover', () => ({
 
 function createProps(overrides: Partial<FlowChatHeaderProps> = {}): FlowChatHeaderProps {
   return {
-    currentTurn: 1,
-    totalTurns: 2,
-    currentUserMessage: 'First prompt',
     visible: true,
     ...overrides,
   };
@@ -125,31 +121,9 @@ describe('FlowChatHeader', () => {
     vi.restoreAllMocks();
   });
 
-  it('reserves the larger action group width on both sides of the centered title', () => {
-    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (
-      this: HTMLElement,
-    ) {
-      const width = this.classList.contains('flowchat-header__actions--left')
-        ? 32
-        : this.classList.contains('flowchat-header__actions')
-          ? 196
-          : 0;
-
-      return {
-        x: 0,
-        y: 0,
-        width,
-        height: 36,
-        top: 0,
-        right: width,
-        bottom: 36,
-        left: 0,
-        toJSON: () => ({}),
-      };
-    });
-
+  it('keeps the inline fallback hidden until the session has content', () => {
     act(() => {
-      root.render(<FlowChatHeader {...createProps()} visible={false} totalTurns={0} />);
+      root.render(<FlowChatHeader {...createProps({ visible: false })} />);
     });
 
     expect(container.querySelector('.flowchat-header')).toBeNull();
@@ -158,8 +132,39 @@ describe('FlowChatHeader', () => {
       root.render(<FlowChatHeader {...createProps()} />);
     });
 
-    const header = container.querySelector<HTMLElement>('.flowchat-header');
-    expect(header?.style.getPropertyValue('--bf-appearance-token-flowchat-header-side-width')).toBe('196px');
+    expect(container.querySelector('.flowchat-header')).not.toBeNull();
+    expect(container.querySelector('[data-bf-part="message"]')).toBeNull();
+    expect(container.querySelector('[data-bf-part="turnBadge"]')).toBeNull();
+  });
+
+  it('contributes only active Session actions to the shared scene top bar', () => {
+    const renderInScene = (activeSceneId: 'session' | 'settings', visible = false) => {
+      root.render(
+        <SceneChromeProvider activeSceneId={activeSceneId}>
+          <SceneChromeHost data-testid="scene-actions-host" />
+          <FlowChatHeader
+            {...createProps({
+              visible,
+              onToggleRightPanel: vi.fn(),
+            })}
+          />
+        </SceneChromeProvider>,
+      );
+    };
+
+    act(() => renderInScene('session'));
+
+    const host = container.querySelector('[data-testid="scene-actions-host"]');
+    expect(host?.querySelector('[data-testid="session-files-badge"]')).not.toBeNull();
+    expect(host?.querySelector('[data-testid="flowchat-header-search"]')).toBeNull();
+    expect(host?.querySelector('[data-testid="flowchat-header-session-overview"]')).not.toBeNull();
+    expect(host?.querySelector('[data-testid="flowchat-header-right-panel"]')).not.toBeNull();
+
+    act(() => renderInScene('settings'));
+    expect(host?.childElementCount).toBe(0);
+
+    act(() => renderInScene('session', true));
+    expect(host?.querySelector('[data-testid="flowchat-header-search"]')).not.toBeNull();
   });
 
   it('omits the list, previous-turn, and next-turn navigation controls', () => {

--- a/src/web-ui/src/flow_chat/components/modern/FlowChatHeader.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/FlowChatHeader.tsx
@@ -1,7 +1,7 @@
 /**
- * FlowChat header.
- * Shows the currently viewed turn and user message.
- * Height matches side panel headers (40px).
+ * Session-level actions for FlowChat.
+ * The workspace scene renders these actions in the shared scene top bar;
+ * standalone FlowChat hosts keep the inline fallback.
  */
 
 import React, { useEffect, useLayoutEffect, useMemo, useRef, useState, useCallback } from 'react';
@@ -21,6 +21,10 @@ import {
   X,
 } from 'lucide-react';
 import { Tooltip } from '@/component-library';
+import {
+  SceneChromeContribution,
+  useSceneChromeContext,
+} from '@/app/components/SceneTopBar/SceneChrome';
 import { useTranslation } from 'react-i18next';
 import { SessionFilesBadge } from './SessionFilesBadge';
 import { SessionTreePopover, type SessionTreeSelection } from './SessionTreePopover';
@@ -58,18 +62,10 @@ export interface FlowChatHeaderCommandSummary {
 }
 
 export interface FlowChatHeaderProps {
-  /** Current turn index. */
-  currentTurn: number;
-  /** Total turns. */
-  totalTurns: number;
-  /** Current user message. */
-  currentUserMessage: string;
   /** Whether the header is visible. */
   visible: boolean;
   /** Session ID. */
   sessionId?: string;
-  /** Jump to the currently displayed turn. */
-  onJumpToCurrentTurn?: () => void;
   /** Current search query string. */
   searchQuery?: string;
   /** Called when the user types in the search box. */
@@ -108,12 +104,8 @@ export interface FlowChatHeaderProps {
   onToggleRightPanel?: () => void;
 }
 export const FlowChatHeader: React.FC<FlowChatHeaderProps> = ({
-  currentTurn,
-  totalTurns,
-  currentUserMessage,
   visible,
   sessionId,
-  onJumpToCurrentTurn,
   searchQuery = '',
   onSearchChange,
   searchMatchCount = 0,
@@ -135,13 +127,12 @@ export const FlowChatHeader: React.FC<FlowChatHeaderProps> = ({
 }) => {
   const { t } = useTranslation('flow-chat');
   const { currentWorkspace } = useWorkspaceContext();
+  const sceneChrome = useSceneChromeContext();
+  const isSceneChromeActive = sceneChrome?.activeSceneId === 'session';
   const [isSessionOverviewOpen, setIsSessionOverviewOpen] = useState(false);
   const [isBackgroundCommandSectionMenuOpen, setIsBackgroundCommandSectionMenuOpen] = useState(false);
   const [openBackgroundCommandMenuId, setOpenBackgroundCommandMenuId] = useState<string | null>(null);
   const [isSearchOpen, setIsSearchOpen] = useState(false);
-  const headerRef = useRef<HTMLDivElement | null>(null);
-  const leftActionsRef = useRef<HTMLDivElement | null>(null);
-  const rightActionsRef = useRef<HTMLDivElement | null>(null);
   const sessionOverviewRootRef = useRef<HTMLDivElement | null>(null);
   const sessionOverviewTriggerRef = useRef<HTMLButtonElement | null>(null);
   const sessionOverviewPanelRef = useRef<HTMLDivElement | null>(null);
@@ -159,13 +150,6 @@ export const FlowChatHeader: React.FC<FlowChatHeaderProps> = ({
     totalCount: 0,
   });
 
-  // Truncate long messages.
-  const truncatedMessage = currentUserMessage.length > 50
-    ? currentUserMessage.slice(0, 50) + '...'
-    : currentUserMessage;
-  const turnBadgeLabel = t('flowChatHeader.turnBadge', {
-    current: currentTurn
-  });
   const hasBackgroundCommands = backgroundCommands.length > 0;
   const backgroundCommandCount = backgroundCommands.length;
   const runningBackgroundCommandCount = backgroundCommands.filter(command => command.status === 'running').length;
@@ -354,35 +338,7 @@ export const FlowChatHeader: React.FC<FlowChatHeaderProps> = ({
     return () => {
       cancelAnimationFrame(frameId);
     };
-  }, [isSearchOpen]);
-
-  useLayoutEffect(() => {
-    const header = headerRef.current;
-    const leftActions = leftActionsRef.current;
-    const rightActions = rightActionsRef.current;
-    if (!header || !leftActions || !rightActions) return;
-
-    const updateSideWidth = () => {
-      const sideWidth = Math.ceil(Math.max(
-        leftActions.getBoundingClientRect().width,
-        rightActions.getBoundingClientRect().width,
-      ));
-      header.style.setProperty('--bf-appearance-token-flowchat-header-side-width', `${sideWidth}px`);
-    };
-
-    updateSideWidth();
-
-    if (typeof ResizeObserver === 'undefined') {
-      window.addEventListener('resize', updateSideWidth);
-      return () => window.removeEventListener('resize', updateSideWidth);
-    }
-
-    const observer = new ResizeObserver(updateSideWidth);
-    observer.observe(leftActions);
-    observer.observe(rightActions);
-
-    return () => observer.disconnect();
-  }, [isSearchOpen, totalTurns, visible]);
+  }, [isSceneChromeActive, isSearchOpen, visible]);
 
   const handleOpenSearch = useCallback(() => {
     setIsSearchOpen(true);
@@ -621,71 +577,22 @@ export const FlowChatHeader: React.FC<FlowChatHeaderProps> = ({
     ? t('common:header.collapseRightPanel')
     : t('common:header.expandRightPanel');
 
-  // The header occupies a row above the message list, so its mount state must
-  // not depend on turn measurement: unmounting on a transient `totalTurns === 0`
-  // would resize the list mid-session. Only the centre message is withheld.
-  if (!visible) {
-    return null;
-  }
-  const hasTurnInfo = totalTurns > 0;
-
-  return (
+  const leftActions = (
     <div
-      className="flowchat-header"
-      ref={headerRef}
+      className="flowchat-header__actions flowchat-header__actions--left"
       data-bf-component="flow-chat-header"
-      data-bf-part="root"
+      data-bf-part="leftActions"
     >
-      <div
-        className="flowchat-header__actions flowchat-header__actions--left"
-        ref={leftActionsRef}
-        data-bf-component="flow-chat-header"
-        data-bf-part="leftActions"
-      >
-        <SessionFilesBadge sessionId={sessionId} />
-      </div>
-
-      {hasTurnInfo ? (
-        <Tooltip content={currentUserMessage} placement="bottom">
-          <div
-            className="flowchat-header__message"
-            data-bf-component="flow-chat-header"
-            data-bf-part="message"
-            role="button"
-            tabIndex={0}
-            onClick={onJumpToCurrentTurn}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                onJumpToCurrentTurn?.();
-              }
-            }}
-            aria-label={t('flowChatHeader.jumpToCurrentTurn', {
-              turn: currentTurn
-            })}
-          >
-            <span
-              className="flowchat-header__turn-badge"
-              aria-label={turnBadgeLabel}
-              data-bf-component="flow-chat-header"
-              data-bf-part="turnBadge"
-            >
-              <span>{turnBadgeLabel}</span>
-            </span>
-            <span className="flowchat-header__message-text">
-              {truncatedMessage}
-            </span>
-          </div>
-        </Tooltip>
-      ) : null}
-
-      <div
-        className="flowchat-header__actions"
-        ref={rightActionsRef}
-        data-bf-component="flow-chat-header"
-        data-bf-part="actions"
-      >
-        {isSearchOpen ? (
+      <SessionFilesBadge sessionId={sessionId} />
+    </div>
+  );
+  const rightActions = (
+    <div
+      className="flowchat-header__actions"
+      data-bf-component="flow-chat-header"
+      data-bf-part="actions"
+    >
+        {visible ? (isSearchOpen ? (
           <div
             className="flowchat-header__search"
             role="search"
@@ -767,7 +674,7 @@ export const FlowChatHeader: React.FC<FlowChatHeaderProps> = ({
               icon={<Search size={14} />}
             />
           </Tooltip>
-        )}
+        )) : null}
         <div
           className="flowchat-header__session-overview"
           ref={sessionOverviewRootRef}
@@ -1095,6 +1002,36 @@ export const FlowChatHeader: React.FC<FlowChatHeaderProps> = ({
           </Tooltip>
         ) : null}
       </div>
+  );
+
+  if (sceneChrome) {
+    return (
+      <SceneChromeContribution sceneId="session">
+        <div
+          className="flowchat-header__chrome-actions flow-chat-typography"
+          data-shortcut-scope="chat"
+          data-bf-component="flow-chat-header"
+          data-bf-part="root"
+        >
+          {leftActions}
+          {rightActions}
+        </div>
+      </SceneChromeContribution>
+    );
+  }
+
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <div
+      className="flowchat-header"
+      data-bf-component="flow-chat-header"
+      data-bf-part="root"
+    >
+      {leftActions}
+      {rightActions}
     </div>
   );
 };

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
@@ -45,7 +45,6 @@ import {
 } from '../../store/modernFlowChatStore';
 import type {
   FlowChatConfig,
-  DialogTurn,
   Session,
   SessionHistoryPresentation,
 } from '../../types/flow-chat';
@@ -73,7 +72,6 @@ import { createBackgroundCommandOutputTab, createReviewPlatformPullRequestDetail
 import { isAcpFlowSession } from '../../utils/acpSession';
 import { flowChatStore } from '../../store/FlowChatStore';
 import { openBtwSessionInAuxPane } from '../../services/btwSessionPane';
-import { resolveThreadGoalHeaderTitle } from '../../utils/threadGoalDisplay';
 import { hasActiveSessionLineageDescendants } from '../../utils/sessionLineage';
 import {
   findDialogTurn,
@@ -979,19 +977,6 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     searchCurrentMatchVirtualIndex,
   ]);
 
-  const resolveLocalCommandHeaderTitle = useCallback((metadata: DialogTurn['userMessage']['metadata']) => {
-    if (metadata?.localCommandKind === 'usage_report') {
-      return t('usage.title');
-    }
-    const threadGoalTitle = resolveThreadGoalHeaderTitle(
-      metadata as Record<string, unknown> | undefined
-    );
-    if (threadGoalTitle) {
-      return threadGoalTitle;
-    }
-    return null;
-  }, [t]);
-
   const turnSummaries = useMemo<FlowChatTurnSummary[]>(() => {
     if (!activeSession) {
       return [];
@@ -1276,19 +1261,6 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
       turnRailItems.flatMap(turn => turn.turnId ? [turn.turnId] : []),
     );
   }, [turnRailItems]);
-
-  const currentHeaderMessage = useMemo(() => {
-    const turnId = effectiveVisibleTurnInfo?.turnId;
-    if (!turnId) {
-      return effectiveVisibleTurnInfo?.userMessage ?? '';
-    }
-    const turn = renderedTurns.find(item => item.id === turnId);
-    const localCommandTitle = resolveLocalCommandHeaderTitle(turn?.userMessage?.metadata);
-    if (localCommandTitle) {
-      return localCommandTitle;
-    }
-    return effectiveVisibleTurnInfo?.userMessage ?? '';
-  }, [effectiveVisibleTurnInfo?.turnId, effectiveVisibleTurnInfo?.userMessage, renderedTurns, resolveLocalCommandHeaderTitle]);
 
   const requestTurnNavigation = useCallback((turnId: string): FlowChatTurnNavigationStatus => {
     if (!isViewportActive) {
@@ -2606,17 +2578,10 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
         data-bf-part="root"
       >
         <FlowChatHeader
-          currentTurn={effectiveVisibleTurnInfo?.turnIndex ?? 0}
-          totalTurns={effectiveVisibleTurnInfo?.totalTurns ?? 0}
-          currentUserMessage={currentHeaderMessage}
           visible={virtualItems.length > 0}
           sessionId={activeSession?.sessionId}
           isRightPanelOpen={isRightPanelOpen}
           onToggleRightPanel={onToggleRightPanel}
-          onJumpToCurrentTurn={() => {
-            const turnId = effectiveVisibleTurnInfo?.turnId;
-            if (turnId) navigateToTurn(turnId);
-          }}
           searchQuery={searchQuery}
           onSearchChange={handleSearchChange}
           searchMatchCount={searchMatches.length}

--- a/src/web-ui/src/infrastructure/appearance/compiler/AppearanceCompiler.test.ts
+++ b/src/web-ui/src/infrastructure/appearance/compiler/AppearanceCompiler.test.ts
@@ -732,11 +732,6 @@ describe('AppearanceCompiler', () => {
             trigger: { states: { open: { borderColor: accent } } },
           },
         },
-        'flow-chat-header': {
-          parts: {
-            turnBadge: { base: { backgroundColor: accent } },
-          },
-        },
         'session-files-badge': {
           parts: {
             file: { facets: { operation: { modify: { borderColor: accent } } } },
@@ -942,7 +937,6 @@ describe('AppearanceCompiler', () => {
     expect(snapshot.cssText).toContain('[data-bf-component="flexible-panel"][data-bf-part="code"][data-bf-state~="needsFix"]');
     expect(snapshot.cssText).toContain('[data-bf-component="btw-session-panel"][data-bf-part="root"][data-bf-view="session"]');
     expect(snapshot.cssText).toContain('[data-bf-component="model-selector"][data-bf-part="trigger"][data-bf-state~="open"]');
-    expect(snapshot.cssText).toContain('[data-bf-component="flow-chat-header"][data-bf-part="turnBadge"]');
     expect(snapshot.cssText).toContain('[data-bf-component="session-files-badge"][data-bf-part="file"][data-bf-operation="modify"]');
     expect(snapshot.cssText).toContain('[data-bf-component="code-review-tool-card"][data-bf-part="group"][data-bf-state~="expanded"]');
     expect(snapshot.cssText).toContain('[data-bf-component="create-agent-page"][data-bf-part="levelOption"][data-bf-state~="active"]');

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -1328,7 +1328,6 @@
     "searchNext": "Next match",
     "searchClose": "Close search",
     "searchOpen": "Search messages",
-    "jumpToCurrentTurn": "Jump to Turn {{turn}}",
     "sessionOverview": "Session overview",
     "sessionOverviewActive": "Session overview, activity in progress",
     "sessionOverviewAgentsUnavailable": "No active session",

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -1328,7 +1328,6 @@
     "searchNext": "下一个匹配结果",
     "searchClose": "关闭搜索",
     "searchOpen": "搜索消息",
-    "jumpToCurrentTurn": "跳转到第 {{turn}} 轮",
     "sessionOverview": "会话概览",
     "sessionOverviewActive": "会话概览，有活动正在进行",
     "sessionOverviewAgentsUnavailable": "当前没有可用会话",

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -1328,7 +1328,6 @@
     "searchNext": "下一個匹配結果",
     "searchClose": "關閉搜尋",
     "searchOpen": "搜尋消息",
-    "jumpToCurrentTurn": "跳轉到第 {{turn}} 輪",
     "sessionOverview": "會話概覽",
     "sessionOverviewActive": "會話概覽，有活動正在進行",
     "sessionOverviewAgentsUnavailable": "目前沒有可用會話",


### PR DESCRIPTION
## Summary
- merge the scene tab strip and Session header actions into one shell-owned top bar
- let active scenes contribute chrome without moving session state into the scene registry
- remove turn count, turn title, and the top-bar bottom border
- keep standalone FlowChat hosts on the inline fallback

## Validation
- No additional validation was run for submission, per request.

## Remote scenarios
- Not exercised; this is a Web UI shell composition change.