### PR TITLE
fix(ai): terminal 4xx and TTFT in stream retries

### DIFF
--- a/src/crates/adapters/ai-adapters/src/client/sse.rs
+++ b/src/crates/adapters/ai-adapters/src/client/sse.rs
@@ -399,17 +399,12 @@ where
                         .await;
                 }
 
-                if attempt < max_tries - 1 {
-                    let delay_ms = exponential_retry_delay_ms(attempt);
-                    debug!(
-                        "Retrying {} after {}ms (transport_attempt {})",
-                        label,
-                        delay_ms,
-                        attempt + 2
-                    );
-                    tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
-                }
-                continue;
+                // The request body was already sent to the server before the TTFT
+                // timeout fired (send() completed and the first-token wait began).
+                // Retrying with the same body re-sends an already-billed request
+                // (double-billing). Treat it as a terminal error: break out of the
+                // retry loop and surface the timeout to the caller.
+                break;
             }
         };
 
@@ -488,6 +483,16 @@ mod tests {
                 .into_response(),
             _ => StatusCode::OK.into_response(),
         }
+    }
+
+    async fn hanging_until_timeout(
+        State(state): State<RetryFixtureState>,
+        Json(_body): Json<serde_json::Value>,
+    ) -> impl IntoResponse {
+        state.attempts.fetch_add(1, Ordering::SeqCst);
+        // Never complete the response so the client's send() future blocks and the
+        // injected ttft_timeout fires as StreamSendOutcome::TtftTimeout.
+        std::future::pending::<axum::response::Response>().await
     }
 
     async fn forbidden_with_retry_after(Json(body): Json<serde_json::Value>) -> impl IntoResponse {
@@ -657,6 +662,48 @@ mod tests {
             result.is_err(),
             "deterministic 400 responses should be terminal and not retried"
         );
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn ttft_timeout_is_terminal_and_not_retried() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let app = Router::new()
+            .route("/chat/completions", post(hanging_until_timeout))
+            .with_state(RetryFixtureState {
+                attempts: Arc::clone(&attempts),
+            });
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind ttft fixture");
+        let address = listener.local_addr().expect("ttft fixture address");
+        let server_task = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("ttft fixture should run");
+        });
+        let url = format!("http://{address}/chat/completions");
+        let client = reqwest::Client::new();
+        let request_body = serde_json::json!({"model": "configured-model"});
+
+        let result = execute_sse_request(
+            "OpenAI Streaming API",
+            &url,
+            &request_body,
+            3,
+            Some(Duration::from_millis(100)),
+            None,
+            || client.post(&url),
+            |_response, tx, _tx_raw, _remaining_ttft_timeout| async move {
+                drop(tx);
+            },
+        )
+        .await;
+
+        server_task.abort();
+        // A TTFT timeout means the request was already sent; it must be terminal
+        // (no re-send of the same body) so the fixture is called exactly once.
+        assert!(result.is_err(), "TTFT timeout should be terminal");
         assert_eq!(attempts.load(Ordering::SeqCst), 1);
     }
 

--- a/src/crates/adapters/ai-adapters/src/client/sse.rs
+++ b/src/crates/adapters/ai-adapters/src/client/sse.rs
@@ -189,6 +189,19 @@ fn retry_delay_ms(attempt: usize, headers: &HeaderMap, status: StatusCode) -> u6
     }
 }
 
+/// Returns true when `status` represents a transient condition that may succeed
+/// on a later attempt: server errors (5xx), rate limiting (429), and request or
+/// gateway timeouts (408/504).
+///
+/// Deterministic client errors (400/401/403/404/413/422) are excluded because
+/// retrying them reproduces the same failure and burns request budget/credits.
+fn is_transient_http_status(status: StatusCode) -> bool {
+    status.is_server_error()
+        || status == StatusCode::TOO_MANY_REQUESTS
+        || status == StatusCode::REQUEST_TIMEOUT
+        || status == StatusCode::GATEWAY_TIMEOUT
+}
+
 struct ManagedResponseStream {
     inner: UnboundedReceiverStream<Result<UnifiedResponse>>,
     handler_cancel: CancellationToken,
@@ -320,7 +333,7 @@ where
                             .await;
                     }
 
