### PR TITLE
fix(flow-chat): keep composer stable across queue changes

### DIFF
--- a/design-system/packages/ui/src/flow-chat/composer/ChatComposer.module.css
+++ b/design-system/packages/ui/src/flow-chat/composer/ChatComposer.module.css
@@ -29,35 +29,18 @@
   }
 
   .body {
-    display: contents;
+    display: flex;
+    min-inline-size: 0;
+    inline-size: 100%;
+    flex-direction: column;
+    gap: var(--bf-space-2);
   }
 
   .queue {
-    min-inline-size: 0;
-  }
-
-  .queue:empty {
-    display: none;
-  }
-
-  .body:has(> .queue:not(:empty)) {
-    box-sizing: border-box;
-    display: grid;
-    min-inline-size: 0;
-    inline-size: 100%;
-    gap: var(--bf-space-2);
-    padding: var(--bf-space-2);
-    border: var(--bf-border-width-default) solid var(--bf-color-action-neutral-border);
-    border-radius: var(--bf-radius-2xl);
-    background: var(--bf-color-surface-panel);
-    box-shadow: var(--bf-shadow-base);
-    transition:
-      border-color var(--bf-motion-duration-fast) var(--bf-motion-easing-standard),
-      box-shadow var(--bf-motion-duration-fast) var(--bf-motion-easing-standard);
-  }
-
-  .body:has(> .queue:not(:empty)):focus-within {
-    border-color: var(--bf-color-border-default);
+    /* The wrapper exists when a queue component later renders `null`. Keeping
+       it out of the box tree makes both that transition and the no-queue path
+       geometrically identical to a composer that never received the slot. */
+    display: contents;
   }
 
   .surface {
@@ -109,20 +92,6 @@
 
   .surface:focus-within {
     border-color: var(--bf-color-border-default);
-  }
-
-  .body:has(> .queue:not(:empty)) .surface {
-    border-color: transparent;
-    background: transparent;
-    box-shadow: none;
-  }
-
-  .body:has(> .queue:not(:empty)) .surface:focus-within {
-    border-color: transparent;
-  }
-
-  .body:has(> .queue:not(:empty)) .surface[data-bf-layout="compact"] {
-    padding-inline: 0;
   }
 
   .content {
@@ -199,7 +168,6 @@
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .body,
     .surface {
       transition: none;
     }
@@ -207,8 +175,7 @@
 
   @media (forced-colors: active) {
     .surface,
-    .surface:focus-within,
-    .body:has(> .queue:not(:empty)) {
+    .surface:focus-within {
       border-color: CanvasText;
       box-shadow: none;
     }

--- a/design-system/packages/ui/tests/chat-composer.test.mjs
+++ b/design-system/packages/ui/tests/chat-composer.test.mjs
@@ -189,6 +189,24 @@ test("ChatComposer queue promotes message text from secondary to primary on inte
   );
 });
 
+test("ChatComposer queue never changes the input surface geometry", async () => {
+  const styles = await readFile(
+    new URL("../src/flow-chat/composer/ChatComposer.module.css", import.meta.url),
+    "utf8",
+  );
+  const bodyRule = styles.match(/\.body\s*\{[^}]*\}/s)?.[0];
+  const queueRule = styles.match(/\.queue\s*\{[^}]*\}/s)?.[0];
+
+  assert.ok(bodyRule);
+  assert.match(bodyRule, /display:\s*flex/);
+  assert.match(bodyRule, /flex-direction:\s*column/);
+  assert.match(bodyRule, /gap:\s*var\(--bf-space-2\)/);
+  assert.ok(queueRule);
+  assert.match(queueRule, /display:\s*contents/);
+  assert.doesNotMatch(styles, /\.body:has\(/);
+  assert.doesNotMatch(styles, /\.queue:empty/);
+});
+
 test("ChatComposer resolves compound slots into the same stable anatomy", () => {
   const markup = renderToStaticMarkup(
     createElement(


### PR DESCRIPTION
## Summary

- keep the composer input surface geometry identical whether queued messages exist or not
- remove dynamic `:has()` / `:empty` styling that could leave a stale double shell after automatic dequeue
- add a regression test that locks the queue-independent composer contract

## Validation

- `pnpm run design-system:check`
- `pnpm run check:web`
- `pnpm --dir src/web-ui run test:run src/flow_chat/components/PendingQueuePanel.test.tsx` (5 tests)
- `pnpm --dir src/web-ui exec vitest run --maxWorkers=50% src/flow_chat/utils/flowChatScrollLayout.test.ts src/flow_chat/components/modern/flowChatTailFollow.test.ts` (43 tests)

## Scope

Presentation-only change. No remote-workspace, remote-control, Peer Device Mode, or Detached Dispatch behavior is changed.