### PR TITLE
fix(flow-chat): distinguish composer context surface

### DIFF
--- a/design-system/packages/ui/src/flow-chat/composer/ChatComposer.module.css
+++ b/design-system/packages/ui/src/flow-chat/composer/ChatComposer.module.css
@@ -11,7 +11,13 @@
   }
 
   .root[data-has-context="true"] {
-    background: var(--bf-color-surface-panel);
+    /* Keep the band opaque while moving it toward the foreground: lighter in
+       dark themes and darker in light themes. */
+    background: color-mix(
+      in srgb,
+      var(--bf-color-surface-panel) 94%,
+      var(--bf-color-content-primary) 6%
+    );
   }
 
   .context {

--- a/design-system/packages/ui/tests/chat-composer.test.mjs
+++ b/design-system/packages/ui/tests/chat-composer.test.mjs
@@ -93,10 +93,15 @@ test("ChatComposer geometry is driven by public system and semantic tokens", asy
   assert.match(styles, /--bf-space-8/);
   assert.match(styles, /--bf-radius-2xl/);
   assert.match(styles, /--bf-color-surface-panel/);
-  assert.match(
-    styles,
-    /\.\w+\[data-has-context=(?:"true"|true)\][^{]*\{[^}]*background:\s*var\(--bf-color-surface-panel\)/,
+  const contextBackgroundRule = styles.match(
+    /\.\w+\[data-has-context=(?:"true"|true)\][^{]*\{[^}]*\}/,
   );
+  assert.ok(contextBackgroundRule);
+  assert.match(
+    contextBackgroundRule[0],
+    /background:\s*color-mix\(in srgb,\s*var\(--bf-color-surface-panel\)\s*94%,\s*var\(--bf-color-content-primary\)\s*6%\)/,
+  );
+  assert.doesNotMatch(contextBackgroundRule[0], /\btransparent\b/);
   assert.match(styles, /--bf-color-action-neutral-border/);
   assert.match(styles, /--bf-shadow-base/);
   assert.match(


### PR DESCRIPTION
## Summary

- Follow up on #2618 by restoring visual separation between the composer context band and the input surface without reintroducing transparency.
- Mix the opaque panel surface 94% with primary content 6%, which makes the band lighter in dark themes and darker in light themes.
- Strengthen the ChatComposer contract test to require the theme-adaptive mix and reject a transparent background.

## Type and Areas

Type: UI/UX regression fix

Areas: Design system, Web UI / FlowChat

## Motivation / Impact

Using the panel token directly made the context band visually merge with the input surface. The new opaque mix preserves a distinct hierarchy in both color schemes: approximately #28282b over #1c1c1f in the default dark theme, and #f1f1f1 over #ffffff in the default light theme. No product behavior, persistence, protocol, or localization changes are involved.

## Verification

- pnpm run check:web — passed, including Web UI type-check, Appearance contracts, theme color audits, and visual governance.
- pnpm --filter @bitfun/ui run build — passed.
- node --test design-system/packages/ui/tests/chat-composer.test.mjs — passed (4/4).
- git diff --check — passed.

## Reviewer Notes

- This is a focused visual follow-up to merged PR #2618.
- Remote workspace, remote control, Peer Device Mode, and Detached Dispatch were not exercised separately; this CSS-only shared-component change has no behavioral or transport impact.
- AI-assisted contribution. Testing level: fully tested for the scoped UI change.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above.
- [x] User-facing strings, docs, and locales are unchanged and not applicable.