### PR TITLE
fix(ui): prevent text descender clipping in components and navigation

### DIFF
--- a/design-system/packages/ui/src/components/ActionCard/ActionCard.module.css
+++ b/design-system/packages/ui/src/components/ActionCard/ActionCard.module.css
@@ -119,14 +119,14 @@
     color: var(--bf-color-content-primary);
     font-size: var(--bf-font-size-lg);
     font-weight: var(--bf-font-weight-semibold);
-    line-height: var(--bf-line-height-tight);
+    line-height: var(--bf-line-height-base);
   }
 
   .description {
     color: var(--bf-color-content-muted);
     font-size: var(--bf-font-size-small);
     font-weight: var(--bf-font-weight-regular);
-    line-height: var(--bf-line-height-tight);
+    line-height: var(--bf-line-height-base);
   }
 
   .actions {

--- a/design-system/packages/ui/src/components/ActionItem/ActionItem.module.css
+++ b/design-system/packages/ui/src/components/ActionItem/ActionItem.module.css
@@ -97,7 +97,7 @@
     font-family: var(--bf-font-family-control);
     font-size: var(--bf-font-size-small);
     font-weight: var(--bf-font-weight-regular);
-    line-height: var(--bf-line-height-tight);
+    line-height: var(--bf-line-height-base);
     text-overflow: ellipsis;
     white-space: nowrap;
   }

--- a/design-system/packages/ui/src/components/Button/Button.module.css
+++ b/design-system/packages/ui/src/components/Button/Button.module.css
@@ -174,6 +174,7 @@
     align-items: center;
     min-inline-size: 0;
     gap: var(--bf-space-1);
+    line-height: var(--bf-line-height-base);
     overflow: hidden;
     text-overflow: ellipsis;
   }

--- a/design-system/packages/ui/src/components/Disclosure/Disclosure.module.css
+++ b/design-system/packages/ui/src/components/Disclosure/Disclosure.module.css
@@ -83,7 +83,7 @@
     overflow: hidden;
     font-size: var(--bf-font-size-small);
     font-weight: var(--bf-font-weight-medium);
-    line-height: var(--bf-line-height-tight);
+    line-height: var(--bf-line-height-base);
     text-overflow: ellipsis;
     white-space: nowrap;
   }

--- a/design-system/packages/ui/src/components/Menu/Menu.module.css
+++ b/design-system/packages/ui/src/components/Menu/Menu.module.css
@@ -73,7 +73,7 @@
     font-family: var(--bf-font-family-control);
     font-size: var(--bf-overlay-menu-heading-font-size);
     font-weight: var(--bf-font-weight-medium);
-    line-height: var(--bf-line-height-tight);
+    line-height: var(--bf-line-height-base);
     text-overflow: ellipsis;
     white-space: nowrap;
   }

--- a/design-system/packages/ui/src/components/Modal/Modal.module.css
+++ b/design-system/packages/ui/src/components/Modal/Modal.module.css
@@ -147,7 +147,7 @@
     font-family: var(--bf-font-family-control);
     font-size: var(--bf-overlay-modal-title-font-size);
     font-weight: var(--bf-overlay-modal-title-font-weight);
-    line-height: var(--bf-line-height-tight);
+    line-height: var(--bf-line-height-base);
     text-overflow: ellipsis;
     white-space: nowrap;
   }

--- a/design-system/packages/ui/src/components/NavigationPanel/NavigationPanel.module.css
+++ b/design-system/packages/ui/src/components/NavigationPanel/NavigationPanel.module.css
@@ -86,7 +86,7 @@
     font-family: var(--bf-font-family-control);
     font-size: var(--bf-layout-navigation-panel-heading-font-size);
     font-weight: var(--bf-font-weight-medium);
-    line-height: var(--bf-line-height-tight);
+    line-height: var(--bf-line-height-base);
     text-overflow: ellipsis;
     white-space: nowrap;
   }

--- a/design-system/packages/ui/src/components/SegmentedControl/SegmentedControl.module.css
+++ b/design-system/packages/ui/src/components/SegmentedControl/SegmentedControl.module.css
@@ -85,6 +85,7 @@
 
   .label {
     min-inline-size: 0;
+    line-height: var(--bf-line-height-base);
     overflow: hidden;
     text-overflow: ellipsis;
   }

