### PR TITLE
refactor(web-ui): adopt shared components in miniapps

### DIFF
--- a/src/web-ui/src/app/scenes/miniapps/components/MiniAppCard.presentation.test.ts
+++ b/src/web-ui/src/app/scenes/miniapps/components/MiniAppCard.presentation.test.ts
@@ -18,6 +18,24 @@ describe('Mini App card presentation', () => {
     expect(readRelative('../views/MiniAppGalleryView.tsx')).toContain('<NumberBadge value={activeApps.length} />');
     expect(readRelative('../views/MiniAppGalleryView.tsx')).not.toContain('gallery-zone-badge');
   });
+
+  it('uses shared controls and card anatomy across Mini App surfaces', () => {
+    const gallery = readRelative('../views/MiniAppGalleryView.tsx');
+    const market = readRelative('../views/MiniAppMarketView.tsx');
+    const submissions = readRelative('../views/MiniAppSubmissionsView.tsx');
+
+    expect(gallery).toContain('<SegmentedControl');
+    expect(gallery).not.toContain('gallery-cat-chip');
+    expect(market).toContain('<SegmentedControl');
+    expect(market).toContain('<Card');
+    expect(market).toContain('<CardMedia');
+    expect(market).toContain('<CardBody');
+    expect(market).toContain('<IconButton');
+    expect(market).not.toContain('gallery-cat-chip');
+    expect(submissions).toContain('<Disclosure');
+    expect(submissions).toContain('<IconButton');
+    expect(submissions).not.toContain('miniapp-submissions__advanced-toggle');
+  });
   it('bounds the card without coupling its height to its width', () => {
     const stylesheet = readRelative('./MiniAppCard.scss');
     const rootStart = stylesheet.indexOf('.miniapp-card {');

--- a/src/web-ui/src/app/scenes/miniapps/views/MiniAppGalleryView.scss
+++ b/src/web-ui/src/app/scenes/miniapps/views/MiniAppGalleryView.scss
@@ -92,6 +92,16 @@
     min-height: 152px;
   }
 
+  &__categories {
+    max-width: min(56vw, 720px);
+    overflow-x: auto;
+    scrollbar-width: thin;
+
+    > [data-bf-part='segment'] {
+      flex: 0 0 auto;
+    }
+  }
+
 }
 
 /* Positioning-only overrides; the design-system Menu owns the surface look. */
@@ -113,6 +123,10 @@
       > :first-child {
         width: 100%;
       }
+    }
+
+    &__categories {
+      max-width: min(64vw, 520px);
     }
   }
 }

--- a/src/web-ui/src/app/scenes/miniapps/views/MiniAppGalleryView.tsx
+++ b/src/web-ui/src/app/scenes/miniapps/views/MiniAppGalleryView.tsx
@@ -21,7 +21,16 @@ import {
   type MarketPackageInspection,
 } from '@/infrastructure/api/service-api/MiniAppMarketAPI';
 import { createLogger } from '@/shared/utils/logger';
