### PR TITLE
fix(flowchat): move user actions beside timestamp

### DIFF
--- a/src/web-ui/src/flow_chat/components/modern/UserMessageItem.appearance.ts
+++ b/src/web-ui/src/flow_chat/components/modern/UserMessageItem.appearance.ts
@@ -4,7 +4,7 @@ export const userMessageItemAppearanceDescriptor: AppearanceSurfaceDescriptor = 
   id: 'user-message-item',
   parts: [
     { id: 'root' }, { id: 'main' }, { id: 'content' },
-    { id: 'steeringTag' }, { id: 'actions' }, { id: 'images' }, { id: 'image' },
+    { id: 'steeringTag' }, { id: 'meta' }, { id: 'actions' }, { id: 'images' }, { id: 'image' },
     { id: 'timestamp' }, { id: 'lightbox' }, { id: 'loading' },
   ],
   states: [

--- a/src/web-ui/src/flow_chat/components/modern/UserMessageItem.scss
+++ b/src/web-ui/src/flow_chat/components/modern/UserMessageItem.scss
@@ -20,6 +20,11 @@
     .user-message-item__timestamp {
       opacity: 1;
     }
+
+    .user-message-item__actions {
+      opacity: 1;
+      pointer-events: auto;
+    }
   }
 
   @media (max-width: 768px) {
@@ -62,28 +67,16 @@
   &:hover {
     background: var(--bf-color-action-quiet-hover);
     border-color: color-mix(in srgb, var(--bf-color-border-subtle) 56%, transparent);
-
-    .user-message-item__actions {
-      opacity: 1;
-    }
   }
 
   &:focus-within {
     border-color: color-mix(in srgb, color-mix(in srgb, var(--bf-color-accent-hover) 40%, transparent) 68%, var(--bf-color-border-default));
-
-    .user-message-item__actions {
-      opacity: 1;
-    }
   }
 
 }
 
 .user-message-item__timestamp {
-  position: absolute;
-  top: calc(100% + 0.12rem);
-  /* Align with the visible right edge of the rollback glyph: bubble padding
-     plus half of the 28px action hit area left outside its 14px icon. */
-  right: calc(0.68rem + 7px);
+  /* The timestamp shares the external meta row with the action cluster. */
   color: var(--bf-color-content-muted);
   font-family: var(--bf-type-flow-meta-font-family);
   font-size: var(--bf-type-flow-meta-font-size);
@@ -94,6 +87,24 @@
   opacity: 0;
   pointer-events: none;
   transition: opacity 140ms ease;
+}
+
+.user-message-item__meta {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.125rem;
+  box-sizing: border-box;
+  padding: 0.12rem 0 0;
+  min-height: 1rem;
+  // Keep the shell hovered while the pointer travels from the bubble to the
+  // timestamp/actions row, so the controls do not disappear before they can
+  // be reached.
+  pointer-events: auto;
 }
 
 .user-message-item__main {
@@ -133,19 +144,11 @@
   gap: 0.125rem;
   flex-shrink: 0;
   opacity: 0;
+  pointer-events: none;
   transition: opacity 140ms ease;
-  /*
-   * The 28px hit targets are taller than the first-line box, and they keep that
-   * layout box while idle at `opacity: 0`. Left alone the cluster becomes the
-   * tallest item in `.user-message-item__main`, so `align-items: flex-start`
-   * pins a single-line message to the top of an over-tall row and the text
-   * reads as sitting above the bubble's centre. Collapsing the cluster to the
-   * first-line box hands the row height back to the text — restoring the
-   * bubble's symmetric vertical padding — and centres the buttons on the first
-   * line for taller messages.
-   */
-  margin-top: calc((var(--user-message-line-box) - 28px) / 2);
-  margin-bottom: calc((var(--user-message-line-box) - 28px) / 2);
+  /* Absolute positioning keeps the 28px hit targets out of the message row's
+     height, so moving them beside the timestamp cannot add bottom spacing. */
+  margin: 0;
 }
 
 .user-message-item__blocks {

--- a/src/web-ui/src/flow_chat/components/modern/UserMessageItem.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/UserMessageItem.test.tsx
@@ -256,10 +256,13 @@ describe('UserMessageItem steering tag', () => {
 
     const bubble = container.querySelector('[data-testid="chat-user-message"]');
     const shell = bubble?.parentElement;
+    const meta = container.querySelector('.user-message-item__meta');
     const time = container.querySelector<HTMLTimeElement>('[data-testid="chat-user-message-timestamp"]');
 
     expect(shell?.classList.contains('user-message-item-shell--with-timestamp')).toBe(true);
-    expect(time?.parentElement).toBe(shell);
+    expect(meta?.parentElement).toBe(shell);
+    expect(time?.parentElement).toBe(meta);
+    expect(container.querySelector('.user-message-item__actions')?.parentElement).toBe(meta);
     expect(time?.parentElement).not.toBe(bubble);
     expect(time?.dateTime).toBe('2026-09-03T06:32:08.000Z');
     expect(time?.textContent?.trim()).not.toBe('');

--- a/src/web-ui/src/flow_chat/components/modern/UserMessageItem.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/UserMessageItem.tsx
@@ -621,6 +621,55 @@ export const UserMessageItem = React.memo<UserMessageItemProps>(
                 )}
               </>
             )}
