### PR TITLE
fix(web-ui): restore clipboard copy actions

### DIFF
--- a/src/web-ui/src/infrastructure/api/service-api/SystemAPI.test.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/SystemAPI.test.ts
@@ -2,11 +2,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SystemAPI } from './SystemAPI';
 
 const invokeMock = vi.hoisted(() => vi.fn());
+const copyTextToClipboardMock = vi.hoisted(() => vi.fn());
 
 vi.mock('./ApiClient', () => ({
   api: {
     invoke: invokeMock,
   },
+}));
+
+vi.mock('@/shared/utils/textSelection', () => ({
+  copyTextToClipboard: copyTextToClipboardMock,
 }));
 
 describe('SystemAPI', () => {
@@ -15,6 +20,7 @@ describe('SystemAPI', () => {
   beforeEach(() => {
     systemAPI = new SystemAPI();
     invokeMock.mockReset();
+    copyTextToClipboardMock.mockReset();
   });
 
   afterEach(() => {
@@ -73,5 +79,21 @@ describe('SystemAPI', () => {
         value: true,
       },
     });
+  });
+
+  it('writes clipboard text on the controller without invoking a host command', async () => {
+    copyTextToClipboardMock.mockResolvedValueOnce(true);
+
+    await expect(systemAPI.setClipboard('device-code')).resolves.toBeUndefined();
+
+    expect(copyTextToClipboardMock).toHaveBeenCalledWith('device-code');
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it('reports a clipboard helper failure to the caller', async () => {
+    copyTextToClipboardMock.mockResolvedValueOnce(false);
+
+    await expect(systemAPI.setClipboard('device-code')).rejects.toThrow('Clipboard write failed');
+    expect(invokeMock).not.toHaveBeenCalled();
   });
 });

--- a/src/web-ui/src/infrastructure/api/service-api/SystemAPI.ts
+++ b/src/web-ui/src/infrastructure/api/service-api/SystemAPI.ts
@@ -2,6 +2,7 @@
 
 import { api } from './ApiClient';
 import { createTauriCommandError } from '../errors/TauriCommandError';
+import { copyTextToClipboard } from '@/shared/utils/textSelection';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import { createLogger } from '@/shared/utils/logger';
 import { productControlAPI } from './ProductControlAPI';
@@ -142,11 +143,12 @@ export class SystemAPI {
    
   async setClipboard(text: string): Promise<void> {
     try {
-      await api.invoke('set_clipboard', { 
-        request: { text } 
-      });
+      const copied = await copyTextToClipboard(text);
+      if (!copied) {
+        throw new Error('Clipboard write failed');
+      }
     } catch (error) {
-      throw createTauriCommandError('set_clipboard', error, { text });
+      throw createTauriCommandError('set_clipboard', error);
     }
   }
 


### PR DESCRIPTION
## Summary

Fix clipboard copy actions by routing `SystemAPI.setClipboard()` through the existing controller-side clipboard helper instead of invoking the unregistered Tauri `set_clipboard` command.

This restores copying subscription verification codes and other text copied through the shared System API. It also preserves the existing clipboard fallback behavior and error reporting.

<!-- Add an issue number if applicable: Fixes #123 -->

## Type and Areas

Type:

Regression fix / bug fix / test

Areas:

Web UI, shared System API

## Motivation / Impact

Copying a subscription verification code failed because the frontend invoked a `set_clipboard` Tauri command that is not implemented or registered by the desktop host.

Clipboard writes now happen on the device where the user clicked Copy. This fixes subscription verification-code copying and other callers of `SystemAPI.setClipboard()` while avoiding incorrect HostInvoke routing in Peer Device Mode.

## Verification

Passed:

- `pnpm --dir src/web-ui run test:run src/infrastructure/api/service-api/SystemAPI.test.ts src/shared/utils/textSelection.test.ts src/features/ssh-remote/PortForwardDialog.test.tsx src/app/scenes/pages/PagesScene.test.tsx`
  - 4 test files passed
  - 29 tests passed
- `pnpm run type-check:web`
- `git diff --check`

No manual desktop UI verification was performed.

## Reviewer Notes

- The fix reuses `copyTextToClipboard()`, which attempts the browser/WebView Clipboard API and falls back to selection-based copying.
- Clipboard content is no longer included in the wrapped error context.
- No Rust command, persisted data shape, localization, or protocol contract was changed.
- Peer Device Mode behavior is covered by asserting that clipboard writes do not invoke a host command.
- Remote workspace, remote control, and Detached Dispatch end-to-end scenarios were not exercised; clipboard copying remains a controller-local UI operation.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.