### PR TITLE
fix(agent): stop fabricating empty message content

### DIFF
--- a/src/crates/assembly/core/src/agentic/core/message.rs
+++ b/src/crates/assembly/core/src/agentic/core/message.rs
@@ -268,15 +268,12 @@ impl From<Message> for AIMessage {
             MessageContent::Text(text) => {
                 // Check if text is empty to avoid sending empty content to API
                 let content = if text.trim().is_empty() {
-                    // Should not have empty text messages, but provide default value for defensive programming
+                    // Empty text is a degenerate input; do not fabricate a placeholder.
+                    // Return None so downstream converters apply their existing
+                    // empty-content semantics (skip/drop) instead of treating a fake
+                    // token as a real user/assistant utterance or a system directive.
                     warn!("Empty text message detected: role={}", role);
-                    if role == "user" {
-                        Some("(empty message)".to_string())
-                    } else if role == "system" {
-                        Some("You are a helpful assistant.".to_string())
-                    } else {
-                        Some(" ".to_string()) // Minimum valid value
-                    }
+                    None
                 } else {
                     Some(text)
                 };
@@ -786,6 +783,39 @@ mod tests {
 
         assert_eq!(ai_msg.reasoning_content.as_deref(), Some(""));
         assert_eq!(ai_msg.thinking_signature.as_deref(), Some("sig_1"));
+    }
+
+    #[test]
+    fn empty_text_user_becomes_none_content() {
+        let ai_msg = AIMessage::from(Message::user(String::new()));
+
+        // Empty user text must not be turned into a fabricated "(empty message)"
+        // token that the model would treat as a real user utterance.
+        assert_eq!(ai_msg.content.as_deref(), None);
+    }
+
+    #[test]
+    fn empty_text_system_becomes_none_content() {
+        let ai_msg = AIMessage::from(Message::system(String::new()));
+
+        // Empty system text must not be turned into a fabricated system directive.
+        assert_eq!(ai_msg.content.as_deref(), None);
+    }
+
+    #[test]
+    fn empty_text_assistant_becomes_none_content() {
+        let ai_msg = AIMessage::from(Message::assistant(String::new()));
+
+        // Empty assistant text must not be replaced with a whitespace placeholder.
+        assert_eq!(ai_msg.content.as_deref(), None);
+    }
+
+    #[test]
+    fn non_empty_text_preserves_content() {
+        let ai_msg = AIMessage::from(Message::user("hi".to_string()));
+
+        // Normal non-empty text is unaffected by the empty-text handling.
+        assert_eq!(ai_msg.content.as_deref(), Some("hi"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The Text arm of `impl From<Message> for AIMessage` injected a synthetic placeholder
for empty text to avoid sending empty content to the provider: empty user text became
`"(empty message)"`, empty system text became `"You are a helpful assistant."`, and
any other empty text became a single space. The model then treated these fabricated
strings as a real user utterance or a system directive.

## Root cause

The "avoid empty content" defensive intent was implemented by injecting a non-empty
synthetic token, which defeats the downstream converters' existing empty-content
handling (openai/gemini filter out empty content, anthropic skips an empty system
message) because a non-empty fabricated string bypasses those filters. The Mixed arm
already returns `None` for empty text and is the correct in-file precedent to reuse;
the Text arm did not.

## Fix

Return `None` for empty text in the Text arm instead of fabricating a placeholder,
keeping the existing `warn!` diagnostic. Nothing synthetic reaches the provider, the
converters' empty-content semantics apply, and the normal non-empty path is unchanged.
No new helper or configuration is introduced.

## Testing

- Test degree: tested (focused behavioral tests).
- Added 4 behavioral cases in `message.rs`: empty user/system/assistant text becomes
  `None`; non-empty text is preserved.
- `cargo test -p bitfun-core --features agent-runtime --jobs 4` - `message::tests` green
  (9 passed); one unrelated pre-existing coordinator test still fails on the clean
  baseline.
- AI-assisted: yes (generated with review; commands above recorded).

Closes #2675

Commit list:
- `cc7e90846` `fix(agent): stop fabricating empty message content` - message.rs Text arm
  placeholder -> None; adds 4 behavioral tests.