### PR TITLE
fix(peer): align disconnect semantics with host-owned turns

### DIFF
--- a/docs/architecture/peer-device-mode.md
+++ b/docs/architecture/peer-device-mode.md
@@ -210,7 +210,11 @@ FS) and must not be mixed with Peer Device Mode.
   any other.
 - Selecting this machine only changes what is rendered; peers stay attached and
   keep working. `Disconnect` in the switcher is the separate, explicit action
-  that ends a peer's control link and cancels the work it runs for us.
+  that ends a peer's control link and discards that peer's cached Surface state
+  on the controller. It does not cancel a Turn the peer has already accepted;
+  reconnecting later reattaches to the Host-owned Runtime projection. Pending
+  controller-only interactions still follow their owner's mailbox or fail-closed
+  policy.
 - Local-only commands (window chrome, updater, account login/logout, peer
   control plane) never execute on the peer on behalf of a controller.
 - Unsupported or denied commands fail loudly; they must not fall back to the
@@ -286,17 +290,21 @@ FS) and must not be mixed with Peer Device Mode.
   the exact observed tool and turn. Confirmable Peer tools always wait for the
   controller even when the host's global policy skips confirmation, so an Agent
   pauses until the controller responds; exact background-result follow-ups
-  retain this Peer-only confirmation requirement. The host cancels tracked turns when the
-  last controller detaches/goes offline or the agent-event subscription
-  lags/closes; continuity loss also projects the existing dialog-turn-failed
-  terminal event. Terminal ownership remains tracked until the event reaches the
-  delivery attempt, and a closed local delivery queue uses the same direct
-  DeviceEvent path. Delivery targets are captured when an event is queued and
-  rechecked against the currently attached set before each send. A per-target
-  delivery lease serializes detach or offline removal with the local Relay
-  enqueue attempt. An explicit disconnect still restores the local controller
-  UI, but reports a warning when host cancellation was not confirmed. This
-  boundary does not change the Relay envelope or add ACK or replay.
+  retain this Peer-only confirmation requirement. The host keeps tracked Turns
+  running when the last controller detaches or goes offline and continues
+  materializing their Runtime projection for a later attach. Actual agent-event
+  subscription lag or closure remains a continuity failure: it cancels tracked
+  Turns and projects the existing dialog-turn-failed terminal event. Terminal
+  ownership remains tracked until the event reaches the delivery attempt, and a
+  closed local delivery queue uses the same direct DeviceEvent path. Delivery
+  targets are captured when an event is queued and rechecked against the
+  currently attached set before each send. A per-target delivery lease serializes
+  detach or offline removal with the local Relay enqueue attempt. An explicit
+  disconnect still restores the local controller UI and reports a warning when
+  the host does not confirm attachment teardown; that uncertainty concerns the
+  control link and controller-scoped interaction cleanup, not cancellation of
+  Host-accepted work. This boundary does not change the Relay envelope or add
+  ACK or replay.
 - Relay `POST /api/devices/:id/rpc` still permits up to **120s** for generic
   callers. Peer controllers normally cancel earlier through their per-command
   10s/30s deadlines; reverse proxies must still accommodate any other caller

--- a/src/apps/cli/src/peer_host/control.rs
+++ b/src/apps/cli/src/peer_host/control.rs
@@ -40,23 +40,28 @@ pub(crate) async fn attach_controller(device_id: String) -> Result<(), String> {
     Ok(())
 }
 
