### PR TITLE
fix(skills): stop remote workspace loading from hanging

### DIFF
--- a/src/apps/desktop/src/api/skill_api.rs
+++ b/src/apps/desktop/src/api/skill_api.rs
@@ -44,8 +44,23 @@ const MAX_OUTPUT_PREVIEW_CHARS: usize = 2000;
 const MARKET_DESC_FETCH_TIMEOUT_SECS: u64 = 4;
 const MARKET_DESC_FETCH_CONCURRENCY: usize = 6;
 const MARKET_DESC_MAX_LEN: usize = 220;
+const REMOTE_SKILL_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(60);
 
 static MARKET_DESCRIPTION_CACHE: OnceLock<RwLock<HashMap<String, String>>> = OnceLock::new();
+
+async fn await_remote_skill_discovery<T>(
+    operation: impl std::future::Future<Output = Result<T, String>>,
+    deadline: Duration,
+) -> Result<T, String> {
+    timeout(deadline, operation)
+        .await
+        .map_err(|_| {
+            format!(
+                "Remote Skill discovery timed out after {} seconds. Check the SSH/SFTP connection and retry.",
+                deadline.as_secs().max(1)
+            )
+        })?
+}
 
 fn can_delete_owned_skill(source_id: &str, source_slot: &str, is_builtin: bool) -> bool {
     if is_builtin {
@@ -215,14 +230,20 @@ async fn get_all_skills_for_workspace_input(
     workspace_path: Option<&str>,
 ) -> Result<Vec<SkillInfo>, String> {
     if let Some((remote_root, entry)) = resolve_remote_workspace(state, workspace_path).await? {
-        let remote_fs = state
-            .get_remote_file_service_async()
-            .await
-            .map_err(|e| format!("Remote file service not available: {}", e))?;
-        let remote_workspace_fs = RemoteWorkspaceFs::new(entry.connection_id, remote_fs);
-        Ok(registry
-            .get_all_skills_for_remote_workspace(&remote_workspace_fs, &remote_root)
-            .await)
+        await_remote_skill_discovery(
+            async {
+                let remote_fs = state
+                    .get_remote_file_service_async()
+                    .await
+                    .map_err(|e| format!("Remote file service not available: {}", e))?;
+                let remote_workspace_fs = RemoteWorkspaceFs::new(entry.connection_id, remote_fs);
+                Ok(registry
+                    .get_all_skills_for_remote_workspace(&remote_workspace_fs, &remote_root)
+                    .await)
+            },
+            REMOTE_SKILL_DISCOVERY_TIMEOUT,
+        )
+        .await
     } else {
         Ok(registry
             .get_all_skills_for_workspace(workspace_root_from_input(workspace_path).as_deref())
@@ -237,15 +258,25 @@ async fn get_mode_skill_infos_for_workspace_input(
     workspace_path: Option<&str>,
 ) -> Result<Vec<ModeSkillInfo>, String> {
     if let Some((remote_root, entry)) = resolve_remote_workspace(state, workspace_path).await? {
-        let remote_fs = state
-            .get_remote_file_service_async()
-            .await
-            .map_err(|e| format!("Remote file service not available: {}", e))?;
-        let remote_workspace_fs =
-            RemoteWorkspaceFs::new(entry.connection_id.clone(), remote_fs.clone());
-        Ok(registry
-            .get_mode_skill_infos_for_remote_workspace(&remote_workspace_fs, &remote_root, mode_id)
-            .await)
+        await_remote_skill_discovery(
+            async {
+                let remote_fs = state
+                    .get_remote_file_service_async()
+                    .await
+                    .map_err(|e| format!("Remote file service not available: {}", e))?;
+                let remote_workspace_fs =
+                    RemoteWorkspaceFs::new(entry.connection_id.clone(), remote_fs.clone());
+                Ok(registry
+                    .get_mode_skill_infos_for_remote_workspace(
+                        &remote_workspace_fs,
+                        &remote_root,
+                        mode_id,
+                    )
+                    .await)
+            },
+            REMOTE_SKILL_DISCOVERY_TIMEOUT,
+        )
+        .await
     } else if let Some(workspace_root) = workspace_root_from_input(workspace_path) {
         Ok(registry
             .get_mode_skill_infos_for_workspace(Some(&workspace_root), mode_id)
@@ -1048,8 +1079,34 @@ pub async fn delete_skill(
 }
 
 #[cfg(test)]
-mod skill_delete_policy_tests {
-    use super::can_delete_owned_skill;
+mod tests {
+    use super::{await_remote_skill_discovery, can_delete_owned_skill};
+    use std::future;
+    use tokio::time::Duration;
+
+    #[tokio::test]
+    async fn remote_skill_discovery_returns_before_the_deadline() {
+        let result =
+            await_remote_skill_discovery(async { Ok(vec!["skill"]) }, Duration::from_secs(1))
+                .await
+                .expect("ready discovery should complete");
+
+        assert_eq!(result, vec!["skill"]);
+    }
+
+    #[tokio::test]
+    async fn remote_skill_discovery_times_out_with_recovery_guidance() {
+        let error = await_remote_skill_discovery(
+            future::pending::<Result<(), String>>(),
+            Duration::from_millis(1),
+        )
+        .await
+        .expect_err("stalled discovery should time out");
+
+        assert!(error.contains("Remote Skill discovery timed out"));
+        assert!(error.contains("SSH/SFTP connection"));
+        assert!(error.contains("retry"));
+    }
 
     #[test]
     fn only_bitfun_owned_non_builtin_skills_are_deletable() {

--- a/src/web-ui/src/flow_chat/components/ChatInput.scss
+++ b/src/web-ui/src/flow_chat/components/ChatInput.scss
@@ -1348,6 +1348,19 @@
     color: var(--bf-appearance-token-color-accent-500);
   }
 
+  &__boost-submenu-retry {
+    width: 100%;
+    margin: 0;
+    border: 0;
+    background: transparent;
+    cursor: pointer;
+
+    &:hover {
+      background: var(--bf-appearance-token-element-bg-medium);
+      color: var(--bf-appearance-token-color-text-secondary);
+    }
+  }
+
   &__boost-submenu-list {
     flex: 1;
     min-height: 0;
@@ -1860,6 +1873,18 @@
     text-align: center;
     font-size: flow-type.$support-size;
     color: var(--bf-appearance-token-color-text-muted);
+
+    &--retry {
+      width: 100%;
+      border: 0;
+      background: transparent;
+      cursor: pointer;
+
+      &:hover {
+        background: var(--bf-appearance-token-element-bg-medium);
+        color: var(--bf-appearance-token-color-text-secondary);
+      }
+    }
   }
 
   // Popovers: heavy blur + dark shadows read as gray/black on light theme

--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -1140,6 +1140,8 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   const openCreateAgent = useAgentsStore(s => s.openCreateAgent);
   const [resolvedModeSkills, setResolvedModeSkills] = useState<ModeSkillInfo[]>([]);
   const [resolvedModeSkillsLoading, setResolvedModeSkillsLoading] = useState(false);
+  const [resolvedModeSkillsLoadFailed, setResolvedModeSkillsLoadFailed] = useState(false);
+  const [resolvedModeSkillsRequestVersion, setResolvedModeSkillsRequestVersion] = useState(0);
   const [subagentToolInfo, setSubagentToolInfo] = useState<SubagentInfo | null>(null);
   const [targetModeEnabledTools, setTargetModeEnabledTools] = useState<string[] | null>(null);
   const [targetModeToolsResolved, setTargetModeToolsResolved] = useState(false);
@@ -2929,10 +2931,12 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     if (!shouldLoadResolvedModeSkills) {
       setResolvedModeSkills([]);
       setResolvedModeSkillsLoading(false);
+      setResolvedModeSkillsLoadFailed(false);
       return;
     }
     let cancelled = false;
     setResolvedModeSkillsLoading(true);
+    setResolvedModeSkillsLoadFailed(false);
     (async () => {
       try {
         const list = await configAPI.getModeSkillConfigs({
@@ -2950,6 +2954,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
         });
         if (!cancelled) {
           setResolvedModeSkills([]);
+          setResolvedModeSkillsLoadFailed(true);
         }
       } finally {
         if (!cancelled) {
@@ -2960,7 +2965,16 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [shouldLoadResolvedModeSkills, skillResolutionModeId, targetWorkspacePath]);
+  }, [
+    resolvedModeSkillsRequestVersion,
+    shouldLoadResolvedModeSkills,
+    skillResolutionModeId,
+    targetWorkspacePath,
+  ]);
+
+  const retryResolvedModeSkills = useCallback(() => {
+    setResolvedModeSkillsRequestVersion(version => version + 1);
+  }, []);
 
   useEffect(() => {
     if (!modeState.dropdownOpen) {
@@ -5930,6 +5944,16 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                               ? t('chatInput.boostSkillsLoading')
                               : t('chatInput.loadingMcpPrompts')}
                           </div>
+                        ) : items.length === 0 && resolvedModeSkillsLoadFailed ? (
+                          <button
+                            type="button"
+                            className="bitfun-chat-input__slash-command-empty bitfun-chat-input__slash-command-empty--retry"
+                            data-bf-component="chat-input"
+                            data-bf-part="commandEmpty"
+                            onClick={retryResolvedModeSkills}
+                          >
+                            {t('chatInput.boostSkillsLoadFailed')}
+                          </button>
                         ) : items.length > 0 ? (
                           items.map((item, index) => {
                             const commandText = item.kind === 'mode' ? `/${item.id}` : item.command;
@@ -6056,6 +6080,16 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                           <div className="bitfun-chat-input__slash-command-empty" data-bf-component="chat-input" data-bf-part="commandEmpty">
                             {t('chatInput.boostSkillsLoading')}
                           </div>
+                        ) : items.length === 0 && resolvedModeSkillsLoadFailed ? (
+                          <button
+                            type="button"
+                            className="bitfun-chat-input__slash-command-empty bitfun-chat-input__slash-command-empty--retry"
+                            data-bf-component="chat-input"
+                            data-bf-part="commandEmpty"
+                            onClick={retryResolvedModeSkills}
+                          >
+                            {t('chatInput.boostSkillsLoadFailed')}
+                          </button>
                         ) : items.length > 0 ? (
                           items.map((item, index) => {
                             const commandText = item.kind === 'mode' ? `/${item.id}` : item.command;
@@ -6403,6 +6437,20 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                                     <Loader2 size={14} className="bitfun-chat-input__boost-submenu-spinner" aria-hidden />
                                     <span>{t('chatInput.boostSkillsLoading')}</span>
                                   </div>
+                                ) : resolvedModeSkillsLoadFailed ? (
+                                  <button
+                                    type="button"
+                                    className="bitfun-chat-input__boost-submenu-empty bitfun-chat-input__boost-submenu-retry"
+                                    data-bf-component="chat-input"
+                                    data-bf-part="boostSubmenuState"
+                                    onClick={event => {
+                                      event.stopPropagation();
+                                      retryResolvedModeSkills();
+                                    }}
+                                  >
+                                    <RotateCcw size={13} aria-hidden />
+                                    <span>{t('chatInput.boostSkillsLoadFailed')}</span>
+                                  </button>
                                 ) : userInvocableSkills.length === 0 ? (
                                   <div className="bitfun-chat-input__boost-submenu-empty" data-bf-component="chat-input" data-bf-part="boostSubmenuState" data-bf-state="empty">{t('chatInput.boostSkillsEmpty')}</div>
                                 ) : (

--- a/src/web-ui/src/infrastructure/api/service-api/ApiClient.test.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/ApiClient.test.ts
@@ -220,6 +220,31 @@ describe('ApiClient startup trace classification', () => {
     await expect(pending).resolves.toEqual({ loggedIn: true });
   });
 
+  it('enforces the configured timeout for stalled Tauri commands', async () => {
+    vi.useFakeTimers();
+    try {
+      adapterMocks.request.mockReturnValueOnce(new Promise(() => {}));
+      const client = new ApiClient({ enableLogging: false, retries: 0 });
+
+      const outcome = client
+        .invoke('get_mode_skill_configs', {}, { timeout: 60_000 })
+        .catch((error: unknown) => error);
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      await expect(outcome).resolves.toMatchObject({
+        code: 'REQUEST_TIMEOUT',
+        message: 'Request timeout',
+      });
+      expect(client.getStats()).toMatchObject({
+        successfulRequests: 0,
+        failedRequests: 1,
+        activeRequests: 0,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('uses the message from plain structured Tauri errors', async () => {
     const transportError = {
       code: 'worktree_not_found',

--- a/src/web-ui/src/infrastructure/api/service-api/ApiClient.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/ApiClient.ts
@@ -149,6 +149,31 @@ function traceTargetForCommand(command: string, payload: unknown): string | unde
   return undefined;
 }
 
+async function waitForTransport<T>(request: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) {
+    const error = new Error('Request timeout');
+    error.name = 'AbortError';
+    throw error;
+  }
+
+  let rejectOnAbort!: (error: Error) => void;
+  const aborted = new Promise<never>((_, reject) => {
+    rejectOnAbort = reject;
+  });
+  const handleAbort = () => {
+    const error = new Error('Request timeout');
+    error.name = 'AbortError';
+    rejectOnAbort(error);
+  };
+  signal.addEventListener('abort', handleAbort, { once: true });
+
+  try {
+    return await Promise.race([request, aborted]);
+  } finally {
+    signal.removeEventListener('abort', handleAbort);
+  }
+}
+
 export class ApiClient implements IApiClient {
   private config: ApiConfig;
   private activeRequests = new Map<string, AbortController>();
@@ -343,7 +368,11 @@ export class ApiClient implements IApiClient {
           this.assertRequestSurface(req, traceCommand);
           if (req.type === 'tauri') {
             transportTiming = {};
-            return this.executeTauriCommand(req.config as TauriCommandConfig, transportTiming);
+            return this.executeTauriCommand(
+              req.config as TauriCommandConfig,
+              transportTiming,
+              controller.signal,
+            );
           } else {
             return this.executeHttpRequest(req.config as HttpRequestConfig, controller.signal);
           }
@@ -482,11 +511,15 @@ export class ApiClient implements IApiClient {
 
   private async executeTauriCommand(
     config: TauriCommandConfig,
-    transportTiming?: TransportRequestTiming
+    transportTiming: TransportRequestTiming | undefined,
+    signal: AbortSignal,
   ): Promise<ApiResponse> {
     try {
       
-      const data = await this.adapter.request(config.command, config.args || {}, transportTiming);
+      const data = await waitForTransport(
+        this.adapter.request(config.command, config.args || {}, transportTiming),
+        signal,
+      );
       
       return {
         success: true,
@@ -496,6 +529,9 @@ export class ApiClient implements IApiClient {
     } catch (error) {
       if (isSurfaceChangedError(error)) {
         throw error;
+      }
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw this.createApiError('REQUEST_TIMEOUT', 'Request timeout', error);
       }
       const errorMessage = transportErrorMessage(error);
       

--- a/src/web-ui/src/infrastructure/api/service-api/ConfigAPI.test.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/ConfigAPI.test.ts
@@ -95,4 +95,31 @@ describe('ConfigAPI batch config reads', () => {
       },
     });
   });
+
+  it('bounds Skill catalog requests at sixty seconds', async () => {
+    invokeMock.mockResolvedValue([]);
+
+    await configAPI.getSkillConfigs({ workspacePath: '/remote/project' });
+    await configAPI.getModeSkillConfigs({
+      modeId: 'agentic',
+      workspacePath: '/remote/project',
+    });
+
+    expect(invokeMock).toHaveBeenNthCalledWith(
+      1,
+      'get_skill_configs',
+      { forceRefresh: undefined, workspacePath: '/remote/project' },
+      { timeout: 60_000 },
+    );
+    expect(invokeMock).toHaveBeenNthCalledWith(
+      2,
+      'get_mode_skill_configs',
+      {
+        modeId: 'agentic',
+        forceRefresh: undefined,
+        workspacePath: '/remote/project',
+      },
+      { timeout: 60_000 },
+    );
+  });
 });

--- a/src/web-ui/src/infrastructure/api/service-api/ConfigAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/ConfigAPI.ts
@@ -73,6 +73,8 @@ export interface DownloadSkillMarketParams {
   workspacePath?: string;
 }
 
+const SKILL_CONFIG_REQUEST_TIMEOUT_MS = 60_000;
+
 
 export class ConfigAPI {
    
@@ -314,7 +316,11 @@ export class ConfigAPI {
     workspacePath,
   }: GetSkillConfigsParams = {}): Promise<SkillInfo[]> {
     try {
-      return await api.invoke('get_skill_configs', { forceRefresh, workspacePath });
+      return await api.invoke(
+        'get_skill_configs',
+        { forceRefresh, workspacePath },
+        { timeout: SKILL_CONFIG_REQUEST_TIMEOUT_MS },
+      );
     } catch (error) {
       throw createTauriCommandError('get_skill_configs', error, { forceRefresh, workspacePath });
     }
@@ -327,7 +333,11 @@ export class ConfigAPI {
     workspacePath,
   }: GetModeSkillConfigsParams): Promise<ModeSkillInfo[]> {
     try {
-      return await api.invoke('get_mode_skill_configs', { modeId, forceRefresh, workspacePath });
+      return await api.invoke(
+        'get_mode_skill_configs',
+        { modeId, forceRefresh, workspacePath },
+        { timeout: SKILL_CONFIG_REQUEST_TIMEOUT_MS },
+      );
     } catch (error) {
       throw createTauriCommandError('get_mode_skill_configs', error, { modeId, forceRefresh, workspacePath });
     }

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -806,6 +806,7 @@
     "boostSkills": "Skills",
     "modeSection": "Directives",
     "boostSkillsLoading": "Loading skills…",
+    "boostSkillsLoadFailed": "Skills failed to load. Retry",
     "boostSkillsEmpty": "No enabled skills",
     "openSkillsLibrary": "Manage skills…",
     "insertSkillLine": "Please use the Skill tool with command \"{{name}}\".",

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -806,6 +806,7 @@
     "boostSkills": "Skills",
     "modeSection": "指令",
     "boostSkillsLoading": "正在加载 Skills…",
+    "boostSkillsLoadFailed": "Skills 加载失败，点击重试",
     "boostSkillsEmpty": "暂无已启用的 Skill",
     "openSkillsLibrary": "管理 Skills…",
     "insertSkillLine": "Please use the Skill tool with command \"{{name}}\".",

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -806,6 +806,7 @@
     "boostSkills": "Skills",
     "modeSection": "指令",
     "boostSkillsLoading": "正在載入 Skills…",
+    "boostSkillsLoadFailed": "Skills 載入失敗，點擊重試",
     "boostSkillsEmpty": "暫無已啟用的 Skill",
     "openSkillsLibrary": "管理 Skills…",
     "insertSkillLine": "Please use the Skill tool with command \"{{name}}\".",


### PR DESCRIPTION
## Summary

- cap remote workspace Skill discovery at 60 seconds, including remote file-service acquisition and SSH/SFTP scanning
- make Tauri API calls honor their configured timeout and apply the 60-second budget to Skill catalog requests
- replace the indefinite loading state with a localized retry action in the Skills flyout and slash-command results

## Verification

- `cargo test -p bitfun-desktop api::skill_api::tests --lib`
- `pnpm --dir src/web-ui run test:run src/infrastructure/api/service-api/ApiClient.test.ts src/infrastructure/api/service-api/ConfigAPI.test.ts`
- `pnpm run check:web`
- `pnpm run i18n:audit`
- `pnpm --dir src/web-ui run build:desktop`

## Remote scenarios

- Remote workspace: timeout behavior covered by focused unit tests; no live SSH host was used for manual verification.
- Remote control, Peer Device Mode, and Detached Dispatch: unaffected.