### PR TITLE
feat(harmonyos): polish mobile chat interactions

### DIFF
--- a/src/apps/mobile/harmonyos/AppScope/app.json5
+++ b/src/apps/mobile/harmonyos/AppScope/app.json5
@@ -2,8 +2,8 @@
   "app": {
     "bundleName": "com.bitfun.app",
     "vendor": "example",
-    "versionCode": 1000000,
-    "versionName": "1.0.0",
+    "versionCode": 1,
+    "versionName": "0.0.1",
     "buildVersion": "1",
     "icon": "$media:bitfun_icon",
     "label": "$string:app_name",

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/AdaptiveSheetOptions.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/AdaptiveSheetOptions.ets
@@ -1,8 +1,8 @@
 import {
-import { SCRIM, TRANSPARENT } from './Theme';
   SettingsPlacement,
   SettingsPlacementMode
 } from '../policy/SettingsPlacementPolicy';
+import { SCRIM, TRANSPARENT } from './Theme';
 
 /**
  * Shared SheetOptions for the four overlay sheets. Policy stays ArkUI-free;

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/AppActionButton.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/AppActionButton.ets
@@ -1,5 +1,15 @@
 import { MobileDesignGeometry, MobileDesignTypography } from '../../generated/MobileDesignTokens';
-import { CARD, CONTENT_ON_ACTION, INK, LINE, PRIMARY_ACTION, SOFT, STATUS_DANGER } from './Theme';
+import {
+  CARD,
+  CONTENT_ON_ACTION,
+  INK,
+  LINE,
+  PRIMARY_ACTION,
+  SHADOW_FAINT,
+  SHADOW_SUBTLE,
+  SOFT,
+  STATUS_DANGER
+} from './Theme';
 
 /** Visual intent for a product action. Layout may still choose its own width and height. */
 export enum AppActionStyle {
@@ -28,6 +38,11 @@ export struct AppActionButton {
       .backgroundColor(this.actionBackgroundColor())
       .border({ width: this.style === AppActionStyle.Secondary ? 1 : 0, color: LINE })
       .borderRadius(this.actionHeight / 2)
+      .shadow({
+        radius: this.hasElevation() ? 14 : 0,
+        color: this.isFilled() ? SHADOW_SUBTLE : SHADOW_FAINT,
+        offsetY: this.hasElevation() ? 5 : 0
+      })
       .opacity(this.isEnabled ? 1 : 0.32)
       .enabled(this.isEnabled)
       .onClick(() => {
@@ -37,6 +52,10 @@ export struct AppActionButton {
 
   private isFilled(): boolean {
     return this.style === AppActionStyle.Primary || this.style === AppActionStyle.Destructive;
+  }
+
+  private hasElevation(): boolean {
+    return this.isEnabled && this.style !== AppActionStyle.Quiet;
   }
 
   private actionBackgroundColor(): ResourceColor {

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/AppSidebar.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/AppSidebar.ets
@@ -1,7 +1,20 @@
 import { MobileDesignGeometry, MobileDesignTypography } from '../../generated/MobileDesignTokens';
 import { RemoteSession } from '../../model/RemoteModels';
 import { RemoteI18n } from '../../i18n/RemoteI18n';
-import { CARD, INK, LINE, MUTED, PAGE_BG, PAGE_BG_FADE, SCRIM, SOFT, SUBTLE, TRANSPARENT } from './Theme';
+import {
+  CARD,
+  INK,
+  LINE,
+  MUTED,
+  PAGE_BG,
+  PAGE_BG_FADE,
+  SCRIM,
+  SHADOW_FAINT,
+  SHADOW_SUBTLE,
+  SOFT,
+  SUBTLE,
+  TRANSPARENT
+} from './Theme';
 import { SidebarToggleButton } from './SidebarToggleButton';
 import { SessionActionPresentation, SessionActionSurface } from './SessionActionSurface';
 import { AdaptiveSheetOptions } from './AdaptiveSheetOptions';
@@ -103,17 +116,19 @@ export struct AppSidebar {
         .scrollable(ScrollDirection.Vertical)
         .scrollBar(BarState.Off)
 
-        // The footer floats over the scroll, so rows have to fade out under it
-        // rather than run into it. Without this a workspace row mid-scroll gets
-        // visually sliced by the chat button sitting on top of it.
-        Column()
-          .width('100%')
-          .height(this.usesCompactFooter() ? 92 : 120)
-          .hitTestBehavior(HitTestMode.None)
-          .linearGradient({
-            angle: 180,
-            colors: [[PAGE_BG_FADE, 0.0], [PAGE_BG, 0.62]]
-          })
+        // Signed-out actions form a conventional footer and retain a fade.
+        // Authenticated navigation uses two independent floating controls, so
+        // the scroll remains visible all the way to the bottom behind them.
+        if (!this.isAccountAuthenticated()) {
+          Column()
+            .width('100%')
+            .height(this.usesCompactFooter() ? 92 : 120)
+            .hitTestBehavior(HitTestMode.None)
+            .linearGradient({
+              angle: 180,
+              colors: [[PAGE_BG_FADE, 0.0], [PAGE_BG, 0.62]]
+            })
+        }
 
         if (this.isAccountAuthenticated()) {
           this.AuthenticatedFooter()
@@ -227,11 +242,13 @@ export struct AppSidebar {
         Button() {
           SidebarGlyph({ kind: 'search' })
         }
-        .width(MobileDesignGeometry.controlTouchSize)
-        .height(MobileDesignGeometry.controlTouchSize)
+        .width(44)
+        .height(44)
         .padding(0)
-        .backgroundColor(TRANSPARENT)
-        .borderRadius(12)
+        .backgroundColor(CARD)
+        .border({ width: 0.5, color: LINE })
+        .borderRadius(22)
+        .shadow({ radius: 18, color: SHADOW_FAINT, offsetY: 5 })
         .stateEffect(true)
         .accessibilityText(RemoteI18n.t('common.search'))
         .onClick(() => {
@@ -312,19 +329,21 @@ export struct AppSidebar {
   private AuthenticatedFooter() {
     Row() {
       Button() {
-        Row({ space: 9 }) {
+        Row({ space: 8 }) {
           SidebarGlyph({ kind: 'edit' })
           Text(RemoteI18n.t('sidebar.newChat'))
-            .fontSize(MobileDesignTypography.titleSmall.size)
+            .fontSize(MobileDesignTypography.titleMedium.size)
             .fontWeight(FontWeight.Medium)
             .fontColor(INK)
         }
       }
-      .width(116)
-      .height(48)
+      .width(98)
+      .height(44)
       .padding(0)
-      .backgroundColor(SOFT)
-      .borderRadius(16)
+      .backgroundColor(CARD)
+      .border({ width: 0.5, color: LINE })
+      .borderRadius(22)
+      .shadow({ radius: 24, color: SHADOW_SUBTLE, offsetY: 7 })
       .stateEffect(true)
       .onClick(() => {
         this.onNewChat();
@@ -335,11 +354,12 @@ export struct AppSidebar {
       Button() {
         SidebarGlyph({ kind: 'settings' })
       }
-        .width(48)
-        .height(48)
+        .width(44)
+        .height(44)
         .padding(0)
-        .backgroundColor(TRANSPARENT)
-        .borderRadius(12)
+        .backgroundColor(CARD)
+        .borderRadius(22)
+        .shadow({ radius: 24, color: SHADOW_SUBTLE, offsetY: 7 })
         .stateEffect(true)
         .onClick(() => {
           this.onOpenSettings();
@@ -347,6 +367,7 @@ export struct AppSidebar {
     }
     .width('100%')
     .height(56)
+    .padding({ left: 12 })
     .alignItems(VerticalAlign.Center)
     .zIndex(2)
   }

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/BitFunAccountLoginPage.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/BitFunAccountLoginPage.ets
@@ -7,6 +7,7 @@ import {
   LINE,
   MUTED,
   PAGE_BG_FADE,
+  SHADOW_FAINT,
   STATUS_DANGER,
   SUBTLE
 } from './Theme';
@@ -166,6 +167,7 @@ export struct BitFunAccountLoginPage {
     .backgroundColor(CARD)
     .border({ width: 1, color: LINE })
     .borderRadius(24)
+    .shadow({ radius: 16, color: SHADOW_FAINT, offsetY: 5 })
     .clip(true)
   }
 

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/CompactMenuButton.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/CompactMenuButton.ets
@@ -1,28 +1,45 @@
 import { RemoteI18n } from '../../i18n/RemoteI18n';
 import { TemplateIcon } from './TemplateIcon';
-import { TRANSPARENT } from './Theme';
+import { CARD, SHADOW_SUBTLE } from './Theme';
+
+const MENU_SURFACE_SIZE: number = 42;
 
 @ComponentV2
 export struct CompactMenuButton {
   @Param controlSize: number = 48;
   @Event onOpen: () => void = () => {};
+  @Local pressed: boolean = false;
 
   build() {
-    Button() {
-      TemplateIcon({
-        src: $r('app.media.gpt_home_menu_glyph'),
-        iconWidth: 22,
-        iconHeight: 14
-      })
+    Stack({ alignContent: Alignment.Center }) {
+      Stack({ alignContent: Alignment.Center }) {
+        TemplateIcon({
+          src: $r('app.media.gpt_home_menu_glyph'),
+          iconWidth: 23,
+          iconHeight: 16
+        })
+      }
+      .width(MENU_SURFACE_SIZE)
+      .height(MENU_SURFACE_SIZE)
+      .backgroundColor(CARD)
+      .borderRadius(MENU_SURFACE_SIZE / 2)
+      .shadow({ radius: 30, color: SHADOW_SUBTLE, offsetY: 7 })
+      .scale({ x: this.pressed ? 0.96 : 1, y: this.pressed ? 0.96 : 1 })
+      .animation({ duration: 120, curve: Curve.EaseOut })
+      .hitTestBehavior(HitTestMode.None)
     }
     .width(this.controlSize)
     .height(this.controlSize)
-    .padding(0)
-    .backgroundColor(TRANSPARENT)
-    .borderRadius(12)
-    .stateEffect(true)
     .accessibilityText(RemoteI18n.t('sidebar.more'))
+    .onTouch((event: TouchEvent) => {
+      if (event.type === TouchType.Down) {
+        this.pressed = true;
+      } else if (event.type === TouchType.Up || event.type === TouchType.Cancel) {
+        this.pressed = false;
+      }
+    })
     .onClick(() => {
+      this.pressed = false;
       this.onOpen();
     })
   }

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/ComposerBar.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/ComposerBar.ets
@@ -9,21 +9,16 @@ import {
   ConversationUiSelectedImage
 } from '../state/ConversationUiModels';
 import { ConversationModelPresentationPolicy } from '../policy/ConversationModelPresentationPolicy';
+import { TemplateIcon } from './TemplateIcon';
 import {
   CARD,
-  CONTENT_ON_ACTION,
-  FLOATING_PANEL_BG,
   INK,
   LINE,
   MEDIA_SCRIM,
   MUTED,
-  PRIMARY_ACTION,
   SCRIM,
-  SHADOW_FAINT,
-  SHADOW_MEDIUM,
   SHADOW_SUBTLE,
   SOFT,
-  STATUS_DANGER,
   STATUS_SUCCESS,
   TRANSPARENT
 } from './Theme';
@@ -34,10 +29,26 @@ export enum ComposerPresentation {
 }
 
 const COMPOSER_ACTION_SIZE: number = MobileDesignGeometry.composerActionSize;
+/** ChatGPT's visible send circle is about 32pt inside a 44pt hit target. */
+const COMPOSER_PRIMARY_SURFACE_SIZE: number = 32;
+const COMPOSER_SEND_TRANSITION_DURATION: number = 200;
 const COMPOSER_INPUT_HEIGHT: number = MobileDesignGeometry.composerInputHeight;
 const COMPOSER_EXPANDED_INPUT_HEIGHT: number = MobileDesignGeometry.composerExpandedInputHeight;
 const COMPOSER_COLLAPSED_HEIGHT: number = MobileDesignGeometry.composerCollapsedHeight;
-const COMPOSER_EXPANDED_HEIGHT: number = MobileDesignGeometry.composerExpandedHeight;
+// On a narrow phone, the 44vp controls should nearly fill the pill, matching
+// the compact ChatGPT composer instead of inheriting the roomier 56vp shell.
+const COMPOSER_COMPACT_COLLAPSED_HEIGHT: number = 52;
+// ArkUI's circular action is 44vp. The shared 40vp action-row token is too
+// short for this rendered control, so expand the Harmony row and its card by
+// the same delta instead of allowing the button to overflow the bottom edge.
+const COMPOSER_EXPANDED_ACTION_ROW_HEIGHT: number = Math.max(
+  MobileDesignGeometry.composerExpandedActionRowHeight,
+  COMPOSER_ACTION_SIZE
+);
+const COMPOSER_EXPANDED_HEIGHT: number = MobileDesignGeometry.composerExpandedHeight +
+  COMPOSER_EXPANDED_ACTION_ROW_HEIGHT - MobileDesignGeometry.composerExpandedActionRowHeight;
+/** Matches the compact reference's roughly eight-percent side inset. */
+const COMPOSER_COMPACT_HORIZONTAL_GUTTER: number = 32;
 const COMPOSER_IMAGE_CARD_SIZE: number = 64;
 const COMPOSER_IMAGE_STRIP_TOP_GAP: number = 6;
 /** Strip height plus its top gap and the parent Column's 2vp row spacing. */
@@ -52,6 +63,9 @@ export struct ComposerBar {
   @Param chatInput: string = '';
   @Local inputText: string = '';
   @Local inputFocused: boolean = false;
+  @Local primaryActionPressed: boolean = false;
+  @Local sendTransitionActive: boolean = false;
+  private sendTransitionTimerId: number = -1;
   @Param selectedImages: ConversationUiSelectedImage[] = [];
   @Param isBusy: boolean = false;
   @Param canStop: boolean = false;
@@ -78,6 +92,13 @@ export struct ComposerBar {
     this.inputText = this.chatInput;
   }
 
+  aboutToDisappear(): void {
+    if (this.sendTransitionTimerId >= 0) {
+      clearTimeout(this.sendTransitionTimerId);
+      this.sendTransitionTimerId = -1;
+    }
+  }
+
   @Monitor('chatInput')
   onChatInputParamChanged(): void {
     if (this.inputText !== this.chatInput) {
@@ -98,8 +119,8 @@ export struct ComposerBar {
     .constraintSize({ maxWidth: this.presentation === ComposerPresentation.Floating ? 760 : 10000 })
     .alignSelf(ItemAlign.Center)
     .padding({
-      left: this.presentation === ComposerPresentation.Floating ? 24 : MobileDesignGeometry.contentGutter,
-      right: this.presentation === ComposerPresentation.Floating ? 24 : MobileDesignGeometry.contentGutter,
+      left: this.presentation === ComposerPresentation.Floating ? 24 : COMPOSER_COMPACT_HORIZONTAL_GUTTER,
+      right: this.presentation === ComposerPresentation.Floating ? 24 : COMPOSER_COMPACT_HORIZONTAL_GUTTER,
       top: 8,
       bottom: this.presentation === ComposerPresentation.Floating ? 16 : 12
     })
@@ -136,7 +157,7 @@ export struct ComposerBar {
       }
       .width('100%')
       .height(this.isComposerExpanded() ? MobileDesignGeometry.composerExpandedInputRowHeight :
-        MobileDesignGeometry.composerCollapsedHeight)
+        this.collapsedComposerHeight())
 
       if (this.isComposerExpanded()) {
         Row({ space: 6 }) {
@@ -150,7 +171,7 @@ export struct ComposerBar {
           this.PrimaryActionButton()
         }
         .width('100%')
-        .height(MobileDesignGeometry.composerExpandedActionRowHeight)
+        .height(COMPOSER_EXPANDED_ACTION_ROW_HEIGHT)
         .padding({ left: 2, right: 0 })
         .alignItems(VerticalAlign.Center)
         .transition(TransitionEffect.translate({ x: 0, y: 8 })
@@ -167,12 +188,12 @@ export struct ComposerBar {
       bottom: this.isComposerExpanded() ? 2 : 0
     })
     .backgroundColor(CARD)
-    .border({ width: 1, color: LINE })
+    .border({ width: this.presentation === ComposerPresentation.Compact ? 0.5 : 1, color: LINE })
     .borderRadius(this.composerRadius())
     .shadow({
-      radius: this.presentation === ComposerPresentation.Floating ? 14 : 8,
-      color: this.presentation === ComposerPresentation.Floating ? SHADOW_SUBTLE : SHADOW_FAINT,
-      offsetY: this.presentation === ComposerPresentation.Floating ? 4 : 2
+      radius: this.presentation === ComposerPresentation.Floating ? 14 : 18,
+      color: SHADOW_SUBTLE,
+      offsetY: this.presentation === ComposerPresentation.Floating ? 4 : 6
     })
     .animation({ duration: MobileDesignMotion.structure, curve: Curve.EaseOut })
   }
@@ -267,11 +288,15 @@ export struct ComposerBar {
     }
     .width(asSheet ? '100%' : MobileDesignGeometry.composerModelSelectorWidth)
     .padding({ left: 10, right: 10, top: 10, bottom: 10 })
-    .backgroundColor(asSheet ? CARD : FLOATING_PANEL_BG)
+    .backgroundColor(CARD)
     .borderRadius(asSheet ? { topLeft: 20, topRight: 20 } :
       MobileDesignGeometry.composerModelSelectorRadius)
-    .border({ width: asSheet ? 0 : 1, color: asSheet ? TRANSPARENT : LINE })
-    .shadow({ radius: asSheet ? 0 : 18, color: asSheet ? TRANSPARENT : SHADOW_MEDIUM, offsetY: 7 })
+    .border({ width: asSheet ? 0 : 0.5, color: asSheet ? TRANSPARENT : LINE })
+    .shadow({
+      radius: asSheet ? 0 : 18,
+      color: asSheet ? TRANSPARENT : SHADOW_SUBTLE,
+      offsetY: asSheet ? 0 : 7
+    })
   }
 
   @Builder
@@ -281,7 +306,7 @@ export struct ComposerBar {
         if (this.isSelectedModel(model)) {
           SymbolGlyph($r('sys.symbol.checkmark_circle'))
             .fontSize(16)
-            .fontColor([this.primaryActionForegroundColor()])
+            .fontColor([INK])
         }
       }
       .width(20)
@@ -343,15 +368,17 @@ export struct ComposerBar {
         .layoutWeight(1)
         .height(this.isComposerExpanded() ? COMPOSER_EXPANDED_INPUT_HEIGHT : COMPOSER_INPUT_HEIGHT)
         .fontSize(MobileDesignTypography.bodyLarge.size)
+        .lineHeight(MobileDesignTypography.bodyLarge.lineHeight)
         .fontColor(INK)
         .placeholderColor(this.isVoiceListening ? STATUS_SUCCESS : MUTED)
         .backgroundColor(TRANSPARENT)
         .borderRadius(20)
+        .align(this.isComposerExpanded() ? Alignment.TopStart : Alignment.Start)
         .padding({
           left: this.isVoiceListening ? 0 : 4,
           right: 4,
-          top: this.isComposerExpanded() ? 10 : 9,
-          bottom: this.isComposerExpanded() ? 8 : 9
+          top: this.isComposerExpanded() ? 10 : 0,
+          bottom: this.isComposerExpanded() ? 8 : 0
         })
         .maxLines(this.isComposerExpanded() ? 4 : 1)
         .defaultFocus(false)
@@ -384,12 +411,28 @@ export struct ComposerBar {
   PrimaryActionButton() {
     Button() {
       Stack({ alignContent: Alignment.Center }) {
-        if (this.primaryAction() === ComposerPrimaryAction.Stop) {
-          Text('')
-            .width(13)
-            .height(13)
-            .backgroundColor(CARD)
-            .borderRadius(3)
+        if (this.shouldShowActiveActionSurface()) {
+          Stack({ alignContent: Alignment.Center }) {
+            if (this.shouldShowStopGlyph()) {
+              Text('')
+                .width(10)
+                .height(10)
+                .backgroundColor(CARD)
+                .borderRadius(2.5)
+            } else {
+              TemplateIcon({
+                src: $r('app.media.gpt_composer_send_arrow'),
+                iconWidth: 16,
+                iconHeight: 18,
+                tint: CARD
+              })
+            }
+          }
+          .width(COMPOSER_PRIMARY_SURFACE_SIZE)
+          .height(COMPOSER_PRIMARY_SURFACE_SIZE)
+          .backgroundColor(this.activeActionSurfaceColor())
+          .borderRadius(COMPOSER_PRIMARY_SURFACE_SIZE / 2)
+          .animation({ duration: COMPOSER_SEND_TRANSITION_DURATION, curve: Curve.EaseOut })
         } else if (this.primaryAction() === ComposerPrimaryAction.Voice ||
           this.primaryAction() === ComposerPrimaryAction.VoiceBlocked) {
           this.MicrophoneGlyph()
@@ -397,7 +440,7 @@ export struct ComposerBar {
           SymbolGlyph($r('sys.symbol.arrow_up'))
             .fontSize(23)
             .fontWeight(FontWeight.Medium)
-            .fontColor([INK])
+            .fontColor([this.primaryActionForegroundColor()])
             .opacity(this.primaryAction() === ComposerPrimaryAction.Send ? 1 : 0.38)
         }
       }
@@ -408,11 +451,21 @@ export struct ComposerBar {
     .height(COMPOSER_ACTION_SIZE)
     .padding(0)
     .type(ButtonType.Circle)
-    .backgroundColor(this.actionBackgroundColor())
+    .backgroundColor(this.inactiveActionBackgroundColor())
     .borderRadius(COMPOSER_ACTION_SIZE / 2)
-    .stateEffect(true)
+    .stateEffect(false)
     .accessibilityText(RemoteI18n.t(ChatComposerPolicy.primaryActionAccessibilityKey(
       this.primaryAction(), this.isVoiceListening)))
+    .onTouch((event: TouchEvent) => {
+      if (!this.shouldShowActiveActionSurface()) {
+        return;
+      }
+      if (event.type === TouchType.Down) {
+        this.primaryActionPressed = true;
+      } else if (event.type === TouchType.Up || event.type === TouchType.Cancel) {
+        this.primaryActionPressed = false;
+      }
+    })
     // Driven off the same decision that drew the glyph, so the button can never
     // do something other than what it is showing.
     .onClick(() => {
@@ -426,6 +479,7 @@ export struct ComposerBar {
         return;
       }
       if (action === ComposerPrimaryAction.Send) {
+        this.beginSendTransition();
         this.onSend();
         return;
       }
@@ -556,8 +610,13 @@ export struct ComposerBar {
 
   // Attachments live inside the card, so the card has to grow to hold them.
   private composerHeight(): number {
-    const base = this.isComposerExpanded() ? COMPOSER_EXPANDED_HEIGHT : COMPOSER_COLLAPSED_HEIGHT;
+    const base = this.isComposerExpanded() ? COMPOSER_EXPANDED_HEIGHT : this.collapsedComposerHeight();
     return this.selectedImages.length > 0 ? base + COMPOSER_IMAGE_STRIP_BLOCK : base;
+  }
+
+  private collapsedComposerHeight(): number {
+    return this.presentation === ComposerPresentation.Compact ?
+      COMPOSER_COMPACT_COLLAPSED_HEIGHT : COMPOSER_COLLAPSED_HEIGHT;
   }
 
   // The pill radius only reads as a pill while the card is one row tall.
@@ -678,26 +737,54 @@ export struct ComposerBar {
       RemoteI18n.t('chat.inputPlaceholder');
   }
 
-  // Follows the offered action rather than the raw flags: while a turn runs and
-  // the user has typed something, the button is a send arrow, and a send arrow
-  // on a stop-red circle reads as "this will cancel".
-  private actionBackgroundColor(): ResourceColor {
+  private inactiveActionBackgroundColor(): ResourceColor {
     const action = this.primaryAction();
-    if (action === ComposerPrimaryAction.Send || action === ComposerPrimaryAction.Voice) {
-      return PRIMARY_ACTION;
+    if (action === ComposerPrimaryAction.Send || action === ComposerPrimaryAction.Stop ||
+      this.sendTransitionActive) {
+      return TRANSPARENT;
+    }
+    if (action === ComposerPrimaryAction.Voice) {
+      return CARD;
     }
     if (action === ComposerPrimaryAction.SendBlocked || action === ComposerPrimaryAction.VoiceBlocked ||
       action === ComposerPrimaryAction.Idle) {
       return SOFT;
     }
-    return this.isVoiceListening ? STATUS_SUCCESS : STATUS_DANGER;
+    return TRANSPARENT;
+  }
+
+  private shouldShowActiveActionSurface(): boolean {
+    const action = this.primaryAction();
+    return this.sendTransitionActive || action === ComposerPrimaryAction.Send || action === ComposerPrimaryAction.Stop;
+  }
+
+  private shouldShowStopGlyph(): boolean {
+    return this.sendTransitionActive || this.primaryAction() === ComposerPrimaryAction.Stop;
+  }
+
+  private activeActionSurfaceColor(): ResourceColor {
+    return this.primaryActionPressed || this.sendTransitionActive ? MUTED : INK;
+  }
+
+  private beginSendTransition(): void {
+    this.primaryActionPressed = false;
+    this.sendTransitionActive = true;
+    if (this.sendTransitionTimerId >= 0) {
+      clearTimeout(this.sendTransitionTimerId);
+    }
+    this.sendTransitionTimerId = setTimeout(() => {
+      this.sendTransitionActive = false;
+      this.sendTransitionTimerId = -1;
+    }, COMPOSER_SEND_TRANSITION_DURATION);
   }
 
   private primaryActionForegroundColor(): ResourceColor {
     const action = this.primaryAction();
-    if (action === ComposerPrimaryAction.Send || action === ComposerPrimaryAction.Voice ||
-      action === ComposerPrimaryAction.Stop) {
-      return CONTENT_ON_ACTION;
+    if (action === ComposerPrimaryAction.Voice) {
+      return INK;
+    }
+    if (action === ComposerPrimaryAction.Send || action === ComposerPrimaryAction.Stop) {
+      return CARD;
     }
     return MUTED;
   }

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/ConnectManualPairingOverlay.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/ConnectManualPairingOverlay.ets
@@ -1,6 +1,6 @@
 import { MobileDesignTypography } from '../../generated/MobileDesignTokens';
 import { RemoteI18n } from '../../i18n/RemoteI18n';
-import { CARD, INK, LINE, MUTED, SCRIM, SOFT } from './Theme';
+import { CARD, INK, LINE, MUTED, SCRIM, SHADOW_FAINT } from './Theme';
 import { AppActionButton, AppActionStyle } from './AppActionButton';
 
 @ComponentV2
@@ -41,8 +41,10 @@ export struct ConnectManualPairingOverlay {
           .height(62)
           .fontSize(MobileDesignTypography.bodyLarge.size)
           .fontColor(INK)
-          .backgroundColor(SOFT)
+          .backgroundColor(CARD)
+          .border({ width: 0.5, color: LINE })
           .borderRadius(31)
+          .shadow({ radius: 14, color: SHADOW_FAINT, offsetY: 5 })
           .padding({ left: 20, right: 20 })
           .defaultFocus(true)
           .onChange(this.onRemoteUrlChange)
@@ -54,16 +56,20 @@ export struct ConnectManualPairingOverlay {
             .height(56)
             .fontSize(MobileDesignTypography.bodyLarge.size)
             .fontColor(INK)
-            .backgroundColor(SOFT)
+            .backgroundColor(CARD)
+            .border({ width: 0.5, color: LINE })
             .borderRadius(28)
+            .shadow({ radius: 14, color: SHADOW_FAINT, offsetY: 5 })
             .padding({ left: 20, right: 20 })
             .onChange(this.onUserIdChange)
           TextInput({ placeholder: RemoteI18n.t('connect.accountPasswordPlaceholder'), text: this.password })
             .height(56)
             .fontSize(MobileDesignTypography.bodyLarge.size)
             .fontColor(INK)
-            .backgroundColor(SOFT)
+            .backgroundColor(CARD)
+            .border({ width: 0.5, color: LINE })
             .borderRadius(28)
+            .shadow({ radius: 14, color: SHADOW_FAINT, offsetY: 5 })
             .padding({ left: 20, right: 20 })
             .type(InputType.Password)
             .onChange(this.onPasswordChange)

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/ConversationHeader.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/ConversationHeader.ets
@@ -8,6 +8,7 @@ import {
   LINE,
   MUTED,
   PAGE_BG,
+  SHADOW_SUBTLE,
   SOFT,
   TRANSPARENT,
 } from './Theme';
@@ -15,6 +16,8 @@ import { CompactMenuButton } from './CompactMenuButton';
 import { NavigationBackButton } from './NavigationBackButton';
 import { TemplateIcon } from './TemplateIcon';
 import { SidebarToggleButton } from './SidebarToggleButton';
+
+const HEADER_ACTION_SURFACE_SIZE: number = 42;
 
 @ComponentV2
 export struct ConversationHeader {
@@ -135,17 +138,25 @@ export struct ConversationHeader {
   private TrailingControl() {
     if (this.showActions) {
       Button() {
-        TemplateIcon({
-          src: $r('app.media.remote_ref_more'),
-          iconWidth: 23,
-          iconHeight: 7
-        })
+        Stack({ alignContent: Alignment.Center }) {
+          TemplateIcon({
+            src: $r('app.media.remote_ref_more'),
+            iconWidth: 23,
+            iconHeight: 7
+          })
+        }
+        .width(HEADER_ACTION_SURFACE_SIZE)
+        .height(HEADER_ACTION_SURFACE_SIZE)
+        .backgroundColor(CARD)
+        .borderRadius(HEADER_ACTION_SURFACE_SIZE / 2)
+        .shadow({ radius: 30, color: SHADOW_SUBTLE, offsetY: 7 })
+        .hitTestBehavior(HitTestMode.None)
       }
       .width(MobileDesignGeometry.controlTouchSize)
       .height(MobileDesignGeometry.controlTouchSize)
       .padding(0)
       .backgroundColor(TRANSPARENT)
-      .borderRadius(12)
+      .borderRadius(MobileDesignGeometry.controlTouchSize / 2)
       .stateEffect(true)
       .accessibilityText(RemoteI18n.t('sidebar.more'))
       .bindPopup(this.showActionsMenu, {

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/ConversationView.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/ConversationView.ets
@@ -25,11 +25,12 @@ import { ComposerBar, ComposerPresentation } from './ComposerBar';
 import { ConversationHeader } from './ConversationHeader';
 import { ConversationHeaderPolicy, ConversationHeaderPresentation } from '../policy/ConversationHeaderPolicy';
 import {
-  FLOATING_PANEL_BG,
+  CARD,
   INK,
   LINE,
   MUTED,
   PAGE_BG,
+  SHADOW_SUBTLE,
   SOFT,
   STATUS_DANGER,
   STATUS_SUCCESS,
@@ -300,10 +301,10 @@ export struct ConversationView {
     }
     .width(292)
     .padding({ left: 12, right: 12, top: 10, bottom: 10 })
-    .backgroundColor(FLOATING_PANEL_BG)
-    .border({ width: 1, color: LINE })
+    .backgroundColor(CARD)
+    .border({ width: 0.5, color: LINE })
     .borderRadius(16)
-    .shadow({ radius: 18, color: LINE, offsetY: 7 })
+    .shadow({ radius: 18, color: SHADOW_SUBTLE, offsetY: 7 })
     .transition(TransitionEffect.translate({ x: 8, y: -8 })
       .combine(TransitionEffect.opacity(0))
       .animation({ duration: 180, curve: Curve.EaseOut }))

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/ModelServiceSettingsPanel.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/ModelServiceSettingsPanel.ets
@@ -5,7 +5,18 @@ import { RemoteModelCatalog, RemoteModelConfig } from '../../model/RemoteModels'
 import { GENERAL_CHAT_LOCAL_MODEL_ID } from '../../services/general-chat/GeneralChatConfigStore';
 import { ModelServiceSettingsPolicy } from '../policy/ModelServiceSettingsPolicy';
 import { SettingsSheetState } from '../state/SettingsSheetState';
-import { CARD, INK, LINE, MUTED, SOFT, STATUS_DANGER, STATUS_SUCCESS, SUBTLE, TRANSPARENT } from './Theme';
+import {
+  CARD,
+  INK,
+  LINE,
+  MUTED,
+  SHADOW_FAINT,
+  SOFT,
+  STATUS_DANGER,
+  STATUS_SUCCESS,
+  SUBTLE,
+  TRANSPARENT
+} from './Theme';
 import { SheetCloseHeader } from './SheetCloseHeader';
 import { AppActionButton, AppActionStyle } from './AppActionButton';
 
@@ -433,8 +444,10 @@ export struct ModelServiceSettingsPanel {
         .fontSize(MobileDesignTypography.titleSmall.size)
         .fontColor(INK)
         .placeholderColor(SUBTLE)
-        .backgroundColor(SOFT)
-        .borderRadius(8)
+        .backgroundColor(CARD)
+        .border({ width: 0.5, color: LINE })
+        .borderRadius(12)
+        .shadow({ radius: 12, color: SHADOW_FAINT, offsetY: 4 })
         .padding({ left: 14, right: 14 })
         .onFocus(() => {
           this.scrollFocusedFieldIntoView(kind);
@@ -482,8 +495,10 @@ export struct ModelServiceSettingsPanel {
         .fontSize(MobileDesignTypography.titleSmall.size)
         .fontColor(INK)
         .placeholderColor(SUBTLE)
-        .backgroundColor(SOFT)
-        .borderRadius(8)
+        .backgroundColor(CARD)
+        .border({ width: 0.5, color: LINE })
+        .borderRadius(12)
+        .shadow({ radius: 12, color: SHADOW_FAINT, offsetY: 4 })
         .padding({ left: 14, right: 10 })
         .onFocus(() => {
           this.scrollFocusedFieldIntoView('key');

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/RemoteSessionList.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/RemoteSessionList.ets
@@ -3,11 +3,11 @@ import { RecentWorkspaceEntry, RemoteSession } from '../../model/RemoteModels';
 import { RemoteI18n } from '../../i18n/RemoteI18n';
 import {
   CARD,
-  FLOATING_BORDER,
   INK,
+  LINE,
   MUTED,
   SCRIM,
-  SHADOW_MEDIUM,
+  SHADOW_SUBTLE,
   SOFT,
   TRANSPARENT,
 } from './Theme';
@@ -334,8 +334,8 @@ export struct RemoteSessionList {
     .padding({ top: 8, bottom: 8 })
     .backgroundColor(CARD)
     .borderRadius(14)
-    .border({ width: 1, color: FLOATING_BORDER })
-    .shadow({ radius: 20, color: SHADOW_MEDIUM, offsetY: 8 })
+    .border({ width: 0.5, color: LINE })
+    .shadow({ radius: 20, color: SHADOW_SUBTLE, offsetY: 8 })
   }
 
   @Builder

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/SessionActionSurface.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/SessionActionSurface.ets
@@ -1,6 +1,6 @@
 import { MobileDesignTypography } from '../../generated/MobileDesignTokens';
 import { RemoteI18n } from '../../i18n/RemoteI18n';
-import { CARD, INK, LINE, MUTED, SHADOW_MEDIUM, STATUS_DANGER, TRANSPARENT } from './Theme';
+import { CARD, INK, LINE, MUTED, SHADOW_SUBTLE, STATUS_DANGER, TRANSPARENT } from './Theme';
 import { AppActionButton, AppActionStyle } from './AppActionButton';
 
 export enum SessionActionPresentation {
@@ -104,11 +104,11 @@ export struct SessionActionSurface {
     .width(this.presentation === SessionActionPresentation.Popover ? 300 : '100%')
     .padding({ left: 16, right: 16, top: 10, bottom: 18 })
     .backgroundColor(CARD)
-    .border({ width: 1, color: LINE })
+    .border({ width: this.presentation === SessionActionPresentation.Popover ? 0.5 : 1, color: LINE })
     .borderRadius(16)
     .shadow({
       radius: this.presentation === SessionActionPresentation.Popover ? 20 : 0,
-      color: this.presentation === SessionActionPresentation.Popover ? SHADOW_MEDIUM : TRANSPARENT,
+      color: this.presentation === SessionActionPresentation.Popover ? SHADOW_SUBTLE : TRANSPARENT,
       offsetY: this.presentation === SessionActionPresentation.Popover ? 8 : 0
     })
     .alignItems(HorizontalAlign.Center)

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/SettingsSheet.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/SettingsSheet.ets
@@ -202,7 +202,7 @@ export struct SettingsSheet {
         .width('84%')
         .height(1)
         .backgroundColor(LINE)
-      this.StaticRow(RemoteI18n.t('settings.about.version'), '1.0.0')
+      this.StaticRow(RemoteI18n.t('settings.about.version'), '0.0.1')
     }
     .width('100%')
     .backgroundColor(CARD)

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/SidebarGlyphs.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/SidebarGlyphs.ets
@@ -5,6 +5,7 @@ import { TemplateIcon } from './TemplateIcon';
 export struct SidebarGlyph {
   @Param kind: string = '';
   @Param connectionState: string = '';
+  @Param tint: ResourceColor = INK;
 
   build() {
     if (this.kind === 'session_more') {
@@ -135,14 +136,23 @@ export struct SidebarGlyph {
 
   @Builder
   private Edit() {
-    SymbolGlyph($r('sys.symbol.square_and_pencil'))
-      .fontSize(22).fontColor([INK]).width(24).height(24)
+    Stack({ alignContent: Alignment.Center }) {
+      SymbolGlyph($r('sys.symbol.square_and_pencil'))
+        .fontSize(20)
+        .fontColor([this.tint])
+    }
+    .width(22)
+    .height(22)
   }
 
   @Builder
   private Settings() {
-    SymbolGlyph($r('sys.symbol.gearshape'))
-      .fontSize(22).fontColor([INK]).width(24).height(24)
+    Stack({ alignContent: Alignment.Center }) {
+      SymbolGlyph($r('sys.symbol.gearshape'))
+        .fontSize(24)
+        .fontColor([this.tint])
+    }
+    .width(26)
+    .height(26)
   }
 }
-

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/WideConversationHost.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/WideConversationHost.ets
@@ -27,7 +27,7 @@ import {
 import { SidebarToggleButton } from './SidebarToggleButton';
 import { SidebarWorkspaceSection } from './SidebarWorkspaceSection';
 import {
-  FLOATING_PANEL_BG,
+  CARD,
   LINE,
   PAGE_BG,
   SHADOW_SUBTLE,
@@ -174,7 +174,7 @@ export struct WideConversationHost {
           onDeleteSession: this.actions.onSidebar.deleteSession
         })
       }
-      .width('100%').height('100%').backgroundColor(FLOATING_PANEL_BG)
+      .width('100%').height('100%').backgroundColor(CARD)
       .borderRadius(18).clip(true)
       .shadow({ radius: 24, color: SHADOW_SUBTLE, offsetX: 4, offsetY: 8 })
     }

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/viewmodel/RemoteCreateFlowController.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/viewmodel/RemoteCreateFlowController.ets
@@ -66,7 +66,6 @@ export class RemoteCreateFlowController {
       if (!device) {
         throw new Error(RemoteI18n.t('remote.settings.deviceUnavailable'));
       }
-      runtime.hooks.showToast(RemoteI18n.f('remote.settings.deviceSwitching', device.deviceName || target));
       await runtime.settings.selectCloudAccountDevice(device, false);
     } catch (err) {
       this.remote.setLoadingHome(false);

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/services/general-chat/GeneralChatExportFormatter.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/services/general-chat/GeneralChatExportFormatter.ets
@@ -3,7 +3,11 @@ import { ChatMessage, RemoteSession } from '../../model/RemoteModels';
 export class GeneralChatExportFormatter {
   static markdown(session: RemoteSession, messages: ChatMessage[]): string {
     const title = session.title.trim().length > 0 ? session.title.trim() : '未命名会话';
-    const sections: string[] = [`# ${title}`];
+    const firstUserContent = GeneralChatExportFormatter.firstVisibleUserContent(messages);
+    const sections: string[] = [];
+    if (!GeneralChatExportFormatter.repeatsFirstUserMessage(title, firstUserContent)) {
+      sections.push(`# ${title}`);
+    }
     messages.forEach((message: ChatMessage) => {
       const content = message.text.trim();
       if (content.length === 0) {
@@ -12,6 +16,32 @@ export class GeneralChatExportFormatter {
       sections.push(`## ${GeneralChatExportFormatter.roleLabel(message.role)}\n\n${content}`);
     });
     return `${sections.join('\n\n')}\n`;
+  }
+
+  private static firstVisibleUserContent(messages: ChatMessage[]): string {
+    for (let index = 0; index < messages.length; index += 1) {
+      const message = messages[index];
+      if (message.role === 'user' && message.text.trim().length > 0) {
+        return message.text.trim();
+      }
+    }
+    return '';
+  }
+
+  private static repeatsFirstUserMessage(title: string, firstUserContent: string): boolean {
+    if (firstUserContent.length === 0) {
+      return false;
+    }
+    return GeneralChatExportFormatter.comparableHeading(title) ===
+      GeneralChatExportFormatter.comparableHeading(firstUserContent);
+  }
+
+  private static comparableHeading(value: string): string {
+    return value
+      .trim()
+      .replace(/\s+/g, ' ')
+      .replace(/[。！？!?…，,；;：:]+$/g, '')
+      .trim();
   }
 
   private static roleLabel(role: string): string {

--- a/src/apps/mobile/harmonyos/entry/src/main/resources/base/media/gpt_composer_send_arrow.svg
+++ b/src/apps/mobile/harmonyos/entry/src/main/resources/base/media/gpt_composer_send_arrow.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="16" height="18" viewBox="0 0 16 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M8 16V2.5M2.5 8L8 2.5L13.5 8" stroke="#000000" stroke-width="2.5"
+    stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/apps/mobile/harmonyos/entry/src/test/TransportAndGeneralChatUnit.test.ets
+++ b/src/apps/mobile/harmonyos/entry/src/test/TransportAndGeneralChatUnit.test.ets
@@ -907,6 +907,25 @@ export default function transportAndGeneralChatUnitTest() {
       expect(markdown).assertEqual('# 发布计划\n\n## 用户\n\n帮我整理发布计划\n\n## BitFun\n\n先检查发布清单。\n');
       expect(markdown.indexOf('secret retry context')).assertEqual(-1);
     });
+
+    it('omits a generated heading that repeats the first user message', 0, () => {
+      const session: RemoteSession = {
+        id: 'chat-duplicate-title',
+        title: '你好你好',
+        agentType: 'chat',
+        status: 'ready',
+        updatedAt: '2026-07-20T10:00:00.000Z',
+        createdAt: '2026-07-20T09:00:00.000Z',
+        messageCount: 2,
+        titleGenerated: true
+      };
+      const markdown = GeneralChatExportFormatter.markdown(session, [
+        chatMessage('user-1', 'user', '你好你好。'),
+        chatMessage('assistant-1', 'assistant', '你好！有什么我可以帮你的吗？')
+      ]);
+
+      expect(markdown).assertEqual('## 用户\n\n你好你好。\n\n## BitFun\n\n你好！有什么我可以帮你的吗？\n');
+    });
   });
 
   describe('GeneralChatStreamCoordinator', () => {


### PR DESCRIPTION
## Summary

- refine the HarmonyOS chat chrome, sidebar actions, popovers, and composer proportions with adaptive semantic shadows
- reproduce the send-button interaction states in a monochrome, theme-aware treatment and fix duplicated titles in Markdown export
- disable unavailable devices, improve connected-device expansion and refresh feedback, and remove the redundant switching toast
- reset the HarmonyOS app release version to 0.0.1 with versionCode 1
- repair the target branch adaptive-sheet import so the HarmonyOS HAP builds after rebasing

## Verification

- HarmonyOS HAP assemble: passed
- HarmonyOS LocalTest: passed
- pnpm run harmony:architecture: passed
- pnpm run theme:color-audit:native-mobile: passed
- pnpm run theme:color-audit:all: remaining failures are pre-existing target-branch desktop/MiniApp generated appearance drift; the HarmonyOS raw-color and native token checks pass

## Remote scenarios

- Remote control: exercised through the HarmonyOS remote/general chat UI on the emulator
- Remote workspace, Peer Device Mode, and Detached Dispatch: not exercised; this change does not modify their protocols or backend behavior