### PR TITLE
fix(flow-chat): reorganize composer context controls

### DIFF
--- a/src/web-ui/src/features/dispatch/DispatchTargetPicker.scss
+++ b/src/web-ui/src/features/dispatch/DispatchTargetPicker.scss
@@ -248,8 +248,7 @@
     width: 18px;
     padding: 0;
 
-    > span,
-    > .dispatch-target-picker__chevron {
+    > span {
       display: none;
     }
   }

--- a/src/web-ui/src/features/dispatch/DispatchTargetPicker.test.tsx
+++ b/src/web-ui/src/features/dispatch/DispatchTargetPicker.test.tsx
@@ -97,6 +97,7 @@ describe('DispatchTargetPicker overlay', () => {
     const trigger = container.querySelector<HTMLButtonElement>(
       '[data-testid="chat-input-dispatch-trigger"]',
     );
+    expect(trigger?.querySelectorAll('svg')).toHaveLength(1);
     await act(async () => trigger?.click());
 
     const menu = document.querySelector<HTMLElement>('[data-testid="dispatch-target-menu"]');
@@ -104,5 +105,81 @@ describe('DispatchTargetPicker overlay', () => {
     expect(menu?.style.visibility).toBe('visible');
     expect(menu?.style.left).toBe('240px');
     expect(menu?.style.top).toBe('293px');
+  });
+
+  it('offers New Worktree inside the local target and reflects the selected local mode', async () => {
+    const onSelectLocal = vi.fn();
+    const onWorktreeChange = vi.fn();
+    const localWorktreeControl = {
+      enabled: false,
+      locked: false,
+      label: 'New Worktree',
+      description: 'Run in an isolated worktree.',
+      onChange: onWorktreeChange,
+    };
+
+    await act(async () => {
+      root.render(
+        <DispatchTargetPicker
+          target={{ kind: 'local' }}
+          locked={false}
+          localWorktreeControl={localWorktreeControl}
+          onSelectLocal={onSelectLocal}
+          onSelectTarget={vi.fn()}
+        />,
+      );
+    });
+
+    let trigger = container.querySelector<HTMLButtonElement>(
+      '[data-testid="chat-input-dispatch-trigger"]',
+    );
+    expect(trigger?.textContent).toBe('chatInput.dispatch.local');
+    expect(trigger?.querySelectorAll('svg')).toHaveLength(1);
+
+    await act(async () => trigger?.click());
+
+    const localOption = document.querySelector<HTMLButtonElement>(
+      '[data-testid="dispatch-target-local-option"]',
+    );
+    const worktreeOption = document.querySelector<HTMLButtonElement>(
+      '[data-testid="dispatch-target-new-worktree-option"]',
+    );
+    expect(localOption?.getAttribute('aria-checked')).toBe('true');
+    expect(worktreeOption?.textContent).toContain('New Worktree');
+    expect(worktreeOption?.getAttribute('aria-checked')).toBe('false');
+
+    await act(async () => worktreeOption?.click());
+    expect(onSelectLocal).toHaveBeenCalledTimes(1);
+    expect(onWorktreeChange).toHaveBeenLastCalledWith(true);
+    expect(document.querySelector('[data-testid="dispatch-target-menu"]')).toBeNull();
+
+    await act(async () => {
+      root.render(
+        <DispatchTargetPicker
+          target={{ kind: 'local' }}
+          locked={false}
+          localWorktreeControl={{ ...localWorktreeControl, enabled: true }}
+          onSelectLocal={onSelectLocal}
+          onSelectTarget={vi.fn()}
+        />,
+      );
+    });
+
+    trigger = container.querySelector<HTMLButtonElement>(
+      '[data-testid="chat-input-dispatch-trigger"]',
+    );
+    expect(trigger?.textContent).toBe('New Worktree');
+    expect(trigger?.querySelectorAll('svg')).toHaveLength(1);
+
+    await act(async () => trigger?.click());
+    expect(document.querySelector(
+      '[data-testid="dispatch-target-new-worktree-option"]',
+    )?.getAttribute('aria-checked')).toBe('true');
+
+    await act(async () => document.querySelector<HTMLButtonElement>(
+      '[data-testid="dispatch-target-local-option"]',
+    )?.click());
+    expect(onSelectLocal).toHaveBeenCalledTimes(2);
+    expect(onWorktreeChange).toHaveBeenLastCalledWith(false);
   });
 });

