### PR TITLE
fix(mobile): stabilize remote session creation

### DIFF
--- a/src/apps/mobile/ios/BitFun.xcodeproj/project.pbxproj
+++ b/src/apps/mobile/ios/BitFun.xcodeproj/project.pbxproj
@@ -44,7 +44,12 @@
     A10000000000000000000036 /* MobilePresentationModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000000000000000000036 /* MobilePresentationModels.swift */; };
     A10000000000000000000037 /* MobileLaunchConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000000000000000000037 /* MobileLaunchConfiguration.swift */; };
     A10000000000000000000038 /* PairingFailureCopy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000000000000000000038 /* PairingFailureCopy.swift */; };
+    A20000000000000000000001 /* RemoteCodeSessionSendUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20000000000000000000001 /* RemoteCodeSessionSendUITests.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+    A20000000000000000000002 /* PBXContainerItemProxy */ = {isa = PBXContainerItemProxy; containerPortal = E10000000000000000000000 /* Project object */; proxyType = 1; remoteGlobalIDString = E10000000000000000000001; remoteInfo = BitFun; };
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
     B10000000000000000000000 /* BitFun.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BitFun.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -85,14 +90,17 @@
     B10000000000000000000036 /* MobilePresentationModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobilePresentationModels.swift; sourceTree = "<group>"; };
     B10000000000000000000037 /* MobileLaunchConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileLaunchConfiguration.swift; sourceTree = "<group>"; };
     B10000000000000000000038 /* PairingFailureCopy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingFailureCopy.swift; sourceTree = "<group>"; };
+    B20000000000000000000000 /* BitFunUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BitFunUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+    B20000000000000000000001 /* RemoteCodeSessionSendUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteCodeSessionSendUITests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
     C10000000000000000000001 /* Frameworks */ = {isa = PBXFrameworksBuildPhase; buildActionMask = 2147483647; files = ( A10000000000000000000011 /* BitFunMobileCore.xcframework in Frameworks */, A10000000000000000000012 /* libsqlite3.tbd in Frameworks */ ); runOnlyForDeploymentPostprocessing = 0; };
+    C20000000000000000000001 /* Frameworks */ = {isa = PBXFrameworksBuildPhase; buildActionMask = 2147483647; files = ( ); runOnlyForDeploymentPostprocessing = 0; };
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-    D10000000000000000000000 = {isa = PBXGroup; children = (D10000000000000000000001 /* BitFun */, D10000000000000000000009 /* Products */); sourceTree = "<group>"; };
+    D10000000000000000000000 = {isa = PBXGroup; children = (D10000000000000000000001 /* BitFun */, D20000000000000000000001 /* BitFunUITests */, D10000000000000000000009 /* Products */); sourceTree = "<group>"; };
     D10000000000000000000001 /* BitFun */ = {isa = PBXGroup; children = (D10000000000000000000002 /* App */, D10000000000000000000016 /* Presentation */, D10000000000000000000003 /* Features */, D10000000000000000000008 /* Infrastructure */, D10000000000000000000011 /* Resources */, B10000000000000000000009 /* Resources.xcassets */, B10000000000000000000011 /* BitFunMobileCore.xcframework */, B10000000000000000000012 /* libsqlite3.tbd */); path = BitFun; sourceTree = "<group>"; };
     D10000000000000000000002 /* App */ = {isa = PBXGroup; children = (B10000000000000000000001 /* BitFunApp.swift */, B10000000000000000000037 /* MobileLaunchConfiguration.swift */); path = App; sourceTree = "<group>"; };
     D10000000000000000000003 /* Features */ = {isa = PBXGroup; children = (D10000000000000000000004 /* Chat */, D10000000000000000000012 /* Remote */, D10000000000000000000013 /* Settings */, D10000000000000000000014 /* Pairing */, D10000000000000000000015 /* Account */, D10000000000000000000005 /* Shell */, D10000000000000000000010 /* DesignSystem */); path = Features; sourceTree = "<group>"; };
@@ -107,24 +115,32 @@
     D10000000000000000000016 /* Presentation */ = {isa = PBXGroup; children = (D10000000000000000000018 /* Models */); path = Presentation; sourceTree = "<group>"; };
     D10000000000000000000018 /* Models */ = {isa = PBXGroup; children = (B10000000000000000000036 /* MobilePresentationModels.swift */); path = Models; sourceTree = "<group>"; };
     D10000000000000000000017 /* Platform */ = {isa = PBXGroup; children = (B10000000000000000000034 /* QRCodeScannerView.swift */); path = Platform; sourceTree = "<group>"; };
-    D10000000000000000000009 /* Products */ = {isa = PBXGroup; children = (B10000000000000000000000 /* BitFun.app */); name = Products; sourceTree = "<group>"; };
+    D10000000000000000000009 /* Products */ = {isa = PBXGroup; children = (B10000000000000000000000 /* BitFun.app */, B20000000000000000000000 /* BitFunUITests.xctest */); name = Products; sourceTree = "<group>"; };
+    D20000000000000000000001 /* BitFunUITests */ = {isa = PBXGroup; children = (B20000000000000000000001 /* RemoteCodeSessionSendUITests.swift */); path = BitFunUITests; sourceTree = "<group>"; };
     D10000000000000000000010 /* DesignSystem */ = {isa = PBXGroup; children = (B10000000000000000000013 /* GeneratedMobileDesignTokens.swift */, B10000000000000000000014 /* GeneratedMobilePreviewScenarios.swift */, B10000000000000000000015 /* MobileDesignGallery.swift */, B10000000000000000000018 /* AdaptiveModalComponents.swift */); path = DesignSystem; sourceTree = "<group>"; };
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
     E10000000000000000000001 /* BitFun */ = {isa = PBXNativeTarget; buildConfigurationList = F10000000000000000000002 /* Build configuration list for PBXNativeTarget "BitFun" */; buildPhases = (C10000000000000000000002 /* Sources */, C10000000000000000000001 /* Frameworks */, C10000000000000000000003 /* Resources */); buildRules = ( ); dependencies = ( ); name = BitFun; productName = BitFun; productReference = B10000000000000000000000 /* BitFun.app */; productType = "com.apple.product-type.application"; };
+    E20000000000000000000001 /* BitFunUITests */ = {isa = PBXNativeTarget; buildConfigurationList = F20000000000000000000001 /* Build configuration list for PBXNativeTarget "BitFunUITests" */; buildPhases = (C20000000000000000000002 /* Sources */, C20000000000000000000001 /* Frameworks */, C20000000000000000000003 /* Resources */); buildRules = ( ); dependencies = (A20000000000000000000003 /* PBXTargetDependency */); name = BitFunUITests; productName = BitFunUITests; productReference = B20000000000000000000000 /* BitFunUITests.xctest */; productType = "com.apple.product-type.bundle.ui-testing"; };
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-    E10000000000000000000000 /* Project object */ = {isa = PBXProject; attributes = {LastUpgradeCheck = 1640; TargetAttributes = {E10000000000000000000001 = {CreatedOnToolsVersion = 16.4; }; }; }; buildConfigurationList = F10000000000000000000001 /* Build configuration list for PBXProject "BitFun" */; compatibilityVersion = "Xcode 14.0"; developmentRegion = "zh-Hans"; hasScannedForEncodings = 0; knownRegions = (en, "zh-Hans", Base); mainGroup = D10000000000000000000000; productRefGroup = D10000000000000000000009 /* Products */; projectDirPath = ""; projectRoot = ""; targets = (E10000000000000000000001 /* BitFun */); };
+    E10000000000000000000000 /* Project object */ = {isa = PBXProject; attributes = {LastUpgradeCheck = 1640; TargetAttributes = {E10000000000000000000001 = {CreatedOnToolsVersion = 16.4; }; E20000000000000000000001 = {CreatedOnToolsVersion = 16.4; TestTargetID = E10000000000000000000001; }; }; }; buildConfigurationList = F10000000000000000000001 /* Build configuration list for PBXProject "BitFun" */; compatibilityVersion = "Xcode 14.0"; developmentRegion = "zh-Hans"; hasScannedForEncodings = 0; knownRegions = (en, "zh-Hans", Base); mainGroup = D10000000000000000000000; productRefGroup = D10000000000000000000009 /* Products */; projectDirPath = ""; projectRoot = ""; targets = (E10000000000000000000001 /* BitFun */, E20000000000000000000001 /* BitFunUITests */); };
 /* End PBXProject section */
 
 /* Begin PBXSourcesBuildPhase section */
     C10000000000000000000002 /* Sources */ = {isa = PBXSourcesBuildPhase; buildActionMask = 2147483647; files = (A10000000000000000000001, A10000000000000000000002, A10000000000000000000003, A10000000000000000000004, A10000000000000000000005, A10000000000000000000006, A10000000000000000000007, A10000000000000000000008, A10000000000000000000010, A10000000000000000000013, A10000000000000000000014, A10000000000000000000015, A10000000000000000000017, A10000000000000000000018, A10000000000000000000019, A10000000000000000000020, A10000000000000000000021, A10000000000000000000022, A10000000000000000000024, A10000000000000000000025, A10000000000000000000026, A10000000000000000000027, A10000000000000000000028, A10000000000000000000029, A10000000000000000000030, A10000000000000000000031, A10000000000000000000032, A10000000000000000000033, A10000000000000000000034, A10000000000000000000035, A10000000000000000000036, A10000000000000000000037, A10000000000000000000038); runOnlyForDeploymentPostprocessing = 0; };