-                    if attempt < max_tries - 1 {
+                    if attempt < max_tries - 1 && is_transient_http_status(status) {
                         let delay_ms = retry_delay_ms(attempt, &headers, status);
                         debug!(
                             "Retrying {} after {}ms (transport_attempt {}, status {})",
@@ -331,7 +344,7 @@ where
                         );
                         tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
                     }
-                    continue;
+                    break;
                 }
             }
             StreamSendOutcome::Transport(e) => {
@@ -535,6 +548,41 @@ mod tests {
     }
 
     #[test]
+    fn is_transient_http_status_classifies_terminal_and_transient() {
+        // Deterministic client errors are terminal and must not be retried.
+        for terminal in [
+            StatusCode::BAD_REQUEST,
+            StatusCode::UNAUTHORIZED,
+            StatusCode::FORBIDDEN,
+            StatusCode::NOT_FOUND,
+            StatusCode::PAYLOAD_TOO_LARGE,
+            StatusCode::UNPROCESSABLE_ENTITY,
+        ] {
+            assert!(
+                !is_transient_http_status(terminal),
+                "{} should be terminal",
+                terminal
+            );
+        }
+
+        // Transient conditions are retried: server errors, rate limit, and timeouts.
+        for transient in [
+            StatusCode::INTERNAL_SERVER_ERROR,
+            StatusCode::BAD_GATEWAY,
+            StatusCode::SERVICE_UNAVAILABLE,
+            StatusCode::GATEWAY_TIMEOUT,
+            StatusCode::TOO_MANY_REQUESTS,
+            StatusCode::REQUEST_TIMEOUT,
+        ] {
+            assert!(
+                is_transient_http_status(transient),
+                "{} should be transient",
+                transient
+            );
+        }
+    }
+
+    #[test]
     fn remaining_ttft_timeout_subtracts_elapsed_request_time() {
         let start = std::time::Instant::now() - Duration::from_secs(2);
         let remaining = remaining_ttft_timeout(start, Some(Duration::from_secs(5)));
@@ -568,7 +616,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn every_bad_request_uses_existing_retry_loop() {
+    async fn bad_requests_are_terminal_and_not_retried() {
         let attempts = Arc::new(AtomicUsize::new(0));
         let app = Router::new()
             .route("/chat/completions", post(bad_requests_then_success))
@@ -603,11 +651,13 @@ mod tests {
         .await;
 
         server_task.abort();
+        // Deterministic 4xx (400) must be terminal: the request is not retried
+        // with the same body, so the fixture is called exactly once.
         assert!(
-            result.is_ok(),
-            "ordinary and context-overflow 400 responses should both retry"
+            result.is_err(),
+            "deterministic 400 responses should be terminal and not retried"
         );
-        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]

--- a/src/crates/adapters/ai-adapters/src/client/sse.rs
+++ b/src/crates/adapters/ai-adapters/src/client/sse.rs
@@ -343,6 +343,10 @@ where
                             status
                         );
                         tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+                        // Transient statuses (5xx/429/408) may succeed on a later
+                        // attempt, so retry rather than treating this response as a
+                        // terminal failure.
+                        continue;
                     }
                     break;
                 }
@@ -477,6 +481,27 @@ mod tests {
                         "message": "Maximum context length exceeded",
                         "type": "invalid_request_error",
                         "code": "context_length_exceeded"
+                    }
+                })),
+            )
+                .into_response(),
+            _ => StatusCode::OK.into_response(),
+        }
+    }
+
+    async fn server_errors_then_success(
+        State(state): State<RetryFixtureState>,
+        Json(body): Json<serde_json::Value>,
+    ) -> impl IntoResponse {
+        assert_eq!(body["model"], "configured-model");
+        match state.attempts.fetch_add(1, Ordering::SeqCst) {
+            0 => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({
+                    "error": {
+                        "message": "temporary server overload",
+                        "type": "server_error",
+                        "code": "server_error"
                     }
                 })),
             )
