### PR TITLE
fix(voice): synchronize local model install state

### DIFF
--- a/src/apps/desktop/src/frontend_workbench.rs
+++ b/src/apps/desktop/src/frontend_workbench.rs
@@ -1703,7 +1703,7 @@ mod tests {
         fs::create_dir_all(&misleading).expect("misleading directory");
         let uppercase = manager
             .revisions_dir()
-            .join(".copy-38E14F63-30AD-4AD7-9E4E-5AD556450BA3");
+            .join(".copy-48E14F63-30AD-4AD7-9E4E-5AD556450BA3");
         fs::create_dir_all(&uppercase).expect("uppercase directory");
         let matching_file = manager
             .revisions_dir()

--- a/src/crates/services/services-integrations/src/speech/downloader.rs
+++ b/src/crates/services/services-integrations/src/speech/downloader.rs
@@ -1,7 +1,7 @@
 use super::model_store::{validate_relative_archive_path, SpeechModelStore};
 use super::types::{
-    SpeechModelArtifact, SpeechModelArtifactKind, SpeechModelManifest, SpeechModelProgress,
-    SpeechModelStatus,
+    SpeechModelArtifact, SpeechModelArtifactKind, SpeechModelInstallState, SpeechModelManifest,
+    SpeechModelProgress, SpeechModelStatus,
 };
 use super::{BitFunError, BitFunResult};
 use bzip2::read::BzDecoder;
@@ -23,7 +23,7 @@ pub(super) async fn download_and_install_model<F>(
     on_progress: F,
 ) -> BitFunResult<SpeechModelStatus>
 where
-    F: Fn(SpeechModelProgress) + Send + Sync,
+    F: Fn(SpeechModelInstallState, SpeechModelProgress) + Send + Sync,
 {
     let client = crate::reqwest_client_builder()
         .connect_timeout(Duration::from_secs(15))
@@ -33,6 +33,9 @@ where
     let total_bytes = manifest.expected_bytes();
     let mut completed_bytes = 0u64;
     let mut downloaded_artifacts = Vec::with_capacity(manifest.artifacts.len());
+    let report_download_progress = |progress| {
+        on_progress(SpeechModelInstallState::Downloading, progress);
+    };
 
     for artifact in &manifest.artifacts {
         let artifact_path = ensure_artifact_downloaded(
@@ -43,19 +46,21 @@ where
             completed_bytes,
             total_bytes,
             cancel.clone(),
-            &on_progress,
+            &report_download_progress,
         )
         .await?;
         completed_bytes = completed_bytes.saturating_add(artifact.size_bytes);
         downloaded_artifacts.push((artifact.clone(), artifact_path));
     }
 
-    on_progress(SpeechModelProgress {
+    let completed_progress = SpeechModelProgress {
         model_id: manifest.id.clone(),
         downloaded_bytes: total_bytes,
         total_bytes,
         percent: 100.0,
-    });
+    };
+    report_download_progress(completed_progress.clone());
+    on_progress(SpeechModelInstallState::Verifying, completed_progress);
     install_artifacts(store, manifest, &downloaded_artifacts).await?;
     store.status_for_manifest(manifest).await
 }
@@ -310,6 +315,8 @@ async fn install_artifacts_into_staging(
     }
 
     let payload_dir = find_payload_dir(staging, &manifest.required_files).await?;
+    store.write_install_record(manifest, &payload_dir).await?;
+
     if final_dir.exists() {
         fs::remove_dir_all(&final_dir).await?;
     }
@@ -323,7 +330,6 @@ async fn install_artifacts_into_staging(
         }
     }
 
-    store.write_install_record(manifest, final_dir).await?;
     Ok(())
 }
 
