### PR TITLE
fix(peer): restore AskUserQuestion interactions

### DIFF
--- a/docs/architecture/peer-device-mode.md
+++ b/docs/architecture/peer-device-mode.md
@@ -136,6 +136,16 @@ ordering, so an old response cannot erase a newer request or revive one that was
 already answered. Reattachment only repairs presentation state: it never
 restarts, cancels, or moves the Session, Dialog Turn, or Tool future.
 
+Rendering a mailbox entry and answering it are separate compatibility
+contracts. A Peer Host that accepts `submit_user_answers` advertises
+`peer_mode_ping.capabilities.user_question_response`. Older Desktop hosts are
+compatible because they already exposed the command; older CLI hosts are not,
+so controllers must leave the card visible but disabled with an explicit
+upgrade/unsupported state instead of sending a mutation that cannot complete.
+Current controllers include the owning Session id, and the host rejects an
+answer when that Session no longer owns the pending Tool id. New hosts retain
+the legacy process-wide Tool-id form for older controllers that omit Session id.
+
 This is the contract for any new blocking interaction: its execution owner must
 retain replayable request state and expose it through an attach/snapshot path.
 A one-shot frontend event plus an unresolved channel is not a complete

--- a/src/apps/cli/src/peer_host/commands/dialog.rs
+++ b/src/apps/cli/src/peer_host/commands/dialog.rs
@@ -7,6 +7,7 @@ use std::time::{Duration, Instant};
 use serde_json::{json, Value};
 use tokio::sync::Mutex as AsyncMutex;
 
