### PR TITLE
fix(web): hide native browser beneath image lightbox

### DIFF
--- a/src/web-ui/src/app/scenes/browser/nativeWebviewOcclusionContract.test.ts
+++ b/src/web-ui/src/app/scenes/browser/nativeWebviewOcclusionContract.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { NATIVE_WEBVIEW_OCCLUSION_SELECTOR } from './useEmbeddedBrowserWebview';
+
+function readSource(relativePath: string): string {
+  return readFileSync(fileURLToPath(new URL(relativePath, import.meta.url)), 'utf8')
+    .replace(/\r\n?/g, '\n');
+}
+
+describe('native browser webview occlusion contract', () => {
+  it('recognizes overlays that explicitly occlude native child webviews', () => {
+    expect(NATIVE_WEBVIEW_OCCLUSION_SELECTOR).toContain('[data-bf-native-webview-occlusion]');
+  });
+
+  it('marks the user-message image lightbox as a native-webview occluder', () => {
+    const source = readSource('../../../flow_chat/components/modern/UserMessageItem.tsx');
+
+    expect(source).toContain('data-bf-native-webview-occlusion');
+  });
+});

--- a/src/web-ui/src/app/scenes/browser/useEmbeddedBrowserWebview.ts
+++ b/src/web-ui/src/app/scenes/browser/useEmbeddedBrowserWebview.ts
@@ -7,7 +7,15 @@ import { api } from '@/infrastructure/api/service-api/ApiClient';
 const WEBVIEW_RESIZE_DEBOUNCE_MS = 160;
 const WEBVIEW_BOUNDS_EPSILON = 1;
 const WEBVIEW_BOUNDS_WAIT_TIMEOUT_MS = 2000;
-const OVERLAY_SELECTOR = "[data-bf-component='dialog'][data-bf-part='overlay'], [data-bf-component='sheet'][data-bf-part='overlay'], .canvas-mission-control";
+// Native child WebViews sit above the main document's CSS stacking contexts.
+// Full-window DOM surfaces use this contract so the browser can be hidden while
+// they are open and restored without tearing down its page state.
+export const NATIVE_WEBVIEW_OCCLUSION_SELECTOR = [
+  '[data-bf-native-webview-occlusion]',
+  "[data-bf-component='dialog'][data-bf-part='overlay']",
+  "[data-bf-component='sheet'][data-bf-part='overlay']",
+  '.canvas-mission-control',
+].join(', ');
 const BROWSER_WEBVIEW_PAGE_LOAD_EVENT = 'browser-webview-page-load';
 const WEBVIEW_CREATE_RETRY_DELAYS_MS = [0, 250, 750];
 
@@ -537,7 +545,7 @@ export function useEmbeddedBrowserWebview(options: UseEmbeddedBrowserWebviewOpti
 
     let hiddenByOverlay = false;
     const checkOverlays = () => {
-      const overlay = document.querySelector<HTMLElement>(OVERLAY_SELECTOR);
+      const overlay = document.querySelector<HTMLElement>(NATIVE_WEBVIEW_OCCLUSION_SELECTOR);
       const hasOverlay = overlay !== null;
       // #region agent log
       if (overlay) {
@@ -581,6 +589,7 @@ export function useEmbeddedBrowserWebview(options: UseEmbeddedBrowserWebviewOpti
 
     const observer = new MutationObserver(checkOverlays);
     observer.observe(document.body, { childList: true, subtree: true });
+    checkOverlays();
 
     const handleToolbarActivating = () => {
       void webviewRef.current?.hide().catch(() => {});

--- a/src/web-ui/src/flow_chat/components/modern/UserMessageItem.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/UserMessageItem.tsx
@@ -665,7 +665,13 @@ export const UserMessageItem = React.memo<UserMessageItemProps>(
         )}
 
         {lightboxImage && createPortal(
-          <div className="user-message-item__lightbox" onClick={() => setLightboxImage(null)} data-bf-component="user-message-item" data-bf-part="lightbox">
+          <div
+            className="user-message-item__lightbox"
+            onClick={() => setLightboxImage(null)}
+            data-bf-component="user-message-item"
+            data-bf-part="lightbox"
+            data-bf-native-webview-occlusion
+          >
             <button className="user-message-item__lightbox-close" onClick={() => setLightboxImage(null)}>
               <Icon name="xmark" size="lg" style={{ width: 20, height: 20 }} />
             </button>


### PR DESCRIPTION
## Summary

- Prevent the native embedded browser WebView from rendering above the user-message image lightbox.
- Add an explicit, reusable native-WebView occlusion contract for full-window DOM overlays.
- Check existing overlays immediately when the observer is installed.
- Add regression coverage for the selector and image-lightbox integration.

Fixes: N/A

## Type and Areas

Type: Regression fix / UI/UX / test

Areas: Web UI, desktop embedded browser, FlowChat

## Motivation / Impact

Native child WebViews render above normal document stacking contexts. As a result,
opening an image lightbox from a user message could leave the embedded browser
visible above the lightbox.

This change marks the lightbox as a native-WebView occluder and extends the browser
visibility observer to recognize that contract. The browser is temporarily hidden
and restored without destroying its page state.

## Verification

- `pnpm --dir src/web-ui run test:run src/app/scenes/browser/nativeWebviewOcclusionContract.test.ts`
  - Passed: 1 test file, 2 tests.
- `pnpm run check:web`
  - Passed.
- Interactive desktop UI verification was not performed.
- Remote workspace, remote control, Peer Device Mode, and Detached Dispatch were
  not exercised; this change is limited to local desktop native-WebView layering.

## Reviewer Notes

- Frontend-only change.
- No persisted data, API, localization, or migration changes.
- The new attribute-based contract allows future full-window overlays to opt into
  native-WebView occlusion without expanding a component-specific selector list.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable. No user-facing copy was changed.