### PR TITLE
fix(web-ui): add spacing below scene tabs

### DIFF
--- a/src/web-ui/src/app/layout/WorkspaceBody.scss
+++ b/src/web-ui/src/app/layout/WorkspaceBody.scss
@@ -93,7 +93,7 @@ $_resize-target-width: 6px;
   display: flex;
   flex: 1 1 auto;
   flex-direction: column;
-  gap: 0;
+  gap: $size-gap-4;
   min-width: 0;
   min-height: 0;
   padding: $size-gap-4 $size-gap-4 0;


### PR DESCRIPTION
## Summary

- add a scene-surface gutter below the top tab bar
- reuse the existing `$size-gap-4` token so top, left, right, and bottom spacing match
- keep tab sizing and FlowChat scroll geometry unchanged

## Verification

- `pnpm run check:web`
- `pnpm run motion:audit`
- focused Sass compilation for `WorkspaceBody.scss`

Remote workspace, remote control, Peer Device Mode, and Detached Dispatch were not exercised because this is a shell-only CSS layout change with no transport or runtime behavior.