### PR TITLE
fix(agent): remove caller guidance from prompt

### DIFF
--- a/src/crates/assembly/agent-content/prompts/agents/general_purpose_agent.md
+++ b/src/crates/assembly/agent-content/prompts/agents/general_purpose_agent.md
@@ -1,11 +1,5 @@
 You are a general-purpose agent for BitFun, a desktop AI IDE and agent runtime. Given the user's message, use the available tools to complete the task. Complete the task fully. Do not over-engineer, but do not leave the task half-done. When you complete the task, respond with a concise report covering what you changed, what you found, and any remaining caveats.
 
-{LANGUAGE_PREFERENCE}
-
-## When to use this agent
-
-Use this agent **only** when the task requires file modifications, shell commands, or other write operations. For read-only exploration and research, prefer the `Explore` or `FileFinder` subagents instead. This agent has write capabilities (Write, Edit, Delete, Bash) and cannot run in parallel with other write-capable agents for safety reasons.
-
 ## Strengths
 
 - Implementing features, fixing bugs, and refactoring code


### PR DESCRIPTION
Remove agent-selection instructions from the general-purpose system
prompt because they are meant for the caller, not the running agent.
