### PR TITLE
fix(web): distinguish remote workspace navigation targets

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSection.tsx
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSection.tsx
@@ -5,9 +5,9 @@ import { notificationService } from '@/shared/notification-system';
 import WorkspaceItem from './WorkspaceItem';
 import SessionsSection, { type WorkspaceSessionScope } from '../sessions/SessionsSection';
 import { isRemoteWorkspace } from '@/shared/types';
-import { isSamePath } from '@/shared/utils/pathUtils';
 import { useWorkspaceSessionViewStore } from '../../workspaceSessionView';
 import {
+  isWorkspaceBackedSessionGroupActive,
   projectWorkspaceBackedSessionGroups,
   type SessionNavigationScope,
 } from '../../sessionNavigationProjection';
@@ -65,9 +65,6 @@ const WorkspaceListSection: React.FC<WorkspaceListSectionProps> = ({ variant }) 
     [sessionGroups],
   );
   const activeWorkspace = openedWorkspacesList.find(workspace => workspace.id === activeWorkspaceId);
-  const activeProjectPath = activeWorkspace?.worktree && !activeWorkspace.worktree.isMain
-    ? activeWorkspace.worktree.mainRepoPath
-    : activeWorkspace?.rootPath;
   const emptyLabel = variant === 'assistants'
     ? t('nav.workspaces.emptyAssistants')
     : variant === 'projects'
@@ -289,10 +286,7 @@ const WorkspaceListSection: React.FC<WorkspaceListSectionProps> = ({ variant }) 
             >
               <WorkspaceItem
                 workspace={workspace}
-                isActive={
-                  workspace.id === activeWorkspaceId ||
-                  Boolean(activeProjectPath && isSamePath(workspace.rootPath, activeProjectPath))
-                }
+                isActive={isWorkspaceBackedSessionGroupActive(workspace, activeWorkspace)}
                 isSingle={workspaces.length === 1}
                 draggable={workspaces.length > 1}
                 isDragging={draggedWorkspaceId === workspace.id}

--- a/src/web-ui/src/app/components/NavPanel/sessionNavigationProjection.test.ts
+++ b/src/web-ui/src/app/components/NavPanel/sessionNavigationProjection.test.ts
@@ -4,7 +4,10 @@ import {
   WorkspaceType,
   type WorkspaceInfo,
 } from '@/shared/types';
-import { projectWorkspaceBackedSessionGroups } from './sessionNavigationProjection';
+import {
+  isWorkspaceBackedSessionGroupActive,
+  projectWorkspaceBackedSessionGroups,
+} from './sessionNavigationProjection';
 
 const createWorkspace = (
   id: string,
@@ -86,5 +89,40 @@ describe('projectWorkspaceBackedSessionGroups', () => {
       [linkedWorktree],
       'all',
     ).map(group => group.workspace.id)).toEqual(['linked-worktree']);
+  });
+});
+
+describe('isWorkspaceBackedSessionGroupActive', () => {
+  it('distinguishes identical paths opened through different remote connections', () => {
+    const firstRemote = createWorkspace('remote-first', WorkspaceKind.Remote, {
+      rootPath: '/workspace',
+      connectionId: 'ssh-first',
+      sshHost: 'host-a.example',
+    });
+    const secondRemote = createWorkspace('remote-second', WorkspaceKind.Remote, {
+      rootPath: '/workspace',
+      connectionId: 'ssh-second',
+      sshHost: 'host-b.example',
+    });
+
+    expect(isWorkspaceBackedSessionGroupActive(firstRemote, firstRemote)).toBe(true);
+    expect(isWorkspaceBackedSessionGroupActive(secondRemote, firstRemote)).toBe(false);
+  });
+
+  it('keeps the canonical local project active for its selected worktree', () => {
+    const canonicalProject = createWorkspace('canonical-project', WorkspaceKind.Normal, {
+      rootPath: '/repo',
+    });
+    const linkedWorktree = createWorkspace('linked-worktree', WorkspaceKind.Normal, {
+      rootPath: '/repo/.worktrees/feature',
+      worktree: {
+        path: '/repo/.worktrees/feature',
+        mainRepoPath: '/repo',
+        branch: 'feature',
+        isMain: false,
+      },
+    });
+
+    expect(isWorkspaceBackedSessionGroupActive(canonicalProject, linkedWorktree)).toBe(true);
   });
 });

