### PR TITLE
fix(web): align scrollbars to surface edges

### DIFF
--- a/design-system/packages/ui/src/components/Menu/Menu.module.css
+++ b/design-system/packages/ui/src/components/Menu/Menu.module.css
@@ -14,7 +14,8 @@
     inline-size: var(--bf-overlay-menu-inline-size);
     max-inline-size: 100%;
     max-block-size: var(--bf-overlay-menu-max-block-size);
-    padding: var(--bf-overlay-menu-surface-padding);
+    padding-block: var(--bf-overlay-menu-surface-padding);
+    padding-inline: var(--bf-overlay-menu-surface-padding) 0;
     border: var(--bf-border-width-default) solid var(--bf-color-border-subtle);
     border-radius: var(--bf-overlay-menu-surface-radius);
     color: var(--bf-color-action-neutral-content);
@@ -46,6 +47,8 @@
     gap: calc(var(--bf-space-1) / 2);
     /* Keep item focus rings inside the scroll viewport on every edge. */
     padding: var(--bf-focus-width);
+    /* Keep the content inset while the viewport scrollbar reaches the surface edge. */
+    padding-inline-end: calc(var(--bf-overlay-menu-surface-padding) + var(--bf-focus-width));
   }
 
   .section,

--- a/design-system/packages/ui/tests/menu.test.mjs
+++ b/design-system/packages/ui/tests/menu.test.mjs
@@ -93,3 +93,10 @@ test("Menu reserves space inside its scroll viewport for focus rings on all edge
   assert.match(scrollStyles, /data-bf-orientation="vertical"\]\s*\{[^}]*overflow-x:\s*hidden;[^}]*overflow-y:\s*auto/);
   assert.doesNotMatch(styles, /overflow[^:]*:\s*visible/);
 });
+
+test("Menu keeps its scrollbar on the surface edge without changing the content inset", async () => {
+  const styles = await readFile(new URL("../src/components/Menu/Menu.module.css", import.meta.url), "utf8");
+
+  assert.match(styles, /\.root\s*\{[^}]*padding-inline:\s*var\(--bf-overlay-menu-surface-padding\) 0/);
+  assert.match(styles, /\.list\s*\{[^}]*padding-inline-end:\s*calc\(var\(--bf-overlay-menu-surface-padding\) \+ var\(--bf-focus-width\)\)/);
+});

--- a/src/web-ui/src/app/global-search/GlobalSearchRoot.scss
+++ b/src/web-ui/src/app/global-search/GlobalSearchRoot.scss
@@ -1024,3 +1024,34 @@
     }
   }
 }
+
+/*
+ * DialogBody provides the modal's content inset. Its nested results viewport
+ * must still reach the surface's inline-end edge, so transfer only that inset
+ * to the viewport's content-bearing regions.
+ */
+.global-search-modal-content {
+  --global-search-modal-inline-end-inset: var(--bf-overlay-dialog-content-padding-lg);
+
+  padding-inline-end: 0;
+}
+
+.global-search--modal {
+  > .global-search__header,
+  > .global-search__results,
+  > .global-search__footer {
+    padding-inline-end: var(--global-search-modal-inline-end-inset);
+  }
+}
+
+@media (max-width: 980px) {
+  .global-search-modal-content {
+    --global-search-modal-inline-end-inset: var(--bf-space-4);
+  }
+}
+
+@media (max-width: 700px) {
+  .global-search-modal-content {
+    --global-search-modal-inline-end-inset: var(--bf-space-3);
+  }
+}

--- a/src/web-ui/src/app/global-search/globalSearchArchitecture.test.ts
+++ b/src/web-ui/src/app/global-search/globalSearchArchitecture.test.ts
@@ -74,6 +74,17 @@ describe('global search ownership', () => {
     );
   });
 
