### PR TITLE
fix(harmonyos): reconcile remote session state

### DIFF
--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/runtime/AppRootRuntimeComposition.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/runtime/AppRootRuntimeComposition.ets
@@ -509,7 +509,8 @@ export abstract class AppRootRuntimeComposition {
         onTimelineReady: () => {
           this.remotePageState.setConversationLoading(false);
         },
-        onSendSucceeded: (turnId: string, pendingActiveId: string) => {
+        onSendSucceeded: (turnId: string, pendingActiveId: string, localMessageId: string) => {
+          this.chatTimelineStore.acknowledgeOptimisticTurn(localMessageId, turnId);
           if (turnId.length > 0) {
             this.chatTimelineStore.setLocalActiveTurn(turnId);
             this.conversationController.syncRemoteTimeline();

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/state/DeviceDirectoryState.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/state/DeviceDirectoryState.ets
@@ -81,6 +81,24 @@ export class DeviceDirectoryState {
     this.ensureWorkspace(deviceId, path).status = status;
   }
 
+  /**
+   * Drops disclosure and load facts produced by an older connection to one device.
+   *
+   * A fresh control-target handshake only contains the current workspace's
+   * sessions. Keeping a sibling workspace marked `ready` after that partial
+   * snapshot replaces the directory makes its next disclosure skip the RPC and
+   * render a false empty result. Other devices keep their independent state.
+   */
+  resetWorkspaceDirectory(deviceId: string): void {
+    const targetDeviceId = deviceId.trim();
+    if (targetDeviceId.length === 0) {
+      return;
+    }
+    this.workspaceDirectory = this.workspaceDirectory.filter((item: WorkspaceDirectoryState): boolean =>
+      item.deviceId !== targetDeviceId
+    );
+  }
+
   private findWorkspace(deviceId: string, path: string): WorkspaceDirectoryState | undefined {
     const targetDeviceId = deviceId.trim();
     const normalizedPath = DeviceDirectoryState.normalizeWorkspacePath(path);

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/viewmodel/DeviceDirectoryViewModel.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/viewmodel/DeviceDirectoryViewModel.ets
@@ -146,6 +146,11 @@ export class DeviceDirectoryViewModel {
     if (!entry) {
       return;
     }
+    // A successful handshake starts a new directory generation even when the
+    // transport changed while the desktop id stayed the same (for example,
+    // scan-room -> account-device). The handshake replaces cross-workspace
+    // sessions below, so the old generation's `ready` flags cannot survive it.
+    this.state.resetWorkspaceDirectory(target);
     entry.workspaces = workspaces.slice();
     // The handshake is the authoritative snapshot for the incoming target.
     // Merging the row's old cache here makes any historical cross-device

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/viewmodel/RemoteTranscriptController.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/viewmodel/RemoteTranscriptController.ets
@@ -7,6 +7,7 @@ import {
 import { ChatTimelineItem } from '../../model/ChatTimelineModels';
 import { ChatTimelineState, ChatTimelineStore } from '../../services/ChatTimelineStore';
 import { ConnectionErrorPolicy } from '../../services/ConnectionErrorPolicy';
+import { Encoding } from '../../services/Encoding';
 import { RemoteChatPollingCursor, RemoteChatPollingSnapshot } from '../../services/RemoteChatPollingLifecycleController';
 import { RemoteI18n } from '../../i18n/RemoteI18n';
 import { RemoteLogger } from '../../services/RemoteLogger';
@@ -127,7 +128,8 @@ export class RemoteTranscriptController {
     }
     // Older desktop hosts do not advertise steering. Keep their established
     // queue behavior so mixed-version Remote Connect sessions remain usable.
-    const localMessage = RemoteUiState.localUserMessage(text, images);
+    const clientTurnId = Encoding.randomId('harmony-turn');
+    const localMessage = RemoteUiState.localUserMessage(text, images, clientTurnId);
     runtime.timeline.appendOptimisticMessage(localMessage);
     const pendingActiveId = runtime.timeline.setPendingActiveTurn(localMessage.id);
     this.syncRemoteTimeline();
@@ -147,7 +149,8 @@ export class RemoteTranscriptController {
       localMessage.id,
       pendingActiveId,
       this.remote.isBusy,
-      true
+      true,
+      localMessage.turnId || ''
     );
   }
 

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/services/ChatTimelineStore.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/services/ChatTimelineStore.ets
@@ -125,6 +125,55 @@ export class ChatTimelineStore {
     };
   }
 
+  /**
+   * Binds the optimistic user bubble to the host turn acknowledged by the
+   * send response. New hosts preserve the client turn id, while older hosts
+   * generate a replacement id. Handling both here also closes the race where
+   * polling publishes the persisted message before the send response arrives.
+   */
+  acknowledgeOptimisticTurn(localMessageId: string, turnId: string): void {
+    const normalizedLocalId = localMessageId.trim();
+    const normalizedTurnId = turnId.trim();
+    if (normalizedLocalId.length === 0 || normalizedTurnId.length === 0) {
+      return;
+    }
+    const persistedAlreadyArrived = this.state.persistedMessages.some((message: ChatMessage) => {
+      return message.role === 'user' && (message.turnId || '').trim() === normalizedTurnId;
+    });
+    const optimisticMessages = persistedAlreadyArrived ?
+      this.state.optimisticMessages.filter((message: ChatMessage) => message.id !== normalizedLocalId) :
+      this.state.optimisticMessages.map((message: ChatMessage) => {
+        if (message.id !== normalizedLocalId) {
+          return message;
+        }
+        return {
+          id: message.id,
+          turnId: normalizedTurnId,
+          role: message.role,
+          text: message.text,
+          status: message.status,
+          renderVersion: message.renderVersion,
+          detail: message.detail,
+          error: message.error,
+          timestamp: message.timestamp,
+          thinking: message.thinking,
+          tools: message.tools,
+          items: message.items,
+          images: message.images
+        };
+      });
+    this.state = {
+      sessionId: this.state.sessionId,
+      persistedMessages: this.state.persistedMessages,
+      optimisticMessages,
+      activeTurn: this.state.activeTurn,
+      syncPhase: this.state.syncPhase,
+      cursor: this.state.cursor,
+      modelCatalog: this.state.modelCatalog,
+      selectedModelId: this.state.selectedModelId
+    };
+  }
+
   setPersistedMessages(messages: ChatMessage[]): void {
     const persistedMessages = ChatTimelineStore.carrySteeringItems(
       this.state.activeTurn,
@@ -972,6 +1021,11 @@ export class ChatTimelineStore {
     }
     if (pending.id === message.id) {
       return true;
+    }
+    const pendingTurnId = (pending.turnId || '').trim();
+    const messageTurnId = (message.turnId || '').trim();
+    if (pendingTurnId.length > 0 && messageTurnId.length > 0) {
+      return pendingTurnId === messageTurnId;
     }
     const pendingText = (pending.text || '').trim();
     const messageText = (message.text || '').trim();

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/services/RemoteChatCommandController.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/services/RemoteChatCommandController.ets
@@ -14,12 +14,13 @@ import { TranscriptIntegrityPolicy } from './TranscriptIntegrityPolicy';
 
 export interface RemoteChatCommandClient {
   getSessionMessages(sessionId: string): Promise<SessionMessagesResult>;
-  sendMessage(sessionId: string, text: string, agentType?: string): Promise<string>;
+  sendMessage(sessionId: string, text: string, agentType?: string, turnId?: string): Promise<string>;
   sendMessageWithImages(
     sessionId: string,
     text: string,
     agentType: string,
-    imageContexts: RemoteImageContext[]
+    imageContexts: RemoteImageContext[],
+    turnId?: string
   ): Promise<string>;
   steerTurn(
     sessionId: string,
@@ -40,7 +41,7 @@ export interface RemoteChatCommandCallbacks {
   // before any request has been sent. Without it the loading skeleton would
   // outlive the messages it is standing in for.
   onTimelineReady: () => void;
-  onSendSucceeded: (turnId: string, pendingActiveId: string) => void;
+  onSendSucceeded: (turnId: string, pendingActiveId: string, localMessageId: string) => void;
   onSteerSucceeded?: (
     steeringId: string,
     turnId: string,
@@ -320,7 +321,8 @@ export class RemoteChatCommandController {
     localMessageId: string,
     pendingActiveId: string,
     isBusy: boolean,
-    remoteAvailable: boolean
+    remoteAvailable: boolean,
+    clientTurnId: string = ''
   ): Promise<void> {
     if ((text.length === 0 && images.length === 0) || sessionId.length === 0 || isBusy || !remoteAvailable) {
       return;
@@ -328,10 +330,11 @@ export class RemoteChatCommandController {
     try {
       this.callbacks.onBusy(true);
       this.callbacks.onStatusText(images.length > 0 ? RemoteI18n.t('status.sendImage') : RemoteI18n.t('status.sendCommand'));
+      const requestedTurnId = clientTurnId.trim().length > 0 ? clientTurnId : localMessageId;
       const turnId = images.length > 0 ?
-        await this.client.sendMessageWithImages(sessionId, text, agentType, imageContexts) :
-        await this.client.sendMessage(sessionId, text, agentType);
-      this.callbacks.onSendSucceeded(turnId, pendingActiveId);
+        await this.client.sendMessageWithImages(sessionId, text, agentType, imageContexts, requestedTurnId) :
+        await this.client.sendMessage(sessionId, text, agentType, requestedTurnId);
+      this.callbacks.onSendSucceeded(turnId, pendingActiveId, localMessageId);
       this.callbacks.onStatusText(RemoteI18n.t('status.sentWaiting'));
     } catch (err) {
       this.callbacks.onSendFailed(rawText, images, localMessageId, pendingActiveId);
@@ -395,7 +398,7 @@ export class RemoteChatCommandController {
     try {
       this.callbacks.onBusy(true);
       const turnId = await this.client.buildPlan(sessionId, planFilePath, planName, agentType);
-      this.callbacks.onSendSucceeded(turnId, pendingActiveId);
+      this.callbacks.onSendSucceeded(turnId, pendingActiveId, localMessageId);
       this.callbacks.onStatusText(RemoteI18n.t('status.sentWaiting'));
       this.callbacks.onPollRequested();
     } catch (err) {

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/services/RemoteCommandFactory.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/services/RemoteCommandFactory.ets
@@ -52,7 +52,13 @@ export class RemoteCommandFactory {
     };
   }
 
-  static sendMessage(sessionId: string, text: string, agentType?: string, imageContexts?: RemoteImageContext[]): RemoteCommand {
+  static sendMessage(
+    sessionId: string,
+    text: string,
+    agentType?: string,
+    imageContexts?: RemoteImageContext[],
+    turnId?: string
+  ): RemoteCommand {
     const command: RemoteCommand = {
       cmd: 'send_message',
       session_id: sessionId,
@@ -63,6 +69,9 @@ export class RemoteCommandFactory {
     }
     if (imageContexts && imageContexts.length > 0) {
       command.image_contexts = imageContexts;
+    }
+    if (turnId && turnId.length > 0) {
+      command.turn_id = turnId;
     }
     return command;
   }

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/services/RemoteSessionManager.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/services/RemoteSessionManager.ets
@@ -278,19 +278,29 @@ export class RemoteSessionManager implements RemoteChatCommandClient, RemoteFile
     };
   }
 
-  async sendMessage(sessionId: string, text: string, agentType?: string): Promise<string> {
+  async sendMessage(sessionId: string, text: string, agentType?: string, turnId?: string): Promise<string> {
     const startedAt = Date.now();
     RemoteLogger.info(`send_message start session=${RemoteSessionManager.shortId(sessionId)} len=${text.length}`);
-    const response = await this.send<SendMessageResponse>(RemoteCommandFactory.sendMessage(sessionId, text, agentType));
+    const response = await this.send<SendMessageResponse>(
+      RemoteCommandFactory.sendMessage(sessionId, text, agentType, undefined, turnId)
+    );
     RemoteLogger.info(`send_message done session=${RemoteSessionManager.shortId(sessionId)} turn=${response.turn_id || ''} ms=${Date.now() - startedAt}`);
     return response.turn_id || '';
   }
 
-  async sendMessageWithImages(sessionId: string, text: string, agentType: string, imageContexts: RemoteImageContext[]): Promise<string> {
+  async sendMessageWithImages(
+    sessionId: string,
+    text: string,
+    agentType: string,
+    imageContexts: RemoteImageContext[],
+    turnId?: string
+  ): Promise<string> {
     const startedAt = Date.now();
     RemoteLogger.info(`send_message_images start session=${RemoteSessionManager.shortId(sessionId)} len=${text.length} images=${imageContexts.length}`);
     const response =
-      await this.send<SendMessageResponse>(RemoteCommandFactory.sendMessage(sessionId, text, agentType, imageContexts));
+      await this.send<SendMessageResponse>(
+        RemoteCommandFactory.sendMessage(sessionId, text, agentType, imageContexts, turnId)
+      );
     RemoteLogger.info(`send_message_images done session=${RemoteSessionManager.shortId(sessionId)} turn=${response.turn_id || ''} ms=${Date.now() - startedAt}`);
     return response.turn_id || '';
   }

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/services/RemoteUiState.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/services/RemoteUiState.ets
@@ -153,9 +153,10 @@ export class RemoteUiState {
     });
   }
 
-  static localUserMessage(text: string, images?: ImageAttachment[]): ChatMessage {
+  static localUserMessage(text: string, images?: ImageAttachment[], turnId?: string): ChatMessage {
     return {
       id: `optimistic-user-${Date.now()}`,
+      turnId,
       role: 'user',
       text,
       status: 'sent',
@@ -212,9 +213,15 @@ export class RemoteUiState {
   }
 
   private static isOptimisticDuplicate(local: ChatMessage, remote: ChatMessage): boolean {
-    return RemoteUiState.isLocalOptimisticMessage(local) &&
-      local.role === remote.role &&
-      local.text.trim() === remote.text.trim() &&
+    if (!RemoteUiState.isLocalOptimisticMessage(local) || local.role !== remote.role) {
+      return false;
+    }
+    const localTurnId = (local.turnId || '').trim();
+    const remoteTurnId = (remote.turnId || '').trim();
+    if (localTurnId.length > 0 && remoteTurnId.length > 0) {
+      return localTurnId === remoteTurnId;
+    }
+    return local.text.trim() === remote.text.trim() &&
       local.text.trim().length > 0 &&
       RemoteUiState.imageSignature(local.images || []) === RemoteUiState.imageSignature(remote.images || []);
   }

--- a/src/apps/mobile/harmonyos/entry/src/test/ConversationStateUnit.test.ets
+++ b/src/apps/mobile/harmonyos/entry/src/test/ConversationStateUnit.test.ets
@@ -435,6 +435,45 @@ export default function conversationStateUnitTest() {
       expect(merged[1].id).assertEqual('optimistic-user-image');
     });
 
+    it('reconciles a transformed image by stable turn identity', 0, () => {
+      const optimistic = chatMessageWithImage(
+        'optimistic-user-image', 'user', '分析图片', 'capture.png', 'data:image/png;base64,original'
+      );
+      optimistic.turnId = 'harmony-turn-image';
+      const persisted = chatMessageWithImage(
+        'persisted-user-image', 'user', '分析图片', 'capture.png', 'data:image/jpeg;base64,thumbnail'
+      );
+      persisted.turnId = 'harmony-turn-image';
+
+      const remaining = ChatTimelineStore.optimisticMessagesNotPersisted([optimistic], [persisted]);
+
+      expect(remaining.length).assertEqual(0);
+
+      const merged = RemoteUiState.mergeRemoteWithLocalOptimistic([persisted], [optimistic]);
+      expect(merged.length).assertEqual(1);
+      expect(merged[0].id).assertEqual('persisted-user-image');
+    });
+
+    it('removes an optimistic image when an older host acknowledgement arrives after polling', 0, () => {
+      const store = new ChatTimelineStore();
+      store.reset('session-image-race');
+      const optimistic = chatMessageWithImage(
+        'optimistic-user-image', 'user', '分析图片', 'capture.png', 'data:image/png;base64,original'
+      );
+      optimistic.turnId = 'harmony-client-turn';
+      store.appendOptimisticMessage(optimistic);
+      const persisted = chatMessageWithImage(
+        'persisted-user-image', 'user', '分析图片', 'capture.png', 'data:image/jpeg;base64,thumbnail'
+      );
+      persisted.turnId = 'legacy-host-turn';
+      store.setPersistedMessages([persisted]);
+      expect(store.snapshot().optimisticMessages.length).assertEqual(1);
+
+      store.acknowledgeOptimisticTurn('optimistic-user-image', 'legacy-host-turn');
+
+      expect(store.snapshot().optimisticMessages.length).assertEqual(0);
+    });
+
     it('does not hide an active reply that matches historical assistant text', 0, () => {
       const store = new ChatTimelineStore();
       store.reset('session-repeat-assistant');

--- a/src/apps/mobile/harmonyos/entry/src/test/DeviceDirectoryUnit.test.ets
+++ b/src/apps/mobile/harmonyos/entry/src/test/DeviceDirectoryUnit.test.ets
@@ -505,6 +505,40 @@ export default function deviceDirectoryUnitTest() {
       expect(state.find('desk-b')?.status).assertEqual('loading');
     });
 
+    it('invalidates workspace load state when the same device gets a fresh connection', 0, () => {
+      const state = new DeviceDirectoryState();
+      const viewModel = new DeviceDirectoryViewModel(state, {
+        credentials: () => undefined,
+        activeDeviceId: () => 'desk-a',
+        activeDeviceConnected: () => true
+      });
+      viewModel.syncDevices([
+        { deviceId: 'desk-a', deviceName: 'Alpha', online: true },
+        { deviceId: 'desk-b', deviceName: 'Beta', online: true }
+      ]);
+      state.setWorkspaceExpanded('desk-a', '/stale', true);
+      state.setWorkspaceStatus('desk-a', '/stale', 'ready');
+      state.setWorkspaceExpanded('desk-b', '/independent', true);
+      state.setWorkspaceStatus('desk-b', '/independent', 'ready');
+      viewModel.captureLive('desk-a', [workspace('/stale', 'Stale')], [
+        sessionIn('desk-a', '/stale', 'stale', 'Stale')
+      ]);
+
+      // Models the scan-room -> account-device transition: the physical
+      // desktop id is unchanged, while the new handshake only carries the
+      // current workspace snapshot.
+      viewModel.activateLive('desk-a', [workspace('/current', 'Current')], [
+        sessionIn('desk-a', '/current', 'fresh', 'Fresh')
+      ]);
+
+      expect(state.workspaceExpanded('desk-a', '/stale')).assertFalse();
+      expect(state.workspaceStatus('desk-a', '/stale')).assertEqual('idle');
+      expect(state.workspaceExpanded('desk-b', '/independent')).assertTrue();
+      expect(state.workspaceStatus('desk-b', '/independent')).assertEqual('ready');
+      expect(state.find('desk-a')?.sessions.length).assertEqual(1);
+      expect(state.find('desk-a')?.sessions[0].id).assertEqual('fresh');
+    });
+
     it('keeps an empty incoming catalog loading until the live request completes', 0, async () => {
       const source = new FakeAccountDeviceDirectory();
       const state = new DeviceDirectoryState();

--- a/src/apps/mobile/harmonyos/entry/src/test/LocalTestFixtures.ets
+++ b/src/apps/mobile/harmonyos/entry/src/test/LocalTestFixtures.ets
@@ -889,6 +889,7 @@ export class FakeRemoteChatCommandClient implements RemoteChatCommandClient {
   messageRequests: string[] = [];
   messageResolvers: Array<(result: SessionMessagesResult) => void> = [];
   sendRequests: string[] = [];
+  sendTurnIds: string[] = [];
   buildPlanRequests: string[] = [];
   steerRequests: string[] = [];
   cancelRequests: string[] = [];
@@ -925,8 +926,9 @@ export class FakeRemoteChatCommandClient implements RemoteChatCommandClient {
     resolve(result);
   }
 
-  async sendMessage(sessionId: string, text: string, agentType?: string): Promise<string> {
+  async sendMessage(sessionId: string, text: string, agentType?: string, turnId?: string): Promise<string> {
     this.sendRequests.push(`text:${sessionId}:${text}:${agentType || ''}`);
+    this.sendTurnIds.push(turnId || '');
     if (this.shouldFailSend) {
       throw new Error('Expected send failure.');
     }
@@ -937,9 +939,11 @@ export class FakeRemoteChatCommandClient implements RemoteChatCommandClient {
     sessionId: string,
     text: string,
     agentType: string,
-    imageContexts: RemoteImageContext[]
+    imageContexts: RemoteImageContext[],
+    turnId?: string
   ): Promise<string> {
     this.sendRequests.push(`images:${sessionId}:${text}:${agentType}:${imageContexts.length}`);
+    this.sendTurnIds.push(turnId || '');
     if (this.shouldFailSend) {
       throw new Error('Expected send failure.');
     }

--- a/src/apps/mobile/harmonyos/entry/src/test/RemoteControllersUnit.test.ets
+++ b/src/apps/mobile/harmonyos/entry/src/test/RemoteControllersUnit.test.ets
@@ -2139,8 +2139,8 @@ export default function remoteControllersUnitTest() {
         onMessagesLoaded: (_messages: ChatMessage[], _hasMoreMessages: boolean) => {},
         onMessageCountKnown: (_pollVersion: number, _knownMessageCount: number) => {},
         onTimelineReady: () => {},
-        onSendSucceeded: (turnId: string, pendingActiveId: string) => {
-          succeeded.push(`${turnId}:${pendingActiveId}`);
+        onSendSucceeded: (turnId: string, pendingActiveId: string, localMessageId: string) => {
+          succeeded.push(`${turnId}:${pendingActiveId}:${localMessageId}`);
         },
         onSendFailed: (
           rawText: string,
@@ -2192,7 +2192,9 @@ export default function remoteControllersUnitTest() {
 
       expect(client.sendRequests[0]).assertEqual('images:session-1:Describe image:code:1');
       expect(client.sendRequests[1]).assertEqual('text:session-1:Retry text:code');
-      expect(succeeded[0]).assertEqual('turn-1:pending-1');
+      expect(client.sendTurnIds[0]).assertEqual('local-1');
+      expect(client.sendTurnIds[1]).assertEqual('local-2');
+      expect(succeeded[0]).assertEqual('turn-1:pending-1:local-1');
       expect(failed[0]).assertEqual('Retry text:0:local-2:pending-2');
       expect(busyEvents[0]).assertTrue();
       expect(busyEvents[1]).assertFalse();

--- a/src/apps/mobile/harmonyos/entry/src/test/TransportAndGeneralChatUnit.test.ets
+++ b/src/apps/mobile/harmonyos/entry/src/test/TransportAndGeneralChatUnit.test.ets
@@ -1871,6 +1871,10 @@ export default function transportAndGeneralChatUnitTest() {
 
     it('builds message and polling commands', 0, () => {
       expectCommandJson(RemoteCommandFactory.sendMessage('s1', 'hello', 'code'), '{"cmd":"send_message","session_id":"s1","content":"hello","agent_type":"code"}');
+      expectCommandJson(
+        RemoteCommandFactory.sendMessage('s1', 'hello', 'code', undefined, 'harmony-turn-1'),
+        '{"cmd":"send_message","session_id":"s1","content":"hello","agent_type":"code","turn_id":"harmony-turn-1"}'
+      );
       expectCommandJson(RemoteCommandFactory.sendMessage('s1', 'look', 'code', [{
         id: 'img1',
         data_url: 'data:image/png;base64,abc',

--- a/src/crates/assembly/core/src/service/remote_connect/remote_server.rs
+++ b/src/crates/assembly/core/src/service/remote_connect/remote_server.rs
@@ -560,6 +560,7 @@ mod tests {
             session_id: "session-1".to_string(),
             content: "hello".to_string(),
             display_content: None,
+            turn_id: Some("harmony-turn-1".to_string()),
             agent_type: Some("code".to_string()),
             images: Some(vec![ImageAttachment {
                 name: "clip.png".to_string(),
@@ -570,6 +571,7 @@ mod tests {
         let json = serde_json::to_value(command).expect("serialize send command");
         assert_eq!(json["cmd"], "send_message");
         assert_eq!(json["session_id"], "session-1");
+        assert_eq!(json["turn_id"], "harmony-turn-1");
         assert_eq!(json["agent_type"], "code");
         assert_eq!(json["images"][0]["name"], "clip.png");
         assert!(json["image_contexts"].is_null());

--- a/src/crates/services/services-integrations/src/remote_connect.rs
+++ b/src/crates/services/services-integrations/src/remote_connect.rs
@@ -2324,6 +2324,10 @@ pub enum RemoteCommand {
         content: String,
         #[serde(default)]
         display_content: Option<String>,
+        /// Client-generated stable identity for the turn. Older clients omit it;
+        /// older hosts ignore it as an unknown optional field.
+        #[serde(default)]
+        turn_id: Option<String>,
         agent_type: Option<String>,
         images: Option<Vec<ImageAttachment>>,
         image_contexts: Option<Vec<RemoteImageContext>>,
@@ -2754,6 +2758,7 @@ where
             session_id,
             content,
             display_content,
+            turn_id,
             agent_type,
             images,
             image_contexts,
@@ -2778,7 +2783,7 @@ where
                     agent_type: agent_type.clone(),
                     image_contexts: resolved_contexts,
                     policy: RemoteDialogSubmissionPolicy::for_source(source),
-                    turn_id: None,
+                    turn_id: turn_id.clone(),
                 })
                 .await,
             )

--- a/src/crates/services/services-integrations/tests/remote_connect_contracts.rs
+++ b/src/crates/services/services-integrations/tests/remote_connect_contracts.rs
@@ -1027,6 +1027,7 @@ async fn remote_connect_command_owner_routes_send_message_and_prefers_explicit_i
             session_id: "session-1".to_string(),
             content: "hello".to_string(),
             display_content: None,
+            turn_id: Some("harmony-turn-1".to_string()),
             agent_type: Some("code".to_string()),
             images: Some(vec![ImageAttachment {
                 name: "legacy.png".to_string(),
@@ -1064,7 +1065,7 @@ async fn remote_connect_command_owner_routes_send_message_and_prefers_explicit_i
     assert_eq!(submitted.agent_type.as_deref(), Some("code"));
     assert_eq!(submitted.image_contexts, vec!["explicit:ctx-1".to_string()]);
     assert_eq!(submitted.policy.source, RemoteConnectSubmissionSource::Bot);
-    assert!(submitted.turn_id.is_none());
+    assert_eq!(submitted.turn_id.as_deref(), Some("harmony-turn-1"));
 }
 
 #[tokio::test]
@@ -2205,6 +2206,7 @@ fn remote_connect_command_wire_shape_lives_in_owner_contract() {
         session_id: "session-1".to_string(),
         content: "hello".to_string(),
         display_content: None,
+        turn_id: Some("harmony-turn-1".to_string()),
         agent_type: Some("code".to_string()),
         images: Some(vec![ImageAttachment {
             name: "clip.png".to_string(),
@@ -2222,6 +2224,7 @@ fn remote_connect_command_wire_shape_lives_in_owner_contract() {
 
     assert_eq!(json["cmd"], "send_message");
     assert_eq!(json["session_id"], "session-1");
+    assert_eq!(json["turn_id"], "harmony-turn-1");
     assert_eq!(json["agent_type"], "code");
     assert_eq!(json["images"][0]["name"], "clip.png");
     assert_eq!(json["image_contexts"][0]["id"], "ctx-1");
@@ -2230,6 +2233,18 @@ fn remote_connect_command_wire_shape_lives_in_owner_contract() {
         "D:/workspace/project/screenshot.png"
     );
     assert!(json.get("imageContexts").is_none());
+
+    let legacy: RemoteCommand = serde_json::from_value(serde_json::json!({
+        "cmd": "send_message",
+        "session_id": "session-legacy",
+        "content": "hello",
+        "agent_type": "code"
+    }))
+    .expect("deserialize legacy send command");
+    match legacy {
+        RemoteCommand::SendMessage { turn_id, .. } => assert!(turn_id.is_none()),
+        other => panic!("unexpected legacy command: {other:?}"),
+    }
 
     let cancel = serde_json::to_value(RemoteCommand::CancelTask {
         session_id: "session-1".to_string(),


### PR DESCRIPTION
## Summary

- reconcile image-bearing optimistic messages with authoritative remote history by turn identity, preventing duplicate user bubbles
- invalidate stale workspace disclosure/load state when a fresh connection takes over the same desktop, so expanding a workspace requests its sessions again
- preserve independent directory state for other desktops and add regression coverage

## Root cause

A scan-room connection and an account-device connection can resolve to the same desktop id. The fresh handshake replaces the in-memory cross-workspace session snapshot, while the prior connection generation left workspace rows marked ready. The disclosure component then skipped list_sessions for an empty row. The fix resets only that desktop directory generation when the new live target is activated.

## Verification

- HarmonyOS local unit tests: passed
- HarmonyOS HAP assembly: passed
- bitfun-services-integrations remote_connect_contracts: 62 passed
- bitfun-core remote_server tests: 10 passed
- signed HAP installed and launched on the HarmonyOS simulator
- remote-control trigger path reproduced on a connected HarmonyOS device; no relay change required

AI-assisted change; fully tested with focused local coverage.