+    C20000000000000000000002 /* Sources */ = {isa = PBXSourcesBuildPhase; buildActionMask = 2147483647; files = (A20000000000000000000001 /* RemoteCodeSessionSendUITests.swift in Sources */); runOnlyForDeploymentPostprocessing = 0; };
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+    A20000000000000000000003 /* PBXTargetDependency */ = {isa = PBXTargetDependency; target = E10000000000000000000001 /* BitFun */; targetProxy = A20000000000000000000002 /* PBXContainerItemProxy */; };
+/* End PBXTargetDependency section */
 
 /* Begin PBXResourcesBuildPhase section */
     C10000000000000000000003 /* Resources */ = {isa = PBXResourcesBuildPhase; buildActionMask = 2147483647; files = (A10000000000000000000009, A10000000000000000000016); runOnlyForDeploymentPostprocessing = 0; };
+    C20000000000000000000003 /* Resources */ = {isa = PBXResourcesBuildPhase; buildActionMask = 2147483647; files = ( ); runOnlyForDeploymentPostprocessing = 0; };
 /* End PBXResourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
@@ -132,11 +148,14 @@
     F10000000000000000000004 /* Release */ = {isa = XCBuildConfiguration; buildSettings = {ALWAYS_SEARCH_USER_PATHS = NO; ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon; CLANG_ENABLE_MODULES = YES; DEVELOPMENT_TEAM = ""; FRAMEWORK_SEARCH_PATHS = ( "$(SRCROOT)/../shared/core-feature/build/XCFrameworks/debug" ); INFOPLIST_FILE = BitFun/Info.plist; IPHONEOS_DEPLOYMENT_TARGET = 16.0; PRODUCT_BUNDLE_IDENTIFIER = com.bitfun.mobile.ios; PRODUCT_NAME = "$(TARGET_NAME)"; SWIFT_VERSION = 5.0; TARGETED_DEVICE_FAMILY = "1,2"; }; name = Release; };
     F10000000000000000000005 /* Target Debug */ = {isa = XCBuildConfiguration; buildSettings = {SDKROOT = iphoneos; }; name = Debug; };
     F10000000000000000000006 /* Target Release */ = {isa = XCBuildConfiguration; buildSettings = {SDKROOT = iphoneos; }; name = Release; };
