### PR TITLE
fix(chat): prevent overlapping boost submenus

### DIFF
--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -456,6 +456,8 @@ function renderMcpPromptMessages(messages: MCPPromptMessage[]): string {
     .join('\n\n');
 }
 
+type BoostSubmenuId = 'harness' | 'additional-modes' | 'skills';
+
 export const ChatInput: React.FC<ChatInputProps> = ({
   className = '',
   onSendMessage,
@@ -469,6 +471,15 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   
   const [inputState, dispatchLocalInput] = useReducer(inputReducer, initialInputState);
   const [modeState, dispatchMode] = useReducer(modeReducer, initialModeState);
+  const [activeBoostSubmenu, setActiveBoostSubmenu] = useState<BoostSubmenuId | null>(null);
+  const setBoostSubmenuOpen = useCallback((id: BoostSubmenuId, open: boolean) => {
+    // A late dismissal from one flyout must not close its newly opened sibling.
+    setActiveBoostSubmenu(current => open ? id : current === id ? null : current);
+  }, []);
+
+  useEffect(() => {
+    if (!modeState.dropdownOpen) setActiveBoostSubmenu(null);
+  }, [modeState.dropdownOpen]);
   
   const richTextInputRef = useRef<RichTextInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -6128,6 +6139,8 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                           <HarnessProfileSelector
                             {...harnessProfileSelectorProps}
                             presentation="menu-item"
+                            open={activeBoostSubmenu === 'harness'}
+                            onOpenChange={open => setBoostSubmenuOpen('harness', open)}
                             onSelectionComplete={() => dispatchMode({ type: 'CLOSE_DROPDOWN' })}
                           />
                           <MenuSeparator data-bf-component="chat-input" data-bf-part="boostDivider" />
@@ -6140,6 +6153,8 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                             label={t('chatInput.boostAdditionalModes')}
                             icon={<Sparkles size={14} aria-hidden />}
                             testId="chat-input-additional-modes"
+                            open={activeBoostSubmenu === 'additional-modes'}
+                            onOpenChange={open => setBoostSubmenuOpen('additional-modes', open)}
                           >
                             {additionalModeItems.map(item => (
                               <MenuItem
@@ -6190,6 +6205,8 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                             label={t('chatInput.boostSkills')}
                             icon={<Sparkles size={14} aria-hidden />}
                             testId="chat-input-skills"
+                            open={activeBoostSubmenu === 'skills'}
+                            onOpenChange={open => setBoostSubmenuOpen('skills', open)}
                           >
                             {resolvedModeSkillsLoading ? (
                               <div className="bitfun-chat-input__boost-submenu-loading" data-bf-component="chat-input" data-bf-part="boostSubmenuState" data-bf-state="loading">

--- a/src/web-ui/src/flow_chat/components/ChatInputBoostSubmenu.test.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInputBoostSubmenu.test.tsx
@@ -2,11 +2,55 @@
  * @vitest-environment jsdom
  */
 
-import { act } from 'react';
+import { act, useState, type ComponentProps } from 'react';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Menu, MenuItem } from '@bitfun/ui';
 
 import { ChatInputBoostSubmenu } from './ChatInputBoostSubmenu';
+import { HarnessProfileSelector } from './HarnessProfileSelector';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock('@/component-library', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('@/shared/notification-system', () => ({
+  notificationService: { info: vi.fn() },
+}));
+
+function ControlledSubmenu(props: Omit<ComponentProps<typeof ChatInputBoostSubmenu>, 'open' | 'onOpenChange'>) {
+  const [open, setOpen] = useState(false);
+  return <ChatInputBoostSubmenu {...props} open={open} onOpenChange={setOpen} />;
+}
+
+function SiblingMenus() {
+  const [active, setActive] = useState<string | null>(null);
+  const disclosure = (id: string) => ({
+    open: active === id,
+    onOpenChange: (open: boolean) => setActive(current => open ? id : current === id ? null : current),
+  });
+  return (
+    <Menu>
+      <ChatInputBoostSubmenu {...disclosure('modes')} label="Additional modes" icon={null} testId="modes">
+        <MenuItem>Plan</MenuItem>
+      </ChatInputBoostSubmenu>
+      <ChatInputBoostSubmenu {...disclosure('skills')} label="Skills" icon={null} testId="skills">
+        <MenuItem>Skill A</MenuItem>
+      </ChatInputBoostSubmenu>
+      <HarnessProfileSelector
+        {...disclosure('harness')}
+        presentation="menu-item"
+        selectedProfile="balanced"
+        otherAgents={[{ id: 'research', name: 'Research' }]}
+        onSelectProfile={() => {}}
+      />
+    </Menu>
+  );
+}
 
 describe('ChatInputBoostSubmenu', () => {
   let container: HTMLDivElement;
@@ -30,9 +74,9 @@ describe('ChatInputBoostSubmenu', () => {
   it('opens by click or keyboard and closes with the reverse arrow', async () => {
     await act(async () => {
       root.render(
-        <ChatInputBoostSubmenu label="Additional modes" icon={<span>+</span>}>
+        <ControlledSubmenu label="Additional modes" icon={<span>+</span>}>
           <button type="button" role="menuitem">Plan</button>
-        </ChatInputBoostSubmenu>,
+        </ControlledSubmenu>,
       );
     });
 
@@ -62,9 +106,9 @@ describe('ChatInputBoostSubmenu', () => {
     { label: 'Additional modes' },
   ])('keeps the extracted $label submenu open across pointer movement', ({ label }) => {
     act(() => root.render(
-      <ChatInputBoostSubmenu label={label} icon={<span>+</span>}>
+      <ControlledSubmenu label={label} icon={<span>+</span>}>
         <button type="button" role="menuitem">Plan</button>
-      </ChatInputBoostSubmenu>,
+      </ControlledSubmenu>,
     ));
 
     const trigger = container.querySelector<HTMLElement>('[aria-haspopup="menu"]')!;
@@ -79,5 +123,79 @@ describe('ChatInputBoostSubmenu', () => {
 
     act(() => trigger.click());
     expect(trigger.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it.each(['click', 'keyboard'])('keeps one flyout open when switching siblings by %s', (input) => {
+    act(() => root.render(<SiblingMenus />));
+    const modes = container.querySelector<HTMLButtonElement>('[data-testid="modes"] [aria-haspopup="menu"]')!;
+    const skills = container.querySelector<HTMLButtonElement>('[data-testid="skills"] [aria-haspopup="menu"]')!;
+    const harness = container.querySelector<HTMLButtonElement>('[data-testid="harness-profile-selector"]')!;
+    const triggers = [modes, skills, harness];
+
+    // Exercise both directions, including switching back from the Agent page.
+    for (const trigger of [modes, skills, modes, harness, skills, harness, modes]) {
+      act(() => {
+        if (input === 'click') {
+          trigger.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+          trigger.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+          trigger.focus();
+          trigger.click();
+        } else {
+          trigger.focus();
+          trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+        }
+      });
+      act(() => vi.advanceTimersByTime(20));
+
+      expect(triggers.map(item => item.getAttribute('aria-expanded')))
+        .toEqual(triggers.map(item => item === trigger ? 'true' : 'false'));
+      const panels = document.querySelectorAll('.bitfun-chat-input__boost-submenu-panel, .bitfun-harness-selector__menu');
+      expect(panels).toHaveLength(1);
+      expect(panels[0].id).toBe(trigger.getAttribute('aria-controls'));
+      if (trigger === harness) {
+        expect((panels[0] as HTMLElement).dataset.bfPage).toBe('profiles');
+        act(() => document.querySelector<HTMLButtonElement>('[data-testid="harness-profile-other"]')!.click());
+        expect((panels[0] as HTMLElement).dataset.bfPage).toBe('agents');
+      }
+    }
+
+    act(() => modes.click());
+    expect(modes.getAttribute('aria-expanded')).toBe('false');
+    expect(document.querySelector('.bitfun-chat-input__boost-submenu-panel')).toBeNull();
+  });
+
+  it.each(['Escape', 'ArrowLeft'])('closes only the active flyout with %s and returns focus', key => {
+    act(() => root.render(<SiblingMenus />));
+    const trigger = container.querySelector<HTMLButtonElement>('[data-testid="skills"] [aria-haspopup="menu"]')!;
+    act(() => trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true })));
+    act(() => vi.advanceTimersByTime(20));
+    const panel = document.querySelector<HTMLElement>('.bitfun-chat-input__boost-submenu-panel')!;
+    expect(panel.contains(document.activeElement)).toBe(true);
+    act(() => document.activeElement!.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true })));
+    act(() => vi.advanceTimersByTime(20));
+    expect(document.querySelector('.bitfun-chat-input__boost-submenu-panel')).toBeNull();
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+    expect(document.activeElement).toBe(trigger);
+    expect(container.querySelector('[role="menu"]')).not.toBeNull();
+  });
+
+  it('removes portalled flyouts when the parent menu unmounts', () => {
+    act(() => root.render(<SiblingMenus />));
+    act(() => container.querySelector<HTMLButtonElement>('[data-testid="skills"] [aria-haspopup="menu"]')!.click());
+    expect(document.querySelector('.bitfun-chat-input__boost-submenu-panel')).not.toBeNull();
+    act(() => root.render(null));
+    expect(document.querySelector('.bitfun-chat-input__boost-submenu-panel')).toBeNull();
+    act(() => root.render(<SiblingMenus />));
+    expect(container.querySelector('[aria-expanded="true"]')).toBeNull();
+  });
+
+  it('wires all ChatInput flyouts to one owner and clears it when the add menu closes', () => {
+    const source = readFileSync(path.join(__dirname, 'ChatInput.tsx'), 'utf8');
+    for (const id of ['harness', 'additional-modes', 'skills']) {
+      expect(source).toContain(`open={activeBoostSubmenu === '${id}'}`);
+      expect(source).toContain(`onOpenChange={open => setBoostSubmenuOpen('${id}', open)}`);
+    }
+    expect(source).toContain('if (!modeState.dropdownOpen) setActiveBoostSubmenu(null);');
+    expect(source).toContain('current => open ? id : current === id ? null : current');
   });
 });

--- a/src/web-ui/src/flow_chat/components/ChatInputBoostSubmenu.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInputBoostSubmenu.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useId, useRef, useState } from 'react';
+import React, { useCallback, useId, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { ChevronRight } from 'lucide-react';
 import { Menu, MenuItem } from '@bitfun/ui';
@@ -6,6 +6,8 @@ import { getAppearanceOverlayHost } from '@/infrastructure/appearance/runtime/Ap
 import { useSideAnchoredPopoverPosition } from '@/shared/utils/useSideAnchoredPopoverPosition';
 
 interface ChatInputBoostSubmenuProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
   label: string;
   icon: React.ReactNode;
   children: React.ReactNode;
@@ -14,12 +16,13 @@ interface ChatInputBoostSubmenuProps {
 
 /** Shared second-level disclosure used by ChatInput's add menu. */
 export const ChatInputBoostSubmenu: React.FC<ChatInputBoostSubmenuProps> = ({
+  open,
+  onOpenChange: setOpen,
   label,
   icon,
   children,
   testId,
 }) => {
-  const [open, setOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const submenuRef = useRef<HTMLDivElement>(null);
   const panelId = useId();
@@ -37,7 +40,7 @@ export const ChatInputBoostSubmenu: React.FC<ChatInputBoostSubmenuProps> = ({
         submenuRef.current?.querySelector<HTMLButtonElement>('[data-bf-menu-item]')?.focus();
       });
     }
-  }, []);
+  }, [setOpen]);
 
   return (
     <div

--- a/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStripLayout.test.ts
+++ b/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStripLayout.test.ts
@@ -418,11 +418,12 @@ describe('composer context track layout', () => {
     const component = readLocalFile('HarnessProfileSelector.tsx');
     const stylesheet = readLocalFile('HarnessProfileSelector.scss');
 
-    expect(component).toMatch(/minimal: Scan,[\s\S]*?balanced: Grid2X2,[\s\S]*?ultimate: Grid3X3,/);
+    expect(component).toMatch(/minimal: 'minimal',[\s\S]*?balanced: 'standard',[\s\S]*?ultimate: 'ultimate',[\s\S]*?creative: 'creative',/);
     expect(component).toContain(
       'data-harness-density={densityProfile ? PROFILE_GEARS[densityProfile] : 0}',
     );
-    expect(component).toContain('className="bitfun-harness-selector__density-core"');
+    expect(component).toContain('name={PROFILE_ICONS[profile]}');
+    expect(component).not.toContain('className="bitfun-harness-selector__density-core"');
     expect(component).toContain('<HarnessProfileMark profile={id} />');
     expect(component).toContain('<HarnessProfileMark profile={knownSelectedProfile} />');
     expect(component).not.toContain('compact=');

--- a/src/web-ui/src/flow_chat/components/HarnessProfileSelector.tsx
+++ b/src/web-ui/src/flow_chat/components/HarnessProfileSelector.tsx
@@ -46,6 +46,9 @@ interface HarnessProfileSelectorProps {
    * secondary picker beside it in the shared overlay layer.
    */
   presentation?: HarnessProfileSelectorPresentation;
+  /** A parent menu can coordinate this flyout with its sibling submenus. */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
   onSelectProfile: (profileId: SelectableHarnessProfileId) => void | Promise<void>;
   onSelectAgent?: (agentId: string) => void | Promise<void>;
   onStartNewSession?: (
@@ -137,6 +140,8 @@ export const HarnessProfileSelector: React.FC<HarnessProfileSelectorProps> = ({
   otherAgents = [],
   disabled = false,
   presentation = 'standalone',
+  open: controlledOpen,
+  onOpenChange,
   onSelectProfile,
   onSelectAgent,
   onStartNewSession,
@@ -144,7 +149,12 @@ export const HarnessProfileSelector: React.FC<HarnessProfileSelectorProps> = ({
 }) => {
   const { t } = useTranslation('flow-chat');
   const fixedSession = legacySession || sessionStarted;
-  const [open, setOpen] = useState(false);
+  const [localOpen, setLocalOpen] = useState(false);
+  const open = controlledOpen ?? localOpen;
+  const setOpen = useCallback((nextOpen: boolean) => {
+    if (controlledOpen === undefined) setLocalOpen(nextOpen);
+    onOpenChange?.(nextOpen);
+  }, [controlledOpen, onOpenChange]);
   const [page, setPage] = useState<'profiles' | 'agents'>('profiles');
   const menuId = useId();
   const triggerRef = useRef<HTMLButtonElement>(null);
@@ -168,7 +178,7 @@ export const HarnessProfileSelector: React.FC<HarnessProfileSelectorProps> = ({
   const close = useCallback(() => {
     setOpen(false);
     setPage('profiles');
-  }, []);
+  }, [setOpen]);
 
   const finishSelection = useCallback(() => {
     close();
@@ -272,10 +282,8 @@ export const HarnessProfileSelector: React.FC<HarnessProfileSelectorProps> = ({
   const creatingNewSession = fixedSession;
   const handleTriggerClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
-    setOpen(value => {
-      if (!value) setPage('profiles');
-      return !value;
-    });
+    if (!open) setPage('profiles');
+    setOpen(!open);
   };
   const handleTriggerKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
     if (presentation !== 'menu-item' || event.key !== 'ArrowRight') return;


### PR DESCRIPTION
## Summary

- Coordinate the open state of Additional modes, Skills, and the embedded Harness selector so only one submenu is open at a time.
- Clear submenu state when the parent menu closes.
- Preserve standalone Harness selector behavior, keyboard navigation, and focus restoration.
- Add submenu-switching regression coverage and update outdated mode-icon assertions.

## Type and Areas

Type: Bug fix / UI/UX / Test

Areas: Web UI / FlowChat / ChatInput

## Motivation / Impact

Each submenu previously maintained its own open state. Opening another submenu did not close the previous one, leaving overlapping flyouts visible.

This change moves submenu coordination into the parent menu and prevents a late dismissal from closing a newly opened sibling.

## Verification

The following results were recorded before rebase. `git range-diff` confirmed that the patch is unchanged; tests have not been rerun after rebase.

- Passed: 48 focused tests.
  ```bash
  pnpm --dir src/web-ui exec vitest run --maxWorkers=2 src/flow_chat/components/ChatInputBoostSubmenu.test.tsx src/flow_chat/components/HarnessProfileSelector.test.tsx src/flow_chat/components/ChatInputWorkspaceStripLayout.test.ts
  ```
- Passed: Web UI type checking.
  ```bash
  pnpm --dir src/web-ui exec tsc --noEmit
  ```
- Passed: visual contract validation.
  ```bash
  pnpm run theme:visual-contract
  ```
- `pnpm run check:web` was blocked by existing stale generated artifacts in `miniapp-git-graph` and native mobile token projections. Unrelated generated files were left unchanged.
- Manual visual verification and remote-scenario integration testing were not performed.

## Reviewer Notes

- Changes are limited to transient frontend menu state. Mode IDs, session behavior, APIs, and persisted data remain unchanged.
- `HarnessProfileSelector` gains optional controlled-open props while preserving existing standalone usage.
- Regression coverage includes mouse and keyboard switching, switching from the Agent subpage, Escape/Left Arrow dismissal, focus restoration, and portal cleanup when the parent unmounts.
- No new user-facing strings or data migrations are required.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.