-pub(crate) async fn detach_controller(device_id: &str) -> bool {
+/// Remove one DeviceEvent delivery target.
+///
+/// Controller presence is not Runtime ownership. In particular, removing the
+/// final target must not expose a lifecycle signal that callers could turn into
+/// cancellation of a Host-accepted Turn.
+pub(crate) async fn detach_controller(device_id: &str) {
     let _delivery = controller_delivery().write().await;
-    control_subscribers()
-        .lock()
-        .map(|mut registry| detach_from_registry(&mut registry, device_id))
-        .unwrap_or(false)
+    if let Ok(mut registry) = control_subscribers().lock() {
+        detach_from_registry(&mut registry, device_id);
+    }
 }
 
-pub(crate) async fn retain_online_controllers<'a>(
-    online: impl IntoIterator<Item = &'a str>,
-) -> bool {
+/// Retain only currently reachable DeviceEvent delivery targets.
+///
+/// Losing every target does not end Host-owned Turns; the Runtime projection is
+/// kept for a later controller attachment.
+pub(crate) async fn retain_online_controllers<'a>(online: impl IntoIterator<Item = &'a str>) {
     let online = online.into_iter().collect::<HashSet<_>>();
     let _delivery = controller_delivery().write().await;
-    control_subscribers()
-        .lock()
-        .map(|mut registry| retain_online_in_registry(&mut registry, &online))
-        .unwrap_or(false)
+    if let Ok(mut registry) = control_subscribers().lock() {
+        retain_online_in_registry(&mut registry, &online);
+    }
 }
 
 pub(crate) async fn controller_delivery_lease(
@@ -70,17 +75,14 @@ pub(crate) async fn controller_delivery_lease(
     attached.then_some(lease)
 }
 
-fn detach_from_registry(registry: &mut ControllerRegistry, device_id: &str) -> bool {
-    let was_attached = registry.ids.remove(device_id);
-    was_attached && registry.ids.is_empty()
+fn detach_from_registry(registry: &mut ControllerRegistry, device_id: &str) {
+    registry.ids.remove(device_id);
 }
 
-fn retain_online_in_registry(registry: &mut ControllerRegistry, online: &HashSet<&str>) -> bool {
-    let had_controllers = !registry.ids.is_empty();
+fn retain_online_in_registry(registry: &mut ControllerRegistry, online: &HashSet<&str>) {
     registry
         .ids
         .retain(|device_id| online.contains(device_id.as_str()));
-    had_controllers && registry.ids.is_empty()
 }
 
 pub(crate) fn attached_controllers() -> Vec<String> {
@@ -148,24 +150,31 @@ mod tests {
     };
 
     #[test]
-    fn only_the_last_detach_reports_loss_of_all_controllers() {
+    fn detach_only_updates_delivery_subscribers() {
         let mut registry = ControllerRegistry {
             ids: HashSet::from(["controller-1".to_string(), "controller-2".to_string()]),
         };
-        assert!(!detach_from_registry(&mut registry, "controller-1"));
-        assert!(detach_from_registry(&mut registry, "controller-2"));
-        assert!(!detach_from_registry(&mut registry, "controller-2"));
+        detach_from_registry(&mut registry, "controller-1");
+        assert_eq!(registry.ids, HashSet::from(["controller-2".to_string()]));
+
+        detach_from_registry(&mut registry, "controller-2");
+        assert!(registry.ids.is_empty());
+
+        detach_from_registry(&mut registry, "controller-2");
+        assert!(registry.ids.is_empty());
     }
 
     #[test]
-    fn presence_removal_reports_when_the_last_controller_goes_offline() {
+    fn presence_removal_only_updates_delivery_subscribers() {
         let mut registry = ControllerRegistry {
             ids: HashSet::from(["controller-1".to_string(), "controller-2".to_string()]),
         };
         let first_online = HashSet::from(["controller-1"]);
-        assert!(!retain_online_in_registry(&mut registry, &first_online));
+        retain_online_in_registry(&mut registry, &first_online);
+        assert_eq!(registry.ids, HashSet::from(["controller-1".to_string()]));
 
-        assert!(retain_online_in_registry(&mut registry, &HashSet::new()));
+        retain_online_in_registry(&mut registry, &HashSet::new());
+        assert!(registry.ids.is_empty());
     }
 
     #[tokio::test]

--- a/src/apps/cli/src/peer_host/dispatch.rs
+++ b/src/apps/cli/src/peer_host/dispatch.rs
@@ -268,7 +268,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn attach_detach_updates_subscribers() {
+    async fn attach_detach_only_updates_delivery_subscribers() {
         let _ = handle_host_invoke(
             "peer_control_attach",
             json!({ "controller_device_id": "ctrl-test-1" }),

--- a/src/apps/cli/src/peer_host/fanout.rs
+++ b/src/apps/cli/src/peer_host/fanout.rs
@@ -802,7 +802,7 @@ mod tests {
     }
 
     #[test]
-    fn record_only_gap_keeps_running_turn_owned_until_reattach() {
+    fn zero_controllers_keep_running_turn_owned_until_reattach() {
         let tracker = PeerTurnTracker::new();
         tracker.mark_event_stream_ready();
         let turn = PeerTurnKey::new("session-1", "turn-1");

--- a/src/apps/cli/src/peer_host/state.rs
+++ b/src/apps/cli/src/peer_host/state.rs
@@ -1090,17 +1090,17 @@ mod tests {
     }
 
     #[test]
-    fn detach_reports_any_unconfirmed_cancellation_round() {
+    fn continuity_loss_reports_any_unconfirmed_cancellation_round() {
         assert!(aggregate_cancellation_results(Ok(()), Ok(())).is_ok());
 
         let error =
             aggregate_cancellation_results(Err("initial cancellation failed".to_string()), Ok(()))
-                .expect_err("detach must not hide an unconfirmed cancellation");
+                .expect_err("continuity loss must not hide an unconfirmed cancellation");
         assert!(error.contains("initial cancellation failed"), "{error}");
 
         let error =
             aggregate_cancellation_results(Ok(()), Err("raced cancellation failed".to_string()))
-                .expect_err("detach must report a raced cancellation failure");
+                .expect_err("continuity loss must report a raced cancellation failure");
         assert!(error.contains("raced cancellation failed"), "{error}");
     }
 

--- a/src/web-ui/src/infrastructure/peer-device/PeerConnectionManager.test.ts
+++ b/src/web-ui/src/infrastructure/peer-device/PeerConnectionManager.test.ts
@@ -323,7 +323,7 @@ describe('PeerConnectionManager disposal', () => {
   beforeEach(() => vi.useFakeTimers());
   afterEach(() => vi.useRealTimers());
 
-  it('detaches, disposes the transport, and drops the entry', async () => {
+  it('detaches without issuing a Turn cancellation command', async () => {
     const rpc = createRpc();
     const manager = createManager(rpc.deviceRpc);
     const connection = await manager.connect('peer-1', 'Studio');
@@ -331,6 +331,8 @@ describe('PeerConnectionManager disposal', () => {
     await manager.dispose('peer-1');
 
     expect(rpc.commands()).toContain('peer_control_detach');
+    expect(rpc.commands()).not.toContain('cancel_dialog_turn');
+    expect(rpc.commands()).not.toContain('cancel_acp_dialog_turn');
     expect(connection.adapter.isDisposed()).toBe(true);
     expect(manager.get('peer-1')).toBeUndefined();
     expect(manager.list()).toEqual([]);

--- a/src/web-ui/src/infrastructure/peer-device/PeerConnectionManager.ts
+++ b/src/web-ui/src/infrastructure/peer-device/PeerConnectionManager.ts
@@ -271,9 +271,11 @@ export class PeerConnectionManager {
    * End a control link for good: stop its timers, settle everything still
    * waiting on its transport, then tell the peer.
    *
-   * The detach RPC is last and its failure is re-thrown, because a peer that
-   * did not confirm may still be running our work — the caller decides whether
-   * that is worth surfacing. Local teardown has already completed either way.
+   * The detach RPC is last and its failure is re-thrown because the controller
+   * cannot otherwise confirm that the Host removed its delivery subscription
+   * and finalized controller-scoped interactions. Host-accepted work remains
+   * Host-owned and keeps running either way. Local teardown has already
+   * completed before the RPC settles.
    */
   async dispose(deviceId: string, options: PeerDisposeOptions = {}): Promise<void> {
     const entry = this.entries.get(deviceId);

--- a/src/web-ui/src/locales/en-US/common.json
+++ b/src/web-ui/src/locales/en-US/common.json
@@ -820,7 +820,7 @@
       "switched": "Now showing {{name}}",
       "switchedLocal": "Now showing this device",
       "disconnected": "Disconnected from {{name}}",
-      "disconnectHint": "Stop controlling this device and cancel work it is running for you"
+      "disconnectHint": "Stop controlling this device; work already started there will continue"
     },
     "peerAutoExitOffline": "Remote device \"{{name}}\" went offline — disconnected",
     "peerAutoExitRpc": "Lost connection to remote device \"{{name}}\" — disconnected",

--- a/src/web-ui/src/locales/zh-CN/common.json
+++ b/src/web-ui/src/locales/zh-CN/common.json
@@ -820,7 +820,7 @@
       "switched": "已切换到 {{name}}",
       "switchedLocal": "已切换回本机",
       "disconnected": "已断开 {{name}}",
-      "disconnectHint": "结束对该设备的控制，并取消它正在为你执行的任务"
+      "disconnectHint": "结束对该设备的控制；已开始的任务仍会在该设备上继续执行"
     },
     "peerAutoExitOffline": "远程设备「{{name}}」已离线 — 已断开",
     "peerAutoExitRpc": "与远程设备「{{name}}」连接丢失 — 已断开",

--- a/src/web-ui/src/locales/zh-TW/common.json
+++ b/src/web-ui/src/locales/zh-TW/common.json
@@ -820,7 +820,7 @@
       "switched": "已切換至 {{name}}",
       "switchedLocal": "已切換回本機",
       "disconnected": "已中斷 {{name}} 的連線",
-      "disconnectHint": "結束對該裝置的控制，並取消它正在為你執行的工作"
+      "disconnectHint": "結束對該裝置的控制；已開始的工作仍會在該裝置上繼續執行"
     },
     "peerAutoExitOffline": "遠端裝置「{{name}}」已離線 — 已中斷連線",
     "peerAutoExitRpc": "與遠端裝置「{{name}}」連線遺失 — 已中斷連線",


### PR DESCRIPTION
## Summary

- clarify that disconnect ends the control link while Host-accepted Turns continue running
- remove the CLI control registry signal that could be reused to cancel work when the final controller leaves
- align Peer Device Mode architecture notes and controller teardown comments
- strengthen controller and zero-controller regression coverage

## Verification

- pnpm run fmt:rs
- cargo test -p bitfun-cli peer_host:: (88 passed)
- pnpm --dir src/web-ui run test:run src/infrastructure/peer-device/PeerConnectionManager.test.ts (22 passed)
- pnpm run i18n:audit
- pnpm run check:web:appearance
- pnpm --dir src/web-ui run gen:types
- pnpm run type-check:web
- git diff --check

## Remote scenarios

Peer Device Mode was exercised through controller and CLI Host automated tests, including the zero-controller execution path. No physical two-device end-to-end run was performed. Remote workspace, mobile/IM remote control, and Detached Dispatch are unchanged.