### PR TITLE
fix(arhive): return to welcome after archiving active session

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.tsx
+++ b/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.tsx
@@ -24,7 +24,10 @@ import {
   openBtwSessionInAuxPane,
   selectActiveBtwSessionTab,
 } from '@/flow_chat/services/btwSessionPane';
-import { openMainSession } from '@/flow_chat/services/sessionActivation';
+import {
+  closeSessionSceneAfterActiveSessionArchive,
+  openMainSession,
+} from '@/flow_chat/services/sessionActivation';
 import {
   dispatchHistorySessionOpenIntent,
   shouldShowHistorySessionOpenIntent,
@@ -1297,7 +1300,9 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
       );
       if (!confirmed) return;
       try {
+        const activeSessionIdBeforeArchive = flowChatStore.getState().activeSessionId;
         await flowChatManager.archiveChatSession(sessionId);
+        closeSessionSceneAfterActiveSessionArchive(activeSessionIdBeforeArchive);
         window.dispatchEvent(new CustomEvent('bitfun:session-archived'));
       } catch (err) {
         log.error('Failed to archive session', err);

--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceSessionBatchModal.tsx
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceSessionBatchModal.tsx
@@ -18,6 +18,8 @@ import type { SessionMetadata } from '@/shared/types/session-history';
 import { sessionBelongsToWorkspaceNavRow, compareSessionMetadataForDisplay } from '@/flow_chat/utils/sessionOrdering';
 import { deriveSessionRelationshipFromMetadata, resolveSessionRelationship } from '@/flow_chat/utils/sessionMetadata';
 import { flowChatManager } from '@/flow_chat/services/FlowChatManager';
+import { flowChatStore } from '@/flow_chat/store/FlowChatStore';
+import { closeSessionSceneAfterActiveSessionArchive } from '@/flow_chat/services/sessionActivation';
 import { confirmWarning } from '@/infrastructure/confirm-dialog';
 import { notificationService } from '@/shared/notification-system';
 import { createLogger } from '@/shared/utils/logger';
@@ -225,6 +227,7 @@ const WorkspaceSessionBatchModal: React.FC<WorkspaceSessionBatchModalProps> = ({
     }
 
     const selectedIds = Array.from(selectedSessionIds);
+    const activeSessionIdBeforeArchive = flowChatStore.getState().activeSessionId;
     setActionKind('archive');
     try {
       const results = await Promise.allSettled(
@@ -233,6 +236,7 @@ const WorkspaceSessionBatchModal: React.FC<WorkspaceSessionBatchModalProps> = ({
       const successCount = results.filter(result => result.status === 'fulfilled').length;
       if (successCount > 0) {
         await refreshWorkspaceSessions();
+        closeSessionSceneAfterActiveSessionArchive(activeSessionIdBeforeArchive);
         window.dispatchEvent(new CustomEvent('bitfun:session-archived'));
         notificationService.success(t('nav.sessions.archivedAll', { count: successCount }), { duration: 3000 });
       }

--- a/src/web-ui/src/flow_chat/services/sessionActivation.test.ts
+++ b/src/web-ui/src/flow_chat/services/sessionActivation.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  flowChatState: {
+    activeSessionId: null as string | null,
+    sessions: new Map<string, unknown>(),
+  },
+  sceneState: {
+    openTabs: [] as Array<{ id: string }>,
+    closeScene: vi.fn(),
+  },
+}));
+
+vi.mock('@/app/services/AppManager', () => ({
+  appManager: { updateLayout: vi.fn() },
+}));
+
+vi.mock('@/app/stores/sceneStore', () => ({
+  useSceneStore: {
+    getState: () => mocks.sceneState,
+  },
+}));
+
+vi.mock('../store/FlowChatStore', () => ({
+  flowChatStore: {
+    getState: () => mocks.flowChatState,
+  },
+}));
+
+vi.mock('./FlowChatManager', () => ({
+  flowChatManager: { switchChatSession: vi.fn() },
+}));
+
+vi.mock('./storeSync', () => ({
+  syncSessionToModernStore: vi.fn(),
+}));
+
+import { closeSessionSceneAfterActiveSessionArchive } from './sessionActivation';
+
+describe('closeSessionSceneAfterActiveSessionArchive', () => {
+  beforeEach(() => {
+    mocks.flowChatState.activeSessionId = null;
+    mocks.flowChatState.sessions = new Map();
+    mocks.sceneState.openTabs = [{ id: 'session' }];
+    mocks.sceneState.closeScene.mockReset();
+  });
+
+  it('closes the Session scene after the archived active session is removed', () => {
+    expect(closeSessionSceneAfterActiveSessionArchive('active-1')).toBe(true);
+    expect(mocks.sceneState.closeScene).toHaveBeenCalledWith('session');
+  });
+
+  it('keeps the Session scene when another session became active', () => {
+    mocks.flowChatState.activeSessionId = 'replacement-1';
+
+    expect(closeSessionSceneAfterActiveSessionArchive('active-1')).toBe(false);
+    expect(mocks.sceneState.closeScene).not.toHaveBeenCalled();
+  });
+
+  it('keeps the Session scene when the archive did not remove the active session', () => {
+    mocks.flowChatState.activeSessionId = 'active-1';
+    mocks.flowChatState.sessions.set('active-1', {});
+
+    expect(closeSessionSceneAfterActiveSessionArchive('active-1')).toBe(false);
+    expect(mocks.sceneState.closeScene).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when a non-active session was archived', () => {
+    expect(closeSessionSceneAfterActiveSessionArchive(null)).toBe(false);
+    expect(mocks.sceneState.closeScene).not.toHaveBeenCalled();
+  });
+});

--- a/src/web-ui/src/flow_chat/services/sessionActivation.ts
+++ b/src/web-ui/src/flow_chat/services/sessionActivation.ts
@@ -4,6 +4,36 @@ import { flowChatStore } from '../store/FlowChatStore';
 import { flowChatManager } from './FlowChatManager';
 import { syncSessionToModernStore } from './storeSync';
 
+/**
+ * Leave the Session scene when archiving removed the session that was active
+ * before the operation. FlowChat intentionally clears activeSessionId for this
+ * transition; keeping the scene open would leave its composer without a
+ * session state machine and render a disabled send button.
+ */
+export function closeSessionSceneAfterActiveSessionArchive(
+  activeSessionIdBeforeArchive: string | null,
+): boolean {
+  if (!activeSessionIdBeforeArchive) {
+    return false;
+  }
+
+  const flowChatState = flowChatStore.getState();
+  if (
+    flowChatState.activeSessionId !== null
+    || flowChatState.sessions.has(activeSessionIdBeforeArchive)
+  ) {
+    return false;
+  }
+
+  const sceneState = useSceneStore.getState();
+  if (!sceneState.openTabs.some(tab => tab.id === 'session')) {
+    return false;
+  }
+
+  sceneState.closeScene('session');
+  return true;
+}
+
 export async function openMainSession(
   sessionId: string,
   options?: {


### PR DESCRIPTION
## Summary

- Close the Session scene when archiving removes the currently active session.
- Return to the tabless welcome surface when no other scene is open.
- Preserve other open scenes and avoid closing the Session scene when another session becomes active.
- Apply the behavior to both single-session and batch archive flows.
- Add focused tests for the archive-to-welcome transition.

Fixes: #2425

## Type and Areas

Type:

Regression fix / UI/UX / test

Areas:

Web UI, Flow Chat session navigation

## Motivation / Impact

Archiving the active session cleared `activeSessionId` while leaving the Session scene mounted. The scene continued to render `ChatInput`, but the composer no longer had a session state machine, leaving users with a visible input that could not send messages.

After this change, archiving the active session closes the Session scene. If it was the only open scene, the app displays the shell-owned welcome surface. If other scenes are open, the existing scene fallback behavior is preserved.

Archiving a non-active session, a failed archive, or activating a replacement session does not close the Session scene.

## Verification

- `pnpm --dir src/web-ui exec vitest run src/flow_chat/services/sessionActivation.test.ts src/app/stores/sceneStore.test.ts --reporter=dot`
  - Passed: 2 test files, 16 tests.
- `pnpm run check:web`
  - Passed appearance contracts, theme audits, and TypeScript type checking.
- Focused ESLint checks for all modified source files passed.
- `git diff --check` passed.
- Manual UI verification was not performed.

## Reviewer Notes

- The Flow Chat layer continues to use `activeSessionId = null` after archiving the active session.
- Scene navigation remains in the app-layer session activation adapter.
- The transition closes the Session scene only when the previously active session was actually removed and no replacement session became active.
- No persisted data, backend API, protocol, or localization contracts changed.
- Remote Workspace, Remote Control, Peer Device Mode, and Detached Dispatch were not exercised end to end.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.