### PR TITLE
fix(plan): harden artifacts and build lifecycle

### DIFF
--- a/src/crates/assembly/core/builtin_skills/plan/SKILL.md
+++ b/src/crates/assembly/core/builtin_skills/plan/SKILL.md
@@ -10,23 +10,16 @@ Produce a concise, evidence-backed implementation plan and leave project source 
 ## Workflow
 
 1. Inspect the relevant code, configuration, documentation, and repository instructions using read-only tools. Resolve important behavior and ownership questions before drafting the plan.
-2. Ask the user only when missing information would materially change the approach. Present concrete options and put the recommended option first. Do not ask whether to proceed merely because research is complete.
+2. Ask the user when missing information would materially change the approach. Present concrete options and put the recommended option first. Do not ask whether to proceed merely because research is complete.
 3. Use `Task` only for read-only research that materially improves the plan. Keep delegated scopes bounded and synthesize the findings yourself.
-4. Write one plan artifact at `.bitfun/plans/<short-kebab-name>.plan.md`. Use a concise descriptive filename, and do not overwrite a different existing plan blindly.
-5. After a successful plan Write, stop tool use and link the plan file without repeating its contents.
+4. Use `Write` to create one plan artifact at `.bitfun/plans/<short-kebab-name>.plan.md`. Use a concise descriptive filename, and do not overwrite a different existing plan blindly.
+5. Once the plan artifact is created and meets the format and content requirements, stop tool use and link the file without repeating its contents.
 
 ## Plan Artifact
 
-Use `Write` with a payload containing the path header followed by the complete file:
+Create the artifact using this complete file structure. The artifact consists of a YAML frontmatter and a non-empty Markdown body whose first line is a level-1 heading.
 
-```text
-+++ .bitfun/plans/<short-kebab-name>.plan.md
-<complete plan file>
-```
-
-The file must start with YAML frontmatter in this shape. Always include `todos`; use `todos: []` for a simple plan. Every todo starts as `pending`, has a stable kebab-case ID, and includes `dependencies`, using `[]` when it has none.
-
-```yaml
+```markdown
 ---
 name: Short Plan Name
 overview: One or two sentence overview
@@ -34,16 +27,20 @@ todos:
   - id: stable-todo-id
     content: Specific actionable task
     status: pending
-    dependencies: []
 ---
