### PR TITLE
fix(extensions): preserve assistant tool output

### DIFF
--- a/src/crates/assembly/core/src/agentic/tools/pipeline/tool_pipeline.rs
+++ b/src/crates/assembly/core/src/agentic/tools/pipeline/tool_pipeline.rs
@@ -92,11 +92,15 @@ fn plugin_after_presentation(
         .and_then(serde_json::Value::as_str)
         .unwrap_or(tool_name)
         .to_string();
-    let output = object
-        .and_then(|value| value.get("output"))
-        .and_then(serde_json::Value::as_str)
-        .map(str::to_string)
-        .or_else(|| tool_result.result_for_assistant.clone())
+    let output = tool_result
+        .result_for_assistant
+        .clone()
+        .or_else(|| {
+            object
+                .and_then(|value| value.get("output"))
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string)
+        })
         .unwrap_or_else(|| tool_result.result.to_string());
     let metadata = object
         .and_then(|value| value.get("metadata"))
@@ -2676,7 +2680,80 @@ mod tests {
 
     #[cfg(feature = "opencode-plugin-host")]
     #[test]
-    fn plugin_after_presentation_prefers_the_plugin_result_contract() {
+    fn plugin_after_presentation_prefers_model_visible_output_over_structured_output() {
+        let result = ModelToolResult {
+            tool_id: "call-a".to_string(),
+            tool_name: "ExecCommand".to_string(),
+            effective_tool_name: None,
+            result: json!({
+                "title": "ExecCommand",
+                "output": "raw terminal output",
+                "metadata": {"tty": true},
+                "session_id": 42
+            }),
+            result_for_assistant: Some("Process is still running with session ID 42.".to_string()),
+            is_error: false,
+            duration_ms: None,
+            image_attachments: None,
+        };
+
+        let presentation = plugin_after_presentation("ExecCommand", &result);
+        assert_eq!(presentation.title, "ExecCommand");
+        assert_eq!(
+            presentation.output,
+            "Process is still running with session ID 42."
+        );
+        assert_eq!(presentation.metadata["tty"], true);
+    }
+
+    #[cfg(feature = "opencode-plugin-host")]
+    #[test]
+    fn plugin_after_presentation_preserves_specialized_exec_and_stdin_results() {
+        let cases = [
+            (
+                "ExecCommand",
+                json!({"output": "", "tty": false}),
+                "Command completed successfully.",
+            ),
+            (
+                "ExecCommand",
+                json!({"output": "\u{1b}[?25l", "tty": true, "session_id": 73}),
+                "Process is still running with session ID 73.",
+            ),
+            (
+                "WriteStdin",
+                json!({"output": "done", "session_id": 73}),
+                "Wrote input to session 73.",
+            ),
+            (
+                "WriteStdin",
+                json!({"output": "", "requested_session_id": 999}),
+                "Session 999 was not found.",
+            ),
+        ];
+
+        for (tool_name, structured_result, assistant_result) in cases {
+            let result = ModelToolResult {
+                tool_id: "call-a".to_string(),
+                tool_name: tool_name.to_string(),
+                effective_tool_name: None,
+                result: structured_result,
+                result_for_assistant: Some(assistant_result.to_string()),
+                is_error: false,
+                duration_ms: None,
+                image_attachments: None,
+            };
+
+            assert_eq!(
+                plugin_after_presentation(tool_name, &result).output,
+                assistant_result
+            );
+        }
+    }
+
+    #[cfg(feature = "opencode-plugin-host")]
+    #[test]
+    fn plugin_after_presentation_falls_back_to_plugin_output_without_assistant_text() {
         let result = ModelToolResult {
             tool_id: "call-a".to_string(),
             tool_name: "report".to_string(),
@@ -2686,16 +2763,16 @@ mod tests {
                 "output": "report ready",
                 "metadata": {"path": "report.md"}
             }),
-            result_for_assistant: Some("report ready".to_string()),
+            result_for_assistant: None,
             is_error: false,
             duration_ms: None,
             image_attachments: None,
         };
 
-        let presentation = plugin_after_presentation("report", &result);
-        assert_eq!(presentation.title, "Generated report");
-        assert_eq!(presentation.output, "report ready");
-        assert_eq!(presentation.metadata["path"], "report.md");
+        assert_eq!(
+            plugin_after_presentation("report", &result).output,
+            "report ready"
+        );
     }
 
     #[cfg(feature = "opencode-plugin-host")]

--- a/src/crates/assembly/core/src/native_hooks.rs
+++ b/src/crates/assembly/core/src/native_hooks.rs
@@ -21,6 +21,8 @@ use crate::infrastructure::try_get_path_manager_arc;
 use crate::service::config::get_global_config_service;
 pub use crate::service::config::types::AgentHooksConfig;
 use async_trait::async_trait;
+#[cfg(feature = "opencode-plugin-host")]
+use bitfun_agent_runtime::native_hooks::PluginHookDispatchResult;
 use bitfun_agent_runtime::native_hooks::{
     AgentHookEngine, AgentHookEvent, AgentHookEventPayload, AgentHookMatcher, AgentHookOutcome,
     AgentHookPayload, AgentHookPayloadCommon, AgentHookPermissionMode, AgentHookPermissionOutcome,
@@ -84,6 +86,36 @@ pub(crate) async fn dispatch_plugin_hook(
 }
 
 #[cfg(feature = "opencode-plugin-host")]
+fn plugin_tool_before_output(result: PluginHookDispatchResult) -> Result<Option<Value>, String> {
+    if let Some(failure) = result.failure {
+        return Err(failure);
+    }
+    if result.executed_handlers == 0 {
+        return Ok(None);
+    }
+    Ok(result
+        .output
+        .get("args")
+        .cloned()
+        .filter(|updated| updated != &serde_json::Value::Null))
+}
+
+#[cfg(feature = "opencode-plugin-host")]
+fn plugin_tool_after_output(
+    result: PluginHookDispatchResult,
+) -> Result<Option<PluginToolAfterOutput>, String> {
+    if let Some(failure) = result.failure {
+        return Err(failure);
+    }
+    if result.executed_handlers == 0 {
+        return Ok(None);
+    }
+    serde_json::from_value::<PluginToolAfterOutput>(result.output)
+        .map(Some)
+        .map_err(|error| format!("Invalid tool.execute.after output: {error}"))
+}
+
+#[cfg(feature = "opencode-plugin-host")]
 pub(crate) async fn dispatch_plugin_tool_before(
     workspace_scope: &str,
     tool_name: &str,
@@ -123,14 +155,7 @@ pub(crate) async fn dispatch_plugin_tool_before(
     for warning in &result.warnings {
         warn!("OpenCode plugin hook warning (tool.execute.before): {warning}");
     }
-    if let Some(failure) = result.failure {
-        return Err(failure);
-    }
-    Ok(result
-        .output
-        .get("args")
-        .cloned()
-        .filter(|updated| updated != &serde_json::Value::Null))
+    plugin_tool_before_output(result)
 }
 
 #[cfg(feature = "opencode-plugin-host")]
@@ -181,13 +206,7 @@ pub(crate) async fn dispatch_plugin_tool_after(
     for warning in &result.warnings {
         warn!("OpenCode plugin hook warning (tool.execute.after): {warning}");
     }
-    if let Some(failure) = result.failure {
-        return Err(failure);
-    }
-    match serde_json::from_value::<PluginToolAfterOutput>(result.output) {
-        Ok(output) => Ok(Some(output)),
-        Err(error) => Err(format!("Invalid tool.execute.after output: {error}")),
-    }
+    plugin_tool_after_output(result)
 }
 
 #[cfg(feature = "opencode-plugin-host")]
@@ -215,6 +234,78 @@ impl PluginToolAfterOutput {
         // specified.
         drop((title, metadata));
         output
+    }
+}
+
+#[cfg(all(test, feature = "opencode-plugin-host"))]
+mod plugin_tool_output_tests {
+    use super::{plugin_tool_after_output, plugin_tool_before_output};
+    use bitfun_agent_runtime::native_hooks::PluginHookDispatchResult;
+    use serde_json::{json, Value};
+
+    fn dispatch_result(output: Value, executed_handlers: usize) -> PluginHookDispatchResult {
+        PluginHookDispatchResult {
+            input: Value::Null,
+            output,
+            warnings: Vec::new(),
+            failure: None,
+            executed_handlers,
+        }
+    }
+
+    #[test]
+    fn zero_plugin_handlers_do_not_report_before_or_after_transformations() {
+        let before =
+            plugin_tool_before_output(dispatch_result(json!({"args": {"cmd": "cargo check"}}), 0));
+        assert_eq!(before.expect("zero-handler before result"), None);
+
+        let after = plugin_tool_after_output(dispatch_result(
+            json!({
+                "title": "ExecCommand",
+                "output": "raw output",
+                "metadata": {}
+            }),
+            0,
+        ));
+        assert!(after.expect("zero-handler after result").is_none());
+    }
+
+    #[test]
+    fn executed_plugin_handlers_still_publish_their_transformations() {
+        let before =
+            plugin_tool_before_output(dispatch_result(json!({"args": {"cmd": "cargo test"}}), 1))
+                .expect("before hook output")
+                .expect("executed before hook transformation");
+        assert_eq!(before["cmd"], "cargo test");
+
+        let after = plugin_tool_after_output(dispatch_result(
+            json!({
+                "title": "ExecCommand",
+                "output": "transformed for the model",
+                "metadata": {"source": "test"}
+            }),
+            1,
+        ))
+        .expect("after hook output")
+        .expect("executed after hook transformation");
+        assert_eq!(after.output, "transformed for the model");
+        assert_eq!(after.metadata["source"], "test");
+    }
+
+    #[test]
+    fn plugin_dispatch_failure_is_not_hidden_by_a_zero_handler_count() {
+        let result = PluginHookDispatchResult {
+            input: Value::Null,
+            output: Value::Null,
+            warnings: Vec::new(),
+            failure: Some("plugin registry unavailable".to_string()),
+            executed_handlers: 0,
+        };
+
+        assert_eq!(
+            plugin_tool_before_output(result).expect_err("failure must be preserved"),
+            "plugin registry unavailable"
+        );
     }
 }
 


### PR DESCRIPTION
OpenCode plugin hook dispatch returned the engine's passthrough payload as a
real transformation even when executed_handlers was zero. The presentation
bridge also preferred a generic structured output field over the tool-owned
result_for_assistant text.

Together, these errors replaced ExecCommand and WriteStdin model output with
raw output, and could hide the session_id required to poll TTY sessions.

Treat zero-handler before/after dispatches as no-ops and seed after hooks from
the model-visible result, while retaining structured plugin output as a
fallback. Keep executed hook transformations and plugin presentation fields
unchanged, and cover both contracts with focused regression tests.

The regression was introduced by d46c924407
(fix(extensions): harden OpenCode plugin runtime integration), authored by
limityan
