### PR TITLE
fix(chat): route Escape cancellation to active chat target

### DIFF
--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -112,6 +112,7 @@ import { isRemoteWorkspaceSession, sessionProjectWorkspacePath } from '../utils/
 import { findWorkspaceForSession } from '../utils/workspaceScope';
 import { isTauriRuntime } from '@/infrastructure/runtime';
 import { Tooltip } from '@bitfun/ui';
+import { useShortcut } from '@/infrastructure/hooks/useShortcut';
 import { confirmDanger, confirmWarning } from '@/infrastructure/confirm-dialog';
 import { PendingQueuePanel } from './PendingQueuePanel';
 import { useAgentCanvasStore } from '@/app/components/panels/content-canvas/stores';
@@ -237,7 +238,15 @@ import {
 } from './chatInputRegistration';
 import './ChatInput.scss';
 
-import { setChatPopupActive } from './chatPopupState';
+import {
+  isChatPopupActive,
+  setChatPopupActive,
+  subscribeChatPopupChange,
+} from './chatPopupState';
+import {
+  resolveChatInputTargetSessionId,
+  type ChatInputTarget,
+} from '../utils/chatInputTarget';
 import { Menu, MenuItem, MenuSeparator, Icon } from '@bitfun/ui';
 import {
   ChatComposer,
@@ -323,8 +332,6 @@ type SlashPickerItem =
   | SlashAcpCommandItem
   | SlashSkillItem
   | SlashExternalPromptCommandItem;
-type ChatInputTarget = 'main' | 'btw';
-
 function nativePromptCommandCandidateId(
   kind: Exclude<SlashPickerItem['kind'], 'externalCommand'>,
   id: string,
@@ -547,8 +554,11 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   const activeBtwSessionId = activeBtwSessionData?.parentSessionId === currentSessionId
     ? activeBtwSessionData.childSessionId
     : undefined;
-  const effectiveTargetSessionId =
-    inputTarget === 'btw' && activeBtwSessionId ? activeBtwSessionId : currentSessionId;
+  const effectiveTargetSessionId = resolveChatInputTargetSessionId({
+    currentSessionId,
+    inputTarget,
+    activeBtwSessionId,
+  });
   const effectiveTargetSessionIdRef = useRef<string | null>(effectiveTargetSessionId);
   effectiveTargetSessionIdRef.current = effectiveTargetSessionId;
 
@@ -1668,8 +1678,17 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     }
   }, [externalPromptCommandsLoading, externalPromptCommandsPending, refreshExternalPromptCommands, slashCommandState.isActive]);
 
-  // Keep the module-level popup-active flag in sync so ModernFlowChatContainer
-  // can disable the global Escape shortcut while popups are open.
+  const reportedChatPopupActive = useSyncExternalStore(
+    subscribeChatPopupChange,
+    isChatPopupActive,
+    isChatPopupActive,
+  );
+  const chatPopupActive =
+    slashCommandState.isActive || mentionState.isActive || reportedChatPopupActive;
+
+  // Keep the module-level flag in sync for other Escape owners such as modal
+  // surfaces. The local state is included above so this composer does not wait
+  // for the effect before giving the key to its popup.
   useEffect(() => {
     setChatPopupActive(slashCommandState.isActive || mentionState.isActive);
   }, [slashCommandState.isActive, mentionState.isActive]);
@@ -4309,6 +4328,19 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     await FlowChatManager.getInstance().cancelCurrentTask();
   }, [effectiveTargetSessionId]);
 
+  useShortcut(
+    'chat.stopGeneration',
+    { key: 'Escape', scope: 'chat', allowInInput: true },
+    () => {
+      void handleCancelCurrentTask();
+    },
+    {
+      priority: 20,
+      enabled: isSceneActive && !chatPopupActive && Boolean(derivedState?.canCancel),
+      description: 'keyboard.shortcuts.chat.stopGeneration',
+    },
+  );
+
   const handleModelLoadingChange = useCallback((loading: boolean) => {
     setIsModelSwitching(loading);
   }, []);
