### PR TITLE
fix(web): compact context picker overlays

### DIFF
--- a/src/web-ui/src/features/dispatch/DispatchTargetPicker.scss
+++ b/src/web-ui/src/features/dispatch/DispatchTargetPicker.scss
@@ -1,3 +1,5 @@
+@use '@/shared/styles/overlay-layout' as overlay-layout;
+
 .dispatch-target-picker {
   position: relative;
   display: inline-flex;
@@ -62,20 +64,23 @@
   }
 
   &__menu {
+    @include overlay-layout.anchored-picker-inline-size;
+
+    --bf-overlay-menu-section-gap: var(--bf-space-1);
+
     position: fixed;
     z-index: var(--bf-layer-popover);
   }
 
   &__option-row {
-    min-height: 46px;
-    padding-block: 5px;
+    min-height: var(--bf-control-height-md);
   }
 
   &__option-copy {
     display: flex;
     min-width: 0;
     flex-direction: column;
-    gap: 2px;
+    gap: calc(var(--bf-space-1) / 2);
 
     strong,
     small {
@@ -85,13 +90,20 @@
     }
 
     strong {
-      font-size: var(--bf-type-label-sm-font-size);
-      font-weight: var(--bf-type-label-sm-font-weight);
+      font-family: var(--bf-type-label-md-font-family);
+      font-size: var(--bf-type-label-md-font-size);
+      font-weight: var(--bf-type-label-md-font-weight);
+      line-height: var(--bf-type-label-md-line-height);
+      letter-spacing: var(--bf-type-label-md-letter-spacing);
     }
 
     small {
       color: var(--bf-color-content-muted);
-      font-size: var(--bf-type-micro-font-size);
+      font-family: var(--bf-type-meta-font-family);
+      font-size: var(--bf-type-meta-font-size);
+      font-weight: var(--bf-type-meta-font-weight);
+      line-height: var(--bf-type-meta-line-height);
+      letter-spacing: var(--bf-type-meta-letter-spacing);
     }
   }
 
@@ -99,9 +111,14 @@
     display: flex;
     align-items: center;
     gap: var(--bf-space-2);
-    padding: 9px 8px;
+    min-height: var(--bf-overlay-menu-heading-height);
+    padding-inline: var(--bf-overlay-menu-item-padding-inline);
     color: var(--bf-color-content-muted);
-    font-size: var(--bf-type-label-sm-font-size);
+    font-family: var(--bf-type-meta-font-family);
+    font-size: var(--bf-type-meta-font-size);
+    font-weight: var(--bf-type-meta-font-weight);
+    line-height: var(--bf-type-meta-line-height);
+    letter-spacing: var(--bf-type-meta-letter-spacing);
   }
 
   &__spin {

--- a/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStrip.scss
+++ b/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStrip.scss
@@ -21,7 +21,7 @@
  * form. Inside one segment, grouping is spacing alone, at a fixed 2.5:1 —
  * $track-item-gap between segments, $track-part-gap inside one.
  */
-@use '@/shared/styles/surface-recipes' as surfaces;
+@use '@/shared/styles/overlay-layout' as overlay-layout;
 
 // The only two spacings on the track. Their ratio is what replaces the
 // separators: parts of one segment sit close, segments sit apart.
@@ -474,9 +474,10 @@ $track-item-gap: 10px;
   // strip feel like one family; the layout is simpler — a single column of
   // workspace names with a check on the active one.
   &__workspace-menu {
+    @include overlay-layout.anchored-picker-inline-size;
+
     position: fixed;
     z-index: var(--bf-layer-popover);
-    width: min(220px, calc(100vw - 16px));
   }
 
 }

