### PR TITLE
refactor(ui): refine navigation and flow surfaces

### DIFF
--- a/design-system/packages/design-tokens/src/system.tokens.json
+++ b/design-system/packages/design-tokens/src/system.tokens.json
@@ -540,6 +540,9 @@
   },
   "layout": {
     "$type": "dimension",
+    "overflowText": {
+      "fadeExtent": { "$value": "{space.4}" }
+    },
     "field": {
       "rootGap": { "$value": "{space.2}" },
       "horizontalGap": { "$value": "{space.5}" },

--- a/design-system/packages/design-tokens/tests/contract.test.mjs
+++ b/design-system/packages/design-tokens/tests/contract.test.mjs
@@ -297,6 +297,10 @@ test("Toolbar tokens preserve independent compact and tab-strip compositions", a
   assert.equal(systemDocument.layout.toolbar.groupGapMd.$value, "{space.2}");
 });
 
+test("OverflowText exposes one shared inline-end fade extent", () => {
+  assert.equal(tokens["layout.overflowText.fadeExtent"], "16px");
+});
+
 test("Dialog tokens preserve the reference surface and chrome contract", async () => {
   const systemDocument = await readSource("system.tokens.json");
 

--- a/design-system/packages/ui/README.md
+++ b/design-system/packages/ui/README.md
@@ -18,6 +18,11 @@ export function Example() {
 
 The package owns component anatomy, behavior, accessibility, and stable variants. It does not own theme selection persistence, product state, routes, locale resources, or platform APIs.
 
+Use `OverflowText` for single-line labels that should fade at the inline end only
+when their rendered content is actually clipped. The primitive keeps the full
+text in the accessibility tree, supports right-to-left direction, and leaves
+width constraints and any tooltip content to the consumer.
+
 `Disclosure` is the shared expandable-content primitive. It owns controlled or
 uncontrolled open state, trigger/region accessibility wiring, focus exclusion
 while collapsed, reduced-motion behavior, and independent header actions.

--- a/design-system/packages/ui/src/flow-chat/tool-cards/FlowChatToolCard.module.css
+++ b/design-system/packages/ui/src/flow-chat/tool-cards/FlowChatToolCard.module.css
@@ -20,10 +20,9 @@
     border: var(--bf-border-width-default) solid var(--bf-color-border-default);
     border-radius: var(--bf-radius-md);
     background: var(--bf-color-surface-panel);
-    box-shadow: var(--bf-shadow-xs);
+    box-shadow: none;
     transition:
       border-color var(--_tool-card-transition),
-      box-shadow var(--_tool-card-transition),
       background-color var(--_tool-card-transition);
   }
 
@@ -31,7 +30,6 @@
   .prominentRoot[data-bf-preview-state="hover"],
   :global([data-bf-preview-state="hover"]) .prominentRoot {
     border-color: var(--bf-color-border-strong);
-    box-shadow: var(--bf-shadow-sm);
   }
 
   .prominentRoot[data-bf-state~="confirmation"] {
@@ -466,7 +464,7 @@
     border: var(--bf-border-width-default) solid var(--bf-color-border-default);
     border-radius: var(--bf-radius-md);
     background: var(--bf-color-surface-panel);
-    box-shadow: var(--bf-shadow-xs);
+    box-shadow: none;
   }
 
   .ambientExpandedShell .ambientSurface {

--- a/design-system/packages/ui/src/index.ts
+++ b/design-system/packages/ui/src/index.ts
@@ -252,6 +252,7 @@ export {
   type TooltipTrigger,
 } from "./components/Tooltip";
 export { SessionIcon, type SessionIconProps } from "./icons";
+export { OverflowText, type OverflowTextProps } from "./primitives/OverflowText";
 export { Stack, type StackProps } from "./primitives/Stack";
 export {
   ThemeRoot,

--- a/design-system/packages/ui/src/primitives/OverflowText/OverflowText.module.css
+++ b/design-system/packages/ui/src/primitives/OverflowText/OverflowText.module.css
@@ -1,0 +1,49 @@
+@layer bf.base {
+  .root {
+    display: block;
+    min-inline-size: 0;
+    max-inline-size: 100%;
+    overflow: hidden;
+    text-overflow: clip;
+    white-space: nowrap;
+  }
+
+  .root[data-overflow="true"] {
+    -webkit-mask-image: linear-gradient(
+      to right,
+      currentColor 0,
+      currentColor calc(100% - var(--bf-layout-overflow-text-fade-extent)),
+      transparent 100%
+    );
+    mask-image: linear-gradient(
+      to right,
+      currentColor 0,
+      currentColor calc(100% - var(--bf-layout-overflow-text-fade-extent)),
+      transparent 100%
+    );
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+  }
+
+  .root:dir(rtl)[data-overflow="true"] {
+    -webkit-mask-image: linear-gradient(
+      to left,
+      currentColor 0,
+      currentColor calc(100% - var(--bf-layout-overflow-text-fade-extent)),
+      transparent 100%
+    );
+    mask-image: linear-gradient(
+      to left,
+      currentColor 0,
+      currentColor calc(100% - var(--bf-layout-overflow-text-fade-extent)),
+      transparent 100%
+    );
+  }
+
+  @media (forced-colors: active) {
+    .root[data-overflow="true"] {
+      -webkit-mask-image: none;
+      mask-image: none;
+    }
+  }
+}

--- a/design-system/packages/ui/src/primitives/OverflowText/OverflowText.tsx
+++ b/design-system/packages/ui/src/primitives/OverflowText/OverflowText.tsx
@@ -1,0 +1,83 @@
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ForwardedRef,
+  type HTMLAttributes,
+} from "react";
+import { classNames } from "../../internal/classNames";
+import styles from "./OverflowText.module.css";
+
+const useIsomorphicLayoutEffect = typeof window === "undefined"
+  ? useEffect
+  : useLayoutEffect;
+
+function assignRef<T>(ref: ForwardedRef<T>, value: T | null) {
+  if (typeof ref === "function") ref(value);
+  else if (ref) ref.current = value;
+}
+
+export type OverflowTextProps = HTMLAttributes<HTMLSpanElement>;
+
+export const OverflowText = forwardRef<HTMLSpanElement, OverflowTextProps>(
+  function OverflowText({ className, ...props }, forwardedRef) {
+    const elementRef = useRef<HTMLSpanElement | null>(null);
+    const [isOverflowing, setIsOverflowing] = useState(false);
+
+    const setElementRef = useCallback((element: HTMLSpanElement | null) => {
+      elementRef.current = element;
+      assignRef(forwardedRef, element);
+    }, [forwardedRef]);
+
+    const updateOverflow = useCallback(() => {
+      const element = elementRef.current;
+      if (!element) return;
+
+      const nextIsOverflowing = element.scrollWidth > element.clientWidth;
+      setIsOverflowing((current) => (
+        current === nextIsOverflowing ? current : nextIsOverflowing
+      ));
+    }, []);
+
+    useIsomorphicLayoutEffect(() => {
+      updateOverflow();
+    });
+
+    useEffect(() => {
+      const element = elementRef.current;
+      if (!element) return undefined;
+
+      const resizeObserver = typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(updateOverflow);
+      resizeObserver?.observe(element);
+
+      const fontSet = element.ownerDocument.fonts;
+      fontSet?.addEventListener("loadingdone", updateOverflow);
+
+      if (!resizeObserver) {
+        element.ownerDocument.defaultView?.addEventListener("resize", updateOverflow);
+      }
+
+      return () => {
+        resizeObserver?.disconnect();
+        fontSet?.removeEventListener("loadingdone", updateOverflow);
+        if (!resizeObserver) {
+          element.ownerDocument.defaultView?.removeEventListener("resize", updateOverflow);
+        }
+      };
+    }, [updateOverflow]);
+
+    return (
+      <span
+        {...props}
+        className={classNames(styles.root, className)}
+        data-overflow={isOverflowing ? "true" : "false"}
+        ref={setElementRef}
+      />
+    );
+  },
+);

--- a/design-system/packages/ui/src/primitives/OverflowText/index.ts
+++ b/design-system/packages/ui/src/primitives/OverflowText/index.ts
@@ -1,0 +1,1 @@
+export { OverflowText, type OverflowTextProps } from "./OverflowText";

--- a/design-system/packages/ui/tests/flow-chat-tool-card.test.mjs
+++ b/design-system/packages/ui/tests/flow-chat-tool-card.test.mjs
@@ -119,6 +119,22 @@ test("prominent actions stay hidden until hover, preview-hover, or keyboard focu
   assert.match(styles, /--bf-color-focus-ring/);
 });
 
+test("FlowChat tool-card shells stay flat at rest and on hover", async () => {
+  const styles = await readFile(
+    new URL("../src/flow-chat/tool-cards/FlowChatToolCard.module.css", import.meta.url),
+    "utf8",
+  );
+  const prominentRule = styles.match(/\.prominentRoot\s*\{([^}]*)\}/s)?.[1];
+  const ambientExpandedRule = styles.match(/\.ambientExpandedShell\s*\{([^}]*)\}/s)?.[1];
+
+  assert.ok(prominentRule);
+  assert.ok(ambientExpandedRule);
+  assert.match(prominentRule, /box-shadow:\s*none/);
+  assert.match(ambientExpandedRule, /box-shadow:\s*none/);
+  assert.doesNotMatch(styles, /box-shadow:\s*var\(--bf-shadow-(?:xs|sm)\)/);
+  assert.doesNotMatch(styles, /box-shadow\s+var\(--_tool-card-transition\)/);
+});
+
 test("command text remains plain when a host applies inline-code chrome", async () => {
   const styles = await readFile(new URL("../dist/styles.css", import.meta.url), "utf8");
   const commandRule = styles.match(/\.[_a-zA-Z0-9-]*command[_a-zA-Z0-9-]*\{([^}]*)\}/)?.[1];

--- a/design-system/packages/ui/tests/overflow-text.test.mjs
+++ b/design-system/packages/ui/tests/overflow-text.test.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { OverflowText } from "../dist/index.js";
+
+test("OverflowText preserves the complete accessible text while exposing overflow state", () => {
+  const markup = renderToStaticMarkup(createElement(
+    OverflowText,
+    {
+      "aria-label": "Complete model name",
+      className: "model-name",
+    },
+    "deepseek-v4-pro-with-a-long-suffix",
+  ));
+
+  assert.match(markup, /class="[^" ]+ model-name"/);
+  assert.match(markup, /aria-label="Complete model name"/);
+  assert.match(markup, /data-overflow="false"/);
+  assert.match(markup, />deepseek-v4-pro-with-a-long-suffix<\/span>/);
+});
+
+test("OverflowText applies an inline-end mask only after real clipping is measured", async () => {
+  const [source, styles] = await Promise.all([
+    readFile(new URL("../src/primitives/OverflowText/OverflowText.tsx", import.meta.url), "utf8"),
+    readFile(new URL("../src/primitives/OverflowText/OverflowText.module.css", import.meta.url), "utf8"),
+  ]);
+
+  assert.match(source, /scrollWidth > element\.clientWidth/);
+  assert.match(source, /new ResizeObserver\(updateOverflow\)/);
+  assert.match(styles, /text-overflow:\s*clip/);
+  assert.match(styles, /\.root\[data-overflow="true"\]/);
+  assert.match(styles, /--bf-layout-overflow-text-fade-extent/);
+  assert.match(styles, /\.root:dir\(rtl\)\[data-overflow="true"\]/);
+  assert.doesNotMatch(styles, /text-overflow:\s*ellipsis/);
+});

--- a/src/web-ui/src/app/components/SceneBar/SceneBar.test.tsx
+++ b/src/web-ui/src/app/components/SceneBar/SceneBar.test.tsx
@@ -20,7 +20,7 @@ const sceneHarness = vi.hoisted(() => ({
     activeTabId: 'session' as SceneTabId,
     navigationMotion: 'instant' as InteractionMotion,
     tabDefs: [
-      { id: 'session' as const, label: 'Session', pinned: true, singleton: true, defaultOpen: false },
+      { id: 'session' as const, label: 'Session', pinned: true, closable: true, singleton: true, defaultOpen: false },
       { id: 'settings' as const, label: 'Settings', pinned: false, singleton: true, defaultOpen: false },
       { id: 'terminal' as const, label: 'Terminal', pinned: false, singleton: true, defaultOpen: false },
       { id: 'git' as const, label: 'Git', pinned: false, singleton: true, defaultOpen: false },
@@ -171,14 +171,45 @@ describe('SceneBar overflow navigation', () => {
     expect(scrollTo).toHaveBeenCalledWith({ left: 340, behavior: 'smooth' });
   });
 
-  it('renders close actions beside tabs and closes the owning scene', () => {
+  it('renders close actions from closeability metadata, including the leading session tab', () => {
     renderSceneBar();
+    const sessionTab = container.querySelector<HTMLElement>('[role="tab"][data-bf-value="session"]')!;
+    const sessionItem = sessionTab.closest<HTMLElement>('[data-bf-part="item"]')!;
+    const sessionCloseButton = sessionItem.querySelector<HTMLButtonElement>('[data-scene-bar-part="closeTab"]')!;
     const settingsTab = container.querySelector<HTMLElement>('[role="tab"][data-bf-value="settings"]')!;
     const settingsItem = settingsTab.closest<HTMLElement>('[data-bf-part="item"]')!;
     const closeButton = settingsItem.querySelector<HTMLButtonElement>('[data-scene-bar-part="closeTab"]')!;
 
+    expect(sessionCloseButton).not.toBeNull();
+    act(() => sessionCloseButton.click());
+    expect(sceneHarness.closeScene).toHaveBeenCalledWith('session');
+
     expect(settingsTab.contains(closeButton)).toBe(false);
     act(() => closeButton.click());
     expect(sceneHarness.closeScene).toHaveBeenCalledWith('settings');
+  });
+
+  it('supports standard middle-click and Delete-key close interactions for session', () => {
+    renderSceneBar();
+    const sessionTab = container.querySelector<HTMLElement>('[role="tab"][data-bf-value="session"]')!;
+
+    act(() => {
+      sessionTab.dispatchEvent(new MouseEvent('auxclick', {
+        button: 1,
+        bubbles: true,
+        cancelable: true,
+      }));
+    });
+    expect(sceneHarness.closeScene).toHaveBeenCalledWith('session');
+
+    sceneHarness.closeScene.mockReset();
+    act(() => {
+      sessionTab.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Delete',
+        bubbles: true,
+        cancelable: true,
+      }));
+    });
+    expect(sceneHarness.closeScene).toHaveBeenCalledWith('session');
   });
 });

--- a/src/web-ui/src/app/components/SceneBar/SceneBar.tsx
+++ b/src/web-ui/src/app/components/SceneBar/SceneBar.tsx
@@ -12,6 +12,7 @@ import { useSceneTabNavigation } from './useSceneTabNavigation';
 import { useSceneManager } from '../../hooks/useSceneManager';
 import { useCurrentSessionTitle } from '../../hooks/useCurrentSessionTitle';
 import { useCurrentSettingsPageTitle } from '../../hooks/useCurrentSettingsPageTitle';
+import { isSceneTabClosable } from '../../scenes/registry';
 import { useI18n } from '@/infrastructure/i18n/hooks/useI18n';
 import type { SceneTabId } from './types';
 import './SceneBar.scss';
@@ -63,7 +64,7 @@ const SceneBar: React.FC<SceneBarProps> = ({
     if (e.button !== 1) return;
     if ((e.target as HTMLElement | null)?.closest('[data-scene-bar-part="closeTab"]')) return;
     const sceneId = getSceneIdFromTabTarget(e.target);
-    if (!sceneId || tabDefs.find(def => def.id === sceneId)?.pinned) return;
+    if (!sceneId || !isSceneTabClosable(tabDefs.find(def => def.id === sceneId))) return;
     e.preventDefault();
   }, [tabDefs]);
 
@@ -71,7 +72,16 @@ const SceneBar: React.FC<SceneBarProps> = ({
     if (e.button !== 1) return;
     if ((e.target as HTMLElement | null)?.closest('[data-scene-bar-part="closeTab"]')) return;
     const sceneId = getSceneIdFromTabTarget(e.target);
-    if (!sceneId || tabDefs.find(def => def.id === sceneId)?.pinned) return;
+    if (!sceneId || !isSceneTabClosable(tabDefs.find(def => def.id === sceneId))) return;
+    e.preventDefault();
+    e.stopPropagation();
+    closeScene(sceneId);
+  }, [closeScene, tabDefs]);
+
+  const handleTabsKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key !== 'Delete') return;
+    const sceneId = getSceneIdFromTabTarget(e.target);
+    if (!sceneId || !isSceneTabClosable(tabDefs.find(def => def.id === sceneId))) return;
     e.preventDefault();
     e.stopPropagation();
     closeScene(sceneId);
@@ -86,6 +96,7 @@ const SceneBar: React.FC<SceneBarProps> = ({
       (tab.id === 'session' && sessionTitle ? sessionTitle : undefined)
       ?? (tab.id === 'settings' && settingsPageTitle ? settingsPageTitle : undefined);
     const closeLabel = t('sceneBar.closeTab', { label: translatedLabel });
+    const closable = isSceneTabClosable(def);
 
     items.push({
       value: tab.id,
@@ -101,7 +112,7 @@ const SceneBar: React.FC<SceneBarProps> = ({
           )}
         </span>
       ),
-      endAction: def.pinned ? undefined : (
+      endAction: closable ? (
         <button
           type="button"
           aria-label={closeLabel}
@@ -116,7 +127,7 @@ const SceneBar: React.FC<SceneBarProps> = ({
         >
           <Icon name="xmark" size="xs" aria-hidden="true" />
         </button>
-      ),
+      ) : undefined,
     });
     return items;
   }, []);
@@ -156,6 +167,7 @@ const SceneBar: React.FC<SceneBarProps> = ({
           onValueChange={handleTabValueChange}
           onScroll={handleTabsScroll}
           onWheel={handleTabsWheel}
+          onKeyDown={handleTabsKeyDown}
           onMouseDown={handleTabsMouseDown}
           onAuxClick={handleTabsAuxClick}
           data-scene-bar-part="tabs"

--- a/src/web-ui/src/app/components/SceneBar/types.ts
+++ b/src/web-ui/src/app/components/SceneBar/types.ts
@@ -39,9 +39,9 @@ export interface SceneTabDef {
   /** i18n key resolved through the common namespace, or an explicit namespace key such as shared:features.settings. */
   labelKey?: string;
   Icon?: SceneTabIcon;
-  /** Pinned tabs cannot be closed. */
+  /** Keep this tab ahead of regular tabs while it is open. */
   pinned: boolean;
-  /** If false, user cannot close the tab. Default true for non-pinned scenes. */
+  /** If false, the user cannot close the tab. Defaults to true. */
   closable?: boolean;
   /** Only one instance allowed */
   singleton: boolean;

--- a/src/web-ui/src/app/global-search/GlobalSearchRoot.scss
+++ b/src/web-ui/src/app/global-search/GlobalSearchRoot.scss
@@ -1,8 +1,10 @@
 @use '../styles/nav-panel-font-scope.scss' as nav-font;
 
 .global-search-dialog {
+  // Fits the default two-row action grid plus one workspace and assistant.
+  // Query and drilldown views keep the results region scrollable when needed.
   block-size: min(
-    520px,
+    480px,
     calc(100vh - 2 * var(--bf-overlay-dialog-viewport-gutter))
   );
 }

--- a/src/web-ui/src/app/global-search/globalSearchResultPresentation.test.ts
+++ b/src/web-ui/src/app/global-search/globalSearchResultPresentation.test.ts
@@ -26,23 +26,23 @@ const entityItems = [
 ];
 
 describe('global search result presentation', () => {
-  it('shows only two projects and two assistants in the default overview', () => {
+  it('shows one workspace and one assistant in the default overview', () => {
     const presentation = buildGlobalSearchResultPresentation(entityItems, {
       hasQuery: false,
       drilldownGroup: null,
     });
 
-    expect(DEFAULT_ENTITY_PREVIEW_LIMIT).toBe(2);
+    expect(DEFAULT_ENTITY_PREVIEW_LIMIT).toBe(1);
     expect(presentation.groups.map((group) => ({
       id: group.id,
       visible: group.items.length,
       total: group.totalCount,
       canOpenDetails: group.canOpenDetails,
     }))).toEqual([
-      { id: 'workspaces', visible: 2, total: 4, canOpenDetails: true },
-      { id: 'assistants', visible: 2, total: 3, canOpenDetails: true },
+      { id: 'workspaces', visible: 1, total: 4, canOpenDetails: true },
+      { id: 'assistants', visible: 1, total: 3, canOpenDetails: true },
     ]);
-    expect(presentation.navigableItems).toHaveLength(4);
+    expect(presentation.navigableItems).toHaveLength(2);
   });
 
   it('keeps all matching entities visible when the user searches', () => {

--- a/src/web-ui/src/app/global-search/globalSearchResultPresentation.ts
+++ b/src/web-ui/src/app/global-search/globalSearchResultPresentation.ts
@@ -4,7 +4,7 @@ import {
   type GlobalSearchItem,
 } from './types';
 
-export const DEFAULT_ENTITY_PREVIEW_LIMIT = 2;
+export const DEFAULT_ENTITY_PREVIEW_LIMIT = 1;
 
 export type GlobalSearchDrilldownGroupId = Extract<
   GlobalSearchGroupId,

--- a/src/web-ui/src/app/scenes/registry.ts
+++ b/src/web-ui/src/app/scenes/registry.ts
@@ -3,7 +3,8 @@
  *
  * Rules:
  *  - Every explicitly opened scene remains open until the user closes it.
- *  - pinned = true: protected from manual close.
+ *  - pinned = true: stays ahead of regular tabs while open.
+ *  - closable = false: protected from manual close; pinning is independent.
  *  - Scene ids are unique, while Mini Apps use one id per app instance.
  */
 
@@ -34,7 +35,7 @@ export const SCENE_TAB_REGISTRY: SceneTabDef[] = [
     labelKey: 'scenes.aiAgent',
     Icon: catalogSceneIcon('session'),
     pinned: true,
-    closable: false,
+    closable: true,
     singleton: true,
     defaultOpen: false,
   },
@@ -182,6 +183,11 @@ export const SCENE_TAB_REGISTRY: SceneTabDef[] = [
 
 export function getSceneDef(id: SceneTabId): SceneTabDef | undefined {
   return SCENE_TAB_REGISTRY.find(d => d.id === id);
+}
+
+/** Shared closeability policy for the scene store and every tab interaction. */
+export function isSceneTabClosable(def: SceneTabDef | undefined): boolean {
+  return def !== undefined && def.closable !== false;
 }
 
 /** Static singleton scene def for the panel-view scene. */

--- a/src/web-ui/src/app/stores/sceneStore.test.ts
+++ b/src/web-ui/src/app/stores/sceneStore.test.ts
@@ -35,7 +35,7 @@ describe('sceneStore transition snapshots', () => {
 
     expect(snapshots).toHaveLength(1);
     expect(snapshots[0].activeTabId).toBe('settings');
-    expect(snapshots[0].openTabIds).toEqual(['session', 'settings']);
+    expect(snapshots[0].openTabIds).toEqual(['settings']);
   });
 
   it('records pointer scene navigation without animating keyboard activation', () => {
@@ -57,7 +57,6 @@ describe('sceneStore transition snapshots', () => {
     useSceneStore.getState().openScene('miniapp:second');
 
     expect(useSceneStore.getState().openTabs.map(tab => tab.id)).toEqual([
-      'session',
       'settings',
       'terminal',
       'git',
@@ -75,7 +74,6 @@ describe('sceneStore transition snapshots', () => {
 
     const state = useSceneStore.getState();
     expect(state.openTabs.map(tab => tab.id)).toEqual([
-      'session',
       'settings',
       'terminal',
     ]);
@@ -83,14 +81,32 @@ describe('sceneStore transition snapshots', () => {
     expect(state.activeTabId).toBe('settings');
   });
 
-  it('keeps the pinned session tab when close is requested', () => {
-    useSceneStore.getState().openScene('settings');
+  it('closes the last session tab into the tabless welcome state', () => {
+    useSceneStore.getState().openScene('session');
     useSceneStore.getState().closeScene('session');
+
+    const state = useSceneStore.getState();
+    expect(state.openTabs).toEqual([]);
+    expect(state.activeTabId).toBeNull();
+    expect(state.navHistory).toEqual([]);
+    expect(state.navCursor).toBe(-1);
+  });
+
+  it('keeps the session tab first while allowing it to close back to another scene', () => {
+    useSceneStore.getState().openScene('settings');
+    useSceneStore.getState().openScene('session');
 
     expect(useSceneStore.getState().openTabs.map(tab => tab.id)).toEqual([
       'session',
       'settings',
     ]);
+
+    useSceneStore.getState().closeScene('session');
+
+    const state = useSceneStore.getState();
+    expect(state.openTabs.map(tab => tab.id)).toEqual(['settings']);
+    expect(state.activeTabId).toBe('settings');
+    expect(state.navHistory).not.toContain('session');
   });
 
   it('preserves close fallback and history navigation across many open tabs', () => {
@@ -104,7 +120,7 @@ describe('sceneStore transition snapshots', () => {
     useSceneStore.getState().closeScene('settings');
 
     const state = useSceneStore.getState();
-    expect(state.openTabs.map(tab => tab.id)).toEqual(['session', 'terminal', 'git']);
+    expect(state.openTabs.map(tab => tab.id)).toEqual(['terminal', 'git']);
     expect(state.activeTabId).toBe('git');
     expect(state.navHistory).not.toContain('settings');
 
@@ -116,7 +132,7 @@ describe('sceneStore transition snapshots', () => {
     useSceneStore.getState().openScene('settings');
     useSceneStore.getState().openScene('terminal');
     useSceneStore.getState().openScene('git');
-    expect(useSceneStore.getState().openTabs).toHaveLength(4);
+    expect(useSceneStore.getState().openTabs).toHaveLength(3);
 
     useSceneStore.getState().resetForPeerSwitch();
 

--- a/src/web-ui/src/app/stores/sceneStore.ts
+++ b/src/web-ui/src/app/stores/sceneStore.ts
@@ -3,7 +3,8 @@
  *
  * Tab rules:
  *   - Every explicitly opened scene stays in openTabs until the user closes it.
- *   - Pinned tabs (e.g. session/agent) cannot be manually closed.
+ *   - Pinned tabs stay ahead of regular tabs; closeability is an independent
+ *     scene-definition capability.
  *   - The app starts with no tabs. SceneViewport owns the tabless welcome
  *     surface until the first scene is explicitly opened.
  *
@@ -16,7 +17,12 @@
  */
 
 import { create } from 'zustand';
-import { SCENE_TAB_REGISTRY, getSceneDef, getMiniAppSceneDef } from '../scenes/registry';
+import {
+  SCENE_TAB_REGISTRY,
+  getSceneDef,
+  getMiniAppSceneDef,
+  isSceneTabClosable,
+} from '../scenes/registry';
 import { getSceneNav } from '../scenes/nav-registry';
 import { useNavSceneStore } from './navSceneStore';
 import {
@@ -24,8 +30,6 @@ import {
   type InteractionMotion,
 } from '@/shared/utils/motionPreference';
 import type { SceneTab, SceneTabId } from '../components/SceneBar/types';
-
-const AGENT_SCENE_ID: SceneTabId = 'session';
 
 function getSceneDefOrMiniapp(id: SceneTabId) {
   const d = getSceneDef(id);
@@ -38,8 +42,7 @@ function getSceneDefOrMiniapp(id: SceneTabId) {
 }
 
 function isClosableScene(id: SceneTabId): boolean {
-  const def = getSceneDefOrMiniapp(id);
-  return (def?.closable ?? !def?.pinned) !== false;
+  return isSceneTabClosable(getSceneDefOrMiniapp(id));
 }
 
 function buildSceneTab(id: SceneTabId, now: number): SceneTab {
@@ -79,13 +82,15 @@ function buildDefaultTabs(): SceneTab[] {
 }
 
 /**
- * Ensures the session tab is first in the display order when present,
- * but never auto-adds it — session only appears when explicitly opened.
+ * Keeps pinned tabs ahead of regular tabs without opening or protecting them.
  */
-function ensureAgentFirst(tabs: SceneTab[]): SceneTab[] {
-  const agentTab = tabs.find(tab => tab.id === AGENT_SCENE_ID);
-  if (!agentTab) return tabs;
-  return [agentTab, ...tabs.filter(tab => tab.id !== AGENT_SCENE_ID)];
+function orderPinnedTabsFirst(tabs: SceneTab[]): SceneTab[] {
+  const pinnedTabs = tabs.filter(tab => getSceneDefOrMiniapp(tab.id)?.pinned);
+  if (pinnedTabs.length === 0) return tabs;
+  return [
+    ...pinnedTabs,
+    ...tabs.filter(tab => !getSceneDefOrMiniapp(tab.id)?.pinned),
+  ];
 }
 
 /** Push id to history, trimming any forward entries. Deduplicates consecutive same id. */
@@ -142,17 +147,7 @@ export const useSceneStore = create<SceneState>((set, get) => ({
     const isMiniappTab = typeof id === 'string' && id.startsWith('miniapp:');
     if (!isAlreadyOpen && !def && !isMiniappTab) return;
 
-    let openTabs = state.openTabs;
-    let navHistory = state.navHistory;
-    let navCursor = state.navCursor;
-
-    // If the first opened scene is not session, companion-open the pinned
-    // session tab alongside it without turning the welcome surface into a tab.
-    if (openTabs.length === 0) {
-      if (id !== AGENT_SCENE_ID && !openTabs.some(tab => tab.id === AGENT_SCENE_ID)) {
-        openTabs = [buildSceneTab(AGENT_SCENE_ID, 0), ...openTabs];
-      }
-    }
+    const { openTabs, navHistory, navCursor } = state;
 
     const histUpdate = pushHistory(navHistory, navCursor, id);
 
@@ -161,7 +156,7 @@ export const useSceneStore = create<SceneState>((set, get) => ({
       const activatedAt = Date.now();
       set({
         activeTabId: id,
-        openTabs: ensureAgentFirst(openTabs.map(tab =>
+        openTabs: orderPinnedTabsFirst(openTabs.map(tab =>
           tab.id === id ? { ...tab, lastUsed: activatedAt } : tab
         )),
         navigationMotion,
@@ -173,7 +168,7 @@ export const useSceneStore = create<SceneState>((set, get) => ({
 
     const next = [...openTabs, buildSceneTab(id, Date.now())];
     set({
-      openTabs: ensureAgentFirst(next),
+      openTabs: orderPinnedTabsFirst(next),
       activeTabId: id,
       navigationMotion,
       navigationSequence: state.navigationSequence + 1,
@@ -188,27 +183,10 @@ export const useSceneStore = create<SceneState>((set, get) => ({
   closeScene: (id) => {
     const state = get();
     const { openTabs, activeTabId, navHistory, navCursor } = state;
-    if (!isClosableScene(id)) return;
+    if (!openTabs.some(tab => tab.id === id) || !isClosableScene(id)) return;
 
     const nextTabs = openTabs.filter(t => t.id !== id);
-
-    let newActiveId = activeTabId;
-    if (id === activeTabId) {
-      if (nextTabs.length === 0) {
-        set({
-          openTabs: [],
-          activeTabId: null,
-          navHistory: [],
-          navCursor: -1,
-          navigationMotion: getInteractionMotion(),
-          navigationSequence: state.navigationSequence + 1,
-        });
-        return;
-      }
-      newActiveId = [...nextTabs].sort((a, b) => b.lastUsed - a.lastUsed)[0].id;
-    }
-
-    if (newActiveId === null) {
+    if (nextTabs.length === 0) {
       set({
         openTabs: [],
         activeTabId: null,
@@ -220,9 +198,16 @@ export const useSceneStore = create<SceneState>((set, get) => ({
       return;
     }
 
+    const fallbackTabId = [...nextTabs].sort((a, b) => b.lastUsed - a.lastUsed)[0].id;
+    const newActiveId = id === activeTabId
+      ? fallbackTabId
+      : activeTabId && nextTabs.some(tab => tab.id === activeTabId)
+        ? activeTabId
+        : fallbackTabId;
+
     const histUpdate = removeFromHistory(navHistory, navCursor, id, newActiveId);
     set({
-      openTabs: ensureAgentFirst(nextTabs),
+      openTabs: orderPinnedTabsFirst(nextTabs),
       activeTabId: newActiveId,
       navigationMotion: getInteractionMotion(),
       navigationSequence: state.navigationSequence + 1,

--- a/src/web-ui/src/flow_chat/_flat-markdown-surfaces.scss
+++ b/src/web-ui/src/flow_chat/_flat-markdown-surfaces.scss
@@ -1,0 +1,13 @@
+@mixin apply {
+  .markdown-renderer {
+    pre,
+    .code-block-wrapper,
+    .table-wrapper,
+    .mermaid-block,
+    blockquote,
+    .custom-blockquote,
+    details {
+      box-shadow: none;
+    }
+  }
+}

--- a/src/web-ui/src/flow_chat/components/FlowChatSurfaceElevation.test.ts
+++ b/src/web-ui/src/flow_chat/components/FlowChatSurfaceElevation.test.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+function readSource(relativePath: string): string {
+  return readFileSync(
+    fileURLToPath(new URL(relativePath, import.meta.url)),
+    'utf8',
+  ).replace(/\r\n?/g, '\n');
+}
+
+function boxShadowValues(source: string): string[] {
+  return Array.from(source.matchAll(/box-shadow\s*:\s*([^;]+);/g), match => match[1].trim());
+}
+
+describe('FlowChat flat content surfaces', () => {
+  it('flattens every Markdown block surface through one shared policy', () => {
+    const policy = readSource('../_flat-markdown-surfaces.scss');
+
+    for (const selector of [
+      'pre',
+      '.code-block-wrapper',
+      '.table-wrapper',
+      '.mermaid-block',
+      'blockquote',
+      '.custom-blockquote',
+      'details',
+    ]) {
+      expect(policy).toContain(selector);
+    }
+    expect(policy).toContain('box-shadow: none;');
+
+    for (const consumer of [
+      './FlowTextBlock.scss',
+      './modern/VirtualItemRenderer.scss',
+      './usage/SessionUsagePanel.scss',
+      './usage/SessionUsageReportCard.scss',
+    ]) {
+      expect(readSource(consumer)).toContain('@include flatMarkdownSurfaces.apply;');
+    }
+  });
+
+  it('keeps product-owned transcript cards free of elevation shadows', () => {
+    const sources = [
+      readSource('../tool-cards/CreatePlanDisplay.scss'),
+      readSource('../tool-cards/TaskToolDisplay.scss'),
+      readSource('./usage/SessionUsageReportCard.scss'),
+    ];
+
+    for (const source of sources) {
+      expect(boxShadowValues(source).every(value => value === 'none')).toBe(true);
+    }
+    expect(sources[0]).not.toContain('translateY(-1px)');
+  });
+});

--- a/src/web-ui/src/flow_chat/components/FlowTextBlock.scss
+++ b/src/web-ui/src/flow_chat/components/FlowTextBlock.scss
@@ -2,8 +2,11 @@
  * FlowTextBlock styles
  */
 @use '@/infrastructure/markdown/layout' as markdown;
+@use '../flat-markdown-surfaces' as flatMarkdownSurfaces;
 
 .flow-text-block {
+  @include flatMarkdownSurfaces.apply;
+
   width: 100%;
   margin: 0 0 var(--bf-control-flow-chat-flow-item-gap) 0;
   font-size: var(--bf-type-flow-body-font-size);
@@ -112,11 +115,6 @@
   .markdown-renderer .code-block-wrapper .copy-button.copy-success:hover {
     color: var(--bf-color-status-success-content);
     transform: scale(1.08);
-  }
-
-  /* MermaidBlock.scss adds a heavy hover shadow; keep chat diagrams flat. */
-  .markdown-renderer .mermaid-block:hover {
-    box-shadow: none;
   }
 
   .text-content {

--- a/src/web-ui/src/flow_chat/components/ModelSelector.scss
+++ b/src/web-ui/src/flow_chat/components/ModelSelector.scss
@@ -74,9 +74,6 @@
 
   &__name {
     max-width: 100px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
   }
 
   &__trigger-reasoning {

--- a/src/web-ui/src/flow_chat/components/ModelSelector.tsx
+++ b/src/web-ui/src/flow_chat/components/ModelSelector.tsx
@@ -8,7 +8,7 @@
  * - Supports 'primary' | 'fast' | specific model IDs
  */
 
-import { Menu, MenuItem, MenuSection, MenuSeparator } from '@bitfun/ui';
+import { Menu, MenuItem, MenuSection, MenuSeparator, OverflowText } from '@bitfun/ui';
 import React, { useState, useEffect, useId, useRef, useCallback, useLayoutEffect, useMemo, useSyncExternalStore } from 'react';
 import { createPortal } from 'react-dom';
 import { getAppearanceOverlayHost } from '@/infrastructure/appearance/runtime/AppearanceOverlayHost';
@@ -1544,9 +1544,9 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
             }}
             disabled={disabled || loading || externalSelection.disabled}
           >
-            <span className="bitfun-model-selector__name">
+            <OverflowText className="bitfun-model-selector__name">
               {getModelDisplayLabel(externalCurrentModel, externalCurrentModelId)}
-            </span>
+            </OverflowText>
             <ChevronDown size={10} className="bitfun-model-selector__chevron" />
           </button>
         </Tooltip>
@@ -1676,11 +1676,11 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
             }}
             disabled={disabled || loading}
            data-bf-component="model-selector" data-bf-part="trigger" data-bf-state={dropdownOpen ? 'open' : undefined}>
-            <span className="bitfun-model-selector__name" data-bf-component="model-selector" data-bf-part="name">
+            <OverflowText className="bitfun-model-selector__name" data-bf-component="model-selector" data-bf-part="name">
               {acpAvailableModels.length > 0
                 ? getModelDisplayLabel(acpCurrentModel, currentAcpModelId)
                 : t('modelSelector.fastMode')}
-            </span>
+            </OverflowText>
             {acpFastMode?.enabled && (
               <Zap size={9} className="bitfun-model-selector__fast-icon" />
             )}
@@ -1844,9 +1844,9 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
           }}
           disabled={disabled || loading || reasoningLoading}
          data-bf-component="model-selector" data-bf-part="trigger" data-bf-state={dropdownOpen ? 'open' : undefined}>
-          <span className="bitfun-model-selector__name" data-bf-component="model-selector" data-bf-part="name">
+          <OverflowText className="bitfun-model-selector__name" data-bf-component="model-selector" data-bf-part="name">
             {getModelDisplayLabel(currentModel, t('modelSelector.primaryModel'))}
-          </span>
+          </OverflowText>
           {hasNativeReasoningSettings && (
             <span
               className="bitfun-model-selector__trigger-reasoning"

--- a/src/web-ui/src/flow_chat/components/modern/UserMessageItem.scss
+++ b/src/web-ui/src/flow_chat/components/modern/UserMessageItem.scss
@@ -27,9 +27,7 @@
     var(--bf-control-flow-chat-content-padding-inline)
     var(--bf-control-flow-chat-turn-gap)
     var(--bf-control-flow-chat-content-padding-inline);
-  box-shadow:
-    0 1px 0 color-mix(in srgb, var(--bf-color-content-on-dark) 5%, transparent) inset,
-    0 2px 8px color-mix(in srgb, var(--bf-color-content-on-light) 8%, transparent);
+  box-shadow: none;
   transition: opacity 140ms ease;
   /*
    * No enter animation: the message list is virtualized, so a mount-triggered

--- a/src/web-ui/src/flow_chat/components/modern/VirtualItemRenderer.scss
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualItemRenderer.scss
@@ -2,8 +2,11 @@
  * Virtual item renderer wrapper styles.
  * A4-like reading width with centered content.
  */
+@use '../../flat-markdown-surfaces' as flatMarkdownSurfaces;
 
 .virtual-item-wrapper {
+  @include flatMarkdownSurfaces.apply;
+
   width: 100%;
   /*
    * Single reading column shared by every item type (model rounds, explore
@@ -15,6 +18,13 @@
   box-sizing: border-box;
   min-height: 1px;
   padding: 0;
+
+  // A regular user message starts a new Turn. Give it a clear boundary from
+  // the preceding Turn while keeping the first message aligned to the list
+  // header and steering messages grouped with the active Turn.
+  &[data-item-type='user-message']:not([data-virtual-index='0']) {
+    padding-top: var(--bf-space-6);
+  }
 
   @media (max-width: 768px) {
     max-width: 100%;

--- a/src/web-ui/src/flow_chat/components/usage/SessionUsagePanel.scss
+++ b/src/web-ui/src/flow_chat/components/usage/SessionUsagePanel.scss
@@ -1,4 +1,8 @@
+@use '../../flat-markdown-surfaces' as flatMarkdownSurfaces;
+
 .session-usage-panel {
+  @include flatMarkdownSurfaces.apply;
+
   display: flex;
   flex-direction: column;
   height: 100%;

--- a/src/web-ui/src/flow_chat/components/usage/SessionUsageReportCard.scss
+++ b/src/web-ui/src/flow_chat/components/usage/SessionUsageReportCard.scss
@@ -1,4 +1,8 @@
+@use '../../flat-markdown-surfaces' as flatMarkdownSurfaces;
+
 .session-usage-report-card {
+  @include flatMarkdownSurfaces.apply;
+
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -10,7 +14,7 @@
   border: 1px solid color-mix(in srgb, var(--bf-color-border-default) 68%, transparent);
   border-radius: 8px;
   background: color-mix(in srgb, var(--bf-color-surface-panel) 82%, var(--bf-color-surface-scene));
-  box-shadow: 0 1px 0 color-mix(in srgb, var(--bf-color-content-primary) 4%, transparent) inset;
+  box-shadow: none;
   color: var(--bf-color-content-primary);
 
   &--fallback {

--- a/src/web-ui/src/flow_chat/tool-cards/CreatePlanDisplay.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/CreatePlanDisplay.scss
@@ -12,19 +12,11 @@
   border-radius: 8px;
   margin: var(--bf-control-flow-chat-card-gap) 0;
   overflow: hidden;
-  transition:
-    border-color 180ms ease,
-    box-shadow 180ms ease,
-    transform 180ms ease;
+  transition: border-color 180ms ease;
   box-sizing: border-box;
 
   &:hover {
     border-color: var(--bf-color-field-border-hover);
-    box-shadow:
-      0 4px 16px color-mix(in srgb, var(--bf-color-content-on-light) 20%, transparent),
-      0 2px 8px color-mix(in srgb, var(--bf-color-content-on-light) 12%, transparent),
-      inset 0 1px 0 color-mix(in srgb, var(--bf-color-content-on-dark) 4%, transparent);
-    transform: translateY(-1px);
   }
 
   &--loading {

--- a/src/web-ui/src/flow_chat/tool-cards/TaskToolDisplay.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/TaskToolDisplay.scss
@@ -524,32 +524,23 @@
 /**
  * Unified task + subagent card wrapper.
  * Wraps the task tool header card and the subagent items container so they
- * behave as a single card with a shared hover/shadow effect.
+ * behave as a single flat card with shared border feedback.
  */
 .task-with-subagent-wrapper {
   position: relative;
   border-radius: 8px;
   margin: 4px 0 10px;
-  transition: box-shadow 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: border-color 0.25s cubic-bezier(0.4, 0, 0.2, 1);
   contain: layout paint style;
 
   .flow-tool-card-wrapper .task-tool-display[data-bf-component='flow-chat-tool-card'][data-bf-part='root'] {
     margin: 0;
     /*
-     * Keep only shadow/border hover feedback in this grouped shell. Layout
-     * properties must not interpolate while the task and subagent surfaces
-     * merge into one card.
+     * Keep only border hover feedback in this grouped shell. Layout properties
+     * must not interpolate while the task and subagent surfaces merge into one
+     * card.
      */
-    transition:
-      box-shadow 0.18s ease,
-      border-color 0.18s ease;
-  }
-
-  // Keep expand/collapse press feedback subtle inside grouped subagent cards.
-  .flow-tool-card-wrapper .task-tool-display[data-bf-component='flow-chat-tool-card'][data-bf-part='root']:active {
-    box-shadow:
-      0 1px 3px color-mix(in srgb, var(--bf-color-content-on-light) 14%, transparent),
-      inset 0 1px 2px color-mix(in srgb, var(--bf-color-content-on-light) 18%, transparent);
+    transition: border-color 0.18s ease;
   }
 
   // Expanded state: the wrapper becomes the unified visual container.
@@ -559,9 +550,7 @@
     border: 1px solid var(--bf-color-border-default);
     backdrop-filter: blur(10px);
     overflow: hidden;
-    box-shadow:
-      0 2px 6px color-mix(in srgb, var(--bf-color-content-on-light) 15%, transparent),
-      0 1px 3px color-mix(in srgb, var(--bf-color-content-on-light) 12%, transparent);
+    box-shadow: none;
 
     // Strip the shared framework shell so it merges
     // into the wrapper; the wrapper provides the unified card chrome.
@@ -616,12 +605,9 @@
 
   }
 
-  // Hover over expanded card: stronger elevation.
+  // Hover over expanded card: border feedback without elevation.
   &.task-with-subagent-wrapper--expanded:hover {
-    box-shadow:
-      0 2px 8px color-mix(in srgb, var(--bf-color-content-on-light) 18%, transparent),
-      0 1px 4px color-mix(in srgb, var(--bf-color-content-on-light) 12%, transparent),
-      inset 0 1px 0 color-mix(in srgb, var(--bf-color-content-on-dark) 4%, transparent);
+    box-shadow: none;
     border-color: var(--bf-color-field-border-hover);
   }
 }


### PR DESCRIPTION
## Summary

- decouple scene pinning from closeability, allow Session to close back to the tabless welcome state, and support close button, middle-click, and Delete-key flows
- compact the default global-search overview and add the public `OverflowText` primitive for measured inline-end fading in model labels
- flatten FlowChat tool and Markdown surfaces while preserving border feedback and clearer Turn separation

## Type and Areas

Type: Refactor / UI/UX

Areas: Design system, Web UI navigation, global search, FlowChat

## Motivation / Impact

This aligns navigation with standard tab behavior, keeps the command surface more compact, prevents long model names from ending abruptly, and removes unnecessary elevation from transcript content surfaces.

## Verification

- `pnpm run design-system:check` — passed
- `pnpm run check:web` — passed
- `pnpm --dir src/web-ui run test:run src/app/components/SceneBar/SceneBar.test.tsx src/app/global-search/globalSearchResultPresentation.test.ts src/app/stores/sceneStore.test.ts src/flow_chat/components/FlowChatSurfaceElevation.test.ts` — 4 files / 19 tests passed
- `git diff --check` — passed before commit
- Browser automation, manual visual validation, and E2E were not run; broad platform coverage is left to CI

## Reviewer Notes

AI-assisted change. Only the local Web UI/design-system path was exercised; remote workspace, remote control, Peer Device Mode, and Detached Dispatch were not exercised because this change does not alter their transport or runtime contracts.

This PR is intended for CI validation and will be closed after all required checks pass.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.