+            </div>
+          </div>
+        )}
+
+        {message.images && message.images.length > 0 && (
+          <div className="user-message-item__images" data-bf-component="user-message-item" data-bf-part="images">
+            {message.images.map(img => {
+              const src = img.dataUrl || (img.imagePath ? `https://asset.localhost/${encodeURIComponent(img.imagePath)}` : undefined);
+              return src ? (
+                <div data-bf-component="user-message-item" data-bf-part="image" key={img.id} className="user-message-item__image-thumb" onClick={(e) => { e.stopPropagation(); setLightboxImage(src); }}>
+                  <img src={src} alt={img.name} />
+                </div>
+              ) : null;
+            })}
+          </div>
+        )}
+
+          {lightboxImage && createPortal(
+            <div
+              className="user-message-item__lightbox"
+              onClick={() => setLightboxImage(null)}
+              data-bf-component="user-message-item"
+              data-bf-part="lightbox"
+              data-bf-native-webview-occlusion
+            >
+              <button className="user-message-item__lightbox-close" onClick={() => setLightboxImage(null)}>
+                <Icon name="xmark" size="lg" style={{ width: 20, height: 20 }} />
+              </button>
+              <img src={lightboxImage} alt="Preview" onClick={(e) => e.stopPropagation()} />
+            </div>,
+            getAppearanceOverlayHost(),
+          )}
+        </div>
+
+        <div className="user-message-item__meta" data-bf-component="user-message-item" data-bf-part="meta">
+          {sentTime && sentAtLabel && sentTimestamp !== null && (
+            <time
+              className="user-message-item__timestamp"
+              data-bf-component="user-message-item"
+              data-bf-part="timestamp"
+              data-testid="chat-user-message-timestamp"
+              dateTime={new Date(sentTimestamp).toISOString()}
+              title={sentAtLabel}
+              aria-label={sentAtLabel}
+            >
+              {sentTime}
+            </time>
+          )}
+          {!isEditing && (
             <div className="user-message-item__actions" data-bf-component="user-message-item" data-bf-part="actions">
               <button
                 className={`user-message-item__copy-btn ${copied ? 'copied' : ''}`}
@@ -668,53 +717,9 @@ export const UserMessageItem = React.memo<UserMessageItemProps>(
                 </Tooltip>
               ) : null}
             </div>
-            </div>
-          </div>
-        )}
-
-        {message.images && message.images.length > 0 && (
-          <div className="user-message-item__images" data-bf-component="user-message-item" data-bf-part="images">
-            {message.images.map(img => {
-              const src = img.dataUrl || (img.imagePath ? `https://asset.localhost/${encodeURIComponent(img.imagePath)}` : undefined);
-              return src ? (
-                <div data-bf-component="user-message-item" data-bf-part="image" key={img.id} className="user-message-item__image-thumb" onClick={(e) => { e.stopPropagation(); setLightboxImage(src); }}>
-                  <img src={src} alt={img.name} />
-                </div>
-              ) : null;
-            })}
-          </div>
-        )}
-
-          {lightboxImage && createPortal(
-            <div
-              className="user-message-item__lightbox"
-              onClick={() => setLightboxImage(null)}
-              data-bf-component="user-message-item"
-              data-bf-part="lightbox"
-              data-bf-native-webview-occlusion
-            >
-              <button className="user-message-item__lightbox-close" onClick={() => setLightboxImage(null)}>
-                <Icon name="xmark" size="lg" style={{ width: 20, height: 20 }} />
-              </button>
-              <img src={lightboxImage} alt="Preview" onClick={(e) => e.stopPropagation()} />
-            </div>,
-            getAppearanceOverlayHost(),
           )}
         </div>
 
-        {sentTime && sentAtLabel && sentTimestamp !== null && (
-          <time
-            className="user-message-item__timestamp"
-            data-bf-component="user-message-item"
-            data-bf-part="timestamp"
-            data-testid="chat-user-message-timestamp"
-            dateTime={new Date(sentTimestamp).toISOString()}
-            title={sentAtLabel}
-            aria-label={sentAtLabel}
-          >
-            {sentTime}
-          </time>
-        )}
       </div>
     );
   }

