### PR TITLE
fix(packaging): prevent incomplete desktop and installer artifacts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,12 +16,24 @@
 # reads LF fine and pinning them would churn every non-Windows working tree.
 #**
 
+/.gitattributes     text eol=lf
 *.sh                text eol=lf
 *.bash              text eol=lf
 *.rs                text eol=lf
 *.py                text eol=lf
 *.mjs               text eol=lf
 *.cjs               text eol=lf
+
+# Generated frontend/mobile contracts compare exact file contents. Keep both
+# their source fragments and generated outputs stable on every checkout so a
+# Windows or hosted runner cannot report newline-only generated drift.
+MiniApp/Demo/git-graph/source/** text eol=lf
+src/crates/assembly/core/builtin_skills/miniapp-dev/references/examples/demo-git-graph/source/** text eol=lf
+src/apps/mobile/**/*.json text eol=lf
+src/apps/mobile/**/*.js text eol=lf
+src/apps/mobile/**/*.ets text eol=lf
+src/apps/mobile/**/*.kt text eol=lf
+src/apps/mobile/**/*.swift text eol=lf
 
 # models.dev provenance hashes exact redistributed bytes. Keep these assets
 # stable across checkout platforms so the offline release check is reproducible.

--- a/.github/workflows/desktop-package.yml
+++ b/.github/workflows/desktop-package.yml
@@ -187,6 +187,7 @@ jobs:
               if (-not (Test-Path $desktopExe)) {
                 throw "Desktop executable was not found after NSIS build: $desktopExe"
               }
+              $env:BITFUN_INSTALLER_APP_EXE = $desktopExe
               pnpm run installer:build:only
               if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 

--- a/BitFun-Installer/README.md
+++ b/BitFun-Installer/README.md
@@ -43,7 +43,14 @@ Use this as the release entrypoint. `pnpm run tauri:build` does not prepare vali
 pnpm run installer:build:only
 ```
 
-`installer:build:only` requires an existing valid desktop executable in the expected target output path.
+`installer:build:only` requires an existing `target/release/bitfun-desktop.exe`
+and its adjacent runtime directories. It never falls back to `release-fast` or
+`debug`. For an explicit Cargo target, pass the exact executable:
+
+```powershell
+$env:BITFUN_INSTALLER_APP_EXE = "target/x86_64-pc-windows-msvc/release/bitfun-desktop.exe"
+pnpm run installer:build:only
+```
 
 ## Architecture
 
@@ -176,7 +183,9 @@ pnpm run installer:build:fast
 pnpm run installer:build:only
 ```
 
-If payload validation fails, the build exits with an error.
+If any required desktop runtime file is missing, or payload validation fails,
+the build exits with an error. The installer verifies every manifest file's
+size and SHA-256 after extraction before registering the installation.
 
 ### Installer-only fast build
 

--- a/BitFun-Installer/package.json
+++ b/BitFun-Installer/package.json
@@ -25,15 +25,15 @@
   },
   "dependencies": {
     "@bitfun/theme-bitfun": "workspace:^",
-    "@tauri-apps/api": "^2.10.1",
-    "@tauri-apps/plugin-dialog": "^2.6.0",
+    "@tauri-apps/api": "2.11.1",
+    "@tauri-apps/plugin-dialog": "2.7.3",
     "i18next": "^25.8.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-i18next": "^16.5.3"
   },
   "devDependencies": {
-    "@tauri-apps/cli": "^2.10.0",
+    "@tauri-apps/cli": "2.11.4",
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.6.0",

--- a/BitFun-Installer/scripts/build-installer.cjs
+++ b/BitFun-Installer/scripts/build-installer.cjs
@@ -7,7 +7,7 @@
  * 3. Build installer app (Tauri).
  *
  * Usage:
- *   node scripts/build-installer.cjs [--skip-app-build] [--dev] [--mode fast|release]
+ *   node scripts/build-installer.cjs [--skip-app-build] [--dev] [--mode fast|release] [--app-exe path]
  *   node scripts/build-installer.cjs --fast   # same as --mode fast
  */
 
@@ -26,6 +26,14 @@ const isDev = rawArgs.includes("--dev");
 const showHelp = rawArgs.includes("--help") || rawArgs.includes("-h");
 const STRICT_PAYLOAD_VALIDATION = !isDev;
 const MIN_APP_EXE_BYTES = 5 * 1024 * 1024;
+const REQUIRED_PAYLOAD_FILES = [
+  "bitfun-desktop.exe",
+  "frontend/dist/index.html",
+  "mobile-web/dist/index.html",
+  "resources/ext-host/extension-host.js",
+  "resources/worker_host.js",
+  "flashgrep/flashgrep-x86_64-pc-windows-msvc.exe",
+];
 
 function getMode(args) {
   if (args.includes("--fast")) return "fast";
@@ -34,6 +42,16 @@ function getMode(args) {
     return args[modeFlagIndex + 1].trim();
   }
   return "release";
+}
+
+function getArgValue(args, flag) {
+  const flagIndex = args.indexOf(flag);
+  if (flagIndex < 0) return null;
+  const value = args[flagIndex + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`Missing value for ${flag}`);
+  }
+  return value.trim();
 }
 
 const buildMode = getMode(rawArgs);
@@ -68,6 +86,8 @@ Options:
   --mode <fast|release>  Build mode (default: release)
   --fast                 Alias for --mode fast
   --skip-app-build       Skip building main BitFun app
+  --app-exe <path>       Exact desktop executable to package. Required when the
+                         desired build is outside the active Cargo target dir.
   --dev                  Run installer with tauri dev instead of tauri build
                          and allow placeholder payload fallback
   --help, -h             Show this help