@@ -663,6 +688,54 @@ mod tests {
             "deterministic 400 responses should be terminal and not retried"
         );
         assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn transient_server_errors_are_retried() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let app = Router::new()
+            .route("/chat/completions", post(server_errors_then_success))
+            .with_state(RetryFixtureState {
+                attempts: Arc::clone(&attempts),
+            });
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind transient fixture");
+        let address = listener.local_addr().expect("transient fixture address");
+        let server_task = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("transient fixture should run");
+        });
+        let url = format!("http://{address}/chat/completions");
+        let client = reqwest::Client::new();
+        let request_body = serde_json::json!({"model": "configured-model"});
+
+        let result = execute_sse_request(
+            "OpenAI Streaming API",
+            &url,
+            &request_body,
+            2,
+            None,
+            None,
+            || client.post(&url),
+            |_response, tx, _tx_raw, _remaining_ttft_timeout| async move {
+                drop(tx);
+            },
+        )
+        .await;
+
+        server_task.abort();
+        // A transient server error (503) must be retried before the request
+        // succeeds, so the fixture is expected to be called more than once.
+        assert!(
+            result.is_ok(),
+            "transient server error should be retried and eventually succeed"
+        );
+        assert!(
+            attempts.load(Ordering::SeqCst) > 1,
+            "transient 5xx should be retried rather than treated as terminal"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

`execute_sse_request` retries with the same `request_body` in two cases that
should be terminal: a TTFT (time-to-first-token) timeout re-sends an
already-sent (already-billed) request, and a deterministic 4xx is retried even
though it fails identically on every attempt.

## Root cause

The retry decision does not distinguish terminal from transient outcomes. The
TTFT branch `continue`s using the same request body, and the non-2xx branch
retries every status, including 400. A deterministic 4xx increases the
attempt count without any chance of success, and a TTFT re-send double-bills.

## Fix

- Make a TTFT timeout terminal: break out of the retry loop and surface the
  timeout instead of re-sending the request.
- Add a module-private `is_transient_http_status` predicate that classifies
  server errors (5xx), rate limiting (429), and request/gateway timeouts
  (408/504) as transient, and every other status as terminal. Only transient
  statuses are retried; deterministic 4xx and the no-retries-remaining case
  break out of the loop. The existing `retry_delay_ms` /
  `exponential_retry_delay_ms` / `retry_after_delay_ms` backoff is reused.
- Correct the transient branch to continue the loop after sleeping, so 5xx/429/408
  are retried rather than exited.

Note: the upstream client has no request-id/idempotency mechanism (code-level
finding): the request body is a serialized value reused across attempts. This
fix removes the re-send instead of relying on provider-side idempotency. No
request-level total timeout is added (the config default `stream_ttft_timeout_secs`
is `Some(600)`, already bounding the wait).

## Testing

- Test degree: tested (focused behavioral tests).
- Reversed `bad_requests_then_success` to assert terminal 400 (`attempts == 1`);
  added `is_transient_http_status` classification coverage, `ttft_timeout_is_terminal`
  (hanging mock, single attempt, terminal error), and
  `transient_server_errors_are_retried` (503 -> 200, attempts > 1).
- `cargo test -p bitfun-ai-adapters --jobs 4 sse::tests` - 16 passed, 0 failed.
- AI-assisted: yes (generated with review; commands above recorded).

Closes #2677

Commit list:
- `ee4e20046` `fix(ai): don't retry deterministic 4xx statuses` - adds
  `is_transient_http_status`; terminal 4xx break; reverses bad_requests coverage.
- `5319e9c54` `fix(ai): don't resend requests on TTFT timeout` - TtftTimeout
  terminal break; adds ttft_timeout_is_terminal.
- `47689a040` `fix(ai): retry transient statuses after sleep` - adds the missing
  `continue` for transient statuses; adds transient_server_errors_are_retried.