### PR TITLE
fix(web): restore scrolling in the Skills page

### DIFF
--- a/src/web-ui/src/app/scenes/skills/SkillsScene.presentation.test.ts
+++ b/src/web-ui/src/app/scenes/skills/SkillsScene.presentation.test.ts
@@ -14,6 +14,7 @@ describe('Skills scene presentation', () => {
     const source = readSibling('./SkillsScene.tsx');
 
     expect(source).toContain('{installedFiltered.map((skill, index) => (');
+    expect(source).toContain('<ScrollArea\n                        className="skills-main__grid"');
     expect(source).not.toContain('INSTALLED_PAGE_SIZE');
     expect(source).not.toContain('skills-installed__pagination');
   });

--- a/src/web-ui/src/app/scenes/skills/SkillsScene.tsx
+++ b/src/web-ui/src/app/scenes/skills/SkillsScene.tsx
@@ -427,7 +427,7 @@ const SkillsScene: React.FC = () => {
                     )}
 
                     {!installed.loading && !installed.error && installedFiltered.length > 0 && (
-                      <div
+                      <ScrollArea
                         className="skills-main__grid"
                         data-testid="skill-list"
                         data-bf-scene="skills"
@@ -591,7 +591,7 @@ const SkillsScene: React.FC = () => {
                             </div>
                           </div>
                         ))}
-                      </div>
+                      </ScrollArea>
                     )}
                   </div>
 


### PR DESCRIPTION
## Summary

Restore vertical scrolling for the installed Skills list by using the shared `ScrollArea` component.

Add a presentation regression test to ensure the installed Skills collection remains inside a scrollable region.


## Type and Areas

Type:

Regression fix / UI/UX / test

Areas:

Web UI

## Motivation / Impact

Long installed Skill lists were clipped because their parent container hid overflow while the list itself used a non-scrollable `div`.

Users can now scroll through the complete installed Skills list.

## Verification

- `pnpm --dir src/web-ui run test:run src/app/scenes/skills/SkillsScene.presentation.test.ts`
  - Passed: 5 tests
- `pnpm run check:web`
  - Passed appearance, typography, theme, and TypeScript checks
- `git diff --check`
  - Passed

## Reviewer Notes

This is a focused shared Web UI container change with no API, persisted-data, migration, or localization impact.

Remote workspace, remote control, Peer Device Mode, and Detached Dispatch were not manually exercised. The change uses the existing cross-surface `ScrollArea` component.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.