### PR TITLE
fix(web-ui): preserve scroll appearance metadata

### DIFF
--- a/design-system/packages/ui/src/components/ScrollArea/ScrollArea.tsx
+++ b/design-system/packages/ui/src/components/ScrollArea/ScrollArea.tsx
@@ -8,6 +8,8 @@ export type ScrollbarVisibility = "auto" | "always" | "hidden";
 export interface ScrollAreaProps extends HTMLAttributes<HTMLDivElement> {
   orientation?: ScrollAreaOrientation;
   scrollbarVisibility?: ScrollbarVisibility;
+  "data-bf-component"?: string;
+  "data-bf-part"?: string;
 }
 
 export const ScrollArea = forwardRef<HTMLDivElement, ScrollAreaProps>(
@@ -15,15 +17,17 @@ export const ScrollArea = forwardRef<HTMLDivElement, ScrollAreaProps>(
     className,
     orientation = "vertical",
     scrollbarVisibility = "auto",
+    "data-bf-component": dataBfComponent = "scroll-area",
+    "data-bf-part": dataBfPart = "viewport",
     ...props
   }, ref) {
     return (
       <div
         {...props}
         className={classNames(styles.root, className)}
-        data-bf-component="scroll-area"
+        data-bf-component={dataBfComponent}
         data-bf-orientation={orientation}
-        data-bf-part="viewport"
+        data-bf-part={dataBfPart}
         data-bf-scrollbar-visibility={scrollbarVisibility}
         ref={ref}
       />

--- a/design-system/packages/ui/tests/scroll-area.test.mjs
+++ b/design-system/packages/ui/tests/scroll-area.test.mjs
@@ -30,6 +30,23 @@ test("ScrollArea exposes orientation and scrollbar visibility contracts", () => 
   assert.match(markup, /data-bf-scrollbar-visibility="always"/);
 });
 
+test("ScrollArea preserves caller-owned appearance metadata", () => {
+  const markup = renderToStaticMarkup(
+    createElement(
+      ScrollArea,
+      {
+        "data-bf-component": "model-settings",
+        "data-bf-part": "provider-list",
+      },
+      "Content",
+    ),
+  );
+
+  assert.match(markup, /data-bf-component="model-settings"/);
+  assert.match(markup, /data-bf-part="provider-list"/);
+  assert.match(markup, /data-bf-orientation="vertical"/);
+});
+
 test("ScrollArea styling uses public scrollbar tokens and preserves native scrolling", async () => {
   const styles = await readFile(
     new URL("../src/components/ScrollArea/ScrollArea.module.css", import.meta.url),

--- a/src/web-ui/src/infrastructure/config/components/HooksConfig.test.tsx
+++ b/src/web-ui/src/infrastructure/config/components/HooksConfig.test.tsx
@@ -30,6 +30,7 @@ vi.mock('@bitfun/ui', () => ({
   Button: ({ children, disabled, onClick }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
     <button type="button" disabled={disabled} onClick={onClick}>{children}</button>
   ),
+  Icon: ({ name }: { name: string }) => <span data-icon={name} />,
   ConfirmDialog: ({ confirmText, isOpen, message, onConfirm, title }: {
     confirmText?: string;
     isOpen: boolean;


### PR DESCRIPTION
## Summary

- preserve caller-owned `data-bf-component` and `data-bf-part` metadata when product surfaces compose `ScrollArea`
- retain the design-system defaults when callers do not supply appearance metadata
- update the `HooksConfig` UI mock for the newly adopted catalog `Icon`

This repairs the two deterministic test files currently failing on the `1.0.0-explore` branch (9 failed tests total) after the ScrollArea/Icon migration.

## Testing

- `pnpm --dir design-system/packages/ui run build && node --test design-system/packages/ui/tests/scroll-area.test.mjs` (4 passed)
- `pnpm --dir src/web-ui run test:run src/infrastructure/config/components/HooksConfig.test.tsx src/infrastructure/config/components/common/ConfigPageLayout.test.tsx` (14 passed)
- `pnpm run check:web:appearance`
- `git diff --check`

## Scope

- no visual styling or product behavior changes beyond restoring the existing caller-owned Appearance metadata contract
- no remote workspace, remote control, peer-device, or detached-dispatch behavior changes

## AI assistance

AI-assisted change; implementation and focused verification were completed locally.