@@ -5201,11 +5233,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       handleSendOrCancel();
     }
     
-    if (e.key === 'Escape' && derivedState?.canCancel) {
-      e.preventDefault();
-      void handleCancelCurrentTask();
-    }
-  }, [canUseThreadGoal, handleSendOrCancel, submitBtwFromInput, submitGoalFromInput, derivedState, dispatchInput, handleCancelCurrentTask, slashCommandState, getActiveSlashPickerItems, selectSlashCommandAction, selectSlashExternalPromptCommand, selectSlashPromptCommand, selectSlashAcpCommand, selectSlashSkill, getRichTextInlineTriggerController, historyIndex, inputHistory, savedDraft, inputState.value, currentSessionId, isBtwSession, showTargetSwitcher, setInputTarget, removeContext, t]);
+  }, [canUseThreadGoal, handleSendOrCancel, submitBtwFromInput, submitGoalFromInput, derivedState, dispatchInput, slashCommandState, getActiveSlashPickerItems, selectSlashCommandAction, selectSlashExternalPromptCommand, selectSlashPromptCommand, selectSlashAcpCommand, selectSlashSkill, getRichTextInlineTriggerController, historyIndex, inputHistory, savedDraft, inputState.value, currentSessionId, isBtwSession, showTargetSwitcher, setInputTarget, removeContext, t]);
 
   const handleImeCompositionStart = useCallback(() => {
     isImeComposingRef.current = true;

--- a/src/web-ui/src/flow_chat/components/btw/BtwSessionPanel.review-action.test.tsx
+++ b/src/web-ui/src/flow_chat/components/btw/BtwSessionPanel.review-action.test.tsx
@@ -11,6 +11,7 @@ import type { PermissionRequest } from '@/infrastructure/api/service-api/AgentAP
 
 const panelMocks = vi.hoisted(() => ({
   cancelSession: vi.fn(),
+  cancelSessionTask: vi.fn(),
   hydrateSessionHistoryForDetail: vi.fn(),
   notificationError: vi.fn(),
   permissionRequests: [] as PermissionRequest[],
@@ -188,6 +189,11 @@ vi.mock('../../store/FlowChatStore', () => ({
 }));
 
 vi.mock('../../services/FlowChatManager', () => ({
+  FlowChatManager: {
+    getInstance: () => ({
+      cancelSessionTask: (...args: unknown[]) => panelMocks.cancelSessionTask(...args),
+    }),
+  },
   flowChatManager: {
     hydrateSessionHistoryForDetail: (...args: unknown[]) =>
       panelMocks.hydrateSessionHistoryForDetail(...args),
@@ -368,6 +374,29 @@ function createPendingDeepReviewSession(): Session {
   } as Session;
 }
 
+function createRunningBtwSession(): Session {
+  return {
+    sessionId: 'btw-child',
+    title: 'Side question',
+    dialogTurns: [{
+      id: 'btw-turn-1',
+      sessionId: 'btw-child',
+      userMessage: { id: 'btw-user-1', content: 'question', timestamp: 1 },
+      modelRounds: [],
+      status: 'processing',
+      startTime: 1,
+    }],
+    status: 'running',
+    config: {},
+    createdAt: 1,
+    lastActiveAt: 1,
+    error: null,
+    sessionKind: 'btw',
+    parentSessionId: 'parent-session',
+    workspacePath: 'D:/workspace/project',
+  } as Session;
+}
+
 function createParentSessionWithId(sessionId: string): Session {
   return {
     sessionId,
@@ -492,6 +521,8 @@ describe('BtwSessionPanel review action bar integration', () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     useReviewActionBarStore.getState().reset();
     panelMocks.cancelSession.mockReset();
+    panelMocks.cancelSessionTask.mockReset();
+    panelMocks.cancelSessionTask.mockResolvedValue(true);
     panelMocks.hydrateSessionHistoryForDetail.mockReset();
     panelMocks.hydrateSessionHistoryForDetail.mockResolvedValue(undefined);
     panelMocks.notificationError.mockReset();
@@ -537,6 +568,81 @@ describe('BtwSessionPanel review action bar integration', () => {
     container.remove();
     useReviewActionBarStore.getState().reset();
     vi.useRealTimers();
+  });
+
+  it('cancels a running side question with Escape inside its panel', async () => {
+    flowChatState = {
+      ...flowChatState,
+      sessions: new Map([
+        ['btw-child', createRunningBtwSession()],
+        ['parent-session', flowChatState.sessions.get('parent-session')!],
+      ]),
+      activeSessionId: 'parent-session',
+    } as FlowChatState;
+
+    await act(async () => {
+      root.render(
+        <BtwSessionPanel
+          childSessionId="btw-child"
+          parentSessionId="parent-session"
+          workspacePath="D:/workspace/project"
+        />,
+      );
+    });
+
+    const panelBody = container.querySelector<HTMLElement>('.btw-session-panel__body');
+    const escape = new KeyboardEvent('keydown', {
+      key: 'Escape',
+      bubbles: true,
+      cancelable: true,
+    });
+
+    await act(async () => {
+      panelBody?.dispatchEvent(escape);
+      await Promise.resolve();
+    });
+
+    expect(escape.defaultPrevented).toBe(true);
+    expect(panelMocks.cancelSessionTask).toHaveBeenCalledTimes(1);
+    expect(panelMocks.cancelSessionTask).toHaveBeenCalledWith('btw-child');
+    expect(panelMocks.cancelSession).not.toHaveBeenCalled();
+  });
+
+  it('keeps Escape with the IME inside a running side-question panel', async () => {
+    flowChatState = {
+      ...flowChatState,
+      sessions: new Map([
+        ['btw-child', createRunningBtwSession()],
+        ['parent-session', flowChatState.sessions.get('parent-session')!],
+      ]),
+      activeSessionId: 'parent-session',
+    } as FlowChatState;
+
+    await act(async () => {
+      root.render(
+        <BtwSessionPanel
+          childSessionId="btw-child"
+          parentSessionId="parent-session"
+          workspacePath="D:/workspace/project"
+        />,
+      );
+    });
+
+    const panelBody = container.querySelector<HTMLElement>('.btw-session-panel__body');
+    const imeEscape = new KeyboardEvent('keydown', {
+      key: 'Escape',
+      keyCode: 229,
+      bubbles: true,
+      cancelable: true,
+    });
+
+    await act(async () => {
+      panelBody?.dispatchEvent(imeEscape);
+      await Promise.resolve();
+    });
+
+    expect(imeEscape.defaultPrevented).toBe(false);
+    expect(panelMocks.cancelSessionTask).not.toHaveBeenCalled();
   });
 
   it('answers direct child permissions in the embedded panel without claiming delegated ones', async () => {

--- a/src/web-ui/src/flow_chat/components/btw/BtwSessionPanel.tsx
+++ b/src/web-ui/src/flow_chat/components/btw/BtwSessionPanel.tsx
@@ -64,6 +64,8 @@ import { sessionLineageLifecycleForSession } from '../../utils/sessionLineage';
 import {
   SubagentAvatar,
 } from '../../subagent-identity';
+import { FlowChatManager } from '../../services/FlowChatManager';
+import { isImeOwnedKeyboardEvent } from '@/shared/utils/ime';
 
 function findReviewChildByRequestId(
   parentSessionId: string | null | undefined,
@@ -995,6 +997,23 @@ export const BtwSessionPanel: React.FC<BtwSessionPanelProps> = ({
     );
   }, [btwOrigin, parentSessionId]);
 
+  const handlePanelKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (
+      event.key !== 'Escape' ||
+      event.defaultPrevented ||
+      childKind !== 'btw' ||
+      !isTurnProcessing ||
+      !childSessionId ||
+      isImeOwnedKeyboardEvent(event.nativeEvent)
+    ) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    void FlowChatManager.getInstance().cancelSessionTask(childSessionId);
+  }, [childKind, childSessionId, isTurnProcessing]);
+
   if (!childSessionId || !childSession) {
     return (
       <div className="btw-session-panel btw-session-panel--empty" data-bf-component="btw-session-panel" data-bf-part="root" data-bf-view="empty">
@@ -1010,6 +1029,7 @@ export const BtwSessionPanel: React.FC<BtwSessionPanelProps> = ({
       <FlowChatVolatileContext.Provider value={volatileContextValue}>
       <div
         className={`btw-session-panel${retainsReviewActionBarLayout ? ' btw-session-panel--has-action-bar' : ''}`}
+        onKeyDown={handlePanelKeyDown}
         data-bf-component="btw-session-panel"
         data-bf-part="root"
         data-bf-view="session"

--- a/src/web-ui/src/flow_chat/components/chatPopupState.ts
+++ b/src/web-ui/src/flow_chat/components/chatPopupState.ts
@@ -1,6 +1,5 @@
-// Module-level popup state – used by ModernFlowChatContainer to conditionally
-// disable the Escape shortcut so that slash-command and @-mention popups can be
-// closed with Escape.
+// Module-level popup state used by Escape shortcut owners so slash-command,
+// mention, and modal surfaces can close without cancelling the current task.
 let _chatPopupActive = false;
 const _chatPopupListeners = new Set<() => void>();
 

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
@@ -59,7 +59,6 @@ import {
   useBackgroundSubagentActivityStore,
 } from '../../store/backgroundSubagentActivityStore';
 import { type LineRange } from '@/shared/editor/LineRange';
-import { isChatPopupActive, subscribeChatPopupChange } from '../chatPopupState';
 import { useWorkspaceContext } from '@/infrastructure/contexts/WorkspaceContext';
 import { flowChatSessionConfigForCurrentWorkspace } from '@/app/utils/projectSessionWorkspace';
 import { createLogger } from '@/shared/utils/logger';
@@ -467,17 +466,7 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
   const [queuedTurnNavigation, setQueuedTurnNavigation] = useState<QueuedTurnNavigation | null>(null);
   const [pendingHistoryOpenSession, setPendingHistoryOpenSession] = useState<HistorySessionOpenIntentDetail | null>(null);
   const [searchOpenRequest, setSearchOpenRequest] = useState(0);
-  // Track whether a slash-command or @-mention popup is open in ChatInput.
-  // When a popup is active, the global Escape shortcut is disabled so the
-  // popup can be closed with Escape instead of cancelling the current task.
-  const [chatPopupActive, setChatPopupActive] = useState(() => isChatPopupActive());
   const backgroundCommandActivities = useBackgroundCommandActivityStore(state => state.activities);
-
-  useEffect(() => {
-    return subscribeChatPopupChange(() => {
-      setChatPopupActive(isChatPopupActive());
-    });
-  }, []);
   const [stoppingBackgroundCommandIds, setStoppingBackgroundCommandIds] = useState<Set<string>>(() => new Set());
   const [backgroundCommandInputTarget, setBackgroundCommandInputTarget] = useState<FlowChatHeaderCommandSummary | null>(null);
   const [isSendingBackgroundCommandInput, setIsSendingBackgroundCommandInput] = useState(false);
@@ -2489,15 +2478,6 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
       void handleStopBackgroundCommand(command);
     }
   }, [handleStopBackgroundCommand, headerBackgroundCommands]);
-
-  useShortcut(
-    'chat.stopGeneration',
-    { key: 'Escape', scope: 'chat', allowInInput: true },
-    () => {
-      void FlowChatManager.getInstance().cancelCurrentTask();
-    },
-    { priority: 20, enabled: !chatPopupActive, description: 'keyboard.shortcuts.chat.stopGeneration' }
-  );
 
   useShortcut(
     'chat.newSession',

--- a/src/web-ui/src/flow_chat/utils/chatInputTarget.test.ts
+++ b/src/web-ui/src/flow_chat/utils/chatInputTarget.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { resolveChatInputTargetSessionId } from './chatInputTarget';
+
+describe('resolveChatInputTargetSessionId', () => {
+  it('keeps the main session as the stop target when main is selected', () => {
+    expect(resolveChatInputTargetSessionId({
+      currentSessionId: 'main-session',
+      inputTarget: 'main',
+      activeBtwSessionId: 'btw-session',
+    })).toBe('main-session');
+  });
+
+  it('uses the side-question session when it is selected', () => {
+    expect(resolveChatInputTargetSessionId({
+      currentSessionId: 'main-session',
+      inputTarget: 'btw',
+      activeBtwSessionId: 'btw-session',
+    })).toBe('btw-session');
+  });
+
+  it('falls back to the main session when the side-question tab is gone', () => {
+    expect(resolveChatInputTargetSessionId({
+      currentSessionId: 'main-session',
+      inputTarget: 'btw',
+    })).toBe('main-session');
+  });
+});

--- a/src/web-ui/src/flow_chat/utils/chatInputTarget.ts
+++ b/src/web-ui/src/flow_chat/utils/chatInputTarget.ts
@@ -1,0 +1,12 @@
+export type ChatInputTarget = 'main' | 'btw';
+
+export function resolveChatInputTargetSessionId(params: {
+  currentSessionId: string | null;
+  inputTarget: ChatInputTarget;
+  activeBtwSessionId?: string;
+}): string | null {
+  if (params.inputTarget === 'btw' && params.activeBtwSessionId) {
+    return params.activeBtwSessionId;
+  }
+  return params.currentSessionId;
+}


### PR DESCRIPTION
## Summary

- Route the Escape stop shortcut through the composer’s effective target session instead of always cancelling the active main session.
- Allow Escape inside a running side-question panel to cancel that side conversation.
- Preserve popup and IME ownership of Escape.
- Add focused regression coverage for main/side-question target resolution and side-panel interruption.

## Type and Areas

Type:

Bug fix / regression fix / test

Areas:

Web UI, Flow Chat, side-question sessions, keyboard shortcuts

## Motivation / Impact

Previously, pressing Escape while the composer targeted a side conversation could cancel the main conversation instead, leaving the side conversation running. Escape also did not interrupt a side conversation when focus was inside its auxiliary panel.

After this change:

- Selecting the main conversation makes Escape cancel only the main conversation.
- Selecting the side conversation makes Escape cancel only that side conversation.
- Pressing Escape inside a running side-question panel interrupts that side conversation.
- Popups and IME composition retain priority over task cancellation.

## Verification

- `pnpm --dir src/web-ui run test:run src/flow_chat/utils/chatInputTarget.test.ts src/flow_chat/components/btw/BtwSessionPanel.review-action.test.tsx src/infrastructure/services/ShortcutManager.test.ts src/flow_chat/services/flow-chat-manager/MessageModule.test.ts`
  - Passed: 73 tests.
- `pnpm run check:web`
  - Passed appearance, typography, theme governance, and TypeScript checks.
- `pnpm --dir src/web-ui exec vitest run --maxWorkers=50% src/flow_chat/utils/chatInputTarget.test.ts src/flow_chat/components/btw/BtwSessionPanel.review-action.test.tsx src/infrastructure/services/ShortcutManager.test.ts`
  - Passed: 47 tests.
- Focused ESLint check completed with no errors.
- Manual desktop and remote interaction checks were not performed.

## Reviewer Notes

- No backend protocol or persisted-data changes.
- Cancellation continues through `FlowChatManager.cancelSessionTask`, preserving the existing session-driver routing for local, remote-workspace, and Peer Device execution.
- Commit: `c4e24a300c06b33852a488b6757e971c1c728a65`
- Remote Workspace, Remote Control, Peer Device Mode, and Detached Dispatch were not manually exercised.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.