### PR TITLE
fix(editor): normalize Monaco theme colors

### DIFF
--- a/docs/architecture/theme-token-optimization.md
+++ b/docs/architecture/theme-token-optimization.md
@@ -232,6 +232,13 @@ Monaco、xterm/ANSI、Mermaid、syntax、diff、语言标识、调试 overlay、
 稳定语义。它们必须留在对应 renderer/domain owner 中，并通过明确 payload 或 `--bf-domain-*` 消费；不得
 泄漏成普通组件可随手调用的 palette。
 
+Renderer adapter 同时拥有第三方格式边界。设计系统和 Appearance payload 可以使用其已声明支持的 CSS
+颜色格式，但 adapter 必须在调用第三方 API 前投影为对方的原生格式；不得把通用语义 Token 原样透传并
+假设第三方具有相同的颜色语法或 alpha 语义。例如 Monaco workbench colors 使用 hex alpha，而 token
+colors 必须先相对编辑器背景合成为不透明 hex。
+需要 alpha token color 的 Monaco payload 必须显式提供不透明的 `editor.background`，不得在 adapter 中复制
+或猜测第三方 base theme 的默认背景值。
+
 ### 显式排除不是 allowlist
 
 Monaco 拷贝产物、Relay static、E2E fixture、诊断报表 HTML、PPT 内容 renderer、native template icons 和

--- a/src/web-ui/src/infrastructure/appearance/adapters/MonacoAppearanceAdapter.ts
+++ b/src/web-ui/src/infrastructure/appearance/adapters/MonacoAppearanceAdapter.ts
@@ -5,6 +5,11 @@ import type {
   AppearanceRendererContext,
   MonacoAppearanceSettings,
 } from '../types';
+import {
+  isMonacoAppearanceColor,
+  projectMonacoAppearanceSettings,
+  validateMonacoAppearanceColorSemantics,
+} from './monacoThemeColorCodec';
 
 const log = createLogger('MonacoAppearanceAdapter');
 
@@ -17,8 +22,6 @@ export interface MonacoAppearanceChangeEvent {
 type MonacoModule = typeof Monaco;
 type MonacoAppearanceListener = (event: MonacoAppearanceChangeEvent) => void;
 
-const COLOR_PATTERN = /^(?:#[0-9a-f]{3,8}|rgba?\(\s*\d+(?:\.\d+)?\s*,\s*\d+(?:\.\d+)?\s*,\s*\d+(?:\.\d+)?(?:\s*,\s*(?:0|1|0?\.\d+))?\s*\))$/i;
-const TOKEN_COLOR_PATTERN = /^(?:[0-9a-f]{6}|[0-9a-f]{8}|#[0-9a-f]{3,8}|rgba?\(\s*\d+(?:\.\d+)?\s*,\s*\d+(?:\.\d+)?\s*,\s*\d+(?:\.\d+)?(?:\s*,\s*(?:0|1|0?\.\d+))?\s*\))$/i;
 const FONT_STYLE_PATTERN = /^(?:|italic|bold|underline|strikethrough)(?: (?:italic|bold|underline|strikethrough))*$/;
 const THEME_ID_PATTERN = /^[a-z][a-z0-9-]{0,95}$/;
 
@@ -63,7 +66,7 @@ export class MonacoAppearanceAdapter implements AppearanceRendererAdapter<'monac
         });
         for (const key of ['foreground', 'background'] as const) {
           const color = rule[key];
-          if (color !== undefined && (typeof color !== 'string' || !TOKEN_COLOR_PATTERN.test(color))) {
+          if (color !== undefined && (typeof color !== 'string' || !isMonacoAppearanceColor(color, true))) {
             errors.push(`rules.${index}.${key} is not a supported color`);
           }
         }
@@ -77,8 +80,16 @@ export class MonacoAppearanceAdapter implements AppearanceRendererAdapter<'monac
     } else {
       Object.entries(settings.colors).forEach(([key, value]) => {
         if (!/^[A-Za-z][A-Za-z0-9.]{0,159}$/.test(key)) errors.push(`colors.${key} has an invalid key`);
-        if (typeof value !== 'string' || !COLOR_PATTERN.test(value)) errors.push(`colors.${key} is not a supported color`);
+        if (typeof value !== 'string' || !isMonacoAppearanceColor(value)) {
+          errors.push(`colors.${key} is not a supported color`);
+        }
       });
+    }
+    if (Array.isArray(settings.rules)
+      && settings.rules.every(isRecord)
+      && isRecord(settings.colors)
+      && Object.values(settings.colors).every(value => typeof value === 'string')) {
+      errors.push(...validateMonacoAppearanceColorSemantics(settings as unknown as MonacoAppearanceSettings));
     }
     return errors;
   }
