### PR TITLE
fix(execution): treat empty initial turns as successful terminal responses (light-tested)

### DIFF
--- a/src/crates/assembly/core/src/agentic/execution/execution_engine.rs
+++ b/src/crates/assembly/core/src/agentic/execution/execution_engine.rs
@@ -4980,7 +4980,7 @@ impl ExecutionEngine {
         let success = has_final_response
             || matches!(
                 effective_finish_reason,
-                "max_rounds" | "repeated_tool_failures"
+                "max_rounds" | "repeated_tool_failures" | "empty_initial_turn"
             );
 
         // Post-processing hook: when a DeepResearch dialog turn finishes


### PR DESCRIPTION
Closes #2658

## Summary

A turn whose first round carries only system-injection user messages (no real user content) is finalized locally without a model request; the success whitelist only accepts max_rounds/repeated_tool_failures, so this terminal reason classifies as failure. Add empty_initial_turn to the whitelist so locally synthesized terminal turns settle as success like the other no-model-request reasons.

Note: no production path emits empty_initial_turn at this baseline (grep zero hits across the tree at 32f2427697); this is a defensive alignment so the reason settles correctly once an empty-input first-round guard is introduced upstream.

## Changes

- src/crates/assembly/core/src/agentic/execution/execution_engine.rs: the success whitelist (:4983) gains "empty_initial_turn" next to "max_rounds" | "repeated_tool_failures" (single line).
- Commit: 5e3c8617dedff5c0d2af5528e1650e5e5018fb95 — fix(execution): treat empty initial turns as successful terminal responses

## Testing

- cargo check --locked -p bitfun-core --jobs 4 → exit 0
- cargo test --locked -p bitfun-core --lib --features agent-runtime --jobs 4 execution_engine → 48 passed, 0 failed (the agentic tree is behind the agent-runtime feature gate since the crate has default = [])

## Environment

All platforms; baseline 32f2427697.

---
AI-assisted change, reviewed and verified as described above (light-tested locally).
