### PR TITLE
feat(mcp-display): Improve expanded content controls

### DIFF
--- a/src/web-ui/src/flow_chat/tool-cards/MCPToolDisplay.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/MCPToolDisplay.scss
@@ -53,11 +53,24 @@
       flex-direction: column;
     }
 
+    .mcp-copyable-content {
+      position: relative;
+      min-width: 0;
+    }
+
+    .mcp-copy-action {
+      position: absolute;
+      z-index: 1;
+      top: var(--bf-space-1);
+      right: var(--bf-space-1);
+    }
+
     .mcp-input-code {
       max-height: 240px;
       margin: 0;
       overflow: auto;
       padding: var(--bf-control-flow-chat-card-expanded-padding-block) var(--bf-control-flow-chat-card-expanded-padding-inline);
+      padding-inline-end: calc(var(--bf-control-flow-chat-card-expanded-padding-inline) + var(--bf-space-8));
       border: 1px solid var(--bf-color-border-subtle);
       border-radius: var(--bf-radius-sm);
       background: var(--bf-color-action-neutral-surface);
@@ -71,8 +84,11 @@
 
     .text-content {
       pre {
+        max-height: 240px;
         margin: 0;
+        overflow: auto;
         padding: var(--bf-control-flow-chat-card-expanded-padding-block) var(--bf-control-flow-chat-card-expanded-padding-inline);
+        padding-inline-end: calc(var(--bf-control-flow-chat-card-expanded-padding-inline) + var(--bf-space-8));
         background: color-mix(in srgb, var(--bf-color-content-on-light) 20%, transparent);
         border-radius: 4px;
         font-size: var(--bf-type-flow-control-font-size);

--- a/src/web-ui/src/flow_chat/tool-cards/MCPToolDisplay.test.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/MCPToolDisplay.test.tsx
@@ -4,6 +4,7 @@ import { createRoot, type Root } from 'react-dom/client';
 import { JSDOM } from 'jsdom';
 
 import { MCPToolDisplay } from './MCPToolDisplay';
+import { copyTextToClipboard } from '@/shared/utils/textSelection';
 import type { FlowToolItem, ToolCardConfig } from '../types/flow-chat';
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
@@ -42,6 +43,21 @@ vi.mock('@/shared/utils/logger', () => ({
     warn: vi.fn(),
     info: vi.fn(),
   }),
+}));
+
+vi.mock('@/shared/utils/textSelection', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/shared/utils/textSelection')>();
+  return {
+    ...actual,
+    copyTextToClipboard: vi.fn(async () => true),
+  };
+});
+
+vi.mock('@/shared/notification-system', () => ({
+  notificationService: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
 }));
 
 const config: ToolCardConfig = {
@@ -89,6 +105,7 @@ describe('MCPToolDisplay', () => {
     mcpMocks.getMCPToolUiUri.mockReset().mockImplementation(() => new Promise(() => {}));
     mcpMocks.fetchMCPAppResource.mockReset();
     mcpMocks.sendMCPAppMessage.mockReset();
+    vi.mocked(copyTextToClipboard).mockClear();
 
     dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
       pretendToBeVisual: true,
@@ -181,6 +198,49 @@ describe('MCPToolDisplay', () => {
     });
 
     expect(container.querySelector('.mcp-input-code')?.textContent).toContain('"query": "input only"');
+  });
+
+  it('copies the displayed input parameters and each text result', async () => {
+    act(() => {
+      root.render(<MCPToolDisplay toolItem={toolItem()} config={config} />);
+    });
+
+    act(() => {
+      container.querySelector('[data-testid="mcp-tool-card-toggle"]')?.dispatchEvent(
+        new dom.window.MouseEvent('click', { bubbles: true })
+      );
+    });
+
+    const resultCopyButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Copy text result"]',
+    );
+    expect(resultCopyButton).not.toBeNull();
+    expect(container.querySelector('button[aria-label="Copy input parameters"]')).toBeNull();
+
+    act(() => {
+      container.querySelector<HTMLButtonElement>('.mcp-input-disclosure button[aria-expanded]')?.dispatchEvent(
+        new dom.window.MouseEvent('click', { bubbles: true })
+      );
+    });
+
+    const inputCopyButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Copy input parameters"]',
+    );
+    expect(inputCopyButton).not.toBeNull();
+
+    await act(async () => {
+      inputCopyButton?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+    });
+    expect(copyTextToClipboard).toHaveBeenLastCalledWith(
+      '{\n  "query": "BitFun",\n  "limit": 5\n}',
+    );
+
+    await act(async () => {
+      resultCopyButton?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+    });
+    expect(copyTextToClipboard).toHaveBeenLastCalledWith('Search result');
   });
 
   it('keeps failed calls collapsed until the user expands their parameters', () => {

--- a/src/web-ui/src/flow_chat/tool-cards/MCPToolDisplay.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/MCPToolDisplay.tsx
@@ -17,6 +17,7 @@ import { isMcpToolName } from '@/infrastructure/mcp/toolName';
 import { getCachedToolInfo } from '@/infrastructure/mcp/toolInfoCache';
 import { APPEARANCE_DOMAIN_TOKENS } from '@/infrastructure/appearance/appearanceDomainTokens';
 import type { ToolInfo } from '@/shared/types/agent-api';
+import { ToolCardCopyAction } from './ToolCardCopyAction';
 import { useToolCardHeightContract } from './useToolCardHeightContract';
 import './MCPToolDisplay.scss';
 
@@ -739,7 +740,19 @@ export const MCPToolDisplay: React.FC<ToolCardProps> = ({
           summary={t('toolCards.common.inputParams')}
         >
           {formattedToolInput !== null && (
-            <pre className="mcp-input-code">{formattedToolInput}</pre>
+            <div className="mcp-copyable-content">
+              <pre className="mcp-input-code">{formattedToolInput}</pre>
+              <ToolCardCopyAction
+                getText={() => formattedToolInput}
+                tooltip={t('toolCards.common.copy')}
+                copiedTooltip={t('toolCards.common.copied')}
+                successMessage={t('toolCards.common.copied')}
+                failureMessage={t('toolCards.common.copyFailed')}
+                ariaLabel={t('toolCards.mcp.copyInputParams')}
+                className="mcp-copy-action"
+                showSuccessNotification={false}
+              />
+            </div>
           )}
         </Disclosure>
       </div>
@@ -786,7 +799,21 @@ export const MCPToolDisplay: React.FC<ToolCardProps> = ({
             <div data-bf-component="mcp-tool-display" data-bf-part="item" key={index} className={`content-item content-item-${item.type}`}>
               {item.type === 'text' && (
                 <div className="text-content" data-bf-component="mcp-tool-display" data-bf-part="text">
-                  <pre>{item.text}</pre>
+                  <div className="mcp-copyable-content">
+                    <pre>{item.text}</pre>
+                    {typeof item.text === 'string' && item.text.length > 0 && (
+                      <ToolCardCopyAction
+                        getText={() => item.text ?? ''}
+                        tooltip={t('toolCards.common.copy')}
+                        copiedTooltip={t('toolCards.common.copied')}
+                        successMessage={t('toolCards.common.copied')}
+                        failureMessage={t('toolCards.common.copyFailed')}
+                        ariaLabel={t('toolCards.mcp.copyTextResult')}
+                        className="mcp-copy-action"
+                        showSuccessNotification={false}
+                      />
+                    )}
+                  </div>
                 </div>
               )}
               {item.type === 'image' && item.data && (

--- a/src/web-ui/src/infrastructure/config/components/WebSearchSettingsPage.scss
+++ b/src/web-ui/src/infrastructure/config/components/WebSearchSettingsPage.scss
@@ -42,15 +42,15 @@
 
     h4 {
       color: var(--bf-color-content-primary);
-      font-size: var(--bf-font-size-sm);
-      font-weight: var(--bf-font-weight-semibold);
-      line-height: var(--bf-line-height-dense);
+      font-size: var(--bf-type-label-selected-font-size);
+      font-weight: var(--bf-type-label-selected-font-weight);
+      line-height: var(--bf-type-modifier-leading-dense-line-height);
     }
 
     p {
       color: var(--bf-color-content-secondary);
-      font-size: var(--bf-font-size-meta);
-      line-height: var(--bf-line-height-snug);
+      font-size: var(--bf-type-meta-font-size);
+      line-height: var(--bf-type-modifier-leading-snug-line-height);
     }
 
     pre {
@@ -62,9 +62,9 @@
       border-radius: var(--bf-radius-sm);
       background: var(--bf-color-action-neutral-surface-hover);
       color: var(--bf-color-content-primary);
-      font-family: var(--bf-font-family-mono);
-      font-size: var(--bf-font-size-xs);
-      line-height: var(--bf-line-height-relaxed);
+      font-family: var(--bf-type-code-sm-font-family);
+      font-size: var(--bf-type-code-sm-font-size);
+      line-height: var(--bf-type-code-sm-line-height);
       white-space: pre-wrap;
     }
   }
@@ -75,7 +75,7 @@
     margin: 0;
     padding-inline-start: var(--bf-space-5);
     color: var(--bf-color-content-secondary);
-    font-size: var(--bf-font-size-meta);
-    line-height: var(--bf-line-height-snug);
+    font-size: var(--bf-type-meta-font-size);
+    line-height: var(--bf-type-modifier-leading-snug-line-height);
   }
 }

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -2004,6 +2004,8 @@
       "interactiveApp": "interactive app",
       "actionLabel": "MCP:",
       "failedLabel": "MCP failed",
+      "copyInputParams": "Copy input parameters",
+      "copyTextResult": "Copy text result",
       "executionFailed": "MCP execution failed"
     },
     "acpPermission": {

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -2004,6 +2004,8 @@
       "interactiveApp": "交互应用",
       "actionLabel": "MCP：",
       "failedLabel": "MCP 失败",
+      "copyInputParams": "复制输入参数",
+      "copyTextResult": "复制文本结果",
       "executionFailed": "MCP 执行失败"
     },
     "acpPermission": {

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -2004,6 +2004,8 @@
       "interactiveApp": "交互應用",
       "actionLabel": "MCP：",
       "failedLabel": "MCP 失敗",
+      "copyInputParams": "複製輸入參數",
+      "copyTextResult": "複製文字結果",
       "executionFailed": "MCP 執行失敗"
     },
     "acpPermission": {


### PR DESCRIPTION
Previously, long text results could grow the MCP card indefinitely,
and input parameters or text results had no direct copy action.

- Limit long text results to a scrollable 240px viewport
- Add localized copy actions for formatted input and text results
- Cover copied payloads and disclosure visibility with regression tests
