### PR TITLE
feat(flow-chat): show MCP tool input parameters

### DIFF
--- a/design-system/packages/ui/src/flow-chat/tool-cards/FlowChatToolCard.tsx
+++ b/design-system/packages/ui/src/flow-chat/tool-cards/FlowChatToolCard.tsx
@@ -223,6 +223,7 @@ function CollapsibleRegion({
 
 export interface ProminentToolCardProps
   extends Omit<HTMLAttributes<HTMLDivElement>, "children" | "onClick"> {
+  allowExpandedWhenFailed?: boolean;
   className?: string;
   disableExpandAnimation?: boolean;
   errorContent?: ReactNode;
@@ -239,6 +240,7 @@ export interface ProminentToolCardProps
 }
 
 export function ProminentToolCard({
+  allowExpandedWhenFailed = false,
   className,
   disableExpandAnimation = false,
   errorContent,
@@ -255,7 +257,8 @@ export function ProminentToolCard({
   ...props
 }: ProminentToolCardProps) {
   const failed = isFailed || status === "error";
-  const expandable = headerExpandAffordance ?? Boolean(onClick && expandedContent && !failed);
+  const expandable = headerExpandAffordance
+    ?? Boolean(onClick && expandedContent && (!failed || allowExpandedWhenFailed));
   const loading = LOADING_STATUSES.has(status);
   const confirmation = requiresConfirmation && ![
     "completed",
@@ -323,7 +326,7 @@ export function ProminentToolCard({
 
       <CollapsibleRegion
         disableAnimation={disableExpandAnimation}
-        isOpen={Boolean(isExpanded && expandedContent && !failed)}
+        isOpen={Boolean(isExpanded && expandedContent && (!failed || allowExpandedWhenFailed))}
         part="expanded"
         status={status}
       >

--- a/design-system/packages/ui/src/flow-chat/tool-cards/ProminentToolCard.meta.ts
+++ b/design-system/packages/ui/src/flow-chat/tool-cards/ProminentToolCard.meta.ts
@@ -11,6 +11,7 @@ export const prominentToolCardMeta = {
     { defaultValue: "false", name: "isExpanded", type: "boolean" },
     { name: "expandedContent", type: "ReactNode" },
     { name: "errorContent", type: "ReactNode" },
+    { defaultValue: "false", name: "allowExpandedWhenFailed", type: "boolean" },
     { defaultValue: "false", name: "requiresConfirmation", type: "boolean" },
   ],
   states: ["default", "hover", "loading", "expanded", "error", "confirmation"],

--- a/design-system/packages/ui/tests/flow-chat-tool-card.test.mjs
+++ b/design-system/packages/ui/tests/flow-chat-tool-card.test.mjs
@@ -103,6 +103,28 @@ test("prominent error status opens error content without a separate failure flag
   assert.match(markup, /Command failed/);
 });
 
+test("prominent error status can opt into expandable supporting details", () => {
+  const markup = renderToStaticMarkup(
+    createElement(ProminentToolCard, {
+      allowExpandedWhenFailed: true,
+      errorContent: createElement("div", null, "Command failed"),
+      expandedContent: createElement("div", null, "Invocation input"),
+      header: createElement(ProminentToolCardHeader, { action: "Run command" }),
+      isExpanded: true,
+      onClick() {},
+      status: "error",
+    }),
+  );
+
+  assert.match(markup, /data-bf-state="expanded failed"/);
+  assert.match(markup, /data-bf-expandable="true"/);
+  assert.match(markup, /aria-expanded="true"/);
+  assert.match(markup, /data-bf-part="expandedCollapse"[^>]+data-open="true"/);
+  assert.match(markup, /Invocation input/);
+  assert.match(markup, /data-bf-part="errorCollapse"[^>]+data-open="true"/);
+  assert.match(markup, /Command failed/);
+});
+
 test("prominent actions stay hidden until hover, preview-hover, or keyboard focus", async () => {
   const styles = await readFile(new URL("../dist/styles.css", import.meta.url), "utf8");
 

--- a/src/web-ui/src/flow_chat/tool-cards/MCPToolDisplay.appearance.ts
+++ b/src/web-ui/src/flow_chat/tool-cards/MCPToolDisplay.appearance.ts
@@ -4,7 +4,7 @@ export const mcpToolDisplayAppearanceDescriptor: AppearanceSurfaceDescriptor = {
   id: 'mcp-tool-display',
   parts: [
     { id: 'root' }, { id: 'info' }, { id: 'expanded' },
-    { id: 'item' }, { id: 'text' }, { id: 'image' }, { id: 'resource' },
+    { id: 'item' }, { id: 'input' }, { id: 'text' }, { id: 'image' }, { id: 'resource' },
     { id: 'iframe' }, { id: 'loading' }, { id: 'error' },
   ],
   states: [

--- a/src/web-ui/src/flow_chat/tool-cards/MCPToolDisplay.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/MCPToolDisplay.scss
@@ -28,26 +28,6 @@
     white-space: nowrap;
   }
 
-  .preview-toggle-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 4px;
-    border: none;
-    background: transparent;
-    cursor: pointer;
-    color: var(--bf-color-content-secondary);
-    transition: color 0.2s ease;
-
-    &:hover {
-      color: var(--bf-color-content-primary);
-    }
-
-    svg {
-      display: block;
-    }
-  }
-
   .error-expand-indicator {
     display: flex;
     align-items: center;
@@ -66,6 +46,27 @@
         padding-bottom: var(--bf-control-flow-chat-card-gap);
         border-bottom: 1px solid color-mix(in srgb, var(--bf-color-content-on-dark) 8%, transparent);
       }
+    }
+
+    .content-item-input {
+      display: flex;
+      flex-direction: column;
+    }
+
+    .mcp-input-code {
+      max-height: 240px;
+      margin: 0;
+      overflow: auto;
+      padding: var(--bf-control-flow-chat-card-expanded-padding-block) var(--bf-control-flow-chat-card-expanded-padding-inline);
+      border: 1px solid var(--bf-color-border-subtle);
+      border-radius: var(--bf-radius-sm);
+      background: var(--bf-color-action-neutral-surface);
+      color: var(--bf-color-content-primary);
+      font-family: var(--bf-font-family-mono);
+      font-size: var(--bf-type-flow-control-font-size);
+      line-height: var(--bf-type-flow-support-line-height);
+      white-space: pre-wrap;
+      word-break: break-word;
     }
 
     .text-content {

--- a/src/web-ui/src/flow_chat/tool-cards/MCPToolDisplay.test.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/MCPToolDisplay.test.tsx
@@ -1,0 +1,305 @@
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { JSDOM } from 'jsdom';
+
+import { MCPToolDisplay } from './MCPToolDisplay';
+import type { FlowToolItem, ToolCardConfig } from '../types/flow-chat';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const mcpMocks = vi.hoisted(() => ({
+  getCachedToolInfo: vi.fn(),
+  getMCPToolUiUri: vi.fn(),
+  fetchMCPAppResource: vi.fn(),
+  sendMCPAppMessage: vi.fn(),
+}));
+
+vi.mock('react-i18next', async () => {
+  const { createTestI18nT } = await import('@/test/i18nTestUtils');
+  return {
+    useTranslation: () => ({
+      t: createTestI18nT('flow-chat'),
+    }),
+  };
+});
+vi.mock('@/infrastructure/mcp/toolInfoCache', () => ({
+  getCachedToolInfo: mcpMocks.getCachedToolInfo,
+}));
+
+vi.mock('@/infrastructure/api/service-api/MCPAPI', () => ({
+  MCP_APPS_PROTOCOL_VERSION: '2026-01-26',
+  MCPAPI: {
+    getMCPToolUiUri: mcpMocks.getMCPToolUiUri,
+    fetchMCPAppResource: mcpMocks.fetchMCPAppResource,
+    sendMCPAppMessage: mcpMocks.sendMCPAppMessage,
+  },
+}));
+
+vi.mock('@/shared/utils/logger', () => ({
+  createLogger: () => ({
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+  }),
+}));
+
+const config: ToolCardConfig = {
+  toolName: 'mcp__example__search',
+  displayName: 'Search',
+  icon: 'MCP',
+  requiresConfirmation: false,
+  resultDisplayType: 'detailed',
+  description: 'Search through an MCP server',
+  displayMode: 'compact',
+};
+
+function toolItem(overrides: Partial<FlowToolItem> = {}): FlowToolItem {
+  return {
+    id: 'tool-mcp-1',
+    type: 'tool',
+    toolName: config.toolName,
+    status: 'completed',
+    timestamp: Date.now(),
+    toolCall: {
+      id: 'call-mcp-1',
+      input: {
+        query: 'BitFun',
+        limit: 5,
+        _early_detection: false,
+      },
+    },
+    toolResult: {
+      success: true,
+      result: {
+        content: [{ type: 'text', text: 'Search result' }],
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe('MCPToolDisplay', () => {
+  let dom: JSDOM;
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    mcpMocks.getCachedToolInfo.mockReset().mockImplementation(() => new Promise(() => {}));
+    mcpMocks.getMCPToolUiUri.mockReset().mockImplementation(() => new Promise(() => {}));
+    mcpMocks.fetchMCPAppResource.mockReset();
+    mcpMocks.sendMCPAppMessage.mockReset();
+
+    dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+      pretendToBeVisual: true,
+    });
+    Object.defineProperty(dom.window, 'matchMedia', {
+      configurable: true,
+      value: () => ({ matches: true }),
+    });
+    vi.stubGlobal('window', dom.window);
+    vi.stubGlobal('document', dom.window.document);
+    vi.stubGlobal('HTMLElement', dom.window.HTMLElement);
+    vi.stubGlobal('CustomEvent', dom.window.CustomEvent);
+    vi.stubGlobal('ResizeObserver', class {
+      observe = vi.fn();
+      disconnect = vi.fn();
+    });
+
+    container = dom.window.document.getElementById('root') as HTMLDivElement;
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps invocation parameters collapsed until their nested toggle is used', () => {
+    act(() => {
+      root.render(<MCPToolDisplay toolItem={toolItem()} config={config} />);
+    });
+
+    expect(container.querySelector('.mcp-input-code')).toBeNull();
+
+    act(() => {
+      container.querySelector('[data-testid="mcp-tool-card-toggle"]')?.dispatchEvent(
+        new dom.window.MouseEvent('click', { bubbles: true })
+      );
+    });
+
+    const input = container.querySelector('.content-item-input');
+    const result = container.querySelector('.content-item-text');
+    expect(input?.textContent).toContain('Input Parameters');
+    expect(container.querySelector('.mcp-input-code')).toBeNull();
+    expect(result?.textContent).toContain('Search result');
+    expect(input?.compareDocumentPosition(result as Node) & dom.window.Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
+    act(() => {
+      container.querySelector<HTMLButtonElement>('.mcp-input-disclosure button[aria-expanded]')?.dispatchEvent(
+        new dom.window.MouseEvent('click', { bubbles: true })
+      );
+    });
+
+    expect(input?.textContent).toContain('"query": "BitFun"');
+    expect(input?.textContent).toContain('"limit": 5');
+    expect(input?.textContent).not.toContain('_early_detection');
+    expect(container.querySelector('[data-bf-component="mcp-tool-display"]')?.getAttribute('data-bf-state')).toContain('expanded');
+  });
+
+  it('can expand a completed call that has parameters but no result content', () => {
+    const item = toolItem({
+      toolCall: {
+        id: 'call-mcp-2',
+        input: '{"query":"input only"}',
+      },
+      toolResult: {
+        success: true,
+        result: { content: [] },
+      },
+    });
+
+    act(() => {
+      root.render(<MCPToolDisplay toolItem={item} config={config} />);
+    });
+
+    const toggle = container.querySelector<HTMLButtonElement>('[data-bf-component="flow-chat-tool-card"][data-bf-part="affordanceButton"]');
+    expect(toggle).not.toBeNull();
+
+    act(() => {
+      toggle?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(container.querySelector('.mcp-input-code')).toBeNull();
+
+    act(() => {
+      container.querySelector<HTMLButtonElement>('.mcp-input-disclosure button[aria-expanded]')?.dispatchEvent(
+        new dom.window.MouseEvent('click', { bubbles: true })
+      );
+    });
+
+    expect(container.querySelector('.mcp-input-code')?.textContent).toContain('"query": "input only"');
+  });
+
+  it('keeps failed calls collapsed until the user expands their parameters', () => {
+    const item = toolItem({
+      status: 'error',
+      toolResult: {
+        success: false,
+        result: null,
+        error: 'MCP server rejected the request',
+      },
+    });
+
+    act(() => {
+      root.render(<MCPToolDisplay toolItem={item} config={config} />);
+    });
+
+    expect(container.querySelector('.mcp-input-code')).toBeNull();
+    expect(container.textContent).toContain('MCP server rejected the request');
+    expect(container.querySelector('[data-bf-component="mcp-tool-display"]')?.getAttribute('data-bf-state')).toBe('error');
+
+    act(() => {
+      container.querySelector<HTMLButtonElement>('[data-bf-component="flow-chat-tool-card"][data-bf-part="affordanceButton"]')?.dispatchEvent(
+        new dom.window.MouseEvent('click', { bubbles: true })
+      );
+    });
+
+    expect(container.querySelector('[data-bf-component="mcp-tool-display"]')?.getAttribute('data-bf-state')).toContain('expanded');
+    expect(container.querySelector('.mcp-input-code')).toBeNull();
+
+    act(() => {
+      container.querySelector<HTMLButtonElement>('.mcp-input-disclosure button[aria-expanded]')?.dispatchEvent(
+        new dom.window.MouseEvent('click', { bubbles: true })
+      );
+    });
+
+    expect(container.querySelector('.mcp-input-code')?.textContent).toContain('"query": "BitFun"');
+  });
+
+  it('does not expose incomplete streaming parameters as expandable details', () => {
+    const item = toolItem({
+      status: 'streaming',
+      isParamsStreaming: true,
+      toolResult: undefined,
+    });
+
+    act(() => {
+      root.render(<MCPToolDisplay toolItem={item} config={config} />);
+    });
+
+    expect(container.querySelector('[data-bf-component="flow-chat-tool-card"][data-bf-part="affordanceButton"]')).toBeNull();
+    expect(container.querySelector('.mcp-input-code')).toBeNull();
+  });
+
+  it('auto-expands an MCP App with input collapsed and resets input when the parent closes', async () => {
+    const resourceUri = 'ui://example/search';
+    mcpMocks.getCachedToolInfo.mockReset().mockResolvedValue({
+      dynamic_info: {
+        mcp: {
+          serverId: 'example',
+          toolName: 'search',
+        },
+      },
+    });
+    mcpMocks.fetchMCPAppResource.mockResolvedValue({
+      contents: [{
+        uri: resourceUri,
+        content: '<!doctype html><html><body>MCP App</body></html>',
+      }],
+    });
+
+    const item = toolItem({
+      toolResult: {
+        success: true,
+        result: {
+          content: [{
+            type: 'resource',
+            resource: { uri: resourceUri },
+          }],
+        },
+      },
+    });
+
+    await act(async () => {
+      root.render(<MCPToolDisplay toolItem={item} config={config} />);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    const cardRoot = container.querySelector('[data-bf-component="mcp-tool-display"]');
+    expect(container.querySelector('.mcp-app-iframe')).not.toBeNull();
+    expect(cardRoot?.getAttribute('data-bf-state')).toContain('expanded');
+    expect(container.querySelector<HTMLButtonElement>('.mcp-input-disclosure button[aria-expanded]')?.getAttribute('aria-expanded')).toBe('false');
+    expect(container.querySelector('.mcp-input-code')).toBeNull();
+
+    act(() => {
+      container.querySelector<HTMLButtonElement>('.mcp-input-disclosure button[aria-expanded]')?.dispatchEvent(
+        new dom.window.MouseEvent('click', { bubbles: true })
+      );
+    });
+
+    expect(cardRoot?.getAttribute('data-bf-state')).toContain('expanded');
+    expect(container.querySelector<HTMLButtonElement>('.mcp-input-disclosure button[aria-expanded]')?.getAttribute('aria-expanded')).toBe('true');
+    expect(container.querySelector('.mcp-input-code')).not.toBeNull();
+
+    act(() => {
+      container.querySelector<HTMLButtonElement>('[data-bf-component="flow-chat-tool-card"][data-bf-part="affordanceButton"]')?.dispatchEvent(
+        new dom.window.MouseEvent('click', { bubbles: true })
+      );
+    });
+
+    expect(cardRoot?.getAttribute('data-bf-state') ?? '').not.toContain('expanded');
+
+    act(() => {
+      container.querySelector<HTMLButtonElement>('[data-bf-component="flow-chat-tool-card"][data-bf-part="affordanceButton"]')?.dispatchEvent(
+        new dom.window.MouseEvent('click', { bubbles: true })
+      );
+    });
+
+    expect(cardRoot?.getAttribute('data-bf-state')).toContain('expanded');
+    expect(container.querySelector<HTMLButtonElement>('.mcp-input-disclosure button[aria-expanded]')?.getAttribute('aria-expanded')).toBe('false');
+    expect(container.querySelector('.mcp-input-code')).toBeNull();
+  });
+});

--- a/src/web-ui/src/flow_chat/tool-cards/MCPToolDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/MCPToolDisplay.tsx
@@ -3,10 +3,10 @@
  * Supports MCP Apps: when tool result contains ui:// resource, renders interactive UI in sandboxed iframe.
  */
 
-import React, { useState, useCallback, useEffect, useLayoutEffect, useRef } from 'react';
+import React, { useState, useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react';
 import { Package } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { Spinner } from '@bitfun/ui';
+import { Disclosure, Spinner } from '@bitfun/ui';
 import type { ToolCardProps } from '../types/flow-chat';
 import { ProminentToolCard, ProminentToolCardHeader } from '@bitfun/ui/flow-chat';
 import { createLogger } from '@/shared/utils/logger';
@@ -58,6 +58,46 @@ interface MCPToolResult {
   content?: MCPToolResultContent[];
   is_error?: boolean;
 }
+
+const parseMcpToolInput = (input: unknown): unknown => {
+  if (typeof input !== 'string') return input;
+
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return input;
+  }
+};
+
+const sanitizeMcpToolInput = (input: unknown): unknown => {
+  const parsed = parseMcpToolInput(input);
+  if (!parsed || Array.isArray(parsed) || typeof parsed !== 'object') return parsed;
+
+  return Object.fromEntries(
+    Object.entries(parsed).filter(([key]) => !key.startsWith('_')),
+  );
+};
+
+const hasVisibleMcpToolInput = (input: unknown): boolean => {
+  if (input === null || input === undefined) return false;
+  if (typeof input === 'string') return input.trim().length > 0;
+  if (Array.isArray(input)) return input.length > 0;
+  if (typeof input === 'object') return Object.keys(input).length > 0;
+  return true;
+};
+
+const formatMcpToolInput = (input: unknown): string => {
+  if (typeof input === 'string') return input;
+
+  try {
+    return JSON.stringify(input, null, 2);
+  } catch {
+    return String(input);
+  }
+};
 
 /** Clean and escape domains for CSP injection (prevent HTML injection). */
 const cleanDomains = (domains: string[] | undefined): string => {
@@ -151,14 +191,39 @@ export const MCPToolDisplay: React.FC<ToolCardProps> = ({
   config,
 }) => {
   const { t } = useTranslation('flow-chat');
-  const { status, toolCall, toolResult, requiresConfirmation, userConfirmed } = toolItem;
+  const {
+    status,
+    toolCall,
+    toolResult,
+    requiresConfirmation,
+    userConfirmed,
+    isParamsStreaming,
+  } = toolItem;
   const [isExpanded, setIsExpanded] = useState(false);
+  const [isInputExpanded, setIsInputExpanded] = useState(false);
   const toolId = toolItem.id ?? toolCall?.id;
-  const { cardRootRef, applyExpandedState } = useToolCardHeightContract({
+  const { cardRootRef, applyExpandedState, dispatchToolCardToggle } = useToolCardHeightContract({
     toolId,
     toolName: toolItem.toolName,
   });
   const [resolvedToolInfo, setResolvedToolInfo] = useState<ToolInfo | null>(null);
+  const toolInputIsIncomplete = Boolean(
+    isParamsStreaming
+    || (toolCall?.input && typeof toolCall.input === 'object' && (
+      toolCall.input._early_detection === true || toolCall.input._partial_params === true
+    )),
+  );
+  const displayToolInput = useMemo(
+    () => sanitizeMcpToolInput(toolCall?.input),
+    [toolCall?.input],
+  );
+  const hasToolInput = !toolInputIsIncomplete && hasVisibleMcpToolInput(displayToolInput);
+  const formattedToolInput = useMemo(
+    () => isExpanded && isInputExpanded && hasToolInput
+      ? formatMcpToolInput(displayToolInput)
+      : null,
+    [displayToolInput, hasToolInput, isExpanded, isInputExpanded],
+  );
 
   const getResultData = (): MCPToolResult | null => {
     if (!toolResult?.result) return null;
@@ -207,6 +272,7 @@ export const MCPToolDisplay: React.FC<ToolCardProps> = ({
   const isFailed = status === 'error';
 
   const mcpAppIframeRef = useRef<HTMLIFrameElement | null>(null);
+  const autoExpandedMcpAppRef = useRef<{ toolId: string | undefined; uri: string } | null>(null);
   const [mcpAppHeight, setMcpAppHeight] = useState<number | undefined>(undefined);
   const bridgeDataRef = useRef({ config, toolCall, resultData, status, isFailed });
   bridgeDataRef.current = { config, toolCall, resultData, status, isFailed };
@@ -249,12 +315,21 @@ export const MCPToolDisplay: React.FC<ToolCardProps> = ({
       .catch(() => setToolMetaUiUri(null));
   }, [config.toolName, uiResourceUriFromResult, status, isFailed, toolId]);
 
-  // Auto-expand when MCP App UI is ready so user sees the interactive UI immediately
+  // Auto-expand once when this tool call's MCP App UI becomes ready. Mark an
+  // already-open card as handled too, so a later user collapse is preserved.
   useLayoutEffect(() => {
-    if (mcpAppState?.html && !isExpanded) {
+    if (!mcpAppState?.html) return;
+
+    const autoExpandedApp = autoExpandedMcpAppRef.current;
+    if (autoExpandedApp?.toolId === toolId && autoExpandedApp.uri === mcpAppState.uri) {
+      return;
+    }
+
+    autoExpandedMcpAppRef.current = { toolId, uri: mcpAppState.uri };
+    if (!isExpanded) {
       applyExpandedState(isExpanded, true, setIsExpanded);
     }
-  }, [applyExpandedState, isExpanded, mcpAppState?.html]);
+  }, [applyExpandedState, isExpanded, mcpAppState?.html, mcpAppState?.uri, toolId]);
 
   // Iframe <-> parent postMessage bridge (MCP App protocol). Register in useLayoutEffect so listener is attached before iframe script runs.
   useLayoutEffect(() => {
@@ -577,16 +652,26 @@ export const MCPToolDisplay: React.FC<ToolCardProps> = ({
   };
 
   const contentSummary = getContentSummary();
-  const hasContent =
+  const hasResultContent =
     status === 'completed' &&
     (!!uiResourceUri || (resultData?.content && resultData.content.length > 0));
+  const hasExpandableDetails = hasToolInput || hasResultContent;
   const isLoading = status === 'preparing' || status === 'streaming' || status === 'running';
   const needsConfirmation =
     requiresConfirmation && !userConfirmed && status !== 'completed' && status !== 'cancelled' && status !== 'rejected' && status !== 'error';
 
   const toggleExpanded = useCallback(() => {
-    applyExpandedState(isExpanded, !isExpanded, setIsExpanded);
+    const nextExpanded = !isExpanded;
+    if (!nextExpanded) {
+      setIsInputExpanded(false);
+    }
+    applyExpandedState(isExpanded, nextExpanded, setIsExpanded);
   }, [applyExpandedState, isExpanded]);
+
+  const handleInputOpenChange = useCallback((open: boolean) => {
+    setIsInputExpanded(open);
+    dispatchToolCardToggle();
+  }, [dispatchToolCardToggle]);
 
   const getErrorMessage = () => {
     if (toolResult && 'error' in toolResult) {
@@ -594,21 +679,6 @@ export const MCPToolDisplay: React.FC<ToolCardProps> = ({
     }
     return t('toolCards.mcp.executionFailed');
   };
-
-  const handleCardClick = useCallback((e: React.MouseEvent) => {
-    const target = e.target as HTMLElement;
-    if (target.closest('.preview-toggle-btn')) {
-      return;
-    }
-    
-    if (isFailed) {
-      return;
-    }
-    
-    if (hasContent) {
-      toggleExpanded();
-    }
-  }, [hasContent, isFailed, toggleExpanded]);
 
   const renderToolIcon = () => {
     return <Package size={16} />;
@@ -649,14 +719,35 @@ export const MCPToolDisplay: React.FC<ToolCardProps> = ({
   );
 
   const renderExpandedContent = () => {
-    const hasResultContent = resultData?.content && resultData.content.length > 0;
+    const hasRenderableResultContent = resultData?.content && resultData.content.length > 0;
     const hasMcpApp = mcpAppState?.html;
-    if (!hasResultContent && !hasMcpApp) {
+    const hasMcpAppState = Boolean(mcpAppState);
+    if (!hasRenderableResultContent && !hasMcpApp && !hasToolInput) {
       return null;
     }
 
+    const inputContent = hasToolInput ? (
+      <div
+        className="content-item content-item-input"
+        data-bf-component="mcp-tool-display"
+        data-bf-part="input"
+      >
+        <Disclosure
+          className="mcp-input-disclosure"
+          open={isInputExpanded}
+          onOpenChange={handleInputOpenChange}
+          summary={t('toolCards.common.inputParams')}
+        >
+          {formattedToolInput !== null && (
+            <pre className="mcp-input-code">{formattedToolInput}</pre>
+          )}
+        </Disclosure>
+      </div>
+    ) : null;
+
     return (
       <div data-bf-component="mcp-tool-display" data-bf-part="expanded" data-bf-state="expanded" className="mcp-expanded-content">
+        {!hasMcpAppState && inputContent}
         {/* MCP App: sandboxed iframe for ui:// resources */}
         {mcpAppState && (
           <div className="content-item content-item-mcp-app" data-bf-component="mcp-tool-display" data-bf-part="item">
@@ -686,6 +777,7 @@ export const MCPToolDisplay: React.FC<ToolCardProps> = ({
             )}
           </div>
         )}
+        {hasMcpAppState && inputContent}
         {/* Text, image, and non-ui resources */}
         {(resultData?.content ?? []).map((item, index) => {
           const isUiResource = item.type === 'resource' && item.resource?.uri?.startsWith('ui://');
@@ -734,13 +826,15 @@ export const MCPToolDisplay: React.FC<ToolCardProps> = ({
       <ProminentToolCard
         status={status}
         isExpanded={isExpanded}
-        onClick={handleCardClick}
+        onClick={hasExpandableDetails ? toggleExpanded : undefined}
         className="mcp-tool-display"
         header={renderHeader()}
         expandedContent={renderExpandedContent()}
         errorContent={renderErrorContent()}
         isFailed={isFailed}
+        allowExpandedWhenFailed={isFailed && hasToolInput}
         requiresConfirmation={needsConfirmation}
+        toggleTestId="mcp-tool-card-toggle"
       />
     </div>
   );


### PR DESCRIPTION
Expose stable MCP invocation parameters in a nested details section so
users can inspect requests without crowding the default card view.

- Keep parameter details collapsed by default and reset them when the
  parent card closes
- Allow failed and result-less calls to expose available input
- Auto-expand each MCP App once while preserving later user collapse
- Add focused coverage for input parsing and expansion behavior
