### PR TITLE
fix(usage): unify token usage display formatting

### DIFF
--- a/scripts/request-trace-tools/usage-dashboard.html
+++ b/scripts/request-trace-tools/usage-dashboard.html
@@ -908,10 +908,22 @@
       if (value === null || value === undefined || Number.isNaN(value)) {
         return "-";
       }
-      return new Intl.NumberFormat("zh-CN", {
-        notation: "compact",
-        maximumFractionDigits: 1
-      }).format(value);
+      const units = [
+        { divisor: 1_000, suffix: "K" },
+        { divisor: 1_000_000, suffix: "M" },
+        { divisor: 1_000_000_000, suffix: "B" }
+      ];
+      const safeValue = Math.max(0, value);
+      if (safeValue < 1_000) {
+        return formatNumber(safeValue);
+      }
+      let unitIndex = safeValue >= 1_000_000_000 ? 2 : safeValue >= 1_000_000 ? 1 : 0;
+      let scaledValue = Math.round((safeValue / units[unitIndex].divisor + Number.EPSILON) * 100) / 100;
+      if (scaledValue >= 1_000 && unitIndex < units.length - 1) {
+        unitIndex += 1;
+        scaledValue = Math.round((safeValue / units[unitIndex].divisor + Number.EPSILON) * 100) / 100;
+      }
+      return `${new Intl.NumberFormat("zh-CN", { maximumFractionDigits: 2 }).format(scaledValue)}${units[unitIndex].suffix}`;
     }
 
     function formatPercent(value) {
@@ -1321,10 +1333,10 @@
           <tr>
             <td>${formatNumber(row.sequence)}</td>
             <td>${escapeHtml(formatDate(row.recorded_at))}</td>
-            <td>${formatNumber(row[peakMetricKey])}</td>
-            <td>${formatNumber(row[detailKeys[0]])}</td>
-            <td>${formatNumber(row[detailKeys[1]])}</td>
-            <td>${formatNumber(row[detailKeys[2]])}</td>
+            <td>${formatCompact(row[peakMetricKey])}</td>
+            <td>${formatCompact(row[detailKeys[0]])}</td>
+            <td>${formatCompact(row[detailKeys[1]])}</td>
+            <td>${formatCompact(row[detailKeys[2]])}</td>
             <td>${escapeHtml(row.model_id || "-")}</td>
           </tr>
         `).join("")
@@ -1347,7 +1359,7 @@
             <td>${formatNumber(row.sequence)}</td>
             <td>${escapeHtml(formatDate(row.recorded_at))}</td>
             <td>${escapeHtml(row.response_kind || "-")}</td>
-            <td>${formatNumber(row.prompt_tokens)}</td>
+            <td>${formatCompact(row.prompt_tokens)}</td>
             <td>${row.has_usage ? "yes" : "no"}</td>
           </tr>
         `).join("")
@@ -1549,7 +1561,7 @@
       const viewportStart = chartRows[viewport.start]?.sequence ?? "-";
       const viewportEnd = chartRows[viewport.end]?.sequence ?? "-";
       elements.chartSubtitle.textContent =
