### PR TITLE
fix(web-ui): make pet bubbles theme-aware

### DIFF
--- a/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.scss
+++ b/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPet.scss
@@ -103,15 +103,19 @@
     height: 21px;
     box-sizing: border-box;
     padding: 2px 5px;
-    border: 1px solid color-mix(in srgb, var(--bf-color-content-muted) 12%, transparent);
+    border: 1px solid var(--bf-color-field-border);
     border-radius: 5px;
-    background: color-mix(in srgb, var(--bf-color-content-on-dark) 95%, transparent);
-    color: inherit;
+    background: var(--bf-color-field-background);
+    color: var(--bf-color-content-primary);
     font: inherit;
     font-size: var(--bf-type-micro-font-size);
     line-height: var(--bf-type-modifier-leading-snug-line-height);
     user-select: text;
     -webkit-user-select: text;
+
+    &::placeholder {
+      color: var(--bf-color-content-muted);
+    }
 
     &:focus,
     &:focus-visible {
@@ -130,14 +134,14 @@
     padding: 0;
     display: grid;
     place-items: center;
-    border: 1px solid color-mix(in srgb, var(--bf-color-content-muted) 12%, transparent);
+    border: 1px solid var(--bf-color-action-neutral-border);
     border-radius: 5px;
-    background: color-mix(in srgb, var(--bf-color-content-muted) 4%, transparent);
-    color: inherit;
+    background: var(--bf-color-action-neutral-surface);
+    color: var(--bf-color-action-neutral-content);
     cursor: pointer;
 
     &:hover:not(:disabled) {
-      background: color-mix(in srgb, var(--bf-color-content-muted) 8%, transparent);
+      background: var(--bf-color-action-neutral-surface-hover);
     }
 
     &:disabled {
@@ -251,10 +255,10 @@
     padding: 0;
     display: grid;
     place-items: center;
-    border: 1px solid color-mix(in srgb, var(--bf-color-content-muted) 12%, transparent);
+    border: 1px solid var(--bf-color-border-default);
     border-radius: 50%;
-    background: color-mix(in srgb, var(--bf-color-content-on-dark) 95%, transparent);
-    color: var(--bf-color-content-on-light);
+    background: var(--bf-color-surface-raised);
+    color: var(--bf-color-content-primary);
     opacity: 0;
     visibility: hidden;
     pointer-events: none;
@@ -264,7 +268,7 @@
     cursor: pointer;
 
     &:hover {
-      background: color-mix(in srgb, var(--bf-color-content-muted) 8%, transparent);
+      background: var(--bf-color-surface-tertiary);
     }
 
     &:focus-visible {
@@ -289,10 +293,10 @@
     max-width: 100%;
     box-sizing: border-box;
     padding: 7px 10px;
-    border: 1px solid color-mix(in srgb, var(--bf-color-content-muted) 12%, transparent);
+    border: 1px solid var(--bf-color-border-default);
     border-radius: 10px 10px 2px 10px;
-    background: color-mix(in srgb, var(--bf-color-content-on-dark) 95%, transparent);
-    color: var(--bf-color-content-on-light);
+    background-color: var(--bf-color-surface-raised);
+    color: var(--bf-color-content-primary);
     backdrop-filter: blur(10px);
     cursor: pointer;
     position: relative;
@@ -364,7 +368,7 @@
     margin-top: 2px;
     font-size: var(--bf-type-micro-font-size);
     line-height: var(--bf-type-modifier-leading-dense-line-height);
-    color: color-mix(in srgb, var(--bf-color-content-on-light) 70%, transparent);
+    color: var(--bf-color-content-secondary);
   }
 
   &__bubble-output {
@@ -375,7 +379,7 @@
     height: calc(12px * 4);
     font-size: var(--bf-type-micro-font-size);
     line-height: var(--bf-type-label-md-line-height);
-    color: color-mix(in srgb, var(--bf-color-content-on-light) 82%, transparent);
+    color: var(--bf-color-content-secondary);
     white-space: pre-wrap;
     word-break: break-word;
     overflow-wrap: anywhere;
@@ -394,14 +398,17 @@
       height: 1em;
       margin-left: 2px;
       vertical-align: -0.12em;
-      background: color-mix(in srgb, var(--bf-color-content-on-light) 55%, transparent);
+      background: var(--bf-color-content-muted);
       animation: bitfun-agent-companion-caret 920ms steps(2, start) infinite;
     }
   }
 
   &__bubble--attention {
     border-color: var(--bf-color-status-warning-border);
-    background: var(--bf-color-status-warning-surface);
+    background-image: linear-gradient(
+      var(--bf-color-status-warning-surface),
+      var(--bf-color-status-warning-surface)
+    );
     box-shadow: 0 0 0 0 color-mix(in srgb, var(--bf-color-status-warning-content) 50%, transparent);
     animation: bitfun-agent-companion-attention-pulse 1.5s ease-in-out infinite !important;
 
@@ -420,18 +427,27 @@
 
   &__bubble--waiting {
     border-color: var(--bf-color-status-warning-border);
-    background: var(--bf-color-status-warning-surface);
+    background-image: linear-gradient(
+      var(--bf-color-status-warning-surface),
+      var(--bf-color-status-warning-surface)
+    );
   }
 
   &__bubble--completed {
     border-color: var(--bf-color-status-success-border);
-    background: var(--bf-color-status-success-surface);
+    background-image: linear-gradient(
+      var(--bf-color-status-success-surface),
+      var(--bf-color-status-success-surface)
+    );
   }
 
   &__bubble--error,
   &__bubble--interrupted {
     border-color: var(--bf-color-status-danger-border);
-    background: var(--bf-color-status-danger-surface);
+    background-image: linear-gradient(
+      var(--bf-color-status-danger-surface),
+      var(--bf-color-status-danger-surface)
+    );
   }
 
   .bitfun-agent-companion-pet {

--- a/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPetStyles.test.ts
+++ b/src/web-ui/src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPetStyles.test.ts
@@ -28,13 +28,51 @@ function readPublicActionItemStyles(): string {
 
 function extractBlock(stylesheet: string, selector: string): string {
   const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const match = stylesheet.match(
-    new RegExp(`^\\s*${escapedSelector}\\s*\\{(?<body>[\\s\\S]*?)\\n\\s*\\}`, 'm'),
-  );
-  return match?.groups?.body ?? '';
+  const matches = [...stylesheet.matchAll(
+    new RegExp(`^\\s*${escapedSelector}\\s*\\{(?<body>[\\s\\S]*?)\\n\\s*\\}`, 'gm'),
+  )];
+  return matches.at(-1)?.groups?.body ?? '';
 }
 
 describe('AgentCompanionDesktopPet styles', () => {
+  it('pairs theme-aware bubble surfaces with readable theme content colors', () => {
+    const stylesheet = readStylesheet();
+    const bubble = extractBlock(stylesheet, '&__bubble');
+    const status = extractBlock(stylesheet, '&__bubble-status');
+    const output = extractBlock(stylesheet, '&__bubble-output');
+    const composerInput = extractBlock(stylesheet, '&__bubble-composer-input');
+
+    expect(bubble).toContain('background-color: var(--bf-color-surface-raised);');
+    expect(bubble).toContain('color: var(--bf-color-content-primary);');
+    expect(status).toContain('color: var(--bf-color-content-secondary);');
+    expect(output).toContain('color: var(--bf-color-content-secondary);');
+    expect(composerInput).toContain('background: var(--bf-color-field-background);');
+    expect(composerInput).toContain('color: var(--bf-color-content-primary);');
+    expect(stylesheet).toContain('background: var(--bf-color-surface-raised);');
+
+    expect(stylesheet).not.toContain('--bf-color-content-on-light');
+    expect(stylesheet).not.toContain('--bf-color-content-on-dark');
+    expect(stylesheet).not.toMatch(
+      /&__bubble--(?:attention|waiting|completed|error|interrupted)\s+&__bubble-status/,
+    );
+  });
+
+  it('layers translucent task-state colors over the opaque themed bubble surface', () => {
+    const stylesheet = readStylesheet();
+
+    for (const [selector, surfaceToken] of [
+      ['&__bubble--attention', '--bf-color-status-warning-surface'],
+      ['&__bubble--waiting', '--bf-color-status-warning-surface'],
+      ['&__bubble--completed', '--bf-color-status-success-surface'],
+      ['&__bubble--error,\n  &__bubble--interrupted', '--bf-color-status-danger-surface'],
+    ] as const) {
+      const state = extractBlock(stylesheet, selector);
+      expect(state).toContain('background-image: linear-gradient(');
+      expect(state).toContain(`var(${surfaceToken})`);
+      expect(state).not.toContain(`background: var(${surfaceToken});`);
+    }
+  });
+
   it('delegates context-menu foregrounds and interaction states to the public menu item', () => {
     const source = readSource();
     const stylesheet = readStylesheet();


### PR DESCRIPTION
## Summary
- make desktop pet bubble surfaces, text, composer, and edit controls follow BitFun semantic theme tokens
- layer task-state tints over the raised surface so translucent dark-theme colors cannot erase the bubble background
- add style-contract coverage for readable light/dark token pairing and state-background layering

## Verification
- `pnpm --dir src/web-ui exec vitest run --maxWorkers=50% src/app/components/AgentCompanionDesktopPet/AgentCompanionDesktopPetStyles.test.ts`
- `pnpm run check:web`
- resolved light/dark contrast check across working, completed, waiting, and error states (minimum 5.44:1)