@@ -379,4 +385,82 @@ fn has_required_files_at(path: &Path, required_files: &[String]) -> bool {
     required_files
         .iter()
         .all(|relative| path.join(relative).is_file())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::speech::model_catalog::sensevoice_small_int8_manifest;
+    use std::sync::Mutex;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn completed_download_enters_verifying_before_model_is_published() {
+        let root = tempdir().unwrap();
+        let paths = super::super::SpeechStoragePaths::new(
+            root.path().join("models"),
+            root.path().join("downloads"),
+            root.path().join("input"),
+        );
+        let store = SpeechModelStore::new(paths);
+        let mut manifest = sensevoice_small_int8_manifest();
+        manifest.id = "install-phase-test".to_string();
+        manifest.version = "test-version".to_string();
+        manifest.required_files.clear();
+        manifest.artifacts.clear();
+        let final_dir = store.model_dir(&manifest);
+        let observed_states = Mutex::new(Vec::new());
+
+        let status =
+            download_and_install_model(&store, &manifest, CancellationToken::new(), |state, _| {
+                if state == SpeechModelInstallState::Verifying {
+                    assert!(!final_dir.exists());
+                }
+                observed_states.lock().unwrap().push(state);
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(
+            *observed_states.lock().unwrap(),
+            vec![
+                SpeechModelInstallState::Downloading,
+                SpeechModelInstallState::Verifying,
+            ]
+        );
+        assert_eq!(status.state, SpeechModelInstallState::Installed);
+        assert!(final_dir.join("bitfun-model-install.json").is_file());
+    }
+
+    #[tokio::test]
+    async fn failed_install_record_write_does_not_publish_model_files() {
+        let root = tempdir().unwrap();
+        let paths = super::super::SpeechStoragePaths::new(
+            root.path().join("models"),
+            root.path().join("downloads"),
+            root.path().join("input"),
+        );
+        let store = SpeechModelStore::new(paths);
+        let mut manifest = sensevoice_small_int8_manifest();
+        manifest.id = "staged-install-test".to_string();
+        manifest.version = "test-version".to_string();
+        manifest.required_files = vec!["model.onnx".to_string()];
+        manifest.artifacts.clear();
+
+        let final_dir = store.model_dir(&manifest);
+        let staging = final_dir.parent().unwrap().join(".installing-test");
+        fs::create_dir_all(staging.join("bitfun-model-install.json"))
+            .await
+            .unwrap();
+        fs::write(staging.join("model.onnx"), b"model-data")
+            .await
+            .unwrap();
+
+        let result =
+            install_artifacts_into_staging(&store, &manifest, &[], &staging, &final_dir).await;
+
+        assert!(result.is_err());
+        assert!(!final_dir.exists());
+        assert!(staging.join("model.onnx").is_file());
+    }
 }

--- a/src/crates/services/services-integrations/src/speech/mod.rs
+++ b/src/crates/services/services-integrations/src/speech/mod.rs
@@ -148,7 +148,7 @@ impl SpeechService {
                 &store,
                 &manifest,
                 task_control.cancel.clone(),
-                |progress| {
+                |state, progress| {
                     let status = SpeechModelStatus {
                         model_id: manifest.id.clone(),
                         display_name: manifest.display_name.clone(),
@@ -156,7 +156,7 @@ impl SpeechService {
                         version: manifest.version.clone(),
                         description: manifest.description.clone(),
                         languages: manifest.languages.clone(),
-                        state: SpeechModelInstallState::Downloading,
+                        state,
                         installed_path: None,
                         installed_bytes: progress.downloaded_bytes,
                         expected_bytes: manifest.expected_bytes(),

--- a/src/web-ui/src/flow_chat/components/voice/useComposerVoiceInput.test.tsx
+++ b/src/web-ui/src/flow_chat/components/voice/useComposerVoiceInput.test.tsx
@@ -15,7 +15,16 @@ globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 const mocks = vi.hoisted(() => ({
   finishText: 'Transcribed request',
+  voiceInputSettings: {
+    enabled: true,
+    provider: 'local',
+    model_id: 'sensevoice-test-model',
+    default_language: 'auto',
+    max_recording_seconds: 60,
+    microphone_device_id: '',
+  },
   recorderStop: vi.fn(async () => undefined),
+  listModels: vi.fn(),
   finishInputSession: vi.fn(),
   cancelInputSession: vi.fn(async () => undefined),
   downloadModel: vi.fn(),
@@ -29,19 +38,7 @@ vi.mock('@/infrastructure/api', () => ({
   DEFAULT_SPEECH_SAMPLE_RATE: 16000,
   LOCAL_SENSEVOICE_SMALL_INT8_MODEL_ID: 'sensevoice-test-model',
   speechAPI: {
-    listModels: vi.fn(async () => ({
-      models: [{
-        modelId: 'sensevoice-test-model',
-        displayName: 'SenseVoice test',
-        provider: 'test',
-        version: 'test',
-        description: 'Test speech model',
-        languages: ['auto', 'en'],
-        state: 'installed',
-        installedBytes: 1,
-        expectedBytes: 1,
-      }],
-    })),
+    listModels: mocks.listModels,
     onModelStatusChanged: vi.fn((listener: (status: Record<string, unknown>) => void) => {
       mocks.modelStatusListener = listener;
       return () => undefined;
@@ -59,14 +56,7 @@ vi.mock('@/infrastructure/api', () => ({
 vi.mock('@/infrastructure/config/hooks', () => ({
   useAIExperienceSettings: () => ({
     settings: {
-      voice_input: {
-        enabled: true,
-        provider: 'local',
-        model_id: 'sensevoice-test-model',
-        default_language: 'auto',
-        max_recording_seconds: 60,
-        microphone_device_id: '',
-      },
+      voice_input: mocks.voiceInputSettings,
     },
     isLoading: false,
     error: null,
@@ -125,6 +115,34 @@ function Probe({ onController, ...options }: ProbeProps) {
   return null;
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function speechModel(
+  modelId: string,
+  state: 'installed' | 'not_installed',
+  expectedBytes = 1,
+) {
+  return {
+    modelId,
+    displayName: modelId === 'qwen-test-model' ? 'Qwen test' : 'SenseVoice test',
+    provider: 'test',
+    version: 'test',
+    description: 'Test speech model',
+    languages: ['auto', 'en'],
+    state,
+    installedBytes: state === 'installed' ? expectedBytes : 0,
+    expectedBytes,
+  };
+}
+
 describe('useComposerVoiceInput completion modes', () => {
   let host: HTMLDivElement;
   let root: Root;
@@ -134,6 +152,18 @@ describe('useComposerVoiceInput completion modes', () => {
   let submitText: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
+    mocks.voiceInputSettings = {
+      enabled: true,
+      provider: 'local',
+      model_id: 'sensevoice-test-model',
+      default_language: 'auto',
+      max_recording_seconds: 60,
+      microphone_device_id: '',
+    };
+    mocks.listModels.mockReset();
+    mocks.listModels.mockImplementation(async () => ({
+      models: [speechModel('sensevoice-test-model', 'installed')],
+    }));
     mocks.finishText = 'Transcribed request';
     mocks.finishInputSession.mockImplementation(async () => ({
       text: mocks.finishText,
@@ -300,6 +330,107 @@ describe('useComposerVoiceInput completion modes', () => {
     });
 
     expect(mocks.downloadModel).toHaveBeenCalledWith('sensevoice-test-model');
+    expect(controller?.phase).toBe('recording');
+  });
+
+  it('dismisses a stale setup prompt when the selected model becomes installed', async () => {
+    await act(async () => {
+      mocks.modelStatusListener?.(speechModel(
+        'sensevoice-test-model',
+        'not_installed',
+        165 * 1024 * 1024,
+      ));
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      controller?.toggle();
+      await Promise.resolve();
+    });
+    expect(controller?.phase).toBe('setup');
+
+    await act(async () => {
+      mocks.modelStatusListener?.(speechModel(
+        'sensevoice-test-model',
+        'installed',
+        165 * 1024 * 1024,
+      ));
+      await Promise.resolve();
+    });
+
+    expect(controller?.phase).toBe('idle');
+  });
+
+  it('ignores an old model query that completes after the selected model query', async () => {
+    mocks.listModels.mockImplementationOnce(async () => ({
+      models: [speechModel('qwen-test-model', 'installed', 838 * 1024 * 1024)],
+    }));
+    mocks.voiceInputSettings = {
+      ...mocks.voiceInputSettings,
+      model_id: 'qwen-test-model',
+    };
+    await act(async () => {
+      root.render(
+        <Probe
+          focusInputSoon={focusInputSoon}
+          insertText={insertText}
+          submitText={submitText}
+          onController={(next) => { controller = next; }}
+        />,
+      );
+      await Promise.resolve();
+    });
+
+    const oldSenseVoiceQuery = createDeferred<{ models: ReturnType<typeof speechModel>[] }>();
+    const currentQwenQuery = createDeferred<{ models: ReturnType<typeof speechModel>[] }>();
+    mocks.listModels
+      .mockImplementationOnce(() => oldSenseVoiceQuery.promise)
+      .mockImplementationOnce(() => currentQwenQuery.promise);
+
+    mocks.voiceInputSettings = {
+      ...mocks.voiceInputSettings,
+      model_id: 'sensevoice-test-model',
+    };
+    await act(async () => {
+      root.render(
+        <Probe
+          focusInputSoon={focusInputSoon}
+          insertText={insertText}
+          submitText={submitText}
+          onController={(next) => { controller = next; }}
+        />,
+      );
+    });
+
+    mocks.voiceInputSettings = {
+      ...mocks.voiceInputSettings,
+      model_id: 'qwen-test-model',
+    };
+    await act(async () => {
+      root.render(
+        <Probe
+          focusInputSoon={focusInputSoon}
+          insertText={insertText}
+          submitText={submitText}
+          onController={(next) => { controller = next; }}
+        />,
+      );
+    });
+
+    await act(async () => {
+      currentQwenQuery.resolve({
+        models: [speechModel('qwen-test-model', 'installed', 838 * 1024 * 1024)],
+      });
+      await currentQwenQuery.promise;
+    });
+    await act(async () => {
+      oldSenseVoiceQuery.resolve({
+        models: [speechModel('sensevoice-test-model', 'not_installed', 165 * 1024 * 1024)],
+      });
+      await oldSenseVoiceQuery.promise;
+    });
+
+    await startRecording();
     expect(controller?.phase).toBe('recording');
   });
 });

--- a/src/web-ui/src/flow_chat/components/voice/useComposerVoiceInput.ts
+++ b/src/web-ui/src/flow_chat/components/voice/useComposerVoiceInput.ts
@@ -22,6 +22,10 @@ const log = createLogger('ComposerVoiceInput');
 
 type VoiceInputPhase = 'idle' | 'setup' | 'downloading' | 'preparing' | 'recording' | 'transcribing';
 export type VoiceInputCompletionMode = 'transcribe' | 'send';
+interface SelectedModelCapability {
+  modelId: string;
+  status: SpeechModelStatus | null;
+}
 const STARTUP_AUDIO_BUFFER_LIMIT_SECONDS = 5;
 const RECORDING_CHUNK_DURATION_MS = 1000;
 const LOW_VOLUME_LEVEL_THRESHOLD = 0.002;
@@ -99,8 +103,7 @@ export function useComposerVoiceInput({
   const settings = aiExperienceSettings?.voice_input ?? null;
   const selectedProvider = settings?.provider === 'cloud' ? 'cloud' : 'local';
   const selectedModelId = settings?.model_id || DEFAULT_LOCAL_VOICE_MODEL_ID;
-  const [modelInstalled, setModelInstalled] = useState<boolean | null>(null);
-  const [selectedModelStatus, setSelectedModelStatus] = useState<SpeechModelStatus | null>(null);
+  const [modelCapability, setModelCapability] = useState<SelectedModelCapability | null>(null);
   const [downloadProgress, setDownloadProgress] = useState<number | null>(null);
   const [phase, setPhase] = useState<VoiceInputPhase>('idle');
   const [completionMode, setCompletionMode] = useState<VoiceInputCompletionMode | null>(null);
@@ -115,12 +118,23 @@ export function useComposerVoiceInput({
   const audioLevelFrameRef = useRef<number | null>(null);
   const activeRecordingIdRef = useRef(0);
   const activeInstallIdRef = useRef(0);
+  const capabilityRequestIdRef = useRef(0);
   const bufferedChunksRef = useRef<Array<{ pcm16Base64: string; seconds: number }>>([]);
   const bufferedSecondsRef = useRef(0);
   const cancelRecordingRef = useRef<(() => Promise<void>) | null>(null);
   const recordingLimitTimerRef = useRef<number | null>(null);
   const lowVolumeStartedAtRef = useRef<number | null>(null);
   const speechRuntimeSupported = isTauriRuntime();
+  const selectedModelCapability = selectedProvider === 'local'
+    && modelCapability?.modelId === selectedModelId
+    ? modelCapability
+    : null;
+  const selectedModelStatus = selectedModelCapability?.status ?? null;
+  const modelInstalled = selectedProvider !== 'local'
+    ? false
+    : selectedModelCapability === null
+      ? null
+      : selectedModelCapability.status?.state === 'installed';
 
   const clearRecordingLimitTimer = useCallback(() => {
     if (recordingLimitTimerRef.current !== null) {
@@ -137,27 +151,30 @@ export function useComposerVoiceInput({
   }, []);
 
   const refreshCapability = useCallback(async (): Promise<boolean | null> => {
+    const requestId = capabilityRequestIdRef.current + 1;
+    capabilityRequestIdRef.current = requestId;
     if (!speechRuntimeSupported) {
-      setModelInstalled(null);
-      setSelectedModelStatus(null);
+      setModelCapability(null);
       return null;
     }
     if (selectedProvider !== 'local') {
-      setModelInstalled(false);
-      setSelectedModelStatus(null);
+      setModelCapability(null);
       return false;
     }
     try {
       const modelResponse = await speechAPI.listModels();
       const status = modelResponse.models.find(model => model.modelId === selectedModelId) ?? null;
       const installed = status?.state === 'installed';
-      setSelectedModelStatus(status);
-      setModelInstalled(installed);
+      if (capabilityRequestIdRef.current !== requestId) {
+        return null;
+      }
+      setModelCapability({ modelId: selectedModelId, status });
       return installed;
     } catch (error) {
       log.warn('Failed to refresh voice input capability', { error });
-      setModelInstalled(null);
-      setSelectedModelStatus(null);
+      if (capabilityRequestIdRef.current === requestId) {
+        setModelCapability(null);
+      }
       return null;
     }
   }, [selectedModelId, selectedProvider, speechRuntimeSupported]);
@@ -167,29 +184,52 @@ export function useComposerVoiceInput({
       return undefined;
     }
     if (selectedProvider !== 'local') {
-      setModelInstalled(false);
-      setSelectedModelStatus(null);
+      capabilityRequestIdRef.current += 1;
+      setModelCapability(null);
       return undefined;
     }
     void refreshCapability();
     const removeModelListener = speechAPI.onModelStatusChanged(status => {
       if (status.modelId === selectedModelId) {
-        setSelectedModelStatus(status);
-        setModelInstalled(status.state === 'installed');
+        capabilityRequestIdRef.current += 1;
+        setModelCapability({ modelId: selectedModelId, status });
       }
     });
     const removeProgressListener = speechAPI.onModelProgress(event => {
       if (event.status.modelId === selectedModelId) {
-        setSelectedModelStatus(event.status);
+        capabilityRequestIdRef.current += 1;
+        setModelCapability({ modelId: selectedModelId, status: event.status });
         setDownloadProgress(Math.min(100, Math.max(0, event.status.progress?.percent ?? 0)));
       }
     });
 
     return () => {
+      capabilityRequestIdRef.current += 1;
       removeModelListener();
       removeProgressListener();
     };
   }, [refreshCapability, selectedModelId, selectedProvider, speechRuntimeSupported]);
+
+  useEffect(() => {
+    if (phase !== 'setup' || modelInstalled !== true) return;
+    setDownloadProgress(null);
+    setPhase('idle');
+  }, [modelInstalled, phase]);
+
+  const markSelectedModelMissing = useCallback(() => {
+    capabilityRequestIdRef.current += 1;
+    setModelCapability(current => ({
+      modelId: selectedModelId,
+      status: current?.modelId === selectedModelId && current.status
+        ? {
+            ...current.status,
+            state: 'not_installed',
+            installedBytes: 0,
+            progress: null,
+          }
+        : null,
+    }));
+  }, [selectedModelId]);
 
   useEffect(() => () => {
     activeRecordingIdRef.current += 1;
@@ -568,7 +608,7 @@ export function useComposerVoiceInput({
             });
           }
           if (isModelMissingError(error)) {
-            setModelInstalled(false);
+            markSelectedModelMissing();
             setDownloadProgress(null);
             setPhase('setup');
             return;
@@ -603,7 +643,7 @@ export function useComposerVoiceInput({
           });
       }
       if (isModelMissingError(error)) {
-        setModelInstalled(false);
+        markSelectedModelMissing();
         setDownloadProgress(null);
         setPhase('setup');
         return;
@@ -617,7 +657,7 @@ export function useComposerVoiceInput({
       setAudioLevel(0);
       setPhase('idle');
     }
-  }, [attachSession, enqueueChunk, modelInstalled, openVoiceInputSettings, refreshCapability, settings, speechRuntimeSupported, stopAndTranscribe, t, updateAudioLevel]);
+  }, [attachSession, enqueueChunk, markSelectedModelMissing, modelInstalled, openVoiceInputSettings, refreshCapability, settings, speechRuntimeSupported, stopAndTranscribe, t, updateAudioLevel]);
 
   const installAndStart = useCallback(async () => {
     if (selectedProvider !== 'local' || phase !== 'setup') return;
@@ -628,8 +668,8 @@ export function useComposerVoiceInput({
     try {
       const status = await speechAPI.downloadModel(selectedModelId);
       if (activeInstallIdRef.current !== installId) return;
-      setSelectedModelStatus(status);
-      setModelInstalled(status.state === 'installed');
+      capabilityRequestIdRef.current += 1;
+      setModelCapability({ modelId: selectedModelId, status });
       setDownloadProgress(status.state === 'installed' ? 100 : null);
       if (status.state !== 'installed') {
         setPhase('setup');


### PR DESCRIPTION
## Summary

- bind composer model capability state to the currently selected local model and ignore stale async status responses
- report post-download processing as `verifying` instead of leaving the UI at `downloading 100%`
- write and validate the install record inside staging before publishing the final model directory
- add regressions for model-selection races and staged install publication

## Root cause

The model payload was moved into its final directory before the install record and required-file hashes were finished. `speech_list_models` could therefore report the model as installed and enable **Use** while the active download task still emitted `downloading` at 100%. The composer also retained an unkeyed capability snapshot, so a response for the previous model could overwrite the selected model state.

## Verification

- `cargo test -p bitfun-services-integrations --no-default-features --features speech --lib speech::` (6 passed)
- `pnpm --dir src/web-ui run test:run src/flow_chat/components/voice/useComposerVoiceInput.test.tsx` (7 passed)
- `pnpm run check:web`
- `git diff --check`

## Remote scenarios

Exercised on the local Desktop/service path. Remote Workspace, Remote Control, Peer Device Mode, and Detached Dispatch were not runtime-tested; the service-side state transition remains platform-neutral and does not change the transport contract.

AI-assisted change; fully tested with the focused checks above.