### PR TITLE
fix(settings): refine model provider editing, testing, and deletion

### DIFF
--- a/src/web-ui/src/infrastructure/config/components/ModelSettingsDialog.presentation.test.ts
+++ b/src/web-ui/src/infrastructure/config/components/ModelSettingsDialog.presentation.test.ts
@@ -59,4 +59,13 @@ describe('ModelSettingsPage dialog presentation', () => {
     expect(source).toContain('onConfirm={continueEditingCurrentDraft}');
     expect(source).toContain('onSecondary={discardDraftBeforeOpeningPendingEditor}');
   });
+
+  it('offers atomic provider deletion with provider-specific confirmation', () => {
+    expect(source).toContain("<Tooltip content={t('actions.deleteProvider')}>");
+    expect(source).toContain('onClick={() => void requestProviderDelete(group)}');
+    expect(source).toContain("kind: 'provider',");
+    expect(source).toContain('removeProviderModelConfigs(current, request.groupKey)');
+    expect(source).toContain("? 'providerDeleteConfirm.title'");
+    expect(source).toContain("? 'providerDeleteConfirm.confirm'");
+  });
 });

--- a/src/web-ui/src/infrastructure/config/components/ModelSettingsDialog.presentation.test.ts
+++ b/src/web-ui/src/infrastructure/config/components/ModelSettingsDialog.presentation.test.ts
@@ -43,4 +43,20 @@ describe('ModelSettingsPage dialog presentation', () => {
     expect(styles).toMatch(/&__selected-model-row\s*{[\s\S]*?background:\s*var\(--bf-color-surface-raised\);/);
     expect(styles).toMatch(/&__reasoning-summary\s*{[\s\S]*?background:\s*var\(--bf-color-surface-tertiary\);/);
   });
+
+  it('keeps unsaved editor state behind an explicit draft decision', () => {
+    expect(source).toContain('if (editingModalHasUnsavedChanges) {');
+    expect(source).toContain('setDraftCloseConfirmOpen(true);');
+    expect(source).toContain('onConfirm={preserveEditingDraftAndClose}');
+    expect(source).toContain('onSecondary={closeEditingModal}');
+    expect(source).toContain("confirmText={t('draftClose.keepAndClose')}");
+    expect(source).toContain("cancelText={t('draftClose.continueEditing')}");
+    expect(source).toContain("statusMessage={t('draftClose.retainedHint')}");
+  });
+
+  it('protects a retained draft when another editor target is requested', () => {
+    expect(source).toContain('pendingEditorOpenRef.current = { open };');
+    expect(source).toContain('onConfirm={continueEditingCurrentDraft}');
+    expect(source).toContain('onSecondary={discardDraftBeforeOpeningPendingEditor}');
+  });
 });

--- a/src/web-ui/src/infrastructure/config/components/ModelSettingsPage.presentation.test.ts
+++ b/src/web-ui/src/infrastructure/config/components/ModelSettingsPage.presentation.test.ts
@@ -6,6 +6,10 @@ const source = readFileSync(
   fileURLToPath(new URL('./ModelSettingsPage.tsx', import.meta.url)),
   'utf8',
 );