--- a/src/web-ui/src/flow_chat/components/modern/UserMessageItemActions.test.ts
+++ b/src/web-ui/src/flow_chat/components/modern/UserMessageItemActions.test.ts
@@ -27,14 +27,14 @@ describe('UserMessageItem action visibility', () => {
       fileURLToPath(new URL('./UserMessageItem.scss', import.meta.url)),
       'utf8',
     ).replace(/\r\n?/g, '\n');
-    const item = extractBlock(stylesheet, '.user-message-item {');
     const actions = extractBlock(stylesheet, '\n.user-message-item__actions {');
-    const hover = extractBlock(item, '&:hover {');
-    const focusWithin = extractBlock(item, '&:focus-within {');
+    const shell = extractBlock(stylesheet, '.user-message-item-shell {');
+    const shellHover = extractBlock(shell, '&:hover,');
+    const shellFocusWithin = extractBlock(shell, '&:focus-within {');
 
     expect(actions).toContain('opacity: 0;');
-    expect(extractBlock(hover, '.user-message-item__actions {')).toContain('opacity: 1;');
-    expect(extractBlock(focusWithin, '.user-message-item__actions {')).toContain('opacity: 1;');
+    expect(extractBlock(shellHover, '.user-message-item__actions {')).toContain('opacity: 1;');
+    expect(extractBlock(shellFocusWithin, '.user-message-item__actions {')).toContain('opacity: 1;');
 
     expect(stylesheet).toContain([
       '.user-message-item__copy-btn,',
@@ -53,11 +53,20 @@ describe('UserMessageItem action visibility', () => {
     const timestamp = extractBlock(stylesheet, '\n.user-message-item__timestamp {');
     const hover = extractBlock(shell, '&:hover,');
 
-    expect(timestamp).toContain('position: absolute;');
-    expect(timestamp).toContain('right: calc(0.68rem + 7px);');
     expect(timestamp).toContain('opacity: 0;');
     expect(timestamp).toContain('pointer-events: none;');
+    const meta = extractBlock(stylesheet, '\n.user-message-item__meta {');
+    expect(meta).toContain('position: absolute;');
+    expect(meta).toContain('top: 100%;');
+    expect(meta).toContain('left: 0;');
+    expect(meta).toContain('right: 0;');
+    expect(meta).toContain('justify-content: flex-end;');
+    expect(meta).toContain('padding: 0.12rem 0 0;');
+    expect(meta).toContain('pointer-events: auto;');
+    expect(stylesheet).toContain('margin: 0;');
     expect(extractBlock(hover, '.user-message-item__timestamp {')).toContain('opacity: 1;');
+    expect(extractBlock(hover, '.user-message-item__actions {')).toContain('opacity: 1;');
+    expect(extractBlock(hover, '.user-message-item__actions {')).toContain('pointer-events: auto;');
     expect(shell).toContain('margin-bottom: calc(var(--bf-control-flow-chat-flow-item-gap) + 1rem);');
   });
 });

--- a/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualMessageList.tsx
@@ -452,6 +452,11 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     before: false,
     after: false,
   });
+  /** Re-arming is a transition out of a boundary, not a repeated level read. */
+  const boundaryReachedRef = useRef<Record<SessionHistoryWindowDirection, boolean>>({
+    before: false,
+    after: false,
+  });
   /**
    * `exhausted` describes the window that asked, not the session.
    *
@@ -474,6 +479,7 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
   if (previousWindowBoundsKeyRef.current !== windowBoundsKey) {
     previousWindowBoundsKeyRef.current = windowBoundsKey;
     exhaustedBoundaryRef.current = { before: false, after: false };
+    boundaryReachedRef.current = { before: false, after: false };
   }
   /**
    * Whether a boundary may be asked about again.
@@ -2336,9 +2342,11 @@ const VirtualMessageListSession = forwardRef<VirtualMessageListRef, VirtualMessa
     for (const direction of HISTORY_WINDOW_DIRECTIONS) {
       // Off the boundary: whatever the last page added has been absorbed, and
       // arriving there again will be the reader's own doing.
-      if (!reached.has(direction)) {
+      const isReached = reached.has(direction);
+      if (!isReached && boundaryReachedRef.current[direction]) {
         boundaryArmedRef.current[direction] = true;
       }
+      boundaryReachedRef.current[direction] = isReached;
       if (asking.has(direction)) requestHistoryBoundary(direction);
     }
   }, [


### PR DESCRIPTION
Move user message copy, edit, and rollback controls into the external metadata row beside the send time. Keep the metadata hit area continuous across the message width and align the final control with the bubble edge without adding message-row height or downstream spacing. Update appearance and layout tests for the new structure.
