### PR TITLE
fix(ui): keep parent session highlighted

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.tsx
+++ b/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.tsx
@@ -1034,6 +1034,11 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
     return out;
   }, [sessionDisplayLimit, topLevelSessions, visibleChildrenByParent]);
 
+  const visibleSessionIds = useMemo(
+    () => new Set(visibleItems.map(item => item.session.sessionId)),
+    [visibleItems],
+  );
+
   const visibleRowSignature = useMemo(
     () => visibleItems.map(item => item.session.sessionId).join('|'),
     [visibleItems],
@@ -1670,6 +1675,9 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
             activeSessionId,
             activeChildSessionId: activeBtwSessionData?.childSessionId,
             activeChildParentSessionId: activeBtwSessionData?.parentSessionId,
+            activeChildHasVisibleRow: activeBtwSessionData?.childSessionId
+              ? visibleSessionIds.has(activeBtwSessionData.childSessionId)
+              : false,
           });
           // Determine the notification state for this session row.
           // Priority: needsUserAttention > hasUnreadCompletion.

--- a/src/web-ui/src/app/components/NavPanel/sections/sessions/sessionNavSelection.test.ts
+++ b/src/web-ui/src/app/components/NavPanel/sections/sessions/sessionNavSelection.test.ts
@@ -10,6 +10,7 @@ describe('isSessionNavRowActive', () => {
         activeSessionId: 'session-2',
         activeChildSessionId: 'child-1',
         activeChildParentSessionId: 'session-1',
+        activeChildHasVisibleRow: true,
       }),
     ).toBe(false);
 
@@ -20,6 +21,7 @@ describe('isSessionNavRowActive', () => {
         activeSessionId: 'session-2',
         activeChildSessionId: 'child-1',
         activeChildParentSessionId: 'session-1',
+        activeChildHasVisibleRow: true,
       }),
     ).toBe(true);
   });
@@ -32,6 +34,7 @@ describe('isSessionNavRowActive', () => {
         activeSessionId: 'session-1',
         activeChildSessionId: 'child-1',
         activeChildParentSessionId: 'session-1',
+        activeChildHasVisibleRow: true,
       }),
     ).toBe(true);
 
@@ -42,6 +45,31 @@ describe('isSessionNavRowActive', () => {
         activeSessionId: 'session-1',
         activeChildSessionId: 'child-1',
         activeChildParentSessionId: 'session-1',
+        activeChildHasVisibleRow: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('keeps the parent highlighted when the active child has no visible nav row', () => {
+    expect(
+      isSessionNavRowActive({
+        rowSessionId: 'session-1',
+        activeTabId: 'session',
+        activeSessionId: 'session-1',
+        activeChildSessionId: 'child-1',
+        activeChildParentSessionId: 'session-1',
+        activeChildHasVisibleRow: false,
+      }),
+    ).toBe(true);
+
+    expect(
+      isSessionNavRowActive({
+        rowSessionId: 'child-1',
+        activeTabId: 'session',
+        activeSessionId: 'session-1',
+        activeChildSessionId: 'child-1',
+        activeChildParentSessionId: 'session-1',
+        activeChildHasVisibleRow: false,
       }),
     ).toBe(false);
   });

--- a/src/web-ui/src/app/components/NavPanel/sections/sessions/sessionNavSelection.ts
+++ b/src/web-ui/src/app/components/NavPanel/sections/sessions/sessionNavSelection.ts
@@ -4,6 +4,7 @@ interface SessionNavRowActiveInput {
   activeSessionId?: string | null;
   activeChildSessionId?: string | null;
   activeChildParentSessionId?: string | null;
+  activeChildHasVisibleRow: boolean;
 }
 
 const SESSION_TAB_ID = 'session';
@@ -14,12 +15,17 @@ export function isSessionNavRowActive({
   activeSessionId,
   activeChildSessionId,
   activeChildParentSessionId,
+  activeChildHasVisibleRow,
 }: SessionNavRowActiveInput): boolean {
   if (activeTabId !== SESSION_TAB_ID || !activeSessionId) {
     return false;
   }
 
-  if (activeChildSessionId && activeChildParentSessionId === activeSessionId) {
+  if (
+    activeChildHasVisibleRow &&
+    activeChildSessionId &&
+    activeChildParentSessionId === activeSessionId
+  ) {
     return rowSessionId === activeChildSessionId;
   }
 


### PR DESCRIPTION
Previously, opening a hidden subagent session transferred navigation
selection to a row that was not rendered, exposing the workspace card
highlight instead.

Only transfer selection to an auxiliary child when its row is visible.
Keep visible child behavior unchanged and cover the hidden-child fallback.