--- a/src/web-ui/src/features/dispatch/DispatchTargetPicker.tsx
+++ b/src/web-ui/src/features/dispatch/DispatchTargetPicker.tsx
@@ -8,6 +8,7 @@ import React, {
 } from 'react';
 import { createPortal } from 'react-dom';
 import {
+  FolderGit2,
   Laptop,
   Loader2,
   MonitorSmartphone,
@@ -36,6 +37,13 @@ interface DispatchTargetPickerProps {
   sourceWorkspacePath?: string;
   locked: boolean;
   disabled?: boolean;
+  localWorktreeControl?: {
+    enabled: boolean;
+    locked: boolean;
+    label: string;
+    description: string;
+    onChange: (enabled: boolean) => void;
+  };
   onSelectLocal?: () => void;
   onSelectTarget: (selection: DispatchSelection) => void;
 }
@@ -49,6 +57,7 @@ export const DispatchTargetPicker: React.FC<DispatchTargetPickerProps> = ({
   sourceWorkspacePath,
   locked,
   disabled = false,
+  localWorktreeControl,
   onSelectLocal,
   onSelectTarget,
 }) => {
@@ -72,8 +81,11 @@ export const DispatchTargetPicker: React.FC<DispatchTargetPickerProps> = ({
     layoutRevision: `${targets.length}:${loading}:${error ?? ''}`,
   });
 
+  const localDisplayLabel = localWorktreeControl?.enabled
+    ? localWorktreeControl.label
+    : t('chatInput.dispatch.local');
   const displayLabel = target.kind === 'local'
-    ? t('chatInput.dispatch.local')
+    ? localDisplayLabel
     : target.displayName;
   const tooltip = locked
     ? t('chatInput.dispatch.locked', { target: displayLabel })
@@ -116,6 +128,22 @@ export const DispatchTargetPicker: React.FC<DispatchTargetPickerProps> = ({
     [targets],
   );
 
+  const selectLocalMode = (worktreeEnabled: boolean) => {
+    setOpen(false);
+    onSelectLocal?.();
+    if (
+      localWorktreeControl
+      && localWorktreeControl.enabled !== worktreeEnabled
+    ) {
+      localWorktreeControl.onChange(worktreeEnabled);
+    }
+  };
+
+  const localDirectorySelected =
+    target.kind === 'local' && !localWorktreeControl?.enabled;
+  const localWorktreeSelected =
+    target.kind === 'local' && !!localWorktreeControl?.enabled;
+
   const menu = open ? (
     <ScrollArea
       ref={menuRef}
@@ -143,22 +171,41 @@ export const DispatchTargetPicker: React.FC<DispatchTargetPickerProps> = ({
         <button
           type="button"
           role="menuitemradio"
-          aria-checked={target.kind === 'local'}
+          aria-checked={localDirectorySelected}
           className="dispatch-target-picker__option"
           data-bf-component="dispatch-target-picker"
           data-bf-part="option"
-          onClick={() => {
-            setOpen(false);
-            onSelectLocal?.();
-          }}
+          data-testid="dispatch-target-local-option"
+          disabled={localWorktreeControl?.locked}
+          onClick={() => selectLocalMode(false)}
         >
           <Laptop size={15} aria-hidden />
           <span>
             <strong>{t('chatInput.dispatch.local')}</strong>
             <small>{t('chatInput.dispatch.localDescription')}</small>
           </span>
-          {target.kind === 'local' ? <Icon name="check-line" size="sm" aria-hidden /> : null}
+          {localDirectorySelected ? <Icon name="check-line" size="sm" aria-hidden /> : null}
         </button>
+        {localWorktreeControl ? (
+          <button
+            type="button"
+            role="menuitemradio"
+            aria-checked={localWorktreeSelected}
+            className="dispatch-target-picker__option"
+            data-bf-component="dispatch-target-picker"
+            data-bf-part="option"
+            data-testid="dispatch-target-new-worktree-option"
+            disabled={localWorktreeControl.locked}
+            onClick={() => selectLocalMode(true)}
+          >
+            <FolderGit2 size={15} aria-hidden />
+            <span>
+              <strong>{localWorktreeControl.label}</strong>
+              <small>{localWorktreeControl.description}</small>
+            </span>
+            {localWorktreeSelected ? <Icon name="check-line" size="sm" aria-hidden /> : null}
+          </button>
+        ) : null}
       </div>
 
       <div className="dispatch-target-picker__divider" role="separator" />
@@ -312,14 +359,13 @@ export const DispatchTargetPicker: React.FC<DispatchTargetPickerProps> = ({
             }}
           >
             {target.kind === 'local'
-              ? <Laptop size={12} />
+              ? localWorktreeControl?.enabled
+                ? <FolderGit2 size={12} />
+                : <Laptop size={12} />
               : target.kind === 'device'
                 ? <MonitorSmartphone size={12} />
                 : <Server size={12} />}
             <span>{displayLabel}</span>
-            {!locked ? (
-              <Icon name="chevron-down" size="2xs" className="dispatch-target-picker__chevron" aria-hidden />
-            ) : null}
           </button>
         </Tooltip>
         {menu && createPortal(menu, getAppearanceOverlayHost())}

--- a/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStrip.scss
+++ b/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStrip.scss
@@ -79,9 +79,8 @@ $track-item-gap: 10px;
     opacity: 0.55;
   }
 
-  // One glyph size for the whole track, enforced here so a component that
-  // ships its own `size` prop (the dispatch picker's chevron) still lands on
-  // it without the strip reaching into that component.
+  // One glyph size for the whole track, enforced here so component-owned
+  // icons land on the same rhythm without the strip reaching into them.
   > svg {
     flex: none;
     width: 12px;
@@ -138,15 +137,6 @@ $track-item-gap: 10px;
         overflow: hidden;
         padding-bottom: 1px;
         text-overflow: ellipsis;
-      }
-
-      // The chevron is punctuation, not one of the track's semantic glyphs.
-      // At the shared 12px it outweighed the mark that says which host this
-      // is, which is the thing worth reading.
-      .dispatch-target-picker__chevron {
-        width: 10px;
-        height: 10px;
-        opacity: 0.55;
       }
     }
   }
@@ -686,11 +676,6 @@ $track-item-gap: 10px;
     overflow: hidden;
     text-overflow: ellipsis;
     padding-bottom: 1px;
-  }
-
-  &__workspace-chevron {
-    flex: none;
-    opacity: 0.55;
   }
 
   // Only the interactive form answers a click — the hover fill is the whole

--- a/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStrip.test.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStrip.test.tsx
@@ -32,6 +32,7 @@ vi.mock('react-i18next', () => ({
       'deepReviewConsent.strategyLabels.normal': 'Standard',
       'reasoningSelector.auto': 'Auto',
       'chatInput.permissionMode.ask.label': 'Ask',
+      'strip.newWorktree': 'New Worktree',
     } as Record<string, string>)[key] ?? options?.defaultValue ?? key,
   }),
 }));
