### PR TITLE
fix(release): allow explore beta packaging

### DIFF
--- a/.github/workflows/desktop-package.yml
+++ b/.github/workflows/desktop-package.yml
@@ -113,12 +113,18 @@ jobs:
             "import { validateReleaseVersion } from './scripts/release-channel.mjs'; validateReleaseVersion(process.argv[1], process.argv[2]);" \
             "${CHANNEL}" "${VERSION}"
 
-          git fetch origin main --tags --force
+          git fetch origin main 1.0.0-explore --tags --force
           CHECKOUT_SHA="$(git rev-parse "${CHECKOUT_REF}^{commit}")"
-          if [[ "${GITHUB_REPOSITORY}" == "GCWing/BitFun" ]] && \
-             ! git merge-base --is-ancestor "${CHECKOUT_SHA}" origin/main; then
-            echo "Ref ${CHECKOUT_REF} (${CHECKOUT_SHA}) is not part of the protected main history." >&2
-            exit 1
+          if [[ "${GITHUB_REPOSITORY}" == "GCWing/BitFun" ]]; then
+            if git merge-base --is-ancestor "${CHECKOUT_SHA}" origin/main; then
+              :
+            elif [[ "${CHANNEL}" == "beta" ]] && \
+                 git merge-base --is-ancestor "${CHECKOUT_SHA}" origin/1.0.0-explore; then
+              :
+            else
+              echo "Ref ${CHECKOUT_REF} (${CHECKOUT_SHA}) is not part of the protected main history or the protected 1.0.0-explore beta history." >&2
+              exit 1
+            fi
           fi
           TAG_SHA="$(git rev-parse --verify --quiet "${TAG}^{commit}" || true)"
           if [[ -n "${TAG_SHA}" && "${TAG_SHA}" != "${CHECKOUT_SHA}" ]]; then

--- a/scripts/check-github-config.test.mjs
+++ b/scripts/check-github-config.test.mjs
@@ -1114,6 +1114,12 @@ test('Desktop packaging keeps beta identity explicit and stable-safe', () => {
   );
   assert.match(prepareStep.run, /GITHUB_REPOSITORY.*GCWing\/BitFun/);
   assert.match(prepareStep.run, /merge-base --is-ancestor/);
+  assert.match(prepareStep.run, /git fetch origin main 1\.0\.0-explore/);
+  assert.match(
+    prepareStep.run,
+    /CHANNEL.*beta[\s\S]*origin\/1\.0\.0-explore/,
+    'beta builds may use only the protected explore history',
+  );
   assert.match(prepareStep.run, /rev-parse --verify --quiet/);
 
   const packageJob = workflow.jobs.package;


### PR DESCRIPTION
## Summary

Allow Desktop Beta releases to build commits from the protected `1.0.0-explore` history while preserving the existing Stable restriction to protected `main` history.

## Type and Areas

Type: CI / release regression fix

Areas: Desktop packaging, release safety

## Motivation / Impact

The current release workflow rejects every `1.0.0-explore` commit because it only accepts commits reachable from `main`. This blocks the requested `v1.0.0-beta.1` release.

Stable releases remain restricted to `main`. Beta releases may additionally use commits reachable from the protected `1.0.0-explore` branch. Arbitrary refs remain rejected.

## Verification

- `pnpm run check:github-config` — 20 passed, 1 platform-dependent test skipped
- `git diff --check`

## Reviewer Notes

The release will remain frozen to pre-change explore SHA `66709c3c7a4bb1455447af8783e2ef5a17d24152`; this workflow-only fix will not enter the Beta product artifact.

## Checklist

- [x] This PR is focused and contains no unrelated artifacts.
- [x] Relevant verification is recorded above.
- [x] No user-facing strings or locales are affected.