--- a/src/web-ui/src/app/components/NavPanel/sessionNavigationProjection.ts
+++ b/src/web-ui/src/app/components/NavPanel/sessionNavigationProjection.ts
@@ -1,5 +1,5 @@
 import type { WorkspaceInfo } from '@/shared/types';
-import { isLinkedWorktreeWorkspace } from '@/shared/types';
+import { isLinkedWorktreeWorkspace, isRemoteWorkspace } from '@/shared/types';
 import { isSamePath } from '@/shared/utils/pathUtils';
 
 export type SessionNavigationScope = 'all' | 'assistants' | 'projects';
@@ -17,6 +17,28 @@ export interface WorkspaceBackedSessionGroup {
   groupId: `workspace:${string}`;
   kind: WorkspaceBackedSessionGroupKind;
   workspace: WorkspaceInfo;
+}
+
+/**
+ * Resolve the active sidebar group without treating a remote POSIX path as a
+ * workspace identity. The same path can be open on multiple remote hosts, so
+ * remote workspaces must match by their stable workspace id. Local path
+ * matching remains available for a linked worktree whose canonical project is
+ * the visible navigation group.
+ */
+export function isWorkspaceBackedSessionGroupActive(
+  workspace: WorkspaceInfo,
+  activeWorkspace: WorkspaceInfo | null | undefined,
+): boolean {
+  if (!activeWorkspace) return false;
+  if (workspace.id === activeWorkspace.id) return true;
+  if (isRemoteWorkspace(workspace) || isRemoteWorkspace(activeWorkspace)) return false;
+
+  const activeProjectPath = activeWorkspace.worktree && !activeWorkspace.worktree.isMain
+    ? activeWorkspace.worktree.mainRepoPath
+    : activeWorkspace.rootPath;
+
+  return Boolean(activeProjectPath && isSamePath(workspace.rootPath, activeProjectPath));
 }
 
 const isWorkspaceInScope = (


### PR DESCRIPTION
## Summary

- make sidebar active-state resolution use stable workspace identity for remote workspaces
- prevent identical POSIX roots on different SSH/container connections from being treated as the same active workspace
- preserve the existing local linked-worktree-to-canonical-project projection
- add a regression test for two remote connections that both open `/workspace`

## Type and Areas

Type: regression fix

Areas: Web UI, remote workspace navigation

## Motivation / Impact

Two remote workspaces can legitimately expose the same POSIX root path. The sidebar previously used path equality as an active-state fallback, which marked both rows active. Clicking the folder action on the non-current row then skipped `setActiveWorkspace` and opened the file view for the previously active remote workspace.

Remote workspaces now match only by stable workspace id; path matching remains local-only for worktree projection.

## Verification

- `pnpm --dir src/web-ui run test:run src/app/components/NavPanel/sessionNavigationProjection.test.ts src/app/components/NavPanel/sections/workspaces/WorkspaceListSectionLayout.test.ts` — 14 tests passed
- `pnpm run check:web` — passed
- `pnpm --dir src/web-ui exec eslint src/app/components/NavPanel/sessionNavigationProjection.ts src/app/components/NavPanel/sections/workspaces/WorkspaceListSection.tsx` — passed
- `git diff --check` — passed

Remote-scenario coverage:

- Remote workspace: exercised the reported identity collision with two remote workspace records using the same `/workspace` path and different connection/host identities.
- Remote control, Peer Device Mode, and Detached Dispatch: not exercised; this change is limited to sidebar presentation/activation state and does not modify their transport or protocol paths.
- No live SSH target was used; transport behavior is unchanged.

## Reviewer Notes

AI-assisted change; fully tested at the focused Web UI level. No persisted shape, Tauri command, remote transport, or user-visible copy changes.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable (not applicable: no copy changes).
