### PR TITLE
fix(web): polish realtime voice switch

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/unifiedSessionCreation.test.ts
+++ b/src/web-ui/src/app/components/NavPanel/unifiedSessionCreation.test.ts
@@ -35,6 +35,7 @@ describe('unified project session creation', () => {
     expect(helloLauncher).toContain('<ChatPane');
     expect(helloLauncher).toContain('data-testid="hello-realtime-voice-mode-switch"');
     expect(helloLauncher).toContain('onClick={isVoiceMode ? endVoiceCall : startVoiceCall}');
+    expect(helloLauncher).toContain('<Phone size={15} aria-hidden="true" />');
     expect(helloLauncher).toContain('<RealtimeVoiceCallPanel />');
     expect(helloLauncher).toContain('<LauncherButton');
     expect(helloLauncher).toContain('leadingIcon={<Icon name="mic" />}');

--- a/src/web-ui/src/app/layout/FloatingMiniChat.scss
+++ b/src/web-ui/src/app/layout/FloatingMiniChat.scss
@@ -396,7 +396,7 @@ $panel-height: 680px;
   flex: 0 0 auto;
   padding: var(--bf-space-2);
   border-top: 1px solid var(--bf-color-border-subtle);
-  background: color-mix(in srgb, var(--bf-color-surface-subtle) 78%, transparent);
+  background: transparent;
 }
 
 .bitfun-fmc__mode-switch-button {
@@ -407,9 +407,9 @@ $panel-height: 680px;
   justify-content: center;
   gap: var(--bf-space-2);
   padding: var(--bf-space-2) var(--bf-space-3);
-  border: 1px solid var(--bf-color-border-subtle);
+  border: 0;
   border-radius: var(--bf-radius-base);
-  background: var(--bf-color-action-quiet-hover);
+  background: transparent;
   color: var(--bf-color-content-secondary);
   font: inherit;
   font-size: var(--bf-type-label-sm-font-size);
@@ -418,13 +418,23 @@ $panel-height: 680px;
   cursor: pointer;
   transition:
     background var(--bf-motion-duration-fast) var(--bf-motion-easing-standard),
-    border-color var(--bf-motion-duration-fast) var(--bf-motion-easing-standard),
-    color var(--bf-motion-duration-fast) var(--bf-motion-easing-standard);
+    color var(--bf-motion-duration-fast) var(--bf-motion-easing-standard),
+    transform var(--bf-motion-duration-fast) var(--bf-motion-easing-standard);
 
-  &:hover:not(:disabled) {
-    border-color: var(--bf-color-field-border-hover);
+  @media (hover: hover) and (pointer: fine) {
+    &:hover:not(:disabled) {
+      background: var(--bf-color-action-quiet-hover);
+      color: var(--bf-color-content-primary);
+    }
+
+    &.is-voice:hover:not(:disabled) {
+      background: color-mix(in srgb, var(--bf-color-status-success-content) 13%, transparent);
+    }
+  }
+
+  &:active:not(:disabled) {
     background: var(--bf-color-action-neutral-surface-hover);
-    color: var(--bf-color-content-primary);
+    transform: scale(0.985);
   }
 
   &:focus-visible {
@@ -438,7 +448,6 @@ $panel-height: 680px;
   }
 
   &.is-voice {
-    border-color: color-mix(in srgb, var(--bf-color-status-success-content) 26%, transparent);
     background: color-mix(in srgb, var(--bf-color-status-success-content) 9%, transparent);
     color: var(--bf-color-content-primary);
   }
@@ -648,5 +657,9 @@ $panel-height: 680px;
 
   .bitfun-fmc__mode-switch-spinner {
     animation: none;
+  }
+
+  .bitfun-fmc__mode-switch-button:active:not(:disabled) {
+    transform: none;
   }
 }

--- a/src/web-ui/src/app/layout/FloatingMiniChat.tsx
+++ b/src/web-ui/src/app/layout/FloatingMiniChat.tsx
@@ -11,7 +11,7 @@
 
 import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Loader2 } from 'lucide-react';
+import { Loader2, Phone } from 'lucide-react';
 
 import { flowChatStore } from '../../flow_chat/store/FlowChatStore';
 import { syncSessionToModernStore } from '../../flow_chat/services/storeSync';
@@ -595,7 +595,7 @@ export const FloatingMiniChat: React.FC = () => {
               data-bf-part="voiceModeIcon"
               aria-hidden="true"
             >
-              <Icon name="mic" size="lg" style={{ width: 14, height: 14 }} />
+              <Phone size={14} />
             </span>
           ) : isMiniAppBubbleIsolated ? (
             <div
@@ -698,7 +698,7 @@ export const FloatingMiniChat: React.FC = () => {
             ) : isVoiceMode ? (
               <Icon name="side-chat" size="sm" aria-hidden="true" />
             ) : (
-              <Icon name="mic" size="lg" style={{ width: 15, height: 15 }} aria-hidden="true" />
+              <Phone size={15} aria-hidden="true" />
             )}
             <span>
               {tVoice(isVoiceMode

--- a/src/web-ui/src/infrastructure/config/components/ReasoningConfigPanel.tsx
+++ b/src/web-ui/src/infrastructure/config/components/ReasoningConfigPanel.tsx
@@ -46,6 +46,8 @@ export const ReasoningConfigPanel: React.FC<ReasoningConfigPanelProps> = ({
   const projectionRequestId = useRef(0);
   const onDraftChangeRef = useRef(onDraftChange);
   onDraftChangeRef.current = onDraftChange;
+  const projectionRequestRef = useRef(projectionRequest);
+  projectionRequestRef.current = projectionRequest;
   const projectionRequestKey = JSON.stringify(projectionRequest);
   const fallbackGeneratedProjection = projectionRequest ? undefined : generatedProjection;
   const projectionBindingKey = JSON.stringify({
@@ -72,7 +74,8 @@ export const ReasoningConfigPanel: React.FC<ReasoningConfigPanelProps> = ({
   }, [activeGeneratedProjection, draft]);
 
   useEffect(() => {
-    if (!projectionRequest) {
+    const currentProjectionRequest = projectionRequestRef.current;
+    if (!currentProjectionRequest) {
       setResolvedProjection({
         bindingKey: projectionBindingKey,
         projection: fallbackGeneratedProjection,
@@ -82,7 +85,7 @@ export const ReasoningConfigPanel: React.FC<ReasoningConfigPanelProps> = ({
 
     const requestId = ++projectionRequestId.current;
     void aiApi.projectReasoningCatalog({
-      ...projectionRequest,
+      ...currentProjectionRequest,
       reasoning: draft,
     }).then((projection) => {
       if (projectionRequestId.current !== requestId) return;

--- a/src/web-ui/src/infrastructure/config/settingsDraftRegistry.ts
+++ b/src/web-ui/src/infrastructure/config/settingsDraftRegistry.ts
@@ -304,6 +304,8 @@ export function useSettingsDraftSnapshot(): SettingsDraftSnapshot {
 export function useSettingsDraft(
   registration: SettingsDraftRegistration & { enabled?: boolean },
 ): void {
+  const registrationRef = useRef(registration);
+  registrationRef.current = registration;
   const callbacksRef = useRef({
     save: registration.save,
     discard: registration.discard,
@@ -314,8 +316,9 @@ export function useSettingsDraft(
   };
 
   useLayoutEffect(() => {
-    if (registration.enabled === false) return undefined;
-    const { enabled: _enabled, ...draft } = registration;
+    const currentRegistration = registrationRef.current;
+    if (currentRegistration.enabled === false) return undefined;
+    const { enabled: _enabled, ...draft } = currentRegistration;
     return registerSettingsDraft({
       ...draft,
       save: () => callbacksRef.current.save(),


### PR DESCRIPTION
## Summary

- Simplify the realtime voice mode switch into a borderless ghost action so the floating panel no longer shows nested rounded borders.
- Use a phone handset icon for realtime voice entry and active-call identity while keeping microphone icons for ASR and mute controls.
- Add a regression assertion for the realtime voice phone icon.
- Stabilize two settings Hook inputs introduced by merged PR #2760, clearing deterministic exhaustive-deps errors that blocked Frontend Build on the current base branch.

## Type and Areas

Type: UI/UX, regression fix, CI unblock

Areas: web UI

## Motivation / Impact

The previous switch duplicated the floating panel border and used the same microphone metaphor as ASR dictation. The updated control has a clearer visual hierarchy and distinguishes a realtime call from microphone input without changing behavior or copy.

The first CI run also exposed two lint errors already present in the latest 1.0.0-explore base. The follow-up keeps the latest projection request and settings draft registration in refs while preserving the existing structural rerun triggers, preventing request or registration churn.

## Verification

- pnpm --dir src/web-ui run test:run src/app/components/NavPanel/unifiedSessionCreation.test.ts (9 tests passed)
- pnpm --dir src/web-ui run test:run src/infrastructure/config/components/ReasoningConfigPanel.test.tsx src/infrastructure/config/settingsDraftRegistry.test.ts (12 tests passed)
- pnpm run lint:web (0 errors; 7 pre-existing Fast Refresh warnings)
- pnpm run motion:audit (completed with no new findings; one pre-existing inventory item remains in PortForwardDialog.scss)
- pnpm run check:web (appearance, theme, typography, and type checks passed)
- Manual local Web preview: the idle switch has a transparent background and 0px border; hover and press feedback remain visible.

## Reviewer Notes

The product change is presentation-only shared Web UI. Remote workspace, remote control, Peer Device Mode, and Detached Dispatch were not exercised separately because command, transport, persistence, and runtime behavior are unchanged. No user-facing strings or locale resources changed.

The settings Hook adjustment is isolated to preserving existing rerun semantics while satisfying the repository lint gate.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.