@@ -127,7 +147,7 @@ function copyDirRecursiveWithManifest(srcDir, destDir, manifest, payloadRoot) {
 
 function shouldCopySiblingRuntimeFile(fileName, appExeBaseName) {
   if (fileName === appExeBaseName) return false;
-  if (fileName === ".cargo-lock") return false;
+  if (fileName.startsWith(".cargo-")) return false;
 
   const lower = fileName.toLowerCase();
   if (
@@ -143,45 +163,54 @@ function shouldCopySiblingRuntimeFile(fileName, appExeBaseName) {
   return true;
 }
 
-function getCandidateAppExePaths(mode) {
-  const preferredProfiles =
-    mode === "fast"
-      ? ["release-fast", "release", "debug"]
-      : ["release", "release-fast", "debug"];
+function getExpectedAppProfile(mode) {
+  return mode === "fast" ? "release-fast" : "release";
+}
 
-  const candidates = [];
-  for (const profile of preferredProfiles) {
-    candidates.push(
-      path.join(
-        BITFUN_ROOT,
-        "target",
-        "x86_64-pc-windows-msvc",
-        profile,
-        "bitfun-desktop.exe"
-      ),
-      path.join(
-        BITFUN_ROOT,
-        "src",
-        "apps",
-        "desktop",
-        "target",
-        profile,
-        "bitfun-desktop.exe"
-      ),
-      path.join(BITFUN_ROOT, "target", profile, "bitfun-desktop.exe")
-    );
+function resolveCargoTargetDir(env = process.env) {
+  const configured = env.CARGO_TARGET_DIR;
+  if (!configured) return path.join(BITFUN_ROOT, "target");
+  return path.isAbsolute(configured)
+    ? path.normalize(configured)
+    : path.resolve(BITFUN_ROOT, configured);
+}
+
+function resolveAppExePath(mode, args = rawArgs, env = process.env) {
+  const configured = getArgValue(args, "--app-exe") || env.BITFUN_INSTALLER_APP_EXE;
+  if (configured) {
+    return path.isAbsolute(configured)
+      ? path.normalize(configured)
+      : path.resolve(BITFUN_ROOT, configured);
   }
 
-  return candidates;
+  return path.join(
+    resolveCargoTargetDir(env),
+    getExpectedAppProfile(mode),
+    "bitfun-desktop.exe"
+  );
 }
 
-if (showHelp) {
-  printHelpAndExit();
+function validateRequiredPayloadFiles(payloadDir, manifest) {
+  const manifestPaths = new Set(manifest.files.map((entry) => entry.path));
+  const missing = REQUIRED_PAYLOAD_FILES.filter((relativePath) => {
+    const diskPath = path.join(payloadDir, ...relativePath.split("/"));
+    return !manifestPaths.has(relativePath) || !fs.existsSync(diskPath);
+  });
+  if (missing.length > 0) {
+    throw new Error(
+      `Installer payload is incomplete. Missing required files: ${missing.join(", ")}`
+    );
+  }
 }
 
-if (!validModes.has(buildMode)) {
-  error(`Invalid mode "${buildMode}". Supported: fast, release`);
-}
+function main() {
+  if (showHelp) {
+    printHelpAndExit();
+  }
+
+  if (!validModes.has(buildMode)) {
+    error(`Invalid mode "${buildMode}". Supported: fast, release`);
+  }
 
 log(`Build mode: ${buildMode}`);
 if (isDev) {
@@ -201,20 +230,15 @@ if (!skipAppBuild) {
 // Step 2: Prepare payload.
 log("Step 2: Preparing installer payload...");
 
-const possiblePaths = getCandidateAppExePaths(buildMode);
-let appExePath = null;
-for (const p of possiblePaths) {
-  if (fs.existsSync(p)) {
-    appExePath = p;
-    break;
-  }
-}
+  const expectedAppExePath = resolveAppExePath(buildMode);
+  const appExePath = fs.existsSync(expectedAppExePath) ? expectedAppExePath : null;
 
-if (!appExePath && STRICT_PAYLOAD_VALIDATION) {
-  error(
-    "Could not find built BitFun executable for payload. Build the desktop app first or run with --dev for local debug."
-  );
-}
+  if (!appExePath && STRICT_PAYLOAD_VALIDATION) {
+    error(
+      `Could not find the exact ${getExpectedAppProfile(buildMode)} BitFun executable at ${expectedAppExePath}. ` +
+        "Build that profile first, set BITFUN_INSTALLER_APP_EXE, or pass --app-exe."
+    );
+  }
 
 if (appExePath) {
   ensureCleanDir(PAYLOAD_DIR);
@@ -254,7 +278,14 @@ if (appExePath) {
 
   // Keep installer payload aligned with the desktop app's runtime lookup paths.
   // `mobile-web` may be emitted as a sibling directory in no-bundle builds.
-  const runtimeDirs = ["resources", "locales", "swiftshader", "mobile-web"];
+  const runtimeDirs = [
+    "resources",
+    "locales",
+    "swiftshader",
+    "mobile-web",
+    "frontend",
+    "flashgrep",
+  ];
   for (const dirName of runtimeDirs) {
     const srcDir = path.join(releaseDir, dirName);
     if (!fs.existsSync(srcDir) || !fs.statSync(srcDir).isDirectory()) {
@@ -263,6 +294,14 @@ if (appExePath) {
     const destDir = path.join(PAYLOAD_DIR, dirName);
     copyDirRecursiveWithManifest(srcDir, destDir, manifest, PAYLOAD_DIR);
     log(`Copied runtime directory: ${dirName}`);
+  }
+
+  if (STRICT_PAYLOAD_VALIDATION) {
+    try {
+      validateRequiredPayloadFiles(PAYLOAD_DIR, manifest);
+    } catch (validationError) {
+      error(validationError.message);
+    }
   }
 
   const manifestPath = path.join(PAYLOAD_DIR, "payload-manifest.json");
@@ -307,3 +346,17 @@ if (isDev) {
     )}`
   );
 }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  REQUIRED_PAYLOAD_FILES,
+  getExpectedAppProfile,
+  resolveAppExePath,
+  resolveCargoTargetDir,
+  shouldCopySiblingRuntimeFile,
+  validateRequiredPayloadFiles,
+};

--- a/BitFun-Installer/scripts/build-installer.test.cjs
+++ b/BitFun-Installer/scripts/build-installer.test.cjs
@@ -1,0 +1,110 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  REQUIRED_PAYLOAD_FILES,
+  getExpectedAppProfile,
+  resolveAppExePath,
+  shouldCopySiblingRuntimeFile,
+  validateRequiredPayloadFiles,
+} = require("./build-installer.cjs");
+
+const installerRoot = path.resolve(__dirname, "..");
+
+test("installer modes select only their exact Cargo profile", () => {
+  assert.equal(getExpectedAppProfile("release"), "release");
+  assert.equal(getExpectedAppProfile("fast"), "release-fast");
+
+  const releasePath = resolveAppExePath("release", [], {});
+  assert.match(releasePath, /target[\\/]release[\\/]bitfun-desktop\.exe$/);
+  assert.doesNotMatch(releasePath, /release-fast|debug/);
+});
+
+test("an explicit desktop executable wins over target directory discovery", () => {
+  const explicit = path.join(os.tmpdir(), "custom-target", "bitfun-desktop.exe");
+  assert.equal(
+    resolveAppExePath("release", ["--app-exe", explicit], {
+      CARGO_TARGET_DIR: "ignored-target",
+    }),
+    path.normalize(explicit)
+  );
+});
+
+test("payload validation requires every desktop runtime surface", () => {
+  const payload = fs.mkdtempSync(path.join(os.tmpdir(), "bitfun-installer-payload-"));
+  const manifest = { files: [] };
+
+  for (const relativePath of REQUIRED_PAYLOAD_FILES) {
+    const diskPath = path.join(payload, ...relativePath.split("/"));
+    fs.mkdirSync(path.dirname(diskPath), { recursive: true });
+    fs.writeFileSync(diskPath, relativePath);
+    manifest.files.push({ path: relativePath });
+  }
+
+  assert.doesNotThrow(() => validateRequiredPayloadFiles(payload, manifest));
+
+  fs.rmSync(path.join(payload, "frontend"), { recursive: true, force: true });
+  assert.throws(
+    () => validateRequiredPayloadFiles(payload, manifest),
+    /frontend\/dist\/index\.html/
+  );
+});
+
+test("Cargo implementation locks are not copied into the installer", () => {
+  assert.equal(shouldCopySiblingRuntimeFile(".cargo-lock", "bitfun-desktop.exe"), false);
+  assert.equal(
+    shouldCopySiblingRuntimeFile(".cargo-artifact-lock", "bitfun-desktop.exe"),
+    false
+  );
+  assert.equal(
+    shouldCopySiblingRuntimeFile(".cargo-build-lock", "bitfun-desktop.exe"),
+    false
+  );
+});
+
+test("Rust and JavaScript Tauri package lines stay pinned and aligned", () => {
+  const packageJson = JSON.parse(
+    fs.readFileSync(path.join(installerRoot, "package.json"), "utf8")
+  );
+  const cargoToml = fs.readFileSync(
+    path.join(installerRoot, "src-tauri", "Cargo.toml"),
+    "utf8"
+  );
+  const rustTauri = cargoToml.match(/tauri = \{ version = "=([^"]+)"/)?.[1];
+  const rustDialog = cargoToml.match(/tauri-plugin-dialog = "=([^"]+)"/)?.[1];
+  const jsTauri = packageJson.dependencies["@tauri-apps/api"];
+  const jsDialog = packageJson.dependencies["@tauri-apps/plugin-dialog"];
+
+  assert.match(jsTauri, /^\d+\.\d+\.\d+$/);
+  assert.match(jsDialog, /^\d+\.\d+\.\d+$/);
+  assert.equal(minorLine(rustTauri), minorLine(jsTauri));
+  assert.equal(minorLine(rustDialog), minorLine(jsDialog));
+});
+
+test("all Installer validators share the required runtime file contract", () => {
+  const buildRs = fs.readFileSync(path.join(installerRoot, "src-tauri", "build.rs"), "utf8");
+  const commandsRs = fs.readFileSync(
+    path.join(installerRoot, "src-tauri", "src", "installer", "commands.rs"),
+    "utf8"
+  );
+  for (const relativePath of REQUIRED_PAYLOAD_FILES) {
+    assert.match(buildRs, new RegExp(escapeRegExp(relativePath)));
+    if (relativePath === "bitfun-desktop.exe") {
+      assert.match(commandsRs, /MAIN_APP_EXE/);
+    } else {
+      assert.match(commandsRs, new RegExp(escapeRegExp(relativePath)));
+    }
+  }
+});
+
+function minorLine(version) {
+  assert.match(version, /^\d+\.\d+\.\d+$/);
+  return version.split(".").slice(0, 2).join(".");
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/BitFun-Installer/src-tauri/Cargo.toml
+++ b/BitFun-Installer/src-tauri/Cargo.toml
@@ -14,14 +14,15 @@ name = "bitfun-installer"
 path = "src/main.rs"
 
 [build-dependencies]
-tauri-build = { version = "2", features = [] }
+tauri-build = { version = "=2.6.3", features = [] }
 zip = "0.6"
 
 [dependencies]
-tauri = { version = "2", features = [] }
-tauri-plugin-dialog = "2"
+tauri = { version = "=2.11.5", features = [] }
+tauri-plugin-dialog = "=2.7.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.10"
 anyhow = "1.0"
 log = "0.4"
 dirs = "5.0"

--- a/BitFun-Installer/src-tauri/build.rs
+++ b/BitFun-Installer/src-tauri/build.rs
@@ -5,6 +5,15 @@ use std::path::{Path, PathBuf};
 use zip::write::FileOptions;
 use zip::{CompressionMethod, ZipWriter};
 
+const REQUIRED_PAYLOAD_FILES: [&str; 6] = [
+    "bitfun-desktop.exe",
+    "frontend/dist/index.html",
+    "mobile-web/dist/index.html",
+    "resources/ext-host/extension-host.js",
+    "resources/worker_host.js",
+    "flashgrep/flashgrep-x86_64-pc-windows-msvc.exe",
+];
+
 fn main() {
     if let Err(err) = build_embedded_payload() {
         panic!("failed to build embedded payload: {err}");
@@ -18,12 +27,20 @@ fn build_embedded_payload() -> Result<(), Box<dyn std::error::Error>> {
     let payload_dir = manifest_dir.join("payload");
     let out_dir = PathBuf::from(std::env::var("OUT_DIR")?);
     let out_zip = out_dir.join("embedded_payload.zip");
+    let profile = std::env::var("PROFILE").unwrap_or_else(|_| "debug".to_string());
 
     println!("cargo:rerun-if-changed={}", payload_dir.display());
+
+    if profile != "debug" {
+        validate_release_payload(&payload_dir)?;
+    }
 
     let mut file_count = 0usize;
     if payload_dir.exists() && payload_dir.is_dir() {
         file_count = create_payload_zip(&payload_dir, &out_zip)?;
+        if profile != "debug" {
+            validate_release_payload_zip(&out_zip)?;
+        }
         emit_rerun_for_files(&payload_dir)?;
     } else {
         create_empty_zip(&out_zip)?;
@@ -34,6 +51,50 @@ fn build_embedded_payload() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:warning=embedded payload files: {file_count}");
 
     Ok(())
+}
+
+fn validate_release_payload(payload_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let missing = REQUIRED_PAYLOAD_FILES
+        .iter()
+        .filter(|relative| !payload_dir.join(relative).is_file())
+        .copied()
+        .collect::<Vec<_>>();
+    if missing.is_empty() {
+        return Ok(());
+    }
+
+    Err(format!(
+        "release installer payload is incomplete; run installer:build so these files are staged: {}",
+        missing.join(", ")
+    )
+    .into())
+}
+
+fn validate_release_payload_zip(out_zip: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let file = File::open(out_zip)?;
+    let mut archive = zip::ZipArchive::new(file)?;
+    let mut available = std::collections::HashSet::new();
+    for index in 0..archive.len() {
+        let entry = archive.by_index(index)?;
+        if !entry.name().ends_with('/') {
+            available.insert(entry.name().replace('\\', "/"));
+        }
+    }
+
+    let missing = REQUIRED_PAYLOAD_FILES
+        .iter()
+        .filter(|relative| !available.contains(**relative))
+        .copied()
+        .collect::<Vec<_>>();
+    if missing.is_empty() {
+        return Ok(());
+    }
+
+    Err(format!(
+        "release installer payload zip is incomplete after archiving; missing entries: {}",
+        missing.join(", ")
+    )
+    .into())
 }
 
 fn emit_rerun_for_files(dir: &Path) -> io::Result<()> {

--- a/BitFun-Installer/src-tauri/src/installer/commands.rs
+++ b/BitFun-Installer/src-tauri/src/installer/commands.rs
@@ -1,14 +1,16 @@
 //! Tauri commands exposed to the frontend installer UI.
 
-use super::MAIN_APP_EXE;
 use super::extract::{self, ESTIMATED_INSTALL_SIZE};
 use super::generated_locale_contract::INSTALLER_GENERATED_LOCALES;
 use super::types::{
     ConnectionTestResult, DiskSpaceInfo, InstallOptions, InstallProgress, ModelConfig,
     RemoteModelInfo,
 };
+use super::MAIN_APP_EXE;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
+use sha2::{Digest, Sha256};
+use std::collections::HashSet;
 use std::fs::File;
 use std::io::{Cursor, Read};
 use std::path::{Path, PathBuf};
@@ -26,6 +28,14 @@ struct WindowsInstallState {
 
 const MIN_WINDOWS_APP_EXE_BYTES: u64 = 5 * 1024 * 1024;
 const PAYLOAD_MANIFEST_FILE: &str = "payload-manifest.json";
+const REQUIRED_PAYLOAD_FILES: [&str; 6] = [
+    MAIN_APP_EXE,
+    "frontend/dist/index.html",
+    "mobile-web/dist/index.html",
+    "resources/ext-host/extension-host.js",
+    "resources/worker_host.js",
+    "flashgrep/flashgrep-x86_64-pc-windows-msvc.exe",
+];
 const INSTALLER_STATE_FILE: &str = "installer-state.json";
 const DEFAULT_MODEL_CONTEXT_WINDOW: u64 = 200_000;
 const EMBEDDED_PAYLOAD_ZIP: &[u8] =
@@ -66,6 +76,8 @@ struct PayloadManifest {
 #[derive(Debug, Clone, Deserialize)]
 struct PayloadManifestFile {
     path: String,
+    size: u64,
+    sha256: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -285,7 +297,7 @@ fn launch_windows_registered_uninstaller(
 
 #[cfg(target_os = "windows")]
 fn parse_windows_command_line(command_line: &str) -> Result<Vec<String>, String> {
-    use std::ffi::{OsStr, OsString, c_void};
+    use std::ffi::{c_void, OsStr, OsString};
     use std::os::windows::ffi::{OsStrExt, OsStringExt};
 
     #[link(name = "shell32")]
@@ -350,9 +362,9 @@ pub(crate) fn get_disk_space(path: String) -> Result<DiskSpaceInfo, String> {
                 .to_str()
                 .unwrap_or(fallback_windows_root.as_str()),
         )
-            .encode_wide()
-            .chain(std::iter::once(0))
-            .collect();
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
 
         let mut free_bytes_available: u64 = 0;
         let mut total_bytes: u64 = 0;
@@ -402,7 +414,9 @@ unsafe fn windows_sys_get_disk_free_space(
             lpTotalNumberOfFreeBytes: *mut u64,
         ) -> i32;
     }
-    GetDiskFreeSpaceExW(path, free_bytes_available, total_bytes, total_free_bytes)
+    // SAFETY: the caller supplies the same pointers accepted by this wrapper,
+    // and the Windows API writes only to the three documented output pointers.
+    unsafe { GetDiskFreeSpaceExW(path, free_bytes_available, total_bytes, total_free_bytes) }
 }
 
 #[tauri::command]
@@ -468,13 +482,16 @@ pub(crate) async fn start_installation(
 
         let mut extracted = false;
         let mut used_debug_placeholder = false;
+        let mut installed_manifest: Option<PayloadManifest> = None;
         let mut checked_locations: Vec<String> = Vec::new();
 
         if embedded_payload_available() {
             checked_locations.push("embedded payload zip".to_string());
             preflight_validate_payload_zip_bytes(EMBEDDED_PAYLOAD_ZIP, "embedded payload zip")?;
-            let _ =
-                read_payload_manifest_from_zip_bytes(EMBEDDED_PAYLOAD_ZIP, "embedded payload zip")?;
+            installed_manifest = Some(read_payload_manifest_from_zip_bytes(
+                EMBEDDED_PAYLOAD_ZIP,
+                "embedded payload zip",
+            )?);
             extract::extract_zip_bytes_with_filter(
                 EMBEDDED_PAYLOAD_ZIP,
                 &install_path,
@@ -500,7 +517,10 @@ pub(crate) async fn start_installation(
                         continue;
                     }
                     preflight_validate_payload_zip_file(&candidate.path, &candidate.label)?;
-                    let _ = read_payload_manifest_from_zip_file(&candidate.path, &candidate.label)?;
+                    installed_manifest = Some(read_payload_manifest_from_zip_file(
+                        &candidate.path,
+                        &candidate.label,
+                    )?);
                     extract::extract_zip_with_filter(
                         &candidate.path,
                         &install_path,
@@ -517,7 +537,10 @@ pub(crate) async fn start_installation(
                     continue;
                 }
                 preflight_validate_payload_dir(&candidate.path, &candidate.label)?;
-                let _ = read_payload_manifest_from_dir(&candidate.path, &candidate.label)?;
+                installed_manifest = Some(read_payload_manifest_from_dir(
+                    &candidate.path,
+                    &candidate.label,
+                )?);
                 extract::copy_directory_with_filter(
                     &candidate.path,
                     &install_path,
@@ -549,7 +572,10 @@ pub(crate) async fn start_installation(
         }
 
         if !used_debug_placeholder {
-            verify_installed_payload(&install_path)?;
+            let manifest = installed_manifest.as_ref().ok_or_else(|| {
+                "Installer payload manifest was not retained after extraction".to_string()
+            })?;
+            verify_installed_payload(&install_path, manifest)?;
         }
 
         emit_progress(&window, "extract", 50, "Files extracted successfully");
@@ -1506,6 +1532,7 @@ fn preflight_validate_payload_zip_archive<R: std::io::Read + std::io::Seek>(
     source_label: &str,
 ) -> Result<(), String> {
     let mut exe_size: Option<u64> = None;
+    let mut archive_paths = HashSet::new();
     for i in 0..archive.len() {
         let file = archive
             .by_index(i)
@@ -1513,10 +1540,10 @@ fn preflight_validate_payload_zip_archive<R: std::io::Read + std::io::Seek>(
         if file.name().ends_with('/') {
             continue;
         }
+        archive_paths.insert(normalize_payload_path(file.name()));
         let file_name = zip_entry_file_name(file.name());
         if file_name.eq_ignore_ascii_case(MAIN_APP_EXE) {
             exe_size = Some(file.size());
-            break;
         }
     }
 
@@ -1526,7 +1553,8 @@ fn preflight_validate_payload_zip_archive<R: std::io::Read + std::io::Seek>(
             MAIN_APP_EXE
         )
     })?;
-    validate_payload_exe_size(size, source_label)
+    validate_payload_exe_size(size, source_label)?;
+    validate_required_payload_paths(&archive_paths, source_label)
 }
 
 fn preflight_validate_payload_dir(path: &Path, source_label: &str) -> Result<(), String> {
@@ -1537,7 +1565,14 @@ fn preflight_validate_payload_dir(path: &Path, source_label: &str) -> Result<(),
             app_exe.display()
         )
     })?;
-    validate_payload_exe_size(meta.len(), source_label)
+    validate_payload_exe_size(meta.len(), source_label)?;
+
+    let available = REQUIRED_PAYLOAD_FILES
+        .iter()
+        .filter(|relative| path.join(relative).is_file())
+        .map(|relative| (*relative).to_string())
+        .collect::<HashSet<_>>();
+    validate_required_payload_paths(&available, source_label)
 }
 
 fn validate_payload_exe_size(size: u64, source_label: &str) -> Result<(), String> {
@@ -1611,8 +1646,58 @@ fn read_payload_manifest_from_dir(
 }
 
 fn parse_payload_manifest(raw: &str, source_label: &str) -> Result<PayloadManifest, String> {
-    serde_json::from_str(raw)
-        .map_err(|e| format!("Invalid payload manifest from {source_label}: {}", e))
+    let manifest: PayloadManifest = serde_json::from_str(raw)
+        .map_err(|e| format!("Invalid payload manifest from {source_label}: {}", e))?;
+    validate_payload_manifest(&manifest, source_label)?;
+    Ok(manifest)
+}
+
+fn normalize_payload_path(raw: &str) -> String {
+    raw.replace('\\', "/").trim_start_matches("./").to_string()
+}
+
+fn validate_required_payload_paths(
+    available: &HashSet<String>,
+    source_label: &str,
+) -> Result<(), String> {
+    let missing = REQUIRED_PAYLOAD_FILES
+        .iter()
+        .filter(|required| !available.contains(**required))
+        .copied()
+        .collect::<Vec<_>>();
+    if missing.is_empty() {
+        return Ok(());
+    }
+
+    Err(format!(
+        "Payload from {source_label} is incomplete; missing required files: {}",
+        missing.join(", ")
+    ))
+}
+
+fn validate_payload_manifest(manifest: &PayloadManifest, source_label: &str) -> Result<(), String> {
+    let mut paths = HashSet::new();
+    for entry in &manifest.files {
+        let relative = sanitize_manifest_relative_path(&entry.path)?;
+        if relative.as_os_str().is_empty() {
+            return Err(format!(
+                "Payload manifest from {source_label} has an empty path"
+            ));
+        }
+        let normalized = normalize_payload_path(&entry.path);
+        if !paths.insert(normalized.clone()) {
+            return Err(format!(
+                "Payload manifest from {source_label} contains duplicate path: {normalized}"
+            ));
+        }
+        if entry.sha256.len() != 64 || !entry.sha256.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            return Err(format!(
+                "Payload manifest from {source_label} has an invalid SHA-256 for: {normalized}"
+            ));
+        }
+    }
+
+    validate_required_payload_paths(&paths, source_label)
 }
 
 fn zip_entry_file_name(entry_name: &str) -> &str {
@@ -1636,13 +1721,14 @@ fn should_install_payload_path(relative_path: &Path) -> bool {
 
 fn collect_payload_relative_paths_for_uninstall() -> Result<Vec<String>, String> {
     if embedded_payload_available() {
-        return Ok(
-            read_payload_manifest_from_zip_bytes(EMBEDDED_PAYLOAD_ZIP, "embedded payload zip")?
-                .files
-                .into_iter()
-                .map(|entry| entry.path)
-                .collect(),
-        );
+        return Ok(read_payload_manifest_from_zip_bytes(
+            EMBEDDED_PAYLOAD_ZIP,
+            "embedded payload zip",
+        )?
+        .files
+        .into_iter()
+        .map(|entry| entry.path)
+        .collect());
     }
 
     Ok(vec![MAIN_APP_EXE.to_string()])
@@ -1737,14 +1823,10 @@ fn sanitize_manifest_relative_path(raw: &str) -> Result<PathBuf, String> {
     Ok(path)
 }
 
-fn verify_installed_payload(install_path: &Path) -> Result<(), String> {
+fn verify_installed_payload(install_path: &Path, manifest: &PayloadManifest) -> Result<(), String> {
     let app_exe = install_path.join(MAIN_APP_EXE);
-    let app_meta = std::fs::metadata(&app_exe).map_err(|_| {
-        format!(
-            "Installed {} is missing after extraction",
-            MAIN_APP_EXE
-        )
-    })?;
+    let app_meta = std::fs::metadata(&app_exe)
+        .map_err(|_| format!("Installed {} is missing after extraction", MAIN_APP_EXE))?;
     if app_meta.len() < MIN_WINDOWS_APP_EXE_BYTES {
         return Err(format!(
             "Installed {} is too small ({} bytes). Payload is likely invalid.",
@@ -1753,7 +1835,51 @@ fn verify_installed_payload(install_path: &Path) -> Result<(), String> {
         ));
     }
 
+    for entry in &manifest.files {
+        let relative_path = sanitize_manifest_relative_path(&entry.path)?;
+        let installed_path = install_path.join(&relative_path);
+        let metadata = std::fs::metadata(&installed_path).map_err(|_| {
+            format!(
+                "Installed payload file is missing after extraction: {}",
+                relative_path.display()
+            )
+        })?;
+        if !metadata.is_file() || metadata.len() != entry.size {
+            return Err(format!(
+                "Installed payload file has the wrong size: {} (expected {}, found {})",
+                relative_path.display(),
+                entry.size,
+                metadata.len()
+            ));
+        }
+
+        let actual_sha256 = sha256_file(&installed_path)?;
+        if !actual_sha256.eq_ignore_ascii_case(&entry.sha256) {
+            return Err(format!(
+                "Installed payload file failed SHA-256 validation: {}",
+                relative_path.display()
+            ));
+        }
+    }
+
     Ok(())
+}
+
+fn sha256_file(path: &Path) -> Result<String, String> {
+    let mut file = File::open(path)
+        .map_err(|error| format!("Failed to open {} for hashing: {error}", path.display()))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let count = file
+            .read(&mut buffer)
+            .map_err(|error| format!("Failed to hash {}: {error}", path.display()))?;
+        if count == 0 {
+            break;
+        }
+        hasher.update(&buffer[..count]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
 }
 
 fn paths_equal_for_platform(a: &Path, b: &Path) -> bool {
@@ -1807,7 +1933,13 @@ fn rollback_installation(install_path: &Path, install_dir_was_absent: bool) {
 
 #[cfg(test)]
 mod tests {
-    use super::{normalize_app_language, INSTALLER_APP_LANGUAGE_ALIASES_BY_PRIORITY};
+    use super::{
+        normalize_app_language, preflight_validate_payload_zip_archive,
+        INSTALLER_APP_LANGUAGE_ALIASES_BY_PRIORITY, MAIN_APP_EXE, MIN_WINDOWS_APP_EXE_BYTES,
+        REQUIRED_PAYLOAD_FILES,
+    };
+    use std::io::{Cursor, Write};
+    use zip::write::FileOptions;
 
     #[test]
     fn language_alias_priority_is_descending_and_stable_for_equal_lengths() {
@@ -1819,7 +1951,12 @@ mod tests {
 
         let expected_equal_length_order = super::INSTALLER_GENERATED_LOCALES
             .iter()
-            .flat_map(|locale| locale.aliases.iter().map(move |alias| (locale.code, *alias)))
+            .flat_map(|locale| {
+                locale
+                    .aliases
+                    .iter()
+                    .map(move |alias| (locale.code, *alias))
+            })
             .filter(|(_, alias)| alias.len() == 2)
             .collect::<Vec<_>>();
         let actual_equal_length_order = aliases
@@ -1848,5 +1985,34 @@ mod tests {
     fn normalize_app_language_rejects_unknown_language_codes() {
         assert_eq!(normalize_app_language("fr-FR"), None);
         assert_eq!(normalize_app_language(""), None);
+    }
+
+    #[test]
+    fn payload_zip_preflight_scans_entries_after_main_executable() {
+        let mut bytes = Cursor::new(Vec::new());
+        {
+            let mut writer = zip::ZipWriter::new(&mut bytes);
+            let options = FileOptions::default();
+
+            // The production payload is sorted, so the executable appears before
+            // the required nested directories. Preflight must still scan the rest.
+            writer.start_file(MAIN_APP_EXE, options).unwrap();
+            writer
+                .write_all(&vec![0_u8; MIN_WINDOWS_APP_EXE_BYTES as usize])
+                .unwrap();
+            for required in REQUIRED_PAYLOAD_FILES
+                .iter()
+                .copied()
+                .filter(|path| *path != MAIN_APP_EXE)
+            {
+                writer.start_file(required, options).unwrap();
+                writer.write_all(b"payload").unwrap();
+            }
+            writer.finish().unwrap();
+        }
+
+        bytes.set_position(0);
+        let mut archive = zip::ZipArchive::new(bytes).unwrap();
+        assert!(preflight_validate_payload_zip_archive(&mut archive, "test payload").is_ok());
     }
 }

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "check:core-boundaries": "node scripts/check-core-boundaries.mjs",
     "check:core-boundaries:test": "node --test scripts/check-core-boundaries.test.mjs",
     "check:github-config": "pnpm --dir src/web-ui exec node ../../scripts/check-github-config.mjs && node --test scripts/check-github-config.test.mjs",
-    "test:release-packaging": "node --test scripts/release-channel.test.mjs scripts/desktop-tauri-build.test.mjs scripts/server-build.test.mjs scripts/version-generation.test.mjs scripts/tauri-release-manifest.test.mjs",
+    "test:release-packaging": "node --test scripts/release-channel.test.mjs scripts/desktop-tauri-build.test.mjs scripts/server-build.test.mjs scripts/version-generation.test.mjs scripts/tauri-release-manifest.test.mjs BitFun-Installer/scripts/build-installer.test.cjs",
     "fmt:rs": "node scripts/format-changed-rust.mjs",
     "lint:rs": "cargo clippy --workspace --exclude bitfun-desktop --all-targets",
     "lint:rs:desktop": "pnpm run prepare:mobile-web && cargo clippy -p bitfun-desktop --all-targets",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,11 +60,11 @@ importers:
         specifier: workspace:^
         version: link:../design-system/packages/theme-bitfun
       '@tauri-apps/api':
-        specifier: ^2.10.1
-        version: 2.10.1
+        specifier: 2.11.1
+        version: 2.11.1
       '@tauri-apps/plugin-dialog':
-        specifier: ^2.6.0
-        version: 2.6.0
+        specifier: 2.7.3
+        version: 2.7.3
       i18next:
         specifier: ^25.8.0
         version: 25.8.0(typescript@5.8.3)
@@ -79,8 +79,8 @@ importers:
         version: 16.5.4(i18next@25.8.0(typescript@5.8.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
     devDependencies:
       '@tauri-apps/cli':
-        specifier: ^2.10.0
-        version: 2.10.0
+        specifier: 2.11.4
+        version: 2.11.4
       '@types/react':
         specifier: ^18.3.0
         version: 18.3.27
@@ -1718,8 +1718,17 @@ packages:
   '@tauri-apps/api@2.10.1':
     resolution: {integrity: sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==}
 
+  '@tauri-apps/api@2.11.1':
+    resolution: {integrity: sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA==}
+
   '@tauri-apps/cli-darwin-arm64@2.10.0':
     resolution: {integrity: sha512-avqHD4HRjrMamE/7R/kzJPcAJnZs0IIS+1nkDP5b+TNBn3py7N2aIo9LIpy+VQq0AkN8G5dDpZtOOBkmWt/zjA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tauri-apps/cli-darwin-arm64@2.11.4':
+    resolution: {integrity: sha512-1ryOF3ZhpZ/nemHV5zVwBQBz9jDGKmKPvWPADOhc83ig0P4bMc2iER4NbC6r9sjeIZ6RVQ4g3RZIYvezhcl4TQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -1730,8 +1739,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@tauri-apps/cli-darwin-x64@2.11.4':
+    resolution: {integrity: sha512-uFsGQAAfuyz1k/yGLmkWfkBlgKAqZfxqlHmLWx81QU27RJWfmbNHCIq8T8w1e+VClleIuZUjpHWfoE4E3DLo3A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
   '@tauri-apps/cli-linux-arm-gnueabihf@2.10.0':
     resolution: {integrity: sha512-e5u0VfLZsMAC9iHaOEANumgl6lfnJx0Dtjkd8IJpysZ8jp0tJ6wrIkto2OzQgzcYyRCKgX72aKE0PFgZputA8g==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tauri-apps/cli-linux-arm-gnueabihf@2.11.4':
+    resolution: {integrity: sha512-IaHZn5CdBL21oUmjiVOS1ctw6Ip1O0pjp70FwOWmYz1myWe0SY96ZIj2FYf7pT0m8bI2h/hrs5ZbEXXh44/MkQ==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [linux]
@@ -1742,8 +1763,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@tauri-apps/cli-linux-arm64-gnu@2.11.4':
+    resolution: {integrity: sha512-N41/ukTRVe6XSuUTESuFdGeOW2i7k62tK+6gHK5Kd5/q5RPvvi19GaWAVPPb9u95HSGmTChSolBfzynUsssFaA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
   '@tauri-apps/cli-linux-arm64-musl@2.10.0':
     resolution: {integrity: sha512-GUoPdVJmrJRIXFfW3Rkt+eGK9ygOdyISACZfC/bCSfOnGt8kNdQIQr5WRH9QUaTVFIwxMlQyV3m+yXYP+xhSVA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tauri-apps/cli-linux-arm64-musl@2.11.4':
+    resolution: {integrity: sha512-v277UnT/fB64xAfSroL5N3Km3tLmvATWqJJw/wRI+g6o+HkeD0slyE7gOhNs1MbjE41R7bQOTxMVoL3aomUJmw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -1754,8 +1787,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@tauri-apps/cli-linux-riscv64-gnu@2.11.4':
+    resolution: {integrity: sha512-qqgNkQ2u1yZHxjhxsZaxUtRDW8dIqIYm33rx/mzwQv0SfY9x1B+iraj8vWeFiXjjSVVhEMepXSOts1TqPzvXNQ==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@tauri-apps/cli-linux-x64-gnu@2.10.0':
     resolution: {integrity: sha512-Uvh4SUUp4A6DVRSMWjelww0GnZI3PlVy7VS+DRF5napKuIehVjGl9XD0uKoCoxwAQBLctvipyEK+pDXpJeoHng==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tauri-apps/cli-linux-x64-gnu@2.11.4':
+    resolution: {integrity: sha512-2VRNWl84FOH0m2giiDkO2h0QXlcMJeX+zJDpI5kDIQAx6s+geF3v48F4DXfJez4GS/FdoDGnPnw1C2iYGbQ7bQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -1766,8 +1811,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@tauri-apps/cli-linux-x64-musl@2.11.4':
+    resolution: {integrity: sha512-o9GyhYor/nc7xarmwDE3ka2szuW3uuZzXjHWh64Q8YX5AtSgxdQkFWzrY4O8KiGtVNvFBI14H3Q49Qj5TOIP/A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
   '@tauri-apps/cli-win32-arm64-msvc@2.10.0':
     resolution: {integrity: sha512-97DXVU3dJystrq7W41IX+82JEorLNY+3+ECYxvXWqkq7DBN6FsA08x/EFGE8N/b0LTOui9X2dvpGGoeZKKV08g==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tauri-apps/cli-win32-arm64-msvc@2.11.4':
+    resolution: {integrity: sha512-ld5Ehb598m0VkYyylRPNeCFsBe/km0jxis6KgMpl3IGY6I/i1RwQXO05I1AsXUXO2WC6AvB/Lw4qTf/asiuEiQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -1778,8 +1835,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@tauri-apps/cli-win32-ia32-msvc@2.11.4':
+    resolution: {integrity: sha512-12Hxi0XX/H5VFxO/bGgHkFWhml9VMgEOu9CidjeCeTNQ1l6fpUlbiGgSP7CLI3PFtW9/FfbeHieZ+kyWK5H7CA==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
   '@tauri-apps/cli-win32-x64-msvc@2.10.0':
     resolution: {integrity: sha512-NTpyQxkpzGmU6ceWBTY2xRIEaS0ZLbVx1HE1zTA3TY/pV3+cPoPPOs+7YScr4IMzXMtOw7tLw5LEXo5oIG3qaQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tauri-apps/cli-win32-x64-msvc@2.11.4':
+    resolution: {integrity: sha512-+vDiqBIU5dMISg/wNvX3sF+ZHfgJGJ5T0AcO+EHNXV9GGAG+P5fzodlDXD3QdKCRgZxMoCm5PPvj3BqLNjBthw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -1789,11 +1858,19 @@ packages:
     engines: {node: '>= 10'}
     hasBin: true
 
+  '@tauri-apps/cli@2.11.4':
+    resolution: {integrity: sha512-R8xGtMpwyetawSqm9kYOuMmEqkhUbvcUy8n0aNXIxollKBLESUu5f4Fx+64hgASYm1H+jSWq6jCW6zqTnH6hqQ==}
+    engines: {node: '>= 10'}
+    hasBin: true
+
   '@tauri-apps/plugin-autostart@2.5.1':
     resolution: {integrity: sha512-zS/xx7yzveCcotkA+8TqkI2lysmG2wvQXv2HGAVExITmnFfHAdj1arGsbbfs3o6EktRHf6l34pJxc3YGG2mg7w==}
 
   '@tauri-apps/plugin-dialog@2.6.0':
     resolution: {integrity: sha512-q4Uq3eY87TdcYzXACiYSPhmpBA76shgmQswGkSVio4C82Sz2W4iehe9TnKYwbq7weHiL88Yw19XZm7v28+Micg==}
+
+  '@tauri-apps/plugin-dialog@2.7.3':
+    resolution: {integrity: sha512-CRgE+7TP4tvq9MjBU6f04NLTFIqVMLKHk3hAqlhil00ngK9ACTrXPH3oHpKMProxILodd3YjBoKbMwSI4IEcfA==}
 
   '@tauri-apps/plugin-fs@2.4.5':
     resolution: {integrity: sha512-dVxWWGE6VrOxC7/jlhyE+ON/Cc2REJlM35R3PJX3UvFw2XwYhLGQVAIyrehenDdKjotipjYEVc4YjOl3qq90fA==}
@@ -6815,37 +6892,72 @@ snapshots:
 
   '@tauri-apps/api@2.10.1': {}
 
+  '@tauri-apps/api@2.11.1': {}
+
   '@tauri-apps/cli-darwin-arm64@2.10.0':
+    optional: true
+
+  '@tauri-apps/cli-darwin-arm64@2.11.4':
     optional: true
 
   '@tauri-apps/cli-darwin-x64@2.10.0':
     optional: true
 
+  '@tauri-apps/cli-darwin-x64@2.11.4':
+    optional: true
+
   '@tauri-apps/cli-linux-arm-gnueabihf@2.10.0':
+    optional: true
+
+  '@tauri-apps/cli-linux-arm-gnueabihf@2.11.4':
     optional: true
 
   '@tauri-apps/cli-linux-arm64-gnu@2.10.0':
     optional: true
 
+  '@tauri-apps/cli-linux-arm64-gnu@2.11.4':
+    optional: true
+
   '@tauri-apps/cli-linux-arm64-musl@2.10.0':
+    optional: true
+
+  '@tauri-apps/cli-linux-arm64-musl@2.11.4':
     optional: true
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.10.0':
     optional: true
 
+  '@tauri-apps/cli-linux-riscv64-gnu@2.11.4':
+    optional: true
+
   '@tauri-apps/cli-linux-x64-gnu@2.10.0':
+    optional: true
+
+  '@tauri-apps/cli-linux-x64-gnu@2.11.4':
     optional: true
 
   '@tauri-apps/cli-linux-x64-musl@2.10.0':
     optional: true
 
+  '@tauri-apps/cli-linux-x64-musl@2.11.4':
+    optional: true
+
   '@tauri-apps/cli-win32-arm64-msvc@2.10.0':
+    optional: true
+
+  '@tauri-apps/cli-win32-arm64-msvc@2.11.4':
     optional: true
 
   '@tauri-apps/cli-win32-ia32-msvc@2.10.0':
     optional: true
 
+  '@tauri-apps/cli-win32-ia32-msvc@2.11.4':
+    optional: true
+
   '@tauri-apps/cli-win32-x64-msvc@2.10.0':
+    optional: true
+
+  '@tauri-apps/cli-win32-x64-msvc@2.11.4':
     optional: true
 
   '@tauri-apps/cli@2.10.0':
@@ -6862,29 +6974,47 @@ snapshots:
       '@tauri-apps/cli-win32-ia32-msvc': 2.10.0
       '@tauri-apps/cli-win32-x64-msvc': 2.10.0
 
+  '@tauri-apps/cli@2.11.4':
+    optionalDependencies:
+      '@tauri-apps/cli-darwin-arm64': 2.11.4
+      '@tauri-apps/cli-darwin-x64': 2.11.4
+      '@tauri-apps/cli-linux-arm-gnueabihf': 2.11.4
+      '@tauri-apps/cli-linux-arm64-gnu': 2.11.4
+      '@tauri-apps/cli-linux-arm64-musl': 2.11.4
+      '@tauri-apps/cli-linux-riscv64-gnu': 2.11.4
+      '@tauri-apps/cli-linux-x64-gnu': 2.11.4
+      '@tauri-apps/cli-linux-x64-musl': 2.11.4
+      '@tauri-apps/cli-win32-arm64-msvc': 2.11.4
+      '@tauri-apps/cli-win32-ia32-msvc': 2.11.4
+      '@tauri-apps/cli-win32-x64-msvc': 2.11.4
+
   '@tauri-apps/plugin-autostart@2.5.1':
     dependencies:
-      '@tauri-apps/api': 2.10.1
+      '@tauri-apps/api': 2.11.1
 
   '@tauri-apps/plugin-dialog@2.6.0':
     dependencies:
-      '@tauri-apps/api': 2.10.1
+      '@tauri-apps/api': 2.11.1
+
+  '@tauri-apps/plugin-dialog@2.7.3':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
 
   '@tauri-apps/plugin-fs@2.4.5':
     dependencies:
-      '@tauri-apps/api': 2.10.1
+      '@tauri-apps/api': 2.11.1
 
   '@tauri-apps/plugin-log@2.8.0':
     dependencies:
-      '@tauri-apps/api': 2.10.1
+      '@tauri-apps/api': 2.11.1
 
   '@tauri-apps/plugin-notification@2.3.3':
     dependencies:
-      '@tauri-apps/api': 2.10.1
+      '@tauri-apps/api': 2.11.1
 
   '@tauri-apps/plugin-opener@2.5.3':
     dependencies:
-      '@tauri-apps/api': 2.10.1
+      '@tauri-apps/api': 2.11.1
 
   '@tiptap/core@3.20.4(@tiptap/pm@3.20.4)':
     dependencies:

--- a/scripts/audit-frontend-colors.mjs
+++ b/scripts/audit-frontend-colors.mjs
@@ -804,6 +804,10 @@ function formatSurfaceSummary(surfaceReport) {
   return `${surfaceReport.roots.length} owner roots`;
 }
 
+function formatGitHubCommandValue(value) {
+  return value.replaceAll('%', '%25').replaceAll('\r', '%0D').replaceAll('\n', '%0A');
+}
+
 function main() {
   const options = parseArgs(process.argv.slice(2));
   const registry = loadRegistry(options.registryPath);
@@ -836,7 +840,12 @@ function main() {
     }
     if (report.failures.length > 0) {
       console.error('\nFrontend color governance failures:');
-      for (const failure of report.failures) console.error(`- ${failure}`);
+      for (const failure of report.failures) {
+        console.error(`- ${failure}`);
+        if (process.env.GITHUB_ACTIONS === 'true') {
+          console.error(`::error title=Frontend color governance::${formatGitHubCommandValue(failure)}`);
+        }
+      }
     } else {
       console.log(`[frontend-colors] all ${report.selectedSurfaceIds.length} selected surfaces passed.`);
     }

--- a/scripts/audit-frontend-colors.mjs
+++ b/scripts/audit-frontend-colors.mjs
@@ -387,6 +387,10 @@ function ownerMatchesFinding(owner, finding, content) {
   return true;
 }
 
+function normalizeLineEndings(content) {
+  return content.replace(/\r\n?/g, '\n');
+}
+
 function checkGeneratedBundles(surface, repositoryRoot) {
   const failures = [];
   for (const bundle of surface.audit.generatedBundles ?? []) {
@@ -399,7 +403,7 @@ function checkGeneratedBundles(surface, repositoryRoot) {
       return `/* ${label} */\n${content}\n`;
     }).join('');
     const actual = fs.readFileSync(path.join(repositoryRoot, surface.root, outputRelative), 'utf8');
-    if (actual !== expected) {
+    if (normalizeLineEndings(actual) !== normalizeLineEndings(expected)) {
       failures.push(`${surface.id} generated bundle ${bundle.output} is stale; run its source/build.js.`);
     }
   }

--- a/scripts/audit-frontend-colors.test.mjs
+++ b/scripts/audit-frontend-colors.test.mjs
@@ -61,6 +61,37 @@ test('MiniApp audit accepts a narrow data-viz owner and rejects ordinary raw col
   assert.match(report.failures.join('\n'), /fallback to public host variable --bitfun-bg/);
 });
 
+test('MiniApp generated bundle checks ignore checkout-only line ending differences', (t) => {
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'bitfun-miniapp-generated-eol-'));
+  t.after(() => fs.rmSync(fixtureRoot, { recursive: true, force: true }));
+  writeText(path.join(fixtureRoot, 'app/source/ui/part.js'), 'const ready = true;\r\n');
+  writeText(
+    path.join(fixtureRoot, 'app/source/ui.js'),
+    '/* ui/part.js */\nconst ready = true;\n\n',
+  );
+  const surface = {
+    id: 'fixture-generated-eol',
+    root: 'app',
+    audit: {
+      engine: 'miniapp',
+      generatedBundles: [{
+        output: 'source/ui.js',
+        inputs: ['source/ui/part.js'],
+      }],
+    },
+  };
+
+  const report = auditMiniappSurface(surface, { variables: [] }, { repositoryRoot: fixtureRoot });
+  assert.deepEqual(report.failures, []);
+
+  writeText(
+    path.join(fixtureRoot, 'app/source/ui.js'),
+    '/* ui/part.js */\nconst ready = false;\n\n',
+  );
+  const staleReport = auditMiniappSurface(surface, { variables: [] }, { repositoryRoot: fixtureRoot });
+  assert.match(staleReport.failures.join('\n'), /generated bundle source\/ui\.js is stale/);
+});
+
 test('native source audit rejects raw platform colors while ignoring generated projections', (t) => {
   const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'bitfun-native-colors-'));
   t.after(() => fs.rmSync(fixtureRoot, { recursive: true, force: true }));

--- a/scripts/cli/package-contract.test.mjs
+++ b/scripts/cli/package-contract.test.mjs
@@ -26,7 +26,7 @@ for (const workflow of [
   '.github/workflows/cli-package.yml',
   '.github/workflows/cli-package-manual.yml',
   '.github/workflows/linux-binaries.yml',
-  '.github/workflows/nightly.yml',
+  '.github/workflows/nightly-artifacts.yml',
 ]) {
   const content = read(workflow);
   assert.match(content, /oven-sh\/setup-bun@v2/);

--- a/scripts/desktop-tauri-build.mjs
+++ b/scripts/desktop-tauri-build.mjs
@@ -105,6 +105,12 @@ async function main() {
     console.warn(`[target-gc] skipped: ${error.message || String(error)}`);
   }
 
+  if (r.status === 0 && forward.includes('--no-bundle')) {
+    console.warn(
+      '[tauri-build] No bundle was produced. The raw desktop executable depends on its adjacent frontend, flashgrep, mobile-web, and resources directories and must not be distributed by itself.'
+    );
+  }
+
   process.exit(r.status ?? 1);
 }
 

--- a/scripts/mobile-ui-design-system.mjs
+++ b/scripts/mobile-ui-design-system.mjs
@@ -63,7 +63,7 @@ const outputs = new Map([
 let changed = 0;
 for (const [path, content] of outputs) {
   const current = existsSync(path) ? readFileSync(path, 'utf8') : null;
-  if (current === content) continue;
+  if (current !== null && normalizeLineEndings(current) === normalizeLineEndings(content)) continue;
   changed += 1;
   const relativePath = path.slice(ROOT.length + 1);
   if (CHECK) {
@@ -82,6 +82,10 @@ if (CHECK && changed > 0) {
 
 if (changed === 0) {
   console.log(`[mobile-ui] ${CHECK ? 'Contract and generated files are in sync' : 'Generated files are already current'}.`);
+}
+
+function normalizeLineEndings(content) {
+  return content.replace(/\r\n?/g, '\n');
 }
 
 function readJson(path) {

--- a/scripts/mobile-web-build.cjs
+++ b/scripts/mobile-web-build.cjs
@@ -191,17 +191,29 @@ function writeMobileWebBuildMarker(mobileWebDir) {
   fs.writeFileSync(markerPath, `${new Date().toISOString()}\n`);
 }
 
-function cleanStaleMobileWebResources(logInfo = printInfo) {
+function cleanStaleMobileWebResources(logInfo = printInfo, rootDir = ROOT_DIR) {
   const fs = require('fs');
-  const targetDir = path.join(ROOT_DIR, 'target');
+  const targetDir = path.join(rootDir, 'target');
   if (!fs.existsSync(targetDir)) return 0;
 
   let cleaned = 0;
-  for (const profile of fs.readdirSync(targetDir)) {
-    const mobileWebDir = path.join(targetDir, profile, 'mobile-web');
-    if (fs.existsSync(mobileWebDir) && fs.statSync(mobileWebDir).isDirectory()) {
-      fs.rmSync(mobileWebDir, { recursive: true, force: true });
-      cleaned++;
+  const cleanIfPresent = (candidate) => {
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isDirectory()) {
+      fs.rmSync(candidate, { recursive: true, force: true });
+      cleaned += 1;
+    }
+  };
+
+  for (const firstLevelEntry of fs.readdirSync(targetDir, { withFileTypes: true })) {
+    if (!firstLevelEntry.isDirectory()) continue;
+    const firstLevelDir = path.join(targetDir, firstLevelEntry.name);
+    cleanIfPresent(path.join(firstLevelDir, 'mobile-web'));
+
+    // Explicit Cargo targets stage resources under
+    // target/<target-triple>/<profile>/mobile-web.
+    for (const secondLevelEntry of fs.readdirSync(firstLevelDir, { withFileTypes: true })) {
+      if (!secondLevelEntry.isDirectory()) continue;
+      cleanIfPresent(path.join(firstLevelDir, secondLevelEntry.name, 'mobile-web'));
     }
   }
 

--- a/scripts/mobile-web-build.test.mjs
+++ b/scripts/mobile-web-build.test.mjs
@@ -7,7 +7,7 @@ import path from 'node:path';
 import test from 'node:test';
 
 const require = createRequire(import.meta.url);
-const { getMobileWebRebuildPlan } = require('./mobile-web-build.cjs');
+const { cleanStaleMobileWebResources, getMobileWebRebuildPlan } = require('./mobile-web-build.cjs');
 
 function write(root, relativePath, contents = '') {
   const target = path.join(root, relativePath);
@@ -83,3 +83,29 @@ test('reuses mobile-web output when only generated design-system output is newer
     reason: 'mobile-web dist is up to date; skipping clean/install/build (use --force or BITFUN_MOBILE_WEB_FORCE_BUILD=1 to rebuild)',
   });
 });
+
+test('cleans stale mobile-web resources from native and explicit target profiles', async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'bitfun-mobile-web-clean-'));
+  const native = write(root, 'target/release/mobile-web/dist/index.html', 'native');
+  const targeted = write(
+    root,
+    'target/x86_64-pc-windows-msvc/release/mobile-web/dist/index.html',
+    'targeted',
+  );
+  const unrelated = write(root, 'target/release/frontend/dist/index.html', 'frontend');
+
+  assert.equal(cleanStaleMobileWebResources(() => {}, root), 2);
+  assert.equal(fileExists(native), false);
+  assert.equal(fileExists(targeted), false);
+  assert.equal(fileExists(unrelated), true);
+});
+
+function fileExists(filePath) {
+  try {
+    readFileSync(filePath);
+    return true;
+  } catch (error) {
+    if (error && error.code === 'ENOENT') return false;
+    throw error;
+  }
+}

--- a/scripts/relay/package-contract.test.mjs
+++ b/scripts/relay/package-contract.test.mjs
@@ -20,11 +20,17 @@ test('relay archive contains the runtime and admin binaries plus static assets',
 test('formal and nightly releases gate publication on Linux binaries', () => {
   const desktop = read('.github/workflows/desktop-package.yml');
   const nightly = read('.github/workflows/nightly.yml');
+  const nightlyArtifacts = read('.github/workflows/nightly-artifacts.yml');
   const reusable = read('.github/workflows/linux-binaries.yml');
 
-  for (const workflow of [desktop, nightly]) {
+  for (const workflow of [desktop, nightlyArtifacts]) {
     assert.match(workflow, /uses:\s+\.\/\.github\/workflows\/linux-binaries\.yml/);
-    assert.match(workflow, /needs:\s*\[[^\]]*linux-binaries[^\]]*\]/);
+  }
+  assert.match(nightly, /uses:\s+\.\/\.github\/workflows\/nightly-artifacts\.yml/);
+  assert.match(desktop, /needs:\s*\[[^\]]*linux-binaries[^\]]*\]/);
+  assert.match(nightly, /needs:\s*\[[^\]]*build-artifacts[^\]]*\]/);
+
+  for (const workflow of [desktop, nightly]) {
     assert.match(workflow, /bitfun-relay-server-\*\.tar\.gz/);
     assert.match(workflow, /bitfun-cli-\*\.tar\.gz/);
     assert.match(workflow, /linux-release-assets\/\*\.tar\.gz\.sig/);
@@ -50,7 +56,10 @@ test('formal and nightly releases publish signed anonymous multi-platform Relay 
     assert.match(workflow, /packages:\s*write/);
     assert.match(workflow, /docker\/build-push-action@v7/);
     assert.match(workflow, /platforms:\s*linux\/amd64,linux\/arm64/);
-    assert.match(workflow, /ghcr\.io\/gcwing\/bitfun-relay-server/);
+    assert.match(
+      workflow,
+      /ghcr\.io\/(?:gcwing|\$\{GITHUB_REPOSITORY_OWNER,,\})\/bitfun-relay-server/i,
+    );
     assert.match(workflow, /relay-image\.json/);
     assert.match(workflow, /scripts\/sign-release-assets\.sh relay-image\.json/);
     assert.match(workflow, /scripts\/relay\/smoke-image\.sh/);
@@ -102,12 +111,13 @@ test('release asset names carry no SemVer build metadata', () => {
 });
 
 test('nightly publishes signed macOS CLI archives for SSH dispatch', () => {
+  const nightlyArtifacts = read('.github/workflows/nightly-artifacts.yml');
   const nightly = read('.github/workflows/nightly.yml');
 
-  assert.match(nightly, /Package macOS CLI for SSH dispatch/);
-  assert.match(nightly, /scripts\/cli\/package-unix\.sh "\$ASSET_VERSION" "\$TARGET"/);
-  assert.match(nightly, /steps\.macos-cli\.outputs\.archive/);
-  assert.match(nightly, /bitfun-cli-\*-apple-darwin\.tar\.gz\.sha256\.sig/);
+  assert.match(nightlyArtifacts, /Package macOS CLI for SSH dispatch/);
+  assert.match(nightlyArtifacts, /scripts\/cli\/package-unix\.sh "\$ASSET_VERSION" "\$TARGET"/);
+  assert.match(nightlyArtifacts, /steps\.macos-cli\.outputs\.archive/);
+  assert.match(nightlyArtifacts, /bitfun-cli-\*-apple-darwin\.tar\.gz\.sha256\.sig/);
   assert.match(nightly, /for target in aarch64-apple-darwin x86_64-apple-darwin/);
   assert.match(nightly, /\$\{archive\}\.sha256\.sig/);
 });

--- a/src/apps/desktop/AGENTS.md
+++ b/src/apps/desktop/AGENTS.md
@@ -57,7 +57,7 @@ pnpm run prepare:dsh-profile   # optional: local DeepSeek Harness sessions
 | Command | When to use |
 |---|---|
 | `pnpm run desktop:build:fast` | Debug build without bundling; fastest compile for manual testing |
-| `pnpm run desktop:build:release-fast` | Release-like build with reduced LTO; use when you need release behavior but can't wait for full LTO |
+| `pnpm run desktop:build:release-fast` | Release-like no-bundle build with reduced LTO; run it in place and never distribute the raw executable alone |
 | `pnpm run desktop:build:nsis:fast` | Windows installer using `release-fast` profile; for quick installer validation |
 
 Set `CARGO_PROFILE_DEV_DEBUG=2` when full breakpoint debug information is
@@ -68,6 +68,11 @@ required. The default dev profile keeps line tables while reducing PDB size.
 `desktop:dev` (on exit), `desktop:preview:debug` (on shutdown), and `desktop:build*` prune stale `target/<profile>` cache generations. Incremental roots keep the latest crate/session. Cargo fingerprint JSON identifies distinct lib, test, bin, and build-script units; GC keeps the latest generation of each unit plus every generation whose Cargo-managed `invoked.timestamp` was refreshed within the last 24 hours, then removes orphaned `deps` files and `build` directories. Busy detection is scoped to Cargo lock files in the selected profile, so an unrelated worktree build does not suppress GC. Manual: `pnpm run target:gc -- --profile debug`. Disable with `BITFUN_TARGET_GC=0`; dry-run with `BITFUN_TARGET_GC_DRY_RUN=1`; adjust the grace window with `BITFUN_TARGET_GC_MIN_AGE_HOURS`.
 
 `release-fast` profile (`Cargo.toml`): inherits `release` but disables LTO, increases `codegen-units` to 16, enables incremental compilation. Significantly faster at the cost of binary size and marginal runtime performance.
+
+All commands that pass `--no-bundle` emit a staged runtime tree rather than a
+single-file application. The executable depends on the adjacent `frontend`,
+`flashgrep`, `mobile-web`, and `resources` directories. Use
+`pnpm run desktop:build:nsis` for a distributable Windows installer.
 
 ## DevTools feature (model rule)
 

--- a/src/crates/assembly/core/src/agentic/tools/implementations/grep_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/grep_tool.rs
@@ -1763,12 +1763,16 @@ mod tests {
             pending_read: bool,
             pending_operation: Option<&'static str>,
             opened_signal: tokio::sync::Notify,
+            reader_pending_signal: Arc<tokio::sync::Notify>,
             reader_drops: Arc<std::sync::atomic::AtomicUsize>,
         }
-        struct PendingReader(Arc<std::sync::atomic::AtomicUsize>);
+        struct PendingReader {
+            pending_signal: Arc<tokio::sync::Notify>,
+            drops: Arc<std::sync::atomic::AtomicUsize>,
+        }
         impl Drop for PendingReader {
             fn drop(&mut self) {
-                self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                self.drops.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             }
         }
         impl tokio::io::AsyncRead for PendingReader {
@@ -1777,6 +1781,7 @@ mod tests {
                 _: &mut std::task::Context<'_>,
                 _: &mut tokio::io::ReadBuf<'_>,
             ) -> std::task::Poll<std::io::Result<()>> {
+                self.pending_signal.notify_one();
                 std::task::Poll::Pending
             }
         }
@@ -1803,7 +1808,10 @@ mod tests {
                     return std::future::pending().await;
                 }
                 if self.pending_read {
-                    Ok(Box::new(PendingReader(self.reader_drops.clone())))
+                    Ok(Box::new(PendingReader {
+                        pending_signal: self.reader_pending_signal.clone(),
+                        drops: self.reader_drops.clone(),
+                    }))
                 } else {
                     LocalWorkspaceFs.open_read(path).await
                 }
@@ -2350,7 +2358,7 @@ mod tests {
             });
             tokio::time::timeout(
                 std::time::Duration::from_secs(2),
-                fs.opened_signal.notified(),
+                fs.reader_pending_signal.notified(),
             )
             .await
             .unwrap();
@@ -2385,7 +2393,7 @@ mod tests {
             });
             tokio::time::timeout(
                 std::time::Duration::from_secs(2),
-                fs.opened_signal.notified(),
+                fs.reader_pending_signal.notified(),
             )
             .await
             .unwrap();

--- a/src/crates/contracts/product-domains/src/miniapp/generated/default_appearance_style.html
+++ b/src/crates/contracts/product-domains/src/miniapp/generated/default_appearance_style.html
@@ -4,8 +4,8 @@
     background: transparent;
     --bitfun-radius: 8px;
     --bitfun-radius-lg: 12px;
-    --bitfun-font-sans: 'Noto Sans SC', -apple-system, BlinkMacSystemFont, 'PingFang SC', 'Hiragino Sans GB', 'Segoe UI', 'Microsoft YaHei UI', 'Microsoft YaHei', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-    --bitfun-font-mono: 'JetBrains Mono', 'FiraCode', ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Monaco, 'Cascadia Mono', 'Cascadia Code', Consolas, 'Liberation Mono', 'Courier New', monospace;
+    --bitfun-font-sans: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei UI', 'Microsoft YaHei', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    --bitfun-font-mono: 'JetBrains Mono', 'Fira Code', ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Monaco, 'Cascadia Mono', 'Cascadia Code', Consolas, 'Liberation Mono', 'Courier New', monospace;
     --bitfun-bg: #0e0e10;
     --bitfun-bg-secondary: #1c1c1f;
     --bitfun-bg-tertiary: #0e0e10;

--- a/src/crates/execution/tool-execution/src/search/grep_search.rs
+++ b/src/crates/execution/tool-execution/src/search/grep_search.rs
@@ -1379,6 +1379,45 @@ impl Drop for CancelSearchOnDrop {
     }
 }
 
+#[derive(Default)]
+struct WorkspaceSearchWorkers {
+    active: std::sync::atomic::AtomicUsize,
+    idle: tokio::sync::Notify,
+}
+
+impl WorkspaceSearchWorkers {
+    fn start(self: &Arc<Self>) -> WorkspaceSearchWorkerGuard {
+        self.active
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        WorkspaceSearchWorkerGuard(self.clone())
+    }
+
+    async fn wait_until_idle(&self) {
+        loop {
+            let idle = self.idle.notified();
+            if self.active.load(std::sync::atomic::Ordering::SeqCst) == 0 {
+                return;
+            }
+            idle.await;
+        }
+    }
+}
+
+struct WorkspaceSearchWorkerGuard(Arc<WorkspaceSearchWorkers>);
+
+impl Drop for WorkspaceSearchWorkerGuard {
+    fn drop(&mut self) {
+        if self
+            .0
+            .active
+            .fetch_sub(1, std::sync::atomic::Ordering::SeqCst)
+            == 1
+        {
+            self.0.idle.notify_one();
+        }
+    }
+}
+
 struct CancellableWorkspaceReader {
     reader: bitfun_runtime_ports::WorkspaceReader,
     cancelled: std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>,
@@ -1420,16 +1459,20 @@ pub async fn grep_search_workspace(
     };
     options.cancellation = Some(cancellation.clone());
     let _cancel_on_drop = CancelSearchOnDrop(cancellation.clone());
+    let workers = Arc::new(WorkspaceSearchWorkers::default());
     tokio::select! {
         biased;
-        _ = cancellation.token.cancelled() => Ok(WorkspaceGrepResult {
-            result: reduce_grep_results(&options, Vec::new(), true)?,
-            used_rg_candidates: false,
-            used_grep_candidates: false,
-            scanned_file_count: 0,
-            scanned_bytes: 0,
-        }),
-        result = grep_search_workspace_inner(options.clone(), fs, shell) => result,
+        _ = cancellation.token.cancelled() => {
+            workers.wait_until_idle().await;
+            Ok(WorkspaceGrepResult {
+                result: reduce_grep_results(&options, Vec::new(), true)?,
+                used_rg_candidates: false,
+                used_grep_candidates: false,
+                scanned_file_count: 0,
+                scanned_bytes: 0,
+            })
+        },
+        result = grep_search_workspace_inner(options.clone(), fs, shell, workers.clone()) => result,
     }
 }
 
@@ -1440,6 +1483,7 @@ struct WorkspaceGrepCollector<'a> {
     file_results: GrepResultCollector,
     scanned_file_count: usize,
     bytes_read: Arc<std::sync::atomic::AtomicU64>,
+    workers: Arc<WorkspaceSearchWorkers>,
 }
 
 impl WorkspaceGrepCollector<'_> {
@@ -1520,7 +1564,9 @@ impl WorkspaceGrepCollector<'_> {
             let worker_sink = sink.clone();
             let worker_matcher = self.matcher.clone();
             let multiline = self.options.multiline;
+            let worker_guard = self.workers.start();
             tokio::task::spawn_blocking(move || {
+                let _worker_guard = worker_guard;
                 build_grep_searcher(before, after, multiline).search_reader(
                     &worker_matcher,
                     reader,
@@ -1557,6 +1603,7 @@ async fn grep_search_workspace_inner(
     options: GrepOptions,
     fs: &dyn WorkspaceFileSystem,
     shell: Option<&dyn WorkspaceShell>,
+    workers: Arc<WorkspaceSearchWorkers>,
 ) -> Result<WorkspaceGrepResult, String> {
     let matcher = build_grep_matcher(&options)?;
     let globs = build_grep_globs(&options.globs)?;
@@ -1701,6 +1748,7 @@ async fn grep_search_workspace_inner(
         file_results: GrepResultCollector::new(&options),
         scanned_file_count: 0,
         bytes_read: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+        workers,
     };
     let mut pending = Vec::new();
     let command_overhead = grep_prefilter


### PR DESCRIPTION
## Summary

- Make installer builds select the exact requested Cargo profile instead of falling back to stale `release-fast` or `debug` outputs.
- Include and validate all required desktop runtime assets: frontend, mobile web, extension Host, worker Host, and flashgrep.
- Fix installer ZIP preflight so it scans entries after `bitfun-desktop.exe`.
- Verify every installed payload file by size and SHA-256 before registering the installation.
- Warn that raw `--no-bundle` desktop executables are not standalone distributable artifacts.
- Cover explicit Cargo target directories and update packaging contract tests and CI wiring.
- Pin aligned Tauri JavaScript and Rust package versions.

Fixes: N/A

## Type and Areas

Type:

Regression fix / bug fix / test / CI / dependency

Areas:

Desktop/Tauri, installer, mobile web packaging, CLI/relay packaging tests, CI, docs

## Motivation / Impact

Some packaging commands could produce artifacts that appeared distributable but were incomplete:

- Raw desktop executables depended on adjacent runtime directories.
- Installer builds could silently select an executable from the wrong Cargo profile.
- Required frontend and runtime files were not fully staged or validated.
- Installer ZIP preflight stopped after finding the main executable and incorrectly reported all later entries as missing.
- Incomplete payloads could lead to frontend 404/503 errors or installation failure.

Installer and release builds now fail early when required files are missing. Successful installations also verify every manifest entry after extraction, preventing incomplete or corrupted payloads from being registered.

## Verification

- `pnpm run fmt:rs`
- `pnpm run test:release-packaging`
  - 37 tests passed.
- `cargo test --manifest-path BitFun-Installer/src-tauri/Cargo.toml --locked`
  - 5 tests passed.
- `pnpm run installer:build:only`
  - Release installer built successfully.
  - Embedded payload contained 1,141 files.
- Manually verified these embedded ZIP entries:
  - `bitfun-desktop.exe`
  - `frontend/dist/index.html`
  - `mobile-web/dist/index.html`
  - `resources/ext-host/extension-host.js`
  - `resources/worker_host.js`
  - `flashgrep/flashgrep-x86_64-pc-windows-msvc.exe`

## Reviewer Notes

- `installer:build:only` now requires the exact release executable and adjacent runtime directories.
- Builds with a custom Cargo target directory should set `BITFUN_INSTALLER_APP_EXE` or pass `--app-exe`.
- A raw executable produced by a no-bundle build remains dependent on adjacent runtime directories and should not be distributed alone.
- Verification covered local Windows packaging. Remote execution scenarios are not affected.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.