+use bitfun_agent_runtime::sdk::AgentUserAnswersRequest;
 use bitfun_runtime_ports::{
     AgentDialogTurnRequest, AgentSubmissionSource, AgentTurnCancellationRequest,
     DialogSubmissionPolicy, DialogTriggerSource,
@@ -234,14 +235,10 @@ pub(crate) async fn cancel_dialog_turn(
 /// This reaches the Core-owned coordinator via the same compatibility surface
 /// the Desktop `cancel_tool` Tauri command uses — one level finer than
 /// `cancel_dialog_turn`.
-pub(crate) async fn cancel_tool(
-    state: &PeerHostState,
-    args: &Value,
-) -> Result<Value, String> {
+pub(crate) async fn cancel_tool(state: &PeerHostState, args: &Value) -> Result<Value, String> {
     let request = request_value(args);
     let tool_use_id = get_string(request, "toolUseId")?;
-    let reason = optional_string(request, "reason")
-        .unwrap_or_else(|| "User cancelled".to_string());
+    let reason = optional_string(request, "reason").unwrap_or_else(|| "User cancelled".to_string());
     state
         .compatibility
         .cancel_tool(&tool_use_id, reason)
@@ -249,11 +246,97 @@ pub(crate) async fn cancel_tool(
     Ok(json!({ "success": true }))
 }
 
+fn parse_user_answer_submission(
+    args: &Value,
+) -> Result<(Option<String>, AgentUserAnswersRequest), String> {
+    let request = request_value(args);
+    let session_id = optional_string(request, "sessionId");
+    let tool_id = get_string(request, "toolId")?;
+    let answers = request
+        .get("answers")
+        .cloned()
+        .ok_or_else(|| "Missing 'answers' field".to_string())?;
+    Ok((session_id, AgentUserAnswersRequest { tool_id, answers }))
+}
+
+/// Deliver an answer to the Runtime-owned AskUserQuestion mailbox.
+///
+/// Restoring a Peer session already exposes the pending question snapshot. The
+/// response must terminate on the same host as the waiting Tool future; before
+/// this handler existed a CLI peer could render that snapshot but every click
+/// fell through to the unsupported-command branch.
+pub(crate) async fn submit_user_answers(
+    state: &PeerHostState,
+    args: &Value,
+) -> Result<Value, String> {
+    let (session_id, submission) = parse_user_answer_submission(args)?;
+    let tool_id = submission.tool_id.clone();
+
+    if let Some(session_id) = session_id.as_deref() {
+        // Tool ids are process-wide, but current controllers scope the Peer
+        // request to a Session. Keep a stale card from one Session from
+        // answering an interaction rendered from another Session; the Runtime
+        // remains the final arbiter for concurrent answers after this check.
+        let interaction_snapshot = state.agent_runtime.session_interaction_snapshot(session_id);
+        if !interaction_snapshot
+            .user_questions
+            .questions
+            .iter()
+            .any(|question| question.tool_id == tool_id)
+        {
+            return Err(format!(
+                "No pending user question '{tool_id}' exists for session '{session_id}'"
+            ));
+        }
+    }
+
+    // Legacy controllers did not send `sessionId`. Keep their process-wide
+    // Tool-id path working against this newer host, matching Desktop's
+    // long-standing command shape; the Runtime still consumes each answer at
+    // most once.
+    state
+        .agent_runtime
+        .submit_user_answers(submission)
+        .await
+        .map_err(|error| {
+            format!(
+                "Failed to submit user answers for tool '{tool_id}': {}",
+                error.into_message()
+            )
+        })?;
+
+    Ok(json!({ "success": true }))
+}
+
 #[cfg(test)]
 mod tests {
     use serde_json::json;
 
-    use super::{dialog_submission_slot, peer_dialog_metadata};
+    use super::{dialog_submission_slot, parse_user_answer_submission, peer_dialog_metadata};
+
+    #[test]
+    fn user_answer_submission_accepts_legacy_and_session_scoped_payloads() {
+        let (legacy_session, legacy) = parse_user_answer_submission(&json!({
+            "toolId": "ask-legacy",
+            "answers": { "0": "Yes" }
+        }))
+        .expect("legacy answer payload");
+        assert_eq!(legacy_session, None);
+        assert_eq!(legacy.tool_id, "ask-legacy");
+        assert_eq!(legacy.answers, json!({ "0": "Yes" }));
+
+        let (session, current) = parse_user_answer_submission(&json!({
+            "request": {
+                "sessionId": "session-1",
+                "toolId": "ask-current",
+                "answers": { "0": ["A", "B"] }
+            }
+        }))
+        .expect("session-scoped answer payload");
+        assert_eq!(session.as_deref(), Some("session-1"));
+        assert_eq!(current.tool_id, "ask-current");
+        assert_eq!(current.answers, json!({ "0": ["A", "B"] }));
+    }
 
     #[test]
     fn peer_metadata_removes_reserved_runtime_fields() {

--- a/src/apps/cli/src/peer_host/commands/mod.rs
+++ b/src/apps/cli/src/peer_host/commands/mod.rs
@@ -116,6 +116,7 @@ pub(crate) async fn dispatch(
         // Dialog / tools
         "start_dialog_turn" => dialog::start_dialog_turn(state, args).await,
         "cancel_dialog_turn" => dialog::cancel_dialog_turn(state, args).await,
+        "submit_user_answers" => dialog::submit_user_answers(state, args).await,
         // Per-tool interrupt. The controller renders Terminal cards for Turns
         // this host owns, so it must be able to stop a running tool here —
         // same owner as cancel_dialog_turn, one level finer. Reaches the Core

--- a/src/apps/cli/src/peer_host/control.rs
+++ b/src/apps/cli/src/peer_host/control.rs
@@ -104,23 +104,23 @@ pub(crate) fn peer_mode_ping_value() -> Value {
         "device_id": device_id,
         // Declares which kind of host answered so the controller can resolve
         // capabilities that an older CLI did not advertise. An older CLI
-        // (pre-`50b76516`) omits `cancel_tool`/`tool_catalog` and never
-        // implemented them; reporting `host_type: "cli"` lets the controller
-        // gate the Terminal Interrupt button / tool list off instead of showing
-        // an action that silently fails. See PR #2428 round 5 #1.
+        // (pre-`50b76516`) omits `cancel_tool`/`tool_catalog`, and older CLI
+        // hosts also lack `submit_user_answers`; reporting `host_type: "cli"`
+        // lets the controller gate those controls instead of showing actions
+        // that silently fail. See PR #2428 round 5 #1.
         "host_type": "cli",
         "capabilities": {
             "idempotent_dialog_submit": true,
             "targeted_session_rollback": true,
             "token_usage_statistics": true,
             "product_control_v1": true,
-            // Per-tool interrupt and read-only tool catalog are implemented on
-            // this host (see commands::dialog::cancel_tool and
-            // commands::tools::get_all_tools_info). Advertising them lets the
-            // controller gate the Terminal Interrupt button and the tool
-            // catalog UI on a real capability instead of guessing.
+            // Per-tool interrupt, read-only tool catalog, and Runtime-owned
+            // question responses are implemented on this host. Advertising
+            // them lets the controller gate the matching UI on real
+            // capabilities instead of guessing.
             "cancel_tool": true,
             "tool_catalog": true,
+            "user_question_response": true,
         },
     })
 }

--- a/src/apps/cli/src/peer_host/dispatch.rs
+++ b/src/apps/cli/src/peer_host/dispatch.rs
@@ -176,6 +176,10 @@ mod tests {
                     value.pointer("/capabilities/tool_catalog"),
                     Some(&json!(true))
                 );
+                assert_eq!(
+                    value.pointer("/capabilities/user_question_response"),
+                    Some(&json!(true))
+                );
             }
             other => panic!("unexpected response: {other:?}"),
         }
@@ -254,8 +258,8 @@ mod tests {
     /// branch, not here — that is caught by the capability advertisement +
     /// frontend gate instead.
     #[test]
-    fn cancel_tool_and_tool_catalog_are_not_refused_before_dispatch() {
-        for command in ["cancel_tool", "get_all_tools_info"] {
+    fn interactive_tools_and_tool_catalog_are_not_refused_before_dispatch() {
+        for command in ["cancel_tool", "get_all_tools_info", "submit_user_answers"] {
             assert!(
                 !is_local_only_command(command),
                 "{command} must be routable to the peer host"

--- a/src/apps/desktop/src/api/peer_host_invoke.rs
+++ b/src/apps/desktop/src/api/peer_host_invoke.rs
@@ -470,6 +470,7 @@ pub async fn peer_mode_ping() -> Result<Value, String> {
             // catalog UI on these the same way it does on the CLI peer host.
             "cancel_tool": true,
             "tool_catalog": true,
+            "user_question_response": true,
         },
     }))
 }
@@ -635,6 +636,12 @@ mod tests {
         assert_eq!(
             value
                 .pointer("/capabilities/tool_catalog")
+                .and_then(Value::as_bool),
+            Some(true)
+        );
+        assert_eq!(
+            value
+                .pointer("/capabilities/user_question_response")
                 .and_then(Value::as_bool),
             Some(true)
         );

--- a/src/crates/services/services-integrations/src/remote_ssh/manager.rs
+++ b/src/crates/services/services-integrations/src/remote_ssh/manager.rs
@@ -7421,10 +7421,15 @@ mod tests {
 
     fn assert_fixture_server_disconnected(result: Result<(), russh::Error>) {
         // Only used after the assertions and an explicit client disconnect.
-        // russh may observe the closing transport before the disconnect frame.
+        // russh may observe the closing transport before the disconnect frame;
+        // Darwin reports that race as ConnectionReset instead of UnexpectedEof.
         match result {
             Ok(()) => {}
-            Err(russh::Error::IO(error)) if error.kind() == std::io::ErrorKind::UnexpectedEof => {}
+            Err(russh::Error::IO(error))
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::UnexpectedEof | std::io::ErrorKind::ConnectionReset
+                ) => {}
             Err(error) => panic!("SSH fixture failed during disconnect: {error:?}"),
         }
     }

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.test.ts
@@ -474,6 +474,50 @@ describe('PeerSessionRefreshModule re-attach after a surface switch', () => {
     cleanup();
   });
 
+  it('reconciles the blocking mailbox when the Runtime projection is already current', async () => {
+    stateMachineMock.get.mockReturnValue({
+      getCurrentState: () => 'processing',
+      getContext: () => ({ lastUpdateTime: Date.now(), version: 0 }),
+    });
+    const pendingUserQuestions = {
+      revision: 5,
+      questions: [{
+        toolId: 'ask-tool-1',
+        sessionId: 'session-1',
+        dialogTurnId: 'turn-live',
+        modelRoundId: 'round-0',
+        questions: { questions: [] },
+        registeredAtMs: 1,
+      }],
+    };
+    const refresh = vi.fn(async () => ({
+      applied: false,
+      backendState: 'Processing { current_turn_id: "turn-live", phase: ToolExecution }',
+      latestTurnId: 'turn-live',
+      latestTurnStatus: 'processing',
+      runtimeEventReplayRequired: false,
+      runtimeEventSnapshot: {
+        sessionId: 'session-1',
+        streamId: 'runtime-a',
+        cursor: 8,
+        activeTurnId: 'turn-live',
+        events: [],
+      },
+      pendingUserQuestions,
+    }));
+    const context = contextWithSnapshot(refresh);
+
+    const cleanup = installPeerSessionRefresh(context);
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(context.flowChatStore.reconcilePendingUserQuestions).toHaveBeenCalledWith(
+      'session-1',
+      pendingUserQuestions,
+    );
+    expect(agenticListenerMock.dispatchExternal).not.toHaveBeenCalled();
+    cleanup();
+  });
+
   it('replays the Runtime journal even when persist merge was skipped', async () => {
     stateMachineMock.get.mockReturnValue({
       getCurrentState: () => 'processing',

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.ts
@@ -560,8 +560,16 @@ export function installPeerSessionRefresh(context: FlowChatContext): () => void 
         const alreadyCurrent = result.runtimeEventReplayRequired === false
           && runtimeProjectionCaughtUp(restoredSession, snapshot);
         if (alreadyCurrent) {
-          // Cursor match is not enough: the UI must already show journal
-          // terminal tools before we cover those events.
+          // Runtime cursor health and blocking-interaction health are separate
+          // projections. A live event can win the restore race after the
+          // persisted merge, leaving an AskUserQuestion card visible but
+          // unbound/disabled even though every journal event is already
+          // painted. Always reconcile the Runtime mailbox before covering the
+          // cursor.
+          context.flowChatStore.reconcilePendingUserQuestions(
+            sessionId,
+            result.pendingUserQuestions,
+          );
           attachment.finish({
             streamId: snapshot.streamId,
             cursor: snapshot.cursor,
@@ -642,6 +650,14 @@ export function installPeerSessionRefresh(context: FlowChatContext): () => void 
       // and retain the existing persisted-snapshot reconciliation fallback.
       attachment.abort();
       attachmentFinished = true;
+      // `interactionSnapshot` was introduced independently of the Runtime
+      // journal. Apply it even when the persisted Turn merge lost a race; its
+      // own monotonic revision fence makes this safe and keeps the form bound
+      // to the owner mailbox.
+      context.flowChatStore.reconcilePendingUserQuestions(
+        sessionId,
+        result.pendingUserQuestions,
+      );
       if (!result.applied) {
         // A snapshot that changed nothing — or that was refused because it
         // would have dropped projected content — still reports whether the

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
@@ -1881,11 +1881,15 @@ describe('FlowChatStore historical session hydration state', () => {
       activeSessionId: 'history-1',
     }));
 
-    await flowChatStore.refreshPeerSessionSnapshot(
+    const firstRefresh = await flowChatStore.refreshPeerSessionSnapshot(
       'history-1',
       '/Users/host/project',
       { replaceRunningSnapshot: false },
     );
+    expect(firstRefresh.pendingUserQuestions).toEqual({
+      revision: 7,
+      questions: [pendingQuestion],
+    });
 
     const recoveredTurn = flowChatStore
       .getState()
@@ -2022,6 +2026,69 @@ describe('FlowChatStore historical session hydration state', () => {
       questions: [],
     })).toBe(true);
     expect(askUserQuestionDraftStore.getState().drafts[draftKey]).toBeUndefined();
+  });
+
+  it('re-enables a same-revision mailbox card changed back to parameter streaming', () => {
+    flowChatStore.setState(() => ({
+      sessions: new Map([[
+        'history-1',
+        createSession({
+          sessionId: 'history-1',
+          dialogTurns: [{
+            id: 'turn-live',
+            sessionId: 'history-1',
+            userMessage: { id: 'user-live', content: 'ask me', timestamp: 1 },
+            modelRounds: [],
+            status: 'processing',
+            startTime: 1,
+          }],
+        }),
+      ]]),
+      activeSessionId: 'history-1',
+    }));
+    const snapshot = {
+      revision: 4,
+      questions: [{
+        toolId: 'ask-tool-1',
+        sessionId: 'history-1',
+        dialogTurnId: 'turn-live',
+        modelRoundId: 'round-question',
+        questions: {
+          questions: [{
+            question: 'Continue?',
+            header: 'Choice',
+            options: [{ label: 'Yes', description: 'Continue.' }],
+          }],
+        },
+        registeredAtMs: 3,
+      }],
+    };
+
+    expect(flowChatStore.reconcilePendingUserQuestions('history-1', snapshot)).toBe(true);
+    flowChatStore.setState(prev => {
+      const session = prev.sessions.get('history-1')!;
+      const dialogTurns = [...session.dialogTurns];
+      const modelRounds = [...dialogTurns[0].modelRounds];
+      const items = [...modelRounds[0].items];
+      items[0] = {
+        ...items[0],
+        isParamsStreaming: true,
+      } as any;
+      modelRounds[0] = { ...modelRounds[0], items };
+      dialogTurns[0] = { ...dialogTurns[0], modelRounds };
+      const sessions = new Map(prev.sessions);
+      sessions.set('history-1', { ...session, dialogTurns });
+      return { ...prev, sessions };
+    });
+
+    expect(flowChatStore.reconcilePendingUserQuestions('history-1', snapshot)).toBe(true);
+    expect(
+      flowChatStore.getState().sessions.get('history-1')
+        ?.dialogTurns[0].modelRounds[0].items[0],
+    ).toMatchObject({
+      status: 'waiting',
+      isParamsStreaming: false,
+    });
   });
 
   it('acquires an empty current-Turn base for Runtime event replay before applying interactions', async () => {

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.ts
@@ -952,7 +952,10 @@ function reconcilePendingUserQuestionSnapshot(
       : undefined;
     const alreadyProjected =
       existing?._runtimeInteractionProjection?.revision === snapshot.revision &&
-      existing.status === 'waiting';
+      existing.status === 'waiting' &&
+      existing.toolName === 'AskUserQuestion' &&
+      existing.isParamsStreaming === false &&
+      existing.toolResult === undefined;
     if (!alreadyProjected) {
       const projected: FlowToolItem = {
         ...(existing || {
@@ -7720,11 +7723,13 @@ export class FlowChatStore {
       backendState: restored.session.state,
       latestTurnId: latestTurn?.id,
       latestTurnStatus: latestTurn?.status,
+      ...(pendingUserQuestions && scope.isCurrent()
+        ? { pendingUserQuestions }
+        : {}),
       ...(runtimeEventSnapshot && scope.isCurrent()
         ? {
             runtimeEventSnapshot,
             runtimeEventReplayRequired,
-            pendingUserQuestions,
           }
         : {}),
     };

--- a/src/web-ui/src/flow_chat/tool-cards/AskUserQuestionCard.test.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/AskUserQuestionCard.test.tsx
@@ -9,6 +9,7 @@ import {
   LOCAL_SURFACE_ID,
   activateSurface,
 } from '@/infrastructure/peer-device/deviceSurface';
+import { PeerDeviceContext } from '@/infrastructure/peer-device/peerDeviceContextState';
 import { askUserQuestionDraftStore } from '../store/askUserQuestionDraftStore';
 
 vi.mock('react-i18next', () => ({
@@ -190,6 +191,71 @@ describe('AskUserQuestionCard', () => {
     ).toBe(true);
   });
 
+  it('switches to the draft owned by the newly activated device surface', () => {
+    act(() => {
+      root.render(
+        <AskUserQuestionCard
+          toolItem={questionTool('pending_confirmation')}
+          config={config}
+          sessionId="session-a"
+          isLastItem
+        />,
+      );
+    });
+
+    const localRadio = container.querySelector<HTMLInputElement>('input[value="PostgreSQL"]');
+    act(() => localRadio?.click());
+    expect(localRadio?.checked).toBe(true);
+
+    act(() => {
+      activateSurface('peer-device-b');
+    });
+
+    expect(
+      container.querySelector<HTMLInputElement>('input[value="PostgreSQL"]')?.checked,
+    ).toBe(false);
+  });
+
+  it('explains why an older CLI peer cannot answer instead of exposing a dead form', () => {
+    activateSurface('peer-cli');
+    act(() => {
+      root.render(
+        <PeerDeviceContext.Provider value={{
+          peerMode: { active: true, deviceId: 'peer-cli', deviceName: 'CLI' },
+          attachments: [],
+          currentPeerCapabilities: {
+            idempotentDialogSubmit: true,
+            targetedSessionRollback: true,
+            tokenUsageStatistics: true,
+            miniAppAgentContextFilesV1: false,
+            cancelTool: false,
+            toolCatalog: false,
+            userQuestionResponse: null,
+            hostKind: 'cli',
+          },
+          switchToDevice: vi.fn(),
+          switchToLocal: vi.fn(),
+          disconnectDevice: vi.fn(),
+          disconnectAllDevices: vi.fn(),
+        }}>
+          <AskUserQuestionCard
+            toolItem={questionTool('pending_confirmation')}
+            config={config}
+            sessionId="session-a"
+            isLastItem
+          />
+        </PeerDeviceContext.Provider>,
+      );
+    });
+
+    expect(container.querySelector('[data-bf-component="ask-user"]')?.getAttribute('data-bf-state'))
+      .toBe('error');
+    expect(container.querySelector('[data-bf-part="status-label"]')?.textContent)
+      .toBe('toolCards.askUser.unsupportedOnPeer');
+    expect(container.querySelector<HTMLInputElement>('input[value="PostgreSQL"]')?.disabled)
+      .toBe(true);
+  });
+
   it('restores an unsubmitted custom input after the card is remounted', () => {
     const renderCard = () => {
       root.render(
@@ -305,6 +371,33 @@ describe('AskUserQuestionCard', () => {
     expect(toolAPI.submitUserAnswers).toHaveBeenCalledWith(
       'question-tool-1',
       { 0: ['PostgreSQL'] },
+      'session-a',
     );
+  });
+
+  it('keeps the form retryable and reports a failed response submission', async () => {
+    vi.mocked(toolAPI.submitUserAnswers).mockRejectedValueOnce(new Error('peer unavailable'));
+    act(() => {
+      root.render(
+        <AskUserQuestionCard
+          toolItem={questionTool('pending_confirmation')}
+          config={config}
+          sessionId="session-a"
+          isLastItem
+        />,
+      );
+    });
+
+    act(() => {
+      container.querySelector<HTMLInputElement>('input[value="PostgreSQL"]')?.click();
+    });
+    const submitButton = container.querySelector<HTMLButtonElement>(
+      '[data-bf-part="submit"] button',
+    );
+    await act(async () => submitButton?.click());
+
+    expect(container.querySelector('[data-bf-part="status-label"]')?.textContent)
+      .toBe('toolCards.askUser.submitFailed');
+    expect(submitButton?.disabled).toBe(false);
   });
 });

--- a/src/web-ui/src/flow_chat/tool-cards/AskUserQuestionCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/AskUserQuestionCard.tsx
@@ -18,10 +18,17 @@ import React, {
   useLayoutEffect,
   useMemo,
   useState,
+  useSyncExternalStore,
 } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toolAPI } from '@/infrastructure/api/service-api/ToolAPI';
-import { getActiveSurfaceId } from '@/infrastructure/peer-device/deviceSurface';
+import {
+  getActiveSurfaceScope,
+  isSurfaceChangedError,
+  onSurfaceActivated,
+} from '@/infrastructure/peer-device/deviceSurface';
+import { canSubmitUserQuestionsOnSurface } from '@/infrastructure/peer-device/peerCapabilityResolution';
+import { usePeerDeviceModeOptional } from '@/infrastructure/peer-device/peerDeviceContextState';
 import { createLogger } from '@/shared/utils/logger';
 import type { FlowToolItem, ToolCardProps } from '../types/flow-chat';
 import {
@@ -35,6 +42,8 @@ import { useToolCardHeightContract } from './useToolCardHeightContract';
 
 const log = createLogger('AskUserQuestionCard');
 const OTHER_OPTION_VALUE = 'Other';
+const subscribeToSurfaceActivation = (listener: () => void): (() => void) =>
+  onSurfaceActivated(() => listener());
 
 interface QuestionOption {
   description: string;
@@ -125,6 +134,12 @@ export const AskUserQuestionCard: React.FC<ToolCardProps> = ({
   sessionId,
 }) => {
   const { t } = useTranslation('flow-chat');
+  const peerDevice = usePeerDeviceModeOptional();
+  const activeSurfaceScope = useSyncExternalStore(
+    subscribeToSurfaceActivation,
+    getActiveSurfaceScope,
+    getActiveSurfaceScope,
+  );
   const { status, toolCall, toolResult, isParamsStreaming, partialParams } = toolItem;
   const paramsSource = partialParams || toolCall?.input;
   const questions = useMemo(
@@ -139,7 +154,11 @@ export const AskUserQuestionCard: React.FC<ToolCardProps> = ({
 
   const toolId = toolItem.id ?? toolCall?.id;
   const draftToolId = toolCall?.id || toolId;
-  const activeSurfaceId = getActiveSurfaceId();
+  const activeSurfaceId = activeSurfaceScope.surfaceId;
+  const canSubmitUserAnswers = canSubmitUserQuestionsOnSurface(
+    peerDevice?.peerMode.active === true,
+    peerDevice?.currentPeerCapabilities ?? null,
+  );
   const draftKey = useMemo(
     () => sessionId && draftToolId
       ? askUserQuestionDraftKey(sessionId, draftToolId, activeSurfaceId)
@@ -154,6 +173,7 @@ export const AskUserQuestionCard: React.FC<ToolCardProps> = ({
   const { answers, otherInputs, submissionPhase } = draft;
   const isSubmitting = submissionPhase === 'submitting';
   const isSubmitted = submissionPhase === 'submitted';
+  const [submissionFailed, setSubmissionFailed] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
   const [showCompletedSummary, setShowCompletedSummary] = useState(status === 'completed');
   const { cardRootRef, applyExpandedState } = useToolCardHeightContract({
@@ -177,6 +197,10 @@ export const AskUserQuestionCard: React.FC<ToolCardProps> = ({
       setShowCompletedSummary(false);
     }
   }, [applyExpandedState, isLastItem, showCompletedSummary, status]);
+
+  useEffect(() => {
+    setSubmissionFailed(false);
+  }, [draftKey]);
 
   useEffect(() => {
     if (
@@ -316,10 +340,12 @@ export const AskUserQuestionCard: React.FC<ToolCardProps> = ({
   }, [draftKey]);
 
   const handleSubmit = useCallback(async () => {
-    if (!isAllAnswered() || isSubmitting || isSubmitted) return;
+    if (!canSubmitUserAnswers || !isAllAnswered() || isSubmitting || isSubmitted) return;
 
+    setSubmissionFailed(false);
     setSubmissionPhase('submitting');
     try {
+      activeSurfaceScope.assertCurrent('submitUserAnswers');
       const processedAnswers: Record<string, string | string[]> = {};
 
       for (let index = 0; index < questions.length; index += 1) {
@@ -339,20 +365,28 @@ export const AskUserQuestionCard: React.FC<ToolCardProps> = ({
         }
       }
 
-      await toolAPI.submitUserAnswers(toolId, processedAnswers);
+      await toolAPI.submitUserAnswers(toolId, processedAnswers, sessionId);
+      activeSurfaceScope.assertCurrent('submitUserAnswers');
       setSubmissionPhase('submitted');
     } catch (error) {
-      log.error('Failed to submit answers', { toolId, error });
       setSubmissionPhase('idle');
+      if (isSurfaceChangedError(error)) {
+        return;
+      }
+      setSubmissionFailed(true);
+      log.error('Failed to submit answers', { toolId, sessionId, error });
     }
   }, [
+    activeSurfaceScope,
     answers,
+    canSubmitUserAnswers,
     isAllAnswered,
     isSubmitted,
     isSubmitting,
     otherInputs,
     questions.length,
     setSubmissionPhase,
+    sessionId,
     toolId,
   ]);
 
@@ -481,13 +515,18 @@ export const AskUserQuestionCard: React.FC<ToolCardProps> = ({
     [getAnswerDisplay, questions, t],
   );
 
+  const responseUnsupported = status !== 'completed' && !canSubmitUserAnswers;
   const statusText = status === 'completed'
     ? t('toolCards.askUser.completed')
-    : isSubmitted
-      ? t('toolCards.askUser.submittedWaiting')
-      : isSubmitting
-        ? t('toolCards.askUser.submitting')
-        : t('toolCards.askUser.waitingAnswer');
+    : responseUnsupported
+      ? t('toolCards.askUser.unsupportedOnPeer')
+      : isSubmitted
+        ? t('toolCards.askUser.submittedWaiting')
+        : isSubmitting
+          ? t('toolCards.askUser.submitting')
+          : submissionFailed
+            ? t('toolCards.askUser.submitFailed')
+            : t('toolCards.askUser.waitingAnswer');
 
   if (awaitingPayload) {
     return (
@@ -518,11 +557,13 @@ export const AskUserQuestionCard: React.FC<ToolCardProps> = ({
     ? 'timeout'
     : status === 'completed'
       ? 'completed'
-      : isSubmitting
-        ? 'submitting'
-        : isSubmitted
-          ? 'submitted'
-          : 'asking';
+      : responseUnsupported
+        ? 'error'
+        : isSubmitting
+          ? 'submitting'
+          : isSubmitted
+            ? 'submitted'
+            : 'asking';
   const showSubmit = componentState === 'asking'
     || componentState === 'submitting'
     || componentState === 'submitted';
@@ -533,7 +574,7 @@ export const AskUserQuestionCard: React.FC<ToolCardProps> = ({
       aria-label={t('toolCards.askUser.questionsCount', { count: questions.length })}
       customAnswers={presentation.customAnswers}
       data-tool-card-id={toolId ?? ''}
-      disabled={Boolean(isParamsStreaming)}
+      disabled={Boolean(isParamsStreaming) || responseUnsupported}
       expanded={showCompletedSummary ? isExpanded : undefined}
       header={showCompletedSummary
         ? undefined
@@ -554,7 +595,12 @@ export const AskUserQuestionCard: React.FC<ToolCardProps> = ({
       statusLabel={timedOut
         ? t('toolCards.askUser.timeout')
         : showCompletedSummary ? undefined : statusText}
-      submitDisabled={!isAllAnswered() || isSubmitted || Boolean(isParamsStreaming)}
+      submitDisabled={
+        !isAllAnswered()
+        || isSubmitted
+        || Boolean(isParamsStreaming)
+        || responseUnsupported
+      }
       submitLabel={showSubmit ? t('toolCards.askUser.submit') : undefined}
       submittingLabel={t('toolCards.askUser.submitting')}
       submitTitle={!isAllAnswered()

--- a/src/web-ui/src/infrastructure/api/service-api/ToolAPI.test.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/ToolAPI.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ToolAPI } from './ToolAPI';
+
+const invokeMock = vi.hoisted(() => vi.fn());
+
+vi.mock('./ApiClient', () => ({
+  api: { invoke: invokeMock },
+}));
+
+describe('ToolAPI user-question responses', () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    invokeMock.mockResolvedValue(undefined);
+  });
+
+  it('carries the owning Session across a Peer HostInvoke boundary', async () => {
+    const toolAPI = new ToolAPI();
+
+    await toolAPI.submitUserAnswers(
+      'ask-tool-1',
+      { 0: 'Focused' },
+      'session-1',
+    );
+
+    expect(invokeMock).toHaveBeenCalledWith('submit_user_answers', {
+      toolId: 'ask-tool-1',
+      answers: { 0: 'Focused' },
+      sessionId: 'session-1',
+    });
+  });
+
+  it('keeps the legacy Desktop call shape when no Session is available', async () => {
+    const toolAPI = new ToolAPI();
+
+    await toolAPI.submitUserAnswers('ask-tool-1', { 0: 'Focused' });
+
+    expect(invokeMock).toHaveBeenCalledWith('submit_user_answers', {
+      toolId: 'ask-tool-1',
+      answers: { 0: 'Focused' },
+    });
+  });
+});

--- a/src/web-ui/src/infrastructure/api/service-api/ToolAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/ToolAPI.ts
@@ -64,15 +64,20 @@ export class ToolAPI {
   /**
    * Submit user answers.
    */
-  async submitUserAnswers(toolId: string, answers: Record<string, string | string[]>): Promise<void> {
+  async submitUserAnswers(
+    toolId: string,
+    answers: Record<string, string | string[]>,
+    sessionId?: string,
+  ): Promise<void> {
     try {
       await api.invoke('submit_user_answers', { 
         toolId,
-        answers 
+        answers,
+        ...(sessionId ? { sessionId } : {}),
       });
     } catch (error) {
-      log.error('Failed to submit user answers', { toolId, error });
-      throw createTauriCommandError('submit_user_answers', error, { toolId, answers });
+      log.error('Failed to submit user answers', { toolId, sessionId, error });
+      throw createTauriCommandError('submit_user_answers', error, { toolId, sessionId, answers });
     }
   }
 }

--- a/src/web-ui/src/infrastructure/peer-device/PeerConnectionManager.test.ts
+++ b/src/web-ui/src/infrastructure/peer-device/PeerConnectionManager.test.ts
@@ -32,6 +32,7 @@ describe('PeerConnectionManager attach', () => {
         productControlV1: true,
         productControlNativeV1: false,
         productControlPresentationV1: false,
+        userQuestionResponse: true,
       },
     });
     expect(manager.get('peer-1')).toBe(connection);
@@ -83,6 +84,7 @@ describe('PeerConnectionManager attach', () => {
           capabilities: {
             cancel_tool: true,
             tool_catalog: true,
+            user_question_response: true,
             miniapp_agent_context_files_v1: true,
           },
         },
@@ -572,6 +574,7 @@ function createRpc(options: { failCommands?: Set<string> } = {}) {
             product_control_v1: true,
             cancel_tool: true,
             tool_catalog: true,
+            user_question_response: true,
           },
         },
       });

--- a/src/web-ui/src/infrastructure/peer-device/PeerConnectionManager.ts
+++ b/src/web-ui/src/infrastructure/peer-device/PeerConnectionManager.ts
@@ -65,6 +65,12 @@ export interface PeerHostCapabilities {
    */
   readonly toolCatalog: boolean | null;
   /**
+   * Host implements `submit_user_answers` for Runtime-owned
+   * AskUserQuestion interactions. Older Desktop hosts already implemented the
+   * command; older CLI hosts did not.
+   */
+  readonly userQuestionResponse: boolean | null;
+  /**
    * Which kind of host answered `peer_mode_ping` (`"desktop"` | `"cli"`).
    * `null` = the host did not advertise `host_type` (even older host, or the
    * field is genuinely absent). Lets a controller resolve a `null` capability
@@ -141,6 +147,7 @@ interface PeerModePingResult {
     product_control_presentation_v1?: boolean;
     cancel_tool?: boolean;
     tool_catalog?: boolean;
+    user_question_response?: boolean;
   };
 }
 
@@ -156,6 +163,7 @@ const NO_CAPABILITIES: PeerHostCapabilities = {
   // Consumers treat `null` optimistically so an unprobed host is not gated off.
   cancelTool: null,
   toolCatalog: null,
+  userQuestionResponse: null,
   // Host kind is unknown until the first `peer_mode_ping` resolves. Consumers
   // treat `null` optimistically. See PR #2428 round 5 #1.
   hostKind: null,
@@ -432,18 +440,23 @@ export class PeerConnectionManager {
     const caps = result?.capabilities;
     let cancelTool = caps?.cancel_tool === undefined ? null : caps.cancel_tool === true;
     let toolCatalog = caps?.tool_catalog === undefined ? null : caps.tool_catalog === true;
+    let userQuestionResponse = caps?.user_question_response === undefined
+      ? null
+      : caps.user_question_response === true;
     let hostKind = parseHostKind(result?.host_type);
 
     if (hostKind !== null) {
       this.legacyHostKinds.set(deviceId, hostKind);
       cancelTool ??= hostKind === 'desktop';
       toolCatalog ??= hostKind === 'desktop';
+      userQuestionResponse ??= hostKind === 'desktop';
     } else {
       const cachedHostKind = this.legacyHostKinds.get(deviceId);
       if (cachedHostKind !== undefined) {
         hostKind = cachedHostKind;
         cancelTool ??= cachedHostKind === 'desktop';
         toolCatalog ??= cachedHostKind === 'desktop';
+        userQuestionResponse ??= cachedHostKind === 'desktop';
       }
     }
 
@@ -456,6 +469,7 @@ export class PeerConnectionManager {
           hostKind = 'desktop';
           cancelTool = true;
           toolCatalog = true;
+          userQuestionResponse = true;
           this.legacyHostKinds.set(deviceId, hostKind);
         }
       } catch (error) {
@@ -467,6 +481,7 @@ export class PeerConnectionManager {
           hostKind = 'cli';
           cancelTool = false;
           toolCatalog = false;
+          userQuestionResponse = false;
           this.legacyHostKinds.set(deviceId, hostKind);
         } else {
           log.warn('Could not classify legacy peer host', { deviceId, error });
@@ -485,6 +500,7 @@ export class PeerConnectionManager {
         caps?.product_control_presentation_v1 === true,
       cancelTool,
       toolCatalog,
+      userQuestionResponse,
       hostKind,
     };
   }
@@ -719,6 +735,7 @@ function capabilitiesEqual(
     a.miniAppAgentContextFilesV1 === b.miniAppAgentContextFilesV1 &&
     a.cancelTool === b.cancelTool &&
     a.toolCatalog === b.toolCatalog &&
+    a.userQuestionResponse === b.userQuestionResponse &&
     a.hostKind === b.hostKind;
 }
 

--- a/src/web-ui/src/infrastructure/peer-device/README.md
+++ b/src/web-ui/src/infrastructure/peer-device/README.md
@@ -242,8 +242,14 @@ Still to migrate, in order: the interaction mailbox, then history positions.
     and use it only to reconstruct UI in the owning Turn/round. Reattachment
     must never restart or cancel the
     running Session. Older peers may omit the field; absence is not an empty
-    authoritative mailbox. Any new interaction that can suspend execution is
-    incomplete until its owner exposes equivalent replayable attach state.
+    authoritative mailbox. Answering an `AskUserQuestion` is separately gated
+    by `peer_mode_ping.capabilities.user_question_response`: legacy Desktop
+    hosts already support the command, while legacy CLI hosts must show an
+    explicit unsupported/upgrade state. Current controllers include the owning
+    Session id with the mutation and hosts reject stale cross-Session answers;
+    newer hosts still accept the legacy Tool-id-only form. Any new
+    interaction that can suspend execution is incomplete until its owner
+    exposes equivalent replayable attach state and a negotiated response path.
 
 13. **Weak links use bounded, idempotency-aware recovery.** Default Peer
     HostInvoke concurrency is four with one slot reserved from normal/low

--- a/src/web-ui/src/infrastructure/peer-device/peerCapabilityResolution.test.ts
+++ b/src/web-ui/src/infrastructure/peer-device/peerCapabilityResolution.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { canQueryToolCatalogOnSurface } from './peerCapabilityResolution';
+import {
+  canQueryToolCatalogOnSurface,
+  canSubmitUserQuestionsOnSurface,
+} from './peerCapabilityResolution';
 import type { PeerHostCapabilities } from './PeerConnectionManager';
 
 function caps(overrides: Partial<PeerHostCapabilities>): PeerHostCapabilities {
@@ -11,6 +14,7 @@ function caps(overrides: Partial<PeerHostCapabilities>): PeerHostCapabilities {
     miniAppAgentContextFilesV1: false,
     cancelTool: null,
     toolCatalog: null,
+    userQuestionResponse: null,
     hostKind: null,
     ...overrides,
   };
@@ -47,5 +51,26 @@ describe('canQueryToolCatalogOnSurface', () => {
     expect(
       canQueryToolCatalogOnSurface(true, caps({ toolCatalog: true, hostKind: 'cli' })),
     ).toBe(true);
+  });
+});
+
+describe('canSubmitUserQuestionsOnSurface', () => {
+  it('keeps local and Desktop interaction responses available', () => {
+    expect(canSubmitUserQuestionsOnSurface(false, null)).toBe(true);
+    expect(canSubmitUserQuestionsOnSurface(
+      true,
+      caps({ hostKind: 'desktop' }),
+    )).toBe(true);
+  });
+
+  it('requires the advertised capability from CLI peers', () => {
+    expect(canSubmitUserQuestionsOnSurface(
+      true,
+      caps({ hostKind: 'cli' }),
+    )).toBe(false);
+    expect(canSubmitUserQuestionsOnSurface(
+      true,
+      caps({ hostKind: 'cli', userQuestionResponse: true }),
+    )).toBe(true);
   });
 });

--- a/src/web-ui/src/infrastructure/peer-device/peerCapabilityResolution.ts
+++ b/src/web-ui/src/infrastructure/peer-device/peerCapabilityResolution.ts
@@ -35,3 +35,27 @@ export function canQueryToolCatalogOnSurface(
   // toolCatalog === null: older host, field absent — decide by host kind.
   return capabilities.hostKind !== 'cli';
 }
+
+/**
+ * Resolve whether the rendered host can answer a Runtime-owned
+ * AskUserQuestion. Desktop has always exposed `submit_user_answers`; CLI only
+ * gained the Peer Host command together with the advertised capability.
+ */
+export function canSubmitUserQuestionsOnSurface(
+  peerActive: boolean,
+  capabilities: PeerHostCapabilities | null,
+): boolean {
+  if (!peerActive) {
+    return true;
+  }
+  if (capabilities === null) {
+    return true;
+  }
+  if (capabilities.userQuestionResponse === true) {
+    return true;
+  }
+  if (capabilities.userQuestionResponse === false) {
+    return false;
+  }
+  return capabilities.hostKind !== 'cli';
+}

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -1819,6 +1819,8 @@
       "completed": "Completed",
       "submittedWaiting": "Submitted, waiting for processing",
       "submitting": "Submitting...",
+      "submitFailed": "Could not submit the answer. Check the connection and try again.",
+      "unsupportedOnPeer": "This device's BitFun version cannot answer the question. Update BitFun on that device.",
       "waitingAnswer": "Waiting for answer",
       "questionsCount": "{{count}} questions",
       "answerAllBeforeSubmit": "Please answer all questions before submitting",

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -1819,6 +1819,8 @@
       "completed": "已完成",
       "submittedWaiting": "已提交，等待处理",
       "submitting": "提交中...",
+      "submitFailed": "答案提交失败，请检查连接后重试。",
+      "unsupportedOnPeer": "该设备的 BitFun 版本暂不支持回答此问题，请更新该设备上的 BitFun。",
       "waitingAnswer": "等待回答",
       "questionsCount": "{{count}} 个问题",
       "answerAllBeforeSubmit": "请回答所有问题后再提交",

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -1819,6 +1819,8 @@
       "completed": "已完成",
       "submittedWaiting": "已提交，等待處理",
       "submitting": "提交中...",
+      "submitFailed": "答案提交失敗，請檢查連線後重試。",
+      "unsupportedOnPeer": "該裝置的 BitFun 版本暫不支援回答此問題，請更新該裝置上的 BitFun。",
       "waitingAnswer": "等待回答",
       "questionsCount": "{{count}} 個問題",
       "answerAllBeforeSubmit": "請回答所有問題後再提交",


### PR DESCRIPTION
## Summary\n\n- reconcile the Runtime-owned AskUserQuestion mailbox even when the peer event cursor is already current\n- repair same-revision cards that were left parameter-streaming and therefore non-interactive\n- make AskUserQuestion drafts and submissions follow the active device Surface and expose retryable errors\n- add the missing CLI Peer Host submit_user_answers path with a negotiated cross-version capability\n- retain compatibility with legacy Desktop hosts and legacy controller payloads\n\n## Type and Areas\n\nType: regression fix\n\nAreas: Web UI, Peer Device Mode, Desktop/Tauri, CLI Peer Host, i18n, architecture docs, remote SSH test infrastructure\n\n## Motivation / Impact\n\nAfter switching to a same-account peer device, a live-event versus restore race could leave a visible AskUserQuestion card detached from the authoritative interaction mailbox. The card remained disabled even though the target Runtime was still waiting. CLI targets also exposed the pending interaction snapshot without accepting the response command.\n\nThis restores clickability after attach/reconnect, routes the response to the Runtime-owning host, prevents stale cross-Session answers for current clients, and shows an explicit upgrade state for older CLI peers.\n\n## Verification\n\n- pnpm dlx node@22 node_modules/vitest/vitest.mjs run --maxWorkers=50% from src/web-ui: 593 files and 4323 tests passed\n- focused Peer refresh/store/card/API/capability Vitest suite: 6 files and 189 tests passed\n- pnpm --dir src/web-ui run type-check: passed\n- pnpm run lint:web: passed with 0 errors\n- pnpm run i18n:audit: passed\n- pnpm run check:repo-hygiene: passed\n- cargo check -p bitfun-cli: passed\n- cargo check -p bitfun-desktop: passed\n- cargo test -p bitfun-cli peer_host::dispatch::tests: 7 passed\n- cargo test -p bitfun-cli peer_host::commands::dialog::tests: 4 passed\n- cargo test -p bitfun-desktop peer_host_invoke::tests::peer_ping_advertises_mutation_capabilities: passed\n- cargo test --locked -p bitfun-services-integrations --no-default-features --features remote-ssh-concrete --lib remote_ssh::manager::tests::workspace_: 21 passed\n\n## Reviewer Notes\n\nPeer Device Mode was exercised through unit-level HostInvoke capability/routing, runtime snapshot reconciliation, active-Surface switching, and response submission contracts. The first CI run also exposed a macOS-only SSH fixture teardown race; the follow-up accepts Darwin ConnectionReset only after all test assertions and an explicit client disconnect. The new capability is additive. Older Desktop hosts fall back to their existing command; older CLI hosts fail closed in the UI; newer CLI hosts accept both current session-scoped and legacy Tool-id-only payloads.\n\n## Checklist\n\n- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.\n- [x] Relevant verification is recorded above.\n- [x] User-facing strings, docs, and locales are updated.