### PR TITLE
fix(flow-chat): clear image composer atomically

### DIFF
--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -70,6 +70,7 @@ import {
 } from '../store/sessionComposerStore';
 import { getActiveSurfaceScope } from '@/infrastructure/peer-device/deviceSurface';
 import {
+  clearComposerForSubmission,
   failedSubmissionRecoveryTarget,
   shouldRecordContextMutation,
   successfulRetryCleanupTarget,
@@ -4865,6 +4866,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     
     const originalMessage = draftTrimmed;
     const submissionSessionId = effectiveTargetSessionId;
+    const submittedContexts = [...contexts];
     const composerPresentation = messageOverride === undefined
       ? richTextInputRef.current?.getComposerPresentation?.() ?? null
       : null;
@@ -4996,21 +4998,25 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     setHistoryIndex(-1);
     setSavedDraft('');
 
-    dispatchInput({ type: 'CLEAR_VALUE' });
-    clearPendingLargePastes();
-    // Clear machine queue too; otherwise the queuedInput→input sync effect puts the text back after send.
-    setQueuedInput(null);
+    clearComposerForSubmission({
+      clearValue: () => dispatchInput({ type: 'CLEAR_VALUE' }),
+      clearContexts,
+      clearPendingLargePastes,
+      // Clear the machine queue too; otherwise queuedInput→input sync puts
+      // the submitted text back into the composer.
+      clearQueuedInput: () => setQueuedInput(null),
+    });
     const clearedComposerRevision = submissionSessionId
       ? composerMutationRevision(submissionSessionId)
       : 0;
 
     try {
-      const transport = await submitThroughChatInputRegistration(
+      await submitThroughChatInputRegistration(
         registration,
         {
           text: message,
           displayText: originalMessage,
-          contexts: [...contexts],
+          contexts: submittedContexts,
           composerPresentation: persistedComposerPresentation,
           sessionId: effectiveTargetSessionId || undefined,
           workspacePath: workspacePath || undefined,
@@ -5022,13 +5028,9 @@ export const ChatInput: React.FC<ChatInputProps> = ({
             value: originalMessage,
             pendingLargePastes: originalPendingLargePastes,
           },
+          clearContextsOnSuccess: false,
         }),
       );
-      if (transport === 'registered') {
-        clearContexts();
-      }
-      clearPendingLargePastes();
-      dispatchInput({ type: 'CLEAR_VALUE' });
     } catch (error) {
       log.error('Failed to send message', { error });
       const recoveryTarget = failedSubmissionRecoveryTarget(
@@ -5038,14 +5040,16 @@ export const ChatInput: React.FC<ChatInputProps> = ({
         submissionSessionId ? composerMutationRevision(submissionSessionId) : 0,
       );
       if (recoveryTarget === 'current') {
-        replacePendingLargePastes(originalPendingLargePastes);
         dispatchInput({ type: 'SET_VALUE', payload: originalMessage });
+        replaceContexts(submittedContexts);
+        replacePendingLargePastes(originalPendingLargePastes);
         if (derivedState?.isProcessing) {
           setQueuedInput(originalMessage);
         }
       } else if (recoveryTarget === 'stored' && submissionSessionId) {
         const composer = sessionComposerStore.getState();
         composer.setValue(submissionSessionId, originalMessage);
+        composer.setContexts(submissionSessionId, submittedContexts);
         composer.setPendingLargePastes(submissionSessionId, originalPendingLargePastes);
       }
     }
@@ -5070,6 +5074,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     expandComposerSpecialTokens,
     isAcpInputSession,
     richTextInputRef,
+    replaceContexts,
     replacePendingLargePastes,
     setQueuedInput,
     submitBtwFromInput,

--- a/src/web-ui/src/flow_chat/components/ChatInputDraftRecovery.test.ts
+++ b/src/web-ui/src/flow_chat/components/ChatInputDraftRecovery.test.ts
@@ -1,11 +1,35 @@
 import { describe, expect, it } from 'vitest';
 import {
+  clearComposerForSubmission,
   failedSubmissionRecoveryTarget,
   shouldRecordContextMutation,
   successfulRetryCleanupTarget,
 } from './chatInputDraftRecovery';
 
 describe('ChatInput failed submission recovery', () => {
+  it('clears text and attachments in the same synchronous submission step', () => {
+    const draft = {
+      value: 'describe this image',
+      contextIds: ['image-1'],
+      pendingLargePastes: ['paste-1'],
+      queuedInput: 'describe this image' as string | null,
+    };
+
+    clearComposerForSubmission({
+      clearValue: () => { draft.value = ''; },
+      clearContexts: () => { draft.contextIds = []; },
+      clearPendingLargePastes: () => { draft.pendingLargePastes = []; },
+      clearQueuedInput: () => { draft.queuedInput = null; },
+    });
+
+    expect(draft).toEqual({
+      value: '',
+      contextIds: [],
+      pendingLargePastes: [],
+      queuedInput: null,
+    });
+  });
+
   it('restores the visible composer only when the same session is still unchanged', () => {
     expect(failedSubmissionRecoveryTarget('session-a', 'session-a', 4, 4)).toBe('current');
   });

--- a/src/web-ui/src/flow_chat/components/chatInputDraftRecovery.ts
+++ b/src/web-ui/src/flow_chat/components/chatInputDraftRecovery.ts
@@ -1,3 +1,24 @@
+interface ComposerSubmissionClearActions {
+  clearValue: () => void;
+  clearContexts: () => void;
+  clearPendingLargePastes: () => void;
+  clearQueuedInput: () => void;
+}
+
+/**
+ * Clear every user-visible part of a submitted composer before transport work
+ * begins. Keeping these mutations in one synchronous call prevents React from
+ * painting a text-only or attachment-only intermediate draft.
+ */
+export function clearComposerForSubmission(
+  actions: ComposerSubmissionClearActions,
+): void {
+  actions.clearValue();
+  actions.clearContexts();
+  actions.clearPendingLargePastes();
+  actions.clearQueuedInput();
+}
+
 export function failedSubmissionRecoveryTarget(
   submissionSessionId: string | null,
   currentSessionId: string | null,

--- a/src/web-ui/src/flow_chat/hooks/useMessageSender.test.tsx
+++ b/src/web-ui/src/flow_chat/hooks/useMessageSender.test.tsx
@@ -55,6 +55,7 @@ vi.mock('@/shared/utils/logger', () => ({
 
 let sendFromProbe: (() => Promise<void>) | undefined;
 let sendDraftFromProbe: (() => Promise<void>) | undefined;
+let sendWithClearedComposerFromProbe: (() => Promise<void>) | undefined;
 
 function Probe() {
   const { sendMessage } = useMessageSender({
@@ -68,6 +69,9 @@ function Probe() {
       value: '[Pasted text #1]',
       pendingLargePastes: { '[Pasted text #1]': 'expanded paste content' },
     },
+  });
+  sendWithClearedComposerFromProbe = () => sendMessage('image prompt', {
+    clearContextsOnSuccess: false,
   });
   return null;
 }
@@ -90,6 +94,7 @@ describe('useMessageSender', () => {
     container.remove();
     sendFromProbe = undefined;
     sendDraftFromProbe = undefined;
+    sendWithClearedComposerFromProbe = undefined;
     vi.clearAllMocks();
   });
 
@@ -121,6 +126,7 @@ describe('useMessageSender', () => {
         },
       }),
     );
+    expect(mocks.onClearContexts).toHaveBeenCalledOnce();
   });
 
   it('preserves the original large-paste composer draft for queued restoration', async () => {
@@ -145,5 +151,16 @@ describe('useMessageSender', () => {
         },
       }),
     );
+  });
+
+  it('skips delayed context cleanup when the caller already cleared the submission', async () => {
+    await act(async () => {
+      root.render(<Probe />);
+    });
+    await act(async () => {
+      await sendWithClearedComposerFromProbe?.();
+    });
+
+    expect(mocks.onClearContexts).not.toHaveBeenCalled();
   });
 });

--- a/src/web-ui/src/flow_chat/hooks/useMessageSender.ts
+++ b/src/web-ui/src/flow_chat/hooks/useMessageSender.ts
@@ -82,6 +82,8 @@ interface UseMessageSenderReturn {
         value: string;
         pendingLargePastes: PendingLargePasteMap;
       };
+      /** Set false when the caller already cleared the full composer synchronously. */
+      clearContextsOnSuccess?: boolean;
       execution?: AgentDialogTurnExecution;
     }
   ) => Promise<void>;