--- a/design-system/packages/ui/src/components/TabGroup/TabGroup.module.css
+++ b/design-system/packages/ui/src/components/TabGroup/TabGroup.module.css
@@ -102,6 +102,7 @@
 
   .label {
     min-inline-size: 0;
+    line-height: var(--bf-line-height-base);
     overflow: hidden;
     text-overflow: ellipsis;
   }

--- a/design-system/packages/ui/tests/text-clipping.test.mjs
+++ b/design-system/packages/ui/tests/text-clipping.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+// These text slots clip horizontally. Tight line boxes also clip the descenders
+// of fallback fonts, so the slots (not icons or the entire control) own leading.
+for (const [component, selector] of [
+  ["ActionItem", ".label"],
+  ["ActionCard", ".title"],
+  ["ActionCard", ".description"],
+  ["Button", ".label"],
+  ["TabGroup", ".label"],
+  ["SegmentedControl", ".label"],
+  ["NavigationPanel", ".headingLabel"],
+  ["Menu", ".headingLabel"],
+  ["Modal", ".title"],
+  ["Disclosure", ".summary"],
+]) {
+  test(`${component} ${selector} retains ellipsis with font-safe line height`, async () => {
+    const css = await readFile(new URL(
+      `../src/components/${component}/${component}.module.css`, import.meta.url,
+    ), "utf8");
+    const declarations = {};
+    for (const rule of css.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+      if (!rule[1].split(",").some((entry) => entry.trim() === selector)) continue;
+      for (const declaration of rule[2].split(";")) {
+        const colon = declaration.indexOf(":");
+        if (colon < 0) continue;
+        declarations[declaration.slice(0, colon).trim()] = declaration.slice(colon + 1).trim();
+      }
+    }
+    assert.equal(declarations["line-height"], "var(--bf-line-height-base)");
+    assert.equal(declarations.overflow, "hidden");
+    assert.equal(declarations["text-overflow"], "ellipsis");
+    assert.equal(declarations["block-size"], undefined);
+    assert.equal(declarations.height, undefined);
+  });
+}

--- a/src/web-ui/src/app/components/NavPanel/NavPanel.scss
+++ b/src/web-ui/src/app/components/NavPanel/NavPanel.scss
@@ -3312,7 +3312,7 @@ $_section-header-height: 22px;
     font-family: inherit;
     font-size: 13px;
     font-weight: 400;
-    line-height: 16px;
+    line-height: $line-height-base;
     text-align: left;
   }
 

--- a/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.scss
+++ b/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.scss
@@ -933,7 +933,8 @@
     }
 
     &.is-assistant-session {
-      height: 42px;
+      height: auto;
+      min-height: 42px;
     }
   }
 
@@ -953,7 +954,7 @@
     @include nav-font.nav-panel-text-meta;
 
     font-size: var(--bf-appearance-token-font-size-2xs);
