### PR TITLE
feat(miniapp): unify installed and market apps

### DIFF
--- a/src/web-ui/src/app/scenes/miniapps/MiniAppGalleryScene.scss
+++ b/src/web-ui/src/app/scenes/miniapps/MiniAppGalleryScene.scss
@@ -1,4 +1,4 @@
-$miniapp-gallery-content-inline-size: min(calc(100% - var(--bf-space-6)), 680px);
+$miniapp-gallery-content-inline-size: min(calc(100% - var(--bf-space-6)), 880px);
 
 .miniapp-gallery-scene {
   display: flex;
@@ -37,9 +37,8 @@ $miniapp-gallery-content-inline-size: min(calc(100% - var(--bf-space-6)), 680px)
   }
 }
 
-// All three panes share the Installed view's compact content rail. Keep this
-// geometry at the scene owner so Market and Submissions cannot drift back to
-// GalleryLayout's wider default independently.
+// Both panes share one compact content rail. Keep this geometry at the scene
+// owner so the library and submissions cannot drift independently.
 .miniapp-gallery-pane {
   background: var(--bf-color-surface-scene);
 

--- a/src/web-ui/src/app/scenes/miniapps/MiniAppGalleryScene.tsx
+++ b/src/web-ui/src/app/scenes/miniapps/MiniAppGalleryScene.tsx
@@ -4,19 +4,18 @@
  */
 import React, { Suspense, lazy, useState } from 'react';
 
-import { Icon, SegmentedControl } from '@bitfun/ui';
+import { SegmentedControl } from '@bitfun/ui';
 import { useI18n } from '@/infrastructure/i18n';
 import './MiniAppGalleryScene.scss';
 
-const MiniAppGalleryView = lazy(() => import('./views/MiniAppGalleryView'));
-const MiniAppMarketView = lazy(() => import('./views/MiniAppMarketView'));
+const MiniAppLibraryView = lazy(() => import('./views/MiniAppLibraryView'));
 const MiniAppSubmissionsView = lazy(() => import('./views/MiniAppSubmissionsView'));
 
-type MiniAppGalleryTab = 'installed' | 'market' | 'submissions';
+type MiniAppGalleryTab = 'apps' | 'submissions';
 
 const MiniAppGalleryScene: React.FC = () => {
   const { t } = useI18n('scenes/miniapp');
-  const [activeTab, setActiveTab] = useState<MiniAppGalleryTab>('installed');
+  const [activeTab, setActiveTab] = useState<MiniAppGalleryTab>('apps');
   const tabs = (
     <SegmentedControl
       aria-label={t('title')}
@@ -24,18 +23,11 @@ const MiniAppGalleryScene: React.FC = () => {
       distribution="fill"
       options={[
         {
-          value: 'installed',
-          icon: <Icon name="arrow-down" size="sm" />,
-          label: t('market.tabs.installed'),
-        },
-        {
-          value: 'market',
-          icon: <Icon name="store" size="sm" />,
-          label: t('market.tabs.market'),
+          value: 'apps',
+          label: t('market.tabs.apps'),
         },
         {
           value: 'submissions',
-          icon: <Icon name="upload" size="sm" />,
           label: t('market.tabs.submissions'),
         },
       ]}
@@ -49,8 +41,7 @@ const MiniAppGalleryScene: React.FC = () => {
     <div className="miniapp-gallery-scene" data-bf-scene="miniapp-gallery" data-bf-part="root">
       <div className="miniapp-gallery-scene__content">
         <Suspense fallback={null}>
-          {activeTab === 'installed' && <MiniAppGalleryView tabs={tabs} />}
-          {activeTab === 'market' && <MiniAppMarketView tabs={tabs} />}
+          {activeTab === 'apps' && <MiniAppLibraryView tabs={tabs} />}
           {activeTab === 'submissions' && <MiniAppSubmissionsView tabs={tabs} />}
         </Suspense>
       </div>

--- a/src/web-ui/src/app/scenes/miniapps/components/MiniAppCard.presentation.test.ts
+++ b/src/web-ui/src/app/scenes/miniapps/components/MiniAppCard.presentation.test.ts
@@ -13,48 +13,45 @@ function readRelative(filename: string): string {
 const cardCss = compile(fileURLToPath(new URL('./MiniAppCard.scss', import.meta.url))).css;
 
 describe('Mini App card presentation', () => {
-  it('keeps destructive actions in details and places counts beside section titles', () => {
+  it('keeps destructive actions in details and uses one unified app count', () => {
+    const library = readRelative('../views/MiniAppLibraryView.tsx');
+
     expect(readRelative('./MiniAppCard.tsx')).not.toContain('name="delete"');
-    expect(readRelative('../views/MiniAppGalleryView.tsx')).toContain('titleAdornment={<NumberBadge value={activeApps.length} />}');
-    expect(readRelative('../views/MiniAppGalleryView.tsx')).toContain('titleAdornment={<NumberBadge value={filtered.length} />}');
-    expect(readRelative('../views/MiniAppGalleryView.tsx')).not.toContain('gallery-zone-badge');
+    expect(library).toContain('titleAdornment={<NumberBadge value={libraryItems.length} />}');
+    expect(library).not.toContain('miniapp-running-zone');
+    expect(library).not.toContain('gallery-zone-badge');
   });
 
-  it('uses shared controls and card anatomy across Mini App surfaces', () => {
-    const gallery = readRelative('../views/MiniAppGalleryView.tsx');
-    const market = readRelative('../views/MiniAppMarketView.tsx');
+  it('merges installed and marketplace apps into the shared library surface', () => {
+    const library = readRelative('../views/MiniAppLibraryView.tsx');
     const submissions = readRelative('../views/MiniAppSubmissionsView.tsx');
     const tabs = readRelative('../MiniAppGalleryScene.tsx');
 
-    expect(gallery).toContain('<SegmentedControl');
-    expect(gallery).toContain('variant="pills"');
-    expect(gallery).not.toContain('gallery-cat-chip');
+    expect(library).toContain('<SegmentedControl');
+    expect(library).toContain('variant="pills"');
+    expect(library).toContain('buildMiniAppLibraryItems(marketItems, apps, marketOrigins)');
+    expect(library).toContain('<MiniAppLibraryRow');
+    expect(library).not.toContain('<MiniAppCard');
     expect(tabs).toContain('distribution="fill"');
     expect(tabs).toContain('size="md"');
-    expect(market).toContain('<SegmentedControl');
-    expect(market).toContain('<Card');
-    expect(market).toContain('<CardMedia');
-    expect(market).toContain('<CardBody');
-    expect(market).toContain('<IconButton');
-    expect(market).not.toContain('gallery-cat-chip');
+    expect(tabs).toContain("type MiniAppGalleryTab = 'apps' | 'submissions';");
+    expect(tabs).not.toContain('MiniAppMarketView');
     expect(submissions).toContain('<Disclosure');
     expect(submissions).toContain('<IconButton');
     expect(submissions).not.toContain('miniapp-submissions__advanced-toggle');
   });
 
-  it('keeps every gallery pane on the same compact content rail', () => {
+  it('keeps both gallery panes on the same content rail', () => {
     const sceneStyles = readRelative('../MiniAppGalleryScene.scss');
-    const gallery = readRelative('../views/MiniAppGalleryView.tsx');
-    const market = readRelative('../views/MiniAppMarketView.tsx');
+    const gallery = readRelative('../views/MiniAppLibraryView.tsx');
     const submissions = readRelative('../views/MiniAppSubmissionsView.tsx');
     const submissionStyles = readRelative('../views/MiniAppSubmissionsView.scss');
 
     expect(gallery).toContain('className="miniapp-gallery-pane miniapp-gallery"');
-    expect(market).toContain('className="miniapp-gallery-pane miniapp-market-native"');
     expect(submissions.match(/className="miniapp-gallery-pane miniapp-submissions"/g)).toHaveLength(3);
     expect(submissions.match(/<GalleryPageHeader/g)).toHaveLength(3);
     expect(sceneStyles).toContain(
-      '$miniapp-gallery-content-inline-size: min(calc(100% - var(--bf-space-6)), 680px);',
+      '$miniapp-gallery-content-inline-size: min(calc(100% - var(--bf-space-6)), 880px);',
     );
     expect(sceneStyles).toMatch(
       /\.miniapp-gallery-pane \{[\s\S]*?\.gallery-page-header \{[\s\S]*?width: \$miniapp-gallery-content-inline-size;/,
@@ -81,39 +78,41 @@ describe('Mini App card presentation', () => {
     expect(stylesheet).toMatch(/&__footer \{[\s\S]*?margin-top: auto;/);
   });
 
-  it('packs cards densely and keeps skeleton geometry aligned', () => {
-    const source = readRelative('../views/MiniAppGalleryView.tsx');
-    const stylesheet = readRelative('../views/MiniAppGalleryView.scss');
+  it('renders one full-width app per row and keeps skeleton geometry aligned', () => {
+    const source = readRelative('../views/MiniAppLibraryView.tsx');
+    const stylesheet = readRelative('../views/MiniAppLibraryView.scss');
     const sceneStyles = readRelative('../MiniAppGalleryScene.scss');
 
-    expect(source).toContain('const MINIAPP_CARD_MIN_WIDTH = 280;');
-    expect(source.match(/minCardWidth=\{MINIAPP_CARD_MIN_WIDTH\}/g)).toHaveLength(3);
-    expect(stylesheet).toMatch(/&__card-grid \{[\s\S]*?grid-template-columns: repeat\(2, minmax\(0, 1fr\)\);[\s\S]*?justify-items: stretch;/);
+    expect(source).toContain('className="miniapp-gallery__list" role="list"');
+    expect(stylesheet).toMatch(/&__list \{[\s\S]*?grid-template-columns: minmax\(0, 1fr\);/);
     expect(stylesheet).toMatch(
-      /&__card-grid\.gallery-grid--skeleton \.gallery-skeleton-card \{[\s\S]*?height: 193px;/,
+      /&__list\.gallery-grid--skeleton \{[\s\S]*?grid-template-columns: minmax\(0, 1fr\);/,
     );
     expect(sceneStyles).toContain('container-name: miniapp-gallery-scene;');
     expect(sceneStyles).toMatch(
       /@container miniapp-gallery-scene \(max-width: 760px\) \{[\s\S]*?\.gallery-page-header \{[\s\S]*?flex-direction: column;/,
     );
-    expect(stylesheet).toMatch(
-      /@container miniapp-gallery-scene \(max-width: 760px\) \{[\s\S]*?grid-template-columns: 1fr;/,
-    );
-    expect(stylesheet).not.toContain('aspect-ratio: 12 / 5;');
+    expect(stylesheet).toContain('@container miniapp-gallery-scene (min-width: 640px)');
+    expect(stylesheet).not.toContain('@container miniapp-gallery-scene (min-width: 520px)');
+    expect(stylesheet).toContain('grid-template-columns: minmax(0, 224px) minmax(0, 1fr);');
   });
 
-  it('uses dedicated artwork for built-in catalog cards and keeps a glyph fallback', () => {
-    const card = readRelative('./MiniAppCard.tsx');
-    const icons = readRelative('../utils/miniAppIcons.tsx');
+  it('crops marketplace images into one fixed showcase slot with a neutral fallback', () => {
+    const row = readRelative('./MiniAppLibraryRow.tsx');
+    const library = readRelative('../views/MiniAppLibraryView.tsx');
+    const stylesheet = readRelative('../views/MiniAppLibraryView.scss');
 
-    expect(card).toContain('getMiniAppIconAsset(app.id)');
-    expect(card).toContain('className="miniapp-card__icon-image"');
-    expect(card).toContain("renderMiniAppIcon(app.icon || 'box', 40)");
-    expect(icons).toContain("'builtin-ppt-live': pptLiveIcon");
-    expect(icons).toContain("'builtin-coding-selfie': codingFootprintIcon");
-    expect(icons).toContain("'builtin-regex-playground': regexPlaygroundIcon");
-    expect(icons).toContain("'builtin-daily-divination': dailyDivinationIcon");
-    expect(icons).toContain("'builtin-gomoku': gomokuIcon");
+    expect(library).toContain('showcaseUrl={item.listing?.screenshotUrls[0]}');
+    expect(row).toContain('marketImageSrcSet(showcaseUrl)');
+    expect(row).toContain('<GalleryHorizontalEnd');
+    expect(row).not.toContain('renderMiniAppIcon');
+    expect(row).not.toContain('getMiniAppIconGradient');
+    expect(stylesheet).toMatch(
+      /&__showcase \{[\s\S]*?aspect-ratio: 16 \/ 9;[\s\S]*?overflow: hidden;/,
+    );
+    expect(stylesheet).toMatch(
+      /&__showcase[\s\S]*?img \{[\s\S]*?position: absolute;[\s\S]*?inset: 0;[\s\S]*?width: 100%;[\s\S]*?height: 100%;[\s\S]*?object-fit: cover;[\s\S]*?object-position: center;/,
+    );
   });
 
   it('keeps tags and the circular run action on one footer row', () => {
@@ -149,13 +148,15 @@ describe('Mini App card presentation', () => {
     expect(source).toContain('localizedTags.slice(0, 4)');
   });
 
-  it('bounds market cards while preserving the media preview ratio', () => {
-    const source = readRelative('../views/MiniAppMarketView.tsx');
-    const stylesheet = readRelative('../views/MiniAppMarketView.scss');
+  it('keeps App Store actions inline and never auto-opens after install or update', () => {
+    const source = readRelative('../views/MiniAppLibraryView.tsx');
+    const row = readRelative('./MiniAppLibraryRow.tsx');
 
-    expect(source.match(/className="miniapp-market-native__card-grid"/g)).toHaveLength(2);
-    expect(stylesheet).toContain('max-width: 360px;');
-    expect(stylesheet).toMatch(/&__card-grid \{\s+justify-items: center;/);
-    expect(stylesheet).toMatch(/&__visual \{[\s\S]*?aspect-ratio: 16 \/ 9;/);
+    expect(source).toContain("item.action === 'get'");
+    expect(source).toContain("item.action === 'update'");
+    expect(source).toContain("item.action === 'open'");
+    expect(source).toContain('setMarketOrigin(result.app.id, result.origin);');
+    expect(source).not.toContain('openInstalledApp(result.app.id)');
+    expect(row).toContain("variant={action === 'open' ? 'outline' : 'primary'}");
   });
 });

--- a/src/web-ui/src/app/scenes/miniapps/components/MiniAppLibraryRow.tsx
+++ b/src/web-ui/src/app/scenes/miniapps/components/MiniAppLibraryRow.tsx
@@ -1,0 +1,156 @@
+import { Button, StatusPill, type StatusPillTone } from '@bitfun/ui';
+import { GalleryHorizontalEnd } from 'lucide-react';
+import React, { useEffect, useState } from 'react';
+
+import {
+  marketImageSrcSet,
+  marketImageUrl,
+  retryOriginalMarketImage,
+} from '@/infrastructure/api/service-api/MarketImage';
+import type { MiniAppLibraryAction } from '../views/miniAppLibraryItems';
+
+interface MiniAppLibraryStatus {
+  label: string;
+  tone: StatusPillTone;
+}
+
+interface MiniAppLibraryRowProps {
+  action: MiniAppLibraryAction;
+  actionDisabled?: boolean;
+  actionLabel: string;
+  actionTitle?: string;
+  busy?: boolean;
+  category: string;
+  description: string;
+  detailsLabel: string;
+  meta?: string;
+  name: string;
+  onOpenDetails: () => void;
+  onPrimaryAction: () => void;
+  showcaseAlt: string;
+  showcaseFallbackLabel: string;
+  showcaseUrl?: string;
+  statuses: MiniAppLibraryStatus[];
+  version: string;
+}
+
+const MiniAppLibraryRow: React.FC<MiniAppLibraryRowProps> = ({
+  action,
+  actionDisabled = false,
+  actionLabel,
+  actionTitle,
+  busy = false,
+  category,
+  description,
+  detailsLabel,
+  meta,
+  name,
+  onOpenDetails,
+  onPrimaryAction,
+  showcaseAlt,
+  showcaseFallbackLabel,
+  showcaseUrl,
+  statuses,
+  version,
+}) => {
+  const [showcaseUnavailable, setShowcaseUnavailable] = useState(!showcaseUrl);
+
+  useEffect(() => {
+    setShowcaseUnavailable(!showcaseUrl);
+  }, [showcaseUrl]);
+
+  return (
+    <article
+      className="miniapp-library-row"
+      role="listitem"
+      data-action={action}
+      data-bf-component="miniapp-gallery-view"
+      data-bf-part="item"
+    >
+      <button
+        type="button"
+        className="miniapp-library-row__details"
+        aria-label={detailsLabel}
+        onClick={onOpenDetails}
+      >
+        <span
+          className="miniapp-library-row__showcase"
+          data-bf-component="miniapp-gallery-view"
+          data-bf-part="showcase"
+        >
+          {!showcaseUnavailable && showcaseUrl ? (
+            <img
+              src={marketImageUrl(showcaseUrl, 'compact-v1')}
+              srcSet={marketImageSrcSet(showcaseUrl)}
+              sizes="(min-width: 64rem) 224px, 100vw"
+              width={640}
+              height={360}
+              alt={showcaseAlt}
+              loading="lazy"
+              decoding="async"
+              onError={(event) => {
+                if (!retryOriginalMarketImage(event.currentTarget, showcaseUrl)) {
+                  setShowcaseUnavailable(true);
+                }
+              }}
+            />
+          ) : (
+            <span
+              className="miniapp-library-row__showcase-fallback"
+              aria-label={showcaseFallbackLabel}
+              role="img"
+            >
+              <GalleryHorizontalEnd size={34} strokeWidth={1.35} aria-hidden="true" />
+            </span>
+          )}
+        </span>
+
+        <span
+          className="miniapp-library-row__summary"
+          data-bf-component="miniapp-gallery-view"
+          data-bf-part="summary"
+        >
+          <span className="miniapp-library-row__status-rail">
+            <span className="miniapp-library-row__category">{category}</span>
+            {statuses.map((status) => (
+              <StatusPill key={`${status.tone}:${status.label}`} tone={status.tone}>
+                {status.label}
+              </StatusPill>
+            ))}
+          </span>
+          <strong className="miniapp-library-row__name">{name}</strong>
+          <span className="miniapp-library-row__description">{description}</span>
+          <span
+            className="miniapp-library-row__meta"
+            data-bf-component="miniapp-gallery-view"
+            data-bf-part="meta"
+          >
+            <span>{version}</span>
+            {meta ? <span>{meta}</span> : null}
+          </span>
+        </span>
+      </button>
+
+      <div
+        className="miniapp-library-row__actions"
+        data-bf-component="miniapp-gallery-view"
+        data-bf-part="actions"
+      >
+        <Button
+          className="miniapp-library-row__primary"
+          size="sm"
+          variant={action === 'open' ? 'outline' : 'primary'}
+          disabled={actionDisabled}
+          loading={busy}
+          title={actionTitle}
+          onClick={onPrimaryAction}
+        >
+          {actionLabel}
+        </Button>
+      </div>
+    </article>
+  );
+};
+
+export default MiniAppLibraryRow;
+export type { MiniAppLibraryRowProps, MiniAppLibraryStatus };

--- a/src/web-ui/src/app/scenes/miniapps/views/MiniAppGalleryView.appearance.ts
+++ b/src/web-ui/src/app/scenes/miniapps/views/MiniAppGalleryView.appearance.ts
@@ -3,6 +3,8 @@ export const miniAppGalleryViewAppearanceDescriptor: AppearanceSurfaceDescriptor
   id: 'miniapp-gallery-view',
   parts: [
     { id: 'root' }, { id: 'content' }, { id: 'categoryFilters' },
-    { id: 'categoryFilter' },
+    { id: 'categoryFilter' }, { id: 'item' }, { id: 'showcase' },
+    { id: 'summary' }, { id: 'meta' }, { id: 'actions' },
+    { id: 'error' }, { id: 'detail' },
   ],
 };

--- a/src/web-ui/src/app/scenes/miniapps/views/MiniAppLibraryView.scss
+++ b/src/web-ui/src/app/scenes/miniapps/views/MiniAppLibraryView.scss
@@ -1,0 +1,444 @@
+/* Hallmark · genre: modern-minimal · macrostructure: Workbench · tone: utilitarian · anchor hue: inherited · pre-emit critique: P5 H5 E5 S5 R5 V5 · contrast: pass · slop: pass · responsive: pass */
+.miniapp-gallery {
+  &__header-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--bf-space-2);
+    min-width: 0;
+
+    > :first-child {
+      width: min(260px, 28vw);
+    }
+  }
+
+  &__import-anchor {
+    display: inline-flex;
+  }
+
+  &__sort {
+    min-width: 132px;
+  }
+
+  &__categories {
+    width: 100%;
+    max-width: 100%;
+    overflow-x: auto;
+    scrollbar-width: thin;
+
+    > [data-bf-part='segment'] {
+      flex: 0 0 auto;
+      white-space: nowrap;
+    }
+  }
+
+  &__list {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: var(--bf-space-3);
+    min-width: 0;
+  }
+
+  &__list.gallery-grid--skeleton {
+    grid-template-columns: minmax(0, 1fr);
+
+    .gallery-skeleton-card {
+      width: 100%;
+      min-height: 140px;
+      border-radius: var(--bf-radius-xl);
+    }
+  }
+
+  &__list--continuation {
+    margin-top: var(--bf-space-3);
+  }
+
+  &__load-more {
+    display: flex;
+    justify-content: center;
+    padding-top: var(--bf-space-4);
+  }
+
+  &__market-error {
+    display: flex;
+    align-items: center;
+    gap: var(--bf-space-2);
+    min-height: var(--bf-control-height-md);
+    padding: var(--bf-space-2) var(--bf-space-3);
+    border: 1px solid var(--bf-color-status-warning-border);
+    border-radius: var(--bf-radius-lg);
+    background: var(--bf-color-status-warning-surface);
+    color: var(--bf-color-status-warning-content);
+    font-family: var(--bf-type-body-sm-font-family);
+    font-size: var(--bf-type-body-sm-font-size);
+    font-weight: var(--bf-type-body-sm-font-weight);
+    line-height: var(--bf-type-body-sm-line-height);
+    letter-spacing: var(--bf-type-body-sm-letter-spacing);
+
+    > span {
+      min-width: 0;
+      flex: 1;
+    }
+  }
+}
+
+.miniapp-library-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid var(--bf-color-border-subtle);
+  border-radius: var(--bf-radius-xl);
+  background: var(--bf-color-surface-raised);
+  transition:
+    background-color var(--bf-motion-duration-fast) var(--bf-motion-easing-standard),
+    border-color var(--bf-motion-duration-fast) var(--bf-motion-easing-standard);
+
+  &:has(&__details:focus-visible) {
+    outline: var(--bf-focus-width) solid var(--bf-color-focus-ring);
+    outline-offset: var(--bf-focus-offset);
+  }
+
+  &__details {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    min-width: 0;
+    padding: 0;
+    border: 0;
+    outline: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    text-align: start;
+    cursor: pointer;
+  }
+
+  &__showcase {
+    position: relative;
+    display: grid;
+    place-items: center;
+    min-width: 0;
+    aspect-ratio: 16 / 9;
+    overflow: hidden;
+    border-block-end: 1px solid var(--bf-color-border-subtle);
+    background: var(--bf-color-surface-tertiary);
+    color: var(--bf-color-content-muted);
+
+    img {
+      position: absolute;
+      inset: 0;
+      display: block;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      object-position: center;
+    }
+  }
+
+  &__showcase-fallback {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+  }
+
+  &__summary {
+    display: grid;
+    align-content: center;
+    gap: var(--bf-space-1);
+    min-width: 0;
+    padding: var(--bf-space-2) var(--bf-space-4);
+  }
+
+  &__status-rail {
+    display: flex;
+    align-items: center;
+    gap: var(--bf-space-2);
+    min-width: 0;
+    overflow-x: auto;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+
+  &__category {
+    flex: 0 0 auto;
+    color: var(--bf-color-content-muted);
+    font-family: var(--bf-type-meta-font-family);
+    font-size: var(--bf-type-meta-font-size);
+    font-weight: var(--bf-type-meta-font-weight);
+    line-height: var(--bf-type-meta-line-height);
+    letter-spacing: var(--bf-type-meta-letter-spacing);
+  }
+
+  &__name {
+    min-width: 0;
+    overflow: hidden;
+    color: var(--bf-color-content-primary);
+    font-family: var(--bf-type-heading-card-font-family);
+    font-size: var(--bf-type-heading-card-font-size);
+    font-weight: var(--bf-type-heading-card-font-weight);
+    line-height: var(--bf-type-heading-card-line-height);
+    letter-spacing: var(--bf-type-heading-card-letter-spacing);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__description {
+    display: -webkit-box;
+    min-width: 0;
+    overflow: hidden;
+    color: var(--bf-color-content-secondary);
+    font-family: var(--bf-type-support-font-family);
+    font-size: var(--bf-type-support-font-size);
+    font-weight: var(--bf-type-support-font-weight);
+    line-height: var(--bf-type-support-line-height);
+    letter-spacing: var(--bf-type-support-letter-spacing);
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+  }
+
+  &__meta {
+    display: flex;
+    align-items: center;
+    gap: var(--bf-space-2);
+    min-width: 0;
+    overflow: hidden;
+    color: var(--bf-color-content-muted);
+    font-family: var(--bf-type-meta-font-family);
+    font-size: var(--bf-type-meta-font-size);
+    font-weight: var(--bf-type-meta-font-weight);
+    font-variant-numeric: tabular-nums;
+    line-height: var(--bf-type-meta-line-height);
+    letter-spacing: var(--bf-type-meta-letter-spacing);
+
+    span {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    span:first-child {
+      flex: 0 0 auto;
+    }
+
+    span:last-child {
+      min-width: 0;
+    }
+
+    span + span::before {
+      content: '·';
+      margin-inline-end: var(--bf-space-2);
+    }
+  }
+
+  &__actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    padding: 0 var(--bf-space-4) var(--bf-space-4);
+  }
+
+  &__primary {
+    min-width: 78px;
+    white-space: nowrap;
+  }
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .miniapp-library-row:hover {
+    border-color: var(--bf-color-border-default);
+    background: var(--bf-color-action-quiet-hover);
+  }
+}
+
+@container miniapp-gallery-scene (min-width: 640px) {
+  .miniapp-library-row {
+    grid-template-columns: minmax(0, 1fr) auto;
+
+    &__details {
+      grid-template-columns: minmax(0, 224px) minmax(0, 1fr);
+    }
+
+    &__showcase {
+      border-block-end: 0;
+      border-inline-end: 1px solid var(--bf-color-border-subtle);
+    }
+
+    &__actions {
+      padding: var(--bf-space-2) var(--bf-space-4);
+    }
+  }
+}
+
+@container miniapp-gallery-scene (max-width: 760px) {
+  .miniapp-gallery {
+    &__header-actions {
+      width: 100%;
+      flex-wrap: wrap;
+
+      > :first-child {
+        width: min(100%, 280px);
+        flex: 1 1 220px;
+      }
+    }
+
+    &__sort {
+      min-width: min(100%, 160px);
+    }
+  }
+}
+
+.miniapp-market-detail {
+  display: grid;
+  gap: var(--bf-space-4);
+
+  &__loading {
+    display: flex;
+    min-height: 240px;
+    align-items: center;
+    justify-content: center;
+    gap: var(--bf-space-2);
+    color: var(--bf-color-content-muted);
+    font-family: var(--bf-type-body-sm-font-family);
+    font-size: var(--bf-type-body-sm-font-size);
+  }
+
+  section {
+    display: grid;
+    gap: var(--bf-space-2);
+
+    h4,
+    p,
+    ul {
+      margin: 0;
+    }
+
+    h4 {
+      color: var(--bf-color-content-primary);
+      font-family: var(--bf-type-heading-card-font-family);
+      font-size: var(--bf-type-heading-card-font-size);
+      font-weight: var(--bf-type-heading-card-font-weight);
+      line-height: var(--bf-type-heading-card-line-height);
+      letter-spacing: var(--bf-type-heading-card-letter-spacing);
+    }
+
+    p,
+    li {
+      color: var(--bf-color-content-secondary);
+      font-family: var(--bf-type-body-sm-font-family);
+      font-size: var(--bf-type-body-sm-font-size);
+      font-weight: var(--bf-type-body-sm-font-weight);
+      line-height: var(--bf-type-body-sm-line-height);
+      letter-spacing: var(--bf-type-body-sm-letter-spacing);
+    }
+  }
+
+  &__installed-state {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--bf-space-1);
+    color: var(--bf-color-status-success-content);
+    font-family: var(--bf-type-label-md-font-family);
+    font-size: var(--bf-type-label-md-font-size);
+    font-weight: var(--bf-type-label-md-font-weight);
+    line-height: var(--bf-type-label-md-line-height);
+    letter-spacing: var(--bf-type-label-md-letter-spacing);
+    white-space: nowrap;
+  }
+
+  &__screenshots {
+    display: flex;
+    gap: var(--bf-space-2);
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+
+    img {
+      width: min(360px, 80%);
+      height: auto;
+      aspect-ratio: 16 / 9;
+      flex: 0 0 auto;
+      border: 1px solid var(--bf-color-border-subtle);
+      border-radius: var(--bf-radius-lg);
+      object-fit: cover;
+      scroll-snap-align: start;
+    }
+  }
+
+  &__warning {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--bf-space-2);
+    padding: var(--bf-space-3);
+    border: 1px solid var(--bf-color-status-warning-border);
+    border-radius: var(--bf-radius-lg);
+    background: var(--bf-color-status-warning-surface);
+    color: var(--bf-color-status-warning-content);
+    font-family: var(--bf-type-body-sm-font-family);
+    font-size: var(--bf-type-body-sm-font-size);
+    font-weight: var(--bf-type-body-sm-font-weight);
+    line-height: var(--bf-type-body-sm-line-height);
+    letter-spacing: var(--bf-type-body-sm-letter-spacing);
+  }
+
+  &__rating {
+    display: flex;
+    align-items: center;
+    gap: var(--bf-space-1);
+
+    &-action {
+      color: var(--bf-color-status-warning-content);
+    }
+
+    span {
+      margin-inline-start: var(--bf-space-2);
+      color: var(--bf-color-content-muted);
+      font-family: var(--bf-type-meta-font-family);
+      font-size: var(--bf-type-meta-font-size);
+      font-weight: var(--bf-type-meta-font-weight);
+      font-variant-numeric: tabular-nums;
+      line-height: var(--bf-type-meta-line-height);
+      letter-spacing: var(--bf-type-meta-letter-spacing);
+    }
+  }
+
+  &__releases {
+    display: grid;
+    gap: var(--bf-space-2);
+
+    > div {
+      display: grid;
+      grid-template-columns: 72px minmax(0, 1fr) auto;
+      align-items: center;
+      padding: var(--bf-space-2) var(--bf-space-3);
+      border: 1px solid var(--bf-color-border-subtle);
+      border-radius: var(--bf-radius-base);
+      color: var(--bf-color-content-secondary);
+      font-family: var(--bf-type-body-sm-font-family);
+      font-size: var(--bf-type-body-sm-font-size);
+      font-weight: var(--bf-type-body-sm-font-weight);
+      font-variant-numeric: tabular-nums;
+      line-height: var(--bf-type-body-sm-line-height);
+      letter-spacing: var(--bf-type-body-sm-letter-spacing);
+    }
+  }
+
+  &__releases-toggle {
+    margin-top: var(--bf-space-2);
+    color: var(--bf-color-content-muted);
+  }
+}
+
+/* Positioning-only overrides; the design-system Menu owns the surface look. */
+.miniapp-gallery__import-menu {
+  position: fixed;
+  z-index: var(--bf-layer-popover);
+  min-inline-size: 196px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .miniapp-library-row {
+    transition: none;
+  }
+}

--- a/src/web-ui/src/app/scenes/miniapps/views/MiniAppLibraryView.tsx
+++ b/src/web-ui/src/app/scenes/miniapps/views/MiniAppLibraryView.tsx
@@ -1,0 +1,1271 @@
+import {
+  Button,
+  ConfirmDialog,
+  Icon,
+  IconButton,
+  Menu,
+  MenuItem,
+  NumberBadge,
+  SearchField,
+  SegmentedControl,
+  Select,
+  StatusPill,
+  type SelectOption,
+} from '@bitfun/ui';
+import { open } from '@tauri-apps/plugin-dialog';
+import {
+  AlertTriangle,
+  FolderPlus,
+  Heart,
+  Loader2,
+  PackageCheck,
+  PackagePlus,
+  ShieldCheck,
+} from 'lucide-react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+import {
+  GalleryDetailModal,
+  GalleryEmpty,
+  GalleryLayout,
+  GalleryPageHeader,
+  GallerySkeleton,
+  GalleryZone,
+} from '@/app/components';
+import { useApp } from '@/app/hooks/useApp';
+import { useGallerySceneAutoRefresh } from '@/app/hooks/useGallerySceneAutoRefresh';
+import { useSceneManager } from '@/app/hooks/useSceneManager';
+import { flowChatSessionConfigForCurrentWorkspace } from '@/app/utils/projectSessionWorkspace';
+import { MarketAccountControls } from '@/features/market-account';
+import { flowChatManager } from '@/flow_chat/services/FlowChatManager';
+import type {
+  MiniAppMeta,
+  MiniAppPermissions,
+} from '@/infrastructure/api/service-api/MiniAppAPI';
+import { miniAppAPI } from '@/infrastructure/api/service-api/MiniAppAPI';
+import {
+  miniAppMarketAPI,
+  type MarketInstalledStatus,
+  type MarketListingDetail,
+  type MarketListingSummary,
+  type MarketPackageInspection,
+  type MarketSort,
+} from '@/infrastructure/api/service-api/MiniAppMarketAPI';
+import {
+  marketImageSrcSet,
+  marketImageUrl,
+  retryOriginalMarketImage,
+} from '@/infrastructure/api/service-api/MarketImage';
+import { systemAPI } from '@/infrastructure/api/service-api/SystemAPI';
+import { getAppearanceOverlayHost } from '@/infrastructure/appearance/runtime/AppearanceOverlayHost';
+import { useCurrentWorkspace } from '@/infrastructure/contexts/WorkspaceContext';
+import { useI18n } from '@/infrastructure/i18n';
+import { useMarketAccount } from '@/infrastructure/market-account';
+import { useNotification } from '@/shared/notification-system';
+import { isRemoteWorkspace } from '@/shared/types';
+import { isImeOwnedKeyboardEvent } from '@/shared/utils/ime';
+import { createLogger } from '@/shared/utils/logger';
+import { useAnchoredPopoverPosition } from '@/shared/utils/useAnchoredPopoverPosition';
+import MiniAppDetailModal from '../components/MiniAppDetailModal';
+import MiniAppLibraryRow, {
+  type MiniAppLibraryStatus,
+} from '../components/MiniAppLibraryRow';
+import { useMiniAppActivity } from '../hooks/useMiniAppActivity';
+import { getMiniAppSceneId, stopMiniAppActivity } from '../miniAppActivity';
+import { useMiniAppStore } from '../miniAppStore';
+import { loadInstalledMarketOrigins } from '../utils/loadInstalledMarketOrigins';
+import { pickLocalizedString, pickLocalizedTags } from '../utils/pickLocalizedString';
+import { buildMiniAppLibraryItems, type MiniAppLibraryItem } from './miniAppLibraryItems';
+import { buildReleaseHistory } from './miniAppReleaseHistory';
+import './MiniAppLibraryView.scss';
+
+const log = createLogger('MiniAppLibraryView');
+const CATEGORIES = [
+  'all',
+  'developer',
+  'productivity',
+  'data',
+  'creative',
+  'education',
+  'utilities',
+  'entertainment',
+  'other',
+] as const;
+
+type MiniAppCategory = (typeof CATEGORIES)[number];
+type Translate = (key: string, params?: Record<string, unknown>) => string;
+
+interface MiniAppLibraryViewProps {
+  tabs?: React.ReactNode;
+}
+
+const MiniAppLibraryView: React.FC<MiniAppLibraryViewProps> = ({ tabs }) => {
+  const apps = useMiniAppStore((state) => state.apps);
+  const loading = useMiniAppStore((state) => state.loading);
+  const customizingAppIds = useMiniAppStore((state) => state.customizingAppIds);
+  const marketOrigins = useMiniAppStore((state) => state.marketOrigins);
+  const setApps = useMiniAppStore((state) => state.setApps);
+  const upsertApp = useMiniAppStore((state) => state.upsertApp);
+  const setLoading = useMiniAppStore((state) => state.setLoading);
+  const setMarketOrigin = useMiniAppStore((state) => state.setMarketOrigin);
+  const setMarketOrigins = useMiniAppStore((state) => state.setMarketOrigins);
+  const setRunningWorkerIds = useMiniAppStore((state) => state.setRunningWorkerIds);
+  const markWorkerStopped = useMiniAppStore((state) => state.markWorkerStopped);
+  const { workspace, workspacePath } = useCurrentWorkspace();
+  const notification = useNotification();
+  const { switchLeftPanelTab } = useApp();
+  const { openScene, activateScene, closeScene, openTabs } = useSceneManager();
+  const { t, formatNumber, currentLanguage } = useI18n('scenes/miniapp');
+  const miniAppActivities = useMiniAppActivity();
+  const { me } = useMarketAccount();
+
+  const [query, setQuery] = useState('');
+  const [category, setCategory] = useState<MiniAppCategory>('all');
+  const [sort, setSort] = useState<MarketSort>('newest');
+  const [marketItems, setMarketItems] = useState<MarketListingSummary[]>([]);
+  const [nextCursor, setNextCursor] = useState<string>();
+  const [catalogLoading, setCatalogLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [catalogError, setCatalogError] = useState<string>();
+  const [detail, setDetail] = useState<MarketListingDetail>();
+  const [detailOpen, setDetailOpen] = useState(false);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [installed, setInstalled] = useState<MarketInstalledStatus | null>(null);
+  const [loginOpen, setLoginOpen] = useState(false);
+  const [detailActionBusy, setDetailActionBusy] = useState(false);
+  const [busyListingId, setBusyListingId] = useState<string>();
+  const [installPrompt, setInstallPrompt] = useState(false);
+  const [releasesExpanded, setReleasesExpanded] = useState(false);
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+  const [selectedApp, setSelectedApp] = useState<MiniAppMeta | null>(null);
+  const [pendingPackage, setPendingPackage] = useState<{
+    path: string;
+    inspection: MarketPackageInspection;
+  } | null>(null);
+  const [importMenuOpen, setImportMenuOpen] = useState(false);
+  const [creatingWithCreative, setCreatingWithCreative] = useState(false);
+  const importTriggerRef = useRef<HTMLButtonElement>(null);
+  const importMenuRef = useRef<HTMLDivElement>(null);
+  const catalogRequestRef = useRef(0);
+  const detailRequestRef = useRef(0);
+
+  const importMenuLayout = useAnchoredPopoverPosition({
+    open: importMenuOpen,
+    anchorRef: importTriggerRef,
+    popoverRef: importMenuRef,
+    preferredPlacement: 'bottom',
+    alignment: 'end',
+    gap: 6,
+    layoutRevision: currentLanguage,
+  });
+
+  const closeImportMenu = useCallback(() => setImportMenuOpen(false), []);
+
+  useEffect(() => {
+    if (!importMenuOpen) return;
+
+    const handlePointerDown = (event: MouseEvent) => {
+      const target = event.target as Node | null;
+      if (
+        target
+        && (importTriggerRef.current?.contains(target) || importMenuRef.current?.contains(target))
+      ) {
+        return;
+      }
+      closeImportMenu();
+    };
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape' || isImeOwnedKeyboardEvent(event)) return;
+      closeImportMenu();
+      requestAnimationFrame(() => importTriggerRef.current?.focus());
+    };
+
+    document.addEventListener('mousedown', handlePointerDown);
+    document.addEventListener('keydown', handleEscape, true);
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown);
+      document.removeEventListener('keydown', handleEscape, true);
+    };
+  }, [closeImportMenu, importMenuOpen]);
+
+  const openTabIds = useMemo(() => new Set(openTabs.map((tab) => tab.id)), [openTabs]);
+  const activityById = useMemo(
+    () => new Map(miniAppActivities.map((activity) => [activity.app.id, activity])),
+    [miniAppActivities],
+  );
+  const activeIdSet = useMemo(() => new Set(activityById.keys()), [activityById]);
+  const customizingIdSet = useMemo(() => new Set(customizingAppIds), [customizingAppIds]);
+
+  const handleOpenApp = useCallback((appId: string) => {
+    setSelectedApp(null);
+    setDetailOpen(false);
+    const tabId = getMiniAppSceneId(appId);
+    if (openTabIds.has(tabId)) {
+      activateScene(tabId);
+    } else {
+      openScene(tabId);
+    }
+  }, [activateScene, openScene, openTabIds]);
+
+  const fetchCatalog = useCallback(async (cursor?: string, append = false) => {
+    const requestId = ++catalogRequestRef.current;
+    if (append) setLoadingMore(true);
+    else setCatalogLoading(true);
+    setCatalogError(undefined);
+
+    try {
+      const page = await miniAppMarketAPI.browse({
+        query,
+        category,
+        sort,
+        cursor,
+        limit: 30,
+      });
+      if (requestId !== catalogRequestRef.current) return;
+      setMarketItems((current) => append ? [...current, ...page.items] : page.items);
+      setNextCursor(page.nextCursor);
+    } catch (loadError) {
+      if (requestId !== catalogRequestRef.current) return;
+      log.error('Failed to load MiniApp marketplace catalog', loadError);
+      if (!append) {
+        setMarketItems([]);
+        setNextCursor(undefined);
+      }
+      setCatalogError(String(loadError));
+    } finally {
+      if (requestId === catalogRequestRef.current) {
+        setCatalogLoading(false);
+        setLoadingMore(false);
+      }
+    }
+  }, [category, query, sort]);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      void fetchCatalog(undefined, false);
+    }, 250);
+    return () => window.clearTimeout(timeout);
+  }, [fetchCatalog]);
+
+  const refetchMiniAppLibrary = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [refreshed, running, origins] = await Promise.all([
+        miniAppAPI.listMiniApps(),
+        miniAppAPI.workerListRunning(),
+        loadInstalledMarketOrigins(),
+      ]);
+      setApps(refreshed);
+      setRunningWorkerIds(running);
+      setMarketOrigins(origins);
+      await fetchCatalog(undefined, false);
+    } catch (error) {
+      log.error('Failed to refresh MiniApp library', error);
+    } finally {
+      setLoading(false);
+    }
+  }, [fetchCatalog, setApps, setLoading, setMarketOrigins, setRunningWorkerIds]);
+
+  useGallerySceneAutoRefresh({
+    sceneId: 'miniapps',
+    refetch: refetchMiniAppLibrary,
+  });
+
+  const projectedItems = useMemo(
+    () => buildMiniAppLibraryItems(marketItems, apps, marketOrigins),
+    [apps, marketItems, marketOrigins],
+  );
+  const libraryItems = useMemo(
+    () => projectedItems.filter((item) => matchesLibraryFilter(
+      item,
+      query,
+      category,
+      currentLanguage,
+    )),
+    [category, currentLanguage, projectedItems, query],
+  );
+
+  const handleStopRunning = useCallback(async (appId: string) => {
+    const activity = activityById.get(appId);
+    if (!activity) return;
+
+    try {
+      await stopMiniAppActivity(activity, {
+        stopWorker: (id) => miniAppAPI.workerStop(id),
+        markWorkerStopped,
+        closeScene,
+      });
+    } catch (error) {
+      log.warn('Failed to stop MiniApp worker', { appId, error });
+      notification.error(t('stopFailed', {
+        name: pickLocalizedString(activity.app, currentLanguage, 'name'),
+        error: String(error),
+      }));
+    }
+  }, [activityById, closeScene, currentLanguage, markWorkerStopped, notification, t]);
+
+  const handleDeleteConfirm = async () => {
+    if (!pendingDeleteId) return;
+    const appId = pendingDeleteId;
+    setPendingDeleteId(null);
+    try {
+      await miniAppAPI.deleteMiniApp(appId);
+      if (selectedApp?.id === appId) setSelectedApp(null);
+      setApps(apps.filter((app) => app.id !== appId));
+      markWorkerStopped(appId);
+      const tabId = getMiniAppSceneId(appId);
+      if (openTabIds.has(tabId)) closeScene(tabId);
+    } catch (error) {
+      log.error('Delete failed', error);
+      notification.error(t('market.messages.deleteFailed', { error: String(error) }));
+    }
+  };
+
+  const handleAddFromFolder = async () => {
+    try {
+      const selected = await open({
+        directory: true,
+        multiple: false,
+        title: t('selectFolderTitle'),
+      });
+      const path = Array.isArray(selected) ? selected[0] : selected;
+      if (!path) return;
+
+      setLoading(true);
+      const app = await miniAppAPI.importFromPath(path, workspacePath || undefined);
+      upsertApp(app);
+      handleOpenApp(app.id);
+    } catch (error) {
+      log.error('Import from folder failed', error);
+      notification.error(t('market.import.failed', { error: String(error) }));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const preparePackageImport = useCallback(async (path: string) => {
+    if (!path.toLowerCase().endsWith('.bfminiapp')) return;
+    try {
+      const inspection = await miniAppMarketAPI.inspectPackage(path);
+      setPendingPackage({ path, inspection });
+    } catch (error) {
+      log.error('Inspect MiniApp package failed', error);
+      notification.error(t('market.import.invalid', { error: String(error) }));
+    }
+  }, [notification, t]);
+
+  const handleAddPackage = async () => {
+    const selected = await open({
+      directory: false,
+      multiple: false,
+      title: t('market.import.choose'),
+      filters: [{ name: t('market.import.packageFile'), extensions: ['bfminiapp'] }],
+    });
+    const path = Array.isArray(selected) ? selected[0] : selected;
+    if (path) await preparePackageImport(path);
+  };
+
+  useEffect(() => {
+    let stop: (() => void) | undefined;
+    let cancelled = false;
+    void import('@tauri-apps/api/webview')
+      .then(({ getCurrentWebview }) => getCurrentWebview().onDragDropEvent((event) => {
+        if (cancelled || event.payload.type !== 'drop') return;
+        const packagePath = event.payload.paths.find((path) => (
+          path.toLowerCase().endsWith('.bfminiapp')
+        ));
+        if (packagePath) void preparePackageImport(packagePath);
+      }))
+      .then((unlisten) => {
+        if (cancelled) unlisten();
+        else stop = unlisten;
+      })
+      .catch((error) => log.warn('MiniApp package drag-and-drop unavailable', error));
+    return () => {
+      cancelled = true;
+      stop?.();
+    };
+  }, [preparePackageImport]);
+
+  const handlePackageImportConfirm = async () => {
+    if (!pendingPackage) return;
+    const selected = pendingPackage;
+    setPendingPackage(null);
+    setLoading(true);
+    try {
+      const app = await miniAppMarketAPI.importPackage(selected.path, true);
+      upsertApp(app);
+      handleOpenApp(app.id);
+    } catch (error) {
+      log.error('Import MiniApp package failed', error);
+      notification.error(t('market.import.failed', { error: String(error) }));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCreateWithCreative = useCallback(async () => {
+    if (creatingWithCreative) return;
+    if (!workspace) {
+      notification.error(t('creationMode.noWorkspace'));
+      return;
+    }
+    if (isRemoteWorkspace(workspace)) {
+      notification.error(t('creationMode.remoteUnsupported'));
+      return;
+    }
+
+    setCreatingWithCreative(true);
+    closeImportMenu();
+    openScene('session');
+    switchLeftPanelTab('sessions');
+    try {
+      await flowChatManager.createChatSession(
+        flowChatSessionConfigForCurrentWorkspace(workspace),
+        'Creative',
+      );
+      notification.success(t('creationMode.started'));
+    } catch (error) {
+      log.error('Failed to start Creative MiniApp session', error);
+      notification.error(t('creationMode.startFailed'));
+    } finally {
+      setCreatingWithCreative(false);
+    }
+  }, [
+    closeImportMenu,
+    creatingWithCreative,
+    notification,
+    openScene,
+    switchLeftPanelTab,
+    t,
+    workspace,
+  ]);
+
+  const fetchMarketDetail = useCallback(async (summary: MarketListingSummary) => {
+    const [loaded, status] = await Promise.all([
+      miniAppMarketAPI.getListing(summary.slug),
+      miniAppMarketAPI.installedStatus(summary.listingId),
+    ]);
+    return { loaded, status };
+  }, []);
+
+  const openMarketDetail = useCallback(async (summary: MarketListingSummary) => {
+    const requestId = ++detailRequestRef.current;
+    setDetailOpen(true);
+    setDetailLoading(true);
+    setDetail(undefined);
+    setInstalled(null);
+    setReleasesExpanded(false);
+    try {
+      const { loaded, status } = await fetchMarketDetail(summary);
+      if (requestId !== detailRequestRef.current) return;
+      setDetail(loaded);
+      setInstalled(status);
+    } catch (loadError) {
+      if (requestId !== detailRequestRef.current) return;
+      setDetailOpen(false);
+      notification.error(t('market.messages.detailFailed', { error: String(loadError) }));
+    } finally {
+      if (requestId === detailRequestRef.current) setDetailLoading(false);
+    }
+  }, [fetchMarketDetail, notification, t]);
+
+  const prepareMarketInstall = useCallback(async (summary: MarketListingSummary) => {
+    if (busyListingId) return;
+    const requestId = ++detailRequestRef.current;
+    setBusyListingId(summary.listingId);
+    try {
+      const { loaded, status } = await fetchMarketDetail(summary);
+      if (requestId !== detailRequestRef.current) return;
+      setDetail(loaded);
+      setInstalled(status);
+      setInstallPrompt(true);
+    } catch (loadError) {
+      if (requestId !== detailRequestRef.current) return;
+      notification.error(t('market.messages.detailFailed', { error: String(loadError) }));
+    } finally {
+      setBusyListingId((current) => (
+        current === summary.listingId ? undefined : current
+      ));
+    }
+  }, [busyListingId, fetchMarketDetail, notification, t]);
+
+  const refreshPersonalizedDetail = () => {
+    if (!detail) return;
+    const activeSlug = detail.slug;
+    void miniAppMarketAPI.getListing(activeSlug)
+      .then((updated) => setDetail((current) => (
+        current?.slug === activeSlug ? updated : current
+      )))
+      .catch((error) => log.warn(
+        'Failed to refresh MiniApp market detail after account change',
+        error,
+      ));
+  };
+
+  const toggleFavorite = async () => {
+    if (!detail) return;
+    if (!me) {
+      setLoginOpen(true);
+      return;
+    }
+    setDetailActionBusy(true);
+    try {
+      const result = await miniAppMarketAPI.setFavorite(detail.slug, !detail.isFavorited);
+      setDetail({
+        ...detail,
+        isFavorited: result.isFavorited,
+        favoriteCount: result.count,
+      });
+    } catch (actionError) {
+      notification.error(t('market.messages.actionFailed', { error: String(actionError) }));
+    } finally {
+      setDetailActionBusy(false);
+    }
+  };
+
+  const rate = async (value: number) => {
+    if (!detail) return;
+    if (!me) {
+      setLoginOpen(true);
+      return;
+    }
+    setDetailActionBusy(true);
+    try {
+      const result = await miniAppMarketAPI.setRating(detail.slug, value);
+      setDetail({
+        ...detail,
+        ratingAverage: result.average,
+        ratingCount: result.count,
+        myRating: result.myRating,
+      });
+    } catch (actionError) {
+      notification.error(t('market.messages.actionFailed', { error: String(actionError) }));
+    } finally {
+      setDetailActionBusy(false);
+    }
+  };
+
+  const install = async () => {
+    if (!detail) return;
+    setInstallPrompt(false);
+    setBusyListingId(detail.listingId);
+    try {
+      const result = await miniAppMarketAPI.install(detail.slug, detail.latestRelease, {
+        existingAppId: installed?.appId,
+        confirmPermissions: true,
+        confirmOverwrite: Boolean(installed?.localOverride),
+      });
+      upsertApp(result.app);
+      setMarketOrigin(result.app.id, result.origin);
+      setInstalled({
+        appId: result.app.id,
+        appVersion: result.app.version,
+        permissions: result.app.permissions,
+        origin: result.origin,
+        localOverride: false,
+      });
+    } catch (installError) {
+      notification.error(t('market.messages.installFailed', { error: String(installError) }));
+    } finally {
+      setBusyListingId(undefined);
+    }
+  };
+
+  const manageInstalledApp = () => {
+    if (!installed) return;
+    const app = apps.find((candidate) => candidate.id === installed.appId);
+    if (!app) return;
+    setDetailOpen(false);
+    setSelectedApp(app);
+  };
+
+  const permissionLines = detail ? summarizePermissions(detail.permissions, t) : [];
+  const installedPermissionLines = installed
+    ? summarizePermissions(installed.permissions, t)
+    : [];
+  const addedPermissionLines = permissionLines.filter(
+    (line) => !installedPermissionLines.includes(line),
+  );
+  const removedPermissionLines = installedPermissionLines.filter(
+    (line) => !permissionLines.includes(line),
+  );
+  const installedReleaseYanked = Boolean(
+    detail
+      && installed
+      && detail.releases.find(
+        (release) => release.releaseId === installed.origin.releaseId,
+      )?.yanked,
+  );
+  const detailWorkspaceUnsupported = Boolean(
+    detail
+      && workspace
+      && isRemoteWorkspace(workspace)
+      && requiresWorkspace(detail.permissions),
+  );
+  const releaseHistory = buildReleaseHistory(detail?.releases ?? [], releasesExpanded);
+  const canUpdate = Boolean(
+    installed && detail && detail.latestRelease > installed.origin.releaseNumber
+  );
+  const detailName = detail
+    ? pickLocalizedString(detail, currentLanguage, 'name')
+    : '';
+  const detailDescription = detail
+    ? pickLocalizedString(detail, currentLanguage, 'description')
+    : '';
+  const sortOptions = useMemo<SelectOption[]>(() => [
+    { value: 'newest', label: t('market.sort.newest') },
+    { value: 'downloads', label: t('market.sort.downloads') },
+    { value: 'rating', label: t('market.sort.rating') },
+  ], [t]);
+
+  const renderLibrary = () => {
+    const initialLoading = catalogLoading && marketItems.length === 0 && apps.length === 0;
+    if (initialLoading) {
+      return (
+        <GallerySkeleton
+          count={5}
+          cardHeight={140}
+          minCardWidth={640}
+          className="miniapp-gallery__list"
+        />
+      );
+    }
+
+    if (libraryItems.length === 0 && !catalogLoading) {
+      return (
+        <GalleryEmpty
+          icon={<PackageCheck size={34} strokeWidth={1.35} />}
+          message={query || category !== 'all'
+            ? t('empty.noMatch')
+            : t('market.library.empty')}
+        />
+      );
+    }
+
+    return (
+      <>
+        <div className="miniapp-gallery__list" role="list">
+          {libraryItems.map((item) => {
+            const source = item.listing ?? item.app;
+            if (!source) return null;
+            const name = pickLocalizedString(source, currentLanguage, 'name');
+            const description = pickLocalizedString(source, currentLanguage, 'description');
+            const sourceCategory = item.listing?.category ?? item.app?.category ?? 'other';
+            const actionLabel = item.action === 'get'
+              ? t('market.library.get')
+              : item.action === 'update'
+                ? t('market.library.update')
+                : t('market.library.open');
+            const workspaceUnsupported = Boolean(
+              workspace
+                && isRemoteWorkspace(workspace)
+                && requiresWorkspace(source.permissions),
+            );
+            const statuses = libraryStatuses(item, activeIdSet, customizingIdSet, t);
+            if (workspaceUnsupported) {
+              statuses.push({
+                label: t('market.library.remoteUnsupported'),
+                tone: 'warning',
+              });
+            }
+            const anotherMarketActionBusy = Boolean(
+              item.listing
+                && item.action !== 'open'
+                && busyListingId
+                && busyListingId !== item.listing.listingId,
+            );
+            const meta = item.listing
+              ? t('market.library.marketMeta', {
+                owner: item.listing.owner.login,
+                rating: item.listing.ratingAverage.toFixed(1),
+                downloads: formatNumber(item.listing.downloadCount),
+              })
+              : t('market.library.localMeta');
+            const release = item.listing?.latestRelease
+              ?? item.origin?.releaseNumber
+              ?? item.app?.version
+              ?? 1;
+
+            return (
+              <MiniAppLibraryRow
+                key={item.key}
+                action={item.action}
+                actionDisabled={workspaceUnsupported || anotherMarketActionBusy}
+                actionLabel={actionLabel}
+                actionTitle={workspaceUnsupported
+                  ? t('market.library.remoteUnsupported')
+                  : undefined}
+                busy={Boolean(item.listing && busyListingId === item.listing.listingId)}
+                category={categoryLabel(sourceCategory, t)}
+                description={description}
+                detailsLabel={t('market.library.viewDetails', { name })}
+                meta={meta}
+                name={name}
+                showcaseAlt={t('market.library.showcaseAlt', { name })}
+                showcaseFallbackLabel={t('market.library.showcaseFallback', { name })}
+                showcaseUrl={item.listing?.screenshotUrls[0]}
+                statuses={statuses}
+                version={t('market.library.version', { version: release })}
+                onOpenDetails={() => {
+                  if (item.listing) void openMarketDetail(item.listing);
+                  else if (item.app) setSelectedApp(item.app);
+                }}
+                onPrimaryAction={() => {
+                  if (item.action === 'open' && item.app) {
+                    handleOpenApp(item.app.id);
+                  } else if (item.listing) {
+                    void prepareMarketInstall(item.listing);
+                  }
+                }}
+              />
+            );
+          })}
+        </div>
+        {catalogLoading && marketItems.length === 0 ? (
+          <GallerySkeleton
+            count={2}
+            cardHeight={140}
+            minCardWidth={640}
+            className="miniapp-gallery__list miniapp-gallery__list--continuation"
+          />
+        ) : null}
+        {nextCursor ? (
+          <div className="miniapp-gallery__load-more">
+            <Button
+              size="sm"
+              variant="outline"
+              loading={loadingMore}
+              onClick={() => void fetchCatalog(nextCursor, true)}
+            >
+              {t('market.loadMore')}
+            </Button>
+          </div>
+        ) : null}
+      </>
+    );
+  };
+
+  return (
+    <GalleryLayout
+      data-bf-component="miniapp-gallery-view"
+      data-bf-part="root"
+      className="miniapp-gallery-pane miniapp-gallery"
+    >
+      <GalleryPageHeader
+        title={t('title')}
+        subtitle={t('subtitle')}
+        actions={(
+          <div className="miniapp-gallery__header-actions">
+            <SearchField
+              leadingIcon={<Icon name="search" size="lg" aria-hidden />}
+              onValueChange={setQuery}
+              placeholder={t('searchPlaceholder')}
+              size="sm"
+              value={query}
+            />
+            <MarketAccountControls
+              loginOpen={loginOpen}
+              onLoginOpenChange={setLoginOpen}
+              onIdentityChanged={refreshPersonalizedDetail}
+            />
+            <span className="miniapp-gallery__import-anchor">
+              <IconButton
+                ref={importTriggerRef}
+                size="xs"
+                onClick={() => setImportMenuOpen((current) => !current)}
+                disabled={loading}
+                title={t('importAction')}
+                aria-label={t('importAction')}
+                aria-haspopup="menu"
+                aria-expanded={importMenuOpen}
+                data-testid="miniapp-import-action"
+                icon={<Icon name="plus" size="sm" />}
+              />
+              {importMenuOpen ? createPortal(
+                <Menu
+                  ref={importMenuRef}
+                  className="miniapp-gallery__import-menu"
+                  aria-label={t('importMenuLabel')}
+                  data-testid="miniapp-import-menu"
+                  style={{
+                    top: `${importMenuLayout?.top ?? 0}px`,
+                    left: `${importMenuLayout?.left ?? 0}px`,
+                    visibility: importMenuLayout ? 'visible' : 'hidden',
+                  }}
+                >
+                  <MenuItem
+                    leading={<FolderPlus size={15} aria-hidden="true" />}
+                    onClick={() => {
+                      closeImportMenu();
+                      void handleAddFromFolder();
+                    }}
+                    data-testid="miniapp-import-folder-action"
+                  >
+                    {t('importFromFolder')}
+                  </MenuItem>
+                  <MenuItem
+                    leading={<PackagePlus size={15} aria-hidden="true" />}
+                    onClick={() => {
+                      closeImportMenu();
+                      void handleAddPackage();
+                    }}
+                    data-testid="miniapp-import-package-action"
+                  >
+                    {t('market.import.action')}
+                  </MenuItem>
+                </Menu>,
+                getAppearanceOverlayHost(),
+              ) : null}
+            </span>
+            <IconButton
+              size="xs"
+              onClick={() => void handleCreateWithCreative()}
+              loading={creatingWithCreative}
+              title={t('creationMode.action')}
+              aria-label={t('creationMode.action')}
+              data-testid="miniapp-create-action"
+              icon={<Icon name="edit" size="sm" />}
+            />
+          </div>
+        )}
+      />
+
+      {tabs}
+
+      <div
+        data-bf-component="miniapp-gallery-view"
+        data-bf-part="content"
+        className="gallery-zones"
+      >
+        <GalleryZone
+          title={t('allApps')}
+          titleAdornment={<NumberBadge value={libraryItems.length} />}
+          tools={(
+            <Select
+              className="miniapp-gallery__sort"
+              size="sm"
+              options={sortOptions}
+              value={sort}
+              onValueChange={(value) => setSort(value as MarketSort)}
+              aria-label={t('market.sortLabel')}
+            />
+          )}
+        >
+          <div data-bf-component="miniapp-gallery-view" data-bf-part="categoryFilters">
+            <SegmentedControl
+              className="miniapp-gallery__categories"
+              options={CATEGORIES.map((value) => ({
+                label: (
+                  <span data-bf-component="miniapp-gallery-view" data-bf-part="categoryFilter">
+                    {categoryLabel(value, t)}
+                  </span>
+                ),
+                value,
+              }))}
+              value={category}
+              onValueChange={(value) => setCategory(value as MiniAppCategory)}
+              aria-label={t('market.catalog')}
+              variant="pills"
+            />
+          </div>
+
+          {catalogError ? (
+            <div
+              className="miniapp-gallery__market-error"
+              role="alert"
+              data-bf-component="miniapp-gallery-view"
+              data-bf-part="error"
+            >
+              <AlertTriangle size={16} aria-hidden="true" />
+              <span>{t('market.library.marketUnavailable')}</span>
+              <Button
+                size="xs"
+                variant="text"
+                onClick={() => void fetchCatalog(undefined, false)}
+              >
+                {t('scene.retry')}
+              </Button>
+            </div>
+          ) : null}
+
+          {renderLibrary()}
+        </GalleryZone>
+      </div>
+
+      <MiniAppDetailModal
+        app={selectedApp}
+        marketReleaseNumber={selectedApp ? marketOrigins[selectedApp.id]?.releaseNumber : undefined}
+        isActive={selectedApp ? activeIdSet.has(selectedApp.id) : false}
+        isCustomizing={selectedApp ? customizingIdSet.has(selectedApp.id) : false}
+        onClose={() => setSelectedApp(null)}
+        onOpen={handleOpenApp}
+        onDelete={setPendingDeleteId}
+        onStop={handleStopRunning}
+      />
+
+      <GalleryDetailModal
+        isOpen={detailOpen}
+        onClose={() => setDetailOpen(false)}
+        title={detailName || t('market.detail.loading')}
+        titlePlacement="hero"
+        size="lg"
+        stableHeight
+        badges={detail ? (
+          <>
+            <StatusPill tone="info">{categoryLabel(detail.category, t)}</StatusPill>
+            <StatusPill tone="neutral" leading={<ShieldCheck size={11} />}>
+              {t('market.detail.reviewed')}
+            </StatusPill>
+          </>
+        ) : null}
+        description={detailDescription}
+        meta={detail ? <span>{t('market.detail.by', { owner: detail.owner.login })}</span> : null}
+        actions={detail ? (
+          <>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => void toggleFavorite()}
+              disabled={detailActionBusy}
+              leadingIcon={(
+                <Heart size={14} fill={detail.isFavorited ? 'currentColor' : 'none'} />
+              )}
+            >
+              {formatNumber(detail.favoriteCount)}
+            </Button>
+            {installed && !canUpdate ? (
+              <span className="miniapp-market-detail__installed-state">
+                <Icon name="check-line" size="sm" />
+                {t('market.detail.installed')}
+              </span>
+            ) : null}
+            {installed ? (
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={busyListingId === detail.listingId || detailWorkspaceUnsupported}
+                onClick={() => handleOpenApp(installed.appId)}
+              >
+                {t('market.library.open')}
+              </Button>
+            ) : null}
+            {!installed || canUpdate ? (
+              <Button
+                size="sm"
+                variant="primary"
+                loading={busyListingId === detail.listingId}
+                disabled={detailWorkspaceUnsupported}
+                onClick={() => setInstallPrompt(true)}
+              >
+                {canUpdate ? t('market.library.update') : t('market.library.get')}
+              </Button>
+            ) : null}
+            {installed ? (
+              <Button size="sm" variant="text" onClick={manageInstalledApp}>
+                {t('market.library.manage')}
+              </Button>
+            ) : null}
+          </>
+        ) : null}
+      >
+        {detailLoading ? (
+          <div className="miniapp-market-detail__loading" aria-live="polite">
+            <Loader2 size={20} className="gallery-spinning" aria-hidden="true" />
+            {t('market.detail.loading')}
+          </div>
+        ) : null}
+        {detail ? (
+          <div
+            className="miniapp-market-detail"
+            data-bf-component="miniapp-gallery-view"
+            data-bf-part="detail"
+          >
+            {detail.screenshotUrls.length ? (
+              <div className="miniapp-market-detail__screenshots">
+                {detail.screenshotUrls.map((url, index) => (
+                  <img
+                    key={url}
+                    src={marketImageUrl(url, 'compact-v1')}
+                    srcSet={marketImageSrcSet(url)}
+                    sizes="(min-width: 48rem) 360px, 80vw"
+                    width={640}
+                    height={360}
+                    alt={t('market.library.showcaseAlt', { name: detailName })}
+                    loading={index === 0 ? 'eager' : 'lazy'}
+                    decoding="async"
+                    onError={(event) => retryOriginalMarketImage(event.currentTarget, url)}
+                  />
+                ))}
+              </div>
+            ) : null}
+            {detailWorkspaceUnsupported ? (
+              <div className="miniapp-market-detail__warning">
+                <AlertTriangle size={16} aria-hidden="true" />
+                {t('market.detail.remoteWorkspaceUnsupported')}
+              </div>
+            ) : null}
+            {installed?.localOverride ? (
+              <div className="miniapp-market-detail__warning">
+                <AlertTriangle size={16} aria-hidden="true" />
+                {t('market.detail.localOverride')}
+              </div>
+            ) : null}
+            {installedReleaseYanked ? (
+              <div className="miniapp-market-detail__warning">
+                <AlertTriangle size={16} aria-hidden="true" />
+                {t('market.detail.installedYanked')}
+              </div>
+            ) : null}
+            <section>
+              <h4>{t('market.detail.permissions')}</h4>
+              {permissionLines.length ? (
+                <ul>{permissionLines.map((line) => <li key={line}>{line}</li>)}</ul>
+              ) : (
+                <p>{t('market.detail.noPermissions')}</p>
+              )}
+            </section>
+            <section>
+              <h4>{t('market.detail.rating')}</h4>
+              <div className="miniapp-market-detail__rating">
+                {[1, 2, 3, 4, 5].map((value) => (
+                  <IconButton
+                    key={value}
+                    size="xs"
+                    className="miniapp-market-detail__rating-action"
+                    onClick={() => void rate(value)}
+                    disabled={detailActionBusy}
+                    aria-label={`${t('market.detail.rating')} ${value}`}
+                    title={`${t('market.detail.rating')} ${value}`}
+                    icon={<Icon name="star" size="lg" />}
+                  />
+                ))}
+                <span>{detail.ratingAverage.toFixed(1)} · {formatNumber(detail.ratingCount)}</span>
+              </div>
+            </section>
+            <section>
+              <h4>{t('market.detail.changelog')}</h4>
+              <p>{detail.changelog}</p>
+            </section>
+            <section>
+              <h4>{t('market.detail.releases')}</h4>
+              <div className="miniapp-market-detail__releases">
+                {releaseHistory.visible.map((release) => (
+                  <div key={release.releaseId}>
+                    <span>v{release.releaseNumber}</span>
+                    <span>{release.minBitfunVersion}+</span>
+                    {release.yanked
+                      ? <StatusPill tone="warning">{t('market.detail.yanked')}</StatusPill>
+                      : <Icon name="check-line" size="sm" />}
+                  </div>
+                ))}
+              </div>
+              {detail.releases.length > 1 ? (
+                <Button
+                  variant="text"
+                  size="xs"
+                  className="miniapp-market-detail__releases-toggle"
+                  aria-expanded={releasesExpanded}
+                  onClick={() => setReleasesExpanded((current) => !current)}
+                  leadingIcon={releasesExpanded
+                    ? <Icon name="chevron-up" size="lg" />
+                    : <Icon name="chevron-down" size="xs" />}
+                >
+                  {releasesExpanded
+                    ? t('market.detail.releasesCollapse')
+                    : t('market.detail.releasesExpand', { count: releaseHistory.hiddenCount })}
+                </Button>
+              ) : null}
+            </section>
+            {detail.repositoryUrl ? (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => void systemAPI.openExternal(detail.repositoryUrl!)}
+                leadingIcon={<Icon name="arrow-up-right" size="sm" />}
+              >
+                {t('market.detail.repository')}
+              </Button>
+            ) : null}
+          </div>
+        ) : null}
+      </GalleryDetailModal>
+
+      <ConfirmDialog
+        open={pendingDeleteId !== null}
+        onOpenChange={() => setPendingDeleteId(null)}
+        onConfirm={handleDeleteConfirm}
+        title={t('confirmDelete.title', {
+          name: apps.find((app) => app.id === pendingDeleteId)?.name ?? '',
+        })}
+        message={t('confirmDelete.message')}
+        type="warning"
+        confirmDanger
+        confirmText={t('confirmDelete.confirm')}
+        cancelText={t('confirmDelete.cancel')}
+      />
+
+      <ConfirmDialog
+        open={pendingPackage !== null}
+        onOpenChange={() => setPendingPackage(null)}
+        onConfirm={() => void handlePackageImportConfirm()}
+        title={t('market.import.confirmTitle', {
+          name: pendingPackage?.inspection.name ?? '',
+        })}
+        message={t('market.import.confirmMessage', {
+          description: pendingPackage?.inspection.description ?? '',
+          permissions: [
+            ...(pendingPackage?.inspection.permissionDiff.added ?? []),
+            ...(pendingPackage?.inspection.permissionDiff.expanded ?? []),
+          ].join(', ') || t('market.detail.noPermissions'),
+          sha256: pendingPackage?.inspection.packageSha256 ?? '',
+        })}
+        type="warning"
+        confirmText={t('market.import.confirm')}
+        cancelText={t('confirmDelete.cancel')}
+      />
+
+      <ConfirmDialog
+        open={installPrompt}
+        onOpenChange={setInstallPrompt}
+        onConfirm={() => void install()}
+        title={t(installed ? 'market.confirmUpdate.title' : 'market.confirmInstall.title', {
+          name: detailName,
+        })}
+        message={[
+          installed?.localOverride ? t('market.confirmUpdate.overwrite') : '',
+          installed
+            ? (
+              addedPermissionLines.length
+                ? t('market.confirmUpdate.addedPermissions', {
+                  permissions: addedPermissionLines.join(', '),
+                })
+                : t('market.confirmUpdate.noAddedPermissions')
+            )
+            : (
+              permissionLines.length
+                ? t('market.confirmInstall.permissions', {
+                  permissions: permissionLines.join(', '),
+                })
+                : t('market.detail.noPermissions')
+            ),
+          installed && removedPermissionLines.length
+            ? t('market.confirmUpdate.removedPermissions', {
+              permissions: removedPermissionLines.join(', '),
+            })
+            : '',
+        ].filter(Boolean).join('\n\n')}
+        type="warning"
+        confirmText={t(installed ? 'market.confirmUpdate.confirm' : 'market.confirmInstall.confirm')}
+        cancelText={t('confirmDelete.cancel')}
+      />
+    </GalleryLayout>
+  );
+};
+
+function matchesLibraryFilter(
+  item: MiniAppLibraryItem,
+  query: string,
+  category: MiniAppCategory,
+  currentLanguage: string,
+): boolean {
+  const source = item.listing ?? item.app;
+  if (!source) return false;
+  if (category !== 'all' && source.category.toLowerCase() !== category) return false;
+
+  const keyword = query.trim().toLowerCase();
+  if (!keyword) return true;
+  const localizedName = pickLocalizedString(source, currentLanguage, 'name').toLowerCase();
+  const localizedDescription = pickLocalizedString(
+    source,
+    currentLanguage,
+    'description',
+  ).toLowerCase();
+  const tags = pickLocalizedTags(source, currentLanguage);
+  return [
+    localizedName,
+    localizedDescription,
+    source.name,
+    source.description,
+    ...tags,
+    ...source.tags,
+  ].some((value) => value.toLowerCase().includes(keyword));
+}
+
+function libraryStatuses(
+  item: MiniAppLibraryItem,
+  activeIdSet: Set<string>,
+  customizingIdSet: Set<string>,
+  t: Translate,
+): MiniAppLibraryStatus[] {
+  const statuses: MiniAppLibraryStatus[] = [];
+  if (item.action === 'update') {
+    statuses.push({ label: t('market.library.updateAvailable'), tone: 'warning' });
+  } else if (item.app) {
+    statuses.push({ label: t('market.library.installed'), tone: 'success' });
+  }
+
+  if (item.app && activeIdSet.has(item.app.id)) {
+    statuses.push({ label: t('running'), tone: 'info' });
+  } else if (item.app && customizingIdSet.has(item.app.id)) {
+    statuses.push({ label: t('market.library.customizing'), tone: 'accent' });
+  } else if (!item.listing && !item.origin && item.app) {
+    statuses.push({ label: t('market.library.local'), tone: 'neutral' });
+  }
+  return statuses;
+}
+
+function requiresWorkspace(permissions: MiniAppPermissions): boolean {
+  return [
+    ...(permissions.fs?.read ?? []),
+    ...(permissions.fs?.write ?? []),
+  ].includes('{workspace}');
+}
+
+function summarizePermissions(
+  permissions: MiniAppPermissions,
+  t: Translate,
+): string[] {
+  const result: string[] = [];
+  if (permissions.fs?.read?.length) {
+    result.push(t('market.permissions.fsRead', { value: permissions.fs.read.join(', ') }));
+  }
+  if (permissions.fs?.write?.length) {
+    result.push(t('market.permissions.fsWrite', { value: permissions.fs.write.join(', ') }));
+  }
+  if (permissions.shell?.allow?.length) {
+    result.push(t('market.permissions.shell', { value: permissions.shell.allow.join(', ') }));
+  }
+  if (permissions.net?.allow?.length) {
+    result.push(t('market.permissions.net', { value: permissions.net.allow.join(', ') }));
+  }
+  if (permissions.ai?.enabled) result.push(t('market.permissions.ai'));
+  if (permissions.agent?.enabled) result.push(t('market.permissions.agent'));
+  if (permissions.notifications?.system) result.push(t('market.permissions.notifications'));
+  if (permissions.host?.dialog) result.push(t('market.permissions.dialog'));
+  if (permissions.host?.clipboard_read) result.push(t('market.permissions.clipboardRead'));
+  if (permissions.host?.clipboard_write) result.push(t('market.permissions.clipboardWrite'));
+  if (permissions.host?.open_external) result.push(t('market.permissions.openExternal'));
+  if (permissions.host?.reveal_in_folder) result.push(t('market.permissions.revealInFolder'));
+  if (permissions.host?.deck_render) result.push(t('market.permissions.deckRender'));
+  if (permissions.host?.chat_composer) result.push(t('market.permissions.chatComposer'));
+  if (permissions.host?.system_info) result.push(t('market.permissions.systemInfo'));
+  return result;
+}
+
+function categoryLabel(category: string, t: Translate): string {
+  switch (category) {
+    case 'all': return t('market.categories.all');
+    case 'developer': return t('market.categories.developer');
+    case 'productivity': return t('market.categories.productivity');
+    case 'data': return t('market.categories.data');
+    case 'creative': return t('market.categories.creative');
+    case 'education': return t('market.categories.education');
+    case 'utilities': return t('market.categories.utilities');
+    case 'entertainment': return t('market.categories.entertainment');
+    default: return t('market.categories.other');
+  }
+}
+
+export default MiniAppLibraryView;

--- a/src/web-ui/src/app/scenes/miniapps/views/miniAppLibraryItems.test.ts
+++ b/src/web-ui/src/app/scenes/miniapps/views/miniAppLibraryItems.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+
+import type { MiniAppMeta } from '@/infrastructure/api/service-api/MiniAppAPI';
+import type {
+  InstalledMarketOrigin,
+  MarketListingSummary,
+} from '@/infrastructure/api/service-api/MiniAppMarketAPI';
+import { buildMiniAppLibraryItems } from './miniAppLibraryItems';
+
+function app(id: string, name = id): MiniAppMeta {
+  return {
+    id,
+    name,
+    description: `${name} description`,
+    icon: 'box',
+    category: 'utilities',
+    tags: [],
+    version: 1,
+    created_at: 1,
+    updated_at: 1,
+    permissions: {},
+  };
+}
+
+function listing(
+  listingId: string,
+  latestRelease: number,
+): MarketListingSummary {
+  return {
+    listingId,
+    slug: listingId,
+    name: listingId,
+    description: `${listingId} description`,
+    icon: 'box',
+    category: 'utilities',
+    tags: [],
+    owner: { githubId: 1, login: 'owner', avatarUrl: '' },
+    latestRelease,
+    minBitfunVersion: '1.0.0',
+    permissions: {},
+    screenshotUrls: [],
+    ratingAverage: 0,
+    ratingCount: 0,
+    favoriteCount: 0,
+    downloadCount: 0,
+    publishedAt: 1,
+  };
+}
+
+function origin(listingId: string, releaseNumber: number): InstalledMarketOrigin {
+  return {
+    listingId,
+    releaseId: `${listingId}-release-${releaseNumber}`,
+    releaseNumber,
+    packageSha256: 'sha256',
+  };
+}
+
+describe('buildMiniAppLibraryItems', () => {
+  it('joins installed marketplace apps and projects App Store actions', () => {
+    const installed = app('local-market-id');
+    const result = buildMiniAppLibraryItems(
+      [listing('needs-update', 3), listing('available', 1)],
+      [installed],
+      { [installed.id]: origin('needs-update', 2) },
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({
+      key: 'market:needs-update',
+      action: 'update',
+      app: { id: installed.id },
+      origin: { releaseNumber: 2 },
+    });
+    expect(result[1]).toMatchObject({
+      key: 'market:available',
+      action: 'get',
+    });
+  });
+
+  it('deduplicates current marketplace installs and keeps local-only apps', () => {
+    const current = app('current');
+    const localOnly = app('local-only');
+    const result = buildMiniAppLibraryItems(
+      [listing('current-listing', 4)],
+      [current, localOnly],
+      { [current.id]: origin('current-listing', 4) },
+    );
+
+    expect(result.map((item) => item.key)).toEqual([
+      'market:current-listing',
+      'local:local-only',
+    ]);
+    expect(result.every((item) => item.action === 'open')).toBe(true);
+  });
+
+  it('surfaces updates first, installed apps next, and new apps last', () => {
+    const current = app('current');
+    const update = app('update');
+    const result = buildMiniAppLibraryItems(
+      [listing('new-app', 1), listing('current-listing', 2), listing('update-listing', 3)],
+      [current, update],
+      {
+        [current.id]: origin('current-listing', 2),
+        [update.id]: origin('update-listing', 2),
+      },
+    );
+
+    expect(result.map((item) => item.action)).toEqual(['update', 'open', 'get']);
+  });
+
+  it('keeps off-page installs and ignores duplicate marketplace rows', () => {
+    const installed = app('off-page-install');
+    const duplicate = listing('duplicate', 2);
+    const installedOrigin = origin('off-page-listing', 4);
+    const result = buildMiniAppLibraryItems(
+      [duplicate, duplicate],
+      [installed],
+      { [installed.id]: installedOrigin },
+    );
+
+    expect(result.map((item) => item.key)).toEqual([
+      'local:off-page-install',
+      'market:duplicate',
+    ]);
+    expect(result[0]).toMatchObject({
+      action: 'open',
+      app: { id: installed.id },
+      origin: installedOrigin,
+    });
+  });
+});

--- a/src/web-ui/src/app/scenes/miniapps/views/miniAppLibraryItems.ts
+++ b/src/web-ui/src/app/scenes/miniapps/views/miniAppLibraryItems.ts
@@ -1,0 +1,93 @@
+import type { MiniAppMeta } from '@/infrastructure/api/service-api/MiniAppAPI';
+import type {
+  InstalledMarketOrigin,
+  MarketListingSummary,
+} from '@/infrastructure/api/service-api/MiniAppMarketAPI';
+
+export type MiniAppLibraryAction = 'get' | 'open' | 'update';
+
+export interface MiniAppLibraryItem {
+  key: string;
+  action: MiniAppLibraryAction;
+  app?: MiniAppMeta;
+  listing?: MarketListingSummary;
+  origin?: InstalledMarketOrigin;
+}
+
+const ACTION_PRIORITY: Record<MiniAppLibraryAction, number> = {
+  update: 0,
+  open: 1,
+  get: 2,
+};
+
+/**
+ * Projects the local catalog and the marketplace into one App Store-style
+ * library. A marketplace origin is the durable join key: local app ids may
+ * differ from listing ids and local version counters are not market releases.
+ */
+export function buildMiniAppLibraryItems(
+  listings: MarketListingSummary[],
+  apps: MiniAppMeta[],
+  origins: Record<string, InstalledMarketOrigin>,
+): MiniAppLibraryItem[] {
+  const seenListingIds = new Set<string>();
+  const uniqueListings = listings.filter((listing) => {
+    if (seenListingIds.has(listing.listingId)) return false;
+    seenListingIds.add(listing.listingId);
+    return true;
+  });
+  const installedByListingId = new Map<
+    string,
+    { app: MiniAppMeta; origin: InstalledMarketOrigin }
+  >();
+
+  for (const app of apps) {
+    const origin = origins[app.id];
+    if (origin && !installedByListingId.has(origin.listingId)) {
+      installedByListingId.set(origin.listingId, { app, origin });
+    }
+  }
+
+  const consumedAppIds = new Set<string>();
+  const projected: Array<{ item: MiniAppLibraryItem; order: number }> = uniqueListings.map((listing, index) => {
+    const installed = installedByListingId.get(listing.listingId);
+    if (installed) consumedAppIds.add(installed.app.id);
+
+    const action: MiniAppLibraryAction = !installed
+      ? 'get'
+      : installed.origin.releaseNumber < listing.latestRelease
+        ? 'update'
+        : 'open';
+
+    return {
+      item: {
+        key: `market:${listing.listingId}`,
+        action,
+        app: installed?.app,
+        listing,
+        origin: installed?.origin,
+      } satisfies MiniAppLibraryItem,
+      order: index,
+    };
+  });
+
+  for (const [index, app] of apps.entries()) {
+    if (consumedAppIds.has(app.id)) continue;
+    projected.push({
+      item: {
+        key: `local:${app.id}`,
+        action: 'open',
+        app,
+        origin: origins[app.id],
+      },
+      order: uniqueListings.length + index,
+    });
+  }
+
+  return projected
+    .sort((left, right) => (
+      ACTION_PRIORITY[left.item.action] - ACTION_PRIORITY[right.item.action]
+      || left.order - right.order
+    ))
+    .map(({ item }) => item);
+}

--- a/src/web-ui/src/locales/en-US/scenes/miniapp.json
+++ b/src/web-ui/src/locales/en-US/scenes/miniapp.json
@@ -1,6 +1,6 @@
 {
   "title": "Mini Apps",
-  "subtitle": "Instantly generated mini apps, ready to use right away. You can also continue to iterate on them.",
+  "subtitle": "Browse, install, update, and open every mini app in one place.",
   "searchPlaceholder": "Search mini apps...",
   "importFromFolder": "Import from folder",
   "importAction": "Import mini app",
@@ -129,9 +129,29 @@
     "loadMore": "Load more",
     "tabs": {
       "label": "MiniApp pages",
+      "apps": "All apps",
       "installed": "Installed",
       "market": "Market",
       "submissions": "My submissions"
+    },
+    "library": {
+      "get": "Get",
+      "update": "Update",
+      "open": "Open",
+      "manage": "Manage",
+      "installed": "Installed",
+      "updateAvailable": "Update available",
+      "customizing": "Customizing",
+      "local": "Local",
+      "version": "v{{version}}",
+      "marketMeta": "By @{{owner}} · {{rating}} rating · {{downloads}} downloads",
+      "localMeta": "On this device",
+      "viewDetails": "View details for {{name}}",
+      "showcaseAlt": "{{name}} showcase image",
+      "showcaseFallback": "No showcase image for {{name}}",
+      "remoteUnsupported": "This app needs a local workspace.",
+      "marketUnavailable": "The marketplace is unavailable. Installed apps are still ready to use.",
+      "empty": "No mini apps are available yet."
     },
     "sort": {
       "newest": "Newest",
@@ -210,6 +230,7 @@
       "installed": "MiniApp installed.",
       "updated": "MiniApp updated; the old version was saved.",
       "installFailed": "Install or update failed: {{error}}",
+      "deleteFailed": "Could not delete the MiniApp: {{error}}",
       "catalogFailed": "The market is unavailable: {{error}}",
       "submissionsFailed": "Could not load submissions: {{error}}"
     },

--- a/src/web-ui/src/locales/zh-CN/scenes/miniapp.json
+++ b/src/web-ui/src/locales/zh-CN/scenes/miniapp.json
@@ -1,6 +1,6 @@
 {
   "title": "小应用",
-  "subtitle": "即时生成的小应用，打开就能用，也能继续迭代。",
+  "subtitle": "在一个列表中发现、安装、更新和打开所有小应用。",
   "searchPlaceholder": "搜索小应用...",
   "importFromFolder": "从文件夹导入",
   "importAction": "导入小应用",
@@ -129,9 +129,29 @@
     "loadMore": "加载更多",
     "tabs": {
       "label": "MiniApp 页面",
+      "apps": "全部应用",
       "installed": "已安装",
       "market": "市场",
       "submissions": "我的投稿"
+    },
+    "library": {
+      "get": "获取",
+      "update": "更新",
+      "open": "打开",
+      "manage": "管理",
+      "installed": "已安装",
+      "updateAvailable": "可更新",
+      "customizing": "定制中",
+      "local": "本地",
+      "version": "v{{version}}",
+      "marketMeta": "作者 @{{owner}} · 评分 {{rating}} · {{downloads}} 次下载",
+      "localMeta": "位于此设备",
+      "viewDetails": "查看“{{name}}”详情",
+      "showcaseAlt": "{{name}} 展示图",
+      "showcaseFallback": "{{name}} 暂无展示图",
+      "remoteUnsupported": "此应用需要本地工作区。",
+      "marketUnavailable": "小应用市场暂时不可用，已安装应用仍可正常使用。",
+      "empty": "暂时没有可用的小应用。"
     },
     "sort": {
       "newest": "最新发布",
@@ -210,6 +230,7 @@
       "installed": "MiniApp 已安装。",
       "updated": "MiniApp 已更新，旧版本已保存。",
       "installFailed": "安装或更新失败：{{error}}",
+      "deleteFailed": "删除小应用失败：{{error}}",
       "catalogFailed": "市场暂时不可用：{{error}}",
       "submissionsFailed": "加载投稿失败：{{error}}"
     },

--- a/src/web-ui/src/locales/zh-TW/scenes/miniapp.json
+++ b/src/web-ui/src/locales/zh-TW/scenes/miniapp.json
@@ -1,6 +1,6 @@
 {
   "title": "小應用",
-  "subtitle": "即時生成的小應用，開啟就能用，也能繼續迭代。",
+  "subtitle": "在一個列表中探索、安裝、更新和開啟所有小應用。",
   "searchPlaceholder": "搜尋小應用...",
   "importFromFolder": "從資料夾匯入",
   "importAction": "匯入小應用",
@@ -129,9 +129,29 @@
     "loadMore": "載入更多",
     "tabs": {
       "label": "MiniApp 頁面",
+      "apps": "全部應用",
       "installed": "已安裝",
       "market": "市場",
       "submissions": "我的投稿"
+    },
+    "library": {
+      "get": "取得",
+      "update": "更新",
+      "open": "開啟",
+      "manage": "管理",
+      "installed": "已安裝",
+      "updateAvailable": "可更新",
+      "customizing": "自訂中",
+      "local": "本機",
+      "version": "v{{version}}",
+      "marketMeta": "作者 @{{owner}} · 評分 {{rating}} · {{downloads}} 次下載",
+      "localMeta": "位於此裝置",
+      "viewDetails": "查看「{{name}}」詳情",
+      "showcaseAlt": "{{name}} 展示圖",
+      "showcaseFallback": "{{name}} 暫無展示圖",
+      "remoteUnsupported": "此應用需要本機工作區。",
+      "marketUnavailable": "小應用市場暫時無法使用，已安裝應用仍可正常使用。",
+      "empty": "暫時沒有可用的小應用。"
     },
     "sort": {
       "newest": "最新發佈",
@@ -210,6 +230,7 @@
       "installed": "MiniApp 已安裝。",
       "updated": "MiniApp 已更新，舊版本已儲存。",
       "installFailed": "安裝或更新失敗：{{error}}",
+      "deleteFailed": "刪除小應用失敗：{{error}}",
       "catalogFailed": "市場暫時無法使用：{{error}}",
       "submissionsFailed": "載入投稿失敗：{{error}}"
     },


### PR DESCRIPTION
## Summary

- merge installed MiniApps and marketplace listings into one All Apps library
- use App Store-style Get, Update, and Open actions while retaining local app management
- redesign the catalog as a one-column row layout driven by marketplace showcase images
- render every showcase in a fixed 16:9 slot with centered cover cropping and a neutral fallback
- keep category, sorting, pagination, permission confirmation, and remote-workspace gating in the unified flow

## Verification

- 
> BitFun@0.2.19 check:web /Users/liwenbo/.codex/worktrees/f4f3/BitFun
> pnpm run check:web:appearance && pnpm run type-check:web


> BitFun@0.2.19 check:web:appearance /Users/liwenbo/.codex/worktrees/f4f3/BitFun
> pnpm run typography:audit:test && pnpm run typography:audit && pnpm run appearance:contract-audit && pnpm run theme:color-audit:test && pnpm run theme:color-audit:all && pnpm run theme:visual-contract


> BitFun@0.2.19 typography:audit:test /Users/liwenbo/.codex/worktrees/f4f3/BitFun
> node --test scripts/audit-typography-tokens.test.mjs

✔ accepts canonical CSS typography, inheritance, structural zeros, and documented geometry (1.823792ms)
✔ rejects raw CSS sizes, weights, line heights, tracking, and font stacks (0.484958ms)
✔ accepts only build-owned font faces and stacks in Web font profiles (0.173584ms)
✔ rejects unrelated raw typography inside Web font profiles (0.096125ms)
✔ requires semantic roles in the complete component library and every React product frontend (0.505167ms)
✔ rejects static TypeScript typography but accepts tokens, adapters, and dynamic previews (4.552167ms)
✔ requires semantic roles in product frontend inline styles and embedded CSS (0.664ms)
✔ rejects retired aliases and FlowChat font APIs (0.2545ms)
✔ rejects retired component typography tokens and variables (0.114167ms)
✔ allows retired names only inside explicit negative-test blocks (0.097625ms)
✔ does not mistake token-editor labels or schema property maps for typography values (0.309292ms)
✔ limits the AppearanceStyle typography ban to that interface block (0.580583ms)
✔ rejects a backend FlowChat font snapshot (0.08775ms)
✔ rejects retired FlowChat typography in the distributed Appearance registry (0.108708ms)
✔ rejects typography in the standalone Appearance validator but allows Monaco fontStyle (0.30575ms)
ℹ tests 15
ℹ suites 0
ℹ pass 15
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 150.559292

> BitFun@0.2.19 typography:audit /Users/liwenbo/.codex/worktrees/f4f3/BitFun
> node scripts/audit-typography-tokens.mjs

Typography token audit passed with zero violations.

> BitFun@0.2.19 appearance:contract-audit /Users/liwenbo/.codex/worktrees/f4f3/BitFun
> node scripts/audit-appearance-contracts.mjs

Appearance contract audit passed (238 surfaces, 2941 DOM contracts, 266 styled component owners, 10 shared-style owner warnings, 2704 Web UI files, 257 cross-boundary files).

> BitFun@0.2.19 theme:color-audit:test /Users/liwenbo/.codex/worktrees/f4f3/BitFun
> node --test scripts/audit-theme-colors.test.mjs scripts/audit-cli-theme-colors.test.mjs scripts/audit-frontend-colors.test.mjs

✔ normalizeHexColor accepts supported CLI hex colors only (0.7815ms)
✔ normalizeHexColor blends eight-digit hex colors like the CLI parser (0.107459ms)
✔ collectPresetColorEntriesFromJson reads opencode theme colors (0.485583ms)
✔ collectPresetColorEntriesFromJson resolves defs and light/dark variants (0.123417ms)
✔ isRuntimePresetEntry separates consumed CLI keys from OpenCode compatibility declarations (0.117916ms)
✔ CLI runtime key audit stays aligned with the Rust theme resolver (0.781875ms)
✔ CLI OpenCode presets keep compatibility declarations outside the runtime projection (15.058833ms)
✔ collectRustFallbackEntriesFromText reads Theme struct RGB fields only (0.159375ms)
✔ findNearPairs reports nearby but not identical colors (0.107291ms)
✔ checkBaseline requires budgets to be lowered when CLI color debt drops (0.534167ms)
✔ checkBaseline validates CLI baseline budget shape (0.277ms)
✔ writeReportJson creates parent directories for report output (0.319834ms)
✔ CLI audit can print a machine-readable JSON report (37.241458ms)
✔ frontend color surface registry covers every discovered MiniApp and names valid owners (4.5735ms)
✔ MiniApp audit accepts a narrow data-viz owner and rejects ordinary raw colors or host fallbacks (9.620833ms)
✔ MiniApp generated bundle checks ignore checkout-only line ending differences (1.699708ms)
✔ native source audit rejects raw platform colors while ignoring generated projections (1.02ms)
✔ MiniApp reference mirrors are byte-exact, including file inventory (1.068375ms)
✔ theme CSS var contract registry is explicit and non-overlapping (1.294542ms)
✔ repository dynamic CSS var families match the registered contract (1105.12625ms)
✔ plugin appearance projection stays compact and isolated from runtime/widget contracts (0.579708ms)
✔ repository specialized near color pairs have explicit decisions (986.970292ms)
✔ generated widget iframe has no compatibility alias module or contracts (0.093916ms)
✔ theme color audit emits scoped machine-readable reports (49.265375ms)
✔ theme color audit reports static contract token external consumption (45.369542ms)
✔ theme color audit resolves canonical variables from imported package CSS contracts (44.086334ms)
✔ theme color audit does not require a widget payload on surfaces without that contract (43.176292ms)
✔ theme color audit counts only the generated widget variable contract (45.298917ms)
✔ theme color audit fails closed when the generated widget variable contract is not parseable (41.928833ms)
✔ theme color audit reports fallback tokens that lack a boundary contract (41.360083ms)
✔ theme color audit reports specialized color domains separately from app UI (49.9985ms)
✔ theme color audit ignores comment-only color-like text (41.485916ms)
✔ theme color audit counts named CSS colors and raw RGB channel variables without selector or comment noise (44.120167ms)
✔ theme color audit ignores numeric character references in SVG metadata (39.554542ms)
✔ theme color audit does not exempt executable styles merely because their path contains assets (41.468708ms)
✔ theme color audit can resolve peer-owned public package variables explicitly (41.815459ms)
✔ theme color audit keeps template literal and expression color values (41.011625ms)
✔ theme color audit counts full CSS var governance debt before row truncation (51.901208ms)
✔ theme color audit reports app literals that duplicate token values (48.07525ms)
✔ theme color audit reports near color pair sources and enforces pair budgets (86.253958ms)
✔ theme color audit reports near color pairs inside specialized color domains (43.932208ms)
✔ theme color audit excludes test files from production color budgets (46.962084ms)
✔ theme color audit fails when metrics exceed the checked baseline (42.6065ms)
✔ theme color audit fails when fallback tokens lack a boundary contract (43.382083ms)
✔ theme color audit requires dynamic CSS var families to be registered (42.287709ms)
✔ theme color audit accepts registered dynamic CSS var families (61.051667ms)
✔ theme color audit requires exact exports for dynamic-family CSS var usages (90.890959ms)
✔ theme color audit requires non-contract cross-file vars to be explicitly allowlisted (96.52875ms)
✔ theme color audit fails stale non-contract var allowlist entries (44.764625ms)
✔ theme color audit excludes only explicitly named root-relative paths (42.984125ms)
ℹ tests 50
ℹ suites 0
ℹ pass 50
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 3511.682542

> BitFun@0.2.19 theme:color-audit:all /Users/liwenbo/.codex/worktrees/f4f3/BitFun
> node scripts/audit-frontend-colors.mjs

[frontend-colors] ok design-system-token-owner: 2 owner roots
[frontend-colors] ok web-ui: 2091 files, app raw=0, fallbacks=0
[frontend-colors] ok design-system-ui: 302 files, app raw=0, fallbacks=0
[frontend-colors] ok design-lab: 30 files, app raw=0, fallbacks=0
[frontend-colors] ok miniapp-market: 17 files, app raw=0, fallbacks=0
[frontend-colors] ok skin-market: 23 files, app raw=0, fallbacks=0
[frontend-colors] ok website: 6 files, app raw=0, fallbacks=0
[frontend-colors] ok mobile-web: 53 files, app raw=0, fallbacks=0
[frontend-colors] ok installer: 30 files, app raw=0, fallbacks=0
[frontend-colors] ok desktop-bootstrap: 2 files, app raw=0, fallbacks=0
[frontend-colors] ok mobile-design-preview: 3 files, app raw=0, fallbacks=0
[frontend-colors] ok cli: 6 presets, runtime colors=75
[frontend-colors] ok native-android: 64 files, raw=0
[frontend-colors] ok native-ios: 31 files, raw=0
[frontend-colors] ok native-harmonyos: 230 files, raw=0
[frontend-colors] ok miniapp-coding-selfie: 4 files, host vars=20, specialized=data-viz:10
[frontend-colors] ok miniapp-divination: 4 files, host vars=1, specialized=bespoke-theme:349
[frontend-colors] ok miniapp-gomoku: 4 files, host vars=25, specialized=game-renderer:7
[frontend-colors] ok miniapp-ppt-live: 37 files, host vars=41, specialized=slide-renderer:662
[frontend-colors] ok miniapp-regex-playground: 4 files, host vars=26, specialized=none
[frontend-colors] ok miniapp-git-graph: 22 files, host vars=74, specialized=data-viz:6
[frontend-colors] ok miniapp-icon-design-system: 4 files, host vars=25, specialized=none
[frontend-colors] ok MiniApp discovery: 13 registered roots
[frontend-colors] ok mirror miniapp-git-graph
[frontend-colors] ok mirror miniapp-icon-design-system
[frontend-colors] ok mirror miniapp-coding-selfie
[frontend-colors] ok mirror miniapp-divination
[frontend-colors] ok mirror miniapp-gomoku
[frontend-colors] ok mirror miniapp-regex-playground
[frontend-colors] ok generated desktop-appearance-projection
[frontend-colors] ok generated miniapp-appearance-projection
[frontend-colors] ok generated native-mobile-token-projection
[frontend-colors] ok generated native-mobile-preview-assets
[frontend-colors] all 22 selected surfaces passed.

> BitFun@0.2.19 theme:visual-contract /Users/liwenbo/.codex/worktrees/f4f3/BitFun
> node scripts/validate-theme-visual-contract.mjs

Theme visual governance contract: 10 surfaces, 10 required surfaces covered.

> BitFun@0.2.19 type-check:web /Users/liwenbo/.codex/worktrees/f4f3/BitFun
> pnpm --dir src/web-ui run type-check


> @bitfun/web-ui@0.2.19 pretype-check /Users/liwenbo/.codex/worktrees/f4f3/BitFun/src/web-ui
> pnpm run prepare:design-system:build


> @bitfun/web-ui@0.2.19 prepare:design-system:build /Users/liwenbo/.codex/worktrees/f4f3/BitFun/src/web-ui
> pnpm --dir ../../design-system run build:packages


> @bitfun/design-system-workspace@0.1.0 build:packages /Users/liwenbo/.codex/worktrees/f4f3/BitFun/design-system
> pnpm run build:tokens && pnpm run build:theme && pnpm run build:ui


> @bitfun/design-system-workspace@0.1.0 build:tokens /Users/liwenbo/.codex/worktrees/f4f3/BitFun/design-system
> pnpm --filter @bitfun/design-tokens run build


> @bitfun/design-tokens@0.1.0 build /Users/liwenbo/.codex/worktrees/f4f3/BitFun/design-system/packages/design-tokens
> node scripts/build.mjs


> @bitfun/design-system-workspace@0.1.0 build:theme /Users/liwenbo/.codex/worktrees/f4f3/BitFun/design-system
> pnpm --filter @bitfun/theme-bitfun run build


> @bitfun/theme-bitfun@0.1.0 build /Users/liwenbo/.codex/worktrees/f4f3/BitFun/design-system/packages/theme-bitfun
> node scripts/build.mjs


> @bitfun/design-system-workspace@0.1.0 build:ui /Users/liwenbo/.codex/worktrees/f4f3/BitFun/design-system
> pnpm --filter @bitfun/ui run build


> @bitfun/ui@0.1.0 build /Users/liwenbo/.codex/worktrees/f4f3/BitFun/design-system/packages/ui
> vite build && tsc -p tsconfig.build.json

vite v7.3.1 building client environment for production...
transforming...
✓ 1938 modules transformed.
rendering chunks...
computing gzip size...
dist/styles.css          195.29 kB │ gzip: 24.41 kB
dist/registry.js          68.13 kB │ gzip: 10.24 kB │ map: 127.94 kB
dist/flow-chat.js         99.39 kB │ gzip: 20.76 kB │ map: 229.31 kB
dist/index.js            121.00 kB │ gzip: 29.99 kB │ map: 312.48 kB
dist/Dialog-BLbMq3yS.js  149.25 kB │ gzip: 42.97 kB │ map: 202.91 kB
✓ built in 737ms

> @bitfun/web-ui@0.2.19 type-check /Users/liwenbo/.codex/worktrees/f4f3/BitFun/src/web-ui
> tsc --noEmit
- undefined
 ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "vitest" not found

Did you mean "pnpm exec vite"? (13 tests)
- 
> BitFun@0.2.19 lint:web /Users/liwenbo/.codex/worktrees/f4f3/BitFun
> pnpm --dir src/web-ui run lint


> @bitfun/web-ui@0.2.19 lint /Users/liwenbo/.codex/worktrees/f4f3/BitFun/src/web-ui
> eslint .


/Users/liwenbo/.codex/worktrees/f4f3/BitFun/src/web-ui/src/app/components/NavPanel/components/DeviceArtwork.tsx
  6:17  warning  Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components  react-refresh/only-export-components

/Users/liwenbo/.codex/worktrees/f4f3/BitFun/src/web-ui/src/app/components/SceneTopBar/SceneChrome.tsx
  121:17  warning  Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components  react-refresh/only-export-components

/Users/liwenbo/.codex/worktrees/f4f3/BitFun/src/web-ui/src/app/scenes/browser/HtmlPreviewPanel.tsx
  57:3  warning  Unused eslint-disable directive (no problems were reported from 'react-hooks/exhaustive-deps')

/Users/liwenbo/.codex/worktrees/f4f3/BitFun/src/web-ui/src/flow_chat/components/ReasoningPresetSelector.tsx
   36:17  warning  Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components  react-refresh/only-export-components
  113:17  warning  Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components  react-refresh/only-export-components

/Users/liwenbo/.codex/worktrees/f4f3/BitFun/src/web-ui/src/flow_chat/components/voice/RealtimeVoiceCallContext.tsx
  23:17  warning  Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components  react-refresh/only-export-components
  32:17  warning  Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components  react-refresh/only-export-components

/Users/liwenbo/.codex/worktrees/f4f3/BitFun/src/web-ui/src/flow_chat/tool-cards/AgentWaitToolCard.tsx
  17:17  warning  Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components  react-refresh/only-export-components

✖ 8 problems (0 errors, 8 warnings)
  0 errors and 1 warning potentially fixable with the `--fix` option. (0 errors; 7 unrelated existing warnings)
- 
> BitFun@0.2.19 i18n:audit /Users/liwenbo/.codex/worktrees/f4f3/BitFun
> node scripts/i18n-audit.mjs

[i18n:audit] Passed with 0 warning(s).
- 
> BitFun@0.2.19 motion:audit /Users/liwenbo/.codex/worktrees/f4f3/BitFun
> node scripts/audit-web-motion.mjs

BitFun Web UI motion inventory
Scanned 2015 source files under src/web-ui/src.
Interactive handler attributes: 1532
Explicit data-motion opt-ins: 2

transition: all: 0

scale(0): 0

JavaScript smooth scrolling (verify keyboard and reduced-motion paths): 0

Files with infinite animation and no local reduced-motion rule: 1
  src/web-ui/src/features/ssh-remote/PortForwardDialog.scss:1

Duplicate global keyframe names: 0

This command is an inventory, not a pass/fail gate. Review intent before changing layout transitions or virtualized content.
- local desktop visual QA at wide and narrow window widths

## Remote scenarios

Local desktop was exercised. Remote-workspace restrictions are represented and type-checked, but remote workspace, remote control, Peer Device Mode, and Detached Dispatch were not run end to end. This change does not alter their transport or protocol contracts.