@@ -67,10 +68,38 @@ vi.mock('@/tools/git/hooks/useGitState', () => ({
 }));
 
 // The real picker pulls in account state, SSH dialogs and a lazy remote-connect
-// route. This suite only asserts whether the strip mounts it at all.
+// route. This suite observes the strip-to-picker contract through a lightweight
+// stand-in; picker behavior itself stays covered in its focused suite.
 vi.mock('@/features/dispatch/DispatchTargetPicker', () => ({
-  DispatchTargetPicker: ({ locked }: { locked: boolean }) => (
-    <div data-testid="chat-input-dispatch-trigger" data-locked={locked ? 'true' : 'false'} />
+  DispatchTargetPicker: ({
+    locked,
+    localWorktreeControl,
+  }: {
+    locked: boolean;
+    localWorktreeControl?: {
+      enabled: boolean;
+      locked: boolean;
+      label: string;
+      onChange: (enabled: boolean) => void;
+    };
+  }) => (
+    <div
+      data-testid="chat-input-dispatch-trigger"
+      data-locked={locked ? 'true' : 'false'}
+      data-worktree-enabled={localWorktreeControl?.enabled ? 'true' : 'false'}
+      data-worktree-label={localWorktreeControl?.label}
+    >
+      {localWorktreeControl ? (
+        <button
+          type="button"
+          data-testid="dispatch-target-new-worktree-option"
+          disabled={localWorktreeControl.locked}
+          onClick={() => localWorktreeControl.onChange(true)}
+        >
+          {localWorktreeControl.label}
+        </button>
+      ) : null}
+    </div>
   ),
 }));
 
@@ -881,13 +910,14 @@ describe('ChatInputWorkspaceStrip git refresh behavior', () => {
     expect(container.querySelector('[data-testid="chat-input-worktree-toggle"]')).toBeNull();
   });
 
-  it('shows the dispatch picker and the worktree toggle together in a Git workspace', async () => {
+  it('orders workspace and branch before the target and nests worktree under local', async () => {
+    const onChange = vi.fn();
     await act(async () => {
       root.render(
         <ChatInputWorkspaceStrip
           repositoryPath="/repo"
           workspaceLabel="repo"
-          worktreeControl={{ enabled: false, locked: false, onChange: vi.fn() }}
+          worktreeControl={{ enabled: false, locked: false, onChange }}
           dispatchControl={{
             target: { kind: 'local' },
             locked: false,
@@ -897,8 +927,24 @@ describe('ChatInputWorkspaceStrip git refresh behavior', () => {
       );
     });
 
-    expect(container.querySelector('[data-testid="chat-input-worktree-toggle"]')).not.toBeNull();
-    expect(container.querySelector('[data-testid="chat-input-dispatch-trigger"]')).not.toBeNull();
+    const context = container.querySelector<HTMLElement>('[data-bf-part="context"]');
+    const location = context?.querySelector('.bitfun-chat-input-workspace-strip__location');
+    const dispatchTrigger = context?.querySelector<HTMLElement>(
+      '[data-testid="chat-input-dispatch-trigger"]',
+    );
+    expect(context).not.toBeNull();
+    expect(location).not.toBeNull();
+    expect(dispatchTrigger).not.toBeNull();
+    expect(Array.from(context?.children ?? []).indexOf(location as Element))
+      .toBeLessThan(Array.from(context?.children ?? []).indexOf(dispatchTrigger as Element));
+    expect(container.querySelector('[data-testid="chat-input-worktree-toggle"]')).toBeNull();
+    expect(dispatchTrigger?.dataset.worktreeEnabled).toBe('false');
+    expect(dispatchTrigger?.dataset.worktreeLabel).toBe('New Worktree');
+
+    await act(async () => container.querySelector<HTMLButtonElement>(
+      '[data-testid="dispatch-target-new-worktree-option"]',
+    )?.click());
+    expect(onChange).toHaveBeenCalledWith(true);
   });
 
   it('shows the dispatched branch instead of the source branch once dispatch is locked', async () => {

--- a/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStrip.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStrip.tsx
@@ -1,9 +1,10 @@
 /**
  * Two fixed rails in the composer's upper context band.
  *
- * The left rail is the situation the session is in — where it runs, on which
- * branch, and whether that branch is isolated in a worktree. The right rail is
- * the contract for the next turn — how much confirmation it asks for and how
+ * The left rail is the situation the session is in — its workspace and branch,
+ * followed by the local/remote execution target. Worktree isolation is a local
+ * target mode. The right rail is the contract for the next turn — how much
+ * confirmation it asks for and how
  * much context is left. Nothing is centered and no column template is
  * conditional, so a control appearing or disappearing cannot move the rest of
  * the track.
@@ -14,7 +15,6 @@ import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import {
   Check,
-  ChevronDown,
   Circle,
   EyeOff,
   GitBranch,
@@ -95,7 +95,7 @@ export interface ChatInputWorkspaceStripProps {
   /** Resolved target bound to the active session. */
   executionTarget?: SessionExecutionTarget;
   /**
-   * Per-session worktree isolation, rendered next to the branch for Git workspaces.
+   * Per-session worktree isolation, exposed as a local execution-target mode.
    * Omitted when the session cannot host a worktree at all (remote, no session).
    */
   worktreeControl?: {
@@ -402,18 +402,25 @@ export const ChatInputWorkspaceStrip: React.FC<ChatInputWorkspaceStripProps> = (
   const usageTooltip = `${formatCompactTokenCount(usageCurrentTokens)}/${formatCompactTokenCount(usageMaxTokens)} ${usagePercentage}%`;
   const usageDash = `${((usagePercentage / 100) * 62.83).toFixed(2)} 62.83`;
 
-  const handleWorktreeToggle = () => {
+  const handleWorktreeChange = (enabled: boolean) => {
     if (!worktreeControl || worktreeToggleDisabled) {
       return;
     }
-    const nextEnabled = !worktreeEnabledRef.current;
-    worktreeEnabledRef.current = nextEnabled;
-    worktreeControl.onChange(nextEnabled);
+    if (worktreeEnabledRef.current === enabled) {
+      return;
+    }
+    worktreeEnabledRef.current = enabled;
+    worktreeControl.onChange(enabled);
+  };
+
+  const handleWorktreeToggle = () => {
+    handleWorktreeChange(!worktreeEnabledRef.current);
   };
 
   // The branch reports where the session sits; it is a fact, not a control.
-  // Isolation is the control, and it says so with a checkbox of its own rather
-  // than hiding a switch under a label that reads as a breadcrumb.
+  // Isolation is selected from the local destination menu when that picker is
+  // present; the checkbox below remains a fallback for embedded surfaces that
+  // do not expose dispatch targets.
   const renderBranchChip = () => (
     <Tooltip content={branchTooltipContent} placement="top">
       <span className="bitfun-chat-input-workspace-strip__chip bitfun-chat-input-workspace-strip__chip--branch">
@@ -460,11 +467,6 @@ export const ChatInputWorkspaceStrip: React.FC<ChatInputWorkspaceStripProps> = (
             }}
           >
             <span className="bitfun-chat-input-workspace-strip__workspace-name">{label}</span>
-            <ChevronDown
-              className="bitfun-chat-input-workspace-strip__workspace-chevron"
-              size={10}
-              aria-hidden
-            />
           </button>
         </Tooltip>
         {workspaceMenuOpen ? createPortal(
@@ -548,10 +550,9 @@ export const ChatInputWorkspaceStrip: React.FC<ChatInputWorkspaceStripProps> = (
     </Tooltip>
   ) : null);
 
-  // A hairline between segments that are not part of the same thought — the
-  // host picker, the location phrase and the isolation switch are three
-  // separate statements and the row reads calmer when they part on a rule
-  // instead of running together.
+  // A hairline parts the workspace/branch coordinate from the execution
+  // destination. Worktree isolation belongs inside the local destination
+  // menu, so it no longer creates a third statement on this rail.
   const renderDivider = (key: string) => (
     <span
       key={key}
@@ -572,28 +573,33 @@ export const ChatInputWorkspaceStrip: React.FC<ChatInputWorkspaceStripProps> = (
         data-bf-part="context"
         className="bitfun-chat-input-workspace-strip__context"
       >
-        {showDispatchPicker && dispatchControl ? (
-          <>
-            <DispatchTargetPicker
-              target={dispatchControl.target}
-              sourceWorkspacePath={dispatchControl.sourceWorkspacePath}
-              locked={dispatchPickerLocked}
-              onSelectLocal={dispatchControl.onSelectLocal}
-              onSelectTarget={dispatchControl.onSelectTarget}
-            />
-          </>
-        ) : null}
-        {showDispatchPicker && label ? renderDivider('context-host') : null}
         {label ? (
-          <>
-            <span className="bitfun-chat-input-workspace-strip__location">
-              {renderWorkspaceControl()}
-              {renderBranchChip()}
-            </span>
-            {showWorktreeToggle ? renderDivider('context-isolation') : null}
-            {renderWorktreeToggle()}
-          </>
+          <span className="bitfun-chat-input-workspace-strip__location">
+            {renderWorkspaceControl()}
+            {renderBranchChip()}
+          </span>
         ) : null}
+        {showDispatchPicker && label ? renderDivider('context-target') : null}
+        {showDispatchPicker && dispatchControl ? (
+          <DispatchTargetPicker
+            target={dispatchControl.target}
+            sourceWorkspacePath={dispatchControl.sourceWorkspacePath}
+            locked={dispatchPickerLocked}
+            localWorktreeControl={showWorktreeToggle && worktreeControl ? {
+              enabled: worktreeEnabled,
+              locked: worktreeToggleDisabled,
+              label: tWorktrees('strip.newWorktree'),
+              description: worktreeTooltip,
+              onChange: handleWorktreeChange,
+            } : undefined}
+            onSelectLocal={dispatchControl.onSelectLocal}
+            onSelectTarget={dispatchControl.onSelectTarget}
+          />
+        ) : null}
+        {!showDispatchPicker && showWorktreeToggle
+          ? renderDivider('context-isolation')
+          : null}
+        {!showDispatchPicker ? renderWorktreeToggle() : null}
       </div>
 
       <div

--- a/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStripLayout.test.ts
+++ b/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStripLayout.test.ts
@@ -10,6 +10,10 @@ function readLocalFile(name: string): string {
 const readWorkspaceStripStylesheet = () => readLocalFile('ChatInputWorkspaceStrip.scss');
 const readChatInputStylesheet = () => readLocalFile('ChatInput.scss');
 const readWorkspaceStripComponent = () => readLocalFile('ChatInputWorkspaceStrip.tsx');
+const readDispatchTargetPickerComponent = () => readFileSync(
+  fileURLToPath(new URL('../../features/dispatch/DispatchTargetPicker.tsx', import.meta.url)),
+  'utf8',
+).replace(/\r\n/g, '\n');
 
 describe('composer context track layout', () => {
   it('is two fixed rails rather than a conditional column template', () => {
@@ -158,14 +162,21 @@ describe('composer context track layout', () => {
     const stylesheet = readWorkspaceStripStylesheet();
     const contextIndex = component.indexOf('data-bf-part="context"');
     const nextIndex = component.indexOf('data-bf-part="next"');
+    const contextMarkup = component.slice(contextIndex, nextIndex);
+    const locationIndex = contextMarkup.indexOf('__location');
+    const targetIndex = contextMarkup.indexOf('<DispatchTargetPicker');
 
     expect(contextIndex).toBeGreaterThan(-1);
     expect(nextIndex).toBeGreaterThan(contextIndex);
-    // Situation: destination, workspace, branch, and whether it is isolated.
+    // Situation reads in geographic order: workspace and branch first, then
+    // the execution target. Worktree is a local target mode rather than a
+    // third standalone segment.
     expect(component).toContain('<DispatchTargetPicker');
     expect(component).toContain('__location');
     expect(component).toContain('__chip--branch');
-    expect(component).toContain('data-testid="chat-input-worktree-toggle"');
+    expect(locationIndex).toBeGreaterThan(-1);
+    expect(targetIndex).toBeGreaterThan(locationIndex);
+    expect(contextMarkup).toContain('localWorktreeControl=');
     // The workspace doubles as the rail's switcher once more than one is
     // open; the menu lists every open workspace and marks the active one.
     expect(component).toContain('data-testid="chat-input-workspace-trigger"');
@@ -436,20 +447,27 @@ describe('composer context track layout', () => {
     expect(stylesheet).toMatch(
       /@media \(max-width: 460px\)[\s\S]*?__worktree-label \{\n {6}display: none;/,
     );
-    // …while the isolation checkbox, the permission shield, and the context
-    // ring stay.
+    // …while the embedded-surface isolation fallback, the permission shield,
+    // and the context ring stay.
     expect(stylesheet).not.toMatch(/@media[\s\S]*?__worktree-toggle \{\n {6}display: none;/);
     expect(stylesheet).not.toMatch(/@media[\s\S]*?__usage-ring \{\n {6}display: none;/);
     expect(stylesheet).not.toMatch(/@media[\s\S]*?__permission-overview-icon \{\n {6}display: none;/);
   });
 
-  it('states worktree isolation as a checkbox rather than hiding it on the branch', () => {
+  it('nests worktree isolation in the local target and keeps an embedded fallback', () => {
     const component = readWorkspaceStripComponent();
+    const targetPicker = readDispatchTargetPickerComponent();
     const stylesheet = readWorkspaceStripStylesheet();
 
-    // The branch is a fact and the isolation is a control. Folding the switch
-    // into the branch label left the composer with no visible way to say the
-    // session can run somewhere else.
+    // The normal composer offers both local modes in one target menu. A rare
+    // embedded surface without that picker retains the standalone switch so
+    // it does not lose worktree capability.
+    expect(component).toContain('localWorktreeControl={showWorktreeToggle && worktreeControl ? {');
+    expect(component).toContain('!showDispatchPicker ? renderWorktreeToggle() : null');
+    expect(targetPicker).toContain('data-testid="dispatch-target-local-option"');
+    expect(targetPicker).toContain('data-testid="dispatch-target-new-worktree-option"');
+    expect(targetPicker).toContain('<strong>{localWorktreeControl.label}</strong>');
+    expect(targetPicker).toContain('role="menuitemradio"');
     expect(component).toContain('role="switch"');
     expect(component).toContain('__worktree-toggle');
     expect(component).not.toContain('__chip--branch-toggle');
@@ -460,6 +478,18 @@ describe('composer context track layout', () => {
       /&--on \{\n\s*color: var\(--bf-appearance-token-color-accent-500\);/,
     );
     expect(stylesheet).not.toMatch(/&__worktree-toggle \{[\s\S]*?border: 1px/);
+  });
+
+  it('removes down chevrons from the clickable workspace and target labels', () => {
+    const component = readWorkspaceStripComponent();
+    const targetPicker = readDispatchTargetPickerComponent();
+    const stylesheet = readWorkspaceStripStylesheet();
+
+    expect(component).not.toContain('ChevronDown');
+    expect(component).not.toContain('__workspace-chevron');
+    expect(targetPicker).not.toContain('chevron-down');
+    expect(targetPicker).not.toContain('__chevron');
+    expect(stylesheet).not.toContain('__workspace-chevron');
   });
 
   it('answers a blocked turn from the composer stack, not from over the transcript', () => {
@@ -523,5 +553,6 @@ describe('composer context track layout', () => {
       'const dispatchPickerLocked = !!dispatchControl && (dispatchControl.locked || !isGitWorkspace);',
     );
     expect(component).toContain('locked={dispatchPickerLocked}');
+    expect(component).toContain('localWorktreeControl={showWorktreeToggle && worktreeControl ? {');
   });
 });

--- a/src/web-ui/src/locales/en-US/worktrees.json
+++ b/src/web-ui/src/locales/en-US/worktrees.json
@@ -4,6 +4,7 @@
   },
   "strip": {
     "toggleLabel": "worktree",
+    "newWorktree": "New Worktree",
     "toggleOffDescription": "Run this session in its own Git worktree so parallel agents do not disturb each other.",
     "toggleOnDescription": "Running in an isolated worktree at {{path}}. Turn off to run in the project directory.",
     "togglePendingOnDescription": "Worktree isolation is armed. The worktree will be created after you send the first message.",

--- a/src/web-ui/src/locales/zh-CN/worktrees.json
+++ b/src/web-ui/src/locales/zh-CN/worktrees.json
@@ -4,6 +4,7 @@
   },
   "strip": {
     "toggleLabel": "worktree",
+    "newWorktree": "New Worktree",
     "toggleOffDescription": "让这个会话在独立的 Git worktree 中执行，多个 agent 并行跑任务时互不打扰。",
     "toggleOnDescription": "正在隔离的 worktree 中执行：{{path}}。关闭后会回到项目目录。",
     "togglePendingOnDescription": "已开启 worktree 隔离；发送第一条消息后才会创建 worktree。",

--- a/src/web-ui/src/locales/zh-TW/worktrees.json
+++ b/src/web-ui/src/locales/zh-TW/worktrees.json
@@ -4,6 +4,7 @@
   },
   "strip": {
     "toggleLabel": "worktree",
+    "newWorktree": "New Worktree",
     "toggleOffDescription": "讓這個工作階段在獨立的 Git worktree 中執行，多個 agent 並行執行任務時互不干擾。",
     "toggleOnDescription": "正在隔離的 worktree 中執行：{{path}}。關閉後會回到專案目錄。",
     "togglePendingOnDescription": "已開啟 worktree 隔離；傳送第一則訊息後才會建立 worktree。",


### PR DESCRIPTION
## Summary

- reorder the composer context rail to show workspace and branch before the execution target
- move worktree isolation into the local target menu as `New Worktree`, reflecting the selected local mode on the trigger
- remove the down chevrons from the workspace and execution-target controls while preserving their menus
- keep the standalone worktree switch only as a fallback for embedded surfaces without the target picker

## Verification

- `pnpm --dir src/web-ui run test:run src/features/dispatch/DispatchTargetPicker.test.tsx src/flow_chat/components/ChatInputWorkspaceStrip.test.tsx src/flow_chat/components/ChatInputWorkspaceStripLayout.test.ts` (54 tests)
- `pnpm run check:web`
- `pnpm run i18n:audit`
- targeted ESLint for changed TypeScript files (0 errors; test files are ignored by repository config)
- browser visual/interaction QA in dark zh-CN state: workspace menu, local menu, `New Worktree` selection, local restoration, and icon counts

## Remote scenarios

This is a Web UI presentation and local session-mode wiring change. It was exercised in a local browser harness. Remote workspace, remote control, Peer Device Mode, and Detached Dispatch behavior are unchanged and were not separately exercised.

## AI assistance

Implemented and verified with AI assistance.