--- a/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStripLayout.test.ts
+++ b/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStripLayout.test.ts
@@ -10,8 +10,20 @@ function readLocalFile(name: string): string {
 const readWorkspaceStripStylesheet = () => readLocalFile('ChatInputWorkspaceStrip.scss');
 const readChatInputStylesheet = () => readLocalFile('ChatInput.scss');
 const readWorkspaceStripComponent = () => readLocalFile('ChatInputWorkspaceStrip.tsx');
+const readOverlayLayoutStylesheet = () => readFileSync(
+  fileURLToPath(new URL('../../shared/styles/_overlay-layout.scss', import.meta.url)),
+  'utf8',
+).replace(/\r\n/g, '\n');
+const readBranchQuickSwitchStylesheet = () => readFileSync(
+  fileURLToPath(new URL('../../tools/git/components/BranchQuickSwitch.scss', import.meta.url)),
+  'utf8',
+).replace(/\r\n/g, '\n');
 const readDispatchTargetPickerComponent = () => readFileSync(
   fileURLToPath(new URL('../../features/dispatch/DispatchTargetPicker.tsx', import.meta.url)),
+  'utf8',
+).replace(/\r\n/g, '\n');
+const readDispatchTargetPickerStylesheet = () => readFileSync(
+  fileURLToPath(new URL('../../features/dispatch/DispatchTargetPicker.scss', import.meta.url)),
   'utf8',
 ).replace(/\r\n/g, '\n');
 
@@ -40,6 +52,42 @@ describe('composer context track layout', () => {
 
     expect(stylesheet).toMatch(/&__context \{[\s\S]*?flex: 1 1 auto;/);
     expect(stylesheet).toMatch(/&__next \{[\s\S]*?flex: 0 0 auto;/);
+  });
+
+  it('keeps context pickers on one responsive width and one option rhythm', () => {
+    const overlayLayout = readOverlayLayoutStylesheet();
+    const workspaceStrip = readWorkspaceStripStylesheet();
+    const branchPicker = readBranchQuickSwitchStylesheet();
+    const targetPicker = readDispatchTargetPickerStylesheet();
+
+    expect(overlayLayout).toContain(
+      '@mixin anchored-picker-inline-size($inline-size: 280px)',
+    );
+    for (const stylesheet of [workspaceStrip, branchPicker, targetPicker]) {
+      expect(stylesheet).toContain('@include overlay-layout.anchored-picker-inline-size;');
+    }
+
+    expect(branchPicker).toMatch(
+      /branch-quick-switch__item \{[\s\S]*?min-height: var\(--bf-control-height-sm\);/,
+    );
+    expect(branchPicker).toMatch(
+      /branch-quick-switch__list \[data-bf-part='list'\] \{\n  gap: calc\(var\(--bf-space-1\) \/ 2\);/,
+    );
+    expect(targetPicker).toContain(
+      '&__option-row {\n    min-height: var(--bf-control-height-md);\n  }',
+    );
+    expect(targetPicker).toMatch(
+      /&__menu \{[\s\S]*?--bf-overlay-menu-section-gap: var\(--bf-space-1\);/,
+    );
+    expect(targetPicker).toMatch(
+      /&__status \{[\s\S]*?min-height: var\(--bf-overlay-menu-heading-height\);/,
+    );
+    expect(targetPicker).toMatch(
+      /strong \{[\s\S]*?font-size: var\(--bf-type-label-md-font-size\);/,
+    );
+    expect(targetPicker).toMatch(
+      /small \{[\s\S]*?font-size: var\(--bf-type-meta-font-size\);/,
+    );
   });
 
   it('keeps passive context aligned and promotes consequential controls', () => {

--- a/src/web-ui/src/shared/styles/_overlay-layout.scss
+++ b/src/web-ui/src/shared/styles/_overlay-layout.scss
@@ -1,0 +1,11 @@
+/**
+ * Product-level overlay geometry that sits on top of public @bitfun/ui
+ * anatomy. This recipe changes only responsive sizing; Menu, Listbox, and
+ * other primitives continue to own their surface and interaction styles.
+ */
+
+@mixin anchored-picker-inline-size($inline-size: 280px) {
+  --bf-overlay-menu-inline-size: min(#{$inline-size}, calc(100vw - 16px));
+
+  inline-size: min(#{$inline-size}, calc(100vw - 16px));
+}

--- a/src/web-ui/src/tools/git/components/BranchQuickSwitch.scss
+++ b/src/web-ui/src/tools/git/components/BranchQuickSwitch.scss
@@ -1,16 +1,21 @@
 /** Branch picker and its guarded-checkout recovery dialogs. */
+@use '@/shared/styles/overlay-layout' as overlay-layout;
 @use '@/shared/styles/surface-recipes' as surfaces;
 
 .branch-quick-switch {
   @include surfaces.floating;
+  @include overlay-layout.anchored-picker-inline-size;
 
   position: fixed;
   z-index: var(--bf-layer-popover);
   box-sizing: border-box;
-  width: min(280px, calc(100vw - 16px));
   overflow: hidden;
   color: var(--bf-color-content-primary);
-  font-family:var(--bf-type-body-sm-font-family);
+  font-family: var(--bf-type-label-md-font-family);
+  font-size: var(--bf-type-label-md-font-size);
+  font-weight: var(--bf-type-label-md-font-weight);
+  line-height: var(--bf-type-label-md-line-height);
+  letter-spacing: var(--bf-type-label-md-letter-spacing);
   user-select: none;
 }
 
@@ -25,7 +30,14 @@
 
 .branch-quick-switch__list {
   max-height: min(280px, calc(100vh - 96px));
-  padding: var(--bf-space-1);
+  padding: calc(
+    var(--bf-overlay-menu-surface-padding)
+    + var(--bf-focus-width)
+  );
+}
+
+.branch-quick-switch__list [data-bf-part='list'] {
+  gap: calc(var(--bf-space-1) / 2);
 }
 
 .branch-quick-switch__loading,
@@ -36,11 +48,17 @@
   gap: 8px;
   padding: 20px;
   color: var(--bf-color-content-muted);
-  font-size: var(--bf-type-label-sm-font-size);
+  font-family: var(--bf-type-label-md-font-family);
+  font-size: var(--bf-type-label-md-font-size);
+  font-weight: var(--bf-type-label-md-font-weight);
+  line-height: var(--bf-type-label-md-line-height);
+  letter-spacing: var(--bf-type-label-md-letter-spacing);
   text-align: center;
 }
 
 .branch-quick-switch__item {
+  min-height: var(--bf-control-height-sm);
+
   &[data-bf-state='current'] {
     cursor: default;
   }


### PR DESCRIPTION
## Summary

- unify dispatch, branch, and workspace picker widths with one responsive 280px overlay mixin
- compact dispatch target rows and section spacing while aligning labels and secondary text to design-system typography tokens
- align branch/workspace picker control heights and add layout regression coverage

## Verification

- `pnpm --dir src/web-ui run test:run src/flow_chat/components/ChatInputWorkspaceStripLayout.test.ts src/features/dispatch/DispatchTargetPicker.test.tsx src/tools/git/components/BranchQuickSwitch.test.tsx` (33 tests passed)
- `pnpm run check:web`
- visual source/implementation comparison at the same 280px width; compact dispatch rows resolve to 36px and the full menu to about 407px

## Remote scenarios

This is a CSS/layout-only change. It was exercised in the local desktop visual path; remote workspace, remote control, peer-device, and detached-dispatch protocols and behavior are unchanged.