### PR TITLE
fix(scene-bar): keep close target stable on press

### DIFF
--- a/src/web-ui/src/app/components/SceneBar/SceneBar.test.tsx
+++ b/src/web-ui/src/app/components/SceneBar/SceneBar.test.tsx
@@ -189,6 +189,16 @@ describe('SceneBar overflow navigation', () => {
     expect(sceneHarness.closeScene).toHaveBeenCalledWith('settings');
   });
 
+  it('keeps close targets out of press transforms so pointer hit testing stays stable', () => {
+    renderSceneBar();
+    const closeButtons = container.querySelectorAll<HTMLButtonElement>('[data-scene-bar-part="closeTab"]');
+
+    expect(closeButtons.length).toBeGreaterThan(0);
+    for (const closeButton of closeButtons) {
+      expect(closeButton.dataset.motion).toBe('none');
+    }
+  });
+
   it('supports standard middle-click and Delete-key close interactions for session', () => {
     renderSceneBar();
     const sessionTab = container.querySelector<HTMLElement>('[role="tab"][data-bf-value="session"]')!;

--- a/src/web-ui/src/app/components/SceneBar/SceneBar.tsx
+++ b/src/web-ui/src/app/components/SceneBar/SceneBar.tsx
@@ -112,11 +112,14 @@ const SceneBar: React.FC<SceneBarProps> = ({
           )}
         </span>
       ),
+      // Keep the close hit target stationary between pointer down and up;
+      // shrinking it can retarget the click at the button edge (issue #2210).
       endAction: closable ? (
         <button
           type="button"
           aria-label={closeLabel}
           title={closeLabel}
+          data-motion="none"
           data-scene-bar-part="closeTab"
           data-scene-id={tab.id}
           onClick={(event) => {


### PR DESCRIPTION
## Summary

Keep SceneBar close-button hit targets stationary between pointer down and pointer up.

The close buttons now opt out of global press transforms with `data-motion="none"`, preventing edge clicks from being retargeted when the button shrinks. A regression test locks this interaction contract.

Fixes #2210

## Type and Areas

Type:

Regression fix / bug fix / UI/UX / test

Areas:

Web UI — SceneBar

## Motivation / Impact

Scene tab close buttons participate in the global interactive press animation, which scales buttons to `0.97`. When clicking near an edge, that geometric change can move the button out from under the pointer before release, causing the close click to be lost.

This change keeps the close target geometrically stable while preserving its functional and accessible button behavior. Users should be able to close scene tabs reliably with a single click, including at the button edges.

## Verification

- `pnpm --dir src/web-ui run test:run src/app/components/SceneBar/SceneBar.test.tsx`
  - Passed: 1 test file, 6 tests.
- `pnpm run check:web`
  - Passed, including type checking and appearance/theme governance checks.
- `pnpm run motion:audit`
  - Completed with no new findings from this change. The existing `PortForwardDialog.scss` inventory item is unrelated.
- `git diff --check`
  - Passed.

Manual macOS edge-click stress testing is recommended because #2210 was originally reported on macOS and depends on real browser pointer hit testing.

## Reviewer Notes

- The current SceneBar renders close buttons as `TabGroup` sibling `endAction` controls rather than nesting them inside the tab button.
- The fix is intentionally scoped to SceneBar close controls and uses the existing global motion opt-out contract.
- No user-facing strings, persistence formats, protocols, or remote behavior changed.
- Remote scenarios were not separately exercised; this is a shared Web UI pointer interaction.
- AI-assisted change; focused automated verification completed, desktop manual stress testing pending.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.