### PR TITLE
fix(web-ui): correct turn rail selection and refine hover feedback

### DIFF
--- a/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_VERIFICATION.md
+++ b/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_VERIFICATION.md
@@ -24,7 +24,7 @@ each missing what the other had.
 | `flowChatLiveTailWindow.test.ts` | "does the transcript still reach the newest Turn" |
 | `flowChatViewportAnchor.test.ts` | anchor geometry and the DOM contract |
 | `useFlowChatViewportAnchor.test.tsx` | capture, restore, carry, the settle window |
-| `VirtualMessageList.session-boundary.test.tsx` | prepend compensation and the ask |
+| `VirtualMessageList.session-boundary.test.tsx` | prepend compensation, the ask, and navigation-target current Turn with gesture/follow/session handoff |
 | `ModernFlowChatContainer.history-state.test.tsx` | history presentation and the submission event |
 | `flowChatViewportOwnership.test.ts` | the priority order, preemption, expiry |
 | `../../../infrastructure/diagnostics/flowChatViewportDiagnostics.test.ts` | coalescing, placement sampling, the switch |
@@ -32,6 +32,7 @@ each missing what the other had.
 | `useFlowChatVirtualizer.measurement.test.tsx` | `measureRenderedItems` against a real virtualizer |
 | `useFlowChatVirtualizer.aim.test.tsx` | the re-aim, and giving it up on takeover |
 | `VirtualMessageList.layout.test.ts` | the item-height estimate and the spacer |
+| `FlowChatTurnRail.test.tsx` | single-marker emphasis, neighboring hover fan, independent keyboard focus, reduced motion, and rail navigation |
 
 ## Manual
 
@@ -207,6 +208,12 @@ group does not renumber the others.
 
 ### Turn navigation
 
+At rest the rail's dark emphasis belongs only to its current step
+(`aria-current`), not to every Turn visible in the transcript. Hover temporarily
+emphasizes just the pointed marker, with a symmetric fan of muted neighbors;
+it never changes `aria-current`. Leaving restores the current-step emphasis.
+Keyboard focus has its own outline and does not navigate until activation.
+
 1. Turn Rail and Usage Report navigation can top-align the final Turns.
 2. Click the last Turn on the Turn Rail while it is short. It must land in one
    movement at the end of the transcript — no top-align followed by a slide
@@ -236,3 +243,17 @@ group does not renumber the others.
    enough history to keep re-measuring. Each flick keeps its distance — the
    failure was arriving and then sliding back part of the way, every time, so
    that a given point in the transcript could not be passed at all.
+9. With several short Turns visible together, only the current Turn's rail marker
+   is dark at rest. Hover a different marker: it becomes the only dark line and
+   longest line, with three progressively shorter muted neighbors on each side.
+   Leaving restores the current marker; hovering must not navigate. Repeat at
+   both ends of the rail and after scrolling a long rail. Keyboard focus must
+   remain visible without changing the current Turn before activation.
+10. Click each of several short tail Turns in sequence, including two that land
+    at the same content-end offset. Only the clicked Turn is dark, even when an
+    earlier Turn remains visible. Repeat with a top-aligned Turn and a sliver of
+    the preceding Turn above it. Scroll manually afterwards: current must follow
+    the reading position again. Jump to latest and switch sessions to confirm
+    neither retains the old navigation selection.
+11. With reduced motion enabled, the hover fan changes without animation. Touch
+    navigation must not leave a hover fan behind.

--- a/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_VIEWPORT_REGISTER.md
+++ b/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_VIEWPORT_REGISTER.md
@@ -88,6 +88,30 @@ ownership to the reader, and their resting position is preserved.
 One-shot Turn, search and history navigation lives in `VirtualMessageList`, and
 holds `one-shot-navigation` for as long as it is still arriving.
 
+**The current Turn is not always the first visible Turn.** The top alignment
+gap can leave a sliver of the preceding Turn on screen; the content-end clamp
+can leave several earlier Turns visible. `VirtualMessageList` remembers the
+accepted navigation target and reports it as current once it intersects the
+viewport. Without a visible target, current still comes from the first visible
+Turn. This identity affects the rail and current-Turn affordances only: it
+never changes the scroll position, the viewport snapshot anchor, or the set of
+visible Turns. A rejected navigation does not replace it.
+
+Update that identity even when two targets produce the same clamped offset and
+no scroll event fires. Ordinary placement/measurement scroll events must not
+erase it. An explicit scroll gesture clears it, including a gesture that cannot
+move the viewport; item/search navigation replaces it; returning to follow or
+switching sessions clears it. The rail's single `aria-current` marker then
+reflects the chosen visible Turn, not another Turn sharing its viewport.
+
+The rail's pointer preview is separate from this navigation identity. Hover
+temporarily gives primary ink to the pointed marker and widens it to 19px;
+its three neighbors in each direction widen to 16px, 13px, and 11px, remaining
+muted. Other markers stay at 10px. Leaving restores current-step ink without
+navigating. Rail scrolling clears the preview, touch does not latch it, and
+reduced-motion keeps the shape change but removes the transition. Fixed row
+heights and hit areas keep this feedback out of transcript geometry.
+
 **Alignment is asked for, not computed, wherever it fits.** A navigation
 correcting its own scroll must re-issue through the virtualizer, never by
 writing the scroller. The virtualizer keeps re-aiming at its last target for as

