### PR TITLE
fix(execution): detect and finalize on successful repeated tool loops

### DIFF
--- a/src/crates/assembly/core/src/agentic/execution/execution_engine.rs
+++ b/src/crates/assembly/core/src/agentic/execution/execution_engine.rs
@@ -892,13 +892,7 @@ impl ExecutionEngine {
         tool_calls.iter().all(|tool_call| {
             matches!(
                 tool_call.tool_name.as_str(),
-                "Read"
-                    | "Grep"
-                    | "Glob"
-                    | "LS"
-                    | "WebSearch"
-                    | "WebFetch"
-                    | "ListModels"
+                "Read" | "Grep" | "Glob" | "LS" | "WebSearch" | "WebFetch" | "ListModels"
             )
         })
     }
@@ -3729,7 +3723,7 @@ impl ExecutionEngine {
         let mut recent_failed_tool_signatures: Vec<String> = Vec::new();
         let mut failed_tool_recovery_attempts: usize = 0;
         const MAX_FAILED_TOOL_RECOVERY_ATTEMPTS: usize = 3;
-        let mut successful_tool_signature_count: usize = 0;
+        let mut successful_tool_signature_count: usize;
         let mut successful_recovery_attempts: usize = 0;
         const MAX_SUCCESSFUL_LOOP_RECOVERY_ATTEMPTS: usize = 3;
         const MAX_PARTIAL_CONTINUATION_ATTEMPTS: usize = 3;
@@ -4377,7 +4371,9 @@ impl ExecutionEngine {
                     recent_failed_tool_signatures.clear();
                     failed_tool_recovery_attempts = 0;
                     successful_tool_signature_count =
-                        ContextHealthSnapshot::repeated_tool_signature_count(&recent_tool_signatures);
+                        ContextHealthSnapshot::repeated_tool_signature_count(
+                            &recent_tool_signatures,
+                        );
                 }
             } else {
                 recent_tool_signatures.clear();
@@ -4484,11 +4480,9 @@ impl ExecutionEngine {
                     or stop if the goal is already met.</system_reminder>",
                     successful_tool_signature_count
                 );
-                let user_msg = Message::internal_reminder(
-                    InternalReminderKind::LoopRecovery,
-                    reminder,
-                )
-                .with_turn_id(context.dialog_turn_id.clone());
+                let user_msg =
+                    Message::internal_reminder(InternalReminderKind::LoopRecovery, reminder)
+                        .with_turn_id(context.dialog_turn_id.clone());
                 messages.push(user_msg.clone());
                 self.remember_generation_message(
                     &context.session_id,

--- a/src/crates/assembly/core/src/agentic/execution/execution_engine.rs
+++ b/src/crates/assembly/core/src/agentic/execution/execution_engine.rs
@@ -882,6 +882,27 @@ impl ExecutionEngine {
         Self::tool_call_signature(tool_calls)
     }
 
+    /// Tools that legitimately poll or read and may repeat without indicating a
+    /// no-progress loop. A round whose calls are all read/poll tools is exempted
+    /// from successful-repeat convergence detection, but stays subject to the
+    /// deterministic max-round/exhaustion backstops. A round containing a
+    /// non-poll (write/execute/mutating) tool with an identical signature is the
+    /// signal the convergence detector looks for.
+    fn is_legitimate_poll_tool(tool_calls: &[crate::agentic::core::ToolCall]) -> bool {
+        tool_calls.iter().all(|tool_call| {
+            matches!(
+                tool_call.tool_name.as_str(),
+                "Read"
+                    | "Grep"
+                    | "Glob"
+                    | "LS"
+                    | "WebSearch"
+                    | "WebFetch"
+                    | "ListModels"
+            )
+        })
+    }
+
     /// Whether a partial stream recovery should trigger a continuation round
     /// instead of treating truncated assistant text as the final answer.
     ///
@@ -3708,6 +3729,9 @@ impl ExecutionEngine {
         let mut recent_failed_tool_signatures: Vec<String> = Vec::new();
         let mut failed_tool_recovery_attempts: usize = 0;
         const MAX_FAILED_TOOL_RECOVERY_ATTEMPTS: usize = 3;
+        let mut successful_tool_signature_count: usize = 0;
+        let mut successful_recovery_attempts: usize = 0;
+        const MAX_SUCCESSFUL_LOOP_RECOVERY_ATTEMPTS: usize = 3;
         const MAX_PARTIAL_CONTINUATION_ATTEMPTS: usize = 3;
         let mut full_compression_count = 0usize;
         let mut compression_failure_count = 0u32;
@@ -4348,14 +4372,18 @@ impl ExecutionEngine {
                 .is_some()
                 {
                     recent_failed_tool_signatures.push(round_signature);
+                    successful_tool_signature_count = 0;
                 } else {
                     recent_failed_tool_signatures.clear();
                     failed_tool_recovery_attempts = 0;
+                    successful_tool_signature_count =
+                        ContextHealthSnapshot::repeated_tool_signature_count(&recent_tool_signatures);
                 }
             } else {
                 recent_tool_signatures.clear();
                 recent_failed_tool_signatures.clear();
                 failed_tool_recovery_attempts = 0;
+                successful_tool_signature_count = 0;
             }
 
             let after_round_pressure = Self::estimate_auto_compression_pressure(
@@ -4434,6 +4462,48 @@ impl ExecutionEngine {
                         break;
                     }
                 }
+            }
+
+            // Successful-tool convergence detection (mirror of the failed-path recovery
+            // above). A model that keeps calling the same non-read-only tool with identical
+            // arguments is not making progress even though each call succeeds: inject a
+            // convergence reminder so it changes strategy. The deterministic backstop that
+            // finalizes after the cap is enforced in the follow-up branch.
+            if !Self::is_legitimate_poll_tool(&round_result.tool_calls)
+                && successful_tool_signature_count >= max_consec
+                && successful_recovery_attempts < MAX_SUCCESSFUL_LOOP_RECOVERY_ATTEMPTS
+            {
+                successful_recovery_attempts += 1;
+                warn!(
+                    "Repeated successful tool call detected: {} consecutive rounds with identical tool signatures, injecting convergence reminder #{}",
+                    successful_tool_signature_count, successful_recovery_attempts
+                );
+                let reminder = format!(
+                    "<system_reminder>Repeated successful tool calls detected: the same tool call with identical arguments has succeeded {} times in a row. \
+                    This looks like a loop without progress. You MUST now change your strategy: try a different approach, break the task into smaller steps, \
+                    or stop if the goal is already met.</system_reminder>",
+                    successful_tool_signature_count
+                );
+                let user_msg = Message::internal_reminder(
+                    InternalReminderKind::LoopRecovery,
+                    reminder,
+                )
+                .with_turn_id(context.dialog_turn_id.clone());
+                messages.push(user_msg.clone());
+                self.remember_generation_message(
+                    &context.session_id,
+                    &context.dialog_turn_id,
+                    &user_msg,
+                );
+                if let Err(e) = self
+                    .session_manager
+                    .add_message(&context.session_id, user_msg)
+                    .await
+                {
+                    warn!("Failed to persist successful-tool recovery reminder: {}", e);
+                }
+                recent_tool_signatures.clear();
+                successful_tool_signature_count = 0;
             }
 
             // Periodic-pattern loop detection.
@@ -5181,6 +5251,60 @@ mod tests {
         assert!(!reached_fixed_model_round_limit(200, 199));
         assert!(reached_fixed_model_round_limit(200, 200));
         assert!(reached_fixed_model_round_limit(200, 201));
+    }
+
+    #[test]
+    fn legitimate_poll_tools_are_exempt_from_successful_loop_detection() {
+        let read = vec![ToolCall {
+            tool_id: "call-1".to_string(),
+            tool_name: "Read".to_string(),
+            arguments: json!({ "path": "src/main.rs" }),
+            raw_arguments: None,
+            is_error: false,
+            parse_error: None,
+            recovered_from_truncation: false,
+            repair_kind: Default::default(),
+        }];
+        assert!(ExecutionEngine::is_legitimate_poll_tool(&read));
+
+        let mixed_poll = vec![
+            ToolCall {
+                tool_id: "call-1".to_string(),
+                tool_name: "Grep".to_string(),
+                arguments: json!({ "pattern": "fn main" }),
+                raw_arguments: None,
+                is_error: false,
+                parse_error: None,
+                recovered_from_truncation: false,
+                repair_kind: Default::default(),
+            },
+            ToolCall {
+                tool_id: "call-2".to_string(),
+                tool_name: "Glob".to_string(),
+                arguments: json!({ "pattern": "**/*.rs" }),
+                raw_arguments: None,
+                is_error: false,
+                parse_error: None,
+                recovered_from_truncation: false,
+                repair_kind: Default::default(),
+            },
+        ];
+        assert!(ExecutionEngine::is_legitimate_poll_tool(&mixed_poll));
+    }
+
+    #[test]
+    fn mutating_tools_are_not_exempt_from_successful_loop_detection() {
+        let edit = vec![ToolCall {
+            tool_id: "call-1".to_string(),
+            tool_name: "Edit".to_string(),
+            arguments: json!({ "filePath": "src/main.rs" }),
+            raw_arguments: None,
+            is_error: false,
+            parse_error: None,
+            recovered_from_truncation: false,
+            repair_kind: Default::default(),
+        }];
+        assert!(!ExecutionEngine::is_legitimate_poll_tool(&edit));
     }
 
     #[test]

--- a/src/crates/assembly/core/src/agentic/execution/execution_engine.rs
+++ b/src/crates/assembly/core/src/agentic/execution/execution_engine.rs
@@ -4506,6 +4506,21 @@ impl ExecutionEngine {
                 successful_tool_signature_count = 0;
             }
 
+            // Deterministic backstop: if the model ignored the convergence reminders and keeps
+            // repeating the same successful tool signature past the cap, finalize without tools
+            // instead of looping forever.
+            if !Self::is_legitimate_poll_tool(&round_result.tool_calls)
+                && successful_tool_signature_count >= max_consec
+                && successful_recovery_attempts >= MAX_SUCCESSFUL_LOOP_RECOVERY_ATTEMPTS
+            {
+                warn!(
+                    "Repeated successful tool calls exceeded max convergence attempts ({}), finalizing without tools",
+                    MAX_SUCCESSFUL_LOOP_RECOVERY_ATTEMPTS
+                );
+                finalization_reason = Some("repeated_successful_tool_calls");
+                break;
+            }
+
             // Periodic-pattern loop detection.
             //
             // The strict consecutive check above only fires on `A-A-A` patterns.


### PR DESCRIPTION

## Problem

The tool-call loop in the execution engine is gated only by `max_rounds`, and
`max_rounds=0` is the upstream default for unlimited rounds. A long-running round
could therefore keep calling the same tool with identical arguments many times:
each call succeeds, so no failure recovery fires, and the round never makes
progress toward a final response.

## Root cause

Successful repeats were only logged at debug level
(`log_policy_thresholds`'s `has_repeated_tool_loop`) and never surfaced as a signal
that the model is stuck. The failure path tracks a consecutive count of failed tool
calls, but the successful path had no equivalent convergence detection, so a
repeating successful call stream continued indefinitely.

## Fix

- Mirror the failed-tool recovery detection onto the successful path: track a
  consecutive count of identical successful tool signatures (reusing
  `tool_call_signature` + `repeated_tool_signature_count`).
- Exempt rounds whose calls are all legitimate read/poll tools
  (`is_legitimate_poll_tool`): Read, Grep, Glob, LS, WebSearch, WebFetch, ListModels.
- Once the effective loop threshold is crossed, inject a `LoopRecovery`
  internal reminder so the model changes strategy; after
  `MAX_SUCCESSFUL_LOOP_RECOVERY_ATTEMPTS`, finalize the round without further tool
  calls via the existing `finalization_reason` path.
- Drop the dead `= 0` initializer on `successful_tool_signature_count`
  (unused_assignments warning) and reflow the rustfmt deviations so the crate is
  warning-clean and formatted.

## Testing

- Test degree: tested (focused behavioral tests).
- Added `legitimate_poll_tools_are_exempt_from_successful_loop_detection` and
  `mutating_tools_are_not_exempt_from_successful_loop_detection` to confirm
  legitimate read/poll tooling is not misfiring the detector.
- `cargo test -p bitfun-core --features agent-runtime --jobs 4` — execution_engine
  loop-detection tests pass (successful_loop x2, zero_max_rounds,
  failed_tool_round_signature x2).
- `cargo check -p bitfun-core --features agent-runtime` — no new warnings (the base
  `fork_session_for_plugin` dead-code warning remains).
- `git diff --check` clean.
- AI-assisted: yes (generated with review; commands above recorded).

Closes #2688

Commit list:
- `68314eee6` `fix(execution): detect successful repeated tool loops` — successful
  convergence signal + poll-tool whitelist + LoopRecovery reminder.
- `646e3ea74` `fix(execution): finalize on successful tool loop cap` —
  deterministic backstop via `finalization_reason`.
- `400bc0355` `fix(execution): drop dead init in successful loop counter` —
  removes the unused_assignments warning; rustfmt reflow.