+    F20000000000000000000002 /* UI Test Debug */ = {isa = XCBuildConfiguration; buildSettings = {CODE_SIGN_STYLE = Automatic; DEVELOPMENT_TEAM = ""; GENERATE_INFOPLIST_FILE = YES; IPHONEOS_DEPLOYMENT_TARGET = 16.0; PRODUCT_BUNDLE_IDENTIFIER = com.bitfun.mobile.ios.ui-tests; PRODUCT_NAME = "$(TARGET_NAME)"; SDKROOT = iphoneos; SWIFT_VERSION = 5.0; TARGETED_DEVICE_FAMILY = "1,2"; TEST_TARGET_NAME = BitFun; }; name = Debug; };
+    F20000000000000000000003 /* UI Test Release */ = {isa = XCBuildConfiguration; buildSettings = {CODE_SIGN_STYLE = Automatic; DEVELOPMENT_TEAM = ""; GENERATE_INFOPLIST_FILE = YES; IPHONEOS_DEPLOYMENT_TARGET = 16.0; PRODUCT_BUNDLE_IDENTIFIER = com.bitfun.mobile.ios.ui-tests; PRODUCT_NAME = "$(TARGET_NAME)"; SDKROOT = iphoneos; SWIFT_VERSION = 5.0; TARGETED_DEVICE_FAMILY = "1,2"; TEST_TARGET_NAME = BitFun; }; name = Release; };
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
     F10000000000000000000001 /* Build configuration list for PBXProject "BitFun" */ = {isa = XCConfigurationList; buildConfigurations = (F10000000000000000000003 /* Debug */, F10000000000000000000004 /* Release */); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
     F10000000000000000000002 /* Build configuration list for PBXNativeTarget "BitFun" */ = {isa = XCConfigurationList; buildConfigurations = (F10000000000000000000005 /* Target Debug */, F10000000000000000000006 /* Target Release */); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
+    F20000000000000000000001 /* Build configuration list for PBXNativeTarget "BitFunUITests" */ = {isa = XCConfigurationList; buildConfigurations = (F20000000000000000000002 /* UI Test Debug */, F20000000000000000000003 /* UI Test Release */); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
 /* End XCConfigurationList section */
   };
   rootObject = E10000000000000000000000 /* Project object */;

--- a/src/apps/mobile/ios/BitFun/App/MobileLaunchConfiguration.swift
+++ b/src/apps/mobile/ios/BitFun/App/MobileLaunchConfiguration.swift
@@ -133,9 +133,15 @@ enum MobileLaunchConfiguration {
             arguments.contains("--pairing-account") {
             model.pairingSheetOpen = true
         }
-        if arguments.contains("--remote-create") || arguments.contains("--remote-create-workspace-picker") {
+        if arguments.contains("--remote-create") || arguments.contains("--remote-create-workspace-picker") ||
+            arguments.contains("--remote-create-session-loading") {
             model.remoteCreatePreview = true
             if !model.remoteConnected { model.configureConnectedPreview() }
+            if arguments.contains("--remote-create-session-loading") {
+                // Reproduces the real-device race: workspace authority is ready
+                // while the independent session directory still reports busy.
+                model.busy = true
+            }
             model.remoteCreateOpen = true
         }
         if arguments.contains("--remote-home-preview") {
@@ -212,6 +218,13 @@ private extension MobileAppModel {
         directPairingConnected = true
         surface = .remote
         remoteConnected = true
+        remoteExpectedDeviceKey = "pairing"
+        remoteInitialSessionReady = true
+        remoteInitialWorkspaceReady = true
+        remoteCreateWorkspacePhase = .ready
+        workspaceLoading = false
+        workspaceLoadFailed = false
+        workspaceSelectionBusy = false
         connectionPhase = .connected
         remoteSessionSelected = true
         accountUser = "preview@bitfun"

--- a/src/apps/mobile/ios/BitFun/Features/Chat/ComposerBar.swift
+++ b/src/apps/mobile/ios/BitFun/Features/Chat/ComposerBar.swift
@@ -40,12 +40,11 @@ struct ComposerBar: View {
                 attachmentStrip
             }
 
+            stableInputRow
+
             if expanded {
-                expandedInputRow
                 expandedActionRow
                     .transition(.move(edge: .bottom).combined(with: .opacity))
-            } else {
-                collapsedRow
             }
         }
         .padding(.horizontal, 8)
@@ -129,22 +128,26 @@ struct ComposerBar: View {
         }
     }
 
-    private var collapsedRow: some View {
-        HStack(spacing: 5) {
-            attachmentAction
-            inputField(maxLines: 1)
-                .frame(height: MobileDesignGeometry.composerInputHeight)
-            primaryAction
+    /// Keep the same TextField instance alive while focus expands the composer.
+    /// Replacing the collapsed row with a separate expanded row destroys the
+    /// first responder during the keyboard transition and leaves UIKit without
+    /// a focused input target.
+    private var stableInputRow: some View {
+        HStack(spacing: expanded ? 0 : 5) {
+            if !expanded {
+                attachmentAction
+            }
+            inputField(maxLines: expanded ? 4 : 1)
+                .frame(height: expanded
+                    ? MobileDesignGeometry.composerExpandedInputHeight
+                    : MobileDesignGeometry.composerInputHeight)
+            if !expanded {
+                primaryAction
+            }
         }
-        .frame(height: MobileDesignGeometry.composerCollapsedHeight)
-    }
-
-    private var expandedInputRow: some View {
-        HStack(spacing: 0) {
-            inputField(maxLines: 4)
-                .frame(height: MobileDesignGeometry.composerExpandedInputHeight)
-        }
-        .frame(height: MobileDesignGeometry.composerExpandedInputRowHeight)
+        .frame(height: expanded
+            ? MobileDesignGeometry.composerExpandedInputRowHeight
+            : MobileDesignGeometry.composerCollapsedHeight)
     }
 
     private var expandedActionRow: some View {
@@ -191,6 +194,7 @@ struct ComposerBar: View {
             .foregroundStyle(BitFunTheme.ink)
             .lineLimit(1...maxLines)
             .focused($focused)
+            .accessibilityIdentifier("composer.input")
             .submitLabel(.send)
             .onSubmit {
                 if canSend { model.send() }

--- a/src/apps/mobile/ios/BitFun/Features/Shell/MobileShellView.swift
+++ b/src/apps/mobile/ios/BitFun/Features/Shell/MobileShellView.swift
@@ -319,7 +319,6 @@ struct MobileShellView: View {
                     sidebarAction: sidebarAction,
                     sidebarActionLabel: sidebarActionLabel
                 )
-                .ignoresSafeArea(.keyboard, edges: .bottom)
             }
         }
         .background(BitFunTheme.page)

--- a/src/apps/mobile/ios/BitFun/Features/Shell/RemoteCreateSessionView.swift
+++ b/src/apps/mobile/ios/BitFun/Features/Shell/RemoteCreateSessionView.swift
@@ -51,7 +51,8 @@ struct RemoteCreateSessionView: View {
             contextButton(
                 kind: .workspace,
                 icon: selectedWorkspacePath.isEmpty ? "message" : "folder",
-                label: model.workspaceLoading ? model.localized("正在加载工作区") : selectedWorkspaceName,
+                label: model.remoteCreateWorkspacePhase == .loading
+                    ? model.localized("正在加载工作区") : selectedWorkspaceName,
                 automationIdentifier: selectedWorkspaceAutomationIdentifier
             )
             createComposer
@@ -87,10 +88,14 @@ struct RemoteCreateSessionView: View {
                 .presentationDragIndicator(.visible)
         }
         .onAppear {
-            if let selected = model.remoteWorkspaces.first(where: \.selected) {
-                selectedWorkspacePath = selected.path
-            }
+            reconcileSelectedWorkspace()
             selectedModelID = model.modelOptions.first(where: \.selected)?.id ?? model.modelOptions.first?.id
+        }
+        .onChange(of: model.remoteTargetEpoch) { _ in
+            selectedWorkspacePath = ""
+        }
+        .onChange(of: model.remoteWorkspaces) { _ in
+            reconcileSelectedWorkspace()
         }
     }
 
@@ -155,7 +160,9 @@ struct RemoteCreateSessionView: View {
             .padding(.horizontal, 28)
         }
         .buttonStyle(.plain)
-        .disabled(model.busy || model.remoteCreateSubmitting || model.accountBusy)
+        .disabled(kind == .device
+            ? !model.remoteCreateInteraction.canOpenDevicePicker
+            : !model.remoteCreateInteraction.canOpenWorkspacePicker)
         .accessibilityIdentifier(automationIdentifier)
         .accessibilityLabel(model.localized(kind.accessibilityLabelKey))
         .accessibilityValue(label)
@@ -176,6 +183,7 @@ struct RemoteCreateSessionView: View {
             )
             .font(MobileDesignTypography.bodyLarge.font)
             .lineLimit(1...4)
+            .accessibilityIdentifier("remoteCreate.composer.input")
             .padding(.horizontal, 6)
             .frame(minHeight: MobileDesignGeometry.composerExpandedInputRowHeight)
 
@@ -200,6 +208,7 @@ struct RemoteCreateSessionView: View {
                     .accessibilityLabel(model.localized(RemoteCreateSelectionKind.model.accessibilityLabelKey))
                     .accessibilityValue(selectedModel.primaryLabel)
                     .accessibilityHint(model.localized(RemoteCreateSelectionKind.model.accessibilityHintKey))
+                    .disabled(model.remoteCreateSubmitting || model.isSending)
                 }
                 Spacer(minLength: 0)
                 Button(action: primaryAction) {
@@ -243,7 +252,7 @@ struct RemoteCreateSessionView: View {
 
     private var canSubmit: Bool {
         !instruction.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
-            model.remoteConnected && !model.remoteCreateSubmitting
+            model.remoteCreateInteraction.canSubmit
     }
 
     private func createStatus(message: String, retryTitle: String, action: @escaping () -> Void) -> some View {
@@ -338,32 +347,53 @@ struct RemoteCreateSessionView: View {
                             }
                         }
                     case .workspace:
-                        selectionRow(
-                            kind: .workspace,
-                            icon: "message",
-                            title: model.localized("对话"),
-                            subtitle: "",
-                            selected: selectedWorkspacePath.isEmpty,
-                            enabled: true
-                        ) {
-                            selectedWorkspacePath = ""
-                            pickerKind = nil
-                            if let assistant = model.remoteAssistants.first {
-                                model.selectRemoteAssistant(assistant)
+                        switch model.remoteCreateWorkspacePhase {
+                        case .loading:
+                            selectionStatusRow(
+                                title: model.localized("正在加载工作区"),
+                                showsProgress: true
+                            )
+                        case .failed:
+                            selectionRetryRow()
+                        case .unavailable:
+                            selectionStatusRow(
+                                title: model.localized("连接不可用，请重新连接"),
+                                showsProgress: false
+                            )
+                        case .ready:
+                            if model.workspaceSelectionBusy {
+                                selectionStatusRow(
+                                    title: model.localized("正在加载"),
+                                    showsProgress: true
+                                )
                             }
-                        }
-                        ForEach(model.remoteWorkspaces) { workspace in
                             selectionRow(
                                 kind: .workspace,
-                                icon: "folder",
-                                title: workspace.name,
-                                subtitle: workspace.path,
-                                selected: workspace.path == selectedWorkspacePath,
-                                enabled: true
+                                icon: "message",
+                                title: model.localized("对话"),
+                                subtitle: "",
+                                selected: selectedWorkspacePath.isEmpty,
+                                enabled: model.remoteCreateInteraction.canSelectWorkspace
                             ) {
-                                selectedWorkspacePath = workspace.path
+                                selectedWorkspacePath = ""
                                 pickerKind = nil
-                                model.selectRemoteWorkspace(workspace)
+                                if let assistant = model.remoteAssistants.first {
+                                    model.selectRemoteAssistant(assistant)
+                                }
+                            }
+                            ForEach(model.remoteWorkspaces) { workspace in
+                                selectionRow(
+                                    kind: .workspace,
+                                    icon: "folder",
+                                    title: workspace.name,
+                                    subtitle: workspace.path,
+                                    selected: workspace.path == selectedWorkspacePath,
+                                    enabled: model.remoteCreateInteraction.canSelectWorkspace
+                                ) {
+                                    selectedWorkspacePath = workspace.path
+                                    pickerKind = nil
+                                    model.selectRemoteWorkspace(workspace)
+                                }
                             }
                         }
                     case .model:
@@ -441,6 +471,49 @@ struct RemoteCreateSessionView: View {
         .accessibilityValue(subtitle)
         .accessibilityHint(model.localized(kind.accessibilityHintKey))
         .accessibilityAddTraits(selected ? [.isSelected] : [])
+    }
+
+    private func selectionStatusRow(title: String, showsProgress: Bool) -> some View {
+        HStack(spacing: 10) {
+            if showsProgress {
+                ProgressView().controlSize(.small)
+            }
+            Text(title)
+                .font(.system(size: 14))
+                .foregroundStyle(BitFunTheme.muted)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 18)
+        .frame(minHeight: 52)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(title)
+    }
+
+    private func selectionRetryRow() -> some View {
+        Button {
+            model.retryRemoteWorkspaces()
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: "arrow.clockwise")
+                Text(model.localized("工作区加载失败，请重试"))
+                    .font(.system(size: 14, weight: .medium))
+                Spacer(minLength: 0)
+            }
+            .foregroundStyle(BitFunTheme.accent)
+            .padding(.horizontal, 18)
+            .frame(minHeight: 52)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(model.localized("重试"))
+    }
+
+    private func reconcileSelectedWorkspace() {
+        if let selected = model.remoteWorkspaces.first(where: \.selected) {
+            selectedWorkspacePath = selected.path
+        } else if !selectedWorkspacePath.isEmpty,
+                  !model.remoteWorkspaces.contains(where: { $0.path == selectedWorkspacePath }) {
+            selectedWorkspacePath = ""
+        }
     }
 
     private func selectionHeight(_ kind: RemoteCreateSelectionKind) -> CGFloat {

--- a/src/apps/mobile/ios/BitFun/Infrastructure/MobileAppModel+Account.swift
+++ b/src/apps/mobile/ios/BitFun/Infrastructure/MobileAppModel+Account.swift
@@ -65,6 +65,10 @@ extension MobileAppModel {
         remoteExpectedDeviceKey = "account:\(device.id)"
         remoteInitialSessionReady = false
         remoteInitialWorkspaceReady = false
+        remoteCreateWorkspacePhase = .loading
+        workspaceLoading = true
+        workspaceLoadFailed = false
+        workspaceSelectionBusy = false
         pendingDirectorySession = pendingDirectorySession.map { ($0.deviceKey, $0.sessionID, remoteTargetEpoch) }
         remoteCreateSubmitting = false
         remoteCreateRequestID = nil
@@ -140,6 +144,8 @@ extension MobileAppModel {
             remoteSessions = []
             remoteWorkspaces = []
             workspaceCatalog = []
+            workspaceSelectionBusy = false
+            remoteCreateWorkspacePhase = .unavailable
             pendingRemoteWorkspaceCreate = nil
             pendingRemoteAssistantCreate = false
             selectedRemoteWorkspaceKind = ""

--- a/src/apps/mobile/ios/BitFun/Infrastructure/MobileAppModel+RemoteSession.swift
+++ b/src/apps/mobile/ios/BitFun/Infrastructure/MobileAppModel+RemoteSession.swift
@@ -56,8 +56,10 @@ extension MobileAppModel {
         remoteAssistants = []
         workspaceCatalog = []
         selectedRemoteWorkspaceKind = ""
-        workspaceLoading = false
+        workspaceLoading = !targetKey.isEmpty
         workspaceLoadFailed = false
+        workspaceSelectionBusy = false
+        remoteCreateWorkspacePhase = targetKey.isEmpty ? .unavailable : .loading
         let clearingVisibleRemoteConversation = surface == .remote || remoteSessionSelected
         remoteSessionSelected = false
         sessionDetails = nil
@@ -364,18 +366,19 @@ extension MobileAppModel {
 
     func selectRemoteWorkspace(_ workspace: MobileWorkspaceGroup) {
         pendingDirectoryRemoteDraft = nil
-        guard remoteConnected else {
+        guard remoteConnected, remoteCreateInteraction.canSelectWorkspace else {
             showToast(localized("请先连接桌面设备"))
             return
         }
         surface = .remote
         drawerOpen = false
+        workspaceSelectionBusy = true
         coreAdapter?.selectRemoteWorkspace(path: workspace.path)
     }
 
     func createRemoteSession(in workspace: MobileWorkspaceGroup, agentType: String) {
         pendingDirectoryRemoteDraft = nil
-        guard remoteConnected, !busy else { return }
+        guard remoteCreateInteraction.canSubmit else { return }
         drawerOpen = false
         surface = .remote
         createRemoteSession(
@@ -388,7 +391,7 @@ extension MobileAppModel {
 
     func createRemoteAssistantSession() {
         pendingDirectoryRemoteDraft = nil
-        guard remoteConnected, !busy else { return }
+        guard remoteCreateInteraction.canSubmit else { return }
         drawerOpen = false
         surface = .remote
         if selectedRemoteWorkspaceKind.lowercased() == "assistant" {
@@ -400,11 +403,13 @@ extension MobileAppModel {
             return
         }
         pendingRemoteAssistantCreate = true
+        workspaceSelectionBusy = true
         coreAdapter?.selectRemoteAssistant(path: assistant.path)
     }
 
     func selectRemoteAssistant(_ assistant: MobileAssistantOption) {
-        guard remoteConnected else { return }
+        guard remoteConnected, remoteCreateInteraction.canSelectWorkspace else { return }
+        workspaceSelectionBusy = true
         coreAdapter?.selectRemoteAssistant(path: assistant.path)
     }
 
@@ -415,9 +420,7 @@ extension MobileAppModel {
         modelID: String? = nil,
         workspacePath: String? = nil
     ) {
-        // `busy` also covers a background session-list refresh. It is not an
-        // active turn and must not silently discard a new-session request.
-        guard remoteConnected, !remoteCreateSubmitting else {
+        guard remoteCreateInteraction.canSubmit else {
             remoteCreateError = localized("远程会话当前不可创建，请重试")
             return
         }
@@ -622,6 +625,12 @@ extension MobileAppModel {
     }
 
     func retryRemoteWorkspaces() {
+        guard remoteExpectedDeviceKey != nil,
+              remoteCreateWorkspacePhase != .loading,
+              !workspaceSelectionBusy else { return }
+        remoteCreateWorkspacePhase = .loading
+        workspaceLoading = true
+        workspaceLoadFailed = false
         coreAdapter?.loadRemoteWorkspaces()
     }
 
@@ -846,6 +855,12 @@ extension MobileAppModel {
               ) else { return }
         workspaceLoading = state is RemoteWorkspaceUiStateLoading
         workspaceLoadFailed = state is RemoteWorkspaceUiStateFailed
+        workspaceSelectionBusy = (state as? RemoteWorkspaceUiStateReady)?.busy ?? false
+        if state is RemoteWorkspaceUiStateLoading {
+            remoteCreateWorkspacePhase = .loading
+        } else if state is RemoteWorkspaceUiStateFailed {
+            remoteCreateWorkspacePhase = .failed
+        }
         if !(state is RemoteWorkspaceUiStateReady) {
             remoteInitialWorkspaceReady = false
         }
@@ -863,6 +878,8 @@ extension MobileAppModel {
 
         workspaceLoading = false
         workspaceLoadFailed = false
+        workspaceSelectionBusy = ready.busy
+        remoteCreateWorkspacePhase = .ready
         remoteInitialWorkspaceReady = true
         selectedRemoteWorkspaceKind = ready.selected?.kind ?? ""
         var seen = Set<String>()

--- a/src/apps/mobile/ios/BitFun/Infrastructure/MobileAppModel.swift
+++ b/src/apps/mobile/ios/BitFun/Infrastructure/MobileAppModel.swift
@@ -78,6 +78,8 @@ final class MobileAppModel: ObservableObject {
     @Published var remoteWorkspaces: [MobileWorkspaceGroup] = []
     @Published var workspaceLoading = false
     @Published var workspaceLoadFailed = false
+    @Published var workspaceSelectionBusy = false
+    @Published var remoteCreateWorkspacePhase: RemoteCreateWorkspacePhase = .unavailable
     @Published var filePreview: MobileFilePreview?
     @Published var sessionDetails: ChatSession? = nil
     @Published var filePreviewLoading = false
@@ -166,6 +168,18 @@ final class MobileAppModel: ObservableObject {
 
     var visibleSessions: [ChatSession] {
         surface == .local ? sessions : remoteSessions
+    }
+
+    var remoteCreateInteraction: RemoteCreateInteractionState {
+        RemoteCreateInteractionPolicy.resolve(
+            hasTarget: remoteExpectedDeviceKey != nil,
+            remoteConnected: remoteConnected,
+            accountSwitching: accountBusy,
+            workspacePhase: remoteCreateWorkspacePhase,
+            workspaceSelecting: workspaceSelectionBusy,
+            createSubmitting: remoteCreateSubmitting,
+            activeTurn: activeTurnID != nil || isSending
+        )
     }
 
     func switchSurface(_ next: MobileSurface) {
@@ -257,6 +271,12 @@ final class MobileAppModel: ObservableObject {
         remoteSessions = []
         remoteWorkspaces = []
         workspaceCatalog = []
+        remoteInitialSessionReady = false
+        remoteInitialWorkspaceReady = false
+        workspaceLoading = false
+        workspaceLoadFailed = false
+        workspaceSelectionBusy = false
+        remoteCreateWorkspacePhase = .unavailable
         pendingRemoteWorkspaceCreate = nil
         pendingDirectoryRemoteDraft = nil
         pendingRemoteAssistantCreate = false
@@ -347,6 +367,8 @@ final class MobileAppModel: ObservableObject {
         workspaceCatalog = []
         workspaceLoading = false
         workspaceLoadFailed = false
+        workspaceSelectionBusy = false
+        remoteCreateWorkspacePhase = .unavailable
         pendingDirectorySession = nil
         pendingDirectoryWorkspace = nil
         pendingDirectoryRemoteDraft = nil

--- a/src/apps/mobile/ios/BitFun/Infrastructure/RemoteAuthorityGate.swift
+++ b/src/apps/mobile/ios/BitFun/Infrastructure/RemoteAuthorityGate.swift
@@ -53,6 +53,52 @@ enum RemoteAuthorityInvalidationResult: Equatable {
     case notMatched(currentTargetKey: String?, currentEpoch: UInt64)
 }
 
+/// Target-scoped lifecycle of the workspace catalog used by remote creation.
+///
+/// This is intentionally separate from session `busy`: workspace discovery is
+/// an independent request and should become interactive as soon as its own
+/// authority is ready, regardless of a slower session-directory refresh.
+enum RemoteCreateWorkspacePhase: Equatable {
+    case unavailable
+    case loading
+    case ready
+    case failed
+}
+
+struct RemoteCreateInteractionState: Equatable {
+    let canOpenDevicePicker: Bool
+    let canOpenWorkspacePicker: Bool
+    let canSelectWorkspace: Bool
+    let canSubmit: Bool
+}
+
+enum RemoteCreateInteractionPolicy {
+    static func resolve(
+        hasTarget: Bool,
+        remoteConnected: Bool,
+        accountSwitching: Bool,
+        workspacePhase: RemoteCreateWorkspacePhase,
+        workspaceSelecting: Bool,
+        createSubmitting: Bool,
+        activeTurn: Bool
+    ) -> RemoteCreateInteractionState {
+        let contextMutationBlocked = createSubmitting || activeTurn
+        let canOpenDevicePicker = !accountSwitching && !contextMutationBlocked
+        let canOpenWorkspacePicker = hasTarget && !accountSwitching && !contextMutationBlocked
+        let workspaceReady = workspacePhase == .ready && !workspaceSelecting
+
+        return RemoteCreateInteractionState(
+            canOpenDevicePicker: canOpenDevicePicker,
+            // Loading and failure are deliberately openable: the picker owns
+            // progress, retry, and cached-list presentation for its request.
+            canOpenWorkspacePicker: canOpenWorkspacePicker,
+            canSelectWorkspace: canOpenWorkspacePicker && workspaceReady,
+            canSubmit: remoteConnected && hasTarget && !accountSwitching &&
+                !contextMutationBlocked && workspaceReady
+        )
+    }
+}
+
 enum RemoteAuthorityGate {
     static func targetBoundTransition(
         currentTargetKey: String?,

--- a/src/apps/mobile/ios/BitFunUITests/RemoteCodeSessionSendUITests.swift
+++ b/src/apps/mobile/ios/BitFunUITests/RemoteCodeSessionSendUITests.swift
@@ -1,0 +1,298 @@
+import XCTest
+
+final class RemoteCodeSessionSendUITests: XCTestCase {
+    private let app = XCUIApplication(bundleIdentifier: "com.bitfun.mobile.ios")
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app.launch()
+    }
+
+    func testSendMessageInCurrentRemoteCodeSession() throws {
+        let activeSession = app.descendants(matching: .any).matching(
+            NSPredicate(format: "identifier BEGINSWITH %@", "conversation.session.")
+        ).firstMatch
+        guard activeSession.waitForExistence(timeout: 20) else {
+            recordDiagnostics(named: "NoActiveRemoteSession")
+            XCTFail(
+                "No active Remote Code Session is visible. Keep the phone unlocked and navigate BitFun to the intended existing remote code session; this test will not choose a session automatically."
+            )
+            return
+        }
+
+        let composer = app.textFields.firstMatch
+        guard composer.waitForExistence(timeout: 10), composer.isHittable else {
+            recordDiagnostics(named: "ComposerUnavailable")
+            XCTFail("The current remote session is visible, but its composer text field is unavailable or obstructed.")
+            return
+        }
+
+        let message = "iPhone remote send E2E \(Int(Date().timeIntervalSince1970))"
+        composer.tap()
+        composer.typeText(message)
+        XCTAssertEqual(composer.value as? String, message, "The complete harmless E2E message was not entered.")
+
+        let sendButton = firstExistingElement([
+            app.buttons["发送"],
+            app.buttons["Send"],
+        ])
+        guard let sendButton else {
+            recordDiagnostics(named: "SendButtonMissing")
+            XCTFail("The composer contains the E2E message, but no localized Send button is visible.")
+            return
+        }
+        guard sendButton.isEnabled else {
+            recordDiagnostics(named: "SendButtonDisabled")
+            XCTFail("The Send button is disabled; remote mutation authority may not be confirmed or the session may be busy. The draft was not dispatched.")
+            return
+        }
+
+        sendButton.tap()
+
+        let draftCleared = NSPredicate { evaluated, _ in
+            guard let field = evaluated as? XCUIElement else { return false }
+            return (field.value as? String) != message
+        }
+        expectation(for: draftCleared, evaluatedWith: composer)
+        waitForExpectations(timeout: 10)
+
+        let timelineMessage = app.staticTexts[message]
+        guard timelineMessage.waitForExistence(timeout: 20) else {
+            recordDiagnostics(named: "TimelineMessageMissing")
+            XCTFail("The draft cleared after tapping Send, but the exact E2E message did not appear in the current timeline; dispatch or peer synchronization may have failed.")
+            return
+        }
+
+        let evidence = XCTAttachment(string: "Sent message visible in current timeline: \(message)")
+        evidence.name = "RemoteCodeSessionSendEvidence"
+        evidence.lifetime = .keepAlways
+        add(evidence)
+        recordDiagnostics(named: "RemoteCodeSessionSendSucceeded")
+    }
+
+    private func firstExistingElement(_ elements: [XCUIElement]) -> XCUIElement? {
+        elements.first { $0.waitForExistence(timeout: 2) }
+    }
+
+    private func recordDiagnostics(named name: String) {
+        let screenshot = XCTAttachment(screenshot: app.screenshot())
+        screenshot.name = name
+        screenshot.lifetime = .keepAlways
+        add(screenshot)
+
+        let hierarchy = XCTAttachment(string: app.debugDescription)
+        hierarchy.name = "\(name)-Hierarchy"
+        hierarchy.lifetime = .keepAlways
+        add(hierarchy)
+    }
+}
+
+/// Read-only real-device probe for the remote-create critical path. It opens
+/// the workspace picker and observes its first usable row, but never selects a
+/// workspace, creates a session, or sends content.
+final class RemoteWorkspaceLoadingPerformanceUITests: XCTestCase {
+    private let app = XCUIApplication(bundleIdentifier: "com.bitfun.mobile.ios")
+    private var startedAt = Date()
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        startedAt = Date()
+        app.launch()
+    }
+
+    func testConnectedHomeToWorkspaceRowsReadOnly() throws {
+        let connected = firstExistingElement([
+            app.staticTexts["桌面端已连接"],
+            app.staticTexts["Desktop connected"],
+        ], timeout: 30)
+        XCTAssertNotNil(connected, "The existing remote connection did not restore on the device.")
+        recordMilestone("connected_home")
+
+        guard let create = firstExistingElement([
+            app.buttons["新建远程会话"],
+            app.buttons["New remote session"],
+        ], timeout: 10) else {
+            recordDiagnostics(named: "RemoteCreateActionMissing")
+            XCTFail("The connected home did not expose the remote-create action.")
+            return
+        }
+        XCTAssertTrue(create.isHittable)
+        create.tap()
+        recordMilestone("create_opened")
+
+        let selectors = app.buttons.matching(
+            NSPredicate(format: "identifier BEGINSWITH %@", "remoteCreate.workspace.")
+        )
+        let selector = selectors.firstMatch
+        let usableSelector = NSPredicate { evaluated, _ in
+            guard let element = evaluated as? XCUIElement else { return false }
+            return element.exists && element.isHittable && element.isEnabled
+        }
+        expectation(for: usableSelector, evaluatedWith: selector)
+        waitForExpectations(timeout: 15)
+        XCTAssertEqual(selectors.count, 1, "Workspace selector must be unambiguous.")
+        recordMilestone("workspace_selector_usable")
+
+        selector.tap()
+        recordMilestone("workspace_picker_opened")
+
+        let workspaceRows = app.buttons.matching(
+            NSPredicate(
+                format: "label BEGINSWITH %@ OR label BEGINSWITH %@",
+                "工作区:",
+                "Workspace:"
+            )
+        )
+        let firstRow = workspaceRows.firstMatch
+        let usableRow = NSPredicate { evaluated, _ in
+            guard let element = evaluated as? XCUIElement else { return false }
+            return element.exists && element.isHittable && element.isEnabled
+        }
+        expectation(for: usableRow, evaluatedWith: firstRow)
+        waitForExpectations(timeout: 45)
+        recordMilestone("first_workspace_row_usable")
+        recordDiagnostics(named: "WorkspaceRowsReadOnlySucceeded")
+    }
+
+    private func firstExistingElement(_ elements: [XCUIElement], timeout: TimeInterval) -> XCUIElement? {
+        elements.first { $0.waitForExistence(timeout: timeout) }
+    }
+
+    private func recordMilestone(_ name: String) {
+        let elapsed = Date().timeIntervalSince(startedAt)
+        let attachment = XCTAttachment(string: String(format: "%@ +%.3fs", name, elapsed))
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+
+    private func recordDiagnostics(named name: String) {
+        let screenshot = XCTAttachment(screenshot: app.screenshot())
+        screenshot.name = name
+        screenshot.lifetime = .keepAlways
+        add(screenshot)
+
+        let hierarchy = XCTAttachment(string: app.debugDescription)
+        hierarchy.name = "\(name)-Hierarchy"
+        hierarchy.lifetime = .keepAlways
+        add(hierarchy)
+    }
+}
+
+final class RemoteCreateWorkspacePickerUITests: XCTestCase {
+    private let app = XCUIApplication(bundleIdentifier: "com.bitfun.mobile.ios")
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app.launchArguments = ["--remote-create"]
+        app.launch()
+    }
+
+    func testWorkspacePickerOpensAndExposesUsableRows() {
+        assertWorkspacePickerUsable()
+    }
+
+    func testSessionDirectoryBusyDoesNotDisableWorkspacePicker() {
+        app.terminate()
+        app.launchArguments = ["--remote-create-session-loading"]
+        app.launch()
+        assertWorkspacePickerUsable()
+    }
+
+    private func assertWorkspacePickerUsable() {
+        let selectors = app.buttons.matching(
+            NSPredicate(format: "identifier BEGINSWITH %@", "remoteCreate.workspace.")
+        )
+        let selector = selectors.firstMatch
+        XCTAssertTrue(selector.waitForExistence(timeout: 10))
+        XCTAssertEqual(selectors.count, 1)
+        XCTAssertTrue(selector.isHittable)
+        XCTAssertTrue(selector.isEnabled, "Independent session loading must not disable the workspace selector.")
+
+        selector.tap()
+
+        let workspaceRows = app.buttons.matching(
+            NSPredicate(
+                format: "label BEGINSWITH %@ OR label BEGINSWITH %@",
+                "工作区:",
+                "Workspace:"
+            )
+        )
+        let row = workspaceRows.firstMatch
+        XCTAssertTrue(row.waitForExistence(timeout: 10))
+        XCTAssertTrue(row.isHittable)
+        XCTAssertTrue(row.isEnabled)
+
+        let screenshot = XCTAttachment(screenshot: app.screenshot())
+        screenshot.name = "RemoteCreateWorkspacePickerUsable"
+        screenshot.lifetime = .keepAlways
+        add(screenshot)
+    }
+}
+
+/// Read-only responsiveness probes for the two composer implementations. The
+/// tests enter a disposable character but never submit it or mutate a remote
+/// session.
+final class ComposerFocusResponsivenessUITests: XCTestCase {
+    private let app = XCUIApplication(bundleIdentifier: "com.bitfun.mobile.ios")
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testRemoteHomeComposerAcceptsFirstCharacter() {
+        app.launchArguments = ["--remote", "--connected", "--remote-home-preview"]
+        app.launch()
+        assertFirstCharacterResponsiveness(
+            identifier: "composer.input",
+            named: "RemoteHomeComposer"
+        )
+    }
+
+    func testRemoteCreateComposerAcceptsFirstCharacter() {
+        app.launchArguments = ["--remote-create"]
+        app.launch()
+        assertFirstCharacterResponsiveness(
+            identifier: "remoteCreate.composer.input",
+            named: "RemoteCreateComposer"
+        )
+    }
+
+    private func assertFirstCharacterResponsiveness(identifier: String, named name: String) {
+        let field = app.textFields[identifier]
+        XCTAssertTrue(field.waitForExistence(timeout: 10), "\(name) text field did not appear.")
+        XCTAssertTrue(field.isHittable, "\(name) text field is obstructed.")
+
+        let tapStart = Date()
+        field.tap()
+        let tapElapsed = Date().timeIntervalSince(tapStart)
+
+        let typeStart = Date()
+        field.typeText("x")
+        let typeElapsed = Date().timeIntervalSince(typeStart)
+
+        XCTAssertEqual(field.value as? String, "x", "\(name) did not accept the first character.")
+        XCTAssertLessThan(tapElapsed, 2, "\(name) focus transition blocked UI automation.")
+        XCTAssertLessThan(typeElapsed, 2, "\(name) first character handling blocked UI automation.")
+        let keyboard = app.keyboards.firstMatch
+        if keyboard.exists {
+            XCTAssertLessThanOrEqual(
+                field.frame.maxY,
+                keyboard.frame.minY + 1,
+                "\(name) is covered by the software keyboard."
+            )
+        }
+
+        let timing = XCTAttachment(
+            string: String(format: "tap=%.3fs type=%.3fs keyboards=%d", tapElapsed, typeElapsed, app.keyboards.count)
+        )
+        timing.name = "\(name)-Timing"
+        timing.lifetime = .keepAlways
+        add(timing)
+
+        let screenshot = XCTAttachment(screenshot: app.screenshot())
+        screenshot.name = "\(name)-Focused"
+        screenshot.lifetime = .keepAlways
+        add(screenshot)
+    }
+}

--- a/src/apps/mobile/ios/Testing/RemoteAuthorityGateTests.swift
+++ b/src/apps/mobile/ios/Testing/RemoteAuthorityGateTests.swift
@@ -31,6 +31,8 @@ struct RemoteAuthorityGateTests {
             )
         }
 
+        verifyRemoteCreateInteractionPolicy()
+
         expect(
             RemoteAuthorityGate.updatedScope(
                 targetKey: "device-b",
@@ -294,6 +296,181 @@ struct RemoteAuthorityGateTests {
             "token expiry prevents a late old Ready callback from reviving cleared authority"
         )
         verifyProductionInvalidationPaths()
+        verifyWorkspaceAndSessionReadinessProjection()
+    }
+
+    private static func verifyWorkspaceAndSessionReadinessProjection() {
+        let iosDirectory = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let source = readSource(
+            iosDirectory.appendingPathComponent("BitFun/Infrastructure/MobileAppModel+RemoteSession.swift")
+        )
+
+        // Workspace-first: workspace authority is sufficient to dispatch the
+        // pending workspace selection; session authority is intentionally not
+        // part of this gate.
+        let workspaceApply = functionBody(in: source, startingAt: "func apply(workspaceState state:")
+        expect(
+            workspaceApply.contains("remoteInitialWorkspaceReady = true") &&
+                workspaceApply.contains("advancePendingDirectoryRemoteDraftIfReady()"),
+            "workspace-first applies authoritative catalog and advances workspace navigation"
+        )
+        let workspaceSelectionGate = "pending.epoch == remoteTargetEpoch,\n           remoteConnected,\n           remoteInitialWorkspaceReady {"
+        expect(source.contains("if let pending = pendingDirectoryWorkspace") &&
+            source.contains(workspaceSelectionGate), "workspace-first gate requires only workspace authority")
+        expect(!workspaceSelectionGate.contains("remoteInitialSessionReady"), "workspace-first gate does not require session authority")
+
+        // Session-first: opening a session and creating from a directory still
+        // require both authoritative projections, preserving the old guards.
+        let sessionOpen = functionBody(in: source, startingAt: "private func openPendingDirectorySessionIfReady()")
+        expect(
+            sessionOpen.contains("remoteInitialSessionReady") && sessionOpen.contains("remoteInitialWorkspaceReady"),
+            "session-first navigation waits for both session and workspace authority"
+        )
+        let draftOpen = functionBody(in: source, startingAt: "private func advancePendingDirectoryRemoteDraftIfReady()")
+        expect(
+            draftOpen.contains("remoteInitialSessionReady") && draftOpen.contains("remoteInitialWorkspaceReady"),
+            "pending create waits for both session and workspace authority"
+        )
+
+        // Failure and target switch: neither readiness bit can survive an
+        // invalid state or a changed target/epoch.
+        expect(
+            source.contains("if !(state is RemoteWorkspaceUiStateReady) {\n            remoteInitialWorkspaceReady = false") &&
+                source.contains("remoteInitialSessionReady = false"),
+            "workspace/session failure paths revoke readiness"
+        )
+        let clearProjection = functionBody(in: source, startingAt: "private func clearTargetScopedRemoteProjection(")
+        expect(
+            clearProjection.contains("remoteInitialSessionReady = false") &&
+                clearProjection.contains("remoteInitialWorkspaceReady = false"),
+            "target switch clears both readiness projections"
+        )
+        expect(source.contains("busy = ready.busy"), "session state keeps its original busy authority")
+
+        let modelSource = readSource(
+            iosDirectory.appendingPathComponent("BitFun/Infrastructure/MobileAppModel.swift")
+        )
+        let createViewSource = readSource(
+            iosDirectory.appendingPathComponent("BitFun/Features/Shell/RemoteCreateSessionView.swift")
+        )
+        expect(
+            modelSource.contains("RemoteCreateInteractionPolicy.resolve(") &&
+                modelSource.contains("workspacePhase: remoteCreateWorkspacePhase") &&
+                modelSource.contains("workspaceSelecting: workspaceSelectionBusy"),
+            "remote-create interaction is projected from target-scoped workspace state"
+        )
+        expect(
+            createViewSource.contains("model.remoteCreateInteraction.canOpenWorkspacePicker") &&
+                createViewSource.contains("model.remoteCreateInteraction.canSelectWorkspace") &&
+                createViewSource.contains("case .loading:") &&
+                createViewSource.contains("selectionRetryRow()") &&
+                !createViewSource.contains(".disabled(model.busy || model.remoteCreateSubmitting || model.accountBusy)"),
+            "workspace picker owns loading, ready, failure, and retry presentation"
+        )
+    }
+
+    private static func verifyRemoteCreateInteractionPolicy() {
+        let loading = RemoteCreateInteractionPolicy.resolve(
+            hasTarget: true,
+            remoteConnected: true,
+            accountSwitching: false,
+            workspacePhase: .loading,
+            workspaceSelecting: false,
+            createSubmitting: false,
+            activeTurn: false
+        )
+        expect(loading.canOpenWorkspacePicker, "loading workspace picker remains openable")
+        expect(!loading.canSelectWorkspace, "loading workspace rows are not selectable")
+        expect(!loading.canSubmit, "creation waits for workspace authority")
+
+        let ready = RemoteCreateInteractionPolicy.resolve(
+            hasTarget: true,
+            remoteConnected: true,
+            accountSwitching: false,
+            workspacePhase: .ready,
+            workspaceSelecting: false,
+            createSubmitting: false,
+            activeTurn: false
+        )
+        expect(ready.canOpenDevicePicker, "ready state can change device")
+        expect(ready.canOpenWorkspacePicker, "ready state can open workspace picker")
+        expect(ready.canSelectWorkspace, "ready state can select workspace")
+        expect(ready.canSubmit, "ready state can create")
+
+        let selecting = RemoteCreateInteractionPolicy.resolve(
+            hasTarget: true,
+            remoteConnected: true,
+            accountSwitching: false,
+            workspacePhase: .ready,
+            workspaceSelecting: true,
+            createSubmitting: false,
+            activeTurn: false
+        )
+        expect(selecting.canOpenWorkspacePicker, "workspace mutation remains observable")
+        expect(!selecting.canSelectWorkspace, "workspace mutation rejects duplicate selection")
+        expect(!selecting.canSubmit, "workspace mutation cannot race creation")
+
+        let failed = RemoteCreateInteractionPolicy.resolve(
+            hasTarget: true,
+            remoteConnected: true,
+            accountSwitching: false,
+            workspacePhase: .failed,
+            workspaceSelecting: false,
+            createSubmitting: false,
+            activeTurn: false
+        )
+        expect(failed.canOpenWorkspacePicker, "failed workspace picker exposes retry")
+        expect(!failed.canSubmit, "failed workspace authority cannot create")
+
+        let switching = RemoteCreateInteractionPolicy.resolve(
+            hasTarget: true,
+            remoteConnected: false,
+            accountSwitching: true,
+            workspacePhase: .loading,
+            workspaceSelecting: false,
+            createSubmitting: false,
+            activeTurn: false
+        )
+        expect(!switching.canOpenDevicePicker, "account target mutation rejects duplicate device selection")
+        expect(!switching.canOpenWorkspacePicker, "account target mutation isolates old workspace authority")
+
+        let activeTurn = RemoteCreateInteractionPolicy.resolve(
+            hasTarget: true,
+            remoteConnected: true,
+            accountSwitching: false,
+            workspacePhase: .ready,
+            workspaceSelecting: false,
+            createSubmitting: false,
+            activeTurn: true
+        )
+        expect(!activeTurn.canOpenWorkspacePicker, "active turn protects remote workspace context")
+        expect(!activeTurn.canSubmit, "active turn cannot race remote creation")
+
+        let disconnected = RemoteCreateInteractionPolicy.resolve(
+            hasTarget: false,
+            remoteConnected: false,
+            accountSwitching: false,
+            workspacePhase: .unavailable,
+            workspaceSelecting: false,
+            createSubmitting: false,
+            activeTurn: false
+        )
+        expect(disconnected.canOpenDevicePicker, "disconnected state can choose a cached device")
+        expect(!disconnected.canOpenWorkspacePicker, "workspace picker requires a target")
+        expect(!disconnected.canSubmit, "disconnected state cannot create")
+    }
+
+    private static func functionBody(in source: String, startingAt marker: String) -> String {
+        guard let start = source.range(of: marker) else {
+            preconditionFailure("Missing production function contract for \(marker)")
+        }
+        let remainder = source[start.lowerBound...]
+        guard let end = remainder.range(of: "\n    }", range: remainder.startIndex..<remainder.endIndex) else {
+            preconditionFailure("Unable to locate end of production function contract for \(marker)")
+        }
+        return String(remainder[..<end.upperBound])
     }
 
     private static func verifyProductionInvalidationPaths() {

--- a/src/apps/mobile/shared/core-feature/src/commonMain/kotlin/com/bitfun/mobile/core/feature/session/RemoteSessionStore.kt
+++ b/src/apps/mobile/shared/core-feature/src/commonMain/kotlin/com/bitfun/mobile/core/feature/session/RemoteSessionStore.kt
@@ -44,6 +44,8 @@ import com.bitfun.mobile.core.feature.workspace.RemoteWorkspaceUiState
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -402,8 +404,15 @@ public class RemoteSessionStore internal constructor(
                     failKnown(RemoteSessionFailureReason.NO_WORKSPACE, current)
                     return@launch
                 }
-                val page = listSessions(0, query, filter)
-                val catalog = loadModelCatalog(force = false)
+                // The catalog is independent of the authoritative workspace/session
+                // projection. Start both requests together so a slow catalog cannot
+                // add its latency to the session-list request (while still awaiting
+                // both before publishing the existing Ready contract).
+                val (page, catalog) = coroutineScope {
+                    val pageRequest = async { listSessions(0, query, filter) }
+                    val catalogRequest = async { loadModelCatalog(force = false) }
+                    pageRequest.await() to catalogRequest.await()
+                }
                 if (!isCurrentWork(generation)) return@launch
                 commitSessionPage(page)
                 commitModelCatalog(catalog)

--- a/src/apps/mobile/shared/core-feature/src/commonMain/kotlin/com/bitfun/mobile/core/feature/workspace/RemoteWorkspaceStore.kt
+++ b/src/apps/mobile/shared/core-feature/src/commonMain/kotlin/com/bitfun/mobile/core/feature/workspace/RemoteWorkspaceStore.kt
@@ -26,8 +26,11 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -46,6 +49,7 @@ public class RemoteWorkspaceStore internal constructor(
     /** Changes only when this target store is stopped; useful to cancel observers. */
     public val stopVersion: StateFlow<Long> = _stopVersion.asStateFlow()
     private var work: Job? = null
+    private var loadGeneration: Long = 0
     private var targetEpoch: Int = 0
     private var previewGeneration: Long = 0
     private var activePreviewRequestId: String? = null
@@ -81,41 +85,69 @@ public class RemoteWorkspaceStore internal constructor(
 
     public fun stop() {
         _stopVersion.value += 1
+        loadGeneration += 1
         invalidatePreview()
         work?.cancel()
         work = null
     }
 
     private fun load() {
+        val generation = ++loadGeneration
         invalidatePreview()
         work?.cancel()
         _state.value = RemoteWorkspaceUiState.Loading
         work = scope.launch {
             try {
-                val recent = transport.send<RecentWorkspaceListResponse>(RemoteCommand(cmd = "list_recent_workspaces"))
-                val assistants = transport.send<AssistantListResponse>(RemoteCommand(cmd = "list_assistants"))
-                val info = transport.send<WorkspaceInfoResponse>(RemoteCommand(cmd = "get_workspace_info"))
-                _state.value = RemoteWorkspaceUiState.Ready(
-                    workspaces = recent.workspaces.map { item ->
-                        RecentWorkspace(
-                            path = item.path.orEmpty(),
-                            name = item.name?.takeIf(String::isNotBlank) ?: basename(item.path.orEmpty()),
-                            lastOpened = item.lastOpened,
-                            kind = item.workspaceKind.orEmpty(),
-                        )
-                    }.filter { it.path.isNotEmpty() },
-                    assistants = assistants.assistants.map { item ->
-                        WorkspaceAssistant(item.path, item.name, item.assistantId)
-                    },
-                    selected = info.asSelectedWorkspace(),
-                    preview = RemoteFilePreviewUiState.None,
-                    busy = false,
-                    download = RemoteFileDownloadUiState.None,
-                )
+                supervisorScope {
+                    val recentDeferred = async<Any> {
+                        transport.send<RecentWorkspaceListResponse>(RemoteCommand(cmd = "list_recent_workspaces"))
+                    }
+                    val assistantsDeferred = async<Any> {
+                        transport.send<AssistantListResponse>(RemoteCommand(cmd = "list_assistants"))
+                    }
+                    val infoDeferred = async<Any> {
+                        transport.send<WorkspaceInfoResponse>(RemoteCommand(cmd = "get_workspace_info"))
+                    }
+                    try {
+                        val results = awaitAll(recentDeferred, assistantsDeferred, infoDeferred)
+                        val recent = results[0] as RecentWorkspaceListResponse
+                        val assistants = results[1] as AssistantListResponse
+                        val info = results[2] as WorkspaceInfoResponse
+                        if (generation == loadGeneration) {
+                            _state.value = RemoteWorkspaceUiState.Ready(
+                                workspaces = recent.workspaces.map { item ->
+                                    RecentWorkspace(
+                                        path = item.path.orEmpty(),
+                                        name = item.name?.takeIf(String::isNotBlank) ?: basename(item.path.orEmpty()),
+                                        lastOpened = item.lastOpened,
+                                        kind = item.workspaceKind.orEmpty(),
+                                    )
+                                }.filter { it.path.isNotEmpty() },
+                                assistants = assistants.assistants.map { item ->
+                                    WorkspaceAssistant(item.path, item.name, item.assistantId)
+                                },
+                                selected = info.asSelectedWorkspace(),
+                                preview = RemoteFilePreviewUiState.None,
+                                busy = false,
+                                download = RemoteFileDownloadUiState.None,
+                            )
+                        }
+                    } catch (cancelled: CancellationException) {
+                        throw cancelled
+                    } catch (error: Throwable) {
+                        recentDeferred.cancel()
+                        assistantsDeferred.cancel()
+                        infoDeferred.cancel()
+                        recentDeferred.join()
+                        assistantsDeferred.join()
+                        infoDeferred.join()
+                        if (generation == loadGeneration) _state.value = RemoteWorkspaceUiState.Failed(true)
+                    }
+                }
             } catch (cancelled: CancellationException) {
                 throw cancelled
             } catch (_: Throwable) {
-                _state.value = RemoteWorkspaceUiState.Failed(true)
+                if (generation == loadGeneration) _state.value = RemoteWorkspaceUiState.Failed(true)
             }
         }
     }
@@ -134,6 +166,7 @@ public class RemoteWorkspaceStore internal constructor(
 
     private fun runSelection(command: RemoteCommand, assistant: Boolean) {
         val current = _state.value as? RemoteWorkspaceUiState.Ready ?: return
+        val generation = ++loadGeneration
         invalidatePreview()
         work?.cancel()
         _state.value = current.copy(busy = true)
@@ -145,11 +178,12 @@ public class RemoteWorkspaceStore internal constructor(
                     transport.send<SetWorkspaceResponse>(command)
                 }
                 val info = transport.send<WorkspaceInfoResponse>(RemoteCommand(cmd = "get_workspace_info"))
+                if (generation != loadGeneration) return@launch
                 updateReady { it.copy(selected = info.asSelectedWorkspace(), busy = false) }
             } catch (cancelled: CancellationException) {
                 throw cancelled
             } catch (_: Throwable) {
-                _state.value = RemoteWorkspaceUiState.Failed(true)
+                if (generation == loadGeneration) _state.value = RemoteWorkspaceUiState.Failed(true)
             }
         }
     }

--- a/src/apps/mobile/shared/core-feature/src/commonTest/kotlin/com/bitfun/mobile/core/feature/session/RemoteSessionStoreTest.kt
+++ b/src/apps/mobile/shared/core-feature/src/commonTest/kotlin/com/bitfun/mobile/core/feature/session/RemoteSessionStoreTest.kt
@@ -64,6 +64,72 @@ class RemoteSessionStoreTest {
     }
 
     @Test
+    fun initialListingAndCatalogRequestsOverlapWithoutChangingReadyOrdering() = runTest {
+        val transport = FakeSessionTransport()
+        val listGate = CompletableDeferred<Unit>()
+        val catalogGate = CompletableDeferred<Unit>()
+        transport.commandGates["list_sessions"] = listGate
+        transport.commandGates["get_model_catalog"] = catalogGate
+        val store = RemoteSessionStore.create(this, transport)
+
+        store.dispatch(RemoteSessionIntent.Load)
+        runCurrent()
+
+        // Workspace discovery remains authoritative and precedes both requests;
+        // once it completes, the independent requests are in flight together.
+        assertEquals("get_workspace_info", transport.commands.first().cmd)
+        assertEquals(
+            setOf("get_workspace_info", "list_sessions", "get_model_catalog"),
+            transport.commands.map { it.cmd }.toSet(),
+        )
+        assertIs<RemoteSessionUiState.Loading>(store.state.value)
+
+        listGate.complete(Unit)
+        runCurrent()
+        assertIs<RemoteSessionUiState.Loading>(store.state.value)
+
+        catalogGate.complete(Unit)
+        advanceUntilIdle()
+        val ready = assertIs<RemoteSessionUiState.Ready>(store.state.value)
+        assertEquals(listOf("s-code", "s-cowork", "s-agentic"), ready.sessions.map { it.id })
+        assertEquals("model-primary", ready.modelCatalog?.defaultModels?.primary)
+    }
+
+    @Test
+    fun cancelledInitialCatalogCannotOverwriteANewerTargetLoad() = runTest {
+        val transport = FakeSessionTransport()
+        // Keep the catalog uncached so the replacement load has a real request
+        // whose late completion can be exercised.
+        transport.modelCatalogFailure = RelayFailure.Timeout
+        val store = RemoteSessionStore.create(this, transport)
+
+        store.dispatch(RemoteSessionIntent.Load)
+        advanceUntilIdle()
+        transport.modelCatalogFailure = null
+        transport.nonCancellableCommands += "get_model_catalog"
+
+        // Start the delayed request from an already usable state. This lets the
+        // replacement search exercise target switching rather than being rejected
+        // by the cold-start Loading guard.
+        store.dispatch(RemoteSessionIntent.Search("old target"))
+        runCurrent()
+        val lateCatalog = transport.lateCommandContinuations.remove("get_model_catalog")!!
+
+        store.dispatch(RemoteSessionIntent.Search("new target"))
+        runCurrent()
+        val current = assertIs<RemoteSessionUiState.Ready>(store.state.value)
+        assertEquals("new target", current.query)
+
+        // Complete the cancelled request after the replacement is authoritative.
+        // Its result must not restore the previous query or generation's state.
+        lateCatalog.resume(Unit)
+        runCurrent()
+        val afterLateCatalog = assertIs<RemoteSessionUiState.Ready>(store.state.value)
+        assertEquals("new target", afterLateCatalog.query)
+        assertEquals(current.sessions, afterLateCatalog.sessions)
+    }
+
+    @Test
     fun modelCatalogRemoteRejectedIsRetryableAndRefreshRecovers() = runTest {
         val transport = FakeSessionTransport()
         transport.modelCatalogFailure = RelayFailure.RemoteRejected("Unknown command")

--- a/src/apps/mobile/shared/core-feature/src/commonTest/kotlin/com/bitfun/mobile/core/feature/workspace/RemoteWorkspaceStoreTest.kt
+++ b/src/apps/mobile/shared/core-feature/src/commonTest/kotlin/com/bitfun/mobile/core/feature/workspace/RemoteWorkspaceStoreTest.kt
@@ -34,7 +34,10 @@ class RemoteWorkspaceStoreTest {
         assertEquals(listOf("/repo"), ready.workspaces.map { it.path })
         assertEquals(listOf("/assistant"), ready.assistants.map { it.path })
         assertEquals("/repo", ready.selected?.path)
-        assertEquals(listOf("list_recent_workspaces", "list_assistants", "get_workspace_info"), transport.commands.map { it.cmd })
+        assertEquals(
+            setOf("list_recent_workspaces", "list_assistants", "get_workspace_info"),
+            transport.commands.map { it.cmd }.toSet(),
+        )
     }
 
     @Test
@@ -280,6 +283,72 @@ class RemoteWorkspaceStoreTest {
     }
 
     @Test
+    fun initialWorkspaceRequestsOverlapAndReadyWaitsForAllAuthoritativeResults() = runTest {
+        val transport = OverlappingWorkspaceTransport()
+        val store = RemoteWorkspaceStore.create(this, transport, StandardTestDispatcher(testScheduler))
+
+        store.dispatch(RemoteWorkspaceIntent.Load)
+        runCurrent()
+
+        assertEquals(
+            setOf("list_recent_workspaces", "list_assistants", "get_workspace_info"),
+            transport.started,
+        )
+        assertIs<RemoteWorkspaceUiState.Loading>(store.state.value)
+
+        transport.release("list_recent_workspaces")
+        runCurrent()
+        assertIs<RemoteWorkspaceUiState.Loading>(store.state.value)
+        transport.release("list_assistants")
+        runCurrent()
+        assertIs<RemoteWorkspaceUiState.Loading>(store.state.value)
+        transport.release("get_workspace_info")
+        advanceUntilIdle()
+
+        val ready = assertIs<RemoteWorkspaceUiState.Ready>(store.state.value)
+        assertEquals("/authoritative", ready.selected?.path)
+    }
+
+    @Test
+    fun switchingLoadRejectsLateResultsFromThePreviousTargetGeneration() = runTest {
+        val transport = SwitchingWorkspaceTransport()
+        val store = RemoteWorkspaceStore.create(this, transport, StandardTestDispatcher(testScheduler))
+
+        store.dispatch(RemoteWorkspaceIntent.Load)
+        runCurrent()
+        store.dispatch(RemoteWorkspaceIntent.Load)
+        advanceUntilIdle()
+        assertEquals("/new", assertIs<RemoteWorkspaceUiState.Ready>(store.state.value).selected?.path)
+
+        transport.releaseFirstLoad()
+        advanceUntilIdle()
+        assertEquals("/new", assertIs<RemoteWorkspaceUiState.Ready>(store.state.value).selected?.path)
+    }
+
+    @Test
+    fun initialWorkspaceFailureRemainsExplicit() = runTest {
+        val transport = FailingWorkspaceTransport()
+        val store = RemoteWorkspaceStore.create(this, transport, StandardTestDispatcher(testScheduler))
+
+        store.dispatch(RemoteWorkspaceIntent.Load)
+        advanceUntilIdle()
+
+        assertIs<RemoteWorkspaceUiState.Failed>(store.state.value)
+    }
+
+    @Test
+    fun anImmediateInitialFailureCancelsHeldSiblingAndPublishesFailure() = runTest {
+        val transport = FailingAndHeldWorkspaceTransport()
+        val store = RemoteWorkspaceStore.create(this, transport, StandardTestDispatcher(testScheduler))
+
+        store.dispatch(RemoteWorkspaceIntent.Load)
+        runCurrent()
+
+        assertTrue(transport.heldRequestCancelled)
+        assertIs<RemoteWorkspaceUiState.Failed>(store.state.value)
+    }
+
+    @Test
     fun downloadsAFileInChunksAndWaitsForThePlatformSaver() = runTest {
         val transport = FakeWorkspaceTransport(downloadChunks = true)
         val store = RemoteWorkspaceStore.create(this, transport, StandardTestDispatcher(testScheduler))
@@ -312,6 +381,98 @@ class RemoteWorkspaceStoreTest {
             assertIs<RemoteWorkspaceUiState.Ready>(store.state.value).download,
         )
         assertEquals(FilePreviewFailureKind.LOAD_FAILED, download.kind)
+    }
+}
+
+private class OverlappingWorkspaceTransport : RemoteCommandTransport {
+    val started = mutableSetOf<String>()
+    private val gates = mutableMapOf<String, CompletableDeferred<Unit>>()
+
+    fun release(command: String) {
+        gates.getValue(command).complete(Unit)
+    }
+
+    override suspend fun <T : CommandStatus> send(
+        deserializer: DeserializationStrategy<T>,
+        command: RemoteCommand,
+        timeoutMs: Long,
+    ): T {
+        started += command.cmd
+        val gate = CompletableDeferred<Unit>().also { gates[command.cmd] = it }
+        gate.await()
+        val json = when (command.cmd) {
+            "list_recent_workspaces" -> """{"resp":"ok","workspaces":[{"path":"/repo"}]}"""
+            "list_assistants" -> """{"resp":"ok","assistants":[]}"""
+            "get_workspace_info" -> """{"resp":"ok","has_workspace":true,"path":"/authoritative"}"""
+            else -> error("Unexpected command ${command.cmd}")
+        }
+        return RelayJson.decodeFromString(deserializer, json)
+    }
+}
+
+private class SwitchingWorkspaceTransport : RemoteCommandTransport {
+    private var loadCount = 0
+    private val firstLoadGates = mutableListOf<CompletableDeferred<Unit>>()
+
+    fun releaseFirstLoad() {
+        firstLoadGates.forEach { it.complete(Unit) }
+    }
+
+    override suspend fun <T : CommandStatus> send(
+        deserializer: DeserializationStrategy<T>,
+        command: RemoteCommand,
+        timeoutMs: Long,
+    ): T {
+        val firstLoad = loadCount < 3
+        if (command.cmd in setOf("list_recent_workspaces", "list_assistants", "get_workspace_info")) loadCount += 1
+        if (firstLoad) {
+            val gate = CompletableDeferred<Unit>()
+            firstLoadGates += gate
+            withContext(NonCancellable) { gate.await() }
+        }
+        val path = if (firstLoad) "/old" else "/new"
+        val json = when (command.cmd) {
+            "list_recent_workspaces" -> """{"resp":"ok","workspaces":[{"path":"$path"}]}"""
+            "list_assistants" -> """{"resp":"ok","assistants":[]}"""
+            "get_workspace_info" -> """{"resp":"ok","has_workspace":true,"path":"$path"}"""
+            else -> error("Unexpected command ${command.cmd}")
+        }
+        return RelayJson.decodeFromString(deserializer, json)
+    }
+}
+
+private class FailingWorkspaceTransport : RemoteCommandTransport {
+    override suspend fun <T : CommandStatus> send(
+        deserializer: DeserializationStrategy<T>,
+        command: RemoteCommand,
+        timeoutMs: Long,
+    ): T {
+        error("workspace catalog unavailable")
+    }
+}
+
+private class FailingAndHeldWorkspaceTransport : RemoteCommandTransport {
+    var heldRequestCancelled = false
+
+    override suspend fun <T : CommandStatus> send(
+        deserializer: DeserializationStrategy<T>,
+        command: RemoteCommand,
+        timeoutMs: Long,
+    ): T {
+        when (command.cmd) {
+            "list_recent_workspaces" -> {
+                try {
+                    CompletableDeferred<Unit>().await()
+                } catch (cancelled: kotlinx.coroutines.CancellationException) {
+                    heldRequestCancelled = true
+                    throw cancelled
+                }
+            }
+            "get_workspace_info" -> error("workspace info failed")
+            "list_assistants" -> Unit
+            else -> error("Unexpected command ${command.cmd}")
+        }
+        error("held request should not complete")
     }
 }
 


### PR DESCRIPTION
## Summary

- separate remote workspace readiness from the independent session-directory busy state so the remote-create picker can expose loading, retry, and usable workspace rows without being disabled by unrelated refresh work
- preserve the iOS composer text field across collapsed and expanded layouts so keyboard focus and the first typed character are not lost during the transition
- overlap session/catalog and workspace discovery requests in the shared KMP stores while rejecting cancelled or stale generations
- add focused Swift, KMP, and iOS UI regression coverage for interaction gating, overlapping requests, stale results, picker usability, and composer responsiveness

## Root cause

The iOS remote-create surface used broad model busy flags to gate workspace interactions even though workspace authority and session-directory refreshes are independent. The composer also replaced its text field when focus expanded the input row, which could destroy the first responder. In shared core, independent remote requests were serialized and older completions did not have a store-local generation guard.

## Validation

- `pnpm run mobile:architecture` — passed
- `(cd src/apps/mobile/ios && ./Testing/run-pure-swift-tests.sh)` — passed
- `(cd src/apps/mobile/shared && JAVA_HOME='/Applications/Android Studio.app/Contents/jbr/Contents/Home' ./gradlew jvmTest)` — passed
- `git diff --cached --check` — passed before commit
- `xcodebuild -project BitFun.xcodeproj -list` — blocked: the active developer directory is Command Line Tools rather than a full Xcode installation, so the new UI test target was not compiled or executed locally

## Risks

- The iOS UI tests include read-only preview probes plus one explicitly invoked real-session send test; they were not run locally because full Xcode is unavailable.
- Remote workspace/control behavior was covered by local policy and store tests only. No real relay, remote workspace, Peer Device Mode, or Detached Dispatch scenario was exercised in this validation pass.
- The existing wire format and persisted data shapes are unchanged.

Generated with [BitFun](https://github.com/bitfun-ai)
