### PR TITLE
feat(flow-chat): show user message send time

### DIFF
--- a/src/web-ui/src/flow_chat/components/modern/UserMessageItem.appearance.ts
+++ b/src/web-ui/src/flow_chat/components/modern/UserMessageItem.appearance.ts
@@ -5,7 +5,7 @@ export const userMessageItemAppearanceDescriptor: AppearanceSurfaceDescriptor = 
   parts: [
     { id: 'root' }, { id: 'main' }, { id: 'content' },
     { id: 'steeringTag' }, { id: 'actions' }, { id: 'images' }, { id: 'image' },
-    { id: 'lightbox' }, { id: 'loading' },
+    { id: 'timestamp' }, { id: 'lightbox' }, { id: 'loading' },
   ],
   states: [
     { id: 'expanded', selector: { kind: 'self', suffix: '[data-bf-state~="expanded"]' } },

--- a/src/web-ui/src/flow_chat/components/modern/UserMessageItem.scss
+++ b/src/web-ui/src/flow_chat/components/modern/UserMessageItem.scss
@@ -1,6 +1,33 @@
 /**
  * User message item styles (BEM).
  */
+.user-message-item-shell {
+  position: relative;
+  margin:
+    0.06rem
+    var(--bf-control-flow-chat-content-padding-inline)
+    var(--bf-control-flow-chat-flow-item-gap)
+    var(--bf-control-flow-chat-content-padding-inline);
+
+  &--with-timestamp {
+    /* The timestamp occupies stable space even while transparent. Hover must
+       never resize a virtualized transcript row. */
+    margin-bottom: calc(var(--bf-control-flow-chat-flow-item-gap) + 1rem);
+  }
+
+  &:hover,
+  &:focus-within {
+    .user-message-item__timestamp {
+      opacity: 1;
+    }
+  }
+
+  @media (max-width: 768px) {
+    margin-left: var(--bf-control-flow-chat-content-padding-inline-mobile);
+    margin-right: var(--bf-control-flow-chat-content-padding-inline-mobile);
+  }
+}
+
 .user-message-item {
   box-sizing: border-box;
   /*
@@ -22,11 +49,7 @@
   background: var(--bf-color-action-quiet-hover);
   border: 1px solid color-mix(in srgb, var(--bf-color-border-default) 72%, transparent);
   border-radius: calc(var(--bf-control-flow-chat-card-radius) + 2px);
-  margin:
-    0.06rem
-    var(--bf-control-flow-chat-content-padding-inline)
-    var(--bf-control-flow-chat-flow-item-gap)
-    var(--bf-control-flow-chat-content-padding-inline);
+  margin: 0;
   box-shadow: none;
   transition: opacity 140ms ease;
   /*
@@ -53,11 +76,24 @@
     }
   }
 
-  // Responsive: reduce margins on smaller screens.
-  @media (max-width: 768px) {
-    margin-left: var(--bf-control-flow-chat-content-padding-inline-mobile);
-    margin-right: var(--bf-control-flow-chat-content-padding-inline-mobile);
-  }
+}
+
+.user-message-item__timestamp {
+  position: absolute;
+  top: calc(100% + 0.12rem);
+  /* Align with the visible right edge of the rollback glyph: bubble padding
+     plus half of the 28px action hit area left outside its 14px icon. */
+  right: calc(0.68rem + 7px);
+  color: var(--bf-color-content-muted);
+  font-family: var(--bf-type-flow-meta-font-family);
+  font-size: var(--bf-type-flow-meta-font-size);
+  font-weight: var(--bf-type-flow-meta-font-weight);
+  font-variant-numeric: tabular-nums;
+  line-height: var(--bf-type-flow-meta-line-height);
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 140ms ease;
 }
 
 .user-message-item__main {
@@ -468,6 +504,7 @@
 
 @media (prefers-reduced-motion: reduce) {
   .user-message-item,
+  .user-message-item__timestamp,
   .user-message-item__actions,
   .user-message-item__copy-btn,
   .user-message-item__edit-btn,

--- a/src/web-ui/src/flow_chat/components/modern/UserMessageItem.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/UserMessageItem.test.tsx
@@ -240,6 +240,47 @@ describe('UserMessageItem steering tag', () => {
     expect(tag?.textContent).toBe('等待触发');
   });
 
+  it('renders a localized send time outside the user message bubble', () => {
+    const timestamp = Date.UTC(2026, 8, 3, 6, 32, 8);
+
+    act(() => {
+      root.render(
+        <FlowChatContext.Provider value={{ allowUserMessageRollback: false }}>
+          <UserMessageItem
+            message={{ id: 'user-time-1', content: 'Timestamped message', timestamp }}
+            turnId="turn-time-1"
+          />
+        </FlowChatContext.Provider>,
+      );
+    });
+
+    const bubble = container.querySelector('[data-testid="chat-user-message"]');
+    const shell = bubble?.parentElement;
+    const time = container.querySelector<HTMLTimeElement>('[data-testid="chat-user-message-timestamp"]');
+
+    expect(shell?.classList.contains('user-message-item-shell--with-timestamp')).toBe(true);
+    expect(time?.parentElement).toBe(shell);
+    expect(time?.parentElement).not.toBe(bubble);
+    expect(time?.dateTime).toBe('2026-09-03T06:32:08.000Z');
+    expect(time?.textContent?.trim()).not.toBe('');
+  });
+
+  it('does not invent a send time when the persisted timestamp is invalid', () => {
+    act(() => {
+      root.render(
+        <FlowChatContext.Provider value={{ allowUserMessageRollback: false }}>
+          <UserMessageItem
+            message={{ id: 'user-time-invalid', content: 'Legacy message', timestamp: 0 }}
+            turnId="turn-time-invalid"
+          />
+        </FlowChatContext.Provider>,
+      );
+    });
+
+    expect(container.querySelector('[data-testid="chat-user-message-timestamp"]')).toBeNull();
+    expect(container.querySelector('.user-message-item-shell--with-timestamp')).toBeNull();
+  });
+
   it('does not render a steering tag after steering is triggered', () => {
     act(() => {
       root.render(

--- a/src/web-ui/src/flow_chat/components/modern/UserMessageItem.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/UserMessageItem.tsx
@@ -97,7 +97,7 @@ function buildPresentationRerunPayload(presentation: ComposerPresentation): {
 
 export const UserMessageItem = React.memo<UserMessageItemProps>(
   ({ message, turnId, absoluteTurnIndex, turnStatus, steeringStatus }) => {
-    const { t } = useI18n('flow-chat');
+    const { t, formatDate } = useI18n('flow-chat');
     const {
       sessionId,
       activeSessionOverride,
@@ -122,6 +122,26 @@ export const UserMessageItem = React.memo<UserMessageItemProps>(
     const containerRef = useRef<HTMLDivElement>(null);
     const contentRef = useRef<HTMLDivElement>(null);
     const messageContent = typeof message?.content === 'string' ? message.content : String(message?.content || '');
+    const sentTimestamp = typeof message?.timestamp === 'number'
+      && Number.isFinite(message.timestamp)
+      && message.timestamp > 0
+      ? message.timestamp
+      : null;
+    const sentTime = useMemo(() => sentTimestamp === null ? null : formatDate(sentTimestamp, {
+      hour: '2-digit',
+      minute: '2-digit',
+    }), [formatDate, sentTimestamp]);
+    const sentAtLabel = useMemo(() => sentTimestamp === null ? null : t('message.sentAt', {
+      time: formatDate(sentTimestamp, {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        timeZoneName: 'short',
+      }),
+    }), [formatDate, sentTimestamp, t]);
     const composerPresentation = useMemo(() => {
       const presentation = parseComposerPresentation(message?.metadata?.composerPresentation);
       return hasComposerPresentationReferences(presentation) ? presentation : null;
@@ -505,17 +525,18 @@ export const UserMessageItem = React.memo<UserMessageItemProps>(
     }
     
     return (
-      <div
-        data-bf-component="user-message-item"
-        data-bf-part="root"
-        data-bf-state={[expanded && 'expanded', isFailed && 'failed'].filter(Boolean).join(' ') || undefined}
-        ref={containerRef}
-        className={`user-message-item ${expanded ? 'user-message-item--expanded' : ''}${isFailed ? ' user-message-item--failed' : ''}`}
-        data-testid="chat-user-message"
-        data-turn-id={turnId}
-        data-status={resolvedTurnStatus || ''}
-        data-failed={isFailed ? 'true' : 'false'}
-      >
+      <div className={`user-message-item-shell${sentTime ? ' user-message-item-shell--with-timestamp' : ''}`}>
+        <div
+          data-bf-component="user-message-item"
+          data-bf-part="root"
+          data-bf-state={[expanded && 'expanded', isFailed && 'failed'].filter(Boolean).join(' ') || undefined}
+          ref={containerRef}
+          className={`user-message-item ${expanded ? 'user-message-item--expanded' : ''}${isFailed ? ' user-message-item--failed' : ''}`}
+          data-testid="chat-user-message"
+          data-turn-id={turnId}
+          data-status={resolvedTurnStatus || ''}
+          data-failed={isFailed ? 'true' : 'false'}
+        >
         {isEditing ? (
           <UserMessageEditComposer
             value={editDraft}
@@ -664,20 +685,35 @@ export const UserMessageItem = React.memo<UserMessageItemProps>(
           </div>
         )}
 
-        {lightboxImage && createPortal(
-          <div
-            className="user-message-item__lightbox"
-            onClick={() => setLightboxImage(null)}
+          {lightboxImage && createPortal(
+            <div
+              className="user-message-item__lightbox"
+              onClick={() => setLightboxImage(null)}
+              data-bf-component="user-message-item"
+              data-bf-part="lightbox"
+              data-bf-native-webview-occlusion
+            >
+              <button className="user-message-item__lightbox-close" onClick={() => setLightboxImage(null)}>
+                <Icon name="xmark" size="lg" style={{ width: 20, height: 20 }} />
+              </button>
+              <img src={lightboxImage} alt="Preview" onClick={(e) => e.stopPropagation()} />
+            </div>,
+            getAppearanceOverlayHost(),
+          )}
+        </div>
+
+        {sentTime && sentAtLabel && sentTimestamp !== null && (
+          <time
+            className="user-message-item__timestamp"
             data-bf-component="user-message-item"
-            data-bf-part="lightbox"
-            data-bf-native-webview-occlusion
+            data-bf-part="timestamp"
+            data-testid="chat-user-message-timestamp"
+            dateTime={new Date(sentTimestamp).toISOString()}
+            title={sentAtLabel}
+            aria-label={sentAtLabel}
           >
-            <button className="user-message-item__lightbox-close" onClick={() => setLightboxImage(null)}>
-              <Icon name="xmark" size="lg" style={{ width: 20, height: 20 }} />
-            </button>
-            <img src={lightboxImage} alt="Preview" onClick={(e) => e.stopPropagation()} />
-          </div>,
-          getAppearanceOverlayHost(),
+            {sentTime}
+          </time>
         )}
       </div>
     );

--- a/src/web-ui/src/flow_chat/components/modern/UserMessageItemActions.test.ts
+++ b/src/web-ui/src/flow_chat/components/modern/UserMessageItemActions.test.ts
@@ -43,4 +43,21 @@ describe('UserMessageItem action visibility', () => {
     ].join('\n'));
     expect(stylesheet).not.toContain('.user-message-item__edit-btn {\n  opacity: 1;');
   });
+
+  it('reveals the out-of-bubble timestamp without changing row geometry', () => {
+    const stylesheet = readFileSync(
+      fileURLToPath(new URL('./UserMessageItem.scss', import.meta.url)),
+      'utf8',
+    ).replace(/\r\n?/g, '\n');
+    const shell = extractBlock(stylesheet, '.user-message-item-shell {');
+    const timestamp = extractBlock(stylesheet, '\n.user-message-item__timestamp {');
+    const hover = extractBlock(shell, '&:hover,');
+
+    expect(timestamp).toContain('position: absolute;');
+    expect(timestamp).toContain('right: calc(0.68rem + 7px);');
+    expect(timestamp).toContain('opacity: 0;');
+    expect(timestamp).toContain('pointer-events: none;');
+    expect(extractBlock(hover, '.user-message-item__timestamp {')).toContain('opacity: 1;');
+    expect(shell).toContain('margin-bottom: calc(var(--bf-control-flow-chat-flow-item-gap) + 1rem);');
+  });
 });

--- a/src/web-ui/src/flow_chat/components/modern/VirtualItemRenderer.scss
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualItemRenderer.scss
@@ -33,11 +33,16 @@
    * thinking, compact/expanded tools, notices, and completed-round footers all
    * resolve to the same `turnGap` instead of stacking two unrelated gaps. */
   &[data-turn-boundary-after='true'] {
-    > .user-message-item,
+    > .user-message-item-shell,
     > .turn-completion-notice,
     > .turn-failure-notice,
     > .explore-region {
       margin-bottom: 0;
+    }
+
+    > .user-message-item-shell--with-timestamp {
+      /* Preserve the timestamp line; the next Turn owns the trailing gap. */
+      margin-bottom: 1rem;
     }
 
     > .model-round-item > :is(

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -480,6 +480,7 @@
     "edit": "Edit Message",
     "delete": "Delete Message",
     "retry": "Retry",
+    "sentAt": "Sent at {{time}}",
     "clickToExpand": "Click to expand",
     "clickToCollapse": "Click to collapse",
     "fillToInput": "Fill to input",

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -480,6 +480,7 @@
     "edit": "编辑消息",
     "delete": "删除消息",
     "retry": "重试",
+    "sentAt": "发送于 {{time}}",
     "clickToExpand": "点击展开",
     "clickToCollapse": "点击收起",
     "fillToInput": "填充到输入框",

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -480,6 +480,7 @@
     "edit": "編輯消息",
     "delete": "刪除消息",
     "retry": "重試",
+    "sentAt": "傳送於 {{time}}",
     "clickToExpand": "點擊展開",
     "clickToCollapse": "點擊收起",
     "fillToInput": "填充到輸入框",


### PR DESCRIPTION
## Summary

Display the send time for user messages outside the bottom-right corner of the message bubble.

The timestamp:

- Uses the localized `HH:mm` format.
- Appears when the message is hovered or focused.
- Aligns with the visible right edge of the rollback icon.
- Exposes the full localized date, time, and timezone through accessible metadata.
- Remains hidden when the persisted timestamp is missing or invalid.
- Reserves stable layout space to avoid virtualized-list height changes.


## Type and Areas

Type:

UI/UX

Areas:

Web UI, Flow Chat

## Motivation / Impact

Users can now check when a message was sent without adding persistent visual noise to the conversation.

The timestamp is displayed only on hover or keyboard focus. Its placement and reserved space prevent layout shifts, including in the virtualized message list.

## Verification

- `pnpm run check:web`
  - Passed, including Web UI type checking, appearance checks, and theme checks.
- `pnpm run i18n:audit`
  - Passed.
- `pnpm run motion:audit`
  - Completed with no new issue in the changed code; one pre-existing inventory item remains elsewhere.
- `pnpm --dir src/web-ui exec vitest run src/flow_chat/components/modern/UserMessageItemActions.test.ts --reporter=verbose`
  - Passed: 2 tests.
- Focused `UserMessageItem` component tests
  - Passed: 19 tests.
- `git diff --check`
  - Passed; only line-ending conversion warnings were reported.
- Manual visual interaction was not performed.

## Reviewer Notes

- Added localized copy for `en-US`, `zh-CN`, and `zh-TW`.
- Invalid or legacy timestamps are omitted instead of being replaced with the current time.
- The timestamp is rendered with a semantic native `<time>` element and existing Flow Chat design tokens.
- This is a Web UI presentation-only change. It does not modify persisted data, APIs, or remote protocols.
- Remote workspace, remote control, Peer Device Mode, and Detached Dispatch were not exercised because the change only consumes the existing message timestamp on the client.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.