### PR TITLE
test(windows): stabilize subscription lock contention

### DIFF
--- a/src/crates/adapters/ai-adapters/src/subscription_auth/store.rs
+++ b/src/crates/adapters/ai-adapters/src/subscription_auth/store.rs
@@ -1773,6 +1773,8 @@ mod file_lock_tests {
     const LOCK_CHILD_METADATA_ENV: &str = "BITFUN_SUBAUTH_LOCK_CHILD_METADATA";
     const LOCK_CHILD_STARTED_ENV: &str = "BITFUN_SUBAUTH_LOCK_CHILD_STARTED";
     const LOCK_CHILD_OBSERVED_ENV: &str = "BITFUN_SUBAUTH_LOCK_CHILD_OBSERVED";
+    const CROSS_PROCESS_TEST_LOCK_TIMEOUT: Duration = Duration::from_secs(30);
+    const CROSS_PROCESS_TEST_PROCESS_TIMEOUT: Duration = Duration::from_secs(10);
 
     fn temporary_metadata_path(label: &str) -> PathBuf {
         std::env::temp_dir()
@@ -1781,6 +1783,19 @@ mod file_lock_tests {
                 uuid::Uuid::new_v4()
             ))
             .join("subscription_auth.json")
+    }
+
+    fn assert_store_file_lock_is_contended(metadata_path: &Path) {
+        let lock_path = store_lock_path(metadata_path);
+        let file = open_store_lock_file(&lock_path).expect("open contended transaction lock");
+        match fs2::FileExt::try_lock_exclusive(&file) {
+            Ok(()) => {
+                let _ = fs2::FileExt::unlock(&file);
+                panic!("child transaction unexpectedly acquired the parent lock");
+            }
+            Err(error) if error.raw_os_error() == fs2::lock_contended_error().raw_os_error() => {}
+            Err(error) => panic!("child transaction lock attempt failed unexpectedly: {error}"),
+        }
     }
 
     #[tokio::test]
@@ -1874,11 +1889,13 @@ mod file_lock_tests {
         let observed_path = PathBuf::from(
             std::env::var_os(LOCK_CHILD_OBSERVED_ENV).expect("child observed marker path"),
         );
-        std::fs::write(&started_path, b"started").expect("write child started marker");
+        assert_store_file_lock_is_contended(&metadata_path);
+        std::fs::write(&started_path, b"contended").expect("write child contention marker");
 
-        let _lock = acquire_store_file_lock_with_timeout(&metadata_path, Duration::from_secs(5))
-            .await
-            .expect("child transaction lock");
+        let _lock =
+            acquire_store_file_lock_with_timeout(&metadata_path, CROSS_PROCESS_TEST_LOCK_TIMEOUT)
+                .await
+                .expect("child transaction lock");
         // Keep a lock-regression failure inside the process-local test vault;
         // it must never touch the developer's native credential store.
         set_store_path_for_test(metadata_path.clone());
@@ -1931,14 +1948,13 @@ mod file_lock_tests {
         .spawn()
         .expect("spawn lock-contending child process");
 
-        tokio::time::timeout(Duration::from_secs(2), async {
+        tokio::time::timeout(CROSS_PROCESS_TEST_PROCESS_TIMEOUT, async {
             while !started_path.exists() {
                 tokio::time::sleep(Duration::from_millis(10)).await;
             }
         })
         .await
-        .expect("child should begin its transaction attempt");
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        .expect("child should observe the contended parent transaction lock");
         assert!(
             !observed_path.exists(),
             "child process must not reconcile while the parent transaction is uncommitted"
@@ -1956,7 +1972,7 @@ mod file_lock_tests {
         .expect("parent metadata commit");
         drop(first);
 
-        let status = tokio::time::timeout(Duration::from_secs(5), async {
+        let status = tokio::time::timeout(CROSS_PROCESS_TEST_PROCESS_TIMEOUT, async {
             loop {
                 if let Some(status) = child.try_wait().expect("poll child process") {
                     break status;


### PR DESCRIPTION
## Summary

Stabilize the cross-process subscription-auth file-lock regression test on loaded Windows runners.

The child process now confirms an actual OS-level lock contention before notifying the parent, replacing the previous fixed 100 ms scheduling assumption. Test-only timeout headroom covers Windows process startup, antivirus scanning, and metadata `sync_all` latency without changing production lock behavior.

## Type and Areas

Type: regression fix / test

Areas: Rust, AI adapters, subscription authentication, Windows CI

## Motivation / Impact

The Windows Rust matrix intermittently failed `separate_process_waits_for_metadata_commit_before_reconciliation` because the test announced child startup before the child had attempted the lock and used overlapping five-second timeouts.

No direct user-facing change. Production file-lock behavior is unchanged.

## Verification

- `pnpm run fmt:rs`
- `git diff --check`
- Target test repeated 20 times locally: 20/20 passed
- `cargo test --locked -p bitfun-ai-adapters --features subscription-auth --lib subscription_auth`: 63 passed
- Fork Windows CI `Run subscription authentication tests`: passed
- Fork `Rust Build Check (windows-latest)`: passed
- Fork `Rust / CLI Validation`: passed
- Evidence: https://github.com/wgqqqqq/BitFun/actions/runs/33232411871

The fork run had an unrelated Web UI assertion failure in `ConfigPageLayout.test.tsx`; all Rust and CLI matrix jobs and the Rust/CLI summary gate passed.

## Reviewer Notes

This only changes code under `#[cfg(test)]`. No persisted formats, product behavior, or remote-scenario behavior are affected.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable (not applicable; test-only change).