### PR TITLE
test(web-ui): align Hello launcher contract

### DIFF
--- a/src/web-ui/src/app/layout/floatingMiniChatActivity.test.ts
+++ b/src/web-ui/src/app/layout/floatingMiniChatActivity.test.ts
@@ -20,10 +20,11 @@ function readSource(relativePath: string): string {
 }
 
 describe('floating MiniApp chat activity', () => {
-  it('uses a compact glyph for the standalone chat trigger', () => {
+  it('uses a text-only label for the standalone Hello trigger', () => {
     const component = readSource('./FloatingMiniChat.tsx');
-    expect(component).toContain('<Icon name="side-chat" size="md" />');
-    expect(component).not.toContain('<Icon name="side-chat" size="lg" />');
+    expect(component).toContain('className="bitfun-fmc__button-label"');
+    expect(component).toContain("tVoice('voiceCall.call.launcherLabel')");
+    expect(component).not.toContain('<Icon name="side-chat" size="md" />');
   });
 
   it.each([


### PR DESCRIPTION
## Summary

- Update the stale floating Hello source contract after PR #2736 intentionally removed the launcher icon.
- Assert the text-only launcher label and continue rejecting the removed medium side-chat icon.

## Type and Areas

Type: Regression fix / test

Areas: Web UI, FlowChat

## Motivation / Impact

The Frontend Build matrix in PR #2736 had 4304 passing tests and one stale assertion that still required the icon the product change intentionally removed. This aligns that test with the shipped text-only Hello launcher.

## Verification

- pnpm exec vitest run src/app/layout/floatingMiniChatActivity.test.ts src/app/components/NavPanel/unifiedSessionCreation.test.ts — 2 files and 20 tests passed
- Product code is unchanged; this patch only corrects the stale source-contract assertion.

## Reviewer Notes

Follow-up to #2736.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.