+const styles = readFileSync(
+  fileURLToPath(new URL('./ModelSettingsPage.scss', import.meta.url)),
+  'utf8',
+);
 
 describe('ModelSettingsPage presentation', () => {
   it('uses intentional separators instead of Unicode replacement characters', () => {
@@ -19,5 +23,18 @@ describe('ModelSettingsPage presentation', () => {
     expect(source.match(/<ConfigPageRow label=\{t\('form\.modelSelection'\)\} required/g)).toHaveLength(2);
     expect(source.match(/<ConfigPageRow label=\{t\('form\.baseUrl'\)\} required/g)).toHaveLength(1);
     expect(source).toContain('<ConfigPageRow label={label} required align="center" wide>');
+  });
+
+  it('preserves the intrinsic width of design-system switches in edit rows', () => {
+    expect(styles.match(/> :not\(\[data-bf-component='switch'\]\)/g)).toHaveLength(2);
+    expect(styles).not.toMatch(/> \* \{\s*min-width: 0;\s*width: 100%/);
+    expect(styles).not.toMatch(/> \* \{\s*width: auto;\s*max-width: none;/);
+  });
+
+  it('lets advanced mode actions align to the right edge of their rows', () => {
+    expect(styles).toMatch(
+      /&__custom-headers-row,\s*&__custom-request-body-row\s*\{\s*> \.bitfun-config-page-row__meta\s*\{\s*width: 100%;\s*max-width: none;/,
+    );
+    expect(styles).toMatch(/&__inline-header-actions\s*\{[\s\S]*?margin-left: auto;/);
   });
 });

--- a/src/web-ui/src/infrastructure/config/components/ModelSettingsPage.scss
+++ b/src/web-ui/src/infrastructure/config/components/ModelSettingsPage.scss
@@ -394,6 +394,14 @@
     width: 100%;
   }
 
+  &__custom-headers-row,
+  &__custom-request-body-row {
+    > .bitfun-config-page-row__meta {
+      width: 100%;
+      max-width: none;
+    }
+  }
+
   &__warning-inline {
     display: inline-flex;
     align-items: flex-start;
@@ -1051,7 +1059,7 @@
       min-width: 0;
       overflow: visible;
 
-      > * {
+      > :not([data-bf-component='switch']) {
         min-width: 0;
         width: 100%;
         max-width: none;
@@ -1065,7 +1073,7 @@
       min-width: auto;
       justify-self: end;
 
-      > * {
+      > :not([data-bf-component='switch']) {
         width: auto;
         max-width: none;
         flex: 0 0 auto;

--- a/src/web-ui/src/infrastructure/config/components/ModelSettingsPage.tsx
+++ b/src/web-ui/src/infrastructure/config/components/ModelSettingsPage.tsx
@@ -1835,6 +1835,26 @@ const ModelSettingsPage: React.FC = () => {
     }
   };
 
+  const closeEditingModal = () => {
+    resetRemoteModelDiscovery();
+    setSelectedModelDrafts([]);
+    setEditingProviderModelIds(new Set());
+    setManualModelInput('');
+    setShowApiKey(false);
+    setIsEditing(false);
+    setEditingConfig(null);
+    setCreationMode(null);
+    setSelectedProviderId(null);
+    setEditingTargetKey(null);
+    setProviderQuery('');
+    setShowAllProviders(false);
+    setReasoningPanelDraftKey(null);
+    setDraftCloseConfirmOpen(false);
+    setDraftConflictConfirmOpen(false);
+    pendingEditorOpenRef.current = null;
+    reasoningPanelInitialRef.current = null;
+  };
+
   const inspectModelReferenceCount = async (modelIds: string[]): Promise<number> => {
     const [defaultModels, taskModels, agentModelDefaults] = await Promise.all([
       configManager.getConfig<unknown>('ai.default_models'),
@@ -2048,26 +2068,6 @@ const ModelSettingsPage: React.FC = () => {
       streamTimeoutSavingRef.current = false;
       setIsStreamTimeoutSaving(false);
     }
-  };
-
-  const closeEditingModal = () => {
-    resetRemoteModelDiscovery();
-    setSelectedModelDrafts([]);
-    setEditingProviderModelIds(new Set());
-    setManualModelInput('');
-    setShowApiKey(false);
-    setIsEditing(false);
-    setEditingConfig(null);
-    setCreationMode(null);
-    setSelectedProviderId(null);
-    setEditingTargetKey(null);
-    setProviderQuery('');
-    setShowAllProviders(false);
-    setReasoningPanelDraftKey(null);
-    setDraftCloseConfirmOpen(false);
-    setDraftConflictConfirmOpen(false);
-    pendingEditorOpenRef.current = null;
-    reasoningPanelInitialRef.current = null;
   };
 
   const preserveEditingDraftAndClose = () => {

--- a/src/web-ui/src/infrastructure/config/components/ModelSettingsPage.tsx
+++ b/src/web-ui/src/infrastructure/config/components/ModelSettingsPage.tsx
@@ -73,9 +73,13 @@ import {
   ConfigRetryState,
 } from './common';
 import {
-  requestSettingsDraftExit,
   useSettingsDraft,
 } from '@/infrastructure/config/settingsDraftRegistry';
+import {
+  configsNeedingAutoTest,
+  providerConnectionChanged,
+  stableJson,
+} from './modelConnectionTestPlan';
 import DefaultModelConfig from './DefaultModelConfig';
 import ReasoningConfigPanel, { type ReasoningConfigApplyResult } from './ReasoningConfigPanel';
 import { createLogger } from '@/shared/utils/logger';
@@ -83,6 +87,7 @@ import { translateConnectionTestMessage } from '@/shared/utils/aiConnectionTestM
 import { i18nService } from '@/infrastructure/i18n';
 import { isTauriRuntime } from '@/infrastructure/runtime';
 import { isPeerDeviceModeActive } from '@/infrastructure/peer-device/peerModeFlag';
+import { usePeerDeviceModeOptional } from '@/infrastructure/peer-device/peerDeviceContextState';
 import { LONG_CONTEXT_WARNING_THRESHOLD_TOKENS } from '@/shared/constants/modelContext';
 import {
   preferredSubscriptionLoginMethod,
@@ -144,6 +149,15 @@ interface SubscriptionLogoutRequest {
 interface ModelDeleteRequest {
   config: AIModelConfigType;
   referenceCount: number;
+}
+
+interface PendingEditorOpen {
+  open: () => void;
+}
+
+interface ActiveConnectionTest {
+  token: symbol;
+  signature: string;
 }
 
 const SUBSCRIPTION_LOGIN_TIMEOUT_MS = 5 * 60 * 1000;
@@ -325,19 +339,6 @@ function hasHttpUrlScheme(value: string): boolean {
   return /^https?:\/\//i.test(value.trim());
 }
 
-function stableJson(value: unknown): string {
-  if (Array.isArray(value)) {
-    return `[${value.map(stableJson).join(',')}]`;
-  }
-  if (value && typeof value === 'object') {
-    return `{${Object.entries(value as Record<string, unknown>)
-      .sort(([a], [b]) => a.localeCompare(b))
-      .map(([key, entryValue]) => `${JSON.stringify(key)}:${stableJson(entryValue)}`)
-      .join(',')}}`;
-  }
-  return JSON.stringify(value);
-}
-
 function countExactModelReferences(value: unknown, modelId: string): number {
   if (value === modelId) return 1;
   if (Array.isArray(value)) {
@@ -352,43 +353,6 @@ function countExactModelReferences(value: unknown, modelId: string): number {
 
 function normalizeComparableString(value: string | undefined): string {
   return (value || '').trim();
-}
-
-function providerConnectionChanged(
-  previous: AIModelConfigType | undefined,
-  next: AIModelConfigType
-): boolean {
-  if (!previous) return true;
-
-  return (
-    normalizeComparableString(previous.provider) !== normalizeComparableString(next.provider) ||
-    normalizeComparableString(previous.base_url) !== normalizeComparableString(next.base_url) ||
-    normalizeComparableString(previous.api_key) !== normalizeComparableString(next.api_key) ||
-    stableJson(previous.auth || { type: 'api_key' }) !== stableJson(next.auth || { type: 'api_key' }) ||
-    stableJson(previous.custom_headers || {}) !== stableJson(next.custom_headers || {}) ||
-    normalizeComparableString(previous.custom_headers_mode) !== normalizeComparableString(next.custom_headers_mode) ||
-    normalizeComparableString(previous.custom_request_body) !== normalizeComparableString(next.custom_request_body) ||
-    normalizeComparableString(previous.custom_request_body_mode) !== normalizeComparableString(next.custom_request_body_mode) ||
-    (previous.skip_ssl_verify ?? false) !== (next.skip_ssl_verify ?? false)
-  );
-}
-
-function modelRequestBehaviorChanged(
-  previous: AIModelConfigType | undefined,
-  next: AIModelConfigType
-): boolean {
-  if (!previous) return true;
-
-  return (
-    normalizeComparableString(previous.model_name) !== normalizeComparableString(next.model_name) ||
-    normalizeComparableString(previous.request_url) !== normalizeComparableString(next.request_url) ||
-    previous.context_window !== next.context_window ||
-    previous.max_tokens !== next.max_tokens ||
-    previous.category !== next.category ||
-    stableJson(previous.capabilities || []) !== stableJson(next.capabilities || []) ||
-    stableJson(canonicalReasoningConfig(previous)) !== stableJson(next.reasoning || canonicalReasoningConfig(next)) ||
-    (previous.inline_think_in_text ?? true) !== (next.inline_think_in_text ?? true)
-  );
 }
 
 function modelDraftHasUnsavedChanges(
@@ -410,34 +374,13 @@ function modelDraftHasUnsavedChanges(
   );
 }
 
-function configsNeedingAutoTest(
-  previousModels: AIModelConfigType[],
-  nextConfigs: AIModelConfigType[],
-  isProviderGroupEdit: boolean
-): AIModelConfigType[] {
-  const previousById = new Map(previousModels.map(model => [model.id, model]));
-  const providerConnectionWasChanged = isProviderGroupEdit && nextConfigs.some(config =>
-    providerConnectionChanged(previousById.get(config.id), config)
-  );
-
-  if (providerConnectionWasChanged) {
-    return nextConfigs;
-  }
-
-  return nextConfigs.filter(config => {
-    const previous = previousById.get(config.id);
-    return (
-      !previous ||
-      providerConnectionChanged(previous, config) ||
-      modelRequestBehaviorChanged(previous, config)
-    );
-  });
-}
-
 const ModelSettingsPage: React.FC = () => {
   const { t, i18n } = useTranslation('settings/models');
   const { t: tDefault } = useTranslation('settings/default-model');
   const { t: tComponents } = useTranslation('components');
+  const peerDevice = usePeerDeviceModeOptional();
+  const connectionTestSupported = !peerDevice?.peerMode.active
+    || peerDevice.currentPeerCapabilities?.hostKind !== 'cli';
   const [aiModels, setAiModels] = useState<AIModelConfigType[]>([]);
   const [isConfigLoading, setIsConfigLoading] = useState(true);
   const [configLoadError, setConfigLoadError] = useState(false);
@@ -449,6 +392,9 @@ const ModelSettingsPage: React.FC = () => {
   const [isEditing, setIsEditing] = useState(false);
   const [isEditorSaving, setIsEditorSaving] = useState(false);
   const [editingConfig, setEditingConfig] = useState<Partial<AIModelConfigType> | null>(null);
+  const [editingTargetKey, setEditingTargetKey] = useState<string | null>(null);
+  const [draftCloseConfirmOpen, setDraftCloseConfirmOpen] = useState(false);
+  const [draftConflictConfirmOpen, setDraftConflictConfirmOpen] = useState(false);
   const [showApiKey, setShowApiKey] = useState(false);
   const [testingConfigs, setTestingConfigs] = useState<Record<string, boolean>>({});
   const [testResults, setTestResults] = useState<Record<string, { success: boolean; message: string } | null>>({});
@@ -515,6 +461,8 @@ const ModelSettingsPage: React.FC = () => {
   const lastRemoteFetchSignatureRef = React.useRef<string | null>(null);
   const activeRemoteFetchSignatureRef = React.useRef<string | null>(null);
   const editorSavingRef = React.useRef(false);
+  const pendingEditorOpenRef = React.useRef<PendingEditorOpen | null>(null);
+  const activeConnectionTestsRef = React.useRef<Record<string, ActiveConnectionTest>>({});
 
   const requestFormatOptions = useMemo(
     () => [
@@ -1095,65 +1043,87 @@ const ModelSettingsPage: React.FC = () => {
     void fetchRemoteModels(editingConfig);
   };
 
+  const requestEditorOpen = useCallback((targetKey: string, open: () => void) => {
+    const matchesSuspendedDraft = editingTargetKey === targetKey
+      || (targetKey === 'new-provider' && editingTargetKey?.startsWith('new-provider:'));
+    if (!isEditing && editingConfig && editingModalHasUnsavedChanges) {
+      if (matchesSuspendedDraft) {
+        setIsEditing(true);
+        return;
+      }
+      pendingEditorOpenRef.current = { open };
+      setDraftConflictConfirmOpen(true);
+      return;
+    }
+    open();
+  }, [editingConfig, editingModalHasUnsavedChanges, editingTargetKey, isEditing]);
+
   
   const handleCreateNew = () => {
-    resetRemoteModelDiscovery();
-    setSelectedModelDrafts([]);
-    setEditingProviderModelIds(new Set());
-    setManualModelInput('');
-    setShowApiKey(false);
-    setSelectedProviderId(null);
-    setProviderQuery('');
-    setShowAllProviders(false);
-    setCreationMode('selection');
+    requestEditorOpen('new-provider', () => {
+      resetRemoteModelDiscovery();
+      setSelectedModelDrafts([]);
+      setEditingProviderModelIds(new Set());
+      setManualModelInput('');
+      setShowApiKey(false);
+      setSelectedProviderId(null);
+      setProviderQuery('');
+      setShowAllProviders(false);
+      setEditingTargetKey(null);
+      setCreationMode('selection');
+    });
   };
 
   const handleImportFromSubscription = useCallback((
     account: SubscriptionAccount,
     offering?: SubscriptionApiOffering,
   ) => {
-    resetRemoteModelDiscovery();
-    const offeringModels = (offering?.models || []).map((model) => ({
-      id: model.id,
-      display_name: model.display_name || undefined,
-    }));
-    if (offeringModels.length > 0) {
-      setRemoteModelOptions(offeringModels);
-      setHasAttemptedRemoteFetch(true);
-    }
-    setManualModelInput('');
-    setShowApiKey(false);
-    setSelectedProviderId(null);
-    setEditingConfig({
-      name: offering
-        ? getOpenCodePlanLabel(offering.plan)
-        : account.display_label,
-      provider: offering?.format || account.suggested_format,
-      base_url: offering?.base_url || account.suggested_base_url,
-      // Leave request_url + model_name empty so the user must pick a model
-      // from the live list. We never inject a hard-coded default slug.
-      request_url: '',
-      api_key: '',
-      model_name: '',
-      enabled: true,
-      context_window: 200000,
-      category: 'general_chat',
-      capabilities: ['text_chat', 'function_calling'],
-      recommended_for: [],
-      metadata: {},
-      inline_think_in_text: true,
-      auth: {
-        type: 'subscription',
-        provider: account.provider,
-        ...(offering ? { plan: offering.plan } : {}),
-      },
+    const targetKey = `new-provider:subscription:${account.provider}:${offering?.plan || offering?.format || 'default'}`;
+    requestEditorOpen(targetKey, () => {
+      resetRemoteModelDiscovery();
+      const offeringModels = (offering?.models || []).map((model) => ({
+        id: model.id,
+        display_name: model.display_name || undefined,
+      }));
+      if (offeringModels.length > 0) {
+        setRemoteModelOptions(offeringModels);
+        setHasAttemptedRemoteFetch(true);
+      }
+      setManualModelInput('');
+      setShowApiKey(false);
+      setSelectedProviderId(null);
+      setEditingTargetKey(targetKey);
+      setEditingConfig({
+        name: offering
+          ? getOpenCodePlanLabel(offering.plan)
+          : account.display_label,
+        provider: offering?.format || account.suggested_format,
+        base_url: offering?.base_url || account.suggested_base_url,
+        // Leave request_url + model_name empty so the user must pick a model
+        // from the live list. We never inject a hard-coded default slug.
+        request_url: '',
+        api_key: '',
+        model_name: '',
+        enabled: true,
+        context_window: 200000,
+        category: 'general_chat',
+        capabilities: ['text_chat', 'function_calling'],
+        recommended_for: [],
+        metadata: {},
+        inline_think_in_text: true,
+        auth: {
+          type: 'subscription',
+          provider: account.provider,
+          ...(offering ? { plan: offering.plan } : {}),
+        },
+      });
+      setSelectedModelDrafts([]);
+      setEditingProviderModelIds(new Set());
+      setShowAdvancedSettings(false);
+      setCreationMode('form');
+      setIsEditing(true);
     });
-    setSelectedModelDrafts([]);
-    setEditingProviderModelIds(new Set());
-    setShowAdvancedSettings(false);
-    setCreationMode('form');
-    setIsEditing(true);
-  }, [getOpenCodePlanLabel, resetRemoteModelDiscovery]);
+  }, [getOpenCodePlanLabel, requestEditorOpen, resetRemoteModelDiscovery]);
 
   const loginCoordinatorRef = React.useRef(new SubscriptionLoginCoordinator());
   const subscriptionLoginMountedRef = React.useRef(true);
@@ -1492,6 +1462,7 @@ const ModelSettingsPage: React.FC = () => {
     setManualModelInput('');
     setShowApiKey(false);
     setSelectedProviderId(providerId);
+    setEditingTargetKey(`new-provider:${providerId}`);
     
     // Dynamically get translated name
     const providerName = t(`providers.${template.id}.name`);
@@ -1535,6 +1506,7 @@ const ModelSettingsPage: React.FC = () => {
     setEditingProviderModelIds(new Set());
     setShowApiKey(false);
     setSelectedProviderId(null);
+    setEditingTargetKey('new-provider:custom');
     setEditingConfig({
       name: '',
       base_url: 'https://open.bigmodel.cn/api/paas/v4',
@@ -1557,79 +1529,137 @@ const ModelSettingsPage: React.FC = () => {
   };
 
   const handleEditProvider = (config: AIModelConfigType) => {
-    resetRemoteModelDiscovery();
-    setManualModelInput('');
-    setShowApiKey(false);
-
     const providerName = getProviderDisplayName(config);
     const providerGroupKey = getProviderGroupKey(config);
-    const configuredProviderModels = aiModels
-      .filter(model => getProviderGroupKey(model) === providerGroupKey)
-      .sort((a, b) => a.model_name.localeCompare(b.model_name));
-    const providerTemplateId = getProviderTemplateId(config);
-    setEditingProviderModelIds(new Set(
-      configuredProviderModels
-        .map(model => model.id)
-        .filter((id): id is string => !!id)
-    ));
-    setSelectedProviderId(providerTemplateId || null);
-    setEditingConfig({
-      name: providerName,
-      base_url: config.base_url,
-      request_url: resolveRequestUrl(config.base_url, config.provider || 'openai'),
-      api_key: config.api_key || '',
-      model_name: '',
-      provider: config.provider,
-      enabled: true,
-      context_window: config.context_window || 200000,
-      max_tokens: config.max_tokens,
-      category: config.category || 'general_chat',
-      capabilities: config.capabilities || getCapabilitiesByCategory(config.category || 'general_chat'),
-      recommended_for: config.recommended_for || [],
-      metadata: config.metadata || {},
-      inline_think_in_text: config.inline_think_in_text ?? true,
-      custom_headers: config.custom_headers,
-      custom_headers_mode: config.custom_headers_mode,
-      skip_ssl_verify: config.skip_ssl_verify ?? false,
-      custom_request_body: config.custom_request_body,
-      custom_request_body_mode: config.custom_request_body_mode,
-      auth: config.auth || { type: 'api_key' },
+    const targetKey = `provider:${providerGroupKey}`;
+    requestEditorOpen(targetKey, () => {
+      resetRemoteModelDiscovery();
+      setManualModelInput('');
+      setShowApiKey(false);
+
+      const configuredProviderModels = aiModels
+        .filter(model => getProviderGroupKey(model) === providerGroupKey)
+        .sort((a, b) => a.model_name.localeCompare(b.model_name));
+      const providerTemplateId = getProviderTemplateId(config);
+      setEditingProviderModelIds(new Set(
+        configuredProviderModels
+          .map(model => model.id)
+          .filter((id): id is string => !!id)
+      ));
+      setSelectedProviderId(providerTemplateId || null);
+      setEditingTargetKey(targetKey);
+      setEditingConfig({
+        name: providerName,
+        base_url: config.base_url,
+        request_url: resolveRequestUrl(config.base_url, config.provider || 'openai'),
+        api_key: config.api_key || '',
+        model_name: '',
+        provider: config.provider,
+        enabled: true,
+        context_window: config.context_window || 200000,
+        max_tokens: config.max_tokens,
+        category: config.category || 'general_chat',
+        capabilities: config.capabilities || getCapabilitiesByCategory(config.category || 'general_chat'),
+        recommended_for: config.recommended_for || [],
+        metadata: config.metadata || {},
+        inline_think_in_text: config.inline_think_in_text ?? true,
+        custom_headers: config.custom_headers,
+        custom_headers_mode: config.custom_headers_mode,
+        skip_ssl_verify: config.skip_ssl_verify ?? false,
+        custom_request_body: config.custom_request_body,
+        custom_request_body_mode: config.custom_request_body_mode,
+        auth: config.auth || { type: 'api_key' },
+      });
+      setSelectedModelDrafts(createDraftsFromConfigs(configuredProviderModels));
+      setShowAdvancedSettings(
+        !!config.skip_ssl_verify ||
+        config.custom_request_body_mode === 'trim' ||
+        (!!config.custom_request_body && config.custom_request_body.trim() !== '') ||
+        (!!config.custom_headers && Object.keys(config.custom_headers).length > 0)
+      );
+      setCreationMode('form');
+      setIsEditing(true);
     });
-    setSelectedModelDrafts(createDraftsFromConfigs(configuredProviderModels));
-    setShowAdvancedSettings(
-      !!config.skip_ssl_verify ||
-      config.custom_request_body_mode === 'trim' ||
-      (!!config.custom_request_body && config.custom_request_body.trim() !== '') ||
-      (!!config.custom_headers && Object.keys(config.custom_headers).length > 0)
-    );
-    setCreationMode('form');
-    setIsEditing(true);
   };
 
   const handleEdit = (config: AIModelConfigType) => {
-    resetRemoteModelDiscovery();
-    setManualModelInput('');
-    setEditingProviderModelIds(new Set());
-    setShowApiKey(false);
-    setEditingConfig({ ...config, name: getProviderDisplayName(config) });
-    setSelectedModelDrafts([
-      createModelDraft(config.model_name, config, {
-        contextWindow: config.context_window || 200000,
-        maxTokens: config.max_tokens,
-        reasoning: canonicalReasoningConfig(config),
-      })
-    ]);
-    
-    const hasCustomHeaders = !!config.custom_headers && Object.keys(config.custom_headers).length > 0;
-    const hasCustomBody = !!config.custom_request_body && config.custom_request_body.trim() !== '';
-    setShowAdvancedSettings(
-      hasCustomHeaders ||
-      hasCustomBody ||
-      config.custom_request_body_mode === 'trim' ||
-      !!config.skip_ssl_verify
-    );
-    setIsEditing(true);
+    const targetKey = `model:${config.id || `${config.provider}:${config.base_url}:${config.model_name}`}`;
+    requestEditorOpen(targetKey, () => {
+      resetRemoteModelDiscovery();
+      setManualModelInput('');
+      setEditingProviderModelIds(new Set());
+      setShowApiKey(false);
+      setEditingTargetKey(targetKey);
+      setEditingConfig({ ...config, name: getProviderDisplayName(config) });
+      setSelectedModelDrafts([
+        createModelDraft(config.model_name, config, {
+          contextWindow: config.context_window || 200000,
+          maxTokens: config.max_tokens,
+          reasoning: canonicalReasoningConfig(config),
+        })
+      ]);
+
+      const hasCustomHeaders = !!config.custom_headers && Object.keys(config.custom_headers).length > 0;
+      const hasCustomBody = !!config.custom_request_body && config.custom_request_body.trim() !== '';
+      setShowAdvancedSettings(
+        hasCustomHeaders ||
+        hasCustomBody ||
+        config.custom_request_body_mode === 'trim' ||
+        !!config.skip_ssl_verify
+      );
+      setIsEditing(true);
+    });
   };
+
+  const runConfigConnectionTest = useCallback(async (config: AIModelConfigType) => {
+    const configId = config.id;
+    if (!configId || !connectionTestSupported) return;
+
+    const signature = stableJson(config);
+    const activeTest = activeConnectionTestsRef.current[configId];
+    if (activeTest?.signature === signature) return;
+
+    const token = Symbol(configId);
+    activeConnectionTestsRef.current[configId] = { token, signature };
+    setTestingConfigs(previous => ({ ...previous, [configId]: true }));
+    setTestResults(previous => ({ ...previous, [configId]: null }));
+
+    try {
+      const result = await aiApi.testAIConfigConnection(config);
+      if (activeConnectionTestsRef.current[configId]?.token !== token) return;
+
+      const baseMessage = result.success ? t('messages.testSuccess') : t('messages.testFailed');
+      let message = baseMessage + (result.response_time_ms ? ` (${result.response_time_ms}ms)` : '');
+      const localizedMessage = translateConnectionTestMessage(result.message_code, t);
+
+      if (localizedMessage) {
+        message += `\n${localizedMessage}`;
+      }
+      if (result.error_details) {
+        message += result.success
+          ? `\n${result.error_details}`
+          : `\n${t('messages.errorDetails')}: ${result.error_details}`;
+      }
+
+      setTestResults(previous => ({
+        ...previous,
+        [configId]: { success: result.success, message },
+      }));
+    } catch (error) {
+      if (activeConnectionTestsRef.current[configId]?.token !== token) return;
+      const message = `${t('messages.testFailed')}\n${t('messages.errorDetails')}: ${error}`;
+      setTestResults(previous => ({
+        ...previous,
+        [configId]: { success: false, message },
+      }));
+      log.warn('Model connection test failed', { configId, error });
+    } finally {
+      if (activeConnectionTestsRef.current[configId]?.token === token) {
+        delete activeConnectionTestsRef.current[configId];
+        setTestingConfigs(previous => ({ ...previous, [configId]: false }));
+      }
+    }
+  }, [connectionTestSupported, t]);
 
   const handleSave = async (): Promise<boolean> => {
     if (editorSavingRef.current) return false;
@@ -1737,13 +1767,9 @@ const ModelSettingsPage: React.FC = () => {
           auth: editingConfig.auth || { type: 'api_key' },
         };
       });
-      const configsToAutoTest = configsNeedingAutoTest(
-        aiModels,
-        configsToSave,
-        isProviderGroupEdit
-      );
-
+      let previousModelsBeforeSave: AIModelConfigType[] = [];
       const updatedModels = await configManager.updateConfig<AIModelConfigType[]>('ai.models', current => {
+        previousModelsBeforeSave = current;
         if (editingConfig.id) {
           if (!current.some(model => model.id === editingConfig.id)) {
             throw new Error('The model was removed while it was being edited');
@@ -1758,6 +1784,11 @@ const ModelSettingsPage: React.FC = () => {
         }
         return [...current, ...configsToSave];
       });
+      const configsToAutoTest = configsNeedingAutoTest(
+        previousModelsBeforeSave,
+        configsToSave,
+        isProviderGroupEdit
+      );
       setAiModels(updatedModels);
       // The host reconciles default selectors using model capabilities.
       
@@ -1767,58 +1798,28 @@ const ModelSettingsPage: React.FC = () => {
       setCreationMode(null);
       setSelectedProviderId(null);
       setEditingProviderModelIds(new Set());
+      setSelectedModelDrafts([]);
+      setEditingTargetKey(null);
+      setDraftCloseConfirmOpen(false);
+      setDraftConflictConfirmOpen(false);
       
       
       const autoTestConfigIds = configsToAutoTest.map(config => config.id).filter((id): id is string => !!id);
-      if (autoTestConfigIds.length > 0) {
+      if (connectionTestSupported && autoTestConfigIds.length > 0) {
         setExpandedIds(prev => new Set([...prev, ...autoTestConfigIds]));
       }
       
       
       
-      configsToAutoTest.forEach(config => {
-        const configId = config.id;
-        if (!configId) return;
-
+      if (connectionTestSupported) {
         void (async () => {
-          setTestingConfigs(prev => ({ ...prev, [configId]: true }));
-          setTestResults(prev => ({ ...prev, [configId]: null }));
-
-          try {
-            const result = await aiApi.testAIConfigConnection(config);
-            const baseMessage = result.success ? t('messages.testSuccess') : t('messages.testFailed');
-            let message = baseMessage + (result.response_time_ms ? ` (${result.response_time_ms}ms)` : '');
-            const localizedMessage = translateConnectionTestMessage(result.message_code, t);
-
-            if (localizedMessage) {
-              message += `\n${localizedMessage}`;
-            }
-
-            if (result.error_details) {
-              message += result.success
-                ? `\n${result.error_details}`
-                : `\n${t('messages.errorDetails')}: ${result.error_details}`;
-            }
-
-            setTestResults(prev => ({
-              ...prev,
-              [configId]: {
-                success: result.success,
-                message
-              }
-            }));
-          } catch (error) {
-            const message = `${t('messages.testFailed')}\n${t('messages.errorDetails')}: ${error}`;
-            setTestResults(prev => ({
-              ...prev,
-              [configId]: { success: false, message }
-            }));
-            log.warn('Auto test failed after save', { configId, error });
-          } finally {
-            setTestingConfigs(prev => ({ ...prev, [configId]: false }));
+          for (const config of configsToAutoTest) {
+            await runConfigConnectionTest(config);
           }
         })();
-      });
+      } else if (configsToAutoTest.length > 0) {
+        notification.info(t('messages.testUnsupportedOnHost'));
+      }
       return true;
     } catch (error) {
       log.error('Failed to save config', error);
@@ -1876,45 +1877,7 @@ const ModelSettingsPage: React.FC = () => {
   };
 
   const handleTest = async (config: AIModelConfigType) => {
-    if (!config.id) return;
-    
-    const configId = config.id;
-    setTestingConfigs(prev => ({ ...prev, [configId]: true }));
-    setTestResults(prev => ({ ...prev, [configId]: null }));
-
-    try {
-      
-      const result = await aiApi.testAIConfigConnection(config);
-      
-      
-      const baseMessage = result.success ? t('messages.testSuccess') : t('messages.testFailed');
-      let message = baseMessage + (result.response_time_ms ? ` (${result.response_time_ms}ms)` : '');
-      const localizedMessage = translateConnectionTestMessage(result.message_code, t);
-      
-      if (localizedMessage) {
-        message += `\n${localizedMessage}`;
-      }
-
-      if (result.error_details) {
-        message += `\n${t('messages.errorDetails')}: ${result.error_details}`;
-      }
-      
-      setTestResults(prev => ({
-        ...prev,
-        [configId]: { 
-          success: result.success, 
-          message
-        }
-      }));
-    } catch (error) {
-      const message = `${t('messages.testFailed')}\n${t('messages.errorDetails')}: ${error}`;
-      setTestResults(prev => ({
-        ...prev,
-        [configId]: { success: false, message }
-      }));
-    } finally {
-      setTestingConfigs(prev => ({ ...prev, [configId]: false }));
-    }
+    await runConfigConnectionTest(config);
   };
 
   const handleToggleEnabled = async (config: AIModelConfigType, enabled: boolean) => {
@@ -2016,15 +1979,45 @@ const ModelSettingsPage: React.FC = () => {
     setEditingConfig(null);
     setCreationMode(null);
     setSelectedProviderId(null);
+    setEditingTargetKey(null);
     setProviderQuery('');
     setShowAllProviders(false);
     setReasoningPanelDraftKey(null);
+    setDraftCloseConfirmOpen(false);
+    setDraftConflictConfirmOpen(false);
+    pendingEditorOpenRef.current = null;
     reasoningPanelInitialRef.current = null;
+  };
+
+  const preserveEditingDraftAndClose = () => {
+    setDraftCloseConfirmOpen(false);
+    setIsEditing(false);
   };
 
   const requestCloseEditingModal = () => {
     if (editorSavingRef.current) return;
-    requestSettingsDraftExit(['model-provider-editor'], closeEditingModal);
+    if (editingModalHasUnsavedChanges) {
+      setDraftCloseConfirmOpen(true);
+      return;
+    }
+    closeEditingModal();
+  };
+
+  const continueEditingCurrentDraft = () => {
+    pendingEditorOpenRef.current = null;
+    setDraftConflictConfirmOpen(false);
+    setIsEditing(true);
+  };
+
+  const discardDraftBeforeOpeningPendingEditor = () => {
+    const pending = pendingEditorOpenRef.current;
+    closeEditingModal();
+    pending?.open();
+  };
+
+  const cancelPendingEditorOpen = () => {
+    pendingEditorOpenRef.current = null;
+    setDraftConflictConfirmOpen(false);
   };
 
   const discardProxyDraft = useCallback(() => {
@@ -2058,12 +2051,20 @@ const ModelSettingsPage: React.FC = () => {
   useSettingsDraft({
     id: 'model-provider-editor',
     pageId: 'ai.models',
-    label: editingConfig?.id ? t('editModel') : t('newProvider'),
+    label: editingConfig?.id
+      ? t('editModel')
+      : getProviderInstanceId(editingConfig)
+        ? t('editProvider')
+        : t('newProvider'),
     dirty: editingConfig !== null && editingModalHasUnsavedChanges,
     saving: isEditorSaving,
     save: handleSave,
     discard: closeEditingModal,
   });
+
+  const hasSuspendedEditorDraft = !isEditing
+    && editingConfig !== null
+    && editingModalHasUnsavedChanges;
 
   const providerGroups = useMemo<ProviderGroup[]>(() => {
     const grouped = aiModels.reduce<Map<string, ProviderGroup>>((map, model) => {
@@ -3251,11 +3252,14 @@ const ModelSettingsPage: React.FC = () => {
           data-bf-component="model-settings"
           data-bf-part="modelActions"
         >
-          <Tooltip content={t('actions.test')}>
+          <Tooltip content={connectionTestSupported
+            ? t('actions.test')
+            : t('messages.testUnsupportedOnHost')}>
             <IconButton
               aria-label={t('actions.test')}
               size="sm"
               loading={isTesting}
+              disabled={!connectionTestSupported}
               onClick={() => void handleTest(config)}
               icon={isTesting ? <Loader size={14} /> : <Wifi size={14} />}
             />
@@ -3675,6 +3679,16 @@ const ModelSettingsPage: React.FC = () => {
             </Tooltip>
           )}
         >
+          {hasSuspendedEditorDraft && (
+            <ConfigActionBar
+              status="unsaved"
+              statusMessage={t('draftClose.retainedHint')}
+              saveLabel={t('draftClose.continueEditing')}
+              discardLabel={t('draftClose.discardDraft')}
+              onSave={() => setIsEditing(true)}
+              onDiscard={closeEditingModal}
+            />
+          )}
           {aiModels.length === 0 ? (
             <div className="bitfun-model-settings__empty" data-bf-component="model-settings" data-bf-part="empty">
               <Wifi size={36} />
@@ -4093,6 +4107,32 @@ const ModelSettingsPage: React.FC = () => {
           </>
         )}</DialogFooter>
       </Dialog>
+      <ConfirmDialog
+        open={draftCloseConfirmOpen}
+        onOpenChange={(open) => { if (!open) setDraftCloseConfirmOpen(false); }}
+        onConfirm={preserveEditingDraftAndClose}
+        onSecondary={closeEditingModal}
+        title={t('draftClose.title')}
+        message={t('draftClose.message')}
+        confirmText={t('draftClose.keepAndClose')}
+        secondaryText={t('draftClose.discard')}
+        cancelText={t('draftClose.continueEditing')}
+        closeOnPointerOutside={false}
+        type="warning"
+      />
+      <ConfirmDialog
+        open={draftConflictConfirmOpen}
+        onOpenChange={(open) => { if (!open) cancelPendingEditorOpen(); }}
+        onConfirm={continueEditingCurrentDraft}
+        onSecondary={discardDraftBeforeOpeningPendingEditor}
+        title={t('draftConflict.title')}
+        message={t('draftConflict.message')}
+        confirmText={t('draftConflict.continueDraft')}
+        secondaryText={t('draftConflict.discardAndContinue')}
+        cancelText={t('draftConflict.cancel')}
+        closeOnPointerOutside={false}
+        type="warning"
+      />
       <ConfirmDialog
         open={!!deleteRequest}
         onOpenChange={(open) => { if (!open) setDeleteRequest(null); }}

--- a/src/web-ui/src/infrastructure/config/components/ModelSettingsPage.tsx
+++ b/src/web-ui/src/infrastructure/config/components/ModelSettingsPage.tsx
@@ -38,12 +38,14 @@ import { configManager } from '../services/ConfigManager';
 import { getCapabilitiesByCategory, resolveModelCategory } from '../services/modelCategory';
 import {
   allocateModelConfigId,
+  countModelConfigReferences,
   getModelDisplayName,
   getProviderDisplayName,
   getProviderGroupKey,
   getProviderInstanceId,
   getProviderTemplateId,
   PROVIDER_INSTANCE_METADATA_KEY,
+  removeProviderModelConfigs,
 } from '../services/modelConfigs';
 import { resolveProviderTemplates } from '../services/builtinProviderCatalog';
 import { normalizeProviderBaseUrl } from '../services/providerCatalog';
@@ -147,9 +149,23 @@ interface SubscriptionLogoutRequest {
 }
 
 interface ModelDeleteRequest {
+  kind: 'model';
   config: AIModelConfigType;
+  modelIds: string[];
   referenceCount: number;
 }
+
+interface ProviderDeleteRequest {
+  kind: 'provider';
+  groupKey: string;
+  providerName: string;
+  modelIds: string[];
+  modelCount: number;
+  referenceCount: number;
+  discardsRetainedDraft: boolean;
+}
+
+type DeleteRequest = ModelDeleteRequest | ProviderDeleteRequest;
 
 interface PendingEditorOpen {
   open: () => void;
@@ -339,18 +355,6 @@ function hasHttpUrlScheme(value: string): boolean {
   return /^https?:\/\//i.test(value.trim());
 }
 
-function countExactModelReferences(value: unknown, modelId: string): number {
-  if (value === modelId) return 1;
-  if (Array.isArray(value)) {
-    return value.reduce<number>((count, entry) => count + countExactModelReferences(entry, modelId), 0);
-  }
-  if (value && typeof value === 'object') {
-    return Object.values(value as Record<string, unknown>)
-      .reduce<number>((count, entry) => count + countExactModelReferences(entry, modelId), 0);
-  }
-  return 0;
-}
-
 function normalizeComparableString(value: string | undefined): string {
   return (value || '').trim();
 }
@@ -449,7 +453,7 @@ const ModelSettingsPage: React.FC = () => {
   const [subscriptionLoginPanel, setSubscriptionLoginPanel] = useState<SubscriptionLoginPanelState | null>(null);
   const [subscriptionLoginClock, setSubscriptionLoginClock] = useState(() => Date.now());
   const [subscriptionLogoutRequest, setSubscriptionLogoutRequest] = useState<SubscriptionLogoutRequest | null>(null);
-  const [deleteRequest, setDeleteRequest] = useState<ModelDeleteRequest | null>(null);
+  const [deleteRequest, setDeleteRequest] = useState<DeleteRequest | null>(null);
   const [showSubscriptionMigrationNotice, setShowSubscriptionMigrationNotice] = useState(() => {
     if (typeof window === 'undefined') return false;
     try {
@@ -1831,36 +1835,113 @@ const ModelSettingsPage: React.FC = () => {
     }
   };
 
+  const inspectModelReferenceCount = async (modelIds: string[]): Promise<number> => {
+    const [defaultModels, taskModels, agentModelDefaults] = await Promise.all([
+      configManager.getConfig<unknown>('ai.default_models'),
+      configManager.getConfig<unknown>('ai.task_models'),
+      configManager.getConfig<unknown>('ai.agent_model_defaults'),
+    ]);
+    const ids = new Set(modelIds);
+    return [defaultModels, taskModels, agentModelDefaults]
+      .reduce<number>((count, value) => count + countModelConfigReferences(value, ids), 0);
+  };
+
   const requestDelete = async (config: AIModelConfigType) => {
     if (!config.id) return;
     try {
-      const [defaultModels, taskModels, agentModelDefaults] = await Promise.all([
-        configManager.getConfig<unknown>('ai.default_models'),
-        configManager.getConfig<unknown>('ai.task_models'),
-        configManager.getConfig<unknown>('ai.agent_model_defaults'),
-      ]);
-      const referenceCount = [defaultModels, taskModels, agentModelDefaults]
-        .reduce<number>((count, value) => count + countExactModelReferences(value, config.id!), 0);
-      setDeleteRequest({ config, referenceCount });
+      const referenceCount = await inspectModelReferenceCount([config.id]);
+      setDeleteRequest({ kind: 'model', config, modelIds: [config.id], referenceCount });
     } catch (error) {
       log.error('Failed to inspect model references before deletion', { configId: config.id, error });
       notification.error(t('messages.referenceCheckFailed'));
     }
   };
 
+  const requestProviderDelete = async (group: ProviderGroup) => {
+    const modelIds = group.models
+      .map(model => model.id)
+      .filter((id): id is string => !!id);
+    try {
+      const referenceCount = await inspectModelReferenceCount(modelIds);
+      setDeleteRequest({
+        kind: 'provider',
+        groupKey: group.key,
+        providerName: group.providerName,
+        modelIds,
+        modelCount: group.models.length,
+        referenceCount,
+        discardsRetainedDraft: editingModalHasUnsavedChanges
+          && editingTargetKey === `provider:${group.key}`,
+      });
+    } catch (error) {
+      log.error('Failed to inspect provider model references before deletion', {
+        providerGroupKey: group.key,
+        error,
+      });
+      notification.error(t('messages.providerReferenceCheckFailed'));
+    }
+  };
+
   const handleDelete = async () => {
-    const id = deleteRequest?.config.id;
-    if (!id) return;
+    const request = deleteRequest;
+    if (!request) return;
+    let deletedModelIds = request.modelIds;
     try {
       const updatedModels = await configManager.updateConfig<AIModelConfigType[]>(
-        'ai.models', current => current.filter(model => model.id !== id)
+        'ai.models',
+        (current) => {
+          if (request.kind === 'provider') {
+            const result = removeProviderModelConfigs(current, request.groupKey);
+            deletedModelIds = result.removed
+              .map(model => model.id)
+              .filter((id): id is string => !!id);
+            return result.remaining;
+          }
+          return current.filter(model => model.id !== request.config.id);
+        },
       );
+      const deletedIdSet = new Set(deletedModelIds);
+      deletedIdSet.forEach(id => {
+        delete activeConnectionTestsRef.current[id];
+      });
+      setTestingConfigs(current => Object.fromEntries(
+        Object.entries(current).filter(([id]) => !deletedIdSet.has(id)),
+      ));
+      setTestResults(current => Object.fromEntries(
+        Object.entries(current).filter(([id]) => !deletedIdSet.has(id)),
+      ));
+      setExpandedIds(current => new Set([...current].filter(id => !deletedIdSet.has(id))));
+      if (request.kind === 'provider') {
+        setExpandedProviderGroupKeys(current => {
+          const next = new Set(current);
+          next.delete(request.groupKey);
+          return next;
+        });
+        if (editingTargetKey === `provider:${request.groupKey}`) {
+          closeEditingModal();
+        }
+      } else if (editingTargetKey === `model:${request.config.id}`) {
+        closeEditingModal();
+      }
       setAiModels(updatedModels);
       setDeleteRequest(null);
-      notification.success(t('messages.deleteSuccess'));
+      notification.success(t(
+        request.kind === 'provider'
+          ? 'messages.providerDeleteSuccess'
+          : 'messages.deleteSuccess',
+      ));
     } catch (error) {
-      log.error('Failed to delete config', { configId: id, error });
-      notification.error(t('messages.deleteFailed'));
+      log.error(
+        request.kind === 'provider' ? 'Failed to delete provider config' : 'Failed to delete model config',
+        request.kind === 'provider'
+          ? { providerGroupKey: request.groupKey, error }
+          : { configId: request.config.id, error },
+      );
+      notification.error(t(
+        request.kind === 'provider'
+          ? 'messages.providerDeleteFailed'
+          : 'messages.deleteFailed',
+      ));
     }
   };
 
@@ -3747,6 +3828,15 @@ const ModelSettingsPage: React.FC = () => {
                             icon={<Icon name="edit" size="sm" />}
                           />
                         </Tooltip>
+                        <Tooltip content={t('actions.deleteProvider')}>
+                          <IconButton
+                            aria-label={`${t('actions.deleteProvider')}: ${group.providerName}`}
+                            tone="danger"
+                            size="sm"
+                            onClick={() => void requestProviderDelete(group)}
+                            icon={<Icon name="delete" size="sm" />}
+                          />
+                        </Tooltip>
                       </div>
                     </div>
                     {isExpanded && (
@@ -4137,12 +4227,24 @@ const ModelSettingsPage: React.FC = () => {
         open={!!deleteRequest}
         onOpenChange={(open) => { if (!open) setDeleteRequest(null); }}
         onConfirm={handleDelete}
-        title={t('deleteConfirm.title')}
-        message={t('deleteConfirm.message', {
-          name: deleteRequest?.config.model_name || '',
-          count: deleteRequest?.referenceCount ?? 0,
-        })}
-        confirmText={t('deleteConfirm.confirm')}
+        title={t(deleteRequest?.kind === 'provider'
+          ? 'providerDeleteConfirm.title'
+          : 'deleteConfirm.title')}
+        message={deleteRequest?.kind === 'provider'
+          ? t(deleteRequest.discardsRetainedDraft
+            ? 'providerDeleteConfirm.messageWithDraft'
+            : 'providerDeleteConfirm.message', {
+              name: deleteRequest.providerName,
+              modelCount: deleteRequest.modelCount,
+              referenceCount: deleteRequest.referenceCount,
+            })
+          : t('deleteConfirm.message', {
+              name: deleteRequest?.config.model_name || '',
+              count: deleteRequest?.referenceCount ?? 0,
+            })}
+        confirmText={t(deleteRequest?.kind === 'provider'
+          ? 'providerDeleteConfirm.confirm'
+          : 'deleteConfirm.confirm')}
         type="warning"
         confirmDanger
       />

--- a/src/web-ui/src/infrastructure/config/components/modelConnectionTestPlan.test.ts
+++ b/src/web-ui/src/infrastructure/config/components/modelConnectionTestPlan.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import type { AIModelConfig } from '../types';
+import { configsNeedingAutoTest } from './modelConnectionTestPlan';
+
+function model(id: string, overrides: Partial<AIModelConfig> = {}): AIModelConfig {
+  return {
+    id,
+    name: 'Provider',
+    provider: 'openai',
+    api_key: 'secret',
+    base_url: 'https://example.com/v1',
+    request_url: 'https://example.com/v1/chat/completions',
+    model_name: id,
+    context_window: 128000,
+    enabled: true,
+    category: 'general_chat',
+    capabilities: ['text_chat', 'function_calling'],
+    auth: { type: 'api_key' },
+    ...overrides,
+  };
+}
+
+describe('configsNeedingAutoTest', () => {
+  it('tests only newly added models when a provider model list changes', () => {
+    const previous = [model('alpha'), model('beta')];
+    const added = model('gamma');
+
+    expect(configsNeedingAutoTest(previous, [...previous, added], true)).toEqual([added]);
+  });
+
+  it('uses one representative when shared provider connection settings change', () => {
+    const previous = [model('alpha'), model('beta'), model('gamma')];
+    const next = previous.map(config => ({ ...config, api_key: 'rotated-secret' }));
+
+    expect(configsNeedingAutoTest(previous, next, true).map(config => config.id)).toEqual(['alpha']);
+  });
+
+  it('uses a newly added model as the representative for a simultaneous provider edit', () => {
+    const previous = [model('alpha'), model('beta')];
+    const next = [
+      ...previous.map(config => ({ ...config, base_url: 'https://new.example.com/v1' })),
+      model('gamma', { base_url: 'https://new.example.com/v1' }),
+    ];
+
+    expect(configsNeedingAutoTest(previous, next, true).map(config => config.id)).toEqual(['gamma']);
+  });
+
+  it('does not probe changes that only affect local model metadata', () => {
+    const previous = [model('alpha')];
+    const next = [{
+      ...previous[0],
+      context_window: 200000,
+      max_tokens: 32000,
+      reasoning: {
+        catalog: { source: 'auto' as const },
+        presets: [],
+      },
+    }];
+
+    expect(configsNeedingAutoTest(previous, next, true)).toEqual([]);
+  });
+
+  it('retests a model when its image probe requirement changes', () => {
+    const previous = [model('alpha')];
+    const next = [model('alpha', {
+      category: 'multimodal',
+      capabilities: ['text_chat', 'image_understanding'],
+    })];
+
+    expect(configsNeedingAutoTest(previous, next, true)).toEqual(next);
+  });
+
+  it('automatically probes only one model for a newly created provider', () => {
+    const next = [model('alpha'), model('beta')];
+
+    expect(configsNeedingAutoTest([], next, false)).toEqual([next[0]]);
+  });
+});

--- a/src/web-ui/src/infrastructure/config/components/modelConnectionTestPlan.ts
+++ b/src/web-ui/src/infrastructure/config/components/modelConnectionTestPlan.ts
@@ -1,0 +1,109 @@
+import type { AIModelConfig } from '../types';
+
+function normalizeComparableString(value: string | undefined): string {
+  return (value || '').trim();
+}
+
+export function stableJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableJson).join(',')}]`;
+  }
+  if (value && typeof value === 'object') {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, entryValue]) => `${JSON.stringify(key)}:${stableJson(entryValue)}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+export function providerConnectionChanged(
+  previous: AIModelConfig | undefined,
+  next: AIModelConfig,
+): boolean {
+  if (!previous) return true;
+
+  return (
+    normalizeComparableString(previous.provider) !== normalizeComparableString(next.provider)
+    || normalizeComparableString(previous.base_url) !== normalizeComparableString(next.base_url)
+    || normalizeComparableString(previous.api_key) !== normalizeComparableString(next.api_key)
+    || stableJson(previous.auth || { type: 'api_key' }) !== stableJson(next.auth || { type: 'api_key' })
+    || stableJson(previous.custom_headers || {}) !== stableJson(next.custom_headers || {})
+    || normalizeComparableString(previous.custom_headers_mode) !== normalizeComparableString(next.custom_headers_mode)
+    || normalizeComparableString(previous.custom_request_body) !== normalizeComparableString(next.custom_request_body)
+    || normalizeComparableString(previous.custom_request_body_mode) !== normalizeComparableString(next.custom_request_body_mode)
+    || (previous.skip_ssl_verify ?? false) !== (next.skip_ssl_verify ?? false)
+  );
+}
+
+function supportsImageProbe(config: AIModelConfig): boolean {
+  return config.category === 'multimodal'
+    || config.capabilities.some(capability => capability === 'image_understanding');
+}
+
+function modelProbeChanged(previous: AIModelConfig, next: AIModelConfig): boolean {
+  return (
+    normalizeComparableString(previous.model_name) !== normalizeComparableString(next.model_name)
+    || normalizeComparableString(previous.request_url) !== normalizeComparableString(next.request_url)
+    || supportsImageProbe(previous) !== supportsImageProbe(next)
+  );
+}
+
+function uniqueConfigs(configs: AIModelConfig[]): AIModelConfig[] {
+  const seen = new Set<string>();
+  return configs.filter(config => {
+    const key = config.id || `${config.provider}:${config.base_url}:${config.model_name}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+/**
+ * Plan the expensive post-save model probes.
+ *
+ * A provider probe is a real model generation (and can include a second image
+ * request), so shared connection edits need one representative model rather
+ * than an unbounded fan-out. Newly added or probe-relevant models are still
+ * checked individually. Local metadata such as context limits and reasoning
+ * presets does not require a connection probe.
+ */
+export function configsNeedingAutoTest(
+  previousModels: AIModelConfig[],
+  nextConfigs: AIModelConfig[],
+  isProviderGroupEdit: boolean,
+): AIModelConfig[] {
+  const previousById = new Map(previousModels.map(model => [model.id, model]));
+  const added = nextConfigs.filter(config => !previousById.get(config.id));
+
+  // A brand-new provider may contain several selected models. One successful
+  // representative request is enough for automatic onboarding verification;
+  // every model remains available for an explicit per-model test.
+  if (!isProviderGroupEdit && added.length === nextConfigs.length) {
+    return nextConfigs.slice(0, 1);
+  }
+
+  const providerChanged = nextConfigs.filter(config => {
+    const previous = previousById.get(config.id);
+    return previous ? providerConnectionChanged(previous, config) : false;
+  });
+  const modelProbeChangedConfigs = nextConfigs.filter(config => {
+    const previous = previousById.get(config.id);
+    return previous ? modelProbeChanged(previous, config) : false;
+  });
+
+  if (!isProviderGroupEdit) {
+    return uniqueConfigs([...added, ...providerChanged, ...modelProbeChangedConfigs]);
+  }
+
+  if (providerChanged.length === 0) {
+    return uniqueConfigs([...added, ...modelProbeChangedConfigs]);
+  }
+
+  const representative = added[0] || modelProbeChangedConfigs[0] || providerChanged[0];
+  return uniqueConfigs([
+    ...(representative ? [representative] : []),
+    ...added,
+    ...modelProbeChangedConfigs,
+  ]);
+}

--- a/src/web-ui/src/infrastructure/config/services/modelConfigs.test.ts
+++ b/src/web-ui/src/infrastructure/config/services/modelConfigs.test.ts
@@ -66,6 +66,31 @@ describe('modelConfigs', () => {
     expect(allocateModelConfigId('AUTO', [])).toBe('AUTO-2');
   });
 
+  it('counts nested references to every model in a provider deletion', async () => {
+    const { countModelConfigReferences } = await import('./modelConfigs');
+    const modelIds = new Set(['model-a', 'model-b']);
+
+    expect(countModelConfigReferences({
+      primary: 'model-a',
+      fast: 'model-c',
+      agents: [{ model: 'model-b' }, { model: 'model-a-suffix' }],
+    }, modelIds)).toBe(2);
+  });
+
+  it('removes only models from the selected provider instance', async () => {
+    const { removeProviderModelConfigs } = await import('./modelConfigs');
+    const configs = [
+      { id: 'model-a', metadata: { provider_instance_id: 'provider-1' } },
+      { id: 'model-b', metadata: { provider_instance_id: 'provider-1' } },
+      { id: 'model-c', metadata: { provider_instance_id: 'provider-2' } },
+    ];
+
+    expect(removeProviderModelConfigs(configs, 'provider-1')).toEqual({
+      remaining: [configs[2]],
+      removed: [configs[0], configs[1]],
+    });
+  });
+
   it('loads ai.models only when the model manager is actually used', async () => {
     configManagerMock.getConfig.mockResolvedValueOnce([
       {

--- a/src/web-ui/src/infrastructure/config/services/modelConfigs.ts
+++ b/src/web-ui/src/infrastructure/config/services/modelConfigs.ts
@@ -41,6 +41,44 @@ export function getProviderGroupKey(config: ProviderConfigLike): string {
     || `${config.name ?? ''}:${config.model_name ?? ''}`;
 }
 
+/** Count exact model-id references in persisted selector/config structures. */
+export function countModelConfigReferences(
+  value: unknown,
+  modelIds: ReadonlySet<string>,
+): number {
+  if (typeof value === 'string') return modelIds.has(value) ? 1 : 0;
+  if (Array.isArray(value)) {
+    return value.reduce<number>(
+      (count, entry) => count + countModelConfigReferences(entry, modelIds),
+      0,
+    );
+  }
+  if (value && typeof value === 'object') {
+    return Object.values(value as Record<string, unknown>).reduce<number>(
+      (count, entry) => count + countModelConfigReferences(entry, modelIds),
+      0,
+    );
+  }
+  return 0;
+}
+
+/** Remove one configured provider instance and every model owned by it. */
+export function removeProviderModelConfigs<T extends ProviderConfigLike>(
+  configs: readonly T[],
+  providerGroupKey: string,
+): { remaining: T[]; removed: T[] } {
+  const remaining: T[] = [];
+  const removed: T[] = [];
+  configs.forEach((config) => {
+    if (getProviderGroupKey(config) === providerGroupKey) {
+      removed.push(config);
+    } else {
+      remaining.push(config);
+    }
+  });
+  return { remaining, removed };
+}
+
 function inferProviderTemplate(config: ProviderConfigLike): ProviderTemplate | undefined {
   const matchedCatalogItem = matchProviderCatalogItemByBaseUrl(config.base_url);
   // Safe module-level forward reference: PROVIDER_TEMPLATES is initialized before this runs.

--- a/src/web-ui/src/locales/en-US/settings/models.json
+++ b/src/web-ui/src/locales/en-US/settings/models.json
@@ -456,6 +456,7 @@
     "cancel": "Cancel",
     "edit": "Edit",
     "delete": "Delete",
+    "deleteProvider": "Delete provider",
     "test": "Test Connection",
     "newConfig": "New Configuration",
     "addModel": "Add Model",
@@ -466,6 +467,12 @@
     "title": "Delete model configuration?",
     "message": "This deletes the model “{{name}}”. It is explicitly referenced by {{count}} setting(s). Those references will not automatically switch to another model, so related features may fall back or become unavailable.",
     "confirm": "Delete model"
+  },
+  "providerDeleteConfirm": {
+    "title": "Delete provider?",
+    "message": "This deletes provider “{{name}}” and its {{modelCount}} model configuration(s). Those models are explicitly referenced by {{referenceCount}} setting(s). The references will not automatically switch to another model, so related features may fall back or become unavailable. Any linked subscription account will remain signed in.",
+    "messageWithDraft": "This deletes provider “{{name}}”, its {{modelCount}} model configuration(s), and the provider's unsaved editing draft. Those models are explicitly referenced by {{referenceCount}} setting(s). The references will not automatically switch to another model, so related features may fall back or become unavailable. Any linked subscription account will remain signed in.",
+    "confirm": "Delete provider"
   },
   "draftClose": {
     "title": "Keep this editing draft?",
@@ -504,7 +511,10 @@
     "saveFailed": "Save failed",
     "deleteFailed": "Failed to delete configuration",
     "deleteSuccess": "Model configuration deleted",
+    "providerDeleteFailed": "Failed to delete provider",
+    "providerDeleteSuccess": "Provider and its model configurations deleted",
     "referenceCheckFailed": "BitFun could not verify whether other settings still reference this model, so deletion was cancelled",
+    "providerReferenceCheckFailed": "BitFun could not verify whether other settings still reference this provider's models, so deletion was cancelled",
     "loadFailed": "Failed to load AI configuration",
     "testSuccess": "Test successful",
     "testFailed": "Test failed",

--- a/src/web-ui/src/locales/en-US/settings/models.json
+++ b/src/web-ui/src/locales/en-US/settings/models.json
@@ -467,10 +467,21 @@
     "message": "This deletes the model “{{name}}”. It is explicitly referenced by {{count}} setting(s). Those references will not automatically switch to another model, so related features may fall back or become unavailable.",
     "confirm": "Delete model"
   },
-  "discardChanges": {
-    "title": "Discard unsaved changes?",
-    "message": "The model or provider draft has not been saved. Closing now will lose these changes.",
-    "confirm": "Discard changes"
+  "draftClose": {
+    "title": "Keep this editing draft?",
+    "message": "These changes have not been written to the model configuration. Keeping the draft will not run a connection test, and you can resume it when you reopen this editor.",
+    "keepAndClose": "Keep draft and close",
+    "discard": "Discard changes",
+    "continueEditing": "Continue editing",
+    "discardDraft": "Discard draft",
+    "retainedHint": "The model editing draft is retained and has not been written to the active configuration."
+  },
+  "draftConflict": {
+    "title": "Resolve the unfinished model draft",
+    "message": "Before opening another model or provider, continue the current draft or discard it and open the selected configuration.",
+    "continueDraft": "Continue current draft",
+    "discardAndContinue": "Discard and continue",
+    "cancel": "Cancel"
   },
   "empty": {
     "noModels": "No model configurations",
@@ -497,6 +508,7 @@
     "loadFailed": "Failed to load AI configuration",
     "testSuccess": "Test successful",
     "testFailed": "Test failed",
+    "testUnsupportedOnHost": "Configuration saved; the current CLI device does not support model connection tests",
     "errorDetails": "Error details",
     "connectionTestMessages": {
       "toolCallsNotDetected": "This test did not detect any tool calls, so tool calling could not be verified this time.",

--- a/src/web-ui/src/locales/zh-CN/settings/models.json
+++ b/src/web-ui/src/locales/zh-CN/settings/models.json
@@ -467,10 +467,21 @@
     "message": "将删除模型“{{name}}”。当前有 {{count}} 处设置显式引用此模型；这些引用不会自动改为其他模型，相关功能可能回退或不可用。",
     "confirm": "删除模型"
   },
-  "discardChanges": {
-    "title": "放弃未保存的修改？",
-    "message": "模型或服务商配置中的草稿尚未保存。关闭后这些修改将丢失。",
-    "confirm": "放弃修改"
+  "draftClose": {
+    "title": "保留这次编辑草稿？",
+    "message": "这些修改尚未写入模型配置。保留草稿不会触发连接测试，再次打开此编辑器时可以继续。",
+    "keepAndClose": "保留草稿并关闭",
+    "discard": "放弃修改",
+    "continueEditing": "继续编辑",
+    "discardDraft": "放弃草稿",
+    "retainedHint": "模型编辑草稿已保留，尚未写入正式配置。"
+  },
+  "draftConflict": {
+    "title": "先处理未完成的模型草稿",
+    "message": "打开另一个模型或服务商前，请继续处理当前草稿，或放弃草稿后打开所选配置。",
+    "continueDraft": "继续当前草稿",
+    "discardAndContinue": "放弃草稿并继续",
+    "cancel": "取消"
   },
   "empty": {
     "noModels": "暂无模型配置",
@@ -497,6 +508,7 @@
     "loadFailed": "加载AI配置失败",
     "testSuccess": "测试成功",
     "testFailed": "测试失败",
+    "testUnsupportedOnHost": "配置已保存，当前 CLI 设备不支持模型连接测试",
     "errorDetails": "详细错误",
     "connectionTestMessages": {
       "toolCallsNotDetected": "本次测试未检测到工具调用，因此暂时无法验证工具调用能力。",

--- a/src/web-ui/src/locales/zh-CN/settings/models.json
+++ b/src/web-ui/src/locales/zh-CN/settings/models.json
@@ -456,6 +456,7 @@
     "cancel": "取消",
     "edit": "编辑",
     "delete": "删除",
+    "deleteProvider": "删除服务商",
     "test": "测试连接",
     "newConfig": "新建配置",
     "addModel": "添加模型",
@@ -466,6 +467,12 @@
     "title": "删除模型配置？",
     "message": "将删除模型“{{name}}”。当前有 {{count}} 处设置显式引用此模型；这些引用不会自动改为其他模型，相关功能可能回退或不可用。",
     "confirm": "删除模型"
+  },
+  "providerDeleteConfirm": {
+    "title": "删除服务商？",
+    "message": "将删除服务商“{{name}}”及其 {{modelCount}} 个模型配置。当前有 {{referenceCount}} 处设置显式引用这些模型；这些引用不会自动改为其他模型，相关功能可能回退或不可用。关联的订阅账号不会退出登录。",
+    "messageWithDraft": "将删除服务商“{{name}}”及其 {{modelCount}} 个模型配置，同时丢弃该服务商尚未保存的编辑草稿。当前有 {{referenceCount}} 处设置显式引用这些模型；这些引用不会自动改为其他模型，相关功能可能回退或不可用。关联的订阅账号不会退出登录。",
+    "confirm": "删除服务商"
   },
   "draftClose": {
     "title": "保留这次编辑草稿？",
@@ -504,7 +511,10 @@
     "saveFailed": "保存失败",
     "deleteFailed": "删除配置失败",
     "deleteSuccess": "模型配置已删除",
+    "providerDeleteFailed": "删除服务商失败",
+    "providerDeleteSuccess": "服务商及其模型配置已删除",
     "referenceCheckFailed": "无法确认此模型是否仍被其他设置引用，已取消删除",
+    "providerReferenceCheckFailed": "无法确认该服务商的模型是否仍被其他设置引用，已取消删除",
     "loadFailed": "加载AI配置失败",
     "testSuccess": "测试成功",
     "testFailed": "测试失败",

--- a/src/web-ui/src/locales/zh-TW/settings/models.json
+++ b/src/web-ui/src/locales/zh-TW/settings/models.json
@@ -467,10 +467,21 @@
     "message": "將刪除模型「{{name}}」。目前有 {{count}} 處設定明確引用此模型；這些引用不會自動改用其他模型，相關功能可能回退或無法使用。",
     "confirm": "刪除模型"
   },
-  "discardChanges": {
-    "title": "放棄未儲存的修改？",
-    "message": "模型或服務商設定中的草稿尚未儲存。關閉後這些修改將遺失。",
-    "confirm": "放棄修改"
+  "draftClose": {
+    "title": "保留這次編輯草稿？",
+    "message": "這些修改尚未寫入模型設定。保留草稿不會觸發連接測試，再次開啟此編輯器時可以繼續。",
+    "keepAndClose": "保留草稿並關閉",
+    "discard": "放棄修改",
+    "continueEditing": "繼續編輯",
+    "discardDraft": "放棄草稿",
+    "retainedHint": "模型編輯草稿已保留，尚未寫入正式設定。"
+  },
+  "draftConflict": {
+    "title": "先處理未完成的模型草稿",
+    "message": "開啟另一個模型或服務商前，請繼續處理目前草稿，或放棄草稿後開啟所選設定。",
+    "continueDraft": "繼續目前草稿",
+    "discardAndContinue": "放棄草稿並繼續",
+    "cancel": "取消"
   },
   "empty": {
     "noModels": "暫無模型設定",
@@ -497,6 +508,7 @@
     "loadFailed": "載入AI設定失敗",
     "testSuccess": "測試成功",
     "testFailed": "測試失敗",
+    "testUnsupportedOnHost": "設定已儲存，目前 CLI 裝置不支援模型連接測試",
     "errorDetails": "詳細錯誤",
     "connectionTestMessages": {
       "toolCallsNotDetected": "本次測試未檢測到工具調用，因此暫時無法驗證工具調用能力。",

--- a/src/web-ui/src/locales/zh-TW/settings/models.json
+++ b/src/web-ui/src/locales/zh-TW/settings/models.json
@@ -456,6 +456,7 @@
     "cancel": "取消",
     "edit": "編輯",
     "delete": "刪除",
+    "deleteProvider": "刪除服務商",
     "test": "測試連接",
     "newConfig": "新增設定",
     "addModel": "新增模型",
@@ -466,6 +467,12 @@
     "title": "刪除模型設定？",
     "message": "將刪除模型「{{name}}」。目前有 {{count}} 處設定明確引用此模型；這些引用不會自動改用其他模型，相關功能可能回退或無法使用。",
     "confirm": "刪除模型"
+  },
+  "providerDeleteConfirm": {
+    "title": "刪除服務商？",
+    "message": "將刪除服務商「{{name}}」及其 {{modelCount}} 個模型設定。目前有 {{referenceCount}} 處設定明確引用這些模型；這些引用不會自動改用其他模型，相關功能可能回退或無法使用。關聯的訂閱帳號不會登出。",
+    "messageWithDraft": "將刪除服務商「{{name}}」及其 {{modelCount}} 個模型設定，同時捨棄該服務商尚未儲存的編輯草稿。目前有 {{referenceCount}} 處設定明確引用這些模型；這些引用不會自動改用其他模型，相關功能可能回退或無法使用。關聯的訂閱帳號不會登出。",
+    "confirm": "刪除服務商"
   },
   "draftClose": {
     "title": "保留這次編輯草稿？",
@@ -504,7 +511,10 @@
     "saveFailed": "儲存失敗",
     "deleteFailed": "刪除設定失敗",
     "deleteSuccess": "模型設定已刪除",
+    "providerDeleteFailed": "刪除服務商失敗",
+    "providerDeleteSuccess": "服務商及其模型設定已刪除",
     "referenceCheckFailed": "無法確認此模型是否仍被其他設定引用，已取消刪除",
+    "providerReferenceCheckFailed": "無法確認該服務商的模型是否仍被其他設定引用，已取消刪除",
     "loadFailed": "載入AI設定失敗",
     "testSuccess": "測試成功",
     "testFailed": "測試失敗",


### PR DESCRIPTION
## Summary

- Preserve unsaved model/provider editor changes as a retained draft when the dialog is closed through Cancel, the close button, or Escape.
- Prompt users to keep, discard, or continue editing a draft, and restore retained drafts when reopening the same provider.
- Limit automatic post-save connection tests to representative, newly added, or probe-relevant models instead of testing every model under a provider.
- Prevent stale asynchronous connection-test results from overwriting newer results.
- Add provider-level deletion that removes all models belonging to the selected provider, with model/reference counts in the confirmation dialog.
- Restore the intrinsic size and clickability of switches under Advanced Settings.
- Align custom-header and custom-request-body mode actions to the right edge of their rows.
- Add and update English, Simplified Chinese, and Traditional Chinese copy.

Fixes: N/A

## Type and Areas

Type:

Bug fix / regression fix / UI/UX / test

Areas:

Web UI — model settings, configuration state, Peer Device capability handling, and i18n.

## Motivation / Impact

The model provider configuration workflow had several related usability and efficiency issues:

- Closing an edited provider discarded the in-progress form state.
- Saving provider-level changes could trigger connection tests for every configured model.
- Providers could not be deleted directly and had to be removed model by model.
- Advanced Settings switches could collapse to zero width because page-level layout styles overrode their design-system dimensions.
- Mode actions for custom headers and request bodies were constrained to the label column instead of aligning with the right edge of the row.

This PR makes provider editing recoverable, reduces unnecessary model requests, adds direct provider deletion, and repairs the advanced-settings layout.

## Verification

- `pnpm run check:web`
  - Passed Web UI type checking, appearance contracts, typography checks, theme color audits, and visual governance checks.
- `pnpm --dir src/web-ui run test:run src/infrastructure/config/components/modelConnectionTestPlan.test.ts src/infrastructure/config/services/modelConfigs.test.ts src/infrastructure/config/components/ModelSettingsDialog.presentation.test.ts src/infrastructure/config/components/ModelSettingsPage.presentation.test.ts src/infrastructure/config/components/ModelServiceCollapse.presentation.test.ts`
  - 5 test files passed.
  - 27 tests passed.
- `pnpm run i18n:audit`
  - Passed with 0 warnings.
- Manually reproduced the collapsed Advanced Settings control and confirmed the corrected control layout after the fix.

## Reviewer Notes

- No persisted configuration shape, Rust API, or Tauri command contract was changed.
- Provider deletion reuses the existing `ai.models` update path and removes every model associated with the selected provider group.
- Connection testing is explicitly disabled when the active Peer Device host is a CLI host that does not support the operation; there is no silent local fallback.
- The shared Web UI path was verified locally. Remote workspace, remote control, Peer Device end-to-end, and Detached Dispatch scenarios were not separately exercised.
- Temporary runtime instrumentation and `debug-agent.log` were removed before submission.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.