### PR TITLE
feat(flow-chat): show MCP tool input parameters

### DIFF
--- a/src/web-ui/src/flow_chat/tool-cards/BaseToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/BaseToolCard.tsx
@@ -47,6 +47,8 @@ export interface BaseToolCardProps {
   errorContent?: ReactNode;
   /** Whether to show error */
   isFailed?: boolean;
+  /** Allow an explicitly expanded details panel to remain available for failed tools. */
+  allowExpandedWhenFailed?: boolean;
   /** Whether user confirmation is required (for highlighting border) */
   requiresConfirmation?: boolean;
   /** data-testid for the real click target that expands/collapses the card. */
@@ -80,6 +82,7 @@ export const BaseToolCard: React.FC<BaseToolCardProps> = ({
   expandedContent,
   errorContent,
   isFailed = false,
+  allowExpandedWhenFailed = false,
   requiresConfirmation = false,
   toggleTestId,
   headerExpandAffordance: headerExpandAffordanceProp,
@@ -94,7 +97,7 @@ export const BaseToolCard: React.FC<BaseToolCardProps> = ({
     onClick(event);
   };
 
-  const hasExpandedContent = isExpanded && expandedContent && !isFailed;
+  const hasExpandedContent = isExpanded && expandedContent && (!isFailed || allowExpandedWhenFailed);
   const showConfirmationHighlight = requiresConfirmation && 
     status !== 'completed' && 
     status !== 'confirmed' &&
@@ -105,7 +108,7 @@ export const BaseToolCard: React.FC<BaseToolCardProps> = ({
   const resolvedHeaderExpandAffordance =
     headerExpandAffordanceProp !== undefined
       ? headerExpandAffordanceProp
-      : Boolean(onClick) && !isFailed && Boolean(expandedContent);
+      : Boolean(onClick) && (!isFailed || allowExpandedWhenFailed) && Boolean(expandedContent);
 
   const headerLayoutValue: ToolCardHeaderLayoutContextValue = {
     headerExpandAffordance: resolvedHeaderExpandAffordance,

--- a/src/web-ui/src/flow_chat/tool-cards/MCPToolDisplay.appearance.ts
+++ b/src/web-ui/src/flow_chat/tool-cards/MCPToolDisplay.appearance.ts
@@ -4,7 +4,7 @@ export const mcpToolDisplayAppearanceDescriptor: AppearanceSurfaceDescriptor = {
   id: 'mcp-tool-display',
   parts: [
     { id: 'root' }, { id: 'info' }, { id: 'expanded' },
-    { id: 'item' }, { id: 'text' }, { id: 'image' }, { id: 'resource' },
+    { id: 'item' }, { id: 'input' }, { id: 'text' }, { id: 'image' }, { id: 'resource' },
     { id: 'iframe' }, { id: 'loading' }, { id: 'error' },
   ],
   states: [

--- a/src/web-ui/src/flow_chat/tool-cards/MCPToolDisplay.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/MCPToolDisplay.scss
@@ -82,6 +82,59 @@
       }
     }
 
+    .content-item-input {
+      display: flex;
+      flex-direction: column;
+    }
+
+    .mcp-input-toggle {
+      display: flex;
+      align-items: center;
+      gap: var(--bf-appearance-token-flowchat-inline-gap);
+      width: 100%;
+      padding: 0;
+      border: 0;
+      background: transparent;
+      color: var(--bf-appearance-token-color-text-secondary);
+      cursor: pointer;
+      text-align: left;
+
+      &:hover {
+        color: var(--bf-appearance-token-color-text-primary);
+      }
+
+      svg {
+        flex-shrink: 0;
+      }
+    }
+
+    .mcp-input-label {
+      font-size: var(--bf-appearance-token-flowchat-font-size-xs);
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+
+    .mcp-input-collapse .smooth-height-collapse__inner {
+      padding-top: var(--bf-appearance-token-flowchat-inline-gap);
+    }
+
+    .mcp-input-code {
+      margin: 0;
+      padding: var(--bf-appearance-token-flowchat-code-block-pad-y) var(--bf-appearance-token-flowchat-code-block-pad-x);
+      border: 1px solid var(--bf-appearance-token-border-subtle);
+      border-radius: 8px;
+      background: var(--bf-appearance-token-color-bg-secondary);
+      color: var(--bf-appearance-token-color-text-primary);
+      font-family: var(--bf-appearance-token-tool-card-font-mono);
+      font-size: var(--bf-appearance-token-flowchat-code-font-size);
+      line-height: var(--bf-appearance-token-flowchat-code-line-height);
+      white-space: pre-wrap;
+      word-break: break-word;
+      overflow: auto;
+      max-height: 240px;
+    }
+
     .content-item-mcp-app {
       min-height: 200px;
     }
@@ -143,6 +196,10 @@
       color: color-mix(in srgb, var(--bf-appearance-token-color-error) 90%, transparent);
       font-size: var(--bf-appearance-token-flowchat-font-size-sm);
     }
+  }
+
+  .base-tool-card.status-error.base-tool-card--header-expandable {
+    cursor: pointer;
   }
 
   .icon-completed {

--- a/src/web-ui/src/flow_chat/tool-cards/MCPToolDisplay.test.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/MCPToolDisplay.test.tsx
@@ -1,0 +1,329 @@
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { JSDOM } from 'jsdom';
+
+import { MCPToolDisplay } from './MCPToolDisplay';
+import type { FlowToolItem, ToolCardConfig } from '../types/flow-chat';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const mcpMocks = vi.hoisted(() => ({
+  getCachedToolInfo: vi.fn(),
+  getMCPToolUiUri: vi.fn(),
+  fetchMCPAppResource: vi.fn(),
+  sendMCPAppMessage: vi.fn(),
+}));
+
+vi.mock('react-i18next', async () => {
+  const { createTestI18nT } = await import('@/test/i18nTestUtils');
+  return {
+    useTranslation: () => ({
+      t: createTestI18nT('flow-chat'),
+    }),
+  };
+});
+
+vi.mock('../../component-library', () => ({
+  CubeLoading: () => <span data-testid="cube-loading" />,
+  IconButton: ({
+    children,
+    tooltip,
+    variant: _variant,
+    size: _size,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    tooltip?: React.ReactNode;
+    variant?: string;
+    size?: string;
+  }) => (
+    <button
+      type="button"
+      aria-label={typeof tooltip === 'string' ? tooltip : undefined}
+      {...props}
+    >
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('@/infrastructure/mcp/toolInfoCache', () => ({
+  getCachedToolInfo: mcpMocks.getCachedToolInfo,
+}));
+
+vi.mock('@/infrastructure/api/service-api/MCPAPI', () => ({
+  MCP_APPS_PROTOCOL_VERSION: '2026-01-26',
+  MCPAPI: {
+    getMCPToolUiUri: mcpMocks.getMCPToolUiUri,
+    fetchMCPAppResource: mcpMocks.fetchMCPAppResource,
+    sendMCPAppMessage: mcpMocks.sendMCPAppMessage,
+  },
+}));
+
+vi.mock('@/shared/utils/logger', () => ({
+  createLogger: () => ({
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+  }),
+}));
+
+const config: ToolCardConfig = {
+  toolName: 'mcp__example__search',
+  displayName: 'Search',
+  icon: 'MCP',
+  requiresConfirmation: false,
+  resultDisplayType: 'detailed',
+  description: 'Search through an MCP server',
+  displayMode: 'compact',
+};
+
+function toolItem(overrides: Partial<FlowToolItem> = {}): FlowToolItem {
+  return {
+    id: 'tool-mcp-1',
+    type: 'tool',
+    toolName: config.toolName,
+    status: 'completed',
+    timestamp: Date.now(),
+    toolCall: {
+      id: 'call-mcp-1',
+      input: {
+        query: 'BitFun',
+        limit: 5,
+        _early_detection: false,
+      },
+    },
+    toolResult: {
+      success: true,
+      result: {
+        content: [{ type: 'text', text: 'Search result' }],
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe('MCPToolDisplay', () => {
+  let dom: JSDOM;
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    mcpMocks.getCachedToolInfo.mockReset().mockImplementation(() => new Promise(() => {}));
+    mcpMocks.getMCPToolUiUri.mockReset().mockImplementation(() => new Promise(() => {}));
+    mcpMocks.fetchMCPAppResource.mockReset();
+    mcpMocks.sendMCPAppMessage.mockReset();
+
+    dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+      pretendToBeVisual: true,
+    });
+    Object.defineProperty(dom.window, 'matchMedia', {
+      configurable: true,
+      value: () => ({ matches: true }),
+    });
+    vi.stubGlobal('window', dom.window);
+    vi.stubGlobal('document', dom.window.document);
+    vi.stubGlobal('HTMLElement', dom.window.HTMLElement);
+    vi.stubGlobal('CustomEvent', dom.window.CustomEvent);
+    vi.stubGlobal('ResizeObserver', class {
+      observe = vi.fn();
+      disconnect = vi.fn();
+    });
+
+    container = dom.window.document.getElementById('root') as HTMLDivElement;
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps invocation parameters collapsed until their nested toggle is used', () => {
+    act(() => {
+      root.render(<MCPToolDisplay toolItem={toolItem()} config={config} />);
+    });
+
+    expect(container.querySelector('.mcp-input-code')).toBeNull();
+
+    act(() => {
+      container.querySelector('.base-tool-card')?.dispatchEvent(
+        new dom.window.MouseEvent('click', { bubbles: true })
+      );
+    });
+
+    const input = container.querySelector('.content-item-input');
+    const result = container.querySelector('.content-item-text');
+    expect(input?.textContent).toContain('Input Parameters');
+    expect(container.querySelector('.mcp-input-code')).toBeNull();
+    expect(result?.textContent).toContain('Search result');
+    expect(input?.compareDocumentPosition(result as Node) & dom.window.Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
+    act(() => {
+      container.querySelector<HTMLButtonElement>('.mcp-input-toggle')?.dispatchEvent(
+        new dom.window.MouseEvent('click', { bubbles: true })
+      );
+    });
+
+    expect(input?.textContent).toContain('"query": "BitFun"');
+    expect(input?.textContent).toContain('"limit": 5');
+    expect(input?.textContent).not.toContain('_early_detection');
+    expect(container.querySelector('[data-bf-component="mcp-tool-display"]')?.getAttribute('data-bf-state')).toContain('expanded');
+  });
+
+  it('can expand a completed call that has parameters but no result content', () => {
+    const item = toolItem({
+      toolCall: {
+        id: 'call-mcp-2',
+        input: '{"query":"input only"}',
+      },
+      toolResult: {
+        success: true,
+        result: { content: [] },
+      },
+    });
+
+    act(() => {
+      root.render(<MCPToolDisplay toolItem={item} config={config} />);
+    });
+
+    const toggle = container.querySelector<HTMLButtonElement>('.preview-toggle-btn');
+    expect(toggle).not.toBeNull();
+
+    act(() => {
+      toggle?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(container.querySelector('.mcp-input-code')).toBeNull();
+
+    act(() => {
+      container.querySelector<HTMLButtonElement>('.mcp-input-toggle')?.dispatchEvent(
+        new dom.window.MouseEvent('click', { bubbles: true })
+      );
+    });
+
+    expect(container.querySelector('.mcp-input-code')?.textContent).toContain('"query": "input only"');
+  });
+
+  it('keeps failed calls collapsed until the user expands their parameters', () => {
+    const item = toolItem({
+      status: 'error',
+      toolResult: {
+        success: false,
+        result: null,
+        error: 'MCP server rejected the request',
+      },
+    });
+
+    act(() => {
+      root.render(<MCPToolDisplay toolItem={item} config={config} />);
+    });
+
+    expect(container.querySelector('.mcp-input-code')).toBeNull();
+    expect(container.textContent).toContain('MCP server rejected the request');
+    expect(container.querySelector('[data-bf-component="mcp-tool-display"]')?.getAttribute('data-bf-state')).toBe('error');
+
+    act(() => {
+      container.querySelector<HTMLButtonElement>('.preview-toggle-btn')?.dispatchEvent(
+        new dom.window.MouseEvent('click', { bubbles: true })
+      );
+    });
+
+    expect(container.querySelector('[data-bf-component="mcp-tool-display"]')?.getAttribute('data-bf-state')).toContain('expanded');
+    expect(container.querySelector('.mcp-input-code')).toBeNull();
+
+    act(() => {
+      container.querySelector<HTMLButtonElement>('.mcp-input-toggle')?.dispatchEvent(
+        new dom.window.MouseEvent('click', { bubbles: true })
+      );
+    });
+
+    expect(container.querySelector('.mcp-input-code')?.textContent).toContain('"query": "BitFun"');
+  });
+
+  it('does not expose incomplete streaming parameters as expandable details', () => {
+    const item = toolItem({
+      status: 'streaming',
+      isParamsStreaming: true,
+      toolResult: undefined,
+    });
+
+    act(() => {
+      root.render(<MCPToolDisplay toolItem={item} config={config} />);
+    });
+
+    expect(container.querySelector('.preview-toggle-btn')).toBeNull();
+    expect(container.querySelector('.mcp-input-code')).toBeNull();
+  });
+
+  it('auto-expands an MCP App with input collapsed and resets input when the parent closes', async () => {
+    const resourceUri = 'ui://example/search';
+    mcpMocks.getCachedToolInfo.mockReset().mockResolvedValue({
+      dynamic_info: {
+        mcp: {
+          serverId: 'example',
+          toolName: 'search',
+        },
+      },
+    });
+    mcpMocks.fetchMCPAppResource.mockResolvedValue({
+      contents: [{
+        uri: resourceUri,
+        content: '<!doctype html><html><body>MCP App</body></html>',
+      }],
+    });
+
+    const item = toolItem({
+      toolResult: {
+        success: true,
+        result: {
+          content: [{
+            type: 'resource',
+            resource: { uri: resourceUri },
+          }],
+        },
+      },
+    });
+
+    await act(async () => {
+      root.render(<MCPToolDisplay toolItem={item} config={config} />);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    const cardRoot = container.querySelector('[data-bf-component="mcp-tool-display"]');
+    expect(container.querySelector('.mcp-app-iframe')).not.toBeNull();
+    expect(cardRoot?.getAttribute('data-bf-state')).toContain('expanded');
+    expect(container.querySelector<HTMLButtonElement>('.mcp-input-toggle')?.getAttribute('aria-expanded')).toBe('false');
+    expect(container.querySelector('.mcp-input-code')).toBeNull();
+
+    act(() => {
+      container.querySelector<HTMLButtonElement>('.mcp-input-toggle')?.dispatchEvent(
+        new dom.window.MouseEvent('click', { bubbles: true })
+      );
+    });
+
+    expect(cardRoot?.getAttribute('data-bf-state')).toContain('expanded');
+    expect(container.querySelector<HTMLButtonElement>('.mcp-input-toggle')?.getAttribute('aria-expanded')).toBe('true');
+    expect(container.querySelector('.mcp-input-code')).not.toBeNull();
+
+    act(() => {
+      container.querySelector<HTMLButtonElement>('.preview-toggle-btn')?.dispatchEvent(
+        new dom.window.MouseEvent('click', { bubbles: true })
+      );
+    });
+
+    expect(cardRoot?.getAttribute('data-bf-state') ?? '').not.toContain('expanded');
+
+    act(() => {
+      container.querySelector<HTMLButtonElement>('.preview-toggle-btn')?.dispatchEvent(
+        new dom.window.MouseEvent('click', { bubbles: true })
+      );
+    });
+
+    expect(cardRoot?.getAttribute('data-bf-state')).toContain('expanded');
+    expect(container.querySelector<HTMLButtonElement>('.mcp-input-toggle')?.getAttribute('aria-expanded')).toBe('false');
+    expect(container.querySelector('.mcp-input-code')).toBeNull();
+  });
+});

--- a/src/web-ui/src/flow_chat/tool-cards/MCPToolDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/MCPToolDisplay.tsx
@@ -3,8 +3,8 @@
  * Supports MCP Apps: when tool result contains ui:// resource, renders interactive UI in sandboxed iframe.
  */
 
-import React, { useState, useCallback, useEffect, useLayoutEffect, useRef } from 'react';
-import { ChevronDown, ChevronUp, Package } from 'lucide-react';
+import React, { useState, useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react';
+import { ChevronDown, ChevronRight, ChevronUp, Package } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { CubeLoading, IconButton } from '../../component-library';
 import type { ToolCardProps } from '../types/flow-chat';
@@ -17,6 +17,8 @@ import { isMcpToolName } from '@/infrastructure/mcp/toolName';
 import { getCachedToolInfo } from '@/infrastructure/mcp/toolInfoCache';
 import { APPEARANCE_DOMAIN_TOKENS } from '@/infrastructure/appearance/appearanceDomainTokens';
 import type { ToolInfo } from '@/shared/types/agent-api';
+import { SmoothHeightCollapse } from '../components/modern/SmoothHeightCollapse';
+import { FLOWCHAT_COLLAPSE_DURATION_MS } from '../components/modern/flowChatCollapseMotion';
 import { useToolCardHeightContract } from './useToolCardHeightContract';
 import './MCPToolDisplay.scss';
 
@@ -58,6 +60,46 @@ interface MCPToolResult {
   content?: MCPToolResultContent[];
   is_error?: boolean;
 }
+
+const parseMcpToolInput = (input: unknown): unknown => {
+  if (typeof input !== 'string') return input;
+
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return input;
+  }
+};
+
+const sanitizeMcpToolInput = (input: unknown): unknown => {
+  const parsed = parseMcpToolInput(input);
+  if (!parsed || Array.isArray(parsed) || typeof parsed !== 'object') return parsed;
+
+  return Object.fromEntries(
+    Object.entries(parsed).filter(([key]) => !key.startsWith('_'))
+  );
+};
+
+const hasVisibleMcpToolInput = (input: unknown): boolean => {
+  if (input === null || input === undefined) return false;
+  if (typeof input === 'string') return input.trim().length > 0;
+  if (Array.isArray(input)) return input.length > 0;
+  if (typeof input === 'object') return Object.keys(input).length > 0;
+  return true;
+};
+
+const formatMcpToolInput = (input: unknown): string => {
+  if (typeof input === 'string') return input;
+
+  try {
+    return JSON.stringify(input, null, 2);
+  } catch {
+    return String(input);
+  }
+};
 
 /** Clean and escape domains for CSP injection (prevent HTML injection). */
 const cleanDomains = (domains: string[] | undefined): string => {
@@ -151,14 +193,37 @@ export const MCPToolDisplay: React.FC<ToolCardProps> = ({
   config,
 }) => {
   const { t } = useTranslation('flow-chat');
-  const { status, toolCall, toolResult, requiresConfirmation, userConfirmed } = toolItem;
+  const {
+    status,
+    toolCall,
+    toolResult,
+    requiresConfirmation,
+    userConfirmed,
+    isParamsStreaming,
+  } = toolItem;
   const [isExpanded, setIsExpanded] = useState(false);
+  const [isInputExpanded, setIsInputExpanded] = useState(false);
   const toolId = toolItem.id ?? toolCall?.id;
-  const { cardRootRef, applyExpandedState } = useToolCardHeightContract({
+  const { cardRootRef, applyExpandedState, dispatchToolCardToggle } = useToolCardHeightContract({
     toolId,
     toolName: toolItem.toolName,
   });
   const [resolvedToolInfo, setResolvedToolInfo] = useState<ToolInfo | null>(null);
+  const toolInputIsIncomplete = Boolean(
+    isParamsStreaming ||
+    (toolCall?.input && typeof toolCall.input === 'object' && (
+      toolCall.input._early_detection === true || toolCall.input._partial_params === true
+    ))
+  );
+  const displayToolInput = useMemo(
+    () => sanitizeMcpToolInput(toolCall?.input),
+    [toolCall?.input]
+  );
+  const hasToolInput = !toolInputIsIncomplete && hasVisibleMcpToolInput(displayToolInput);
+  const formattedToolInput = useMemo(
+    () => isExpanded && isInputExpanded && hasToolInput ? formatMcpToolInput(displayToolInput) : null,
+    [displayToolInput, hasToolInput, isExpanded, isInputExpanded]
+  );
 
   const getResultData = (): MCPToolResult | null => {
     if (!toolResult?.result) return null;
@@ -207,6 +272,7 @@ export const MCPToolDisplay: React.FC<ToolCardProps> = ({
   const isFailed = status === 'error';
 
   const mcpAppIframeRef = useRef<HTMLIFrameElement | null>(null);
+  const autoExpandedMcpAppRef = useRef<{ toolId: string | undefined; uri: string } | null>(null);
   const [mcpAppHeight, setMcpAppHeight] = useState<number | undefined>(undefined);
   const bridgeDataRef = useRef({ config, toolCall, resultData, status, isFailed });
   bridgeDataRef.current = { config, toolCall, resultData, status, isFailed };
@@ -249,12 +315,21 @@ export const MCPToolDisplay: React.FC<ToolCardProps> = ({
       .catch(() => setToolMetaUiUri(null));
   }, [config.toolName, uiResourceUriFromResult, status, isFailed, toolId]);
 
-  // Auto-expand when MCP App UI is ready so user sees the interactive UI immediately
+  // Auto-expand once when this tool call's MCP App UI becomes ready. Mark an
+  // already-open card as handled too, so a later user collapse is preserved.
   useLayoutEffect(() => {
-    if (mcpAppState?.html && !isExpanded) {
+    if (!mcpAppState?.html) return;
+
+    const autoExpandedApp = autoExpandedMcpAppRef.current;
+    if (autoExpandedApp?.toolId === toolId && autoExpandedApp.uri === mcpAppState.uri) {
+      return;
+    }
+
+    autoExpandedMcpAppRef.current = { toolId, uri: mcpAppState.uri };
+    if (!isExpanded) {
       applyExpandedState(isExpanded, true, setIsExpanded);
     }
-  }, [applyExpandedState, isExpanded, mcpAppState?.html]);
+  }, [applyExpandedState, isExpanded, mcpAppState?.html, mcpAppState?.uri, toolId]);
 
   // Iframe <-> parent postMessage bridge (MCP App protocol). Register in useLayoutEffect so listener is attached before iframe script runs.
   useLayoutEffect(() => {
@@ -577,16 +652,26 @@ export const MCPToolDisplay: React.FC<ToolCardProps> = ({
   };
 
   const contentSummary = getContentSummary();
-  const hasContent =
+  const hasResultContent =
     status === 'completed' &&
     (!!uiResourceUri || (resultData?.content && resultData.content.length > 0));
+  const hasExpandableDetails = hasToolInput || hasResultContent;
   const isLoading = status === 'preparing' || status === 'streaming' || status === 'running';
   const needsConfirmation =
     requiresConfirmation && !userConfirmed && status !== 'completed' && status !== 'cancelled' && status !== 'rejected' && status !== 'error';
 
   const toggleExpanded = useCallback(() => {
-    applyExpandedState(isExpanded, !isExpanded, setIsExpanded);
+    const nextExpanded = !isExpanded;
+    if (!nextExpanded) {
+      setIsInputExpanded(false);
+    }
+    applyExpandedState(isExpanded, nextExpanded, setIsExpanded);
   }, [applyExpandedState, isExpanded]);
+
+  const toggleInputExpanded = useCallback(() => {
+    setIsInputExpanded((expanded) => !expanded);
+    dispatchToolCardToggle();
+  }, [dispatchToolCardToggle]);
 
   const getErrorMessage = () => {
     if (toolResult && 'error' in toolResult) {
@@ -601,14 +686,10 @@ export const MCPToolDisplay: React.FC<ToolCardProps> = ({
       return;
     }
     
-    if (isFailed) {
-      return;
-    }
-    
-    if (hasContent) {
+    if (hasExpandableDetails) {
       toggleExpanded();
     }
-  }, [hasContent, isFailed, toggleExpanded]);
+  }, [hasExpandableDetails, toggleExpanded]);
 
   const renderToolIcon = () => {
     return <Package size={16} />;
@@ -639,7 +720,13 @@ export const MCPToolDisplay: React.FC<ToolCardProps> = ({
             </span>
           )}
           
-          {!isFailed && hasContent && (
+          {isFailed && (
+            <div className="error-expand-indicator">
+              <span className="error-text">Failed</span>
+            </div>
+          )}
+
+          {hasExpandableDetails && (
             <IconButton
               className="preview-toggle-btn"
               variant="ghost"
@@ -654,11 +741,6 @@ export const MCPToolDisplay: React.FC<ToolCardProps> = ({
             </IconButton>
           )}
           
-          {isFailed && (
-            <div className="error-expand-indicator">
-              <span className="error-text">Failed</span>
-            </div>
-          )}
         </>
       }
       statusIcon={renderStatusIcon()}
@@ -668,12 +750,44 @@ export const MCPToolDisplay: React.FC<ToolCardProps> = ({
   const renderExpandedContent = () => {
     const hasResultContent = resultData?.content && resultData.content.length > 0;
     const hasMcpApp = mcpAppState?.html;
-    if (!hasResultContent && !hasMcpApp) {
+    const hasMcpAppState = Boolean(mcpAppState);
+    if (!hasResultContent && !hasMcpApp && !hasToolInput) {
       return null;
     }
 
+    const inputContent = hasToolInput ? (
+      <div
+        className="content-item content-item-input"
+        data-bf-component="mcp-tool-display"
+        data-bf-part="input"
+      >
+        <button
+          type="button"
+          className="mcp-input-toggle"
+          aria-expanded={isInputExpanded}
+          onClick={(event) => {
+            event.stopPropagation();
+            toggleInputExpanded();
+          }}
+        >
+          {isInputExpanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+          <span className="mcp-input-label">{t('toolCards.common.inputParams')}</span>
+        </button>
+        <SmoothHeightCollapse
+          isOpen={isInputExpanded}
+          className="mcp-input-collapse"
+          durationMs={FLOWCHAT_COLLAPSE_DURATION_MS}
+        >
+          {formattedToolInput !== null && (
+            <pre className="mcp-input-code">{formattedToolInput}</pre>
+          )}
+        </SmoothHeightCollapse>
+      </div>
+    ) : null;
+
     return (
       <div data-bf-component="mcp-tool-display" data-bf-part="expanded" data-bf-state="expanded" className="mcp-expanded-content">
+        {!hasMcpAppState && inputContent}
         {/* MCP App: sandboxed iframe for ui:// resources */}
         {mcpAppState && (
           <div className="content-item content-item-mcp-app" data-bf-component="mcp-tool-display" data-bf-part="item">
@@ -703,6 +817,7 @@ export const MCPToolDisplay: React.FC<ToolCardProps> = ({
             )}
           </div>
         )}
+        {hasMcpAppState && inputContent}
         {/* Text, image, and non-ui resources */}
         {(resultData?.content ?? []).map((item, index) => {
           const isUiResource = item.type === 'resource' && item.resource?.uri?.startsWith('ui://');
@@ -757,6 +872,7 @@ export const MCPToolDisplay: React.FC<ToolCardProps> = ({
         expandedContent={renderExpandedContent()}
         errorContent={renderErrorContent()}
         isFailed={isFailed}
+        allowExpandedWhenFailed={isFailed && hasToolInput}
         requiresConfirmation={needsConfirmation}
       />
     </div>


### PR DESCRIPTION
Expose stable MCP invocation parameters in a nested details section so
users can inspect requests without crowding the default card view.

- Keep parameter details collapsed by default and reset them when the
  parent card closes
- Allow failed and result-less calls to expose available input
- Auto-expand each MCP App once while preserving later user collapse
- Add focused coverage for input parsing and expansion behavior
