### PR TITLE
fix(flow-chat): route permission requests to a single owner

### DIFF
--- a/src/web-ui/src/flow_chat/components/btw/BtwSessionPanel.tsx
+++ b/src/web-ui/src/flow_chat/components/btw/BtwSessionPanel.tsx
@@ -5,6 +5,9 @@ import {CornerUpLeft, Link2, Loader2, Square, Sparkles} from 'lucide-react';
 import {FlowChatContext, FlowChatVolatileContext} from '../modern/FlowChatContext';
 import {VirtualItemRenderer} from '../modern/VirtualItemRenderer';
 import {RuntimeStatusSlot} from '../modern/RuntimeStatusSlot';
+import {PermissionRequestPanel} from '../modern/PermissionRequestPanel';
+import {pendingPermissionToolCallIdsForSession} from '../modern/permissionRequestRouting';
+import {usePermissionRequests} from '../modern/usePermissionRequests';
 import {useExploreGroupState} from '../modern/useExploreGroupState';
 import {ScrollToBottomButton} from '@/flow_chat';
 import {flowChatStore} from '../../store/FlowChatStore';
@@ -153,6 +156,22 @@ export const BtwSessionPanel: React.FC<BtwSessionPanelProps> = ({
   const actionBarRef = useRef<HTMLDivElement>(null);
   const [actionBarHeight, setActionBarHeight] = useState(0);
   const shouldAutoScrollRef = useRef(true);
+
+  // BTW/review sessions render outside ModernFlowChatContainer, so they must
+  // own the same permission mailbox projection. Without this, a tool call can
+  // be waiting for runtime authorization while the embedded panel has no way
+  // to show or answer the request.
+  const {
+    requests: permissionRequests,
+    ownedRequests: ownedPermissionRequests,
+    ownedActiveBatch: activePermissionBatch,
+    respond: respondPermission,
+    respondBatch: respondPermissionBatch,
+  } = usePermissionRequests(childSessionId);
+  const pendingPermissionToolCallIds = useMemo(
+    () => pendingPermissionToolCallIdsForSession(permissionRequests, childSessionId),
+    [permissionRequests, childSessionId],
+  );
 
   useEffect(() => {
     return flowChatStore.subscribe(setFlowChatState);
@@ -372,7 +391,29 @@ export const BtwSessionPanel: React.FC<BtwSessionPanelProps> = ({
 
   const volatileContextValue = useMemo(() => ({
     exploreGroupStates,
-  }), [exploreGroupStates]);
+    pendingPermissionToolCallIds,
+  }), [exploreGroupStates, pendingPermissionToolCallIds]);
+
+  const activePermissionPanelSnapshot = childSession && activePermissionBatch
+    ? {
+        ownerSessionId: childSession.sessionId,
+        batch: activePermissionBatch,
+        totalPendingCount: ownedPermissionRequests.length,
+        onRespond: respondPermission,
+        onRespondBatch: respondPermissionBatch,
+      }
+    : null;
+  const retainedPermissionPanelSnapshotRef = useRef(activePermissionPanelSnapshot);
+  let renderedPermissionPanelSnapshot = activePermissionPanelSnapshot;
+  if (activePermissionPanelSnapshot) {
+    retainedPermissionPanelSnapshotRef.current = activePermissionPanelSnapshot;
+  } else if (
+    retainedPermissionPanelSnapshotRef.current?.ownerSessionId === childSessionId
+  ) {
+    renderedPermissionPanelSnapshot = retainedPermissionPanelSnapshotRef.current;
+  } else {
+    retainedPermissionPanelSnapshotRef.current = null;
+  }
 
   const lastDialogTurn = childSession?.dialogTurns[childSession.dialogTurns.length - 1];
   const isTurnProcessing = isActiveReviewTurnStatus(lastDialogTurn?.status);
@@ -1059,6 +1100,19 @@ export const BtwSessionPanel: React.FC<BtwSessionPanelProps> = ({
             )}
           </div>
         </div>
+
+        <PresenceBoundary active={activePermissionPanelSnapshot != null}>
+          {renderedPermissionPanelSnapshot ? (
+            <PermissionRequestPanel
+              key={`${renderedPermissionPanelSnapshot.batch.sessionId}:${renderedPermissionPanelSnapshot.batch.roundId}`}
+              requests={renderedPermissionPanelSnapshot.batch.requests}
+              totalPendingCount={renderedPermissionPanelSnapshot.totalPendingCount}
+              visible={activePermissionPanelSnapshot != null}
+              onRespond={renderedPermissionPanelSnapshot.onRespond}
+              onRespondBatch={renderedPermissionPanelSnapshot.onRespondBatch}
+            />
+          ) : null}
+        </PresenceBoundary>
 
         <div
           ref={scrollContainerRef}

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
@@ -468,7 +468,8 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
 
   const {
     requests: permissionRequests,
-    activeBatch: activePermissionBatch,
+    ownedRequests: ownedPermissionRequests,
+    ownedActiveBatch: activePermissionBatch,
     respond: respondPermission,
     respondBatch: respondPermissionBatch,
   } = usePermissionRequests(activeSession?.sessionId);
@@ -476,7 +477,7 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
     ? {
         ownerSessionId: activeSession.sessionId,
         batch: activePermissionBatch,
-        totalPendingCount: permissionRequests.length,
+        totalPendingCount: ownedPermissionRequests.length,
         aboveChatInput: permissionPanelAboveChatInput,
         onRespond: respondPermission,
         onRespondBatch: respondPermissionBatch,

--- a/src/web-ui/src/flow_chat/components/modern/permissionRequestRouting.test.ts
+++ b/src/web-ui/src/flow_chat/components/modern/permissionRequestRouting.test.ts
@@ -3,8 +3,12 @@ import type { PermissionRequest } from '@/infrastructure/api/service-api/AgentAP
 import {
   applyPermissionRequestEvent,
   pendingPermissionToolCallIdsForSession,
+  permissionRequestIsOwnedBySession,
+  permissionRequestOwnerSessionId,
   reconcilePermissionRequestSnapshot,
+  selectActivePermissionBatchOwnedBySession,
   selectPermissionRequestsForSession,
+  selectPermissionRequestsOwnedBySession,
   selectActivePermissionBatch,
   sortPermissionRequests,
 } from './permissionRequestRouting';
@@ -61,6 +65,36 @@ describe('permission request routing', () => {
       unrelatedRequest,
     ]);
     expect(selectPermissionRequestsForSession(requests, undefined)).toEqual([]);
+  });
+
+  it('assigns delegated requests to exactly one display owner', () => {
+    const requests = [parentRequest, childRequest, unrelatedRequest];
+
+    expect(permissionRequestOwnerSessionId(parentRequest)).toBe('parent-session');
+    expect(permissionRequestOwnerSessionId(childRequest)).toBe('parent-session');
+    expect(permissionRequestIsOwnedBySession(childRequest, 'parent-session')).toBe(true);
+    expect(permissionRequestIsOwnedBySession(childRequest, 'child-session')).toBe(false);
+
+    expect(selectPermissionRequestsOwnedBySession(requests, 'parent-session')).toEqual([
+      parentRequest,
+      childRequest,
+    ]);
+    expect(selectPermissionRequestsOwnedBySession(requests, 'child-session')).toEqual([]);
+    expect(selectPermissionRequestsOwnedBySession(
+      [request('review-child', 'review-child', 'review-tool')],
+      'review-child',
+    )).toEqual([
+      request('review-child', 'review-child', 'review-tool'),
+    ]);
+  });
+
+  it('does not expose a delegated child batch to the child surface', () => {
+    expect(selectActivePermissionBatchOwnedBySession([childRequest], 'child-session')).toBeUndefined();
+    expect(selectActivePermissionBatchOwnedBySession([childRequest], 'parent-session')).toEqual({
+      sessionId: 'child-session',
+      roundId: 'round-child',
+      requests: [childRequest],
+    });
   });
 
   it('maps delegated requests to the parent Task card and direct requests to their tool card', () => {

--- a/src/web-ui/src/flow_chat/components/modern/permissionRequestRouting.ts
+++ b/src/web-ui/src/flow_chat/components/modern/permissionRequestRouting.ts
@@ -11,6 +11,23 @@ export function permissionRequestBelongsToSession(
   return request.sessionId === sessionId || request.delegation?.parentSessionId === sessionId;
 }
 
+/**
+ * Return the single session surface that owns the user interaction for a
+ * permission request. Delegated subagent requests are surfaced by their
+ * parent task; direct requests stay with the session that emitted them.
+ */
+export function permissionRequestOwnerSessionId(request: PermissionRequest): string {
+  return request.delegation?.parentSessionId ?? request.sessionId;
+}
+
+export function permissionRequestIsOwnedBySession(
+  request: PermissionRequest,
+  sessionId?: string,
+): boolean {
+  if (!sessionId) return false;
+  return permissionRequestOwnerSessionId(request) === sessionId;
+}
+
 export function selectPermissionRequestsForSession(
   requests: readonly PermissionRequest[],
   sessionId?: string,
@@ -20,17 +37,30 @@ export function selectPermissionRequestsForSession(
   );
 }
 
+/**
+ * Select requests for the one UI surface that is allowed to present and
+ * answer them. This is intentionally separate from
+ * `selectPermissionRequestsForSession`, which also projects delegated child
+ * requests into the parent session for task-card state and history context.
+ */
+export function selectPermissionRequestsOwnedBySession(
+  requests: readonly PermissionRequest[],
+  sessionId?: string,
+): PermissionRequest[] {
+  return sortPermissionRequests(
+    requests.filter((request) => permissionRequestIsOwnedBySession(request, sessionId)),
+  );
+}
+
 export interface PermissionRequestBatch {
   sessionId: string;
   roundId: string;
   requests: PermissionRequest[];
 }
 
-export function selectActivePermissionBatch(
-  requests: readonly PermissionRequest[],
-  sessionId?: string,
+function selectActivePermissionBatchFromRequests(
+  routed: readonly PermissionRequest[],
 ): PermissionRequestBatch | undefined {
-  const routed = selectPermissionRequestsForSession(requests, sessionId);
   const first = routed[0];
   if (!first) return undefined;
 
@@ -42,6 +72,24 @@ export function selectActivePermissionBatch(
     roundId: first.roundId,
     requests: batchRequests,
   };
+}
+
+export function selectActivePermissionBatch(
+  requests: readonly PermissionRequest[],
+  sessionId?: string,
+): PermissionRequestBatch | undefined {
+  return selectActivePermissionBatchFromRequests(
+    selectPermissionRequestsForSession(requests, sessionId),
+  );
+}
+
+export function selectActivePermissionBatchOwnedBySession(
+  requests: readonly PermissionRequest[],
+  sessionId?: string,
+): PermissionRequestBatch | undefined {
+  return selectActivePermissionBatchFromRequests(
+    selectPermissionRequestsOwnedBySession(requests, sessionId),
+  );
 }
 
 /**

--- a/src/web-ui/src/flow_chat/components/modern/usePermissionRequests.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/usePermissionRequests.test.tsx
@@ -163,6 +163,7 @@ describe('usePermissionRequests', () => {
     emit({ event: 'asked', request: unrelated });
 
     expect(controller?.requests.map((item) => item.requestId)).toEqual(['child-a', 'child-b']);
+    expect(controller?.ownedRequests.map((item) => item.requestId)).toEqual(['child-a', 'child-b']);
 
     emit({ event: 'asked', request: { ...childA, resources: ['src/lib.rs'] } });
     expect(controller?.requests).toHaveLength(2);
@@ -184,6 +185,27 @@ describe('usePermissionRequests', () => {
     });
     emit({ event: 'cancelled', requestId: childB.requestId, reason: 'parent cancelled' });
     expect(controller?.requests).toEqual([]);
+  });
+
+  it('keeps delegated requests actionable only from the parent surface', async () => {
+    const child = request('delegated-child', 'child-session', 'parent-session');
+
+    await renderHarness(root, 'child-session', (next) => {
+      controller = next;
+    });
+    emit({ event: 'asked', request: child });
+
+    expect(controller?.requests.map((item) => item.requestId)).toEqual(['delegated-child']);
+    expect(controller?.ownedRequests).toEqual([]);
+    expect(controller?.ownedActiveBatch).toBeUndefined();
+
+    await renderHarness(root, 'parent-session', (next) => {
+      controller = next;
+    });
+    expect(controller?.ownedRequests.map((item) => item.requestId)).toEqual(['delegated-child']);
+    expect(controller?.ownedActiveBatch?.requests.map((item) => item.requestId)).toEqual([
+      'delegated-child',
+    ]);
   });
 
   it('removes a request only after a successful explicit response', async () => {

--- a/src/web-ui/src/flow_chat/components/modern/usePermissionRequests.ts
+++ b/src/web-ui/src/flow_chat/components/modern/usePermissionRequests.ts
@@ -5,7 +5,9 @@ import {
 } from '@/infrastructure/api/service-api/AgentAPI';
 import {
   selectActivePermissionBatch,
+  selectActivePermissionBatchOwnedBySession,
   selectPermissionRequestsForSession,
+  selectPermissionRequestsOwnedBySession,
 } from './permissionRequestRouting';
 import { FlowChatStore } from '../../store/FlowChatStore';
 import { driverForSession } from '../../session-drivers/registry';
@@ -86,6 +88,24 @@ export function usePermissionRequests(sessionId?: string) {
     () => selectActivePermissionBatch(effectiveRequests, sessionId),
     [effectiveRequests, sessionId],
   );
+  const ownedRequests = useMemo(
+    () => selectPermissionRequestsOwnedBySession(effectiveRequests, sessionId),
+    [effectiveRequests, sessionId],
+  );
+  const ownedActiveBatch = useMemo(
+    () => selectActivePermissionBatchOwnedBySession(effectiveRequests, sessionId),
+    [effectiveRequests, sessionId],
+  );
 
-  return { requests: sessionRequests, activeBatch, respond, respondBatch };
+  // Keep the broad projection for transcript/task-card state, while exposing
+  // the owner-only projection for permission UI so one request has one
+  // actionable surface.
+  return {
+    requests: sessionRequests,
+    activeBatch,
+    ownedRequests,
+    ownedActiveBatch,
+    respond,
+    respondBatch,
+  };
 }


### PR DESCRIPTION
## Summary

- Render the shared permission mailbox in BTW/review side panels so direct child-session requests can be answered.
- Separate broad transcript/task-card routing from actionable permission ownership, keeping each request on exactly one UI surface.
- Add regression coverage for direct and delegated requests and owner-only active batches.

Ported from [GitCode PR #75](https://gitcode.com/OpenHarmonyPCDeveloper/BitFun/pull/75).

## Type and Areas

Type: regression fix

Areas: Web UI, FlowChat permission routing, BTW/review sessions

## Motivation / Impact

BTW and review sessions render outside `ModernFlowChatContainer`. A direct permission request from one of these child sessions could therefore block its runtime without exposing a way to answer it in the side panel. Delegated requests also need one actionable owner to avoid duplicate permission panels.

This change lets direct review-child requests stay actionable on the child surface while delegated subagent requests remain owned by the parent Task surface.

## Verification

- `pnpm --dir src/web-ui run test:run src/flow_chat/components/modern/permissionRequestRouting.test.ts src/flow_chat/components/modern/usePermissionRequests.test.tsx` — 2 files, 17 tests passed.
- `pnpm --dir src/web-ui run lint` — passed.
- `pnpm run type-check:web` — passed.
- `git diff --check` — passed.
- Manual UI interaction checks were not run, per the local FlowChat verification guide.

Remote scenarios: no live remote scenario was exercised. The owner-selection behavior is covered at unit/hook level; Remote Control and Peer Device Mode remain pending manual integration checks. Remote Workspace and Detached Dispatch are not directly affected by this UI-only change.

## Reviewer Notes

- `git range-diff` confirms this is patch-equivalent to GitCode PR #75 on top of the current GitHub `main`.
- AI-assisted change; automated verification above passed, manual UI verification pending.
- No persisted shapes, protocol contracts, user-visible strings, or locale resources changed.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.