### PR TITLE
feat(web): polish remote chat app surfaces

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/NavPanel.scss
+++ b/src/web-ui/src/app/components/NavPanel/NavPanel.scss
@@ -1646,16 +1646,37 @@ $_section-header-height: 22px;
   display: flex;
   flex-shrink: 0;
   align-items: center;
-  gap: 6px;
-  margin-left: 2px;
-  color: var(--bf-appearance-token-color-success);
+  gap: 4px;
+  margin-left: 1px;
+  color: var(--bf-appearance-token-color-text-secondary);
 }
 
 .bitfun-nav-panel__footer-device-status-attached-group {
+  width: 20px;
+  height: 20px;
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 1px;
+  box-sizing: border-box;
+  border: 1px solid var(--bf-appearance-token-border-subtle);
+  border-radius: $size-radius-sm;
+  background: var(--bf-appearance-token-element-bg-subtle);
   line-height: 1;
+
+  &[data-bf-device-kind='message-app'] {
+    border-color: color-mix(
+      in srgb,
+      var(--bf-appearance-token-color-success) 24%,
+      var(--bf-appearance-token-border-subtle)
+    );
+    background: color-mix(
+      in srgb,
+      var(--bf-appearance-token-color-success) 9%,
+      var(--bf-appearance-token-element-bg-subtle)
+    );
+    color: var(--bf-appearance-token-color-success);
+  }
 }
 
 .bitfun-nav-panel__footer-device-status-attached-count {
@@ -2134,15 +2155,19 @@ $_section-header-height: 22px;
 
 // Device overview v2: separate the device roles from the connection service.
 .bitfun-device-overview {
-  width: min(344px, calc(100vw - 16px));
+  width: min(336px, calc(100vw - 16px));
 }
 
 .bitfun-device-overview__header {
-  min-height: 28px;
+  min-height: 24px;
+  padding: 1px 4px 2px;
 
   .bitfun-device-overview__title {
     overflow: hidden;
-    text-align: center;
+    color: var(--bf-appearance-token-color-text-secondary);
+    font-size: var(--bf-appearance-token-font-size-xs);
+    font-weight: 600;
+    text-align: left;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
@@ -2155,9 +2180,11 @@ $_section-header-height: 22px;
 .bitfun-device-overview__local-device {
   display: flex;
   align-items: center;
-  gap: 11px;
-  min-height: 32px;
-  padding: 2px 4px;
+  gap: 10px;
+  min-height: 40px;
+  padding: 4px 6px;
+  border-radius: $size-radius-sm;
+  background: var(--bf-appearance-token-element-bg-subtle);
 
   svg {
     flex-shrink: 0;
@@ -2176,14 +2203,14 @@ $_section-header-height: 22px;
 }
 
 .bitfun-device-overview__device-group {
-  margin-top: 18px;
+  margin-top: 16px;
 
   &.is-primary {
     margin-top: 2px;
   }
 
   h3 {
-    margin: 0 4px 7px;
+    margin: 0 6px 7px;
     color: var(--bf-appearance-token-color-text-muted);
     font-size: 10px;
     font-weight: 600;
@@ -2194,19 +2221,29 @@ $_section-header-height: 22px;
 .bitfun-device-overview__device-rows {
   display: flex;
   flex-direction: column;
-  gap: 3px;
+  gap: 4px;
 }
 
 .bitfun-device-overview__device-row {
   display: grid;
-  grid-template-columns: 18px minmax(0, 1fr) auto;
+  grid-template-columns: 30px minmax(0, 1fr) auto;
   align-items: center;
   gap: 10px;
-  min-height: 32px;
-  padding: 2px 4px;
+  min-height: 42px;
+  padding: 4px 6px;
+  border-radius: $size-radius-sm;
 
-  svg {
-    color: var(--bf-appearance-token-color-text-primary);
+  .is-primary & {
+    background: var(--bf-appearance-token-element-bg-subtle);
+  }
+
+  &[data-bf-device-kind='message-app'] .bitfun-device-overview__device-icon {
+    background: color-mix(
+      in srgb,
+      var(--bf-appearance-token-color-success) 10%,
+      var(--bf-appearance-token-element-bg-subtle)
+    );
+    color: var(--bf-appearance-token-color-success);
   }
 
   strong {
@@ -2241,6 +2278,22 @@ $_section-header-height: 22px;
       background: var(--bf-appearance-token-color-success);
       vertical-align: 1px;
     }
+  }
+}
+
+.bitfun-device-overview__device-icon {
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  border-radius: $size-radius-sm;
+  background: var(--bf-appearance-token-element-bg-soft);
+  color: var(--bf-appearance-token-color-text-primary);
+
+  svg {
+    flex-shrink: 0;
   }
 }
 
@@ -2281,7 +2334,13 @@ $_section-header-height: 22px;
 }
 
 .bitfun-device-overview__actions {
-  padding: 0 4px;
+  margin-top: 2px;
+  padding: 12px 4px 0;
+  border-top: 1px solid var(--bf-appearance-token-border-subtle);
+
+  > [data-bf-component='button'] {
+    min-height: 34px;
+  }
 }
 
 .bitfun-nav-panel__remote-disclaimer {

--- a/src/web-ui/src/app/components/NavPanel/components/DeviceStatusControl.tsx
+++ b/src/web-ui/src/app/components/NavPanel/components/DeviceStatusControl.tsx
@@ -8,6 +8,10 @@ import { useAnchoredPopoverPosition } from '@/shared/utils/useAnchoredPopoverPos
 import { usePeerDeviceModeOptional } from '@/infrastructure/peer-device/peerDeviceContextState';
 import { useNotification } from '@/shared/notification-system';
 import {
+  ChatAppBrandIcon,
+  chatAppBrandFromIdentity,
+} from '../../RemoteConnectDialog/ChatAppBrandIcon';
+import {
   selectActivityFacts,
   selectAttachedGroups,
   type DeviceOverviewActivityFact,
@@ -23,15 +27,26 @@ interface DeviceStatusControlProps {
   onManageDevices: () => void;
 }
 
-function DeviceIcon({ kind, size = 17 }: { kind: DeviceOverviewDeviceKind; size?: number }) {
+function DeviceIcon({
+  identity,
+  kind,
+  size = 17,
+}: {
+  identity?: string | null;
+  kind: DeviceOverviewDeviceKind;
+  size?: number;
+}) {
   const catalogSize = size <= 11 ? '2xs' : size <= 13 ? 'xs' : size <= 15 ? 'sm' : size <= 17 ? 'md' : 'lg';
   switch (kind) {
     case 'mobile':
       return <Smartphone size={size} aria-hidden="true" />;
     case 'execution-host':
       return <Server size={size} aria-hidden="true" />;
-    case 'message-app':
+    case 'message-app': {
+      const chatApp = chatAppBrandFromIdentity(identity);
+      if (chatApp) return <ChatAppBrandIcon app={chatApp} size={size} />;
       return <Icon name="side-chat" size={catalogSize} aria-hidden="true" />;
+    }
     default:
       return <Monitor size={size} aria-hidden="true" />;
   }
@@ -131,6 +146,9 @@ const DeviceStatusControl: React.FC<DeviceStatusControlProps> = ({
     [activityFactSentence, overview],
   );
   const attachedGroups = useMemo(() => selectAttachedGroups(overview), [overview]);
+  const attachedMessageAppIdentity = useMemo(() => (
+    overview.connectedDevices.find(device => device.kind === 'message-app')?.name
+  ), [overview.connectedDevices]);
   const accessibleSummary = [overview.currentWorkDeviceName, ...activityLines].join(' · ');
 
   const deviceActivity = useCallback((device: DeviceOverviewDevice) => {
@@ -147,6 +165,16 @@ const DeviceStatusControl: React.FC<DeviceStatusControlProps> = ({
       }));
     }
     return parts.join(' · ');
+  }, [t]);
+
+  const deviceDisplayName = useCallback((device: DeviceOverviewDevice) => {
+    const chatApp = device.kind === 'message-app'
+      ? chatAppBrandFromIdentity(`${device.id} ${device.name}`)
+      : null;
+    if (chatApp === 'telegram') return 'Telegram';
+    if (chatApp === 'feishu') return t('remoteConnect.feishu');
+    if (chatApp === 'weixin') return t('remoteConnect.weixin');
+    return device.name;
   }, [t]);
 
   const serviceContent = useMemo(() => {
@@ -196,9 +224,14 @@ const DeviceStatusControl: React.FC<DeviceStatusControlProps> = ({
             {attachedGroups.map(group => (
               <span
                 className="bitfun-nav-panel__footer-device-status-attached-group"
+                data-bf-device-kind={group.kind}
                 key={group.kind}
               >
-                <DeviceIcon kind={group.kind} size={13} />
+                <DeviceIcon
+                  identity={group.kind === 'message-app' ? attachedMessageAppIdentity : null}
+                  kind={group.kind}
+                  size={13}
+                />
                 {group.count > 1 && (
                   <span className="bitfun-nav-panel__footer-device-status-attached-count">
                     {group.count}
@@ -238,9 +271,7 @@ const DeviceStatusControl: React.FC<DeviceStatusControlProps> = ({
             }}
           >
             <CardHeader
-              align="center"
               className="bitfun-device-overview__header"
-              contentAlign="center"
               title={<h2 className="bitfun-device-overview__title">{t('deviceOverview.title')}</h2>}
             />
             <ScrollArea className="bitfun-device-overview__scroll">
@@ -250,7 +281,13 @@ const DeviceStatusControl: React.FC<DeviceStatusControlProps> = ({
                   className="bitfun-device-overview__local-device"
                   data-testid="nav-device-status-summary"
                 >
-                  <DeviceIcon kind={overview.primaryDevice.kind} size={19} />
+                  <span className="bitfun-device-overview__device-icon" aria-hidden="true">
+                    <DeviceIcon
+                      identity={`${overview.primaryDevice.id} ${overview.primaryDevice.name}`}
+                      kind={overview.primaryDevice.kind}
+                      size={17}
+                    />
+                  </span>
                   <strong>{overview.currentWorkDeviceName}</strong>
                 </div>
               ) : (
@@ -258,7 +295,13 @@ const DeviceStatusControl: React.FC<DeviceStatusControlProps> = ({
                   <section className="bitfun-device-overview__device-group is-primary">
                     <h3>{t('deviceOverview.currentUse')}</h3>
                     <div className="bitfun-device-overview__device-row">
-                      <DeviceIcon kind={overview.primaryDevice.kind} />
+                      <span className="bitfun-device-overview__device-icon" aria-hidden="true">
+                        <DeviceIcon
+                          identity={`${overview.primaryDevice.id} ${overview.primaryDevice.name}`}
+                          kind={overview.primaryDevice.kind}
+                          size={16}
+                        />
+                      </span>
                       <strong>{overview.primaryDevice.name}</strong>
                       {overview.primaryDevice.activities.includes('background-execution') && (
                         <span>{deviceActivity(overview.primaryDevice)}</span>
@@ -278,8 +321,14 @@ const DeviceStatusControl: React.FC<DeviceStatusControlProps> = ({
                           data-bf-device-kind={device.kind}
                           data-bf-activities={device.activities.join(' ')}
                         >
-                          <DeviceIcon kind={device.kind} />
-                          <strong>{device.name}</strong>
+                          <span className="bitfun-device-overview__device-icon" aria-hidden="true">
+                            <DeviceIcon
+                              identity={`${device.id} ${device.name}`}
+                              kind={device.kind}
+                              size={16}
+                            />
+                          </span>
+                          <strong>{deviceDisplayName(device)}</strong>
                           <span>{deviceActivity(device)}</span>
                         </div>
                       ))}
@@ -321,9 +370,9 @@ const DeviceStatusControl: React.FC<DeviceStatusControlProps> = ({
 
             <CardFooter align="center" className="bitfun-device-overview__actions">
               <Button
-                variant="fill"
+                variant="outline"
                 size="sm"
-                leadingIcon={<Icon name="link" size="lg" />}
+                leadingIcon={<Icon name="link" size="md" />}
                 onClick={handleManageDevices}
                 data-testid="nav-device-status-manage"
               >

--- a/src/web-ui/src/app/components/NavPanel/components/DeviceStatusControl.tsx
+++ b/src/web-ui/src/app/components/NavPanel/components/DeviceStatusControl.tsx
@@ -9,7 +9,7 @@ import { usePeerDeviceModeOptional } from '@/infrastructure/peer-device/peerDevi
 import { useNotification } from '@/shared/notification-system';
 import {
   ChatAppBrandIcon,
-  chatAppBrandFromIdentity,
+  type ChatAppBrand,
 } from '../../RemoteConnectDialog/ChatAppBrandIcon';
 import {
   selectActivityFacts,
@@ -25,6 +25,16 @@ interface DeviceStatusControlProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onManageDevices: () => void;
+}
+
+/** Resolve the provider from backend ids, aliases, or display names. */
+function chatAppBrandFromIdentity(identity: string | null | undefined): ChatAppBrand | null {
+  const normalized = identity?.trim().toLocaleLowerCase();
+  if (!normalized) return null;
+  if (normalized.includes('telegram')) return 'telegram';
+  if (normalized.includes('feishu') || normalized.includes('lark')) return 'feishu';
+  if (normalized.includes('weixin') || normalized.includes('wechat')) return 'weixin';
+  return null;
 }
 
 function DeviceIcon({

--- a/src/web-ui/src/app/components/RemoteConnectDialog/ChatAppBrandIcon.tsx
+++ b/src/web-ui/src/app/components/RemoteConnectDialog/ChatAppBrandIcon.tsx
@@ -5,23 +5,6 @@ interface ChatAppBrandIconProps {
   size?: number;
 }
 
-/** Resolve the provider from backend ids, aliases, or display names. */
-export function chatAppBrandFromIdentity(identity: string | null | undefined): ChatAppBrand | null {
-  const normalized = identity?.trim().toLocaleLowerCase();
-  if (!normalized) return null;
-  if (normalized.includes('telegram')) return 'telegram';
-  if (normalized.includes('feishu') || normalized.includes('lark')) {
-    return 'feishu';
-  }
-  if (
-    normalized.includes('weixin')
-    || normalized.includes('wechat')
-  ) {
-    return 'weixin';
-  }
-  return null;
-}
-
 /**
  * Monochrome contours of the actual chat-app marks. The SVGs intentionally
  * inherit color from the surrounding identity badge so they work in every

--- a/src/web-ui/src/app/components/RemoteConnectDialog/ChatAppBrandIcon.tsx
+++ b/src/web-ui/src/app/components/RemoteConnectDialog/ChatAppBrandIcon.tsx
@@ -1,6 +1,25 @@
+export type ChatAppBrand = 'telegram' | 'feishu' | 'weixin';
+
 interface ChatAppBrandIconProps {
-  app: 'telegram' | 'feishu' | 'weixin';
+  app: ChatAppBrand;
   size?: number;
+}
+
+/** Resolve the provider from backend ids, aliases, or display names. */
+export function chatAppBrandFromIdentity(identity: string | null | undefined): ChatAppBrand | null {
+  const normalized = identity?.trim().toLocaleLowerCase();
+  if (!normalized) return null;
+  if (normalized.includes('telegram')) return 'telegram';
+  if (normalized.includes('feishu') || normalized.includes('lark')) {
+    return 'feishu';
+  }
+  if (
+    normalized.includes('weixin')
+    || normalized.includes('wechat')
+  ) {
+    return 'weixin';
+  }
+  return null;
 }
 
 /**

--- a/src/web-ui/src/app/components/RemoteConnectDialog/RemoteConnectDialog.contract.test.ts
+++ b/src/web-ui/src/app/components/RemoteConnectDialog/RemoteConnectDialog.contract.test.ts
@@ -13,6 +13,10 @@ const chatAppBrandIconSource = readFileSync(
   new URL('./ChatAppBrandIcon.tsx', import.meta.url),
   'utf8',
 );
+const deviceStatusControlSource = readFileSync(
+  new URL('../NavPanel/components/DeviceStatusControl.tsx', import.meta.url),
+  'utf8',
+);
 const accountPanelSource = readFileSync(
   new URL('./AccountPanel.tsx', import.meta.url),
   'utf8',
@@ -98,10 +102,14 @@ describe('Remote Connect safety contracts', () => {
 
   it('uses the real monochrome app marks for every chat provider', () => {
     expect(dialogSource).toContain('<ChatAppBrandIcon app={botTab} size={28} />');
+    expect(dialogSource).toContain('bitfun-remote-connect__chat-brand-group');
+    expect(dialogSource).toContain('<ChatAppBrandIcon app={brand} size={15} />');
     expect(chatAppBrandIconSource).toContain("app === 'telegram'");
     expect(chatAppBrandIconSource).toContain("app === 'feishu'");
     expect(chatAppBrandIconSource.match(/viewBox="0 0 24 24"/g)).toHaveLength(3);
     expect(chatAppBrandIconSource.match(/fill="currentColor"/g)).toHaveLength(5);
+    expect(deviceStatusControlSource).toContain('chatAppBrandFromIdentity(identity)');
+    expect(deviceStatusControlSource).toContain('<ChatAppBrandIcon app={chatApp} size={size} />');
     expect(dialogSource).not.toContain('<Send size={28} />');
     expect(dialogSource).not.toContain('<MessageSquareText size={28} />');
     expect(dialogSource).not.toContain('<MessagesSquare size={28} />');

--- a/src/web-ui/src/app/components/RemoteConnectDialog/RemoteConnectDialog.scss
+++ b/src/web-ui/src/app/components/RemoteConnectDialog/RemoteConnectDialog.scss
@@ -251,6 +251,43 @@
   color: var(--bf-color-content-primary);
 }
 
+[data-bf-component='remote-connect-dialog'][data-bf-part='overviewAction'][data-bf-group='bot'] {
+  grid-template-columns: 70px minmax(0, 1fr) minmax(112px, auto) 16px;
+
+  .bitfun-remote-connect__overview-action-icon {
+    width: 70px;
+    background: transparent;
+  }
+}
+
+.bitfun-remote-connect__chat-brand-group {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+}
+
+.bitfun-remote-connect__chat-brand-item {
+  width: 22px;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: var(--bf-border-width-default) solid var(--bf-color-border-subtle);
+  border-radius: var(--bf-radius-base);
+  background: var(--bf-color-surface-subtle);
+  color: var(--bf-color-content-secondary);
+
+  &[data-connected='true'] {
+    background: color-mix(
+      in srgb,
+      var(--bf-color-accent-default) 12%,
+      var(--bf-color-surface-panel)
+    );
+    color: var(--bf-color-accent-default);
+  }
+}
+
 [data-bf-component='remote-connect-dialog'][data-bf-part='overviewAction'][data-bf-group='account'] {
   .bitfun-remote-connect__overview-action-icon {
     background: color-mix(
@@ -347,6 +384,13 @@
   min-width: 0;
   align-items: center;
   gap: var(--bf-space-1);
+}
+
+.bitfun-remote-connect__tab-brand {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  color: currentColor;
 }
 
 .bitfun-remote-connect__dot-sm {
@@ -791,6 +835,103 @@
   );
 }
 
+.bitfun-remote-connect__connected--bot {
+  align-items: stretch;
+  gap: 0;
+  overflow: hidden;
+  padding: 0;
+  background: var(--bf-color-surface-panel);
+}
+
+.bitfun-remote-connect__connected-app {
+  display: grid;
+  grid-template-columns: 46px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 14px;
+  padding: 20px;
+  border-bottom: var(--bf-border-width-default) solid var(--bf-color-border-subtle);
+}
+
+.bitfun-remote-connect__connected-app-icon {
+  width: 46px;
+  height: 46px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--bf-radius-lg);
+  background: color-mix(
+    in srgb,
+    var(--bf-color-accent-default) 10%,
+    var(--bf-color-surface-panel)
+  );
+  color: var(--bf-color-accent-default);
+}
+
+.bitfun-remote-connect__connected-app-copy {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+
+  strong {
+    color: var(--bf-color-content-primary);
+    font-size: var(--bf-font-size-base);
+    font-weight: var(--bf-font-weight-semibold);
+    line-height: 1.4;
+  }
+
+  > span {
+    max-width: 470px;
+    color: var(--bf-color-content-muted);
+    font-size: var(--bf-font-size-caption);
+    line-height: 1.5;
+  }
+}
+
+.bitfun-remote-connect__connected-notice {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr);
+  align-items: start;
+  gap: 10px;
+  margin: 16px 20px 0;
+  padding: 13px 14px;
+  border: var(--bf-border-width-default) solid var(--bf-color-border-subtle);
+  border-radius: var(--bf-radius-base);
+  background: var(--bf-color-surface-subtle);
+  color: var(--bf-color-content-muted);
+
+  svg {
+    margin-top: 2px;
+  }
+
+  p {
+    margin: 0;
+    font-size: var(--bf-font-size-caption);
+    line-height: 1.6;
+  }
+}
+
+.bitfun-remote-connect__connected-setting {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  margin: 16px 20px 0;
+  padding: 12px 14px;
+  border-radius: var(--bf-radius-base);
+  background: color-mix(
+    in srgb,
+    var(--bf-color-surface-subtle) 72%,
+    var(--bf-color-surface-panel)
+  );
+}
+
+.bitfun-remote-connect__connected-actions {
+  display: flex;
+  justify-content: flex-end;
+  padding: 14px 20px 20px;
+}
+
 .bitfun-remote-connect__hint,
 .bitfun-remote-connect__description {
   width: 100%;
@@ -843,6 +984,10 @@
     color: var(--bf-color-content-primary);
     font-weight: var(--bf-font-weight-semibold);
   }
+}
+
+.bitfun-remote-connect__mode-divider {
+  color: var(--bf-color-border-default);
 }
 
 .bitfun-remote-connect__weixin-qr {
@@ -994,6 +1139,14 @@
     height: 48px;
   }
 
+  [data-bf-component='remote-connect-dialog'][data-bf-part='overviewAction'][data-bf-group='bot'] {
+    grid-template-columns: 70px minmax(0, 1fr) 16px;
+
+    .bitfun-remote-connect__overview-action-icon {
+      width: 70px;
+    }
+  }
+
   .bitfun-remote-connect__overview-action-status {
     grid-column: 2;
     justify-content: flex-start;
@@ -1041,6 +1194,34 @@
 
   .bitfun-remote-connect__bot-identity-description {
     max-width: 360px;
+  }
+
+  .bitfun-remote-connect__connected--bot {
+    margin: 20px 24px 24px;
+  }
+
+  .bitfun-remote-connect__connected-app {
+    grid-template-columns: 42px minmax(0, 1fr);
+    padding: 18px;
+  }
+
+  .bitfun-remote-connect__connected-app-icon {
+    width: 42px;
+    height: 42px;
+  }
+
+  .bitfun-remote-connect__connected-app .bitfun-remote-connect__status {
+    grid-column: 2;
+    justify-self: start;
+  }
+
+  .bitfun-remote-connect__connected-notice,
+  .bitfun-remote-connect__connected-setting {
+    margin-inline: 18px;
+  }
+
+  .bitfun-remote-connect__connected-actions {
+    padding-inline: 18px;
   }
 }
 

--- a/src/web-ui/src/app/components/RemoteConnectDialog/RemoteConnectDialog.tsx
+++ b/src/web-ui/src/app/components/RemoteConnectDialog/RemoteConnectDialog.tsx
@@ -884,6 +884,13 @@ export const RemoteConnectDialog: React.FC<RemoteConnectDialogProps> = ({
     </p>
   );
 
+  const botLabel = (tabId: BotTab | null): string | null => {
+    if (tabId === 'telegram') return 'Telegram';
+    if (tabId === 'feishu') return t('remoteConnect.feishu');
+    if (tabId === 'weixin') return t('remoteConnect.weixin');
+    return null;
+  };
+
   const renderBotIdentity = () => {
     const label = botTab === 'telegram'
       ? 'Telegram'
@@ -1488,13 +1495,6 @@ export const RemoteConnectDialog: React.FC<RemoteConnectDialogProps> = ({
   const networkLabel = (tabId: NetworkTab | null): string | null => {
     const tab = NETWORK_TABS.find(item => item.id === tabId);
     return tab ? t(tab.labelKey) : null;
-  };
-
-  const botLabel = (tabId: BotTab | null): string | null => {
-    if (tabId === 'telegram') return 'Telegram';
-    if (tabId === 'feishu') return t('remoteConnect.feishu');
-    if (tabId === 'weixin') return t('remoteConnect.weixin');
-    return null;
   };
 
   const handleAgreeDisclaimer = useCallback(() => {

--- a/src/web-ui/src/app/components/RemoteConnectDialog/RemoteConnectDialog.tsx
+++ b/src/web-ui/src/app/components/RemoteConnectDialog/RemoteConnectDialog.tsx
@@ -1199,41 +1199,63 @@ export const RemoteConnectDialog: React.FC<RemoteConnectDialogProps> = ({
 
   const renderBotContent = () => {
     if (isBotConnected && connectedBotTab === botTab) {
+      const connectedLabel = botLabel(botTab) ?? botTab;
+      const connectedDescription = t('remoteConnect.botConnectedDescription');
       return (
         <div
           data-bf-component="remote-connect-dialog"
           data-bf-part="body"
           data-bf-state="connected"
-          className="bitfun-remote-connect__connected"
+          className="bitfun-remote-connect__connected bitfun-remote-connect__connected--bot"
         >
-          {botTab === 'weixin' && renderInfoCard(
-            <p className="bitfun-remote-connect__info-text">
-              {t('remoteConnect.botWeixinRestriction')}
-            </p>,
-          )}
-          <div className="bitfun-remote-connect__status" data-bf-component="remote-connect-dialog" data-bf-part="status" data-bf-state="connected">
-            <StatusPill tone="success">{t('remoteConnect.stateConnected')}</StatusPill>
-          </div>
-          <div className="bitfun-remote-connect__mode-setting">
-            <span data-active={!botVerboseMode ? 'true' : undefined}>
-              {t('remoteConnect.botConciseMode')}
+          <div className="bitfun-remote-connect__connected-app">
+            <span className="bitfun-remote-connect__connected-app-icon" aria-hidden="true">
+              <ChatAppBrandIcon app={botTab} size={25} />
             </span>
+            <span className="bitfun-remote-connect__connected-app-copy">
+              <strong>{connectedLabel}</strong>
+              <span>{connectedDescription}</span>
+            </span>
+            <div
+              className="bitfun-remote-connect__status"
+              data-bf-component="remote-connect-dialog"
+              data-bf-part="status"
+              data-bf-state="connected"
+            >
+              <StatusPill tone="success">{t('remoteConnect.stateConnected')}</StatusPill>
+            </div>
+          </div>
+          {botTab === 'weixin' && (
+            <div className="bitfun-remote-connect__connected-notice">
+              <Icon name="info" size="md" aria-hidden="true" />
+              <p>{t('remoteConnect.botWeixinRestriction')}</p>
+            </div>
+          )}
+          <div className="bitfun-remote-connect__connected-setting">
+            <div className="bitfun-remote-connect__mode-setting">
+              <span data-active={!botVerboseMode ? 'true' : undefined}>
+                {t('remoteConnect.botConciseMode')}
+              </span>
+              <span className="bitfun-remote-connect__mode-divider" aria-hidden="true">/</span>
+              <span data-active={botVerboseMode ? 'true' : undefined}>
+                {t('remoteConnect.botVerboseMode')}
+              </span>
+            </div>
             <Switch
               aria-label={`${t('remoteConnect.botConciseMode')} / ${t('remoteConnect.botVerboseMode')}`}
               checked={botVerboseMode}
               onCheckedChange={(checked) => void handleBotVerboseModeChange(checked)}
             />
-            <span data-active={botVerboseMode ? 'true' : undefined}>
-              {t('remoteConnect.botVerboseMode')}
-            </span>
           </div>
-          <Button
-            variant="outline"
-            size="md"
-            onClick={handleDisconnectBot}
-          >
-            {t('remoteConnect.disconnect')}
-          </Button>
+          <div className="bitfun-remote-connect__connected-actions">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleDisconnectBot}
+            >
+              {t('remoteConnect.disconnect')}
+            </Button>
+          </div>
         </div>
       );
     }
@@ -1622,7 +1644,19 @@ export const RemoteConnectDialog: React.FC<RemoteConnectDialogProps> = ({
           })}
           {renderOverviewAction({
             view: 'bot',
-            icon: <Icon name="side-chat" size="lg" />,
+            icon: (
+              <span className="bitfun-remote-connect__chat-brand-group">
+                {BOT_TABS.map(tab => (
+                  <span
+                    className="bitfun-remote-connect__chat-brand-item"
+                    data-connected={isBotConnected && connectedBotTab === tab.id ? 'true' : undefined}
+                    key={tab.id}
+                  >
+                    <ChatAppBrandIcon app={tab.id} size={15} />
+                  </span>
+                ))}
+              </span>
+            ),
             title: t('remoteConnect.chatAppsTitle'),
             description: t('remoteConnect.chatAppsDescription'),
             statusLabel: !hasWorkspace
@@ -1683,10 +1717,19 @@ export const RemoteConnectDialog: React.FC<RemoteConnectDialogProps> = ({
     );
   };
 
-  const renderConnectionTabLabel = (label: string, connected: boolean) => (
+  const renderConnectionTabLabel = (
+    label: string,
+    connected: boolean,
+    brand?: BotTab,
+  ) => (
     <span className="bitfun-remote-connect__tab-label">
-      {connected && <span className="bitfun-remote-connect__dot-sm" aria-hidden="true" />}
+      {brand && (
+        <span className="bitfun-remote-connect__tab-brand" aria-hidden="true">
+          <ChatAppBrandIcon app={brand} size={15} />
+        </span>
+      )}
       <span>{label}</span>
+      {connected && <span className="bitfun-remote-connect__dot-sm" aria-hidden="true" />}
       {connected && (
         <span className="bitfun-remote-connect__visually-hidden">
           {` · ${t('remoteConnect.stateConnected')}`}
@@ -1711,6 +1754,7 @@ export const RemoteConnectDialog: React.FC<RemoteConnectDialogProps> = ({
     label: renderConnectionTabLabel(
       botLabel(tab.id) ?? tab.label,
       isBotConnected && connectedBotTab === tab.id,
+      tab.id,
     ),
     panelId: 'remote-connect-bot-tabpanel',
     value: tab.id,

--- a/src/web-ui/src/infrastructure/config/components/common/ConfigPageLayout.test.tsx
+++ b/src/web-ui/src/infrastructure/config/components/common/ConfigPageLayout.test.tsx
@@ -120,7 +120,7 @@ describe('ConfigPageLayout', () => {
     expect(row?.querySelector('.bitfun-config-page-row__control')).toBeNull();
   });
 
-  it('preserves design-system component ownership while forwarding feature-owned parts', () => {
+  it('forwards feature-owned layout contracts while preserving nested design-system ownership', () => {
     act(() => {
       root.render(
         <ConfigPageLayout
@@ -150,8 +150,8 @@ describe('ConfigPageLayout', () => {
     const contentElement = container.querySelector('[data-testid="feature-content"]');
     const sectionElement = container.querySelector('[data-testid="feature-section"]');
 
-    expect(rootElement?.getAttribute('data-bf-component')).toBe('scroll-area');
-    expect(rootElement?.getAttribute('data-bf-part')).toBe('viewport');
+    expect(rootElement?.getAttribute('data-bf-component')).toBe('model-settings');
+    expect(rootElement?.getAttribute('data-bf-part')).toBe('root');
     expect(contentElement?.getAttribute('data-bf-component')).toBe('model-settings');
     expect(contentElement?.getAttribute('data-bf-part')).toBe('providerSelection');
     expect(sectionElement?.getAttribute('data-bf-component')).toBe('form-section');

--- a/src/web-ui/src/infrastructure/config/components/common/ConfigPageLayout.tsx
+++ b/src/web-ui/src/infrastructure/config/components/common/ConfigPageLayout.tsx
@@ -16,7 +16,12 @@ export const ConfigPageLayout: React.FC<ConfigPageLayoutProps> = ({
   ...props
 }) => {
   return (
-    <ScrollArea className={`bitfun-config-page-layout ${className}`} data-bf-component="config" data-bf-part="root" {...props}>
+    <ScrollArea
+      className={`bitfun-config-page-layout ${className}`}
+      {...props}
+      data-bf-component="scroll-area"
+      data-bf-part="viewport"
+    >
       {children}
       {/* Real DOM spacer: keeps a guaranteed blank tail at the end of the scroll range. */}
       <div className="bitfun-config-page-layout__scroll-end-spacer" aria-hidden="true" />

--- a/src/web-ui/src/infrastructure/config/components/common/ConfigPageLayout.tsx
+++ b/src/web-ui/src/infrastructure/config/components/common/ConfigPageLayout.tsx
@@ -16,12 +16,7 @@ export const ConfigPageLayout: React.FC<ConfigPageLayoutProps> = ({
   ...props
 }) => {
   return (
-    <ScrollArea
-      className={`bitfun-config-page-layout ${className}`}
-      {...props}
-      data-bf-component="scroll-area"
-      data-bf-part="viewport"
-    >
+    <ScrollArea className={`bitfun-config-page-layout ${className}`} data-bf-component="config" data-bf-part="root" {...props}>
       {children}
       {/* Real DOM spacer: keeps a guaranteed blank tail at the end of the scroll range. */}
       <div className="bitfun-config-page-layout__scroll-end-spacer" aria-hidden="true" />

--- a/src/web-ui/src/locales/en-US/common.json
+++ b/src/web-ui/src/locales/en-US/common.json
@@ -1009,6 +1009,7 @@
     "botWeixinPolling": "Waiting for scan…",
     "botVerboseMode": "Verbose Mode",
     "botConciseMode": "Concise Mode",
+    "botConnectedDescription": "This workspace can now send and receive messages through this chat app.",
     "openNgrokSetup": "Open ngrok setup page",
     "disclaimerTitle": "Remote Connect Disclaimer",
     "disclaimerIntro": "Before enabling Remote Connect, please read and accept the following:",

--- a/src/web-ui/src/locales/zh-CN/common.json
+++ b/src/web-ui/src/locales/zh-CN/common.json
@@ -1009,6 +1009,7 @@
     "botWeixinPolling": "等待扫码确认…",
     "botVerboseMode": "详细模式",
     "botConciseMode": "简洁模式",
+    "botConnectedDescription": "当前工作区已可通过该聊天应用收发消息。",
     "openNgrokSetup": "打开 ngrok 安装与配置页面",
     "disclaimerTitle": "远程连接免责声明",
     "disclaimerIntro": "启用远程连接前，请确认你已理解并接受以下事项：",

--- a/src/web-ui/src/locales/zh-TW/common.json
+++ b/src/web-ui/src/locales/zh-TW/common.json
@@ -1009,6 +1009,7 @@
     "botWeixinPolling": "等待掃碼確認…",
     "botVerboseMode": "詳細模式",
     "botConciseMode": "簡潔模式",
+    "botConnectedDescription": "目前工作區已可透過此聊天應用程式收發訊息。",
     "openNgrokSetup": "開啟 ngrok 安裝與設定頁面",
     "disclaimerTitle": "遠程連接免責聲明",
     "disclaimerIntro": "啟用遠程連接前，請確認你已理解並接受以下事項：",


### PR DESCRIPTION
## Summary
- replace generic chat glyphs across the overview, provider tabs, nav status, and device overview with the real monochrome Telegram, Feishu, and WeChat marks
- redesign the connected chat-app panel around app identity, connection state, channel notice, mode control, and a quieter disconnect action
- tighten the device overview hierarchy, icon containers, spacing, and manage-devices action
- localize the connected chat-app description and protect the branded-icon integration with a contract test

## Verification
- pnpm --dir src/web-ui run test:run src/app/components/RemoteConnectDialog/RemoteConnectDialog.contract.test.ts src/app/components/NavPanel/deviceInterconnectionOverview.test.ts (48 tests)
- pnpm run i18n:audit
- pnpm run motion:audit
- pnpm run check:web
- browser visual QA at the desktop dialog and device-overview popover

## Remote scenarios
- Local desktop: exercised in the Vite desktop surface.
- Remote control: Weixin and Telegram controller projections are covered by focused tests; no wire behavior changed.
- Remote workspace, Peer Device Mode, Detached Dispatch: no behavior or protocol changes.