+
+# Short Plan Name
+
+...
 ```
 
-Follow the frontmatter with a non-empty Markdown body whose first line is a level-1 heading. Keep the plan proportional to the request and cite specific workspace-relative files with Markdown links when useful.
+- Todos help break down complex plans into manageable, trackable tasks. Always include `todos`; use `todos: []` for a simple plan. Every todo starts as `pending` and has a stable kebab-case ID.
+- The plan should be concise and actionable. Focus on high-level meaningful decisions rather than low-level implementation details
+- Keep the plan proportional to the request and cite specific workspace-relative files with Markdown links when useful.
 
 ## Rules
 
 - Do not edit project source, change configuration, run mutating commands, or otherwise implement the task while this planning workflow applies. The only permitted mutation is a `.bitfun/plans/*.plan.md` artifact.
-- If the plan Write fails or falls back under `.bitfun/tmp`, fix only the plan artifact write and retry; that fallback is not a completed plan.
-- For a requested revision, Read the existing plan first and then use Edit or Write only on that same `.bitfun/plans/*.plan.md` file. Do not create another plan card merely to revise it.
-- The successful plan Write is the final tool call for the planning turn.
-- Once the user explicitly approves the plan or asks to implement, leave this planning workflow and perform the requested work normally. This skill does not require an Agent or mode switch.
+- Before creating a new plan, inspect `.bitfun/plans` and choose an unused filename.
+- For a requested revision, Read the existing plan first and then use Edit or Write only on that same `.bitfun/plans/*.plan.md` file.
+- Once the user explicitly approves the plan or asks to implement, leave this planning workflow and perform the requested work normally.

--- a/src/crates/assembly/core/src/agentic/tools/implementations/file_write_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/file_write_tool.rs
@@ -1,3 +1,6 @@
+use super::plan_artifact_diagnostics::{
+    diagnose_plan_artifact, is_plan_artifact_path, PlanArtifactIssue,
+};
 use crate::agentic::tools::file_permissions::file_permission_intents_allowing_managed_plan_edits;
 use crate::agentic::tools::file_read_state_runtime::{
     assert_file_not_unexpectedly_modified, file_mutation_timestamp_ms, get_stored_file_read_state,
@@ -240,6 +243,7 @@ impl FileWriteTool {
         missing_path_fallback: bool,
         path_format_warning: Option<&str>,
         ignored_parameter_names: &[String],
+        plan_artifact_issues: Option<&[PlanArtifactIssue]>,
     ) -> ToolResult {
         let mut assistant_message = if missing_path_fallback {
             format!(
@@ -264,19 +268,42 @@ impl FileWriteTool {
                 formatted_names
             ));
         }
+        if let Some(issues) = plan_artifact_issues.filter(|issues| !issues.is_empty()) {
+            assistant_message.push_str("\nThe `.plan.md` artifact does not match the plan format:");
+            for issue in issues {
+                assistant_message.push_str("\n- ");
+                assistant_message.push_str(&issue.message);
+            }
+            assistant_message.push_str(
+                "\nUse Edit on the written file to fix these issues before finishing.",
+            );
+        }
+        let mut data = json!({
+            "file_path": logical_path,
+            "bytes_written": outcome.bytes_written,
+            "lines_written": outcome.lines_written,
+            "success": true,
+            "status": outcome.status.as_str(),
+            "missing_path_fallback": missing_path_fallback,
+            "rename_required": missing_path_fallback,
+            "path_format_corrected": path_format_warning.is_some(),
+            "path_format_warning": path_format_warning,
+            "message": assistant_message,
+        });
+        if let Some(issues) = plan_artifact_issues {
+            data["plan_format"] = json!({
+                "valid": issues.is_empty(),
+                "issues": issues
+                    .iter()
+                    .map(|issue| json!({
+                        "code": issue.code,
+                        "message": issue.message.as_str(),
+                    }))
+                    .collect::<Vec<_>>(),
+            });
+        }
         ToolResult::Result {
-            data: json!({
-                "file_path": logical_path,
-                "bytes_written": outcome.bytes_written,
-                "lines_written": outcome.lines_written,
-                "success": true,
-                "status": outcome.status.as_str(),
-                "missing_path_fallback": missing_path_fallback,
-                "rename_required": missing_path_fallback,
-                "path_format_corrected": path_format_warning.is_some(),
-                "path_format_warning": path_format_warning,
-                "message": assistant_message,
-            }),
+            data,
             result_for_assistant: Some(assistant_message),
             image_attachments: None,
         }
@@ -543,6 +570,8 @@ impl Tool for FileWriteTool {
 
         let resolved = context.resolve_tool_path(&file_path)?;
         let path_format_warning = Self::path_format_correction_warning(&resolved);
+        let plan_artifact_issues =
+            is_plan_artifact_path(&resolved.logical_path).then(|| diagnose_plan_artifact(&content));
         context.enforce_path_operation(ToolPathOperation::Write, &resolved)?;
         context
             .record_light_checkpoint(
@@ -562,6 +591,7 @@ impl Tool for FileWriteTool {
                 missing_path_fallback,
                 path_format_warning.as_deref(),
                 &ignored_parameter_names,
+                plan_artifact_issues.as_deref(),
             );
             return Ok(vec![result]);
         }
@@ -598,6 +628,7 @@ impl Tool for FileWriteTool {
                 missing_path_fallback,
                 path_format_warning.as_deref(),
                 &ignored_parameter_names,
+                plan_artifact_issues.as_deref(),
             );
             return Ok(vec![result]);
         }
@@ -634,6 +665,7 @@ impl Tool for FileWriteTool {
             missing_path_fallback,
             path_format_warning.as_deref(),
             &ignored_parameter_names,
+            plan_artifact_issues.as_deref(),
         );
 
         Ok(vec![result])
@@ -642,7 +674,7 @@ impl Tool for FileWriteTool {
 
 #[cfg(test)]
 mod tests {
-    use super::FileWriteTool;
+    use super::{diagnose_plan_artifact, FileWriteTool};
     use crate::agentic::tools::file_tool_guidance::{
         file_tool_guidance_message, is_file_tool_guidance_message, FILE_TOOL_GUIDANCE_PREFIX,
     };
@@ -893,6 +925,39 @@ mod tests {
         assert!(validation.message.is_none());
     }
 
+    #[test]
+    fn write_success_result_reports_non_blocking_plan_issues() {
+        let logical_path = ".bitfun/plans/example.plan.md";
+        let content = "---\nname: Example\noverview: Overview\ntodos: []\n---\n";
+        let issues = diagnose_plan_artifact(content);
+
+        let result = FileWriteTool::write_success_result(
+            logical_path,
+            super::write_file_success_outcome(logical_path, false, content),
+            false,
+            None,
+            &[],
+            Some(&issues),
+        );
+        let ToolResult::Result {
+            data,
+            result_for_assistant,
+            ..
+        } = result
+        else {
+            panic!("expected result");
+        };
+
+        assert_eq!(data["success"], true);
+        assert_eq!(data["plan_format"]["valid"], false);
+        assert_eq!(
+            data["plan_format"]["issues"][0]["code"],
+            "missing_markdown_body"
+        );
+        let assistant_message = result_for_assistant.as_deref().unwrap_or_default();
+        assert!(assistant_message.contains("does not match the plan format"));
+    }
+
     #[cfg(windows)]
     #[tokio::test]
     async fn write_result_reports_normalized_windows_drive_path() {
@@ -927,6 +992,7 @@ mod tests {
             false,
             Some(&warning),
             &[],
+            None,
         );
         let ToolResult::Result {
             data,

--- a/src/crates/assembly/core/src/agentic/tools/implementations/mod.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/mod.rs
@@ -52,6 +52,7 @@ pub mod miniapp_publish_tool;
 pub mod page_deploy_tool;
 #[cfg(feature = "tools-miniapp")]
 pub mod page_publish_tool;
+mod plan_artifact_diagnostics;
 #[cfg(feature = "tools-miniapp")]
 pub mod playbook_tool;
 #[cfg(feature = "tools-agent-control")]

--- a/src/crates/assembly/core/src/agentic/tools/implementations/plan_artifact_diagnostics.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/plan_artifact_diagnostics.rs
@@ -1,0 +1,255 @@
+use serde_yaml::{Mapping, Value};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct PlanArtifactIssue {
+    pub code: &'static str,
+    pub message: String,
+}
+
+impl PlanArtifactIssue {
+    fn new(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+}
+
+pub(super) fn is_plan_artifact_path(path: &str) -> bool {
+    path.replace('\\', "/")
+        .to_ascii_lowercase()
+        .ends_with(".plan.md")
+}
+
+pub(super) fn diagnose_plan_artifact(content: &str) -> Vec<PlanArtifactIssue> {
+    let (frontmatter, body) = match split_frontmatter(content) {
+        Ok(parts) => parts,
+        Err(issue) => return vec![issue],
+    };
+
+    let mut issues = Vec::new();
+    match serde_yaml::from_str::<Value>(frontmatter) {
+        Ok(Value::Mapping(mapping)) => diagnose_frontmatter(&mapping, &mut issues),
+        Ok(_) => issues.push(PlanArtifactIssue::new(
+            "invalid_frontmatter_object",
+            "Make the YAML frontmatter an object containing `name`, `overview`, and `todos`.",
+        )),
+        Err(error) => issues.push(PlanArtifactIssue::new(
+            "invalid_frontmatter_yaml",
+            format!("Fix the YAML frontmatter syntax: {error}"),
+        )),
+    }
+
+    if body.trim().is_empty() {
+        issues.push(PlanArtifactIssue::new(
+            "missing_markdown_body",
+            "Add a non-empty Markdown body after the YAML frontmatter.",
+        ));
+    }
+
+    issues
+}
+
+fn split_frontmatter(content: &str) -> Result<(&str, &str), PlanArtifactIssue> {
+    let rest = content
+        .strip_prefix("---\n")
+        .or_else(|| content.strip_prefix("---\r\n"))
+        .ok_or_else(|| {
+            PlanArtifactIssue::new(
+                "missing_frontmatter",
+                "Start the plan file with YAML frontmatter delimited by `---` lines.",
+            )
+        })?;
+
+    let mut offset = 0;
+    for segment in rest.split_inclusive('\n') {
+        let line = segment.strip_suffix('\n').unwrap_or(segment);
+        let line = line.strip_suffix('\r').unwrap_or(line);
+        if line == "---" {
+            return Ok((&rest[..offset], &rest[offset + segment.len()..]));
+        }
+        offset += segment.len();
+    }
+
+    Err(PlanArtifactIssue::new(
+        "unterminated_frontmatter",
+        "Close the YAML frontmatter with a second `---` line before the Markdown body.",
+    ))
+}
+
+fn diagnose_frontmatter(mapping: &Mapping, issues: &mut Vec<PlanArtifactIssue>) {
+    diagnose_required_string(mapping, "name", issues);
+    diagnose_required_string(mapping, "overview", issues);
+
+    let Some(todos) = mapping_field(mapping, "todos") else {
+        issues.push(PlanArtifactIssue::new(
+            "missing_todos",
+            "Add a `todos` array to the YAML frontmatter; use `todos: []` for a simple plan.",
+        ));
+        return;
+    };
+    let Value::Sequence(todos) = todos else {
+        issues.push(PlanArtifactIssue::new(
+            "invalid_todos",
+            "Make `todos` a YAML array; use `todos: []` for a simple plan.",
+        ));
+        return;
+    };
+
+    for (index, todo) in todos.iter().enumerate() {
+        let Value::Mapping(todo) = todo else {
+            issues.push(PlanArtifactIssue::new(
+                "invalid_todo",
+                format!("Make `todos[{index}]` an object containing non-empty `id` and `content` fields."),
+            ));
+            continue;
+        };
+
+        match non_empty_string_field(todo, "id") {
+            Some(id) if !is_kebab_case(id) => issues.push(PlanArtifactIssue::new(
+                "invalid_todo_id_format",
+                format!("Change `todos[{index}].id` to a kebab-case identifier."),
+            )),
+            Some(_) => {}
+            None => issues.push(PlanArtifactIssue::new(
+                "invalid_todo_id",
+                format!("Give `todos[{index}].id` a non-empty string value."),
+            )),
+        }
+
+        if non_empty_string_field(todo, "content").is_none() {
+            issues.push(PlanArtifactIssue::new(
+                "invalid_todo_content",
+                format!("Give `todos[{index}].content` a non-empty string value."),
+            ));
+        }
+    }
+}
+
+fn diagnose_required_string(
+    mapping: &Mapping,
+    field: &'static str,
+    issues: &mut Vec<PlanArtifactIssue>,
+) {
+    if non_empty_string_field(mapping, field).is_none() {
+        issues.push(PlanArtifactIssue::new(
+            match field {
+                "name" => "invalid_name",
+                "overview" => "invalid_overview",
+                _ => "invalid_required_field",
+            },
+            format!("Give the frontmatter `{field}` field a non-empty string value."),
+        ));
+    }
+}
+
+fn non_empty_string_field<'a>(mapping: &'a Mapping, field: &str) -> Option<&'a str> {
+    mapping_field(mapping, field)
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+}
+
+fn mapping_field<'a>(mapping: &'a Mapping, field: &str) -> Option<&'a Value> {
+    mapping.get(&Value::String(field.to_string()))
+}
+
+fn is_kebab_case(value: &str) -> bool {
+    let mut segment_has_character = false;
+    for character in value.chars() {
+        if character == '-' {
+            if !segment_has_character {
+                return false;
+            }
+            segment_has_character = false;
+        } else if character.is_ascii_lowercase() || character.is_ascii_digit() {
+            segment_has_character = true;
+        } else {
+            return false;
+        }
+    }
+    segment_has_character
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{diagnose_plan_artifact, is_plan_artifact_path};
+
+    fn issue_codes(content: &str) -> Vec<&'static str> {
+        diagnose_plan_artifact(content)
+            .into_iter()
+            .map(|issue| issue.code)
+            .collect()
+    }
+
+    #[test]
+    fn recognizes_plan_artifact_paths_case_insensitively() {
+        assert!(is_plan_artifact_path(".bitfun/plans/example.plan.md"));
+        assert!(is_plan_artifact_path(
+            r"E:\workspace\.bitfun\plans\EXAMPLE.PLAN.MD"
+        ));
+        assert!(!is_plan_artifact_path(".bitfun/plans/example.plan.md.bak"));
+    }
+
+    #[test]
+    fn reports_missing_or_unterminated_frontmatter_without_cascading_issues() {
+        assert_eq!(issue_codes("# Plan\n"), vec!["missing_frontmatter"]);
+        assert_eq!(
+            issue_codes("---\nname: Plan\n# Body\n"),
+            vec!["unterminated_frontmatter"]
+        );
+    }
+
+    #[test]
+    fn reports_invalid_yaml_and_missing_body() {
+        assert_eq!(
+            issue_codes("---\nname: [\n---\n"),
+            vec!["invalid_frontmatter_yaml", "missing_markdown_body"]
+        );
+    }
+
+    #[test]
+    fn reports_required_frontmatter_and_todo_issues() {
+        let content = r#"---
+name: ""
+overview: 42
+todos:
+  - id: Not Kebab
+    content: ""
+  - content: Missing id
+  - invalid scalar
+---
+
+Plan body.
+"#;
+
+        assert_eq!(
+            issue_codes(content),
+            vec![
+                "invalid_name",
+                "invalid_overview",
+                "invalid_todo_id_format",
+                "invalid_todo_content",
+                "invalid_todo_id",
+                "invalid_todo",
+            ]
+        );
+    }
+
+    #[test]
+    fn requires_todos_to_exist_and_be_an_array() {
+        assert_eq!(
+            issue_codes("---\nname: Plan\noverview: Overview\n---\nBody"),
+            vec!["missing_todos"]
+        );
+        assert_eq!(
+            issue_codes("---\nname: Plan\noverview: Overview\ntodos: nope\n---\nBody"),
+            vec!["invalid_todos"]
+        );
+    }
+
+    #[test]
+    fn accepts_crlf_frontmatter() {
+        let content = "---\r\nname: Plan\r\noverview: Overview\r\ntodos: []\r\n---\r\nBody";
+        assert!(diagnose_plan_artifact(content).is_empty());
+    }
+}

--- a/src/web-ui/src/component-library/components/registry.tsx
+++ b/src/web-ui/src/component-library/components/registry.tsx
@@ -1406,7 +1406,7 @@ console.log(user.greet());`);
             <h3 style={{ color: 'var(--bf-color-content-on-dark)', marginTop: '16px', marginBottom: '8px' }}>创建计划 - 已完成</h3>
             <FileOperationToolCard
               toolItem={createMockToolItem('Write', {
-                payload: '+++ .bitfun/plans/refactor-module.plan.md\n---\nname: Refactor Module\noverview: Refactor the module safely.\ntodos:\n  - id: update-api\n    content: Update the API\n    status: in_progress\n    dependencies: []\n  - id: add-tests\n    content: Add focused tests\n    status: pending\n    dependencies:\n      - update-api\n---\n\n# Refactor Module\n\nImplement the refactor in focused steps.',
+                payload: '+++ .bitfun/plans/refactor-module.plan.md\n---\nname: Refactor Module\noverview: Refactor the module safely.\ntodos:\n  - id: update-api\n    content: Update the API\n    status: in_progress\n  - id: add-tests\n    content: Add focused tests\n    status: pending\n---\n\n# Refactor Module\n\nImplement the refactor in focused steps.',
               }, {
                 file_path: '.bitfun/plans/refactor-module.plan.md',
                 success: true,

--- a/src/web-ui/src/flow_chat/tool-cards/CreatePlanDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/CreatePlanDisplay.tsx
@@ -363,6 +363,10 @@ export const PlanDisplay: React.FC<PlanDisplayProps> = ({
     if (!planFilePath || buildStatus !== 'build') return;
     
     try {
+      const sessionId = flowChatManager.getCurrentSession()?.sessionId;
+      if (!sessionId) {
+        throw new Error('No active session');
+      }
       const content = await workspaceAPI.readFileContent(
         planFilePath,
         undefined,
@@ -383,33 +387,28 @@ export const PlanDisplay: React.FC<PlanDisplayProps> = ({
 
       // Register build in shared service (notifies all subscribers including PlanViewer).
       const todoIds = latestPlanData.todos.map(t => t.id);
-      planBuildStateService.startBuild({
+      const turnId = planBuildStateService.startBuild({
+        sessionId,
         planFilePath,
         todoIds,
         workspacePath: effectiveWorkspacePath,
         remoteConnectionId: effectiveRemoteConnectionId,
       });
+      if (!turnId) return;
 
-      // Send message using the latest data.
-      const simpleTodos = latestPlanData.todos.map(t => ({ 
-        id: t.id, 
-        content: t.content,
-        status: t.status
-      }));
+      const message = `Implement the plan at \`${latestPlanData.planFilePath}\`.
 
-      const message = `Implement the plan as specified, it is attached for your reference. Do NOT edit the plan file itself. To-do's from the plan have already been created. Do not create them again. Mark them as in_progress as you work, starting with the first one. Don't stop until you have completed all the to-dos.
-
-<attached_file path="${latestPlanData.planFilePath}">
-<plan>
-${parsed.planContent}
-</plan>
-<todos>
-${JSON.stringify(simpleTodos, null, 2)}
-</todos>
-</attached_file>`;
+Read the plan file before making changes and treat it as the source of truth. Do not edit the plan file directly. Track progress with TodoWrite using the existing todo IDs from the plan frontmatter; do not rename or invent IDs. Start with the first pending todo and continue until all todos are completed.`;
 
       const displayMessage = `Build Plan: ${latestPlanData.name}`;
-      await flowChatManager.sendMessage(message, undefined, displayMessage, 'agentic', 'agentic');
+      await flowChatManager.sendMessage(
+        message,
+        sessionId,
+        displayMessage,
+        undefined,
+        undefined,
+        { turnId },
+      );
     } catch (error) {
       log.error('Build failed', { cacheKey: effectiveCacheKey, planFilePath, error });
       planBuildStateService.cancelBuild(planFileRef);

--- a/src/web-ui/src/shared/plan/planDocument.test.ts
+++ b/src/web-ui/src/shared/plan/planDocument.test.ts
@@ -9,7 +9,6 @@ todos:
   - id: add-write-card
     content: Render .plan.md writes as plan cards
     status: pending
-    dependencies: []
 ---
 
 # Replace CreatePlan
@@ -25,7 +24,6 @@ describe('planDocument', () => {
         id: 'add-write-card',
         content: 'Render .plan.md writes as plan cards',
         status: 'pending',
-        dependencies: [],
       }],
       planContent: '# Replace CreatePlan\n\nImplement the Write-backed plan flow.',
     });

--- a/src/web-ui/src/shared/plan/planDocument.ts
+++ b/src/web-ui/src/shared/plan/planDocument.ts
@@ -4,7 +4,6 @@ export interface PlanTodo {
   id: string;
   content: string;
   status?: string;
-  dependencies?: string[];
 }
 
 export interface PlanDocument {
@@ -36,13 +35,6 @@ function parseTodos(value: unknown): PlanTodo[] {
     }
 
     const todo = item as Record<string, unknown>;
-    const dependencies = todo.dependencies;
-    if (
-      dependencies != null
-      && (!Array.isArray(dependencies) || dependencies.some(value => typeof value !== 'string'))
-    ) {
-      throw new Error(`Plan todo '${String(todo.id ?? index)}' has invalid dependencies`);
-    }
     if (todo.status != null && typeof todo.status !== 'string') {
       throw new Error(`Plan todo '${String(todo.id ?? index)}' has an invalid status`);
     }
@@ -51,7 +43,6 @@ function parseTodos(value: unknown): PlanTodo[] {
       id: requireNonEmptyString(todo.id, `todos[${index}].id`),
       content: requireNonEmptyString(todo.content, `todos[${index}].content`),
       status: todo.status as string | undefined,
-      dependencies: dependencies as string[] | undefined,
     };
   });
 }

--- a/src/web-ui/src/shared/services/PlanBuildStateService.test.ts
+++ b/src/web-ui/src/shared/services/PlanBuildStateService.test.ts
@@ -1,0 +1,191 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  readFileContent: vi.fn(),
+  writeFileContent: vi.fn(),
+  onDialogTurnCompleted: vi.fn(),
+  onDialogTurnFailed: vi.fn(),
+  onDialogTurnCancelled: vi.fn(),
+  onDialogTurnInterrupted: vi.fn(),
+  dialogTurnCompleted: undefined as ((event: { sessionId: string; turnId: string }) => void) | undefined,
+  dialogTurnFailed: undefined as ((event: { sessionId: string; turnId: string }) => void) | undefined,
+  dialogTurnCancelled: undefined as ((event: { sessionId: string; turnId: string }) => void) | undefined,
+  dialogTurnInterrupted: undefined as ((event: { sessionId: string; turnId: string }) => void) | undefined,
+}));
+
+vi.mock('@/infrastructure/api/service-api/AgentAPI', () => ({
+  agentAPI: {
+    onDialogTurnCompleted: mocks.onDialogTurnCompleted.mockImplementation((callback) => {
+      mocks.dialogTurnCompleted = callback;
+      return vi.fn();
+    }),
+    onDialogTurnFailed: mocks.onDialogTurnFailed.mockImplementation((callback) => {
+      mocks.dialogTurnFailed = callback;
+      return vi.fn();
+    }),
+    onDialogTurnCancelled: mocks.onDialogTurnCancelled.mockImplementation((callback) => {
+      mocks.dialogTurnCancelled = callback;
+      return vi.fn();
+    }),
+    onDialogTurnInterrupted: mocks.onDialogTurnInterrupted.mockImplementation((callback) => {
+      mocks.dialogTurnInterrupted = callback;
+      return vi.fn();
+    }),
+  },
+}));
+
+vi.mock('@/infrastructure/api/service-api/WorkspaceAPI', () => ({
+  workspaceAPI: {
+    readFileContent: mocks.readFileContent,
+    writeFileContent: mocks.writeFileContent,
+  },
+}));
+
+import {
+  planBuildStateService,
+  type PlanFileRef,
+} from './PlanBuildStateService';
+
+const PLAN_CONTENT = `---
+name: Example Plan
+overview: Verify session-scoped build tracking.
+todos:
+  - id: shared-todo
+    content: Update the implementation
+    status: pending
+---
+
+Plan body.`;
+
+describe('PlanBuildStateService', () => {
+  const trackedTargets: PlanFileRef[] = [];
+
+  function target(name: string): PlanFileRef {
+    const value = {
+      planFilePath: `/workspace/.bitfun/plans/${name}.plan.md`,
+      workspacePath: '/workspace',
+    };
+    trackedTargets.push(value);
+    return value;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.readFileContent.mockResolvedValue(PLAN_CONTENT);
+    mocks.writeFileContent.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    for (const value of trackedTargets.splice(0)) {
+      planBuildStateService.cancelBuild(value);
+    }
+  });
+
+  it('cancels only builds owned by the cancelled session', () => {
+    const first = target('first');
+    const second = target('second');
+    planBuildStateService.startBuild({
+      ...first,
+      sessionId: 'session-a',
+      todoIds: ['shared-todo'],
+    });
+    planBuildStateService.startBuild({
+      ...second,
+      sessionId: 'session-b',
+      todoIds: ['shared-todo'],
+    });
+
+    window.dispatchEvent(new CustomEvent('bitfun:dialog-cancelled', {
+      detail: { sessionId: 'session-a' },
+    }));
+
+    expect(planBuildStateService.isBuildActive(first)).toBe(false);
+    expect(planBuildStateService.isBuildActive(second)).toBe(true);
+  });
+
+  it('applies TodoWrite updates only to builds owned by that session', async () => {
+    const first = target('todo-first');
+    const second = target('todo-second');
+    const firstTurnId = planBuildStateService.startBuild({
+      ...first,
+      sessionId: 'session-a',
+      todoIds: ['shared-todo'],
+    });
+    planBuildStateService.startBuild({
+      ...second,
+      sessionId: 'session-b',
+      todoIds: ['shared-todo'],
+    });
+
+    window.dispatchEvent(new CustomEvent('bitfun:todowrite-update', {
+      detail: {
+        sessionId: 'session-a',
+        turnId: firstTurnId,
+        todos: [{
+          id: 'shared-todo',
+          content: 'Update the implementation',
+          status: 'completed',
+        }],
+        merge: false,
+      },
+    }));
+
+    await vi.waitFor(() => {
+      expect(mocks.writeFileContent).toHaveBeenCalledOnce();
+    });
+    expect(mocks.readFileContent).toHaveBeenCalledWith(
+      first.planFilePath,
+      undefined,
+      undefined,
+    );
+    expect(mocks.writeFileContent).toHaveBeenCalledWith(
+      first.workspacePath,
+      first.planFilePath,
+      expect.stringContaining('status: completed'),
+      undefined,
+    );
+    expect(planBuildStateService.isBuildActive(first)).toBe(false);
+    expect(planBuildStateService.isBuildActive(second)).toBe(true);
+  });
+
+  it('does not register a build without valid todo IDs', () => {
+    const plan = target('empty-todos');
+
+    const turnId = planBuildStateService.startBuild({
+      ...plan,
+      sessionId: 'session-a',
+      todoIds: ['', '   '],
+    });
+
+    expect(turnId).toBeNull();
+    expect(planBuildStateService.isBuildActive(plan)).toBe(false);
+  });
+
+  it.each([
+    ['completed', () => mocks.dialogTurnCompleted],
+    ['failed', () => mocks.dialogTurnFailed],
+    ['cancelled', () => mocks.dialogTurnCancelled],
+    ['interrupted', () => mocks.dialogTurnInterrupted],
+  ])('stops only the owning build when its turn is %s', (_status, getListener) => {
+    const first = target(`settled-${_status}`);
+    const second = target(`other-${_status}`);
+    const firstTurnId = planBuildStateService.startBuild({
+      ...first,
+      sessionId: 'session-a',
+      todoIds: ['shared-todo'],
+    });
+    planBuildStateService.startBuild({
+      ...second,
+      sessionId: 'session-a',
+      todoIds: ['shared-todo'],
+    });
+
+    expect(firstTurnId).not.toBeNull();
+    getListener()?.({ sessionId: 'session-a', turnId: firstTurnId! });
+
+    expect(planBuildStateService.isBuildActive(first)).toBe(false);
+    expect(planBuildStateService.isBuildActive(second)).toBe(true);
+  });
+});

--- a/src/web-ui/src/shared/services/PlanBuildStateService.ts
+++ b/src/web-ui/src/shared/services/PlanBuildStateService.ts
@@ -7,6 +7,7 @@
  */
 
 import { workspaceAPI } from '@/infrastructure/api/service-api/WorkspaceAPI';