--- a/src/web-ui/src/flow_chat/components/modern/FlowChatTurnRail.scss
+++ b/src/web-ui/src/flow_chat/components/modern/FlowChatTurnRail.scss
@@ -52,7 +52,7 @@
     height: 2px;
     border-radius: 1px;
     background: var(--bf-appearance-token-color-text-muted);
-    opacity: 0.7;
+    opacity: 0.4;
     transform: translateY(-50%);
     transform-origin: left center;
     transition:
@@ -63,22 +63,32 @@
       transform 100ms ease;
   }
 
-  &__item--visible &__bar {
+  // Hover previews a target without changing the actual current step. Only
+  // one marker uses primary ink: the preview, or current when not hovering.
+  &:not([data-hovering='true']) &__item[aria-current='step'] &__bar {
     width: 10px;
     height: 2px;
     background: var(--bf-appearance-token-color-text-primary);
     opacity: 1;
   }
 
-  &__item:hover &__bar,
   &__item:focus-visible &__bar {
-    width: 22px;
-    background: var(--bf-appearance-token-color-text-primary);
+    width: 19px;
     opacity: 1;
   }
 
   &__item:focus-visible &__bar {
     box-shadow: 0 0 0 2px color-mix(in srgb, var(--bf-appearance-token-color-accent-500) 35%, transparent);
+  }
+
+  // Fixed hit areas and row heights keep the hover fan from moving its target.
+  &__item[data-hover-distance='3'] &__bar { width: 11px; }
+  &__item[data-hover-distance='2'] &__bar { width: 13px; }
+  &__item[data-hover-distance='1'] &__bar { width: 16px; }
+  &__item[data-hover-distance='0'] &__bar {
+    width: 19px;
+    background: var(--bf-appearance-token-color-text-primary);
+    opacity: 1;
   }
 
   &__item:active &__bar {

--- a/src/web-ui/src/flow_chat/components/modern/FlowChatTurnRail.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/FlowChatTurnRail.test.tsx
@@ -1,6 +1,8 @@
 // @vitest-environment jsdom
 
 import React from 'react';
+import { resolve } from 'node:path';
+import { compile } from 'sass';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -52,11 +54,29 @@ function createTurns(count: number): FlowChatTurnRailItem[] {
   }));
 }
 
