### PR TITLE
fix(flow-chat): make composer context background opaque

### DIFF
--- a/design-system/packages/ui/src/flow-chat/composer/ChatComposer.meta.ts
+++ b/design-system/packages/ui/src/flow-chat/composer/ChatComposer.meta.ts
@@ -22,7 +22,6 @@ export const chatComposerMeta = {
     "color.border.default",
     "color.content.primary",
     "color.surface.panel",
-    "color.surface.subtle",
     "control.chatComposer.compactGap",
     "control.chatComposer.compactHeight",
     "control.chatComposer.compactPaddingBlock",

--- a/design-system/packages/ui/src/flow-chat/composer/ChatComposer.module.css
+++ b/design-system/packages/ui/src/flow-chat/composer/ChatComposer.module.css
@@ -11,7 +11,7 @@
   }
 
   .root[data-has-context="true"] {
-    background: var(--bf-color-surface-subtle);
+    background: var(--bf-color-surface-panel);
   }
 
   .context {

--- a/design-system/packages/ui/tests/chat-composer.test.mjs
+++ b/design-system/packages/ui/tests/chat-composer.test.mjs
@@ -92,8 +92,11 @@ test("ChatComposer geometry is driven by public system and semantic tokens", asy
   assert.match(styles, /--bf-control-chat-composer-control-height/);
   assert.match(styles, /--bf-space-8/);
   assert.match(styles, /--bf-radius-2xl/);
-  assert.match(styles, /--bf-color-surface-subtle/);
   assert.match(styles, /--bf-color-surface-panel/);
+  assert.match(
+    styles,
+    /\.\w+\[data-has-context=(?:"true"|true)\][^{]*\{[^}]*background:\s*var\(--bf-color-surface-panel\)/,
+  );
   assert.match(styles, /--bf-color-action-neutral-border/);
   assert.match(styles, /--bf-shadow-base/);
   assert.match(


### PR DESCRIPTION
## Summary

- Replace the translucent ChatComposer context-band background with the opaque panel surface token.
- Keep the component token metadata aligned with the implementation.
- Add a focused contract assertion so the context band cannot regress to a translucent surface token.

## Type and Areas

Type: UI/UX regression fix

Areas: Design system, Web UI / FlowChat

## Motivation / Impact

The extension band above the conversation input no longer reveals the scene behind it, giving workspace, branch, and worktree context a stable background. There are no product-logic, persisted-data, protocol, or localization changes.

## Verification

- pnpm run check:web — passed, including Web UI type-check, Appearance contracts, theme color audits, and theme visual governance.
- node --test design-system/packages/ui/tests/chat-composer.test.mjs — passed (4/4).
- git diff --check — passed.
- pnpm --filter @bitfun/ui run test — package build and ChatComposer tests passed; the broader suite still exits on the existing unrelated AskUser registry allowed-token assertion.

## Reviewer Notes

- Base branch is 1.0.0-explore because main does not yet contain the ChatComposer implementation changed here.
- Remote workspace, remote control, Peer Device Mode, and Detached Dispatch were not exercised separately; this is a CSS-only shared-component change with no behavioral or transport impact.
- AI-assisted contribution. Testing level: fully tested for the scoped UI change.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are unchanged and not applicable.