+  it('keeps the modal results scrollbar on the dialog edge while preserving content inset', () => {
+    const globalSearchStyles = source('src/app/global-search/GlobalSearchRoot.scss');
+
+    expect(globalSearchStyles).toMatch(
+      /\.global-search-modal-content\s*\{[^}]*padding-inline-end:\s*0;/,
+    );
+    expect(globalSearchStyles).toMatch(
+      /> \.global-search__results,[\s\S]*?padding-inline-end:\s*var\(--global-search-modal-inline-end-inset\);/,
+    );
+  });
+
   it('keeps browser and terminal capabilities on the shared product activator without footer shortcuts', () => {
     const footer = source('src/app/components/NavPanel/components/PersistentFooterActions.tsx');
     const activator = source('src/app/global-search/productActionActivator.ts');

--- a/src/web-ui/src/app/scenes/my-agent/InsightsScene.presentation.test.ts
+++ b/src/web-ui/src/app/scenes/my-agent/InsightsScene.presentation.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('InsightsScene scroll layout', () => {
+  it('keeps the list scroll viewport full-width and constrains only its content', () => {
+    const source = readFileSync(resolve(__dirname, 'InsightsScene.tsx'), 'utf8');
+    const styles = readFileSync(resolve(__dirname, 'InsightsScene.scss'), 'utf8');
+    const listRootStart = styles.indexOf('.insights-scene:not(.insights-scene--report) {');
+    const listRootEnd = styles.indexOf('\n}', listRootStart);
+    const listRoot = styles.slice(listRootStart, listRootEnd);
+
+    expect(source).toContain('className="insights-scene__history-inner"');
+    expect(listRoot).toContain('width: 100%;');
+    expect(listRoot).not.toContain('max-width:');
+    expect(styles).toMatch(/\.insights-scene__history-inner\s*\{[\s\S]*?padding: \$ins-xs \$ins-lg \$ins-lg;/);
+    expect(styles).toMatch(/\.insights-scene__history\s*\{\s*flex: 1;\s*min-height: 0;\s*\}/);
+  });
+});

--- a/src/web-ui/src/app/scenes/my-agent/InsightsScene.scss
+++ b/src/web-ui/src/app/scenes/my-agent/InsightsScene.scss
@@ -33,6 +33,7 @@ $ins-sm: 8px;
 $ins-md: 14px;
 $ins-lg: 22px;
 $ins-xl: 40px;
+$ins-content-max: 1080px;
 
 // Radius
 $ins-r:    8px;
@@ -74,13 +75,20 @@ $ins-r-lg: 12px;
 }
 
 // ============================================================
-// List view - constrained width, centered
+// List view - full-width scroll viewport with centered content
 // ============================================================
 
 .insights-scene:not(.insights-scene--report) {
-  max-width: 1080px;
-  margin: 0 auto;
+  --insights-list-inline-inset: #{$ins-lg};
+
   width: 100%;
+}
+
+.insights-scene__header,
+.insights-scene__history-inner {
+  width: min(100%, $ins-content-max);
+  margin-inline: auto;
+  box-sizing: border-box;
 }
 
 // List header
@@ -217,8 +225,13 @@ $ins-r-lg: 12px;
   display: flex;
   align-items: center;
   gap: $ins-sm;
-  margin: $ins-sm $ins-lg 0;
+  width: min(
+    calc(100% - 2 * var(--insights-list-inline-inset)),
+    calc(#{$ins-content-max} - 2 * var(--insights-list-inline-inset))
+  );
+  margin: $ins-sm auto 0;
   padding: 5px $ins-md;
+  box-sizing: border-box;
   background: $ins-red-bg;
   border-radius: $ins-r-sm;
   font-size: var(--bf-type-label-md-font-size);
@@ -228,8 +241,13 @@ $ins-r-lg: 12px;
 }
 
 .insights-generation {
-  margin: 0 $ins-lg $ins-md;
+  width: min(
+    calc(100% - 2 * var(--insights-list-inline-inset)),
+    calc(#{$ins-content-max} - 2 * var(--insights-list-inline-inset))
+  );
+  margin: 0 auto $ins-md;
   padding: $ins-md;
+  box-sizing: border-box;
   border: 1px solid $ins-border;
   border-radius: $ins-r;
   background: $ins-surface;
@@ -365,9 +383,13 @@ $ins-r-lg: 12px;
 // History list
 
 .insights-scene__history {
-  padding: $ins-xs $ins-lg $ins-lg;
   flex: 1;
   min-height: 0;
+}
+
+.insights-scene__history-inner {
+  min-height: 100%;
+  padding: $ins-xs $ins-lg $ins-lg;
 }
 
 .insights-scene__history-header {
@@ -610,16 +632,17 @@ $ins-r-lg: 12px;
 }
 
 @media (max-width: 520px) {
+  .insights-scene:not(.insights-scene--report) {
+    --insights-list-inline-inset: #{$ins-md};
+  }
+
   .insights-scene__header,
-  .insights-scene__history {
+  .insights-scene__history-inner {
     padding-left: $ins-md;
     padding-right: $ins-md;
   }
 
   .insights-generation {
-    margin-left: $ins-md;
-    margin-right: $ins-md;
-
     &__status { grid-template-columns: 32px minmax(0, 1fr); }
     &__status-icon { width: 32px; height: 32px; }
     &__elapsed { grid-column: 2; }

--- a/src/web-ui/src/app/scenes/my-agent/InsightsScene.tsx
+++ b/src/web-ui/src/app/scenes/my-agent/InsightsScene.tsx
@@ -282,28 +282,30 @@ const InsightsScene: React.FC = () => {
       {generating && <GenerationPanel progress={progress} />}
 
       <ScrollArea className="insights-scene__history" data-bf-scene="insights" data-bf-part="content">
-        <div className="insights-scene__history-header">
-          <div className="insights-scene__history-label">
-            {t('insights.history')}
-            {reportMetas.length > 0 && (
-              <span className="insights-scene__history-count">{reportMetas.length}</span>
-            )}
+        <div className="insights-scene__history-inner">
+          <div className="insights-scene__history-header">
+            <div className="insights-scene__history-label">
+              {t('insights.history')}
+              {reportMetas.length > 0 && (
+                <span className="insights-scene__history-count">{reportMetas.length}</span>
+              )}
+            </div>
+            <span className="insights-scene__history-hint">{t('insights.keepLatest5')}</span>
           </div>
-          <span className="insights-scene__history-hint">{t('insights.keepLatest5')}</span>
+          {loadingMetas ? (
+            <div className="insights-scene__loading" data-bf-scene="insights" data-bf-part="loading">
+              <Loader2 size={16} className="insights-scene__spinner" />
+            </div>
+          ) : reportMetas.length === 0 ? (
+            <div className="insights-scene__empty" data-bf-scene="insights" data-bf-part="empty">{t('insights.noReports')}</div>
+          ) : (
+            <div className="insights-scene__report-list">
+              {reportMetas.map((meta) => (
+                <ReportMetaCard key={meta.generated_at} meta={meta} onSelect={loadReport} />
+              ))}
+            </div>
+          )}
         </div>
-        {loadingMetas ? (
-          <div className="insights-scene__loading" data-bf-scene="insights" data-bf-part="loading">
-            <Loader2 size={16} className="insights-scene__spinner" />
-          </div>
-        ) : reportMetas.length === 0 ? (
-          <div className="insights-scene__empty" data-bf-scene="insights" data-bf-part="empty">{t('insights.noReports')}</div>
-        ) : (
-          <div className="insights-scene__report-list">
-            {reportMetas.map((meta) => (
-              <ReportMetaCard key={meta.generated_at} meta={meta} onSelect={loadReport} />
-            ))}
-          </div>
-        )}
       </ScrollArea>
     </div>
   );

--- a/src/web-ui/src/app/scenes/settings/SettingsNav.scss
+++ b/src/web-ui/src/app/scenes/settings/SettingsNav.scss
@@ -19,6 +19,9 @@
   max-inline-size: none;
   height: 100%;
   padding: var(--bf-space-2);
+  // Preserve the content inset on descendants so the scroll viewport itself
+  // can own the panel's inline-end edge.
+  padding-inline-end: 0;
   box-sizing: border-box;
   overflow: hidden;
   line-height: var(--bf-type-meta-line-height);
@@ -28,11 +31,13 @@
     flex-direction: column;
     gap: var(--bf-layout-navigation-panel-content-gap);
     padding: 0;
+    padding-inline-end: var(--bf-space-2);
   }
 
   // The panel owns section spacing; the scene supplies only its outer inset.
   &__content {
     padding: 0;
+    padding-inline-end: var(--bf-space-2);
   }
 
   // ── Header: title (back/forward lives in NavBar) ──────

--- a/src/web-ui/src/app/scenes/settings/SettingsNavTypography.test.ts
+++ b/src/web-ui/src/app/scenes/settings/SettingsNavTypography.test.ts
@@ -57,6 +57,8 @@ describe('SettingsNav typography and layout ownership', () => {
     expect(header.getPropertyValue('flex-direction')).toBe('column');
     expect(header.getPropertyValue('gap')).toBe('var(--bf-layout-navigation-panel-content-gap)');
     expect(header.getPropertyValue('padding')).toBe('0px');
+    expect(root.getPropertyValue('padding-inline-end')).toBe('0px');
+    expect(header.getPropertyValue('padding-inline-end')).toBe('var(--bf-space-2)');
   });
 
   it('resolves shared navigation text against the current chrome instead of secondary action ink', () => {
@@ -69,6 +71,7 @@ describe('SettingsNav typography and layout ownership', () => {
     const content = declarations('.bitfun-settings-nav__content');
     const item = declarations('.bitfun-settings-nav__item');
     expect(content.getPropertyValue('padding')).toBe('0px');
+    expect(content.getPropertyValue('padding-inline-end')).toBe('var(--bf-space-2)');
     expect(content.getPropertyValue('gap')).toBe('');
     expect(item.getPropertyValue('padding-inline-start')).toBe(
       'calc(var(--bf-layout-navigation-panel-item-padding-inline) + 30px)',

--- a/src/web-ui/src/app/scenes/skills/SkillsScene.presentation.test.ts
+++ b/src/web-ui/src/app/scenes/skills/SkillsScene.presentation.test.ts
@@ -38,6 +38,21 @@ describe('Skills scene presentation', () => {
     expect(stylesheet).toContain('font-size: var(--bf-type-flow-section-title-font-size);');
   });
 
+  it('keeps the suite scrollbar on the scene edge without moving its content', () => {
+    const stylesheet = readSibling('./SkillsScene.scss');
+    const suiteStart = stylesheet.indexOf('.skills-suite {');
+    const suiteEnd = stylesheet.indexOf('\n}', suiteStart);
+    const suite = stylesheet.slice(suiteStart, suiteEnd);
+    const sectionsStart = stylesheet.indexOf('.skills-suite__sections {');
+    const sectionsEnd = stylesheet.indexOf('\n}', sectionsStart);
+    const sections = stylesheet.slice(sectionsStart, sectionsEnd);
+
+    expect(suite).toContain('padding-inline: 24px 0;');
+    expect(sections).toContain(
+      'padding-inline-end: calc(var(--skills-suite-inline-end-inset) + 4px);',
+    );
+  });
+
   it('keeps row navigation and destructive actions as separate compact targets', () => {
     const source = readSibling('./SkillsScene.tsx');
     const stylesheet = readSibling('./SkillsScene.scss');

--- a/src/web-ui/src/app/scenes/skills/SkillsScene.scss
+++ b/src/web-ui/src/app/scenes/skills/SkillsScene.scss
@@ -291,13 +291,23 @@ $skills-installed-columns: minmax(220px, 1fr) minmax(82px, 0.24fr) minmax(96px, 
 // ── Suite Page ───────────────────────────────────────────────────────────────
 
 .skills-suite {
+  --skills-suite-inline-end-inset: 24px;
+
   flex: 1;
   min-height: 0;
   display: flex;
   flex-direction: column;
   gap: 14px;
-  padding: 20px 24px 18px;
+  padding-block: 20px 18px;
+  padding-inline: 24px 0;
   overflow: hidden;
+}
+
+.skills-suite__hero,
+.skills-suite__mode-toolbar,
+.skills-suite__loading,
+.skills-suite > .skills-main__empty {
+  margin-inline-end: var(--skills-suite-inline-end-inset);
 }
 
 .skills-suite__hero {
@@ -460,7 +470,7 @@ $skills-installed-columns: minmax(220px, 1fr) minmax(82px, 0.24fr) minmax(96px, 
   display: flex;
   flex-direction: column;
   gap: 16px;
-  padding-right: 4px;
+  padding-inline-end: calc(var(--skills-suite-inline-end-inset) + 4px);
 }
 
 .skills-suite__section {
@@ -1284,7 +1294,10 @@ $skills-installed-columns: minmax(220px, 1fr) minmax(82px, 0.24fr) minmax(96px, 
   }
 
   .skills-suite {
-    padding: 14px 16px 16px;
+    --skills-suite-inline-end-inset: 16px;
+
+    padding-block: 14px 16px;
+    padding-inline: 16px 0;
   }
 
   .skills-suite__hero {

--- a/src/web-ui/src/tools/git/components/CreateBranchDialog/CreateBranchDialog.presentation.test.ts
+++ b/src/web-ui/src/tools/git/components/CreateBranchDialog/CreateBranchDialog.presentation.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('CreateBranchDialog scroll layout', () => {
+  it('keeps the scrollbar on the dialog edge and the content inset', () => {
+    const stylesheet = readFileSync(resolve(__dirname, 'CreateBranchDialog.scss'), 'utf8');
+
+    expect(stylesheet).toContain('padding-block: var(--bf-space-5);');
+    expect(stylesheet).toContain('padding-inline: var(--bf-space-5) 0;');
+    expect(stylesheet).toMatch(
+      /&__scroll\s*\{[\s\S]*?padding-inline-end: var\(--bf-space-5\);/,
+    );
+  });
+});

--- a/src/web-ui/src/tools/git/components/CreateBranchDialog/CreateBranchDialog.scss
+++ b/src/web-ui/src/tools/git/components/CreateBranchDialog/CreateBranchDialog.scss
@@ -1,11 +1,13 @@
 .bitfun-create-branch-dialog {
-  padding: var(--bf-space-5);
+  padding-block: var(--bf-space-5);
+  padding-inline: var(--bf-space-5) 0;
   min-width: 520px;
   max-width: 600px;
   max-height: 90vh;
 
   &__scroll {
     max-height: inherit;
+    padding-inline-end: var(--bf-space-5);
   }
 
   &__header {


### PR DESCRIPTION
## Summary

- move inline-end spacing from outer scroll wrappers into their content so scrollbars sit on the owning surface edge
- cover shared menus plus Settings, Global Search, Insights, Skills Suite, and Create Branch surfaces
- preserve existing content insets and responsive spacing while adding focused layout regression tests

## Verification

- `pnpm run check:web`
- `pnpm --dir design-system --filter @bitfun/ui run test` (221 passed)
- `pnpm --dir src/web-ui exec vitest run --maxWorkers=50% src/app/scenes/settings/SettingsNavTypography.test.ts src/app/global-search/globalSearchArchitecture.test.ts src/app/scenes/my-agent/InsightsScene.presentation.test.ts src/app/scenes/skills/SkillsScene.presentation.test.ts src/tools/git/components/CreateBranchDialog/CreateBranchDialog.presentation.test.ts` (20 passed)
- `git diff --check`

## Remote scenarios

Presentation-only CSS/markup change; remote workspace, remote control, Peer Device Mode, and Detached Dispatch contracts are unchanged and were not separately exercised.