### PR TITLE
fix(flowchat): hide top fade at scroll start

### DIFF
--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.edgeFade.test.ts
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.edgeFade.test.ts
@@ -20,6 +20,12 @@ describe('FlowChat transcript edge fade', () => {
     expect(component).toContain(
       "'--_flow-chat-input-overlay-inset': `${inputOverlayInsetPx}px`",
     );
+    expect(component).toContain(
+      "data-scroll-at-start={isAtScrollStart ? 'true' : 'false'}",
+    );
+    expect(component).toContain(
+      'const FLOWCHAT_SCROLL_START_THRESHOLD_PX = 1;',
+    );
     expect(stylesheet).toContain('-webkit-mask-image: linear-gradient(');
     expect(stylesheet).toContain('mask-image: linear-gradient(');
     const maskGradients = [
@@ -30,7 +36,7 @@ describe('FlowChat transcript edge fade', () => {
 
     expect(maskGradients).toHaveLength(2);
     for (const gradient of maskGradients) {
-      expect(gradient).toContain('transparent 0,');
+      expect(gradient).toContain('var(--_flow-chat-top-mask-start),');
       expect(gradient).toContain(
         'var(--bf-color-content-on-light) var(--bf-space-12),',
       );
@@ -40,6 +46,15 @@ describe('FlowChat transcript edge fade', () => {
     );
     expect(stylesheet).toContain(
       'transparent calc(100% - var(--_flow-chat-input-overlay-inset))',
+    );
+    expect(stylesheet).toContain(
+      "&__scroller[data-scroll-at-start='true']",
+    );
+    expect(stylesheet).toContain(
+      "--_flow-chat-top-mask-start: var(--bf-color-content-on-light) 0;",
+    );
+    expect(stylesheet).toContain(
+      '--_flow-chat-top-mask-start: transparent 0;',
     );
     expect(stylesheet).not.toContain('backdrop-filter');
   });

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.scss
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.scss
@@ -31,6 +31,7 @@
    * the viewport anchor is the only one.
    */
   &__scroller {
+    --_flow-chat-top-mask-start: transparent 0;
     width: 100%;
     height: 100%;
     position: relative;
@@ -47,7 +48,7 @@
     // every other row fade together without intercepting interaction.
     -webkit-mask-image: linear-gradient(
       to bottom,
-      transparent 0,
+      var(--_flow-chat-top-mask-start),
       var(--bf-color-content-on-light) var(--bf-space-12),
       var(--bf-color-content-on-light) calc(
         100% - var(--_flow-chat-input-overlay-inset) - var(--bf-space-12)
@@ -57,7 +58,7 @@
     );
     mask-image: linear-gradient(
       to bottom,
-      transparent 0,
+      var(--_flow-chat-top-mask-start),
       var(--bf-color-content-on-light) var(--bf-space-12),
       var(--bf-color-content-on-light) calc(
         100% - var(--_flow-chat-input-overlay-inset) - var(--bf-space-12)
@@ -69,6 +70,12 @@
     mask-repeat: no-repeat;
     -webkit-mask-size: 100% 100%;
     mask-size: 100% 100%;
+  }
+
+  // At the actual scroll start there is no content entering from above, so
+  // show the first pixels immediately instead of keeping a phantom top fade.
+  &__scroller[data-scroll-at-start='true'] {
+    --_flow-chat-top-mask-start: var(--bf-color-content-on-light) 0;
   }
 
   /*

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
@@ -101,6 +101,12 @@ const OPEN_REVEAL_QUIET_FRAMES = 2;
 /** Hard cap so the transcript is always revealed, settled or not. */
 const OPEN_REVEAL_MAX_FRAMES = 40;
 /**
+ * Treat sub-pixel scroll offsets as the scroll start. WebView2 and inertial
+ * scrolling can leave a tiny positive value after the viewport reaches the
+ * top, which would otherwise make the edge fade flicker back on.
+ */
+const FLOWCHAT_SCROLL_START_THRESHOLD_PX = 1;
+/**
  * Resize callbacks over which a viewport resting at the end is re-aligned after
  * the scroller's own box changes.
  *
@@ -410,6 +416,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
   const [scrollerElement, setScrollerElement] = useState<HTMLElement | null>(null);
   const [viewportHeightPx, setViewportHeightPx] = useState(0);
   const [viewportWidthPx, setViewportWidthPx] = useState(0);
+  const [isAtScrollStart, setIsAtScrollStart] = useState(true);
   /** Last scroller box the resize observer saw, to tell it apart from a content change. */
   const observedViewportBoxRef = useRef<{ width: number; height: number } | null>(null);
   /** Native minimization withdraws the scroller without unmounting the session. */
@@ -1403,6 +1410,15 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     setIsAtBottom(atTail);
   }, [getFollowTargetScrollTop, isFollowCorrectingViewport, readContentEndScrollTop]);
 
+  const updateIsAtScrollStart = useCallback(() => {
+    const scroller = scrollerElementRef.current;
+    if (!scroller) return;
+    const nextIsAtScrollStart = scroller.scrollTop <= FLOWCHAT_SCROLL_START_THRESHOLD_PX;
+    setIsAtScrollStart(previous => (
+      previous === nextIsAtScrollStart ? previous : nextIsAtScrollStart
+    ));
+  }, []);
+
   /*
    * The band's lower edge is whatever the follow rule owns, so it moves when
    * ownership changes — and that can happen with the viewport perfectly still.
@@ -1516,6 +1532,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
        * the drag transfers ownership to the reader and preserves where it ends.
        */
       if (isScrollbarPressRef.current) notifyUserScrollIntent();
+      updateIsAtScrollStart();
       updateIsAtBottom();
       handleScroll();
       /*
@@ -1574,6 +1591,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     publishViewportSnapshot,
     scheduleVisibleTurnInfoUpdate,
     scrollerElement,
+    updateIsAtScrollStart,
     updateIsAtBottom,
     viewportAnchor,
     viewportOwner,
@@ -1619,6 +1637,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
         }
         return;
       }
+      updateIsAtScrollStart();
       const isResumingSuspendedViewport = isViewportSuspendedRef.current;
       if (isResumingSuspendedViewport) {
         traceViewport({
@@ -1714,6 +1733,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     scheduleViewportSnapshot,
     scheduleVisibleTurnInfoUpdate,
     scrollerElement,
+    updateIsAtScrollStart,
     updateIsAtBottom,
     viewportAnchor,
     viewportOwner,
@@ -2377,11 +2397,12 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
       if (isUsableFlowChatViewportRect(initialViewportBox)) {
         setViewportHeightPx(initialViewportBox.height);
         setViewportWidthPx(initialViewportBox.width);
+        updateIsAtScrollStart();
         // Seed the box so the observer's first callback is not read as a resize.
         observedViewportBoxRef.current = initialViewportBox;
       }
     }
-  }, []);
+  }, [updateIsAtScrollStart]);
 
   const scrollToPhysicalBottom = useCallback(() => {
     setNavigatedTurn(null);
@@ -2506,6 +2527,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
         className="virtual-message-list__scroller"
         data-flowchat-scroller="true"
         data-testid="flowchat-scroller"
+        data-scroll-at-start={isAtScrollStart ? 'true' : 'false'}
         style={{
           '--_flow-chat-input-overlay-inset': `${inputOverlayInsetPx}px`,
         } as React.CSSProperties}


### PR DESCRIPTION
Disable the transcript's top mask fade when the reader is within 1px of the scroll start, while preserving the fade during normal scrolling. Keep the bottom ChatInput fade and viewport behavior unchanged, and cover the new mask state in the edge-fade contract test.