+import { agentAPI } from '@/infrastructure/api/service-api/AgentAPI';
 import { createLogger } from '@/shared/utils/logger';
 import {
   parsePlanMarkdown,
@@ -21,7 +22,7 @@ function yamlFrontmatter(content: string): string {
 }
 
 export interface PlanBuildStateEvent {
-  type: 'build-started' | 'build-completed' | 'build-cancelled' | 'todos-updated';
+  type: 'build-started' | 'build-completed' | 'build-cancelled' | 'build-stopped' | 'todos-updated';
   /** Whether the plan is still building after this event. */
   isBuilding: boolean;
   /** Updated todo list (present for todos-updated and build-completed). */
@@ -35,6 +36,8 @@ export interface PlanBuildStateEvent {
 export type BuildStateCallback = (event: PlanBuildStateEvent) => void;
 
 interface BuildEntry {
+  sessionId: string;
+  turnId: string;
   todoIds: Set<string>;
   /** Original file path (preserves platform separators for API calls). */
   planFilePath: string;
@@ -50,6 +53,7 @@ export interface PlanFileRef {
 }
 
 export interface StartPlanBuildRequest extends PlanFileRef {
+  sessionId: string;
   todoIds: string[];
 }
 
@@ -80,17 +84,30 @@ class PlanBuildStateService {
 
   // ==================== Public API ====================
 
-  /** Mark a plan as building and notify all subscribers. */
-  startBuild(request: StartPlanBuildRequest): void {
+  /** Mark a plan as building and return the turn ID that must own the build. */
+  startBuild(request: StartPlanBuildRequest): string | null {
+    const todoIds = request.todoIds.filter(id => id.trim().length > 0);
+    if (todoIds.length === 0) {
+      log.warn('Ignored plan build without valid todo IDs', {
+        planFilePath: request.planFilePath,
+        sessionId: request.sessionId,
+      });
+      return null;
+    }
+
+    const turnId = `dialog_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
     const key = this.targetKey(request);
     this.buildingPlans.set(key, {
-      todoIds: new Set(request.todoIds),
+      sessionId: request.sessionId,
+      turnId,
+      todoIds: new Set(todoIds),
       planFilePath: request.planFilePath,
       workspacePath: request.workspacePath ?? '',
       remoteConnectionId: request.remoteConnectionId,
       startedAt: Date.now(),
     });
     this.notify(key, { type: 'build-started', isBuilding: true });
+    return turnId;
   }
 
   /** Check whether a plan is currently building. */
@@ -168,6 +185,10 @@ class PlanBuildStateService {
   private setupGlobalListeners(): void {
     window.addEventListener('bitfun:todowrite-update', this.handleTodoWriteUpdate);
     window.addEventListener('bitfun:dialog-cancelled', this.handleDialogCancelled);
+    agentAPI.onDialogTurnCompleted(this.handleDialogTurnSettled);
+    agentAPI.onDialogTurnFailed(this.handleDialogTurnSettled);
+    agentAPI.onDialogTurnCancelled(this.handleDialogTurnSettled);
+    agentAPI.onDialogTurnInterrupted(this.handleDialogTurnSettled);
   }
 
   /**
@@ -181,11 +202,12 @@ class PlanBuildStateService {
       todos: Array<{ id: string; content: string; status: string }>;
       merge: boolean;
     }>;
-    const { todos: incomingTodos } = customEvent.detail;
+    const { sessionId, todos: incomingTodos } = customEvent.detail;
 
-    if (!incomingTodos.length) return;
+    if (!sessionId || !incomingTodos.length) return;
 
     for (const [key, entry] of this.buildingPlans.entries()) {
+      if (entry.sessionId !== sessionId || entry.turnId !== customEvent.detail.turnId) continue;
       const matchedTodos = incomingTodos.filter(t => entry.todoIds.has(t.id));
       if (matchedTodos.length === 0) continue;
 
@@ -236,14 +258,37 @@ class PlanBuildStateService {
     }
   };
 
-  /** Cancel all active builds when a dialog is cancelled. */
-  private handleDialogCancelled = (): void => {
-    if (this.buildingPlans.size === 0) return;
+  /** Stop a build when the exact turn that owns it reaches any terminal state. */
+  private handleDialogTurnSettled = (event: {
+    sessionId?: string;
+    session_id?: string;
+    turnId?: string;
+    turn_id?: string;
+  }): void => {
+    const sessionId = event.sessionId ?? event.session_id;
+    const turnId = event.turnId ?? event.turn_id;
+    if (!sessionId || !turnId) return;
 
-    for (const key of Array.from(this.buildingPlans.keys())) {
-      this.notify(key, { type: 'build-cancelled', isBuilding: false });
+    for (const [key, entry] of this.buildingPlans.entries()) {
+      if (entry.sessionId !== sessionId || entry.turnId !== turnId) continue;
+      this.notify(key, { type: 'build-stopped', isBuilding: false });
+      this.buildingPlans.delete(key);
     }
-    this.buildingPlans.clear();
+  };
+
+  /** Cancel active builds owned by the cancelled session. */
+  private handleDialogCancelled = (event: Event): void => {
+    const sessionId = (event as CustomEvent<{ sessionId?: unknown }>).detail?.sessionId;
+    if (typeof sessionId !== 'string' || !sessionId) {
+      log.warn('Ignored dialog cancellation without a session ID');
+      return;
+    }
+
+    for (const [key, entry] of this.buildingPlans.entries()) {
+      if (entry.sessionId !== sessionId) continue;
+      this.notify(key, { type: 'build-cancelled', isBuilding: false });
+      this.buildingPlans.delete(key);
+    }
   };
 }
 

--- a/src/web-ui/src/tools/editor/components/PlanViewer.tsx
+++ b/src/web-ui/src/tools/editor/components/PlanViewer.tsx
@@ -28,7 +28,6 @@ interface PlanTodo {
   id: string;
   content: string;
   status?: string;
-  dependencies?: string[];
 }
 
 interface PlanData {
@@ -718,43 +717,42 @@ const PlanViewer: React.FC<PlanViewerProps> = ({
 
   // Build button click handler
   const handleBuild = useCallback(async () => {
-    if (!filePath || buildStatus !== 'build' || !planData) return;
+    if (!filePath || buildStatus !== 'build' || !planData || hasUnsavedChanges) return;
 
     try {
+      const sessionId = flowChatManager.getCurrentSession()?.sessionId;
+      if (!sessionId) {
+        throw new Error('No active session');
+      }
       // Register build in shared service (notifies all PlanDisplay and PlanViewer subscribers).
       const todoIds = planData.todos.map(t => t.id);
-      planBuildStateService.startBuild({
+      const turnId = planBuildStateService.startBuild({
+        sessionId,
         planFilePath: filePath,
         todoIds,
         workspacePath: effectiveWorkspacePath,
         remoteConnectionId: effectiveRemoteConnectionId,
       });
+      if (!turnId) return;
 
-      // Process todos, keep only id, content, and status
-      const simpleTodos = planData.todos.map(t => ({
-        id: t.id,
-        content: t.content,
-        status: t.status,
-      }));
+      const message = `Implement the plan at \`${filePath}\`.
 
-      const message = `Implement the plan as specified, it is attached for your reference. Do NOT edit the plan file itself. To-do's from the plan have already been created. Do not create them again. Mark them as in_progress as you work, starting with the first one. Don't stop until you have completed all the to-dos.
-
-<attached_file path="${filePath}">
-<plan>
-${planContent}
-</plan>
-<todos>
-${JSON.stringify(simpleTodos, null, 2)}
-</todos>
-</attached_file>`;
+Read the plan file before making changes and treat it as the source of truth. Do not edit the plan file directly. Track progress with TodoWrite using the existing todo IDs from the plan frontmatter; do not rename or invent IDs. Start with the first pending todo and continue until all todos are completed.`;
 
       const displayMessage = t('editor.planViewer.buildPlanTitle', { name: planData.name });
-      await flowChatManager.sendMessage(message, undefined, displayMessage, 'agentic', 'agentic');
+      await flowChatManager.sendMessage(
+        message,
+        sessionId,
+        displayMessage,
+        undefined,
+        undefined,
+        { turnId },
+      );
     } catch (err) {
       log.error('Build failed', err);
       planBuildStateService.cancelBuild(planFileRef);
     }
-  }, [filePath, planFileRef, buildStatus, effectiveRemoteConnectionId, effectiveWorkspacePath, planData, planContent, t]);
+  }, [filePath, planFileRef, buildStatus, effectiveRemoteConnectionId, effectiveWorkspacePath, hasUnsavedChanges, planData, t]);
 
   // Get todo status icon
   function getTodoIcon(status?: string) {
@@ -841,7 +839,7 @@ ${JSON.stringify(simpleTodos, null, 2)}
                       : undefined
                 }
                 onClick={handleBuild}
-                disabled={buildStatus !== 'build'}
+                disabled={buildStatus !== 'build' || hasUnsavedChanges}
               >
                 {buildStatus === 'building'
                   ? t('editor.planViewer.building')


### PR DESCRIPTION
Clarify the plan skill with a complete artifact example and remove the
obsolete todo dependencies field from the frontend contract.

Add non-blocking Write diagnostics for malformed .plan.md artifacts so
files remain saved while agents receive structured repair guidance.

Improve plan builds by:
- Binding active builds to their session and turn
- Rejecting builds without valid todo IDs
- Settling state when the owning turn terminates
- Preventing builds with unsaved editor changes
- Preserving the current agent and sending only the plan path
