### PR TITLE
fix(flow-chat): show raw stdin input

### DIFF
--- a/src/web-ui/src/flow_chat/tool-cards/execProcessToolCardModel.test.ts
+++ b/src/web-ui/src/flow_chat/tool-cards/execProcessToolCardModel.test.ts
@@ -25,7 +25,13 @@ function t(key: string, options?: Record<string, unknown>): string {
   return template.replace(/{{(\w+)}}/g, (_, name) => String(options?.[name] ?? ''));
 }
 
-function writeStdinItem(result: unknown): FlowToolItem {
+function writeStdinItem(
+  result: unknown,
+  input: Record<string, unknown> = {
+    session_id: 42,
+    chars: '',
+  },
+): FlowToolItem {
   return {
     id: 'tool-writestdin-1',
     type: 'tool',
@@ -34,10 +40,7 @@ function writeStdinItem(result: unknown): FlowToolItem {
     timestamp: Date.now(),
     toolCall: {
       id: 'call-writestdin-1',
-      input: {
-        session_id: 42,
-        chars: '',
-      },
+      input,
     },
     toolResult: {
       success: true,
@@ -65,6 +68,17 @@ function execControlItem(input: Record<string, unknown>, result: unknown): FlowT
 }
 
 describe('buildWriteStdinCardModel', () => {
+  it('does not display the appended enter after the input text', () => {
+    const model = buildWriteStdinCardModel(writeStdinItem({}, {
+      session_id: 42,
+      chars: 'yes',
+      append_enter: true,
+    }), t);
+
+    expect(model.primaryText).toBe('yes');
+    expect(model.copyText).toBe('yes');
+  });
+
   it('surfaces session-not-found results as a completed notice', () => {
     const model = buildWriteStdinCardModel(writeStdinItem({
       status: 'session_not_found',

--- a/src/web-ui/src/flow_chat/tool-cards/execProcessToolCardModel.ts
+++ b/src/web-ui/src/flow_chat/tool-cards/execProcessToolCardModel.ts
@@ -104,13 +104,10 @@ export function buildWriteStdinCardModel(
     : result.sessionId;
   const displaySessionId = sessionId ?? result.requestedSessionId;
   const chars = typeof input.chars === 'string' ? input.chars : '';
-  const appendEnter = Boolean(input.append_enter);
   const isPollOnly = chars.length === 0;
   const primaryText = isPollOnly
     ? t('toolCards.execProcess.pollSession', { id: displaySessionId ?? '?' })
-    : appendEnter
-      ? `${chars}\\n`
-      : chars;
+    : chars;
   const resultNoticeText = result.status === 'session_not_found'
     ? t('toolCards.execProcess.sessionNotFound', {
       id: displaySessionId ?? '?',


### PR DESCRIPTION
Keep the WriteStdin card display limited to the provided chars when
append_enter is enabled, while preserving its execution semantics.

Add regression coverage for the displayed and copied input text.