@@ -95,11 +106,15 @@ export class MonacoAppearanceAdapter implements AppearanceRendererAdapter<'monac
     }
     this.settings = settings;
     this.revision = context.revision;
-    if (this.monaco && settings) this.applyToMonaco(this.monaco, settings, context.revision);
+    if (this.monaco && settings) {
+      this.applyToMonaco(this.monaco, settings, context.revision);
+    }
   }
 
   initialize(): void {
-    if (this.monaco && this.settings) this.applyToMonaco(this.monaco, this.settings, this.revision);
+    if (this.monaco && this.settings) {
+      this.applyToMonaco(this.monaco, this.settings, this.revision);
+    }
   }
 
   attachMonaco(monaco: MonacoModule): string {
@@ -118,13 +133,18 @@ export class MonacoAppearanceAdapter implements AppearanceRendererAdapter<'monac
     return () => this.listeners.delete(listener);
   }
 
-  private applyToMonaco(monaco: MonacoModule, settings: MonacoAppearanceSettings, revision: number): void {
+  private applyToMonaco(
+    monaco: MonacoModule,
+    settings: MonacoAppearanceSettings,
+    revision: number,
+  ): void {
     const previousThemeId = this.currentThemeId;
+    const projectedSettings = projectMonacoAppearanceSettings(settings);
     monaco.editor.defineTheme(settings.id, {
-      base: settings.base,
-      inherit: settings.inherit,
-      rules: settings.rules,
-      colors: settings.colors,
+      base: projectedSettings.base,
+      inherit: projectedSettings.inherit,
+      rules: projectedSettings.rules,
+      colors: projectedSettings.colors,
     });
     monaco.editor.setTheme(settings.id);
     monaco.editor.getEditors().forEach((editor, index) => {

--- a/src/web-ui/src/infrastructure/appearance/adapters/RendererAppearanceContracts.test.ts
+++ b/src/web-ui/src/infrastructure/appearance/adapters/RendererAppearanceContracts.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it } from 'vitest';
+import type * as Monaco from 'monaco-editor';
+import { describe, expect, it, vi } from 'vitest';
 import { builtinAppearancePackages } from '../builtins/catalog';
 import { themeTokenAppearanceAdapter } from './ThemeTokenAppearanceAdapter';
 import { MonacoAppearanceAdapter } from './MonacoAppearanceAdapter';
+import { projectMonacoAppearanceSettings } from './monacoThemeColorCodec';
 import { widgetAppearanceAdapter } from './WidgetAppearanceAdapter';
 
 describe('renderer appearance contracts', () => {
@@ -51,4 +53,61 @@ describe('renderer appearance contracts', () => {
       { revision: 1, appearanceId: 'bitfun-linglong', mode: 'dark', globals: {}, assets: {} },
     )).rejects.toThrow('Invalid Monaco appearance');
   });
+
+  it('projects every built-in Monaco payload into Monaco-native colors', () => {
+    const nativeColor = /^#[0-9a-f]{6}(?:[0-9a-f]{2})?$/i;
+    const opaqueTokenColor = /^#[0-9a-f]{6}$/i;
+
+    builtinAppearancePackages.forEach(pkg => {
+      const settings = pkg.renderers?.monaco?.settings;
+      expect(settings, `${pkg.id} must define Monaco settings`).toBeDefined();
+      expect(monacoAppearanceAdapterForValidation.validate(settings)).toEqual([]);
+
+      const projected = projectMonacoAppearanceSettings(settings!);
+      Object.values(projected.colors).forEach(value => {
+        expect(value, `${pkg.id} emitted non-native Monaco color`).toMatch(nativeColor);
+      });
+      [projected.colors['editor.foreground'], projected.colors['editor.background']]
+        .filter((value): value is string => value !== undefined)
+        .forEach(value => expect(value).toMatch(opaqueTokenColor));
+      projected.rules.forEach(rule => {
+        if (rule.foreground) expect(rule.foreground).toMatch(opaqueTokenColor);
+        if (rule.background) expect(rule.background).toMatch(opaqueTokenColor);
+      });
+    });
+  });
+
+  it('passes the projected light theme to Monaco defineTheme', async () => {
+    const settings = builtinAppearancePackages
+      .find(pkg => pkg.id === 'bitfun-light')
+      ?.renderers?.monaco?.settings;
+    expect(settings).toBeDefined();
+
+    let receivedTheme: Monaco.editor.IStandaloneThemeData | undefined;
+    const defineTheme = vi.fn((_: string, theme: Monaco.editor.IStandaloneThemeData) => {
+      receivedTheme = theme;
+    });
+    const monaco = {
+      editor: {
+        defineTheme,
+        setTheme: vi.fn(),
+        getEditors: () => [],
+      },
+    } as unknown as typeof Monaco;
+    const adapter = new MonacoAppearanceAdapter();
+    await adapter.apply(settings!, undefined, {
+      revision: 1,
+      appearanceId: 'bitfun-light',
+      mode: 'light',
+      globals: {},
+      assets: {},
+    });
+
+    expect(() => adapter.attachMonaco(monaco)).not.toThrow();
+    expect(defineTheme).toHaveBeenCalledOnce();
+    expect(receivedTheme?.colors['editor.foreground']).toBe('#333333');
+    expect(receivedTheme?.colors['editor.selectionBackground']).toBe('#101a2724');
+  });
 });
+
+const monacoAppearanceAdapterForValidation = new MonacoAppearanceAdapter();

--- a/src/web-ui/src/infrastructure/appearance/adapters/monacoThemeColorCodec.test.ts
+++ b/src/web-ui/src/infrastructure/appearance/adapters/monacoThemeColorCodec.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import type { MonacoAppearanceSettings } from '../types';
+import {
+  isMonacoAppearanceColor,
+  projectMonacoAppearanceSettings,
+} from './monacoThemeColorCodec';
+
+function createSettings(
+  overrides: Partial<MonacoAppearanceSettings> = {},
+): MonacoAppearanceSettings {
+  return {
+    id: 'test-theme',
+    base: 'vs',
+    inherit: true,
+    rules: [],
+    colors: {},
+    ...overrides,
+  };
+}
+
+describe('Monaco theme color codec', () => {
+  it('projects CSS alpha colors into Monaco-native color formats', () => {
+    const settings = createSettings({
+      rules: [
+        { token: 'comment', foreground: 'rgba(255, 0, 0, 0.5)' },
+        { token: 'keyword', foreground: '6b5a89' },
+      ],
+      colors: {
+        'editor.background': '#ffffff',
+        'editor.foreground': 'rgba(0, 0, 0, 0.80)',
+        'editor.selectionBackground': 'rgba(16, 26, 39, 0.14)',
+        'editorCursor.foreground': '#abc',
+      },
+    });
+
+    const projected = projectMonacoAppearanceSettings(settings);
+
+    expect(projected.colors).toEqual({
+      'editor.background': '#ffffff',
+      'editor.foreground': '#333333',
+      'editor.selectionBackground': '#101a2724',
+      'editorCursor.foreground': '#aabbcc',
+    });
+    expect(projected.rules).toEqual([
+      { token: 'comment', foreground: '#ff8080' },
+      { token: 'keyword', foreground: '#6b5a89' },
+    ]);
+    expect(settings.colors['editor.foreground']).toBe('rgba(0, 0, 0, 0.80)');
+  });
+
+  it('requires an explicit opaque canvas for colors that need alpha compositing', () => {
+    expect(() => projectMonacoAppearanceSettings(createSettings({
+      colors: { 'editor.background': 'rgba(0, 0, 0, 0.5)' },
+    }))).toThrow('colors.editor.background must be opaque');
+    expect(() => projectMonacoAppearanceSettings(createSettings({
+      colors: { 'editor.foreground': 'rgba(255, 255, 255, 0.5)' },
+    }))).toThrow('colors.editor.foreground uses alpha');
+  });
+
+  it('rejects out-of-range channels while preserving supported legacy inputs', () => {
+    expect(isMonacoAppearanceColor('rgba(0, 0, 0, 0.80)')).toBe(true);
+    expect(isMonacoAppearanceColor('6b5a89', true)).toBe(true);
+    expect(isMonacoAppearanceColor('6b5a89')).toBe(false);
+    expect(isMonacoAppearanceColor('rgba(256, 0, 0, 0.5)')).toBe(false);
+    expect(isMonacoAppearanceColor('rgba(0, 0, 0, 1.1)')).toBe(false);
+  });
+});

--- a/src/web-ui/src/infrastructure/appearance/adapters/monacoThemeColorCodec.ts
+++ b/src/web-ui/src/infrastructure/appearance/adapters/monacoThemeColorCodec.ts
@@ -1,0 +1,197 @@
+import type {
+  MonacoAppearanceSettings,
+  MonacoAppearanceTokenRule,
+} from '../types';
+
+interface RgbaColor {
+  red: number;
+  green: number;
+  blue: number;
+  alpha: number;
+}
+
+function parseHexColor(value: string, allowBareHex: boolean): RgbaColor | null {
+  const match = (allowBareHex
+    ? /^#?([0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i
+    : /^#([0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i
+  ).exec(value);
+  if (!match) return null;
+
+  const raw = match[1];
+  const expanded = raw.length <= 4
+    ? raw.split('').map(channel => channel + channel).join('')
+    : raw;
+  return {
+    red: Number.parseInt(expanded.slice(0, 2), 16),
+    green: Number.parseInt(expanded.slice(2, 4), 16),
+    blue: Number.parseInt(expanded.slice(4, 6), 16),
+    alpha: expanded.length === 8
+      ? Number.parseInt(expanded.slice(6, 8), 16) / 255
+      : 1,
+  };
+}
+
+function parseRgbColor(value: string): RgbaColor | null {
+  const match = /^rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)(?:\s*,\s*([\d.]+))?\s*\)$/i.exec(value);
+  if (!match) return null;
+
+  const channels = match.slice(1, 4).map(Number);
+  const alpha = match[4] === undefined ? 1 : Number(match[4]);
+  if (channels.some(channel => !Number.isFinite(channel) || channel < 0 || channel > 255)
+    || !Number.isFinite(alpha)
+    || alpha < 0
+    || alpha > 1) {
+    return null;
+  }
+
+  return {
+    red: channels[0],
+    green: channels[1],
+    blue: channels[2],
+    alpha,
+  };
+}
+
+function parseColor(value: string, allowBareHex: boolean): RgbaColor | null {
+  return parseHexColor(value, allowBareHex) ?? parseRgbColor(value);
+}
+
+function hexChannel(value: number): string {
+  return Math.round(value).toString(16).padStart(2, '0');
+}
+
+function formatHex(color: RgbaColor, preserveAlpha: boolean): string {
+  const rgb = `${hexChannel(color.red)}${hexChannel(color.green)}${hexChannel(color.blue)}`;
+  return preserveAlpha && color.alpha < 1
+    ? `#${rgb}${hexChannel(color.alpha * 255)}`
+    : `#${rgb}`;
+}
+
+function compositeOver(foreground: RgbaColor, background: RgbaColor): RgbaColor {
+  const alpha = foreground.alpha + background.alpha * (1 - foreground.alpha);
+  if (alpha === 0) return { red: 0, green: 0, blue: 0, alpha: 0 };
+
+  const compositeChannel = (foregroundChannel: number, backgroundChannel: number): number => (
+    foregroundChannel * foreground.alpha
+    + backgroundChannel * background.alpha * (1 - foreground.alpha)
+  ) / alpha;
+  return {
+    red: compositeChannel(foreground.red, background.red),
+    green: compositeChannel(foreground.green, background.green),
+    blue: compositeChannel(foreground.blue, background.blue),
+    alpha,
+  };
+}
+
+function parseRequiredColor(value: string, path: string, allowBareHex: boolean): RgbaColor {
+  const parsed = parseColor(value, allowBareHex);
+  if (!parsed) throw new Error(`${path} is not a supported color`);
+  return parsed;
+}
+
+function projectOpaqueColor(
+  color: RgbaColor,
+  path: string,
+  editorBackground: RgbaColor | null,
+): string {
+  if (color.alpha === 1) return formatHex(color, false);
+  if (!editorBackground) {
+    throw new Error(`${path} uses alpha but colors.editor.background is not an opaque color`);
+  }
+  return formatHex(compositeOver(color, editorBackground), false);
+}
+
+function projectTokenRule(
+  rule: MonacoAppearanceTokenRule,
+  index: number,
+  editorBackground: RgbaColor | null,
+): MonacoAppearanceTokenRule {
+  const projectTokenColor = (value: string, field: 'foreground' | 'background'): string => {
+    const parsed = parseRequiredColor(value, `rules.${index}.${field}`, true);
+    return projectOpaqueColor(parsed, `rules.${index}.${field}`, editorBackground);
+  };
+
+  return {
+    ...rule,
+    ...(rule.foreground === undefined
+      ? {}
+      : { foreground: projectTokenColor(rule.foreground, 'foreground') }),
+    ...(rule.background === undefined
+      ? {}
+      : { background: projectTokenColor(rule.background, 'background') }),
+  };
+}
+
+export function isMonacoAppearanceColor(value: string, allowBareHex = false): boolean {
+  return parseColor(value, allowBareHex) !== null;
+}
+
+export function validateMonacoAppearanceColorSemantics(
+  settings: Readonly<MonacoAppearanceSettings>,
+): string[] {
+  const errors: string[] = [];
+  const backgroundValue = settings.colors['editor.background'];
+  const background = backgroundValue === undefined ? null : parseColor(backgroundValue, false);
+  const opaqueBackground = background?.alpha === 1 ? background : null;
+  if (background && background.alpha < 1) {
+    errors.push('colors.editor.background must be opaque because Monaco also uses it as a token color');
+  }
+
+  const requireBackgroundForAlpha = (
+    value: string | undefined,
+    path: string,
+    allowBareHex: boolean,
+  ): void => {
+    if (value === undefined) return;
+    const parsed = parseColor(value, allowBareHex);
+    if (parsed && parsed.alpha < 1 && !opaqueBackground) {
+      errors.push(`${path} uses alpha and requires an opaque colors.editor.background`);
+    }
+  };
+  requireBackgroundForAlpha(
+    settings.colors['editor.foreground'],
+    'colors.editor.foreground',
+    false,
+  );
+  settings.rules.forEach((rule, index) => {
+    requireBackgroundForAlpha(rule.foreground, `rules.${index}.foreground`, true);
+    requireBackgroundForAlpha(rule.background, `rules.${index}.background`, true);
+  });
+  return errors;
+}
+
+/**
+ * Converts BitFun Appearance colors to the narrower formats accepted by Monaco.
+ * Monaco workbench colors accept hex alpha, while token colors must be opaque.
+ */
+export function projectMonacoAppearanceSettings(
+  settings: Readonly<MonacoAppearanceSettings>,
+): MonacoAppearanceSettings {
+  const configuredBackground = settings.colors['editor.background'];
+  const editorBackground = configuredBackground === undefined
+    ? null
+    : parseRequiredColor(configuredBackground, 'colors.editor.background', false);
+  if (editorBackground && editorBackground.alpha < 1) {
+    throw new Error('colors.editor.background must be opaque because Monaco also uses it as a token color');
+  }
+
+  const colors = Object.fromEntries(Object.entries(settings.colors).map(([key, value]) => {
+    const parsed = parseRequiredColor(value, `colors.${key}`, false);
+    return [key, formatHex(parsed, true)];
+  }));
+  const configuredForeground = settings.colors['editor.foreground'];
+  if (configuredForeground !== undefined) {
+    const foreground = parseRequiredColor(configuredForeground, 'colors.editor.foreground', false);
+    colors['editor.foreground'] = projectOpaqueColor(
+      foreground,
+      'colors.editor.foreground',
+      editorBackground,
+    );
+  }
+
+  return {
+    ...settings,
+    rules: settings.rules.map((rule, index) => projectTokenRule(rule, index, editorBackground)),
+    colors,
+  };
+}


### PR DESCRIPTION
Project Appearance CSS colors into Monaco's native hex formats before theme registration. Composite alpha-bearing token colors against the editor background so light theme foregrounds no longer abort editor initialization.

Validate renderer color ranges and background requirements, cover all built-in themes and the light regression, and document renderer format ownership.