-        `${rows.length} 条筛选记录，其中可绘制 ${formatNumber(chartRows.length)} 条；当前视窗 ${formatNumber(viewportRows.length)} 条，请求 ${formatNumber(viewportStart)} - ${formatNumber(viewportEnd)}，来源：${state.sourceLabel || "usage-summary.csv"}，最大值 ${formatNumber(maxValue)} tokens`;
+        `${rows.length} 条筛选记录，其中可绘制 ${formatNumber(chartRows.length)} 条；当前视窗 ${formatNumber(viewportRows.length)} 条，请求 ${formatNumber(viewportStart)} - ${formatNumber(viewportEnd)}，来源：${state.sourceLabel || "usage-summary.csv"}，最大值 ${formatCompact(maxValue)} tokens`;
 
       bindChartInteractions({
         svg,
@@ -1679,7 +1691,7 @@
           <div>kind: ${escapeHtml(nearest.row.response_kind || "-")}</div>
           <div>capture: ${escapeHtml(nearest.row.capture_mode || "-")}</div>
           ${nearest.series.map(item => `
-            <div style="color:${item.color}">${escapeHtml(item.label)}: ${formatNumber(item.value)}</div>
+            <div style="color:${item.color}">${escapeHtml(item.label)}: ${formatCompact(item.value)}</div>
           `).join("")}
         `;
       };

--- a/src/apps/cli/src/ui/chat/status.rs
+++ b/src/apps/cli/src/ui/chat/status.rs
@@ -1,15 +1,34 @@
 use crate::chat_state::ModelTokenUsageSnapshot;
 
 fn format_token_count(value: usize) -> String {
-    let digits = value.to_string();
-    let mut formatted = String::with_capacity(digits.len() + digits.len() / 3);
-    for (index, digit) in digits.chars().enumerate() {
-        if index > 0 && (digits.len() - index) % 3 == 0 {
-            formatted.push(',');
-        }
-        formatted.push(digit);
+    let (mut divisor, mut suffix) = if value >= 1_000_000_000 {
+        (1_000_000_000_usize, "B")
+    } else if value >= 1_000_000 {
+        (1_000_000_usize, "M")
+    } else if value >= 1_000 {
+        (1_000_usize, "K")
+    } else {
+        return value.to_string();
+    };
+
+    let mut rounded_hundredths = (value as u128 * 100 + divisor as u128 / 2) / divisor as u128;
+    if rounded_hundredths >= 100_000 && divisor < 1_000_000_000 {
+        (divisor, suffix) = if divisor == 1_000 {
+            (1_000_000, "M")
+        } else {
+            (1_000_000_000, "B")
+        };
+        rounded_hundredths = (value as u128 * 100 + divisor as u128 / 2) / divisor as u128;
     }
-    formatted
+    let whole = rounded_hundredths / 100;
+    let fraction = rounded_hundredths % 100;
+    if fraction == 0 {
+        format!("{whole}{suffix}")
+    } else if fraction % 10 == 0 {
+        format!("{whole}.{}{suffix}", fraction / 10)
+    } else {
+        format!("{whole}.{fraction:02}{suffix}")
+    }
 }
 
 fn context_window_metrics(usage: &ModelTokenUsageSnapshot) -> Option<(usize, f64)> {
@@ -169,11 +188,11 @@ mod status_tests {
         assert_eq!(context_status_text(None), None);
         assert_eq!(
             context_status_text(Some(&usage(Some(128_000)))),
-            Some("Context: 82,000 / 128,000 (64.1%)".to_string())
+            Some("Context: 82K / 128K (64.1%)".to_string())
         );
         assert_eq!(
             context_status_text(Some(&usage(None))),
-            Some("Last request: 82,000 tokens".to_string())
+            Some("Last request: 82K tokens".to_string())
         );
     }
 
@@ -196,7 +215,7 @@ mod status_tests {
         state.last_primary_model_usage = Some(usage(Some(128_000)));
         assert_eq!(
             default_chat_status_text(&state),
-            "Messages: 3 | Tool calls: 2 | Context: 82,000 / 128,000 (64.1%)"
+            "Messages: 3 | Tool calls: 2 | Context: 82K / 128K (64.1%)"
         );
     }
 
@@ -230,11 +249,11 @@ mod status_tests {
             "Last primary model request",
             "Effective model: example-model",
             "Model config: model-config-1",
-            "Input: 80,000 tokens",
-            "Output: 2,000 tokens",
-            "Cached input: 10,000 tokens",
-            "Total: 82,000 tokens",
-            "Context window: 82,000 / 128,000 tokens (64.1%)",
+            "Input: 80K tokens",
+            "Output: 2K tokens",
+            "Cached input: 10K tokens",
+            "Total: 82K tokens",
+            "Context window: 82K / 128K tokens (64.1%)",
             "For cumulative session usage, use /usage.",
         ] {
             assert!(
@@ -271,5 +290,15 @@ mod status_tests {
                 "missing {expected:?} in:\n{status}"
             );
         }
+    }
+
+    #[test]
+    fn token_counts_use_compact_k_m_b_units_with_normal_rounding() {
+        assert_eq!(format_token_count(999), "999");
+        assert_eq!(format_token_count(1_234), "1.23K");
+        assert_eq!(format_token_count(1_235), "1.24K");
+        assert_eq!(format_token_count(999_999), "1M");
+        assert_eq!(format_token_count(5_396_217), "5.4M");
+        assert_eq!(format_token_count(1_000_000_000), "1B");
     }
 }

--- a/src/crates/services/services-core/src/session_usage/render.rs
+++ b/src/crates/services/services-core/src/session_usage/render.rs
@@ -45,9 +45,9 @@ pub fn render_usage_report_terminal(report: &SessionUsageReport) -> String {
     ));
     out.push(format!(
         "Tokens: input {}, output {}, total {}",
-        format_optional_number(report.tokens.input_tokens),
-        format_optional_number(report.tokens.output_tokens),
-        format_optional_number(report.tokens.total_tokens)
+        format_optional_token_count(report.tokens.input_tokens),
+        format_optional_token_count(report.tokens.output_tokens),
+        format_optional_token_count(report.tokens.total_tokens)
     ));
     out.push(format!(
         "Cached tokens: {}",
@@ -175,15 +175,15 @@ pub fn render_usage_report_markdown(report: &SessionUsageReport) -> String {
     ));
     out.push_str(&format!(
         "| Input | {} |\n",
-        format_optional_number(report.tokens.input_tokens)
+        format_optional_token_count(report.tokens.input_tokens)
     ));
     out.push_str(&format!(
         "| Output | {} |\n",
-        format_optional_number(report.tokens.output_tokens)
+        format_optional_token_count(report.tokens.output_tokens)
     ));
     out.push_str(&format!(
         "| Total | {} |\n",
-        format_optional_number(report.tokens.total_tokens)
+        format_optional_token_count(report.tokens.total_tokens)
     ));
     out.push_str(&format!(
         "| Cached | {} |\n\n",
@@ -214,18 +214,18 @@ pub fn render_usage_report_markdown(report: &SessionUsageReport) -> String {
                     escape_markdown(&model.model_id),
                     model.call_count,
                     format_optional_duration(model.duration_ms),
-                    format_optional_number(model.input_tokens),
-                    format_optional_number(model.output_tokens),
-                    format_optional_number(model.total_tokens)
+                    format_optional_token_count(model.input_tokens),
+                    format_optional_token_count(model.output_tokens),
+                    format_optional_token_count(model.total_tokens)
                 ));
             } else {
                 out.push_str(&format!(
                     "| {} | {} | {} | {} | {} |\n",
                     escape_markdown(&model.model_id),
                     model.call_count,
-                    format_optional_number(model.input_tokens),
-                    format_optional_number(model.output_tokens),
-                    format_optional_number(model.total_tokens)
+                    format_optional_token_count(model.input_tokens),
+                    format_optional_token_count(model.output_tokens),
+                    format_optional_token_count(model.total_tokens)
                 ));
             }
         }
@@ -377,7 +377,46 @@ fn format_optional_number(value: Option<u64>) -> String {
         .unwrap_or_else(|| "unavailable".to_string())
 }
 
-/// Format the "cached tokens" cell with an optional ` (NN%)` hit-rate suffix.
+fn format_optional_token_count(value: Option<u64>) -> String {
+    value
+        .map(format_token_count)
+        .unwrap_or_else(|| "unavailable".to_string())
+}
+
+fn format_token_count(value: u64) -> String {
+    let (mut divisor, mut suffix) = if value >= 1_000_000_000 {
+        (1_000_000_000_u64, "B")
+    } else if value >= 1_000_000 {
+        (1_000_000_u64, "M")
+    } else if value >= 1_000 {
+        (1_000_u64, "K")
+    } else {
+        return value.to_string();
+    };
+
+    let mut rounded_hundredths =
+        (u128::from(value) * 100 + u128::from(divisor) / 2) / u128::from(divisor);
+    if rounded_hundredths >= 100_000 && divisor < 1_000_000_000 {
+        (divisor, suffix) = if divisor == 1_000 {
+            (1_000_000, "M")
+        } else {
+            (1_000_000_000, "B")
+        };
+        rounded_hundredths =
+            (u128::from(value) * 100 + u128::from(divisor) / 2) / u128::from(divisor);
+    }
+    let whole = rounded_hundredths / 100;
+    let fraction = rounded_hundredths % 100;
+    if fraction == 0 {
+        format!("{whole}{suffix}")
+    } else if fraction % 10 == 0 {
+        format!("{whole}.{}{suffix}", fraction / 10)
+    } else {
+        format!("{whole}.{fraction:02}{suffix}")
+    }
+}
+
+/// Format the "cached tokens" cell with an optional ` (NN.NN%)` hit-rate suffix.
 /// Falls back to "not reported" when coverage is unavailable, regardless of
 /// whether the hit-rate field happens to be set.
 fn format_cached_with_hit_rate(
@@ -388,9 +427,12 @@ fn format_cached_with_hit_rate(
     match coverage {
         UsageCacheCoverage::Unavailable => "not reported".to_string(),
         UsageCacheCoverage::Available | UsageCacheCoverage::Partial => {
-            let base = format_optional_number(cached_tokens);
+            let base = format_optional_token_count(cached_tokens);
             match hit_rate {
-                Some(rate) => format!("{} ({:.0}%)", base, rate * 100.0),
+                Some(rate) => {
+                    let rounded_down_percentage = (rate.clamp(0.0, 1.0) * 10_000.0).floor() / 100.0;
+                    format!("{} ({rounded_down_percentage:.2}%)", base)
+                }
                 None => base,
             }
         }
@@ -555,15 +597,25 @@ mod tests {
     fn render_appends_hit_rate_suffix_to_cached_cell() {
         let mut report = test_report();
         // Pretend a session covered cache and 80% of input came from cache.
-        report.tokens.cached_tokens = Some(800);
+        report.tokens.cached_tokens = Some(1_234);
         report.tokens.cache_coverage = UsageCacheCoverage::Available;
-        report.tokens.cache_hit_rate = Some(0.8);
+        report.tokens.cache_hit_rate = Some(0.80409);
 
         let terminal = render_usage_report_terminal(&report);
         let markdown = render_usage_report_markdown(&report);
 
-        assert!(terminal.contains("Cached tokens: 800 (80%)"));
-        assert!(markdown.contains("| Cached | 800 (80%) |"));
+        assert!(terminal.contains("Cached tokens: 1.23K (80.40%)"));
+        assert!(markdown.contains("| Cached | 1.23K (80.40%) |"));
+    }
+
+    #[test]
+    fn token_counts_use_compact_k_m_b_units_with_normal_rounding() {
+        assert_eq!(format_token_count(999), "999");
+        assert_eq!(format_token_count(1_234), "1.23K");
+        assert_eq!(format_token_count(1_235), "1.24K");
+        assert_eq!(format_token_count(999_999), "1M");
+        assert_eq!(format_token_count(5_396_217), "5.4M");
+        assert_eq!(format_token_count(1_000_000_000), "1B");
     }
 
     #[test]

--- a/src/web-ui/src/app/scenes/my-agent/InsightsScene.tsx
+++ b/src/web-ui/src/app/scenes/my-agent/InsightsScene.tsx
@@ -12,6 +12,7 @@ import { createLogger } from '@/shared/utils/logger';
 import { getMotionAwareScrollBehavior } from '@/shared/utils/motionPreference';
 import { notificationService } from '@/shared/notification-system';
 import { APPEARANCE_DOMAIN_TOKENS } from '@/infrastructure/appearance/appearanceDomainTokens';
+import { formatTokenCount } from '@/shared/utils/tokenUsageFormatting';
 import '@/app/components/GalleryLayout/GalleryLayout.scss';
 import './InsightsScene.scss';
 
@@ -335,16 +336,16 @@ const ReportMetaCard: React.FC<{
   const generationModels = meta.generation_models || [];
   const sessionTokenTitle = hasSessionUsage
     ? [
-        `${t('insights.inputTokens')}: ${formatNumber(sessionUsage.input_tokens)}`,
-        `${t('insights.outputTokens')}: ${formatNumber(sessionUsage.output_tokens)}`,
+        `${t('insights.inputTokens')}: ${formatTokenCount(sessionUsage.input_tokens, formatNumber)}`,
+        `${t('insights.outputTokens')}: ${formatTokenCount(sessionUsage.output_tokens, formatNumber)}`,
         `${t('insights.tokenCoverage')}: ${sessionUsage.turns_with_usage}/${sessionUsage.total_turns}`,
       ].join('\n')
     : t('insights.sessionTokensUnavailable');
   const generationTokenTitle = hasGenerationUsage
     ? [
-        `${t('insights.inputTokens')}: ${formatNumber(generationUsage.input_tokens)}`,
-        `${t('insights.outputTokens')}: ${formatNumber(generationUsage.output_tokens)}`,
-        `${t('insights.cachedTokens')}: ${formatNumber(generationUsage.cached_input_tokens)}`,
+        `${t('insights.inputTokens')}: ${formatTokenCount(generationUsage.input_tokens, formatNumber)}`,
+        `${t('insights.outputTokens')}: ${formatTokenCount(generationUsage.output_tokens, formatNumber)}`,
+        `${t('insights.cachedTokens')}: ${formatTokenCount(generationUsage.cached_input_tokens, formatNumber)}`,
       ].join('\n')
     : t('insights.tokensUnavailable');
 
@@ -363,7 +364,7 @@ const ReportMetaCard: React.FC<{
           <span>
             <strong>
               {hasSessionUsage
-                ? formatNumber(sessionUsage.total_tokens, { notation: 'compact', maximumFractionDigits: 1 })
+                ? formatTokenCount(sessionUsage.total_tokens, formatNumber)
                 : '--'}
             </strong>
             {t('insights.sessionTokens')}
@@ -414,7 +415,7 @@ const ReportMetaCard: React.FC<{
               <Icon name="spark" size="2xs" />
               {t('insights.insightsGenerationTokens')}:
               {' '}{hasGenerationUsage
-                ? formatNumber(generationUsage.total_tokens, { notation: 'compact', maximumFractionDigits: 1 })
+                ? formatTokenCount(generationUsage.total_tokens, formatNumber)
                 : '--'} {t('insights.tokens')}
               {!generationUsageComplete && ` · ${t('insights.partialUsage')}`}
             </span>

--- a/src/web-ui/src/flow_chat/components/thread-goal/ThreadGoalDialogs.tsx
+++ b/src/web-ui/src/flow_chat/components/thread-goal/ThreadGoalDialogs.tsx
@@ -11,6 +11,8 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Target } from 'lucide-react';
 import { Textarea } from '@bitfun/ui';
+import { i18nService } from '@/infrastructure/i18n';
+import { formatTokenCount } from '@/shared/utils/tokenUsageFormatting';
 import type { ThreadGoalController } from '../../hooks/useThreadGoalController';
 import type { ThreadGoalUiAction } from '../../services/threadGoalActions';
 import {
@@ -31,8 +33,14 @@ function formatUsageLine(
   if (goal.tokenBudget != null) {
     parts.push(
       t('threadGoal.usageTokens', {
-        used: goal.tokensUsed ?? 0,
-        budget: goal.tokenBudget,
+        used: formatTokenCount(
+          goal.tokensUsed ?? 0,
+          (number, options) => i18nService.formatNumber(number, options),
+        ),
+        budget: formatTokenCount(
+          goal.tokenBudget,
+          (number, options) => i18nService.formatNumber(number, options),
+        ),
       })
     );
   }

--- a/src/web-ui/src/flow_chat/components/usage/SessionUsageComponents.test.tsx
+++ b/src/web-ui/src/flow_chat/components/usage/SessionUsageComponents.test.tsx
@@ -617,7 +617,7 @@ describe('Session usage report UI components', () => {
 
     expect(container.querySelector('.session-usage-report-card--compact')).not.toBeNull();
     expect(container.querySelector('.session-usage-report-card__compact-token-value')?.textContent)
-      .toContain('5,396,217');
+      .toContain('5.4M');
     expect(container.textContent).toContain('Tokens usage');
     expect(container.textContent).toContain('deepseek-v4-flash');
     expect(container.textContent).toContain('68 calls');
@@ -661,9 +661,9 @@ describe('Session usage report UI components', () => {
 
     const cachedMetric = Array.from(container.querySelectorAll('.session-usage-report-card__metric'))
       .find(metric => metric.textContent?.includes('Cached'));
-    // Cached number AND inline (NN%) hit rate must both appear.
-    expect(cachedMetric?.textContent).toMatch(/1,?200/);
-    expect(cachedMetric?.textContent).toContain('(80%)');
+    // Cached number AND inline two-decimal hit rate must both appear.
+    expect(cachedMetric?.textContent).toContain('1.2K');
+    expect(cachedMetric?.textContent).toContain('(80.00%)');
     expect(cachedMetric?.textContent).not.toContain('Cache not reported');
   });
 
@@ -838,7 +838,7 @@ describe('Session usage report UI components', () => {
     expect(container.textContent).not.toContain('src/features');
     expect(container.textContent).not.toContain('/.../');
     expect(container.querySelector(`[data-tooltip="${longPath}"]`)).not.toBeNull();
-    expect(container.textContent).toContain('1,500 tokens');
+    expect(container.textContent).toContain('1.5K tokens');
     expect(refWarnings).toEqual([]);
   });
 

--- a/src/web-ui/src/flow_chat/components/usage/SessionUsagePanel.tsx
+++ b/src/web-ui/src/flow_chat/components/usage/SessionUsagePanel.tsx
@@ -18,6 +18,7 @@ import {
   formatHitRatePercent,
   formatUsageDuration,
   formatUsageNumber,
+  formatTokenCount,
   formatUsagePercent,
   formatUsageTimestamp,
   getAccountingLabel,
@@ -607,7 +608,7 @@ function UsageOverview({ report }: { report: SessionUsageReport }) {
       key: 'tokens',
       icon: Database,
       label: t('usage.metrics.tokens'),
-      value: formatUsageNumber(report.tokens.totalTokens, t),
+      value: formatTokenCount(report.tokens.totalTokens, t),
     },
     {
       key: 'files',
@@ -698,7 +699,7 @@ function UsageModels({ report, sessionId }: { report: SessionUsageReport; sessio
       emptyDescription={t('usage.empty.modelsDescription')}
       headers={headers}
       rows={report.models.map((model, index) => {
-        const cached = formatUsageNumber(model.cachedTokens, t);
+        const cached = formatTokenCount(model.cachedTokens, t);
         const source = model.modelIdSource ?? (model.modelId === 'unknown_model' ? 'legacy_missing' : undefined);
         const modelHelp = getModelHelp(source, t, model.modelId);
         const modelLabel = getModelLabel(model.modelId, t, source);
@@ -724,8 +725,8 @@ function UsageModels({ report, sessionId }: { report: SessionUsageReport; sessio
           );
         }
         cells.push(
-          formatUsageNumber(model.inputTokens, t),
-          formatUsageNumber(model.outputTokens, t),
+          formatTokenCount(model.inputTokens, t),
+          formatTokenCount(model.outputTokens, t),
           report.tokens.cacheCoverage === 'unavailable'
             ? { value: t('usage.status.cacheNotReported'), help: t('usage.help.cachedTokens') }
             : cached,

--- a/src/web-ui/src/flow_chat/components/usage/SessionUsageReportCard.tsx
+++ b/src/web-ui/src/flow_chat/components/usage/SessionUsageReportCard.tsx
@@ -12,6 +12,7 @@ import {
   formatHitRateSuffix,
   formatUsageDuration,
   formatUsageNumber,
+  formatTokenCount,
   formatUsageTimestamp,
   getCoverageLabel,
   getCoverageTone,
@@ -173,7 +174,7 @@ export const SessionUsageReportCard: React.FC<SessionUsageReportCardProps> = ({
   const tokenTotal = report.tokens.totalTokens;
   const cachedTokenText = report.tokens.cacheCoverage === 'unavailable'
     ? t('usage.status.cacheNotReported')
-    : `${formatUsageNumber(report.tokens.cachedTokens, t)}${formatHitRateSuffix(report.tokens.cacheHitRate, t)}`;
+    : `${formatTokenCount(report.tokens.cachedTokens, t)}${formatHitRateSuffix(report.tokens.cacheHitRate, t)}`;
   const cachedTokenHelp = report.tokens.cacheCoverage === 'unavailable'
     ? t('usage.help.cachedTokens')
     : report.tokens.cacheCoverage === 'partial'
@@ -286,7 +287,7 @@ export const SessionUsageReportCard: React.FC<SessionUsageReportCardProps> = ({
               <span>{t('usage.card.tokenUsage')}</span>
             </div>
             <div className="session-usage-report-card__compact-token-value">
-              {formatUsageNumber(tokenTotal, t)}
+              {formatTokenCount(tokenTotal, t)}
             </div>
             <div className="session-usage-report-card__compact-model">
               {primaryModelHelp ? (
@@ -399,7 +400,7 @@ export const SessionUsageReportCard: React.FC<SessionUsageReportCardProps> = ({
     {
       key: 'tokens',
       label: t('usage.metrics.tokens'),
-      value: formatUsageNumber(tokenTotal, t),
+      value: formatTokenCount(tokenTotal, t),
       icon: Database,
     },
     {
@@ -518,8 +519,8 @@ export const SessionUsageReportCard: React.FC<SessionUsageReportCardProps> = ({
             const help = getModelHelp(source, t, model.modelId);
             const label = getModelLabel(model.modelId, t, source);
             const tokenValue = typeof model.totalTokens === 'number' && Number.isFinite(model.totalTokens)
-              ? t('usage.card.tokens', { value: formatUsageNumber(model.totalTokens, t) })
-              : formatUsageNumber(model.totalTokens, t);
+              ? t('usage.card.tokens', { value: formatTokenCount(model.totalTokens, t) })
+              : formatTokenCount(model.totalTokens, t);
             return {
               label: help ? { value: label, help } : label,
               value: tokenValue,

--- a/src/web-ui/src/flow_chat/components/usage/usageReportUtils.test.ts
+++ b/src/web-ui/src/flow_chat/components/usage/usageReportUtils.test.ts
@@ -5,6 +5,7 @@ import {
   coerceSessionUsageReport,
   formatHitRatePercent,
   formatHitRateSuffix,
+  formatTokenCount,
   getFileSummaryLabel,
   getModelHelp,
   getModelLabel,
@@ -117,6 +118,13 @@ function usageReport(overrides: Partial<SessionUsageReport> = {}): SessionUsageR
 }
 
 describe('usageReportUtils', () => {
+  it('formats token counts with compact units', () => {
+    expect(formatTokenCount(999, t)).toBe('999');
+    expect(formatTokenCount(1_234, t)).toBe('1.23K');
+    expect(formatTokenCount(12_345, t)).toBe('12.35K');
+    expect(formatTokenCount(1_000_000_000, t)).toBe('1B');
+  });
+
   it('only accepts structured usage report metadata', () => {
     expect(coerceSessionUsageReport(usageReport())?.reportId).toBe('usage-session-1');
     expect(coerceSessionUsageReport({ reportId: 'usage-1' })).toBeUndefined();
@@ -246,9 +254,9 @@ describe('usageReportUtils', () => {
 
   describe('formatHitRateSuffix', () => {
     it('formats a finite ratio as a parenthesised percentage with leading space', () => {
-      expect(formatHitRateSuffix(0.8, t)).toBe(' (80%)');
-      expect(formatHitRateSuffix(0, t)).toBe(' (0%)');
-      expect(formatHitRateSuffix(1, t)).toBe(' (100%)');
+      expect(formatHitRateSuffix(0.8, t)).toBe(' (80.00%)');
+      expect(formatHitRateSuffix(0, t)).toBe(' (0.00%)');
+      expect(formatHitRateSuffix(1, t)).toBe(' (100.00%)');
     });
 
     it('returns an empty string for missing or non-finite values', () => {
@@ -258,17 +266,16 @@ describe('usageReportUtils', () => {
       expect(formatHitRateSuffix(Number.POSITIVE_INFINITY, t)).toBe('');
     });
 
-    it('rounds the displayed percent to the nearest integer', () => {
-      // 0.804 → 80.4% → "80%"; 0.806 → 80.6% → "81%"
-      expect(formatHitRateSuffix(0.804, t)).toBe(' (80%)');
-      expect(formatHitRateSuffix(0.806, t)).toBe(' (81%)');
+    it('rounds the displayed percent down to two decimal places', () => {
+      expect(formatHitRateSuffix(0.80404, t)).toBe(' (80.40%)');
+      expect(formatHitRateSuffix(0.80409, t)).toBe(' (80.40%)');
     });
   });
 
   describe('formatHitRatePercent', () => {
     it('formats a finite ratio as a bare percentage cell', () => {
-      expect(formatHitRatePercent(0.5, t)).toBe('50%');
-      expect(formatHitRatePercent(1, t)).toBe('100%');
+      expect(formatHitRatePercent(0.5, t)).toBe('50.00%');
+      expect(formatHitRatePercent(1, t)).toBe('100.00%');
     });
 
     it('returns a dash for missing or non-finite values', () => {

--- a/src/web-ui/src/flow_chat/components/usage/usageReportUtils.ts
+++ b/src/web-ui/src/flow_chat/components/usage/usageReportUtils.ts
@@ -1,5 +1,9 @@
 import type { SessionUsageReport } from '@/infrastructure/api/service-api/SessionAPI';
 import { i18nService } from '@/infrastructure/i18n';
+import {
+  formatCacheHitRate,
+  formatTokenCount as formatLocalizedTokenCount,
+} from '@/shared/utils/tokenUsageFormatting';
 
 type Translator = (key: string, options?: Record<string, unknown>) => string;
 type ModelIdentitySource = SessionUsageReport['models'][number]['modelIdSource'];
@@ -44,6 +48,16 @@ export function formatUsageNumber(value: number | undefined, t: Translator): str
     return t('usage.unavailable');
   }
   return i18nService.formatNumber(value);
+}
+
+export function formatTokenCount(value: number | undefined, t: Translator): string {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return t('usage.unavailable');
+  }
+  return formatLocalizedTokenCount(
+    value,
+    (number, options) => i18nService.formatNumber(number, options),
+  );
 }
 
 export function formatUsageDuration(value: number | undefined, t: Translator): string {
@@ -94,26 +108,32 @@ export function formatUsagePercent(value: number | undefined, t: Translator): st
 }
 
 /**
- * Render a 0..1 hit-rate ratio as ` (NN%)` (with a leading space for inline
+ * Render a 0..1 hit-rate ratio as ` (NN.NN%)` (with a leading space for inline
  * use after a token count). Returns an empty string for null/undefined/NaN,
  * so callers can unconditionally append the result.
  */
-export function formatHitRateSuffix(rate: number | undefined | null, t: Translator): string {
+export function formatHitRateSuffix(rate: number | undefined | null, _t: Translator): string {
   if (typeof rate !== 'number' || !Number.isFinite(rate)) {
     return '';
   }
-  return ` (${t('usage.percent', { value: Math.round(rate * 100) })})`;
+  return ` (${formatCacheHitRate(
+    rate,
+    (number, options) => i18nService.formatNumber(number, options),
+  )})`;
 }
 
 /**
- * Render a 0..1 hit-rate ratio as a bare percentage cell (`80%`).
+ * Render a 0..1 hit-rate ratio as a bare percentage cell (`80.00%`).
  * Falls back to the dash placeholder when the rate is null/undefined/NaN.
  */
-export function formatHitRatePercent(rate: number | undefined | null, t: Translator): string {
+export function formatHitRatePercent(rate: number | undefined | null, _t: Translator): string {
   if (typeof rate !== 'number' || !Number.isFinite(rate)) {
     return '-';
   }
-  return t('usage.percent', { value: Math.round(rate * 100) });
+  return formatCacheHitRate(
+    rate,
+    (number, options) => i18nService.formatNumber(number, options),
+  );
 }
 
 export function calculateShare(part: number | undefined, denominator: number | undefined): number | undefined {

--- a/src/web-ui/src/flow_chat/services/usageReportService.ts
+++ b/src/web-ui/src/flow_chat/services/usageReportService.ts
@@ -8,6 +8,11 @@ import {
 } from '../components/usage/sessionUsageModalState';
 import type { Session } from '../types/flow-chat';
 import { sessionProjectWorkspacePath } from '../utils/sessionWorkspace';
+import { i18nService } from '@/infrastructure/i18n';
+import {
+  formatCacheHitRate,
+  formatTokenCount,
+} from '@/shared/utils/tokenUsageFormatting';
 
 const UNKNOWN_MODEL_ID = 'unknown_model';
 const LEGACY_MODEL_LABEL = 'Legacy model not tracked';
@@ -158,16 +163,19 @@ export function renderUsageReportMarkdown(report: SessionUsageReport): string {
     '| Metric | Value |',
     '| --- | --- |',
     `| Source | ${report.tokens.source} |`,
-    `| Input | ${formatNumber(report.tokens.inputTokens)} |`,
-    `| Output | ${formatNumber(report.tokens.outputTokens)} |`,
-    `| Total | ${formatNumber(report.tokens.totalTokens)} |`,
+    `| Input | ${formatUsageTokenCount(report.tokens.inputTokens)} |`,
+    `| Output | ${formatUsageTokenCount(report.tokens.outputTokens)} |`,
+    `| Total | ${formatUsageTokenCount(report.tokens.totalTokens)} |`,
     `| Cached | ${
       report.tokens.cacheCoverage === 'unavailable'
         ? 'not reported'
-        : `${formatNumber(report.tokens.cachedTokens)}${
+        : `${formatUsageTokenCount(report.tokens.cachedTokens)}${
             typeof report.tokens.cacheHitRate === 'number' &&
             Number.isFinite(report.tokens.cacheHitRate)
-              ? ` (${Math.round(report.tokens.cacheHitRate * 100)}%)`
+              ? ` (${formatCacheHitRate(
+                  report.tokens.cacheHitRate,
+                  (number, options) => i18nService.formatNumber(number, options),
+                )})`
               : ''
           }`
     } |`,
@@ -232,6 +240,15 @@ export function renderUsageReportMarkdown(report: SessionUsageReport): string {
 
 function formatNumber(value: number | undefined): string {
   return value === undefined ? 'unavailable' : String(value);
+}
+
+function formatUsageTokenCount(value: number | undefined): string {
+  return value === undefined
+    ? 'unavailable'
+    : formatTokenCount(
+        value,
+        (number, options) => i18nService.formatNumber(number, options),
+      );
 }
 
 function formatDuration(value: number | undefined): string {

--- a/src/web-ui/src/flow_chat/utils/tokenUsageDisplay.test.ts
+++ b/src/web-ui/src/flow_chat/utils/tokenUsageDisplay.test.ts
@@ -190,8 +190,9 @@ describe('tokenUsageDisplay', () => {
 
   it('keeps compact token formatting stable for tooltip strings', () => {
     expect(formatCompactTokenCount(950)).toBe('950');
-    expect(formatCompactTokenCount(1200)).toBe('1.2K');
-    expect(formatCompactTokenCount(4000)).toBe('4K');
+    expect(formatCompactTokenCount(1234)).toBe('1.23K');
+    expect(formatCompactTokenCount(12_345)).toBe('12.35K');
+    expect(formatCompactTokenCount(1_000_000_000)).toBe('1B');
   });
 });
 

--- a/src/web-ui/src/flow_chat/utils/tokenUsageDisplay.ts
+++ b/src/web-ui/src/flow_chat/utils/tokenUsageDisplay.ts
@@ -1,5 +1,7 @@
 import type { DialogTurn, Session, TokenUsage } from '../types/flow-chat';
 import { LONG_CONTEXT_WARNING_THRESHOLD_TOKENS } from '@/shared/constants/modelContext';
+import { i18nService } from '@/infrastructure/i18n';
+import { formatTokenCount } from '@/shared/utils/tokenUsageFormatting';
 
 export const DEFAULT_MAX_CONTEXT_TOKENS = 128128;
 
@@ -36,14 +38,10 @@ const AUTOMATIC_MAX_OUTPUT_TOKEN_TIERS = [8_000, 16_000, 24_000, 32_000, 64_000]
 const AUTO_COMPRESSION_SAFETY_RESERVE_TOKENS = 10_000;
 
 export function formatCompactTokenCount(value: number): string {
-  const safeValue = Math.max(0, Math.round(value));
-  if (safeValue >= 1_000_000) {
-    return `${formatCompactNumber(safeValue / 1_000_000)}M`;
-  }
-  if (safeValue >= 1_000) {
-    return `${formatCompactNumber(safeValue / 1_000)}K`;
-  }
-  return String(safeValue);
+  return formatTokenCount(
+    value,
+    (number, options) => i18nService.formatNumber(number, options),
+  );
 }
 
 function automaticMaxOutputTokens(contextWindow: number): number {

--- a/src/web-ui/src/infrastructure/config/components/UsageStatisticsConfig.test.tsx
+++ b/src/web-ui/src/infrastructure/config/components/UsageStatisticsConfig.test.tsx
@@ -125,7 +125,7 @@ const SAMPLE_STATS: UsageStatistics = {
       attributionStatus: 'resolved',
       requests: 47,
       tokens: 4_800_000,
-      cacheHitRate: 0.95,
+      cacheHitRate: 0.95679,
     },
   ],
   byGroup: [
@@ -225,7 +225,9 @@ describe('UsageStatisticsConfig', () => {
     expect(container.querySelectorAll('[data-bf-part="distributions"] th[scope="row"]')).toHaveLength(3);
     expect(container.querySelector('[data-bf-part="trendPanel"] svg[role="img"]')).not.toBeNull();
     expect(container.querySelector('[data-bf-part="trendPanel"] table.bitfun-sr-only')).not.toBeNull();
-    // Hit rate is truncated to two decimals, never rounded up.
+    expect(container.textContent).toContain('4.8M');
+    // Hit rate rounds down and always keeps two decimal places.
+    expect(container.textContent).toContain('95.67%');
     expect(container.textContent).toContain('95.00%');
   });
 

--- a/src/web-ui/src/infrastructure/config/components/UsageStatisticsConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/UsageStatisticsConfig.tsx
@@ -22,6 +22,11 @@ import {
 } from './common';
 import './UsageStatisticsConfig.scss';
 import { Icon, IconButton, Input, Select, Tooltip, ScrollArea } from '@bitfun/ui';
+import {
+  formatCacheHitRate,
+  formatTokenCount,
+  type LocalizedNumberFormatter,
+} from '@/shared/utils/tokenUsageFormatting';
 
 // ---------------------------------------------------------------------------
 // Chart palette — appearance tokens only (literal vars so the theme color
@@ -51,31 +56,13 @@ const DONUT_PALETTE = [
 // Formatting helpers
 // ---------------------------------------------------------------------------
 
-type NumberFormatter = (
-  value: number,
-  options?: Intl.NumberFormatOptions,
-) => string;
-
-function formatTokens(value: number, formatNumber: NumberFormatter): string {
-  if (Math.abs(value) < 1_000) return formatNumber(value);
-  return formatNumber(value, {
-    notation: 'compact',
-    compactDisplay: 'short',
-    maximumFractionDigits: Math.abs(value) >= 1_000_000 ? 2 : 1,
-  });
+function formatTokens(value: number, formatNumber: LocalizedNumberFormatter): string {
+  return formatTokenCount(value, formatNumber);
 }
 
-function formatHitRate(value: number | null, formatNumber: NumberFormatter): string {
+function formatHitRate(value: number | null, formatNumber: LocalizedNumberFormatter): string {
   if (value === null || !Number.isFinite(value)) return '–';
-  // Only a true full hit (cached == reported input) shows as 100%.
-  if (value >= 1) return formatNumber(1, { style: 'percent', maximumFractionDigits: 0 });
-  // Truncate to two decimals — never round up.
-  const truncated = Math.floor(value * 10_000) / 10_000;
-  return formatNumber(truncated, {
-    style: 'percent',
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  });
+  return formatCacheHitRate(value, formatNumber);
 }
 
 function formatBucketLabel(

--- a/src/web-ui/src/shared/utils/tokenUsageFormatting.test.ts
+++ b/src/web-ui/src/shared/utils/tokenUsageFormatting.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { formatCacheHitRate, formatTokenCount } from './tokenUsageFormatting';
+
+const formatter = (locale: string) => (
+  value: number,
+  options?: Intl.NumberFormatOptions,
+) => new Intl.NumberFormat(locale, options).format(value);
+
+describe('token usage formatting', () => {
+  it('uses fixed K/M/B token units with up to two decimal places', () => {
+    expect(formatTokenCount(999, formatter('en-US'))).toBe('999');
+    expect(formatTokenCount(1_234, formatter('en-US'))).toBe('1.23K');
+    expect(formatTokenCount(999_999, formatter('en-US'))).toBe('1M');
+    expect(formatTokenCount(5_396_217, formatter('en-US'))).toBe('5.4M');
+    expect(formatTokenCount(1_000_000_000, formatter('en-US'))).toBe('1B');
+    expect(formatTokenCount(12_345, formatter('zh-CN'))).toBe('12.35K');
+    expect(formatTokenCount(1_000_000_000, formatter('zh-CN'))).toBe('1B');
+  });
+
+  it('rounds cache hit rates down to exactly two decimal places', () => {
+    expect(formatCacheHitRate(0.95674, formatter('en-US'))).toBe('95.67%');
+    expect(formatCacheHitRate(0.95679, formatter('en-US'))).toBe('95.67%');
+    expect(formatCacheHitRate(1, formatter('en-US'))).toBe('100.00%');
+  });
+});

--- a/src/web-ui/src/shared/utils/tokenUsageFormatting.ts
+++ b/src/web-ui/src/shared/utils/tokenUsageFormatting.ts
@@ -1,0 +1,58 @@
+export type LocalizedNumberFormatter = (
+  value: number,
+  options?: Intl.NumberFormatOptions,
+) => string;
+
+const COMPACT_TOKEN_OPTIONS: Intl.NumberFormatOptions = {
+  maximumFractionDigits: 2,
+};
+
+const TOKEN_UNITS = [
+  { divisor: 1_000, suffix: 'K' },
+  { divisor: 1_000_000, suffix: 'M' },
+  { divisor: 1_000_000_000, suffix: 'B' },
+] as const;
+
+const CACHE_HIT_RATE_OPTIONS: Intl.NumberFormatOptions = {
+  style: 'percent',
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+};
+
+/** Format a token count with fixed K/M/B units in every locale. */
+export function formatTokenCount(
+  value: number,
+  formatNumber: LocalizedNumberFormatter,
+): string {
+  const safeValue = Math.max(0, Math.round(value));
+  if (safeValue < 1_000) {
+    return formatNumber(safeValue);
+  }
+
+  let unitIndex = safeValue >= 1_000_000_000
+    ? 2
+    : safeValue >= 1_000_000
+      ? 1
+      : 0;
+  let scaledValue = roundToTwoDecimals(safeValue / TOKEN_UNITS[unitIndex].divisor);
+  if (scaledValue >= 1_000 && unitIndex < TOKEN_UNITS.length - 1) {
+    unitIndex += 1;
+    scaledValue = roundToTwoDecimals(safeValue / TOKEN_UNITS[unitIndex].divisor);
+  }
+
+  return `${formatNumber(scaledValue, COMPACT_TOKEN_OPTIONS)}${TOKEN_UNITS[unitIndex].suffix}`;
+}
+
+function roundToTwoDecimals(value: number): number {
+  return Math.round((value + Number.EPSILON) * 100) / 100;
+}
+
+/** Format a 0..1 cache-hit ratio with two decimal places, rounded down. */
+export function formatCacheHitRate(
+  value: number,
+  formatNumber: LocalizedNumberFormatter,
+): string {
+  const boundedValue = Math.min(1, Math.max(0, value));
+  const roundedDownValue = Math.floor(boundedValue * 10_000) / 10_000;
+  return formatNumber(roundedDownValue, CACHE_HIT_RATE_OPTIONS);
+}


### PR DESCRIPTION
## Summary

- Standardize token-count displays across Web UI, CLI, session usage reports, and the developer usage dashboard.
- Format token totals with fixed `K` / `M` / `B` units and up to two decimal places.
- Display cache hit rates with exactly two decimal places, rounded down.
- Add shared Web formatting utilities and focused regression tests.

## Type and Areas

Type:

Bug fix / UI/UX

Areas:

Web UI, CLI, Rust services, developer tools

## Motivation / Impact

Token usage statistics previously used inconsistent units and precision across different product surfaces.

This change provides consistent formatting everywhere:

- `1,234` tokens → `1.23K`
- `5,396,217` tokens → `5.4M`
- `999,999` tokens → `1M`
- `95.679%` cache hit rate → `95.67%`

The underlying usage calculations and data structures are unchanged.

## Verification

- `pnpm --dir src/web-ui run test:run src/shared/utils/tokenUsageFormatting.test.ts src/flow_chat/components/usage/usageReportUtils.test.ts src/flow_chat/components/usage/SessionUsageComponents.test.tsx src/flow_chat/utils/tokenUsageDisplay.test.ts src/infrastructure/config/components/UsageStatisticsConfig.test.tsx`
  - Passed: 5 test files, 76 tests.
- `cargo test -p bitfun-services-core --no-default-features --features local-storage --lib session_usage::render::tests`
  - Passed: 7 tests.
- `cargo test -p bitfun-cli status_tests`
  - Passed: 5 tests.
- `pnpm run type-check:web`
  - Passed.
- `git diff --check`
  - Passed.

## Reviewer Notes

- Token counts use normal rounding with at most two decimal places.
- Cache hit rates are clamped to the valid range and rounded down to exactly two decimal places.
- No API, protocol, persisted-data, or migration changes are included.
- No new user-facing copy or locale keys were introduced.
- Verification covered local Web UI and CLI rendering; remote scenarios were not exercised separately because the change only affects shared presentation formatting.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.