+const railCss = compile(resolve(__dirname, 'FlowChatTurnRail.scss')).css;
+
 describe('FlowChatTurnRail', () => {
   let container: HTMLDivElement;
   let root: Root;
+  let style: HTMLStyleElement;
+
+  const emphasizedBars = () => {
+    const selectors = Array.from(style.sheet!.cssRules)
+      .filter((rule): rule is CSSStyleRule => rule instanceof CSSStyleRule)
+      .filter(rule => rule.style.getPropertyValue('background') === 'var(--bf-appearance-token-color-text-primary)')
+      .map(rule => rule.selectorText);
+    expect(selectors.length).toBeGreaterThan(0);
+    // Both current and hover may use primary ink, but their compiled selectors
+    // must never emphasize multiple markers at once. Visibility is not selection.
+    expect(selectors.every(selector => !selector.includes('__item--visible'))).toBe(true);
+    return container.querySelectorAll(selectors.join(', '));
+  };
 
   beforeEach(() => {
+    style = document.createElement('style');
+    style.textContent = railCss;
+    document.head.appendChild(style);
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
@@ -65,15 +85,115 @@ describe('FlowChatTurnRail', () => {
   afterEach(() => {
     act(() => root.unmount());
     container.remove();
+    style.remove();
   });
 
-  it('renders every turn and highlights all viewport turns consistently', () => {
+  function hover(item: HTMLElement, pointerType = 'mouse') {
+    const event = new MouseEvent('pointerover', { bubbles: true });
+    Object.defineProperty(event, 'pointerType', { value: pointerType });
+    act(() => item.dispatchEvent(event));
+  }
+
+  function leave(item: HTMLElement) {
+    act(() => item.dispatchEvent(new MouseEvent('pointerout', {
+      bubbles: true,
+      relatedTarget: document.body,
+    })));
+  }
+
+  function barWidth(item: Element) {
+    return getComputedStyle(item.querySelector('.flowchat-turn-rail__bar')!).width;
+  }
+
+  it('fans out neighboring markers around hover without changing the current turn', () => {
+    const onNavigate = vi.fn();
+    act(() => root.render(
+      <FlowChatTurnRail turns={createTurns(12)} currentTurnId="turn-6" visibleTurnIds={['turn-6']} onNavigate={onNavigate} />,
+    ));
+    const items = container.querySelectorAll<HTMLButtonElement>('.flowchat-turn-rail__item');
+    const current = container.querySelector<HTMLButtonElement>('[data-turn-id="turn-6"]')!;
+    const target = container.querySelector<HTMLButtonElement>('[data-turn-id="turn-7"]')!;
+    const restingPositions = Array.from(items, item => item.style.top);
+    hover(target);
+
+    expect(emphasizedBars()).toHaveLength(1);
+    expect(emphasizedBars()[0].parentElement).toBe(target);
+    expect(current.getAttribute('aria-current')).toBe('step');
+    expect(target.hasAttribute('aria-current')).toBe(false);
+    expect(onNavigate).not.toHaveBeenCalled();
+    for (const item of items) {
+      const distance = Math.abs(Number(item.dataset.turnOrdinal) - 6);
+      expect(barWidth(item)).toBe(`${[19, 16, 13, 11][distance] ?? 10}px`);
+      expect(getComputedStyle(item.querySelector('.flowchat-turn-rail__bar')!).opacity)
+        .toBe(distance === 0 ? '1' : '0.4');
+    }
+    expect(Array.from(items, item => item.style.top)).toEqual(restingPositions);
+    // Even the longest bar fits inside its stable hit area and clipped list.
+    expect(parseFloat(barWidth(target)) + 2).toBeLessThanOrEqual(parseFloat(getComputedStyle(target).width));
+
+    leave(target);
+    expect(emphasizedBars()).toHaveLength(1);
+    expect(emphasizedBars()[0].parentElement).toBe(current);
+    expect(Array.from(items, barWidth)).toEqual(Array(items.length).fill('10px'));
+  });
+
+  it('moves the hover fan at both ends and restores the latest selection on leave', () => {
+    const onNavigate = vi.fn();
+    const render = (currentTurnId: string) => act(() => root.render(
+      <FlowChatTurnRail turns={turns} currentTurnId={currentTurnId} visibleTurnIds={[]} onNavigate={onNavigate} />,
+    ));
+    render('turn-2');
+    const items = container.querySelectorAll<HTMLButtonElement>('.flowchat-turn-rail__item');
+    hover(items[0]);
+    expect(Array.from(items, barWidth)).toEqual(['19px', '16px', '13px', '11px']);
+    leave(items[0]);
+    hover(items[3]);
+    expect(Array.from(items, barWidth)).toEqual(['11px', '13px', '16px', '19px']);
+    act(() => items[3].click());
+    expect(onNavigate).toHaveBeenCalledWith(turns[3]);
+    render('turn-4');
+    expect(emphasizedBars()).toHaveLength(1);
+    leave(items[3]);
+    expect(emphasizedBars()[0].parentElement).toBe(items[3]);
+    expect(items[3].getAttribute('aria-current')).toBe('step');
+  });
+
+  it('does not leave a hover preview after touch or rail scrolling', () => {
+    const onNavigate = vi.fn();
+    act(() => root.render(
+      <FlowChatTurnRail turns={turns} currentTurnId="turn-2" visibleTurnIds={[]} onNavigate={onNavigate} />,
+    ));
+    const target = container.querySelector<HTMLButtonElement>('[data-turn-id="turn-4"]')!;
+    hover(target, 'touch');
+    expect(barWidth(target)).toBe('10px');
+    hover(target);
+    expect(barWidth(target)).toBe('19px');
+    act(() => container.querySelector('.flowchat-turn-rail__list')!
+      .dispatchEvent(new Event('scroll', { bubbles: true })));
+    expect(barWidth(target)).toBe('10px');
+    expect(emphasizedBars()).toHaveLength(1);
+    expect(emphasizedBars()[0].parentElement?.getAttribute('data-turn-id')).toBe('turn-2');
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  it('disables marker transitions when reduced motion is requested', () => {
+    const media = Array.from(style.sheet!.cssRules)
+      .find((rule): rule is CSSMediaRule => rule instanceof CSSMediaRule
+        && rule.conditionText === '(prefers-reduced-motion: reduce)');
+    expect(media).toBeDefined();
+    const rule = Array.from(media!.cssRules).find((candidate): candidate is CSSStyleRule => (
+      candidate instanceof CSSStyleRule && candidate.selectorText === '.flowchat-turn-rail__bar'
+    ));
+    expect(rule?.style.getPropertyValue('transition')).toBe('none');
+  });
+
+  it('emphasizes only the current turn when several turns share the viewport', () => {
     act(() => {
       root.render(
         <FlowChatTurnRail
           turns={turns}
           currentTurnId="turn-2"
-          visibleTurnIds={['turn-2', 'turn-3']}
+          visibleTurnIds={['turn-2', 'turn-3', 'turn-4']}
           onNavigate={vi.fn()}
         />,
       );
@@ -84,9 +204,37 @@ describe('FlowChatTurnRail', () => {
     expect(items[1].getAttribute('aria-current')).toBe('step');
     expect(items[1].className).toContain('flowchat-turn-rail__item--visible');
     expect(items[2].className).toContain('flowchat-turn-rail__item--visible');
-    expect(items[1].className).toBe(items[2].className);
+    expect(container.querySelectorAll('[aria-current="step"]')).toHaveLength(1);
+    expect(emphasizedBars()).toHaveLength(1);
+    expect(emphasizedBars()[0].parentElement).toBe(items[1]);
     expect(items[0].getAttribute('aria-current')).toBeNull();
     expect(items[0].className).not.toContain('flowchat-turn-rail__item--visible');
+  });
+
+  it('moves emphasis with the current turn without retaining emphasis on other visible turns', () => {
+    const onNavigate = vi.fn();
+    const renderCurrent = (currentTurnId: string | null) => act(() => {
+      root.render(
+        <FlowChatTurnRail
+          turns={turns}
+          currentTurnId={currentTurnId}
+          visibleTurnIds={['turn-2', 'turn-3', 'turn-4']}
+          onNavigate={onNavigate}
+        />,
+      );
+    });
+    renderCurrent('turn-2');
+    const target = container.querySelector<HTMLButtonElement>('[data-turn-id="turn-4"]')!;
+    act(() => target.click());
+    expect(onNavigate).toHaveBeenCalledWith(turns[3]);
+    renderCurrent('turn-4');
+    expect(emphasizedBars()).toHaveLength(1);
+    expect(emphasizedBars()[0].parentElement).toBe(target);
+    expect(container.querySelector('[data-turn-id="turn-2"]')?.hasAttribute('aria-current')).toBe(false);
+
+    renderCurrent(null);
+    expect(emphasizedBars()).toHaveLength(0);
+    expect(container.querySelectorAll('[aria-current]')).toHaveLength(0);
   });
 
   it('shows the turn number and user message in the tooltip without a timestamp', () => {
@@ -258,6 +406,8 @@ describe('FlowChatTurnRail', () => {
     expect(document.activeElement).toBe(next);
     expect(next.tabIndex).toBe(0);
     expect(current.tabIndex).toBe(-1);
+    expect(emphasizedBars()).toHaveLength(1);
+    expect(emphasizedBars()[0].parentElement).toBe(current);
   });
 
   it('bounds rendered markers to the viewport plus overscan', () => {

--- a/src/web-ui/src/flow_chat/components/modern/FlowChatTurnRail.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/FlowChatTurnRail.tsx
@@ -60,6 +60,7 @@ export const FlowChatTurnRail: React.FC<FlowChatTurnRailProps> = ({
   );
   const initialFocusOrdinal = currentTurnOrdinal ?? turns[0]?.ordinal ?? null;
   const [focusOrdinal, setFocusOrdinal] = useState<number | null>(initialFocusOrdinal);
+  const [hoverOrdinal, setHoverOrdinal] = useState<number | null>(null);
   const [viewportMetrics, setViewportMetrics] = useState<FlowChatTurnRailViewportMetrics>(() => ({
     scrollTop: initialFocusOrdinal === null
       ? 0
@@ -85,6 +86,10 @@ export const FlowChatTurnRail: React.FC<FlowChatTurnRailProps> = ({
     }
     return windowTurns;
   }, [renderedRange.endOrdinalExclusive, renderedRange.startOrdinal, turnByOrdinal]);
+  const hoveredTurnOrdinal = hoverOrdinal !== null
+    && renderedTurns.some(turn => turn.ordinal === hoverOrdinal)
+    ? hoverOrdinal
+    : null;
   const tabStopOrdinal = focusOrdinal !== null
     && focusOrdinal >= renderedRange.startOrdinal
     && focusOrdinal < renderedRange.endOrdinalExclusive
@@ -218,11 +223,17 @@ export const FlowChatTurnRail: React.FC<FlowChatTurnRailProps> = ({
   }, [focusTurnAt, turns.length]);
 
   const handleScroll = useCallback(() => {
+    // Scrolling can replace the marker underneath a stationary pointer.
+    setHoverOrdinal(null);
     const list = listRef.current;
     if (list) {
       updateViewportMetrics(list);
     }
   }, [updateViewportMetrics]);
+
+  const handlePointerHover = useCallback((event: React.PointerEvent, ordinal: number) => {
+    if (event.pointerType !== 'touch') setHoverOrdinal(ordinal);
+  }, []);
 
   if (turns.length === 0) return null;
 
@@ -240,6 +251,7 @@ export const FlowChatTurnRail: React.FC<FlowChatTurnRailProps> = ({
       data-rendered-start-ordinal={renderedRange.startOrdinal}
       data-rendered-end-ordinal={renderedRange.endOrdinalExclusive}
       data-total-turn-count={totalOrdinalCount}
+      data-hovering={hoveredTurnOrdinal !== null ? 'true' : undefined}
     >
       <div
         ref={listRef}
@@ -256,6 +268,9 @@ export const FlowChatTurnRail: React.FC<FlowChatTurnRailProps> = ({
             const turnArrayIndex = turnArrayIndexByOrdinal.get(turn.ordinal) ?? 0;
             const isCurrent = turn.turnId !== null && turn.turnId === currentTurnId;
             const isVisible = turn.turnId !== null && visibleTurnIdSet.has(turn.turnId);
+            const hoverDistance = hoveredTurnOrdinal === null
+              ? null
+              : Math.abs(turn.ordinal - hoveredTurnOrdinal);
             const turnLabel = t('flowChatHeader.turnBadge', { current: turn.turnIndex });
             const content = turn.content === null
               ? null
@@ -301,10 +316,15 @@ export const FlowChatTurnRail: React.FC<FlowChatTurnRailProps> = ({
                   data-turn-key={turn.itemKey}
                   data-turn-index={turn.turnIndex}
                   data-turn-ordinal={turn.ordinal}
+                  data-hover-distance={hoverDistance !== null && hoverDistance <= 3 ? hoverDistance : undefined}
                   onClick={() => {
                     onNavigate(turn);
                   }}
                   onFocus={() => setFocusOrdinal(turn.ordinal)}
+                  onPointerEnter={event => handlePointerHover(event, turn.ordinal)}
+                  onPointerMove={event => handlePointerHover(event, turn.ordinal)}
+                  onPointerLeave={() => setHoverOrdinal(null)}
+                  onPointerCancel={() => setHoverOrdinal(null)}
                   onKeyDown={(event) => handleKeyDown(event, turnArrayIndex)}
                 >
                   <span className="flowchat-turn-rail__bar" data-bf-component="flow-chat-turn-rail" data-bf-part="bar" aria-hidden="true" />

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
@@ -604,6 +604,163 @@ describe('VirtualMessageList natural scroll contract', () => {
     }
   });
 
+  describe('the current Turn after navigation', () => {
+    let listRef: React.RefObject<VirtualMessageListRef>;
+    let scroller: HTMLElement;
+    let restoreLayout: () => void;
+
+    beforeEach(async () => {
+      mocks.items = Array.from({ length: 4 }, (_, index) => (
+        userMessage(`turn-${index + 1}`, `message-${index + 1}`, `Message ${index + 1}`)
+      ));
+      restoreLayout = fakeLayout({
+        clientHeight: 600,
+        scrollHeight: 1000,
+        turnTopFromScrollerTop: 500,
+      });
+      HTMLElement.prototype.getBoundingClientRect = function getRect() {
+        const isItem = this.classList.contains('virtual-item-wrapper');
+        // The previous Turn's last 5px remain visible above the target. Short
+        // tail Turns all share the same content-end-clamped scroll position.
+        const top = isItem ? Number(this.dataset.virtualIndex) * 80 - 35 : 0;
+        return new DOMRect(0, top, 1000, isItem ? 40 : 600);
+      };
+      listRef = React.createRef<VirtualMessageListRef>();
+      act(() => root.render(<VirtualMessageList ref={listRef} />));
+      await settleOpenReveal();
+      scroller = container.querySelector<HTMLElement>('[data-flowchat-scroller]')!;
+      scroller.scrollTop = 1000 - tailSpacerPxForViewport(600, BOTTOM_INSET) - 600;
+      mocks.setVisibleTurnInfo.mockClear();
+    });
+
+    afterEach(() => restoreLayout());
+
+    async function navigate(turnId: string) {
+      act(() => { listRef.current?.navigateToTurn(turnId, { behavior: 'auto' }); });
+      await settleOpenReveal();
+    }
+
+    function expectCurrent(turnId: string) {
+      expect(mocks.setVisibleTurnInfo).toHaveBeenLastCalledWith(expect.objectContaining({
+        turnId,
+        turnIndex: Number(turnId.split('-')[1]),
+        visibleTurnIds: ['turn-1', 'turn-2', 'turn-3', 'turn-4'],
+      }));
+    }
+
+    it('publishes each clicked Turn even when the clamp produces no scroll event', async () => {
+      const restingOffset = scroller.scrollTop;
+      await navigate('turn-4');
+      expectCurrent('turn-4');
+      await navigate('turn-2');
+      expectCurrent('turn-2');
+      expect(scroller.scrollTop).toBe(restingOffset);
+
+      // Placement and measurement scroll events must not replace the target
+      // with the earlier Turn whose tail happens to intersect the viewport.
+      act(() => scroller.dispatchEvent(new Event('scroll')));
+      await settleOpenReveal();
+      expectCurrent('turn-2');
+    });
+
+    it('does not replace a valid target with a rejected navigation', async () => {
+      await navigate('turn-4');
+      act(() => {
+        expect(listRef.current?.navigateToTurn('missing-turn')).toBe(false);
+        scroller.dispatchEvent(new Event('scroll'));
+      });
+      await settleOpenReveal();
+      expectCurrent('turn-4');
+    });
+
+    it.each(['wheel', 'touchmove', 'keydown', 'scrollbar'])(
+      'returns to viewport-derived current Turn after a %s gesture',
+      async gesture => {
+        await navigate('turn-4');
+        expectCurrent('turn-4');
+        act(() => {
+          if (gesture === 'scrollbar') {
+            scroller.dispatchEvent(new MouseEvent('pointerdown', { clientX: 1005, bubbles: true }));
+            scroller.dispatchEvent(new Event('scroll'));
+          } else if (gesture === 'keydown') {
+            scroller.dispatchEvent(new KeyboardEvent('keydown', { key: 'PageUp', bubbles: true }));
+          } else {
+            scroller.dispatchEvent(new Event(gesture, { bubbles: true }));
+          }
+        });
+        await settleOpenReveal();
+        expectCurrent('turn-1');
+      },
+    );
+
+    it('replaces the target when navigating to a different item', async () => {
+      await navigate('turn-4');
+      act(() => { listRef.current?.scrollToIndex(1); });
+      await settleOpenReveal();
+      expectCurrent('turn-2');
+    });
+
+    it('waits for a distant navigation target to become visible', async () => {
+      const target = container.querySelector<HTMLElement>('[data-turn-id="turn-4"]')!;
+      const rect = vi.spyOn(target, 'getBoundingClientRect')
+        .mockReturnValue(new DOMRect(0, 800, 1000, 40));
+      await navigate('turn-4');
+      expect(mocks.setVisibleTurnInfo).toHaveBeenLastCalledWith(expect.objectContaining({
+        turnId: 'turn-1',
+        visibleTurnIds: ['turn-1', 'turn-2', 'turn-3'],
+      }));
+      rect.mockRestore();
+      act(() => scroller.dispatchEvent(new Event('scroll')));
+      await settleOpenReveal();
+      expectCurrent('turn-4');
+    });
+
+    it('selects a prepared history target once its Turn enters the presentation', async () => {
+      await navigate('turn-4');
+      act(() => {
+        expect(listRef.current?.prepareTurnNavigation('turn-5')).toBe('pending');
+      });
+      mocks.items = [...mocks.items, userMessage('turn-5', 'message-5', 'Message 5')];
+      act(() => root.render(<VirtualMessageList ref={listRef} />));
+      await settleOpenReveal();
+      expect(mocks.setVisibleTurnInfo).toHaveBeenLastCalledWith(expect.objectContaining({
+        turnId: 'turn-5',
+        turnIndex: 5,
+        visibleTurnIds: ['turn-1', 'turn-2', 'turn-3', 'turn-4', 'turn-5'],
+      }));
+    });
+
+    it('clears the target on jump to latest even without a scroll event', async () => {
+      await navigate('turn-4');
+      expectCurrent('turn-4');
+      act(() => { listRef.current?.scrollToLatestEndPosition(); });
+      await settleOpenReveal();
+      expectCurrent('turn-1');
+    });
+
+    it('clears the target when follow-output takes over', async () => {
+      await navigate('turn-4');
+      expectCurrent('turn-4');
+      mocks.followsNow = true;
+      act(() => scroller.dispatchEvent(new Event('scroll')));
+      await settleOpenReveal();
+      expectCurrent('turn-1');
+      mocks.followsNow = false;
+      act(() => scroller.dispatchEvent(new Event('scroll')));
+      await settleOpenReveal();
+      expectCurrent('turn-1');
+    });
+
+    it('does not carry a target into another session with the same Turn IDs', async () => {
+      await navigate('turn-4');
+      expectCurrent('turn-4');
+      mocks.activeSession = { sessionId: 'session-2', dialogTurns: [] };
+      act(() => root.render(<VirtualMessageList ref={listRef} />));
+      await settleOpenReveal();
+      expectCurrent('turn-1');
+    });
+  });
+
   describe('scrollbar drags release the viewport', () => {
     // Content box ends at 0 + 1384; the gutter runs from there to 1394.
     const CONTENT_BOX_WIDTH = 1384;

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
@@ -432,6 +432,8 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     && initialViewportSnapshot.anchorOffsetPx !== null
   );
   const preparedTurnNavigationRef = useRef<PreparedTurnNavigation | null>(null);
+  // Selection identity only; this must never hold or reposition the viewport.
+  const navigatedTurnIdRef = useRef<string | null>(null);
   const boundaryRequestRef = useRef<Record<SessionHistoryWindowDirection, Promise<void> | null>>({
     before: null,
     after: null,
@@ -896,52 +898,6 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     viewportAnchor.openSettleWindow();
   }, [viewportAnchor, virtualItems]);
 
-  const notifyUserScrollIntent = useCallback(() => {
-    /*
-     * The reader outranks everything, and the claim is what makes that true of
-     * writers that are already in flight rather than only of ones yet to
-     * start. It lapses on its own after the same window the anchor uses to
-     * decide a scroll was theirs — a gesture has no completion event, so the
-     * hold has to end by itself or nothing below it could ever write again.
-     */
-    viewportOwner.claim('user-gesture', { holdForMs: USER_DRIVEN_SCROLL_WINDOW_MS });
-    /*
-     * The claim alone does not reach the library's re-aim. It goes on
-     * recomputing its target for five seconds and writes again whenever a
-     * measurement moves it, and the claim only refuses those writes while the
-     * gesture's own hold is live — 200ms after the last wheel notch, against a
-     * five-second re-aim. Measured: a Turn navigation placed at 5358, the
-     * reader took over 6ms later, and 12ms after that the re-aim asked for
-     * 7784 and was refused. Nothing had ended it; it was still armed when the
-     * recording stopped.
-     */
-    virtualizer.cancelAim();
-    viewportAnchor.markUserScrollIntent();
-    handleUserScrollIntent();
-    onUserScrollIntent?.();
-    /*
-     * A gesture that moves nothing is still the reader asking to go up, and it
-     * is the only signal there is once they are already at the top: the wheel
-     * emits no `scroll` event when the offset cannot change, so the scroll
-     * handler's evaluation never runs.
-     *
-     * Measured on a tail window of three Turns that fitted inside the viewport,
-     * so the whole scroll range was reserved blank: twenty gestures over seven
-     * seconds produced twenty `user-gesture` claims, no scroll events, and not
-     * one boundary evaluation. Nothing could ever page.
-     *
-     * After `handleUserScrollIntent`, which clears follow-output's ownership
-     * synchronously — so this asks as the reader rather than as our placement.
-     */
-    evaluateHistoryBoundariesRef.current();
-  }, [
-    handleUserScrollIntent,
-    onUserScrollIntent,
-    viewportAnchor,
-    viewportOwner,
-    virtualizer,
-  ]);
-
   const updateVisibleTurnInfoFromViewport = useCallback(() => {
     const scroller = scrollerElementRef.current;
     if (!scroller) return;
@@ -962,7 +918,14 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       scrollerRect.top,
       scrollerRect.bottom,
     );
-    const currentTurnId = visibleTurnIds[0] ?? null;
+    if (isFollowingOutputNow()) navigatedTurnIdRef.current = null;
+    const navigatedTurnId = navigatedTurnIdRef.current;
+    // A top gap can expose the preceding Turn; a content-end clamp can expose
+    // several. Neither makes that earlier Turn the user's navigation target.
+    // Until the target arrives on screen, keep reporting actual visibility.
+    const currentTurnId = navigatedTurnId && visibleTurnIds.includes(navigatedTurnId)
+      ? navigatedTurnId
+      : visibleTurnIds[0] ?? null;
     const currentTurn = currentTurnId
       ? userMessageItems.find(({ item }) => item.turnId === currentTurnId)
       : undefined;
@@ -988,7 +951,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       && previous.visibleTurnIds.length === visibleTurnIds.length
       && previous.visibleTurnIds.every((turnId, index) => turnId === visibleTurnIds[index]);
     if (!unchanged) store.setVisibleTurnInfo(nextVisibleTurnInfo);
-  }, [userMessageItems]);
+  }, [isFollowingOutputNow, userMessageItems]);
 
   const scheduleVisibleTurnInfoUpdate = useCallback(() => {
     if (visibleTurnUpdateFrameRef.current !== null) return;
@@ -997,6 +960,60 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       updateVisibleTurnInfoFromViewport();
     });
   }, [updateVisibleTurnInfoFromViewport]);
+
+  const setNavigatedTurn = useCallback((turnId: string | null) => {
+    navigatedTurnIdRef.current = turnId;
+    // Different tail Turns can land at the same offset, emitting no scroll.
+    scheduleVisibleTurnInfoUpdate();
+  }, [scheduleVisibleTurnInfoUpdate]);
+
+  const notifyUserScrollIntent = useCallback(() => {
+    /*
+     * The reader outranks everything, and the claim is what makes that true of
+     * writers that are already in flight rather than only of ones yet to
+     * start. It lapses on its own after the same window the anchor uses to
+     * decide a scroll was theirs — a gesture has no completion event, so the
+     * hold has to end by itself or nothing below it could ever write again.
+     */
+    viewportOwner.claim('user-gesture', { holdForMs: USER_DRIVEN_SCROLL_WINDOW_MS });
+    /*
+     * The claim alone does not reach the library's re-aim. It goes on
+     * recomputing its target for five seconds and writes again whenever a
+     * measurement moves it, and the claim only refuses those writes while the
+     * gesture's own hold is live — 200ms after the last wheel notch, against a
+     * five-second re-aim. Measured: a Turn navigation placed at 5358, the
+     * reader took over 6ms later, and 12ms after that the re-aim asked for
+     * 7784 and was refused. Nothing had ended it; it was still armed when the
+     * recording stopped.
+     */
+    virtualizer.cancelAim();
+    viewportAnchor.markUserScrollIntent();
+    handleUserScrollIntent();
+    setNavigatedTurn(null);
+    onUserScrollIntent?.();
+    /*
+     * A gesture that moves nothing is still the reader asking to go up, and it
+     * is the only signal there is once they are already at the top: the wheel
+     * emits no `scroll` event when the offset cannot change, so the scroll
+     * handler's evaluation never runs.
+     *
+     * Measured on a tail window of three Turns that fitted inside the viewport,
+     * so the whole scroll range was reserved blank: twenty gestures over seven
+     * seconds produced twenty `user-gesture` claims, no scroll events, and not
+     * one boundary evaluation. Nothing could ever page.
+     *
+     * After `handleUserScrollIntent`, which clears follow-output's ownership
+     * synchronously — so this asks as the reader rather than as our placement.
+     */
+    evaluateHistoryBoundariesRef.current();
+  }, [
+    handleUserScrollIntent,
+    onUserScrollIntent,
+    setNavigatedTurn,
+    viewportAnchor,
+    viewportOwner,
+    virtualizer,
+  ]);
 
   const captureViewportSnapshot = useCallback((): FlowChatViewportSnapshot | null => {
     const scroller = scrollerElementRef.current;
@@ -1725,6 +1742,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       return 'rejected';
     }
     exitFollowOutput('scroll-to-turn');
+    setNavigatedTurn(turnId);
     /*
      * Ahead of the placement, so that nothing between here and the commit that
      * renders it can restore the position being left. The reading position the
@@ -1860,6 +1878,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     readContentEndScrollTop,
     resolveTurnTopScrollTop,
     scrollToContentEndThroughVirtualizer,
+    setNavigatedTurn,
     viewportAnchor,
     virtualItems,
     virtualizer,
@@ -1889,6 +1908,9 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     if (!element) return false;
 
     exitFollowOutput('scroll-to-index');
+    setNavigatedTurn(
+      element.closest<HTMLElement>('.virtual-item-wrapper[data-turn-id]')?.dataset.turnId ?? null,
+    );
     const scrollerRect = scroller.getBoundingClientRect();
     const elementRect = element.getBoundingClientRect();
     const centred = scroller.scrollTop + elementRect.top - scrollerRect.top
@@ -1899,7 +1921,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       topPx: Math.max(0, Math.min(scroller.scrollHeight - scroller.clientHeight, centred)),
     });
     return true;
-  }, [exitFollowOutput, viewportOwner]);
+  }, [exitFollowOutput, setNavigatedTurn, viewportOwner]);
 
   const prepareTurnNavigation = useCallback((
     turnId: string,
@@ -1939,12 +1961,13 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
   const scrollToIndex = useCallback((index: number) => {
     if (index < 0 || index >= virtualItems.length) return;
     exitFollowOutput('scroll-to-index');
+    setNavigatedTurn(virtualItems[index].turnId);
     virtualizer.scrollItemIntoView(index, {
       align: 'center',
       owner: 'one-shot-navigation',
       holdForMs: ONE_SHOT_NAVIGATION_HOLD_MS,
     });
-  }, [exitFollowOutput, virtualItems.length, virtualizer]);
+  }, [exitFollowOutput, setNavigatedTurn, virtualItems, virtualizer]);
 
   const scrollToTurnEnd = useCallback((turnId: string) => {
     let targetIndex = -1;
@@ -2002,6 +2025,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
   }) => {
     clearSearchMatch();
     exitFollowOutput('scroll-to-index');
+    setNavigatedTurn(virtualItems[target.virtualItemIndex]?.turnId ?? null);
     const requestId = searchNavigationRequestIdRef.current;
     virtualizer.scrollItemIntoView(target.virtualItemIndex, {
       align: 'center',
@@ -2052,7 +2076,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       });
     };
     requestAnimationFrame(resolve);
-  }, [clearSearchMatch, exitFollowOutput, viewportOwner, virtualizer]);
+  }, [clearSearchMatch, exitFollowOutput, setNavigatedTurn, viewportOwner, virtualItems, virtualizer]);
 
   useEffect(() => () => setFlowChatSearchHighlight(null), []);
 
@@ -2327,7 +2351,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
 
   useLayoutEffect(() => {
     scheduleVisibleTurnInfoUpdate();
-  }, [scheduleVisibleTurnInfoUpdate, virtualItems]);
+  }, [isFollowingOutput, scheduleVisibleTurnInfoUpdate, virtualItems]);
 
   useEffect(() => {
     if (userMessageItems.length === 0) {
@@ -2357,17 +2381,19 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
   }, []);
 
   const scrollToPhysicalBottom = useCallback(() => {
+    setNavigatedTurn(null);
     enterFollowOutput('jump-to-latest');
     updateIsAtBottom();
-  }, [enterFollowOutput, updateIsAtBottom]);
+  }, [enterFollowOutput, setNavigatedTurn, updateIsAtBottom]);
 
   const scrollToLatestEndPosition = useCallback(() => {
     onUserScrollIntent?.();
+    setNavigatedTurn(null);
     enterFollowOutput('jump-to-latest');
     // Entering follow can leave the viewport exactly where it is, which
     // produces no scroll event to recompute the band from.
     updateIsAtBottom();
-  }, [enterFollowOutput, onUserScrollIntent, updateIsAtBottom]);
+  }, [enterFollowOutput, onUserScrollIntent, setNavigatedTurn, updateIsAtBottom]);
 
   useImperativeHandle(ref, () => ({
     scrollToTurn,


### PR DESCRIPTION
## Summary

- Fix multiple visible turns being highlighted simultaneously and navigation highlighting the wrong turn.
- Track the visible navigation target as the current turn, including when navigation produces no scroll event.
- Add compact hover feedback with progressively shorter neighboring markers, capped at 19px.
- Add regression tests and update interaction verification documentation.

Fixes: N/A

## Type and Areas

Type: Bug fix / UI/UX / test / docs

Areas: Web UI / FlowChat

## Motivation / Impact

Previously, the current turn was derived from the first visible turn. This could highlight the wrong marker when the preceding turn remained partially visible or multiple short tail turns shared the same clamped scroll position.

The rail now distinguishes current-turn selection, hover preview, and keyboard focus:

- Only the current turn is highlighted at rest.
- Hover emphasizes the pointed marker while neighboring markers remain muted and progressively shorten.
- Leaving restores current-turn highlighting without navigating.
- Manual scrolling, returning to latest, and switching sessions clear stale navigation selection.

## Verification

The following checks passed during implementation. Tests were not rerun while preparing this PR description.

```bash
pnpm --dir src/web-ui exec vitest run src/flow_chat/components/modern/FlowChatTurnRail.test.tsx src/flow_chat/components/modern/flowChatTurnRailWindow.test.ts src/flow_chat/components/modern/flowChatVisibleTurns.test.ts src/flow_chat/components/modern/VirtualMessageList.session-boundary.test.tsx
```

Result: 4 test files and 62 tests passed.

```bash
pnpm run check:web
git diff --check
```

Result: Passed.

Coverage includes navigation-target selection, consecutive navigation without scrolling, user gesture takeover, session switching, hover sizing, touch handling, and reduced-motion behavior.

Manual UI checks and remote scenarios remain unverified. Manual checks are documented in `FLOWCHAT_VERIFICATION.md`.

## Reviewer Notes

- Does not change transcript scroll positioning, tail reservation, or viewport anchor behavior.
- Hover widths are 19 / 16 / 13 / 11px; ordinary markers remain 10px.
- Row heights and hit areas remain fixed during hover.
- No backend API, persisted data, or migration changes.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.