### PR TITLE
fix(appearance): avoid first theme switch timeout

### DIFF
--- a/src/web-ui/src/app/global-search/bitfunControlBridge.test.ts
+++ b/src/web-ui/src/app/global-search/bitfunControlBridge.test.ts
@@ -79,6 +79,29 @@ describe('BitFunControl presentation bridge', () => {
     expect(reconcile).not.toHaveBeenCalled();
   });
 
+  it('acknowledges a runtime-applied pending appearance before its config mutation completes', async () => {
+    vi.spyOn(appearanceService, 'getSnapshot').mockReturnValue({
+      ...appearanceService.getSnapshot(),
+      status: 'applying',
+      selectedAppearanceId: 'system',
+      pendingSelectionId: 'bitfun-dark',
+    });
+    const pendingApplied = vi.spyOn(appearanceService, 'hasAppliedPendingSelection')
+      .mockReturnValue(true);
+    const reload = vi.spyOn(configManager, 'applyExternalReload').mockResolvedValue(undefined);
+    const reconcile = vi.spyOn(appearanceService, 'reconcilePersistedState').mockResolvedValue(undefined);
+
+    await expect(applyBitFunControlEffect({
+      capabilityId: 'setting.application.appearance',
+      optionId: 'theme',
+      changedPaths: ['appearance.selection'],
+      value: 'bitfun-dark',
+    })).resolves.toEqual({ status: 'alreadyApplied' });
+    expect(pendingApplied).toHaveBeenCalledWith('bitfun-dark');
+    expect(reload).not.toHaveBeenCalled();
+    expect(reconcile).not.toHaveBeenCalled();
+  });
+
   it('applies an Agent appearance mutation through persisted-state reconciliation', async () => {
     vi.spyOn(appearanceService, 'getSnapshot').mockReturnValue({
       ...appearanceService.getSnapshot(),

--- a/src/web-ui/src/app/global-search/bitfunControlBridge.ts
+++ b/src/web-ui/src/app/global-search/bitfunControlBridge.ts
@@ -118,9 +118,11 @@ async function handleRequest(request: BitFunControlRequest): Promise<void> {
 }
 
 function appearanceAlreadyApplied(event: BitFunControlAppliedEvent): boolean {
-  return event.changedPaths.includes('appearance.selection')
-    && typeof event.value === 'string'
-    && appearanceService.getSnapshot().selectedAppearanceId === event.value;
+  if (!event.changedPaths.includes('appearance.selection') || typeof event.value !== 'string') {
+    return false;
+  }
+  return appearanceService.getSnapshot().selectedAppearanceId === event.value
+    || appearanceService.hasAppliedPendingSelection(event.value);
 }
 
 function languageAlreadyApplied(event: BitFunControlAppliedEvent): boolean {

--- a/src/web-ui/src/infrastructure/appearance/runtime/AppearanceService.test.ts
+++ b/src/web-ui/src/infrastructure/appearance/runtime/AppearanceService.test.ts
@@ -143,6 +143,29 @@ describe('AppearanceService', () => {
     });
   });
 
+  it('reports a pending selection after its runtime apply while persistence is in flight', async () => {
+    configMocks.getConfig.mockResolvedValue('system');
+    const pendingWrite = deferred<void>();
+    configMocks.setConfig.mockReturnValueOnce(pendingWrite.promise);
+    const { service } = createService();
+    await service.initialize();
+
+    const selection = service.select('bitfun-dark');
+    await vi.waitFor(() => expect(configMocks.setConfig).toHaveBeenCalledOnce());
+
+    expect(service.getSnapshot()).toMatchObject({
+      status: 'applying',
+      selectedAppearanceId: 'system',
+      pendingSelectionId: 'bitfun-dark',
+    });
+    expect(service.hasAppliedPendingSelection('bitfun-dark')).toBe(true);
+    expect(service.hasAppliedPendingSelection('bitfun-light')).toBe(false);
+
+    pendingWrite.resolve(undefined);
+    await selection;
+    expect(service.hasAppliedPendingSelection('bitfun-dark')).toBe(false);
+  });
+
   it('reconciles externally persisted selections without writing them again', async () => {
     configMocks.getConfig.mockResolvedValueOnce('system').mockResolvedValueOnce('bitfun-dark');
     const { service } = createService();

--- a/src/web-ui/src/infrastructure/appearance/runtime/AppearanceService.ts
+++ b/src/web-ui/src/infrastructure/appearance/runtime/AppearanceService.ts
@@ -174,6 +174,14 @@ export class AppearanceService {
     return this.snapshot;
   }
 
+  hasAppliedPendingSelection(id: AppearanceSelectionId): boolean {
+    if (this.snapshot.status !== 'applying' || this.snapshot.pendingSelectionId !== id) {
+      return false;
+    }
+    const resolvedId = id === SYSTEM_APPEARANCE_ID ? getSystemAppearanceId() : id;
+    return this.runtime.getSnapshot()?.id === resolvedId;
+  }
+
   getPackage(id: string): Promise<AppearancePackage | null> {
     const builtin = getBuiltinAppearance(id);
     if (builtin) return Promise.resolve(builtin);


### PR DESCRIPTION
## Summary

Fix the first theme switch becoming disabled for approximately 20 seconds due to a circular wait between the Web UI appearance transaction and the Desktop ProductControl runtime-effect callback.

The Web UI now acknowledges a pending theme selection only when the corresponding theme has actually been applied to `AppearanceRuntime`. External theme changes continue through the existing persisted-state reconciliation path.

Adds regression coverage for:

- Theme persistence remaining in flight after runtime application.
- ProductControl callbacks received while the new theme is pending.

Fixes #<issue-number>

## Type and Areas

Type:

Regression fix

Areas:

Web UI, Desktop/Tauri ProductControl integration

## Motivation / Impact

The first theme change after startup entered the `applying` state and disabled the theme selectors while waiting for configuration persistence. Desktop ProductControl then requested confirmation from the Web UI, but the Web UI queued reconciliation behind the transaction that was already waiting for that confirmation.

This circular wait ended only after the 20-second ProductControl timeout. It could also roll back the first theme selection and mark the presentation surface as unavailable.

After this change, the first theme switch completes normally without waiting for the timeout. External or Agent-initiated theme changes retain their existing reconciliation behavior.

## Verification

- `pnpm --dir src/web-ui run test:run src/app/global-search/bitfunControlBridge.test.ts src/infrastructure/appearance/runtime/AppearanceService.test.ts`
  - Passed: 2 test files, 30 tests.
- `pnpm run check:web`
  - Passed appearance contract audit.
  - Passed theme color governance checks.
  - Passed theme visual contract validation.
  - Passed Web UI TypeScript type checking.
- `git diff --check`
  - Passed.

Manual Peer Device and remote workspace scenarios were not exercised.

## Reviewer Notes

The fix does not remove the normal `applying`-state UI lock or shorten the backend timeout. It prevents the self-originated ProductControl callback from re-entering the serialized appearance mutation queue.

The acknowledgement requires all of the following:

- The appearance service is currently applying a selection.
- The pending selection matches the ProductControl event value.
- `AppearanceRuntime` confirms that the resolved theme is already active.

No user-facing strings, persisted data shapes, migrations, or backend contracts were changed.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.