### PR TITLE
fix(web-ui): prevent submenus from closing during pointer navigation

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/components/WorkspaceSessionFilterMenu.test.tsx
+++ b/src/web-ui/src/app/components/NavPanel/components/WorkspaceSessionFilterMenu.test.tsx
@@ -32,6 +32,7 @@ describe('WorkspaceSessionFilterMenu', () => {
   let root: Root;
 
   beforeEach(() => {
+    vi.useFakeTimers();
     localStorage.clear();
     const view = useWorkspaceSessionViewStore.getState();
     view.setGrouping('grouped');
@@ -52,6 +53,7 @@ describe('WorkspaceSessionFilterMenu', () => {
     act(() => root.unmount());
     container.remove();
     vi.unstubAllGlobals();
+    vi.useRealTimers();
   });
 
   it('keeps filtering available while grouping lives in the separate quick toggle', () => {
@@ -75,5 +77,49 @@ describe('WorkspaceSessionFilterMenu', () => {
     act(() => filterButton!.click());
     expect(document.querySelector('[data-testid="nav-session-filter-menu"]')).not.toBeNull();
     expect(document.querySelector('[data-testid="nav-session-collapse-all"]')).toBeNull();
+  });
+
+  it.each([
+    { side: 'right', parentLeft: 30, submenuLeft: 255, gapX: 252 },
+    { side: 'left', parentLeft: 300, submenuLeft: 75, gapX: 298 },
+  ])('preserves the $side Portal submenu across a pause in the gap in both directions', ({ parentLeft, submenuLeft, gapX }) => {
+    act(() => container.querySelector<HTMLButtonElement>('[data-testid="nav-session-filter-btn"]')!.click());
+    const menu = document.querySelector<HTMLElement>('[data-testid="nav-session-filter-menu"]')!;
+    const ordering = menu.querySelector<HTMLButtonElement>('[aria-haspopup="menu"]')!;
+    act(() => ordering.click());
+    const submenu = document.querySelector<HTMLElement>('[data-testid="nav-session-filter-ordering-menu"]')!;
+    expect(container.contains(submenu)).toBe(false);
+
+    for (const [element, left] of [[menu, parentLeft], [submenu, submenuLeft]] as const) {
+      element.getBoundingClientRect = () => ({
+        left, right: left + 220, top: 20, bottom: 220,
+        width: 220, height: 200, x: left, y: 20, toJSON: () => ({}),
+      });
+    }
+
+    const pauseInGapFrom = (element: HTMLElement) => {
+      act(() => {
+        element.dispatchEvent(new MouseEvent('pointerout', {
+          bubbles: true, relatedTarget: document.body, clientX: gapX, clientY: 80,
+        }));
+        document.body.dispatchEvent(new MouseEvent('pointermove', {
+          bubbles: true, clientX: gapX, clientY: 80,
+        }));
+      });
+      act(() => vi.advanceTimersByTime(1000));
+      expect(document.querySelector('[data-testid="nav-session-filter-ordering-menu"]')).toBe(submenu);
+    };
+
+    pauseInGapFrom(ordering);
+    act(() => submenu.dispatchEvent(new MouseEvent('pointerover', {
+      bubbles: true, relatedTarget: document.body, clientX: submenuLeft + 20, clientY: 80,
+    })));
+    pauseInGapFrom(submenu);
+
+    act(() => document.body.dispatchEvent(new MouseEvent('pointermove', {
+      bubbles: true, clientX: gapX, clientY: 400,
+    })));
+    act(() => vi.advanceTimersByTime(300));
+    expect(document.querySelector('[data-testid="nav-session-filter-ordering-menu"]')).toBeNull();
   });
 });

--- a/src/web-ui/src/app/components/NavPanel/components/WorkspaceSessionFilterMenu.tsx
+++ b/src/web-ui/src/app/components/NavPanel/components/WorkspaceSessionFilterMenu.tsx
@@ -6,6 +6,7 @@ import { useI18n } from '@/infrastructure/i18n';
 import { getAppearanceOverlayHost } from '@/infrastructure/appearance/runtime/AppearanceOverlayHost';
 import { flowChatStore } from '@/flow_chat/store/FlowChatStore';
 import { Icon, Tooltip } from '@bitfun/ui';
+import { useSubmenuIntent } from '@/shared/utils/useSubmenuIntent';
 import {
   DEFAULT_WORKSPACE_SESSION_VIEW,
   hasWorkspaceSessionFilters,
@@ -54,6 +55,18 @@ const WorkspaceSessionFilterMenu: React.FC = () => {
   const buttonRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
   const submenuRef = useRef<HTMLDivElement>(null);
+  const {
+    requestChange: requestSubmenuChange,
+    requestClose: requestSubmenuClose,
+    keepOpen: keepSubmenuOpen,
+    openNow: openSubmenuNow,
+  } = useSubmenuIntent<Submenu>({
+    activeId: activeSubmenu,
+    onActiveIdChange: setActiveSubmenu,
+    parentRef: menuRef,
+    submenuRef,
+    enabled: open,
+  });
 
   const isCustomized = view.ordering !== DEFAULT_WORKSPACE_SESSION_VIEW.ordering
     || view.show !== DEFAULT_WORKSPACE_SESSION_VIEW.show
@@ -130,9 +143,10 @@ const WorkspaceSessionFilterMenu: React.FC = () => {
       role="menuitem"
       aria-haspopup="menu"
       aria-expanded={activeSubmenu === submenu}
-      onMouseEnter={() => setActiveSubmenu(submenu)}
-      onFocus={() => setActiveSubmenu(submenu)}
-      onClick={() => setActiveSubmenu(submenu)}
+      onPointerEnter={event => requestSubmenuChange(submenu, event)}
+      onPointerLeave={requestSubmenuClose}
+      onFocus={() => openSubmenuNow(submenu)}
+      onClick={() => openSubmenuNow(submenu)}
     >
       <span>{t(`nav.sessions.viewMenu.${submenu}.label`)}</span>
       <span className="bitfun-nav-panel__session-filter-menu-value">
@@ -184,7 +198,7 @@ const WorkspaceSessionFilterMenu: React.FC = () => {
           className={view.filters.hideArchived ? 'is-filtered' : ''}
           role="menuitemcheckbox"
           aria-checked={!view.filters.hideArchived}
-          onMouseEnter={() => setActiveSubmenu(null)}
+          onPointerEnter={event => requestSubmenuChange(null, event)}
           onClick={view.toggleArchived}
         >
           <span>{t('nav.sessions.viewMenu.archived')}</span>
@@ -196,7 +210,7 @@ const WorkspaceSessionFilterMenu: React.FC = () => {
             type="button"
             role="menuitem"
             data-testid="nav-session-collapse-all"
-            onMouseEnter={() => setActiveSubmenu(null)}
+            onPointerEnter={event => requestSubmenuChange(null, event)}
             onClick={() => { view.requestCollapseAll(); close(); }}
           >
             <span>{t('nav.sessions.viewMenu.collapseAll')}</span>
@@ -205,7 +219,7 @@ const WorkspaceSessionFilterMenu: React.FC = () => {
         <button
           type="button"
           role="menuitem"
-          onMouseEnter={() => setActiveSubmenu(null)}
+          onPointerEnter={event => requestSubmenuChange(null, event)}
           onClick={() => {
             for (const session of flowChatStore.getState().sessions.values()) {
               if (session.hasUnreadCompletion) flowChatStore.clearSessionUnreadCompletion(session.sessionId);
@@ -228,6 +242,8 @@ const WorkspaceSessionFilterMenu: React.FC = () => {
           role="menu"
           aria-label={t(`nav.sessions.viewMenu.${activeSubmenu}.label`)}
           data-testid={`nav-session-filter-${activeSubmenu}-menu`}
+          onPointerEnter={keepSubmenuOpen}
+          onPointerLeave={requestSubmenuClose}
         >
           {definition.options.map(option => {
             const selected = definition.kind === 'single'

--- a/src/web-ui/src/flow_chat/components/ChatInputBoostSubmenu.test.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInputBoostSubmenu.test.tsx
@@ -4,7 +4,7 @@
 
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ChatInputBoostSubmenu } from './ChatInputBoostSubmenu';
 
@@ -13,6 +13,7 @@ describe('ChatInputBoostSubmenu', () => {
   let root: Root;
 
   beforeEach(() => {
+    vi.useFakeTimers();
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
       .IS_REACT_ACT_ENVIRONMENT = true;
     container = document.createElement('div');
@@ -23,6 +24,7 @@ describe('ChatInputBoostSubmenu', () => {
   afterEach(() => {
     act(() => root.unmount());
     container.remove();
+    vi.useRealTimers();
   });
 
   it('opens by click or keyboard and closes with the reverse arrow', async () => {
@@ -54,5 +56,47 @@ describe('ChatInputBoostSubmenu', () => {
       trigger?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
     });
     expect(trigger?.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it.each([
+    { label: 'Skills', parentLeft: 30, submenuLeft: 260, gapX: 255 },
+    { label: 'Additional modes', parentLeft: 650, submenuLeft: 420, gapX: 645 },
+  ])('retains gap protection in the extracted $label submenu', ({ label, parentLeft, submenuLeft, gapX }) => {
+    act(() => root.render(
+      <ChatInputBoostSubmenu label={label} icon={<span>+</span>}>
+        <button type="button" role="menuitem">Plan</button>
+      </ChatInputBoostSubmenu>,
+    ));
+
+    const host = container.querySelector<HTMLElement>('.bitfun-chat-input__boost-submenu-host')!;
+    const shell = container.querySelector<HTMLElement>('.bitfun-chat-input__boost-submenu-shell')!;
+    const trigger = container.querySelector<HTMLElement>('[aria-haspopup="menu"]')!;
+    host.getBoundingClientRect = () => new DOMRect(parentLeft, 20, 220, 34);
+    shell.getBoundingClientRect = () => new DOMRect(submenuLeft, 20, 220, 200);
+
+    act(() => trigger.dispatchEvent(new MouseEvent('pointerover', {
+      bubbles: true, clientX: parentLeft + 20, clientY: 30,
+    })));
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+
+    for (const element of [host, shell]) {
+      act(() => element.dispatchEvent(new MouseEvent('pointerout', {
+        bubbles: true, relatedTarget: document.body, clientX: gapX, clientY: 80,
+      })));
+      act(() => vi.advanceTimersByTime(1000));
+      expect(trigger.getAttribute('aria-expanded')).toBe('true');
+      act(() => shell.dispatchEvent(new MouseEvent('pointerover', {
+        bubbles: true, relatedTarget: document.body, clientX: submenuLeft + 20, clientY: 80,
+      })));
+    }
+
+    act(() => document.dispatchEvent(new MouseEvent('pointermove', {
+      bubbles: true, clientX: gapX, clientY: 80,
+    })));
+    act(() => document.dispatchEvent(new MouseEvent('pointermove', {
+      bubbles: true, clientX: gapX, clientY: 400,
+    })));
+    act(() => vi.advanceTimersByTime(180));
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
   });
 });

--- a/src/web-ui/src/flow_chat/components/ChatInputBoostSubmenu.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInputBoostSubmenu.tsx
@@ -1,5 +1,6 @@
-import React, { useCallback, useEffect, useId, useRef, useState } from 'react';
+import React, { useCallback, useId, useRef, useState } from 'react';
 import { ChevronRight } from 'lucide-react';
+import { useSubmenuIntent } from '@/shared/utils/useSubmenuIntent';
 
 interface ChatInputBoostSubmenuProps {
   label: string;
@@ -23,48 +24,46 @@ export const ChatInputBoostSubmenu: React.FC<ChatInputBoostSubmenuProps> = ({
   const [openLeft, setOpenLeft] = useState(false);
   const [openUp, setOpenUp] = useState(false);
   const hostRef = useRef<HTMLDivElement>(null);
-  const closeTimerRef = useRef<number | null>(null);
+  const submenuRef = useRef<HTMLDivElement>(null);
   const panelId = useId();
 
-  const clearCloseTimer = useCallback(() => {
-    if (closeTimerRef.current !== null) {
-      window.clearTimeout(closeTimerRef.current);
-      closeTimerRef.current = null;
+  const setActiveSubmenu = useCallback((id: 'submenu' | null) => {
+    if (id !== null) {
+      const host = hostRef.current;
+      if (host) {
+        const bounds = host.getBoundingClientRect();
+        setOpenLeft(bounds.right + estimatedPanelWidth > window.innerWidth - 8);
+        setOpenUp(bounds.top + estimatedPanelHeight > window.innerHeight - 8);
+      }
     }
-  }, []);
+    setOpen(id !== null);
+  }, [estimatedPanelHeight, estimatedPanelWidth]);
+
+  const {
+    requestChange,
+    requestClose,
+    keepOpen,
+    openNow,
+    closeNow: closeImmediately,
+  } = useSubmenuIntent<'submenu'>({
+    activeId: open ? 'submenu' : null,
+    onActiveIdChange: setActiveSubmenu,
+    parentRef: hostRef,
+    submenuRef,
+    openDelayMs: 0,
+    closeDelayMs: 180,
+  });
 
   const openFlyout = useCallback(() => {
-    clearCloseTimer();
-    const host = hostRef.current;
-    if (host) {
-      const bounds = host.getBoundingClientRect();
-      setOpenLeft(bounds.right + estimatedPanelWidth > window.innerWidth - 8);
-      setOpenUp(bounds.top + estimatedPanelHeight > window.innerHeight - 8);
-    }
-    setOpen(true);
-  }, [clearCloseTimer, estimatedPanelHeight, estimatedPanelWidth]);
-
-  const closeFlyout = useCallback(() => {
-    clearCloseTimer();
-    closeTimerRef.current = window.setTimeout(() => {
-      closeTimerRef.current = null;
-      setOpen(false);
-    }, 150);
-  }, [clearCloseTimer]);
-
-  const closeImmediately = useCallback(() => {
-    clearCloseTimer();
-    setOpen(false);
-  }, [clearCloseTimer]);
-
-  useEffect(() => clearCloseTimer, [clearCloseTimer]);
+    openNow('submenu');
+  }, [openNow]);
 
   return (
     <div
       ref={hostRef}
       className="bitfun-chat-input__boost-submenu-host"
-      onMouseEnter={openFlyout}
-      onMouseLeave={closeFlyout}
+      onPointerEnter={event => requestChange('submenu', event)}
+      onPointerLeave={requestClose}
       data-testid={testId}
     >
       <div
@@ -106,6 +105,9 @@ export const ChatInputBoostSubmenu: React.FC<ChatInputBoostSubmenuProps> = ({
         />
       </div>
       <div
+        ref={submenuRef}
+        onPointerEnter={keepOpen}
+        onPointerLeave={requestClose}
         className={[
           'bitfun-chat-input__boost-submenu-shell',
           open ? 'bitfun-chat-input__boost-submenu-shell--open' : '',

--- a/src/web-ui/src/shared/context-menu-system/components/ui/ContextMenu.test.tsx
+++ b/src/web-ui/src/shared/context-menu-system/components/ui/ContextMenu.test.tsx
@@ -157,6 +157,48 @@ describe('ContextMenu presence', () => {
     expect(document.activeElement).toBe(trigger);
   });
 
+  it('keeps the nested submenu open while pausing in the gap in either direction', () => {
+    act(() => root.render(
+      <ContextMenu
+        items={[{ id: 'share', label: 'Share', submenu: [{ id: 'email', label: 'Email' }] }]}
+        position={{ x: 0, y: 0 }}
+        visible
+        onClose={vi.fn()}
+      />,
+    ));
+    const parentItem = container.querySelector<HTMLElement>('[role="menuitem"]')!;
+    act(() => parentItem.dispatchEvent(new window.MouseEvent('pointerover', {
+      bubbles: true, clientX: 150, clientY: 40,
+    })));
+    act(() => vi.advanceTimersByTime(150));
+
+    const parent = container.querySelector<HTMLElement>('[role="menu"]')!;
+    const submenu = container.querySelector<HTMLElement>('.context-menu-submenu.visible')!;
+    parent.getBoundingClientRect = () => new window.DOMRect(0, 20, 215, 200);
+    submenu.getBoundingClientRect = () => new window.DOMRect(220, 20, 220, 200);
+
+    for (const element of [parentItem, submenu]) {
+      act(() => element.dispatchEvent(new window.MouseEvent('pointerout', {
+        bubbles: true, relatedTarget: document.body, clientX: 218, clientY: 80,
+      })));
+      act(() => vi.advanceTimersByTime(1000));
+      expect(parentItem.getAttribute('aria-expanded')).toBe('true');
+
+      act(() => submenu.dispatchEvent(new window.MouseEvent('pointerover', {
+        bubbles: true, relatedTarget: document.body, clientX: 225, clientY: 80,
+      })));
+    }
+
+    act(() => document.dispatchEvent(new window.MouseEvent('pointermove', {
+      bubbles: true, clientX: 218, clientY: 80,
+    })));
+    act(() => document.dispatchEvent(new window.MouseEvent('pointermove', {
+      bubbles: true, clientX: 218, clientY: 400,
+    })));
+    act(() => vi.advanceTimersByTime(300));
+    expect(parentItem.getAttribute('aria-expanded')).toBe('false');
+  });
+
   it('opens a submenu from the keyboard and keeps keyboard handling in the owning menu', () => {
     const items: ContextMenuItem[] = [{
       id: 'share',

--- a/src/web-ui/src/shared/context-menu-system/components/ui/ContextMenu.tsx
+++ b/src/web-ui/src/shared/context-menu-system/components/ui/ContextMenu.tsx
@@ -3,40 +3,21 @@
 import React, { useEffect, useLayoutEffect, useMemo, useRef, useCallback, useState } from 'react';
 import { ContextMenuProps, ContextMenuItem } from './types';
 import { createLogger } from '@/shared/utils/logger';
+import { useSubmenuIntent } from '@/shared/utils/useSubmenuIntent';
 import './ContextMenu.scss';
 
 const log = createLogger('ContextMenu');
 
 
-const SUBMENU_OPEN_DELAY = 150;   
-const SUBMENU_CLOSE_DELAY = 300;  
-const SAFE_TRIANGLE_TOLERANCE = 50; 
+const SUBMENU_OPEN_DELAY = 150;
+const SUBMENU_CLOSE_DELAY = 300;
+const SUBMENU_SWITCH_DELAY = 300;
+const SAFE_TRIANGLE_TOLERANCE = 50;
 const CONTEXT_MENU_EXIT_DURATION_MS = 100;
 
 interface InternalContextMenuProps extends ContextMenuProps {
   autoFocusOnOpen?: boolean;
   onKeyboardBack?: () => void;
-}
-
- 
-function isPointInTriangle(
-  px: number, py: number,
-  x1: number, y1: number,
-  x2: number, y2: number,
-  x3: number, y3: number
-): boolean {
-  const sign = (p1x: number, p1y: number, p2x: number, p2y: number, p3x: number, p3y: number) => {
-    return (p1x - p3x) * (p2y - p3y) - (p2x - p3x) * (p1y - p3y);
-  };
-
-  const d1 = sign(px, py, x1, y1, x2, y2);
-  const d2 = sign(px, py, x2, y2, x3, y3);
-  const d3 = sign(px, py, x3, y3, x1, y1);
-
-  const hasNeg = (d1 < 0) || (d2 < 0) || (d3 < 0);
-  const hasPos = (d1 > 0) || (d2 > 0) || (d3 > 0);
-
-  return !(hasNeg && hasPos);
 }
 
 export const ContextMenu: React.FC<InternalContextMenuProps> = ({
@@ -60,11 +41,26 @@ export const ContextMenu: React.FC<InternalContextMenuProps> = ({
   const [motionPhase, setMotionPhase] = useState<'entering' | 'entered' | 'exiting'>(
     visible ? 'entering' : 'exiting',
   );
-  
-  
   const [activeSubmenuId, setActiveSubmenuId] = useState<string | null>(null);
-  const submenuOpenTimerRef = useRef<number | null>(null);
-  const submenuCloseTimerRef = useRef<number | null>(null);
+  const activeSubmenuRef = useRef<HTMLDivElement>(null);
+  const {
+    requestChange: requestSubmenuChange,
+    requestClose: requestSubmenuClose,
+    keepOpen: keepSubmenuOpen,
+    openNow: openSubmenuNow,
+    closeNow: closeSubmenuNow,
+    cancelPending: cancelPendingSubmenuIntent,
+  } = useSubmenuIntent<string>({
+    activeId: activeSubmenuId,
+    onActiveIdChange: setActiveSubmenuId,
+    parentRef: menuRef,
+    submenuRef: activeSubmenuRef,
+    enabled: visible,
+    openDelayMs: SUBMENU_OPEN_DELAY,
+    closeDelayMs: SUBMENU_CLOSE_DELAY,
+    switchDelayMs: SUBMENU_SWITCH_DELAY,
+    tolerance: SAFE_TRIANGLE_TOLERANCE,
+  });
   const focusableItemIndices = useMemo(
     () => items.reduce<number[]>((indices, item, index) => {
       if (!item.separator && !item.disabled) {
@@ -77,24 +73,6 @@ export const ContextMenu: React.FC<InternalContextMenuProps> = ({
   const [focusedItemIndex, setFocusedItemIndex] = useState(
     () => focusableItemIndices[0] ?? -1,
   );
-  
-  
-  const lastMousePosRef = useRef<{ x: number; y: number } | null>(null);
-  const menuItemRectRef = useRef<DOMRect | null>(null);
-  const submenuRectRef = useRef<DOMRect | null>(null);
-
-  
-  const clearAllTimers = useCallback(() => {
-    if (submenuOpenTimerRef.current) {
-      clearTimeout(submenuOpenTimerRef.current);
-      submenuOpenTimerRef.current = null;
-    }
-    if (submenuCloseTimerRef.current) {
-      clearTimeout(submenuCloseTimerRef.current);
-      submenuCloseTimerRef.current = null;
-    }
-  }, []);
-
   const restorePreviousFocus = useCallback(() => {
     const previousFocus = previousFocusRef.current;
     if (previousFocus?.isConnected && !previousFocus.matches(':disabled')) {
@@ -188,146 +166,14 @@ export const ContextMenu: React.FC<InternalContextMenuProps> = ({
   }, [visible]);
 
   
-  const handleMenuItemMouseEnter = useCallback((
+  const handleMenuItemPointerEnter = useCallback((
     item: ContextMenuItem,
     index: number,
-    event: React.MouseEvent
-  ) => {
-    
-    clearAllTimers();
-
-    
-    const target = event.currentTarget as HTMLElement;
-    menuItemRectRef.current = target.getBoundingClientRect();
-
-    const itemId = item.id || `item-${index}`;
-
-    
-    if (item.submenu && item.submenu.length > 0) {
-      
-      if (activeSubmenuId === itemId) {
-        return;
-      }
-
-      
-      if (activeSubmenuId) {
-        setActiveSubmenuId(null);
-      }
-
-      
-      submenuOpenTimerRef.current = window.setTimeout(() => {
-        setActiveSubmenuId(itemId);
-      }, SUBMENU_OPEN_DELAY);
-    } else {
-      
-      if (activeSubmenuId) {
-        setActiveSubmenuId(null);
-      }
-    }
-  }, [activeSubmenuId, clearAllTimers]);
-
-  
-  const handleMenuItemMouseLeave = useCallback((
-    item: ContextMenuItem,
-    index: number,
-    event: React.MouseEvent
+    event: React.PointerEvent<HTMLDivElement>,
   ) => {
     const itemId = item.id || `item-${index}`;
-    
-    
-    if (activeSubmenuId !== itemId) {
-      if (submenuOpenTimerRef.current) {
-        clearTimeout(submenuOpenTimerRef.current);
-        submenuOpenTimerRef.current = null;
-      }
-      return;
-    }
-
-    
-    if (item.submenu && item.submenu.length > 0 && menuItemRectRef.current) {
-      const mouseX = event.clientX;
-      const mouseY = event.clientY;
-      
-      
-      lastMousePosRef.current = { x: mouseX, y: mouseY };
-
-      
-      const submenuContainer = event.currentTarget.querySelector('.context-menu-submenu');
-      if (submenuContainer) {
-        submenuRectRef.current = submenuContainer.getBoundingClientRect();
-      }
-
-      
-      submenuCloseTimerRef.current = window.setTimeout(() => {
-        setActiveSubmenuId(null);
-      }, SUBMENU_CLOSE_DELAY);
-    }
-  }, [activeSubmenuId]);
-
-  
-  const handleSubmenuMouseEnter = useCallback(() => {
-    if (submenuCloseTimerRef.current) {
-      clearTimeout(submenuCloseTimerRef.current);
-      submenuCloseTimerRef.current = null;
-    }
-  }, []);
-
-  
-  const handleSubmenuMouseLeave = useCallback(() => {
-    submenuCloseTimerRef.current = window.setTimeout(() => {
-      setActiveSubmenuId(null);
-    }, SUBMENU_CLOSE_DELAY);
-  }, []);
-
-  
-  useEffect(() => {
-    if (!activeSubmenuId || !visible) return;
-
-    const handleMouseMove = (event: MouseEvent) => {
-      const mouseX = event.clientX;
-      const mouseY = event.clientY;
-
-      
-      if (lastMousePosRef.current && submenuRectRef.current && menuItemRectRef.current) {
-        const itemRect = menuItemRectRef.current;
-        const submenuRect = submenuRectRef.current;
-
-        
-        const isInSafeZone = isPointInTriangle(
-          mouseX, mouseY,
-          lastMousePosRef.current.x, lastMousePosRef.current.y,
-          submenuRect.left, submenuRect.top - SAFE_TRIANGLE_TOLERANCE,
-          submenuRect.left, submenuRect.bottom + SAFE_TRIANGLE_TOLERANCE
-        );
-
-        
-        const isInMenuItem = (
-          mouseX >= itemRect.left && mouseX <= itemRect.right &&
-          mouseY >= itemRect.top && mouseY <= itemRect.bottom
-        );
-        const isInSubmenu = (
-          mouseX >= submenuRect.left - 10 && mouseX <= submenuRect.right &&
-          mouseY >= submenuRect.top && mouseY <= submenuRect.bottom
-        );
-
-        
-        if (isInSafeZone || isInMenuItem || isInSubmenu) {
-          if (submenuCloseTimerRef.current) {
-            clearTimeout(submenuCloseTimerRef.current);
-            submenuCloseTimerRef.current = null;
-          }
-        }
-      }
-
-      
-      lastMousePosRef.current = { x: mouseX, y: mouseY };
-    };
-
-    document.addEventListener('mousemove', handleMouseMove);
-    return () => {
-      document.removeEventListener('mousemove', handleMouseMove);
-    };
-  }, [activeSubmenuId, visible]);
+    requestSubmenuChange(item.submenu?.length ? itemId : null, event);
+  }, [requestSubmenuChange]);
 
   
   const activateItem = useCallback(async (item: ContextMenuItem, restoreFocusAfter = false) => {
@@ -370,8 +216,7 @@ export const ContextMenu: React.FC<InternalContextMenuProps> = ({
       return;
     }
 
-    clearAllTimers();
-    setActiveSubmenuId(item.id || `item-${index}`);
+    openSubmenuNow(item.id || `item-${index}`);
     if (submenuFocusFrameRef.current !== null) {
       window.cancelAnimationFrame(submenuFocusFrameRef.current);
     }
@@ -382,7 +227,7 @@ export const ContextMenu: React.FC<InternalContextMenuProps> = ({
       firstSubmenuItem?.focus();
       submenuFocusFrameRef.current = null;
     });
-  }, [clearAllTimers]);
+  }, [openSubmenuNow]);
 
   
   const handleKeyDown = useCallback((event: KeyboardEvent) => {
@@ -544,17 +389,10 @@ export const ContextMenu: React.FC<InternalContextMenuProps> = ({
   
   useEffect(() => {
     if (!visible) {
-      clearAllTimers();
+      cancelPendingSubmenuIntent();
       setActiveSubmenuId(null);
-      lastMousePosRef.current = null;
-      menuItemRectRef.current = null;
-      submenuRectRef.current = null;
     }
-    
-    return () => {
-      clearAllTimers();
-    };
-  }, [visible, clearAllTimers]);
+  }, [cancelPendingSubmenuIntent, visible]);
 
   
   const adjustPosition = useCallback(() => {
@@ -626,8 +464,8 @@ export const ContextMenu: React.FC<InternalContextMenuProps> = ({
         key={itemId}
         className={`context-menu-item ${item.disabled ? 'disabled' : ''} ${isSubmenuActive ? 'submenu-active' : ''}`}
         onClick={(event) => handleItemClick(item, event)}
-        onMouseEnter={(event) => handleMenuItemMouseEnter(item, index, event)}
-        onMouseLeave={(event) => handleMenuItemMouseLeave(item, index, event)}
+        onPointerEnter={(event) => handleMenuItemPointerEnter(item, index, event)}
+        onPointerLeave={requestSubmenuClose}
         onContextMenu={(event) => event.preventDefault()}
         data-bf-component="context-menu"
         data-bf-part="item"
@@ -656,9 +494,10 @@ export const ContextMenu: React.FC<InternalContextMenuProps> = ({
           <>
             <span className="context-menu-submenu-arrow" data-bf-component="context-menu" data-bf-part="submenuArrow">▶</span>
             <div 
+              ref={isSubmenuActive ? activeSubmenuRef : undefined}
               className={`context-menu-submenu ${isSubmenuActive ? 'visible' : ''}`}
-              onMouseEnter={handleSubmenuMouseEnter}
-              onMouseLeave={handleSubmenuMouseLeave}
+              onPointerEnter={keepSubmenuOpen}
+              onPointerLeave={requestSubmenuClose}
               data-bf-component="context-menu"
               data-bf-part="submenu"
             >
@@ -671,7 +510,7 @@ export const ContextMenu: React.FC<InternalContextMenuProps> = ({
                 onItemClick={onItemClick}
                 autoFocusOnOpen={false}
                 onKeyboardBack={() => {
-                  setActiveSubmenuId(null);
+                  closeSubmenuNow();
                   focusItemAtIndex(index);
                 }}
               />

--- a/src/web-ui/src/shared/utils/useSubmenuIntent.hook.test.tsx
+++ b/src/web-ui/src/shared/utils/useSubmenuIntent.hook.test.tsx
@@ -1,0 +1,217 @@
+// @vitest-environment jsdom
+
+import React, { act, useRef, useState } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useSubmenuIntent } from './useSubmenuIntent';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const Harness: React.FC = () => {
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const parentRef = useRef<HTMLDivElement>(null);
+  const submenuRef = useRef<HTMLDivElement>(null);
+  const intent = useSubmenuIntent({
+    activeId,
+    onActiveIdChange: setActiveId,
+    parentRef,
+    submenuRef,
+  });
+
+  return (
+    <div>
+      <div ref={parentRef} data-testid="parent">
+        <button
+          data-testid="first"
+          onPointerEnter={event => intent.requestChange('first', event)}
+          onPointerLeave={intent.requestClose}
+        >
+          First
+        </button>
+        <button
+          data-testid="second"
+          onPointerEnter={event => intent.requestChange('second', event)}
+          onPointerLeave={intent.requestClose}
+        >
+          Second
+        </button>
+      </div>
+      {activeId ? (
+        <div
+          ref={submenuRef}
+          data-testid="submenu"
+          data-active-id={activeId}
+          onPointerEnter={intent.keepOpen}
+          onPointerLeave={intent.requestClose}
+        />
+      ) : null}
+    </div>
+  );
+};
+
+const dispatchPointerOver = (element: Element, clientX: number, clientY: number) => {
+  element.dispatchEvent(new MouseEvent('pointerover', {
+    bubbles: true,
+    clientX,
+    clientY,
+  }));
+};
+
+const dispatchPointerMove = (clientX: number, clientY: number) => {
+  document.dispatchEvent(new MouseEvent('pointermove', {
+    bubbles: true,
+    clientX,
+    clientY,
+  }));
+};
+
+const dispatchPointerOut = (element: Element, clientX: number, clientY: number) => {
+  element.dispatchEvent(new MouseEvent('pointerout', {
+    bubbles: true,
+    relatedTarget: document.body,
+    clientX,
+    clientY,
+  }));
+};
+
+const setBounds = (element: HTMLElement, left: number, right: number) => {
+  element.getBoundingClientRect = () => ({
+    left, right, top: 20, bottom: 220,
+    width: right - left, height: 200, x: left, y: 20,
+    toJSON: () => ({}),
+  });
+};
+
+describe('useSubmenuIntent', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => root.render(<Harness />));
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  const openFirstSubmenu = () => {
+    const first = container.querySelector('[data-testid="first"]')!;
+    act(() => dispatchPointerOver(first, 150, 40));
+    act(() => vi.advanceTimersByTime(120));
+
+    const submenu = container.querySelector<HTMLElement>('[data-testid="submenu"]')!;
+    submenu.getBoundingClientRect = () => ({
+      left: 220,
+      right: 440,
+      top: 20,
+      bottom: 220,
+      width: 220,
+      height: 200,
+      x: 220,
+      y: 20,
+      toJSON: () => ({}),
+    });
+    return submenu;
+  };
+
+  it('keeps the current submenu open while the pointer crosses a sibling toward it', () => {
+    const submenu = openFirstSubmenu();
+    const second = container.querySelector('[data-testid="second"]')!;
+
+    act(() => dispatchPointerMove(170, 48));
+    act(() => dispatchPointerOver(second, 190, 82));
+    expect(submenu.dataset.activeId).toBe('first');
+
+    act(() => dispatchPointerOver(submenu, 225, 110));
+    act(() => vi.advanceTimersByTime(400));
+    expect(container.querySelector<HTMLElement>('[data-testid="submenu"]')?.dataset.activeId).toBe('first');
+  });
+
+  it('switches immediately once the pointer turns away from the open submenu', () => {
+    openFirstSubmenu();
+    const second = container.querySelector('[data-testid="second"]')!;
+
+    act(() => dispatchPointerMove(170, 48));
+    act(() => dispatchPointerOver(second, 190, 82));
+    expect(container.querySelector<HTMLElement>('[data-testid="submenu"]')?.dataset.activeId).toBe('first');
+
+    act(() => dispatchPointerMove(165, 100));
+    expect(container.querySelector<HTMLElement>('[data-testid="submenu"]')?.dataset.activeId).toBe('second');
+  });
+
+  it.each([
+    { side: 'right', parentLeft: 0, parentRight: 215, gapX: 218 },
+    { side: 'left', parentLeft: 445, parentRight: 665, gapX: 442 },
+  ])('keeps a $side-opening submenu open while the pointer rests in the gap', ({ parentLeft, parentRight, gapX }) => {
+    openFirstSubmenu();
+    setBounds(container.querySelector<HTMLElement>('[data-testid="parent"]')!, parentLeft, parentRight);
+    const first = container.querySelector('[data-testid="first"]')!;
+
+    act(() => dispatchPointerOut(first, gapX, 80));
+    act(() => dispatchPointerMove(gapX, 80));
+    act(() => vi.advanceTimersByTime(1000));
+
+    expect(container.querySelector<HTMLElement>('[data-testid="submenu"]')?.dataset.activeId).toBe('first');
+  });
+
+  it('keeps the gap open when returning from the submenu, but closes after leaving the bridge', () => {
+    const submenu = openFirstSubmenu();
+    setBounds(container.querySelector<HTMLElement>('[data-testid="parent"]')!, 0, 215);
+    act(() => dispatchPointerOver(submenu, 225, 80));
+    act(() => dispatchPointerOut(submenu, 218, 80));
+    act(() => dispatchPointerMove(218, 80));
+    act(() => vi.advanceTimersByTime(1000));
+    expect(container.querySelector('[data-testid="submenu"]')).not.toBeNull();
+
+    act(() => dispatchPointerMove(218, 400));
+    act(() => vi.advanceTimersByTime(300));
+    expect(container.querySelector('[data-testid="submenu"]')).toBeNull();
+  });
+
+  it('protects a gap stop even if pointerleave is not followed by pointermove', () => {
+    openFirstSubmenu();
+    setBounds(container.querySelector<HTMLElement>('[data-testid="parent"]')!, 0, 215);
+    act(() => dispatchPointerOut(container.querySelector('[data-testid="first"]')!, 218, 80));
+    act(() => vi.advanceTimersByTime(1000));
+    expect(container.querySelector('[data-testid="submenu"]')).not.toBeNull();
+  });
+
+  it('keeps the gap protected during slow sub-pixel and reverse movements', () => {
+    openFirstSubmenu();
+    setBounds(container.querySelector<HTMLElement>('[data-testid="parent"]')!, 0, 215);
+    act(() => dispatchPointerOut(container.querySelector('[data-testid="first"]')!, 218, 80));
+    for (const x of [218.5, 217.5, 218, 217]) {
+      act(() => dispatchPointerMove(x, 80));
+      act(() => vi.advanceTimersByTime(500));
+      expect(container.querySelector('[data-testid="submenu"]')).not.toBeNull();
+    }
+  });
+
+  it('clears pending sibling activation when crossing into the bridge', () => {
+    openFirstSubmenu();
+    setBounds(container.querySelector<HTMLElement>('[data-testid="parent"]')!, 0, 215);
+    act(() => dispatchPointerMove(170, 48));
+    act(() => dispatchPointerOver(container.querySelector('[data-testid="second"]')!, 190, 82));
+    act(() => dispatchPointerMove(218, 110));
+    act(() => vi.advanceTimersByTime(1000));
+    expect(container.querySelector<HTMLElement>('[data-testid="submenu"]')?.dataset.activeId).toBe('first');
+  });
+
+  it.each(['blur', 'pointerleave'])('does not retain bridge protection after %s exits the window', eventName => {
+    openFirstSubmenu();
+    setBounds(container.querySelector<HTMLElement>('[data-testid="parent"]')!, 0, 215);
+    act(() => dispatchPointerOut(container.querySelector('[data-testid="first"]')!, 218, 80));
+    act(() => {
+      (eventName === 'blur' ? window : document).dispatchEvent(new Event(eventName));
+    });
+    act(() => vi.advanceTimersByTime(300));
+    expect(container.querySelector('[data-testid="submenu"]')).toBeNull();
+  });
+});

--- a/src/web-ui/src/shared/utils/useSubmenuIntent.test.ts
+++ b/src/web-ui/src/shared/utils/useSubmenuIntent.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+
+import { isPointInSubmenuBridge, isPointerMovingTowardSubmenu } from './useSubmenuIntent';
+
+const rightSubmenu = {
+  left: 220,
+  right: 440,
+  top: 20,
+  bottom: 220,
+};
+
+describe('isPointerMovingTowardSubmenu', () => {
+  it('recognizes a diagonal path toward a submenu that opens to the right', () => {
+    expect(isPointerMovingTowardSubmenu(
+      { x: 170, y: 48 },
+      { x: 190, y: 82 },
+      rightSubmenu,
+    )).toBe(true);
+  });
+
+  it('recognizes a diagonal path toward a submenu that opens to the left', () => {
+    expect(isPointerMovingTowardSubmenu(
+      { x: 490, y: 48 },
+      { x: 465, y: 92 },
+      { left: 240, right: 440, top: 20, bottom: 220 },
+    )).toBe(true);
+  });
+
+  it('rejects movement away from the open submenu', () => {
+    expect(isPointerMovingTowardSubmenu(
+      { x: 190, y: 82 },
+      { x: 165, y: 96 },
+      rightSubmenu,
+    )).toBe(false);
+  });
+
+  it('rejects vertical movement that does not get closer to the submenu', () => {
+    expect(isPointerMovingTowardSubmenu(
+      { x: 190, y: 82 },
+      { x: 190, y: 130 },
+      rightSubmenu,
+    )).toBe(false);
+  });
+
+  it('keeps the corridor active once the pointer reaches the submenu', () => {
+    expect(isPointerMovingTowardSubmenu(
+      { x: 205, y: 82 },
+      { x: 225, y: 110 },
+      rightSubmenu,
+    )).toBe(true);
+  });
+});
+
+describe('isPointInSubmenuBridge', () => {
+  const parent = { left: 0, right: 215, top: 20, bottom: 220 };
+
+  it('protects the gap and the inner edge padding without needing a movement vector', () => {
+    expect(isPointInSubmenuBridge({ x: 218, y: 80 }, parent, rightSubmenu)).toBe(true);
+    expect(isPointInSubmenuBridge({ x: 213, y: 80 }, parent, rightSubmenu)).toBe(true);
+    expect(isPointInSubmenuBridge({ x: 180, y: 80 }, parent, rightSubmenu)).toBe(false);
+  });
+
+  it('protects a left-opening submenu with upward viewport alignment', () => {
+    expect(isPointInSubmenuBridge(
+      { x: 442, y: 50 },
+      { left: 445, right: 665, top: 150, bottom: 350 },
+      rightSubmenu,
+    )).toBe(true);
+  });
+
+  it('does not protect empty space beyond the height of the submenu', () => {
+    expect(isPointInSubmenuBridge({ x: 218, y: 400 }, parent, rightSubmenu)).toBe(false);
+  });
+
+  it('uses current geometry instead of assuming a fixed gap width', () => {
+    expect(isPointInSubmenuBridge({ x: 230, y: 80 }, parent, {
+      ...rightSubmenu, left: 240,
+    })).toBe(true);
+    expect(isPointInSubmenuBridge({ x: 230, y: 80 }, parent, rightSubmenu)).toBe(false);
+  });
+
+  it('does not invent a bridge for unmeasured or overlapping menus', () => {
+    expect(isPointInSubmenuBridge({ x: 218, y: 80 }, { ...parent, right: 0 }, rightSubmenu)).toBe(false);
+    expect(isPointInSubmenuBridge({ x: 218, y: 80 }, parent, { ...rightSubmenu, left: 100 })).toBe(false);
+  });
+});

--- a/src/web-ui/src/shared/utils/useSubmenuIntent.ts
+++ b/src/web-ui/src/shared/utils/useSubmenuIntent.ts
@@ -1,0 +1,405 @@
+import { useCallback, useEffect, useRef, type RefObject } from 'react';
+
+export interface SubmenuIntentPoint {
+  x: number;
+  y: number;
+}
+
+export interface SubmenuIntentRect {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+}
+
+interface TimedPointerPoint extends SubmenuIntentPoint {
+  time: number;
+}
+
+interface PointerLikeEvent {
+  clientX: number;
+  clientY: number;
+  pointerType?: string;
+  timeStamp: number;
+}
+
+interface PendingTransition<T> {
+  targetId: T | null;
+  kind: 'open' | 'switch';
+  timer: number;
+}
+
+export interface UseSubmenuIntentOptions<T> {
+  activeId: T | null;
+  onActiveIdChange: (id: T | null) => void;
+  parentRef: RefObject<HTMLElement | null>;
+  submenuRef: RefObject<HTMLElement | null>;
+  enabled?: boolean;
+  openDelayMs?: number;
+  closeDelayMs?: number;
+  switchDelayMs?: number;
+  tolerance?: number;
+}
+
+export interface SubmenuIntentControls<T> {
+  requestChange: (targetId: T | null, event: PointerLikeEvent) => void;
+  requestClose: (event?: PointerLikeEvent) => void;
+  keepOpen: () => void;
+  openNow: (id: T) => void;
+  closeNow: () => void;
+  cancelPending: () => void;
+}
+
+const DEFAULT_OPEN_DELAY_MS = 120;
+const DEFAULT_CLOSE_DELAY_MS = 300;
+const DEFAULT_SWITCH_DELAY_MS = 300;
+const DEFAULT_TOLERANCE = 48;
+const POINTER_HISTORY_MAX_AGE_MS = 300;
+const POINTER_HISTORY_MIN_DISTANCE_PX = 2;
+// Include the parent's inner edge padding, not a wide band of sibling rows.
+const BRIDGE_EDGE_PADDING_PX = 4;
+
+const pointInRect = (point: SubmenuIntentPoint, rect: SubmenuIntentRect): boolean => (
+  rect.right > rect.left
+  && rect.bottom > rect.top
+  && point.x >= rect.left
+  && point.x <= rect.right
+  && point.y >= rect.top
+  && point.y <= rect.bottom
+);
+
+/** A stationary, bidirectional bridge across the gap; independent of menu aim. */
+export const isPointInSubmenuBridge = (
+  point: SubmenuIntentPoint,
+  parentRect: SubmenuIntentRect,
+  submenuRect: SubmenuIntentRect,
+): boolean => {
+  if (parentRect.right <= parentRect.left || parentRect.bottom <= parentRect.top
+    || submenuRect.right <= submenuRect.left || submenuRect.bottom <= submenuRect.top) {
+    return false;
+  }
+
+  const opensRight = submenuRect.left + submenuRect.right > parentRect.left + parentRect.right;
+  return pointInRect(point, {
+    left: (opensRight ? parentRect.right : submenuRect.right) - BRIDGE_EDGE_PADDING_PX,
+    right: (opensRight ? submenuRect.left : parentRect.left) + BRIDGE_EDGE_PADDING_PX,
+    top: submenuRect.top - BRIDGE_EDGE_PADDING_PX,
+    bottom: submenuRect.bottom + BRIDGE_EDGE_PADDING_PX,
+  });
+};
+
+const distanceToRect = (point: SubmenuIntentPoint, rect: SubmenuIntentRect): number => {
+  const dx = Math.max(rect.left - point.x, 0, point.x - rect.right);
+  const dy = Math.max(rect.top - point.y, 0, point.y - rect.bottom);
+  return Math.hypot(dx, dy);
+};
+
+const signedArea = (
+  point: SubmenuIntentPoint,
+  start: SubmenuIntentPoint,
+  end: SubmenuIntentPoint,
+): number => (
+  (point.x - end.x) * (start.y - end.y)
+  - (start.x - end.x) * (point.y - end.y)
+);
+
+const pointInTriangle = (
+  point: SubmenuIntentPoint,
+  first: SubmenuIntentPoint,
+  second: SubmenuIntentPoint,
+  third: SubmenuIntentPoint,
+): boolean => {
+  const firstSign = signedArea(point, first, second);
+  const secondSign = signedArea(point, second, third);
+  const thirdSign = signedArea(point, third, first);
+  const hasNegative = firstSign < 0 || secondSign < 0 || thirdSign < 0;
+  const hasPositive = firstSign > 0 || secondSign > 0 || thirdSign > 0;
+  return !(hasNegative && hasPositive);
+};
+
+/**
+ * Returns true when the pointer is entering the corridor between its previous
+ * position and the nearest vertical edge of the open submenu. The nearest edge
+ * makes the same calculation work for menus that open to either side.
+ */
+export const isPointerMovingTowardSubmenu = (
+  previous: SubmenuIntentPoint,
+  current: SubmenuIntentPoint,
+  submenuRect: SubmenuIntentRect,
+  tolerance = DEFAULT_TOLERANCE,
+): boolean => {
+  if (pointInRect(current, submenuRect)) return true;
+
+  const submenuOpensRight = previous.x <= submenuRect.left;
+  const submenuOpensLeft = previous.x >= submenuRect.right;
+  if (!submenuOpensRight && !submenuOpensLeft) return false;
+
+  const edgeX = submenuOpensRight ? submenuRect.left : submenuRect.right;
+  const horizontalDelta = current.x - previous.x;
+  if ((submenuOpensRight && horizontalDelta <= 0) || (submenuOpensLeft && horizontalDelta >= 0)) {
+    return false;
+  }
+
+  if (distanceToRect(current, submenuRect) >= distanceToRect(previous, submenuRect)) {
+    return false;
+  }
+
+  return pointInTriangle(
+    current,
+    previous,
+    { x: edgeX, y: submenuRect.top - tolerance },
+    { x: edgeX, y: submenuRect.bottom + tolerance },
+  );
+};
+
+const isMousePointer = (event: PointerLikeEvent): boolean => (
+  !event.pointerType || event.pointerType === 'mouse'
+);
+
+export const useSubmenuIntent = <T,>({
+  activeId,
+  onActiveIdChange,
+  parentRef,
+  submenuRef,
+  enabled = true,
+  openDelayMs = DEFAULT_OPEN_DELAY_MS,
+  closeDelayMs = DEFAULT_CLOSE_DELAY_MS,
+  switchDelayMs = DEFAULT_SWITCH_DELAY_MS,
+  tolerance = DEFAULT_TOLERANCE,
+}: UseSubmenuIntentOptions<T>): SubmenuIntentControls<T> => {
+  const activeIdRef = useRef(activeId);
+  const onActiveIdChangeRef = useRef(onActiveIdChange);
+  const pointerHistoryRef = useRef<TimedPointerPoint[]>([]);
+  const pendingTransitionRef = useRef<PendingTransition<T> | null>(null);
+  const closeTimerRef = useRef<number | null>(null);
+  // Preserve the leave intent when the bridge cancels its timer, so moving out
+  // of the bridge can arm closing again without another DOM pointerleave.
+  const closeRequestedRef = useRef(false);
+
+  activeIdRef.current = activeId;
+  onActiveIdChangeRef.current = onActiveIdChange;
+
+  const clearPendingTransition = useCallback(() => {
+    const pending = pendingTransitionRef.current;
+    if (pending) {
+      window.clearTimeout(pending.timer);
+      pendingTransitionRef.current = null;
+    }
+  }, []);
+
+  const clearCloseTimer = useCallback(() => {
+    if (closeTimerRef.current !== null) {
+      window.clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+  }, []);
+
+  const cancelPending = useCallback(() => {
+    clearPendingTransition();
+    clearCloseTimer();
+    closeRequestedRef.current = false;
+  }, [clearCloseTimer, clearPendingTransition]);
+
+  const commitChange = useCallback((targetId: T | null) => {
+    cancelPending();
+    activeIdRef.current = targetId;
+    onActiveIdChangeRef.current(targetId);
+  }, [cancelPending]);
+
+  const scheduleTransition = useCallback((
+    targetId: T | null,
+    kind: PendingTransition<T>['kind'],
+    delayMs: number,
+  ) => {
+    clearPendingTransition();
+    const timer = window.setTimeout(() => {
+      pendingTransitionRef.current = null;
+      commitChange(targetId);
+    }, delayMs);
+    pendingTransitionRef.current = { targetId, kind, timer };
+  }, [clearPendingTransition, commitChange]);
+
+  const scheduleClose = useCallback(() => {
+    clearCloseTimer();
+    closeTimerRef.current = window.setTimeout(() => {
+      closeTimerRef.current = null;
+      commitChange(null);
+    }, closeDelayMs);
+  }, [clearCloseTimer, closeDelayMs, commitChange]);
+
+  const findPreviousPoint = useCallback((current: TimedPointerPoint): TimedPointerPoint | null => {
+    for (let index = pointerHistoryRef.current.length - 1; index >= 0; index -= 1) {
+      const candidate = pointerHistoryRef.current[index];
+      const age = current.time - candidate.time;
+      const distance = Math.hypot(current.x - candidate.x, current.y - candidate.y);
+      if (age >= 0 && age <= POINTER_HISTORY_MAX_AGE_MS && distance >= POINTER_HISTORY_MIN_DISTANCE_PX) {
+        return candidate;
+      }
+    }
+    return null;
+  }, []);
+
+  const pointerHeadsToOpenSubmenu = useCallback((
+    previous: TimedPointerPoint | null,
+    current: TimedPointerPoint,
+  ): boolean => {
+    const submenuRect = submenuRef.current?.getBoundingClientRect();
+    return Boolean(
+      previous
+      && submenuRect
+      && isPointerMovingTowardSubmenu(previous, current, submenuRect, tolerance),
+    );
+  }, [submenuRef, tolerance]);
+
+  const getProtectedRegion = useCallback((point: SubmenuIntentPoint): 'submenu' | 'bridge' | null => {
+    if (activeIdRef.current === null) return null;
+    const submenuRect = submenuRef.current?.getBoundingClientRect();
+    if (!submenuRect) return null;
+    if (pointInRect(point, submenuRect)) return 'submenu';
+    const parentRect = parentRef.current?.getBoundingClientRect();
+    return parentRect && isPointInSubmenuBridge(point, parentRect, submenuRect) ? 'bridge' : null;
+  }, [parentRef, submenuRef]);
+
+  const requestChange = useCallback((targetId: T | null, event: PointerLikeEvent) => {
+    if (!enabled || !isMousePointer(event)) return;
+
+    clearCloseTimer();
+    closeRequestedRef.current = false;
+    const currentActiveId = activeIdRef.current;
+    if (Object.is(currentActiveId, targetId)) {
+      clearPendingTransition();
+      return;
+    }
+
+    const currentPoint: TimedPointerPoint = {
+      x: event.clientX,
+      y: event.clientY,
+      time: event.timeStamp,
+    };
+    const previousPoint = findPreviousPoint(currentPoint);
+
+    if (
+      currentActiveId !== null
+      && pointerHeadsToOpenSubmenu(previousPoint, currentPoint)
+    ) {
+      scheduleTransition(targetId, 'switch', switchDelayMs);
+      return;
+    }
+
+    if (currentActiveId === null && targetId !== null && openDelayMs > 0) {
+      scheduleTransition(targetId, 'open', openDelayMs);
+      return;
+    }
+
+    commitChange(targetId);
+  }, [
+    clearCloseTimer,
+    clearPendingTransition,
+    commitChange,
+    enabled,
+    findPreviousPoint,
+    openDelayMs,
+    pointerHeadsToOpenSubmenu,
+    scheduleTransition,
+    switchDelayMs,
+  ]);
+
+  const requestClose = useCallback((event?: PointerLikeEvent) => {
+    if (!enabled || (event && !isMousePointer(event))) return;
+    clearPendingTransition();
+    if (activeIdRef.current === null) return;
+    closeRequestedRef.current = true;
+    // pointerleave can be the last event before the mouse stops in the gap.
+    // Do not depend on receiving a later pointermove to cancel closing.
+    if (event && getProtectedRegion({ x: event.clientX, y: event.clientY })) {
+      clearCloseTimer();
+      return;
+    }
+    scheduleClose();
+  }, [clearCloseTimer, clearPendingTransition, enabled, getProtectedRegion, scheduleClose]);
+
+  const keepOpen = useCallback(() => {
+    cancelPending();
+  }, [cancelPending]);
+
+  const openNow = useCallback((id: T) => {
+    commitChange(id);
+  }, [commitChange]);
+
+  const closeNow = useCallback(() => {
+    commitChange(null);
+  }, [commitChange]);
+
+  useEffect(() => {
+    if (!enabled) {
+      cancelPending();
+      pointerHistoryRef.current = [];
+      return;
+    }
+
+    const handlePointerMove = (event: PointerEvent) => {
+      if (!isMousePointer(event)) return;
+
+      const currentPoint: TimedPointerPoint = {
+        x: event.clientX,
+        y: event.clientY,
+        time: event.timeStamp,
+      };
+      const previousPoint = findPreviousPoint(currentPoint);
+      const protectedRegion = getProtectedRegion(currentPoint);
+      const headingToSubmenu = !protectedRegion && activeIdRef.current !== null
+        && pointerHeadsToOpenSubmenu(previousPoint, currentPoint);
+      const pending = pendingTransitionRef.current;
+
+      if (protectedRegion) {
+        cancelPending();
+        closeRequestedRef.current = protectedRegion === 'bridge';
+      } else if (pending?.kind === 'switch') {
+        if (headingToSubmenu) {
+          scheduleTransition(pending.targetId, 'switch', switchDelayMs);
+        } else {
+          commitChange(pending.targetId);
+        }
+      } else if (closeRequestedRef.current && (closeTimerRef.current === null || headingToSubmenu)) {
+        scheduleClose();
+      }
+
+      pointerHistoryRef.current.push(currentPoint);
+      if (pointerHistoryRef.current.length > 4) {
+        pointerHistoryRef.current.shift();
+      }
+    };
+
+    const handlePointerExit = () => requestClose();
+    document.addEventListener('pointermove', handlePointerMove, { capture: true, passive: true });
+    document.addEventListener('pointerleave', handlePointerExit);
+    window.addEventListener('blur', handlePointerExit);
+    return () => {
+      document.removeEventListener('pointermove', handlePointerMove, true);
+      document.removeEventListener('pointerleave', handlePointerExit);
+      window.removeEventListener('blur', handlePointerExit);
+    };
+  }, [
+    cancelPending,
+    commitChange,
+    enabled,
+    findPreviousPoint,
+    getProtectedRegion,
+    pointerHeadsToOpenSubmenu,
+    requestClose,
+    scheduleClose,
+    scheduleTransition,
+    switchDelayMs,
+  ]);
+
+  useEffect(() => cancelPending, [cancelPending]);
+
+  return {
+    requestChange,
+    requestClose,
+    keepOpen,
+    openNow,
+    closeNow,
+    cancelPending,
+  };
+};


### PR DESCRIPTION
## Summary

- Introduce a shared `useSubmenuIntent` hook with direction-aware safe-triangle detection and bidirectional gap protection.
- Keep submenus open while the pointer moves toward them or pauses between parent and child menus.
- Apply the shared behavior to context menus, workspace session filters, and chat input Skills / Additional modes submenus.
- Add geometry, hook, and component regression tests.

Fixes: N/A — no linked issue.

## Type and Areas

Type: Bug fix / UI/UX / refactor / test

Areas: Web UI — shared menu interactions, navigation panel, chat input

## Motivation / Impact

Submenus could close unexpectedly when users moved diagonally toward them, crossed neighboring menu items, or paused in the gap between menus.

This change makes pointer navigation more forgiving for both left- and right-opening submenus. It preserves immediate click and keyboard interactions while sharing pointer-intent handling across menu components.

## Verification

Passed: 37 tests across 7 test files.

```sh
pnpm --dir src/web-ui exec vitest run src/shared/utils/useSubmenuIntent.test.ts src/shared/utils/useSubmenuIntent.hook.test.tsx src/shared/context-menu-system/components/ui/ContextMenu.test.tsx src/app/components/NavPanel/components/WorkspaceSessionFilterMenu.test.tsx src/flow_chat/components/ChatInputBoostSubmenu.test.tsx src/flow_chat/utils/chatInputQuickSkills.test.ts src/flow_chat/utils/additionalModePromptReference.test.ts
```

Passed: Web UI type checking and appearance/theme governance checks. The appearance audit reported non-blocking shared-style ownership warnings.

```sh
pnpm run check:web
```

Passed: staged whitespace/conflict-marker validation before completing the rebase.

```sh
git diff --cached --check
```

Verification was local and automated. Desktop manual interaction and remote workspace, remote control, Peer Device Mode, and Detached Dispatch scenarios were not exercised.

## Reviewer Notes

- Retains the upstream `ChatInputBoostSubmenu` extraction and Additional modes / Review behavior.
- Pointer protection supports both submenu directions and stationary or reverse movement through the gap.
- Leaving the protected region resumes delayed closing; timers and listeners are cleaned up on unmount.
- No backend, transport, persisted-data, or user-facing string changes. No migration required.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.