@@ -112,6 +114,7 @@ export function useMessageSender(props: UseMessageSenderProps): UseMessageSender
         value: string;
         pendingLargePastes: PendingLargePasteMap;
       };
+      clearContextsOnSuccess?: boolean;
       execution?: AgentDialogTurnExecution;
     }
   ) => {
@@ -252,7 +255,9 @@ export function useMessageSender(props: UseMessageSenderProps): UseMessageSender
         }
       );
 
-      onClearContexts();
+      if (options?.clearContextsOnSuccess !== false) {
+        onClearContexts();
+      }
 
       // The one-off mode belongs to the submission that just left, not to the
       // next one the user types.


### PR DESCRIPTION
## Summary

- clear text, image contexts, large-paste state, and queued input in one synchronous submission step
- restore the full composer draft when submission fails without overwriting newer user edits
- prevent delayed send completion from clearing contexts added for the next message

## Verification

- pnpm --dir src/web-ui exec vitest run --maxWorkers=50% src/flow_chat/components/ChatInputDraftRecovery.test.ts src/flow_chat/hooks/useMessageSender.test.tsx
- pnpm run check:web
- git diff --check

## Remote scenarios

The shared Web UI path and registered transport path are covered by the implementation and type checks. Remote workspace, remote control, Peer Device Mode, and Detached Dispatch were not exercised end to end; no wire protocol or backend behavior changed.