-import { ConfirmDialog, Icon, IconButton, Menu, MenuItem, NumberBadge, SearchField } from '@bitfun/ui';
+import {
+  ConfirmDialog,
+  Icon,
+  IconButton,
+  Menu,
+  MenuItem,
+  NumberBadge,
+  SearchField,
+  SegmentedControl,
+} from '@bitfun/ui';
 
 import {
   GalleryEmpty,
@@ -521,24 +530,27 @@ const MiniAppGalleryView: React.FC = () => {
           tools={(
             <>
               {categories.length > 1 ? (
-                <div data-bf-component="miniapp-gallery-view" data-bf-part="categoryFilters" className="gallery-chip-row">
-                  {categories.map((category) => (
-                    <button
-                      data-bf-component="miniapp-gallery-view"
-                      data-bf-part="categoryFilter"
-                      key={category}
-                      type="button"
-                      className={[
-                        'gallery-cat-chip',
-                        categoryFilter === category && 'gallery-cat-chip--active',
-                      ]
-                        .filter(Boolean)
-                        .join(' ')}
-                      onClick={() => setCategoryFilter(category)}
-                    >
-                      {category === 'all' ? t('all') : category}
-                    </button>
-                  ))}
+                <div
+                  data-bf-component="miniapp-gallery-view"
+                  data-bf-part="categoryFilters"
+                >
+                  <SegmentedControl
+                    className="miniapp-gallery__categories"
+                    options={categories.map((category) => ({
+                      label: (
+                        <span
+                          data-bf-component="miniapp-gallery-view"
+                          data-bf-part="categoryFilter"
+                        >
+                          {category === 'all' ? t('all') : category}
+                        </span>
+                      ),
+                      value: category,
+                    }))}
+                    value={categoryFilter}
+                    onValueChange={setCategoryFilter}
+                    aria-label={t('allApps')}
+                  />
                 </div>
               ) : null}
               <span className="gallery-zone-count">{t('count', { count: filtered.length })}</span>

--- a/src/web-ui/src/app/scenes/miniapps/views/MiniAppMarketView.scss
+++ b/src/web-ui/src/app/scenes/miniapps/views/MiniAppMarketView.scss
@@ -13,6 +13,16 @@
     min-width: 132px;
   }
 
+  &__categories {
+    max-width: 100%;
+    overflow-x: auto;
+    scrollbar-width: thin;
+
+    > [data-bf-part='segment'] {
+      flex: 0 0 auto;
+    }
+  }
+
   &__load-more {
     display: flex;
     justify-content: center;
@@ -33,13 +43,6 @@
   width: 100%;
   max-width: 360px;
   min-width: 0;
-  overflow: hidden;
-  padding: 0;
-  border: 1px solid var(--bf-color-border-subtle);
-  border-radius: var(--bf-radius-xl);
-  background: var(--bf-color-surface-panel);
-  color: inherit;
-  text-align: left;
   cursor: pointer;
   transition:
     transform var(--bf-motion-duration-fast) var(--bf-motion-easing-standard),
@@ -52,9 +55,24 @@
     background: var(--bf-color-action-quiet-hover);
   }
 
-  &:focus-visible {
-    outline: 2px solid var(--bf-color-accent-default);
-    outline-offset: 2px;
+  &:has(&__trigger:focus-visible) {
+    outline: var(--bf-focus-width) solid var(--bf-color-focus-ring);
+    outline-offset: var(--bf-focus-offset);
+  }
+
+  &__trigger {
+    display: flex;
+    width: 100%;
+    min-width: 0;
+    flex-direction: column;
+    padding: 0;
+    border: 0;
+    outline: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
   }
 
   &__visual {
@@ -201,14 +219,8 @@
     align-items: center;
     gap: var(--bf-space-1);
 
-    button {
-      display: grid;
-      place-items: center;
-      padding: 2px;
-      border: 0;
-      background: transparent;
+    &-action {
       color: var(--bf-color-status-warning-content);
-      cursor: pointer;
     }
 
     span {
@@ -235,20 +247,8 @@
   }
 
   &__releases-toggle {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--bf-space-1);
     margin-top: var(--bf-space-2);
-    padding: 0;
-    border: 0;
-    background: transparent;
     color: var(--bf-color-content-muted);
-    font-size: var(--bf-font-size-xs);
-    cursor: pointer;
-
-    &:hover {
-      color: var(--bf-color-content-secondary);
-    }
   }
 }
 

--- a/src/web-ui/src/app/scenes/miniapps/views/MiniAppMarketView.tsx
+++ b/src/web-ui/src/app/scenes/miniapps/views/MiniAppMarketView.tsx
@@ -1,4 +1,17 @@
-import { Button, ConfirmDialog, Icon, SearchField, Select, type SelectOption, StatusPill } from '@bitfun/ui';
+import {
+  Button,
+  Card,
+  CardBody,
+  CardMedia,
+  ConfirmDialog,
+  Icon,
+  IconButton,
+  SearchField,
+  SegmentedControl,
+  Select,
+  type SelectOption,
+  StatusPill,
+} from '@bitfun/ui';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { AlertTriangle, Heart, Loader2, PackageCheck, ShieldCheck } from 'lucide-react';
 
@@ -293,21 +306,16 @@ const MiniAppMarketView: React.FC = () => {
             />
           )}
         >
-          <div className="gallery-chip-row">
-            {CATEGORIES.map((value) => (
-              <button
-                key={value}
-                type="button"
-                className={[
-                  'gallery-cat-chip',
-                  value === category && 'gallery-cat-chip--active',
-                ].filter(Boolean).join(' ')}
-                onClick={() => setCategory(value)}
-              >
-                {categoryLabel(value, t)}
-              </button>
-            ))}
-          </div>
+          <SegmentedControl
+            className="miniapp-market-native__categories"
+            options={CATEGORIES.map((value) => ({
+              label: categoryLabel(value, t),
+              value,
+            }))}
+            value={category}
+            onValueChange={(value) => setCategory(value as (typeof CATEGORIES)[number])}
+            aria-label={t('market.catalog')}
+          />
           {loading ? (
             <GallerySkeleton
               count={8}
@@ -339,46 +347,53 @@ const MiniAppMarketView: React.FC = () => {
                   const name = pickLocalizedString(item, currentLanguage, 'name');
                   const description = pickLocalizedString(item, currentLanguage, 'description');
                   return (
-                    <button
+                    <Card
                       key={item.listingId}
-                      type="button"
                       className="miniapp-market-card"
-                      data-bf-component="miniapp-market-view"
-                      data-bf-part="card"
-                      onClick={() => void openDetail(item)}
+                      appearance="raised"
+                      clip
+                      radius="lg"
                     >
-                      <div className="miniapp-market-card__visual">
-                        {item.screenshotUrls[0] ? (
-                          <img
-                            src={marketImageUrl(item.screenshotUrls[0], 'compact-v1')}
-                            alt=""
-                            loading="lazy"
-                            decoding="async"
-                            onError={(event) => retryOriginalMarketImage(event.currentTarget, item.screenshotUrls[0]!)}
-                          />
-                        ) : (
-                          <span
-                            className="miniapp-market-card__fallback"
-                            style={{ background: getMiniAppIconGradient(item.icon || 'box') }}
-                          >
-                            {renderMiniAppIcon(item.icon || 'box', 30)}
-                          </span>
-                        )}
-                      </div>
-                      <div className="miniapp-market-card__body">
-                        <div className="miniapp-market-card__eyebrow">
-                          <span>{categoryLabel(item.category, t)}</span>
-                          <span>v{item.latestRelease}</span>
-                        </div>
-                        <strong>{name}</strong>
-                        <p>{description}</p>
-                        <div className="miniapp-market-card__stats">
-                          <span><Icon name="star" size="xs" /> {item.ratingAverage.toFixed(1)}</span>
-                          <span><Icon name="download" size="xs" /> {formatNumber(item.downloadCount)}</span>
-                          <span><Heart size={12} /> {formatNumber(item.favoriteCount)}</span>
-                        </div>
-                      </div>
-                    </button>
+                      <button
+                        type="button"
+                        className="miniapp-market-card__trigger"
+                        data-bf-component="miniapp-market-view"
+                        data-bf-part="card"
+                        onClick={() => void openDetail(item)}
+                      >
+                        <CardMedia className="miniapp-market-card__visual">
+                          {item.screenshotUrls[0] ? (
+                            <img
+                              src={marketImageUrl(item.screenshotUrls[0], 'compact-v1')}
+                              alt=""
+                              loading="lazy"
+                              decoding="async"
+                              onError={(event) => retryOriginalMarketImage(event.currentTarget, item.screenshotUrls[0]!)}
+                            />
+                          ) : (
+                            <span
+                              className="miniapp-market-card__fallback"
+                              style={{ background: getMiniAppIconGradient(item.icon || 'box') }}
+                            >
+                              {renderMiniAppIcon(item.icon || 'box', 30)}
+                            </span>
+                          )}
+                        </CardMedia>
+                        <CardBody className="miniapp-market-card__body">
+                          <div className="miniapp-market-card__eyebrow">
+                            <span>{categoryLabel(item.category, t)}</span>
+                            <span>v{item.latestRelease}</span>
+                          </div>
+                          <strong>{name}</strong>
+                          <p>{description}</p>
+                          <div className="miniapp-market-card__stats">
+                            <span><Icon name="star" size="xs" /> {item.ratingAverage.toFixed(1)}</span>
+                            <span><Icon name="download" size="xs" /> {formatNumber(item.downloadCount)}</span>
+                            <span><Heart size={12} /> {formatNumber(item.favoriteCount)}</span>
+                          </div>
+                        </CardBody>
+                      </button>
+                    </Card>
                   );
                 })}
               </GalleryGrid>
@@ -510,9 +525,16 @@ const MiniAppMarketView: React.FC = () => {
               <h4>{t('market.detail.rating')}</h4>
               <div className="miniapp-market-detail__rating">
                 {[1, 2, 3, 4, 5].map((value) => (
-                  <button key={value} type="button" onClick={() => void rate(value)} disabled={actionBusy}>
-                    <Icon name="star" size="lg" />
-                  </button>
+                  <IconButton
+                    key={value}
+                    size="xs"
+                    className="miniapp-market-detail__rating-action"
+                    onClick={() => void rate(value)}
+                    disabled={actionBusy}
+                    aria-label={`${t('market.detail.rating')} ${value}`}
+                    title={`${t('market.detail.rating')} ${value}`}
+                    icon={<Icon name="star" size="lg" />}
+                  />
                 ))}
                 <span>{detail.ratingAverage.toFixed(1)} · {formatNumber(detail.ratingCount)}</span>
               </div>
@@ -533,17 +555,20 @@ const MiniAppMarketView: React.FC = () => {
                 ))}
               </div>
               {detail.releases.length > 1 ? (
-                <button
-                  type="button"
+                <Button
+                  variant="text"
+                  size="xs"
                   className="miniapp-market-detail__releases-toggle"
                   aria-expanded={releasesExpanded}
                   onClick={() => setReleasesExpanded((current) => !current)}
+                  leadingIcon={releasesExpanded
+                    ? <Icon name="chevron-up" size="lg" />
+                    : <Icon name="chevron-down" size="xs" />}
                 >
-                  {releasesExpanded ? <Icon name="chevron-up" size="lg" style={{ width: 13, height: 13 }} /> : <Icon name="chevron-down" size="xs" />}
                   {releasesExpanded
                     ? t('market.detail.releasesCollapse')
                     : t('market.detail.releasesExpand', { count: releaseHistory.hiddenCount })}
-                </button>
+                </Button>
               ) : null}
             </section>
             {detail.repositoryUrl ? (

--- a/src/web-ui/src/app/scenes/miniapps/views/MiniAppSubmissionsView.scss
+++ b/src/web-ui/src/app/scenes/miniapps/views/MiniAppSubmissionsView.scss
@@ -201,55 +201,14 @@
         white-space: nowrap;
       }
 
-      button {
-        display: grid;
-        padding: 3px;
-        border: 0;
-        border-radius: var(--bf-radius-sm);
-        background: transparent;
+      [data-bf-component='icon-button'] {
         color: var(--bf-color-content-muted);
-        cursor: pointer;
-        place-items: center;
-
-        &:hover {
-          background: var(--bf-color-action-neutral-surface-hover);
-          color: var(--bf-color-content-primary);
-        }
       }
     }
   }
 
-  &__advanced-toggle {
-    display: flex;
-    align-items: center;
-    gap: var(--bf-space-2);
-    padding: 0;
-    border: 0;
-    background: transparent;
-    color: var(--bf-color-content-secondary);
-    font-size: var(--bf-font-size-sm);
-    font-weight: var(--bf-font-weight-medium);
-    cursor: pointer;
-    justify-self: start;
+  &__advanced-disclosure {
     max-width: 100%;
-
-    &:hover {
-      color: var(--bf-color-content-primary);
-    }
-
-    svg {
-      flex: 0 0 auto;
-      color: var(--bf-color-content-muted);
-    }
-
-    small {
-      overflow: hidden;
-      color: var(--bf-color-content-muted);
-      font-size: var(--bf-font-size-xs);
-      font-weight: var(--bf-font-weight-regular);
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
   }
 
   &__advanced {

--- a/src/web-ui/src/app/scenes/miniapps/views/MiniAppSubmissionsView.tsx
+++ b/src/web-ui/src/app/scenes/miniapps/views/MiniAppSubmissionsView.tsx
@@ -1,4 +1,14 @@
-import { Button, Field, Icon, Input, Select, StatusPill, Textarea } from '@bitfun/ui';
+import {
+  Button,
+  Disclosure,
+  Field,
+  Icon,
+  IconButton,
+  Input,
+  Select,
+  StatusPill,
+  Textarea,
+} from '@bitfun/ui';
 import React, { useEffect, useMemo, useState } from 'react';
 import { open } from '@tauri-apps/plugin-dialog';
 import { AlertTriangle, Camera, FileImage, Github, History, Loader2, PackageOpen, Send } from 'lucide-react';
@@ -362,29 +372,27 @@ const MiniAppSubmissionsView: React.FC = () => {
                 <div key={path}>
                   <FileImage size={14} />
                   <span title={path}>{fileName(path)}</span>
-                  <button
-                    type="button"
+                  <IconButton
+                    size="xs"
                     aria-label={t('market.submissions.removeScreenshot')}
+                    title={t('market.submissions.removeScreenshot')}
                     onClick={() =>
                       setScreenshotPaths((current) => current.filter((item) => item !== path))
                     }
-                  >
-                    <Icon name="xmark" size="xs" />
-                  </button>
+                    icon={<Icon name="xmark" size="xs" />}
+                  />
                 </div>
               ))}
             </div>
           ) : null}
 
-          <button
-            type="button"
-            className="miniapp-submissions__advanced-toggle"
-            onClick={() => setShowAdvanced((current) => !current)}
-          >
-            {showAdvanced ? <Icon name="chevron-down" size="sm" /> : <Icon name="chevron-right" size="sm" />}
-            <span>{t('market.submissions.advanced')}</span>
-            {!showAdvanced ? (
-              <small>
+          <Disclosure
+            className="miniapp-submissions__advanced-disclosure"
+            open={showAdvanced}
+            onOpenChange={setShowAdvanced}
+            summary={t('market.submissions.advanced')}
+            description={!showAdvanced ? (
+              <span>
                 {[
                   draft.slug,
                   `v${draft.releaseNumber}`,
@@ -394,11 +402,9 @@ const MiniAppSubmissionsView: React.FC = () => {
                   ),
                   draft.license.spdxExpression,
                 ].filter(Boolean).join(' · ')}
-              </small>
-            ) : null}
-          </button>
-
-          {showAdvanced ? (
+              </span>
+            ) : undefined}
+          >
             <div className="miniapp-submissions__advanced">
               <div className="miniapp-submissions__form-grid">
                 <Field
@@ -517,7 +523,7 @@ const MiniAppSubmissionsView: React.FC = () => {
                 />
               </Field>
             </div>
-          ) : null}
+          </Disclosure>
 
           {progress && busy ? (
             <div className="miniapp-submissions__progress">


### PR DESCRIPTION
## Summary

Align MiniApp gallery, market, and submission surfaces with the shared `@bitfun/ui` component library.

- Replace category chips with `SegmentedControl`.
- Use shared `Card`, `CardMedia`, and `CardBody` anatomy for market listings.
- Replace custom icon actions with `IconButton`.
- Replace custom expand/collapse controls with `Button` and `Disclosure`.
- Preserve existing MiniApp behavior and appearance-extension contracts.
- Add presentation coverage for shared component adoption.

Fixes: N/A

## Type and Areas

Type:

Refactor / UI/UX / test

Areas:

Web UI, MiniApp gallery, MiniApp market, MiniApp submissions

## Motivation / Impact

This reduces duplicated control and surface styling across MiniApp screens and keeps them consistent with the shared design system.

Users receive more consistent interaction states, keyboard behavior, focus handling, and responsive category navigation. No backend APIs, persisted data, user-facing strings, or locale resources were changed.

## Verification

- `pnpm --dir src/web-ui exec vitest run --maxWorkers=50% src/app/scenes/miniapps`
  - Passed: 18 test files, 74 tests.
- `pnpm --dir src/web-ui run type-check`
  - Passed.
- `pnpm run theme:visual-contract`
  - Passed: all 10 required surfaces covered.
- `pnpm run check:web`
  - Typography and appearance contract checks passed.
  - Web UI color governance for the changed surfaces passed.
  - The aggregate command was blocked by pre-existing stale generated artifacts in the git-graph MiniApp bundle and native mobile token projections.

## Reviewer Notes

- Existing MiniApp data flow, market operations, submission behavior, and remote-workspace guards remain unchanged.
- Existing appearance parts for gallery category filters are preserved.
- No generated artifacts or unrelated files are included.
- Remote scenarios were not manually exercised because this change is limited to shared presentation components and does not alter remote capability behavior.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.