-    line-height: 1.2;
+    line-height: $line-height-base;
   }
 
   &__inline-toggle {
@@ -961,7 +962,7 @@
     @include nav-font.nav-panel-text-meta;
 
     font-size: var(--bf-appearance-token-font-size-xs);
-    line-height: 1.25;
+    line-height: $line-height-base;
 
     &:hover,
     &:focus-visible {

--- a/src/web-ui/src/app/scenes/skills/SkillsScene.scss
+++ b/src/web-ui/src/app/scenes/skills/SkillsScene.scss
@@ -791,7 +791,7 @@ $skills-installed-columns: minmax(220px, 1fr) minmax(82px, 0.24fr) minmax(96px, 
   font-size: var(--bf-appearance-token-font-size-sm);
   font-weight: $font-weight-semibold;
   color: var(--bf-appearance-token-color-text-primary);
-  line-height: $line-height-tight;
+  line-height: $line-height-base;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -801,7 +801,7 @@ $skills-installed-columns: minmax(220px, 1fr) minmax(82px, 0.24fr) minmax(96px, 
   font-size: 11px;
   color: var(--bf-appearance-token-color-text-muted);
   opacity: 0.82;
-  line-height: 1.35;
+  line-height: $line-height-base;
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;

--- a/src/web-ui/src/app/styles/nav-panel-font-scope.scss
+++ b/src/web-ui/src/app/styles/nav-panel-font-scope.scss
@@ -81,7 +81,8 @@
   font-family: inherit;
   font-size: 13px;
   font-weight: 400;
-  line-height: 16px;
+  // Truncated labels need room for the bundled font's ascenders and descenders.
+  line-height: var(--bf-line-height-base);
 }
 
 @mixin nav-panel-text-row-active {
@@ -97,5 +98,5 @@
   font-size: 11px;
   font-weight: 500;
   letter-spacing: normal;
-  line-height: 13px;
+  line-height: var(--bf-line-height-base);
 }

--- a/src/web-ui/src/app/styles/textClipping.test.ts
+++ b/src/web-ui/src/app/styles/textClipping.test.ts
@@ -1,0 +1,113 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { brotliDecompressSync } from 'node:zlib';
+import { compile } from 'sass';
+import { describe, expect, it } from 'vitest';
+
+const webRoot = resolve(__dirname, '../../..');
+const systemTokens = JSON.parse(readFileSync(
+  resolve(webRoot, '../../design-system/packages/design-tokens/src/system.tokens.json'), 'utf8',
+));
+
+// Read the bundled WOFF2's untransformed head/hhea tables. No font download or
+// platform font fallback is involved in this line-box contract.
+function bundledFontLineHeight(): number {
+  const font = readFileSync(resolve(webRoot,
+    'public/fonts/Noto_Sans_SC/variable/noto-sans-sc-latin-wght-normal.woff2'));
+  expect(font.toString('ascii', 0, 4)).toBe('wOF2');
+  let cursor = 48;
+  const readBase128 = () => {
+    let value = 0;
+    for (let index = 0; index < 5; index += 1) {
+      const byte = font[cursor++];
+      value = value * 128 + (byte & 127);
+      if (!(byte & 128)) return value;
+    }
+    throw new Error('Invalid WOFF2 table length');
+  };
+  const tables: { tag: string; length: number }[] = [];
+  for (let index = 0; index < font.readUInt16BE(12); index += 1) {
+    const flags = font[cursor++];
+    const tagIndex = flags & 63;
+    let tag = String(tagIndex);
+    if (tagIndex === 63) {
+      tag = font.toString('ascii', cursor, cursor + 4);
+      cursor += 4;
+    } else if (tagIndex === 1) tag = 'head';
+    else if (tagIndex === 2) tag = 'hhea';
+    const originalLength = readBase128();
+    const transformed = tagIndex === 10 || tagIndex === 11
+      ? (flags >> 6) === 0 : (flags >> 6) !== 0;
+    if (tag === 'head' || tag === 'hhea') expect(transformed).toBe(false);
+    tables.push({ tag, length: transformed ? readBase128() : originalLength });
+  }
+  const data = brotliDecompressSync(font.subarray(cursor, cursor + font.readUInt32BE(20)));
+  let offset = 0;
+  let unitsPerEm = 0;
+  let extent = 0;
+  for (const { tag, length } of tables) {
+    if (tag === 'head') unitsPerEm = data.readUInt16BE(offset + 18);
+    if (tag === 'hhea') {
+      extent = data.readInt16BE(offset + 4) - data.readInt16BE(offset + 6)
+        + data.readInt16BE(offset + 8);
+    }
+    offset += length;
+  }
+  expect(unitsPerEm).toBeGreaterThan(0);
+  expect(extent).toBeGreaterThan(0);
+  return extent / unitsPerEm;
+}
+
+function compiledRules(filename: string) {
+  const css = compile(resolve(webRoot, 'src/app', filename)).css;
+  return (selector: string) => {
+    const declarations: Record<string, string> = {};
+    let matched = false;
+    for (const rule of css.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+      if (!rule[1].split(',').some((entry) => entry.trim() === selector)) continue;
+      matched = true;
+      for (const declaration of rule[2].split(';')) {
+        const colon = declaration.indexOf(':');
+        if (colon < 0) continue;
+        declarations[declaration.slice(0, colon).trim()] = declaration.slice(colon + 1).trim();
+      }
+    }
+    expect(matched, `Missing selector: ${selector}`).toBe(true);
+    return declarations;
+  };
+}
+
+describe('Truncated product text line boxes', () => {
+  it('fits the bundled font metrics without changing the compact system scale globally', () => {
+    const required = bundledFontLineHeight();
+    expect(systemTokens.lineHeight.tight.$value).toBeLessThan(required);
+    expect(systemTokens.lineHeight.base.$value).toBeGreaterThanOrEqual(required);
+  });
+
+  it.each([
+    ['components/NavPanel/NavPanel.scss', '.bitfun-nav-panel__search-trigger'],
+    ['components/NavPanel/NavPanel.scss', '.bitfun-nav-panel__section-label'],
+    ['components/NavPanel/sections/sessions/SessionsSection.scss', '.bitfun-nav-panel__inline-item'],
+    ['components/NavPanel/sections/sessions/SessionsSection.scss', '.bitfun-nav-panel__inline-item-assistant-name'],
+    ['components/NavPanel/sections/sessions/SessionsSection.scss', '.bitfun-nav-panel__inline-item-workspace-name'],
+    ['components/NavPanel/sections/sessions/SessionsSection.scss', '.bitfun-nav-panel__inline-toggle'],
+    ['components/NavPanel/sections/workspaces/WorkspaceListSection.scss', '.bitfun-nav-panel__workspace-item-label'],
+    ['components/NavPanel/sections/workspaces/WorkspaceListSection.scss', '.bitfun-nav-panel__assistant-item-label'],
+    ['scenes/skills/SkillsScene.scss', '.skills-card__name'],
+    ['scenes/skills/SkillsScene.scss', '.skills-card__desc'],
+  ])('%s gives %s a font-relative, descender-safe line height', (filename, selector) => {
+    expect(compiledRules(filename)(selector)['line-height']).toBe('var(--bf-line-height-base)');
+  });
+
+  it('retains single-line ellipsis and the two-line skills description clamp', () => {
+    const skills = compiledRules('scenes/skills/SkillsScene.scss');
+    expect(skills('.skills-card__name')['text-overflow']).toBe('ellipsis');
+    expect(skills('.skills-card__desc')['-webkit-line-clamp']).toBe('2');
+    const sessions = compiledRules('components/NavPanel/sections/sessions/SessionsSection.scss');
+    expect(sessions('.bitfun-nav-panel__inline-item-label')['text-overflow']).toBe('ellipsis');
+    expect(sessions('.bitfun-nav-panel__inline-item-label')['line-height']).toBe('inherit');
+    expect(sessions('.bitfun-nav-panel__inline-item').height).toBe('30px');
+    expect(sessions('.bitfun-nav-panel__inline-item.is-assistant-session').height).toBe('auto');
+    expect(sessions('.bitfun-nav-panel__inline-item.is-assistant-session')['min-height']).toBe('42px');
+  });
+});


### PR DESCRIPTION
## Summary

- Prevent text descender clipping in shared buttons, tabs, menus, cards, and navigation labels.
- Correct line heights in navigation, session rows, and skill lists.
- Allow session rows with assistant subtitles to grow with their content.
- Add regression tests for text truncation and bundled font metrics.

## Type and Areas

Type: Bug fix / UI/UX / test

Areas: Shared UI component library, web UI navigation, skills

## Motivation / Impact

Tight line heights combined with overflow clipping cut off the lower parts of letters such as g, y, p, and q.

Affected text slots now use the existing base line-height token while preserving font sizes, weights, horizontal ellipsis, and the two-line skill description limit.

## Verification

Completed during implementation:

- `pnpm run check:web` — passed.
- `pnpm run design-system:check` — passed, including 174 UI tests and 52 Design Lab tests.
- `node --test design-system/packages/ui/tests/text-clipping.test.mjs` — 10 tests passed.
- `git diff --check` — passed.

Manual visual verification and remote-scenario testing were not performed.

## Reviewer Notes

- Includes only commits `333868481` and `dce49f064`.
- Excludes the previously merged mini app tag layout fix.
- No font assets, global typography token values, persisted data, or API contracts changed.
- Single-line session rows retain their existing height; rows with assistant subtitles can grow.
- Please review text descenders at different font sizes and display scales.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.