### PR TITLE
fix(flow-chat): preserve images on rollback

### DIFF
--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -2062,6 +2062,8 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     const handleFillChatInput = (data: {
       content?: string;
       context?: ContextItem;
+      /** Complete composer context replacement, including image attachments. */
+      contexts?: ContextItem[];
       composerPresentation?: ComposerPresentation;
       onlyIfEmpty?: boolean;
       mode?: 'replace' | 'append';
@@ -2086,7 +2088,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       const composerPresentation = parseComposerPresentation(data.composerPresentation);
       if (composerPresentation && data.mode !== 'append') {
         const restoredValue = composerPresentationToEditorText(composerPresentation);
-        replaceContexts(composerPresentationContexts(composerPresentation));
+        replaceContexts(data.contexts ?? composerPresentationContexts(composerPresentation));
         clearPendingLargePastes();
         dispatchInput({ type: 'SET_VALUE', payload: restoredValue });
         inputValueRef.current = restoredValue;
@@ -2112,6 +2114,9 @@ export const ChatInput: React.FC<ChatInputProps> = ({
 
       if (data.mode !== 'append') {
         clearPendingLargePastes();
+        if (data.contexts) {
+          replaceContexts(data.contexts);
+        }
       }
       dispatchInput({ type: 'SET_VALUE', payload: nextValue });
       inputValueRef.current = nextValue;

--- a/src/web-ui/src/flow_chat/components/modern/UserMessageItem.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/UserMessageItem.test.tsx
@@ -193,6 +193,11 @@ describe('UserMessageItem steering tag', () => {
     vi.stubGlobal('window', dom.window);
     vi.stubGlobal('document', dom.window.document);
     vi.stubGlobal('HTMLElement', dom.window.HTMLElement);
+    vi.stubGlobal('CustomEvent', dom.window.CustomEvent);
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
     vi.stubGlobal('navigator', {
       clipboard: {
         writeText: vi.fn(),
@@ -308,7 +313,7 @@ describe('UserMessageItem steering tag', () => {
     expect(content?.querySelectorAll('.user-message-item__reference')).toHaveLength(2);
   });
 
-  it('includes the persisted presentation when a failed message is restored to the input', () => {
+  it('restores persisted references and images from a failed message to the input', () => {
     const composerPresentation = {
       version: 1,
       segments: [
@@ -344,6 +349,13 @@ describe('UserMessageItem steering tag', () => {
               content: '[session: Delete all files]',
               timestamp: 1000,
               metadata: { composerPresentation },
+              images: [{
+                id: 'image-failed-1',
+                name: 'failure.png',
+                dataUrl: 'data:image/png;base64,failed',
+                imagePath: 'E:/uploads/failure.png',
+                mimeType: 'image/png',
+              }],
             }}
             turnId="turn-failed-1"
           />
@@ -359,6 +371,21 @@ describe('UserMessageItem steering tag', () => {
 
     expect(globalEventBus.emit).toHaveBeenCalledWith('fill-chat-input', {
       content: '[session: Delete all files]',
+      contexts: [
+        expect.objectContaining({
+          id: 'session-reference-1',
+          type: 'session-reference',
+          sessionId: 'session-1',
+        }),
+        expect.objectContaining({
+          id: 'image-failed-1',
+          type: 'image',
+          imagePath: 'E:/uploads/failure.png',
+          imageName: 'failure.png',
+          dataUrl: 'data:image/png;base64,failed',
+          isLocal: true,
+        }),
+      ],
       composerPresentation,
     });
   });
@@ -421,6 +448,53 @@ describe('UserMessageItem steering tag', () => {
     });
 
     expect(container.querySelector('.user-message-item__rollback-btn')).not.toBeNull();
+  });
+
+  it('restores image attachments to the composer after rollback', async () => {
+    activeSessionRef.current = {
+      sessionId: 'main-session',
+      sessionKind: 'normal',
+      dialogTurns: [{ id: 'turn-1', status: 'completed' }],
+    };
+
+    act(() => {
+      root.render(
+        <FlowChatContext.Provider value={{ sessionId: 'main-session', allowUserMessageRollback: true }}>
+          <UserMessageItem
+            message={{
+              id: 'user-main-1',
+              content: 'inspect this image',
+              timestamp: 1000,
+              images: [{
+                id: 'image-1',
+                name: 'screenshot.png',
+                imagePath: 'E:/uploads/screenshot.png',
+                mimeType: 'image/png',
+              }],
+            }}
+            turnId="turn-1"
+          />
+        </FlowChatContext.Provider>,
+      );
+    });
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('.user-message-item__rollback-btn')?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(globalEventBus.emit).toHaveBeenCalledWith('fill-chat-input', {
+      content: 'restored prompt',
+      contexts: [expect.objectContaining({
+        id: 'image-1',
+        type: 'image',
+        imagePath: 'E:/uploads/screenshot.png',
+        imageName: 'screenshot.png',
+        mimeType: 'image/png',
+        isLocal: true,
+      })],
+    });
   });
 
   it('disables file-consistent rollback and message editing for remote workspaces', () => {

--- a/src/web-ui/src/flow_chat/components/modern/UserMessageItem.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/UserMessageItem.tsx
@@ -53,6 +53,7 @@ import {
   parseComposerPresentation,
   type ComposerPresentation,
 } from '../../utils/composerPresentation';
+import { restoreImageContextsFromPayload } from '../../utils/imageContextRestoration';
 import { UserMessagePresentationContent } from './UserMessagePresentationContent';
 import './UserMessageItem.scss';
 
@@ -126,6 +127,14 @@ export const UserMessageItem = React.memo<UserMessageItemProps>(
       return hasComposerPresentationReferences(presentation) ? presentation : null;
     }, [message?.metadata?.composerPresentation]);
     const messageImages = useMemo(() => message?.images ?? [], [message?.images]);
+    const restoredComposerContexts = useMemo(() => [
+      ...(composerPresentation ? composerPresentationContexts(composerPresentation) : []),
+      ...restoreImageContextsFromPayload({
+        id: message?.id ?? turnId,
+        timestamp: message?.timestamp ?? 0,
+        imageDisplayData: messageImages,
+      }),
+    ], [composerPresentation, message?.id, message?.timestamp, messageImages, turnId]);
     const isUsageReportMessage = message?.metadata?.localCommandKind === 'usage_report';
     const isGoalLoadingMessage = Boolean(message?.metadata?.threadGoalKickoff);
     const isThreadGoalContinuationCheck = Boolean(message?.metadata?.threadGoalContinuation);
@@ -306,9 +315,10 @@ export const UserMessageItem = React.memo<UserMessageItemProps>(
         });
 
         const composerContent = result.composerText ?? messageContent;
-        if (composerContent.trim().length > 0) {
+        if (composerContent.trim().length > 0 || restoredComposerContexts.length > 0) {
           globalEventBus.emit('fill-chat-input', {
             content: composerContent,
+            contexts: restoredComposerContexts,
             ...(composerPresentation ? { composerPresentation } : {}),
           });
         }
@@ -318,7 +328,7 @@ export const UserMessageItem = React.memo<UserMessageItemProps>(
         log.error('Rollback failed', error);
         notificationService.error(`${t('message.rollbackFailed')}: ${error instanceof Error ? error.message : String(error)}`);
       }
-    }, [actionTurnIndex, canRollback, composerPresentation, resolvedSessionId, t, turnId, messageContent]);
+    }, [actionTurnIndex, canRollback, composerPresentation, resolvedSessionId, restoredComposerContexts, t, turnId, messageContent]);
 
     const handleBeginEdit = useCallback((e: React.MouseEvent) => {
       e.stopPropagation();
@@ -429,9 +439,10 @@ export const UserMessageItem = React.memo<UserMessageItemProps>(
       e.stopPropagation();
       globalEventBus.emit('fill-chat-input', {
         content: messageContent,
+        contexts: restoredComposerContexts,
         ...(composerPresentation ? { composerPresentation } : {}),
       });
-    }, [composerPresentation, messageContent]);
+    }, [composerPresentation, messageContent, restoredComposerContexts]);
 
     const handleOpenUsageReport = useCallback((report: SessionUsageReport, initialTab?: SessionUsagePanelTab) => {
       void import('../../services/openSessionUsageReport').then(({ openSessionUsagePanel }) => {

--- a/src/web-ui/src/flow_chat/utils/imageContextRestoration.ts
+++ b/src/web-ui/src/flow_chat/utils/imageContextRestoration.ts
@@ -1,0 +1,94 @@
+import type { ImageContext } from '@/shared/types/context';
+
+type UnknownRecord = Record<string, unknown>;
+
+export interface RestorableImagePayload {
+  id: string;
+  timestamp: number;
+  imageContexts?: unknown[];
+  imageDisplayData?: unknown[];
+}
+
+function asRecord(value: unknown): UnknownRecord | undefined {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as UnknownRecord
+    : undefined;
+}
+
+function readString(record: UnknownRecord | undefined, key: string): string | undefined {
+  const value = record?.[key];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function readNumber(record: UnknownRecord | undefined, key: string): number | undefined {
+  const value = record?.[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function mimeTypeFromDataUrl(dataUrl: string | undefined): string | undefined {
+  return dataUrl?.match(/^data:([^;,]+)[;,]/)?.[1];
+}
+
+/** Rebuilds composer-owned image contexts from persisted display/transport shapes. */
+export function restoreImageContextsFromPayload(
+  message: RestorableImagePayload,
+): ImageContext[] {
+  const displayItems = Array.isArray(message.imageDisplayData)
+    ? message.imageDisplayData.map(asRecord).filter((item): item is UnknownRecord => Boolean(item))
+    : [];
+  const transportItems = Array.isArray(message.imageContexts)
+    ? message.imageContexts.map(asRecord).filter((item): item is UnknownRecord => Boolean(item))
+    : [];
+  const transportById = new Map(
+    transportItems.flatMap(item => {
+      const id = readString(item, 'id');
+      return id ? [[id, item] as const] : [];
+    }),
+  );
+  const restored: ImageContext[] = [];
+  const seenIds = new Set<string>();
+  const entryCount = Math.max(displayItems.length, transportItems.length);
+
+  for (let index = 0; index < entryCount; index += 1) {
+    const display = displayItems[index];
+    const displayId = readString(display, 'id');
+    const transport = (displayId ? transportById.get(displayId) : undefined) ?? transportItems[index];
+    const id = displayId ?? readString(transport, 'id') ?? `${message.id}-image-${index + 1}`;
+    if (seenIds.has(id)) continue;
+    seenIds.add(id);
+
+    const metadata = asRecord(transport?.metadata);
+    const dataUrl = readString(display, 'dataUrl');
+    const imagePath = readString(display, 'imagePath') ?? readString(transport, 'image_path') ?? '';
+    const sourceValue = readString(metadata, 'source');
+    const source: ImageContext['source'] =
+      sourceValue === 'file' || sourceValue === 'clipboard' || sourceValue === 'url'
+        ? sourceValue
+        : dataUrl
+          ? 'clipboard'
+          : 'file';
+
+    restored.push({
+      id,
+      type: 'image',
+      timestamp: message.timestamp,
+      imagePath,
+      imageName: readString(display, 'name') ?? readString(metadata, 'name') ?? 'Image',
+      width: readNumber(metadata, 'width'),
+      height: readNumber(metadata, 'height'),
+      fileSize: readNumber(metadata, 'file_size') ?? 0,
+      mimeType:
+        readString(display, 'mimeType')
+        ?? readString(transport, 'mime_type')
+        ?? mimeTypeFromDataUrl(dataUrl)
+        ?? 'image/png',
+      dataUrl,
+      thumbnailUrl: dataUrl,
+      source,
+      // A host path means the image can be resubmitted without another upload.
+      isLocal: Boolean(imagePath),
+    });
+  }
+
+  return restored;
+}

--- a/src/web-ui/src/flow_chat/utils/pendingQueueDraft.ts
+++ b/src/web-ui/src/flow_chat/utils/pendingQueueDraft.ts
@@ -1,5 +1,6 @@
-import type { ContextItem, ImageContext } from '@/shared/types/context';
+import type { ContextItem } from '@/shared/types/context';
 import type { QueuedComposerDraft, QueuedMessage } from '../types/flow-chat';
+import { restoreImageContextsFromPayload } from './imageContextRestoration';
 
 type QueuedDraftSource = Pick<
   QueuedMessage,
@@ -32,11 +33,6 @@ function readString(record: UnknownRecord | undefined, key: string): string | un
   return typeof value === 'string' && value.length > 0 ? value : undefined;
 }
 
-function readNumber(record: UnknownRecord | undefined, key: string): number | undefined {
-  const value = record?.[key];
-  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
-}
-
 function sanitizePendingLargePastes(value: unknown): Record<string, string> {
   const record = asRecord(value);
   if (!record) return {};
@@ -51,72 +47,6 @@ function sanitizeStoredContexts(value: unknown): ContextItem[] | undefined {
     const record = asRecord(context);
     return Boolean(readString(record, 'id') && readString(record, 'type'));
   });
-}
-
-function mimeTypeFromDataUrl(dataUrl: string | undefined): string | undefined {
-  return dataUrl?.match(/^data:([^;,]+)[;,]/)?.[1];
-}
-
-function restoreLegacyImageContexts(message: QueuedDraftSource): ImageContext[] {
-  const displayItems = Array.isArray(message.imageDisplayData)
-    ? message.imageDisplayData.map(asRecord).filter((item): item is UnknownRecord => Boolean(item))
-    : [];
-  const transportItems = Array.isArray(message.imageContexts)
-    ? message.imageContexts.map(asRecord).filter((item): item is UnknownRecord => Boolean(item))
-    : [];
-  const transportById = new Map(
-    transportItems.flatMap(item => {
-      const id = readString(item, 'id');
-      return id ? [[id, item] as const] : [];
-    }),
-  );
-  const restored: ImageContext[] = [];
-  const seenIds = new Set<string>();
-  const entryCount = Math.max(displayItems.length, transportItems.length);
-
-  for (let index = 0; index < entryCount; index += 1) {
-    const display = displayItems[index];
-    const displayId = readString(display, 'id');
-    const transport = (displayId ? transportById.get(displayId) : undefined) ?? transportItems[index];
-    const id = displayId ?? readString(transport, 'id') ?? `${message.id}-image-${index + 1}`;
-    if (seenIds.has(id)) continue;
-    seenIds.add(id);
-
-    const metadata = asRecord(transport?.metadata);
-    const dataUrl = readString(display, 'dataUrl');
-    const imagePath = readString(display, 'imagePath') ?? readString(transport, 'image_path') ?? '';
-    const sourceValue = readString(metadata, 'source');
-    const source: ImageContext['source'] =
-      sourceValue === 'file' || sourceValue === 'clipboard' || sourceValue === 'url'
-        ? sourceValue
-        : dataUrl
-          ? 'clipboard'
-          : 'file';
-
-    restored.push({
-      id,
-      type: 'image',
-      timestamp: message.timestamp,
-      imagePath,
-      imageName: readString(display, 'name') ?? readString(metadata, 'name') ?? 'Image',
-      width: readNumber(metadata, 'width'),
-      height: readNumber(metadata, 'height'),
-      fileSize: readNumber(metadata, 'file_size') ?? 0,
-      mimeType:
-        readString(display, 'mimeType')
-        ?? readString(transport, 'mime_type')
-        ?? mimeTypeFromDataUrl(dataUrl)
-        ?? 'image/png',
-      dataUrl,
-      thumbnailUrl: dataUrl,
-      source,
-      // Queued payloads with a host path are already uploaded and can be
-      // resubmitted without repeating the clipboard upload.
-      isLocal: Boolean(imagePath),
-    });
-  }
-
-  return restored;
 }
 
 /** Protects an existing composer draft from being replaced by a queued item. */
@@ -143,7 +73,7 @@ export function getQueuedMessageComposerDraft(message: QueuedDraftSource): Queue
 
   return {
     value: message.displayMessage ?? message.content,
-    contexts: restoreLegacyImageContexts(message),
+    contexts: restoreImageContextsFromPayload(message),
     pendingLargePastes: {},
   };
 }


### PR DESCRIPTION
Restore the complete composer context when rolling back a user
message so image attachments remain available for resubmission.

- Rebuild image contexts from persisted display and transport data
- Replace composer contexts together with restored text and references
- Reuse image restoration for legacy queued drafts
- Cover rollback and failed-message restoration with focused tests
