### PR TITLE
feat(web): refine floating chat and MiniApp library alignment

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/unifiedSessionCreation.test.ts
+++ b/src/web-ui/src/app/components/NavPanel/unifiedSessionCreation.test.ts
@@ -49,9 +49,8 @@ describe('unified project session creation', () => {
     expect(toolbarMode).toContain('<ConversationModeSurface');
     expect(toolbarMode).toContain('switchTestId="toolbar-realtime-voice-mode-switch"');
     expect(helloLauncher).toContain('<LauncherButton');
-    expect(helloLauncher).toContain(
-      'leadingIcon={<Phone size={16} aria-hidden="true" />}',
-    );
+    expect(helloLauncher).not.toContain('leadingIcon=');
+    expect(helloLauncher).toContain("tVoice('voiceCall.call.launcherCompactLabel')");
     expect(voicePanel).not.toContain('createPortal');
     expect(helloLauncherStyles).toContain('right: 0;');
     expect(helloLauncherStyles).toContain('bottom: 0;');

--- a/src/web-ui/src/app/layout/FloatingMiniChat.scss
+++ b/src/web-ui/src/app/layout/FloatingMiniChat.scss
@@ -80,12 +80,13 @@ $panel-height: 680px;
 }
 
 // Keep the resting launcher no wider than a standard control so it does not
-// cover nearby composer actions on compact surfaces. Fine pointers reveal the
-// short label on deliberate hover; keyboard focus reveals it immediately.
+// cover nearby composer actions on compact surfaces. Fine pointers replace
+// the compact greeting with the full greeting on deliberate hover; keyboard
+// focus reveals it immediately.
 .bitfun-fmc__button--hello {
   inline-size: var(--bf-control-launcher-button-block-size);
   min-inline-size: var(--bf-control-launcher-button-block-size);
-  justify-content: flex-start;
+  justify-content: center;
   gap: 0;
   padding-inline: 0;
   overflow: hidden;
@@ -96,21 +97,10 @@ $panel-height: 680px;
     background-color var(--bf-motion-duration-fast) var(--bf-motion-easing-standard),
     transform var(--bf-motion-duration-fast) var(--bf-motion-easing-standard);
 
-  > [data-bf-part='icon'] {
-    flex-basis: var(--bf-control-launcher-button-block-size);
-    inline-size: var(--bf-control-launcher-button-block-size);
-  }
-
   > [data-bf-part='label'] {
-    flex: 0 0 auto;
-    padding-inline:
-      var(--bf-control-launcher-button-gap)
-      var(--bf-control-launcher-button-padding-inline);
-    opacity: 0;
-    transform: translateX(var(--bf-space-1));
-    transition:
-      opacity var(--bf-motion-duration-fast) var(--bf-motion-easing-standard),
-      transform var(--bf-motion-duration-fast) var(--bf-motion-easing-standard);
+    display: grid;
+    inline-size: 100%;
+    place-items: center;
   }
 
   &:active {
@@ -121,19 +111,49 @@ $panel-height: 680px;
     inline-size: var(--bf-control-launcher-button-min-inline-size);
     transition-duration: 0s;
 
-    > [data-bf-part='label'] {
-      opacity: 1;
-      transform: none;
+    .bitfun-fmc__button-label {
       transition: none;
     }
+
+    .bitfun-fmc__button-label--compact {
+      opacity: 0;
+      transform: translateX(calc(var(--bf-space-1) * -1));
+    }
+
+    .bitfun-fmc__button-label--expanded {
+      opacity: 1;
+      transform: none;
+    }
   }
+}
+
+.bitfun-fmc__button-label {
+  grid-area: 1 / 1;
+  transition:
+    opacity var(--bf-motion-duration-fast) var(--bf-motion-easing-standard),
+    transform var(--bf-motion-duration-fast) var(--bf-motion-easing-standard);
+}
+
+.bitfun-fmc__button-label--compact {
+  opacity: 1;
+  transform: none;
+}
+
+.bitfun-fmc__button-label--expanded {
+  opacity: 0;
+  transform: translateX(var(--bf-space-1));
 }
 
 @media (hover: hover) and (pointer: fine) {
   .bitfun-fmc__button--hello:hover {
     inline-size: var(--bf-control-launcher-button-min-inline-size);
 
-    > [data-bf-part='label'] {
+    .bitfun-fmc__button-label--compact {
+      opacity: 0;
+      transform: translateX(calc(var(--bf-space-1) * -1));
+    }
+
+    .bitfun-fmc__button-label--expanded {
       opacity: 1;
       transform: none;
     }
@@ -635,7 +655,7 @@ $panel-height: 680px;
 @media (prefers-reduced-motion: reduce) {
   .bitfun-fmc,
   .bitfun-fmc__button,
-  .bitfun-fmc__button--hello > [data-bf-part='label'],
+  .bitfun-fmc__button-label,
   .bitfun-fmc__panel,
   .bitfun-fmc__header-btn,
   .bitfun-fmc__miniapp-suggestion {
@@ -643,7 +663,7 @@ $panel-height: 680px;
   }
 
   .bitfun-fmc__button,
-  .bitfun-fmc__button--hello > [data-bf-part='label'],
+  .bitfun-fmc__button-label,
   .bitfun-fmc__panel,
   .bitfun-fmc__header-btn,
   .bitfun-fmc__miniapp-suggestion {

--- a/src/web-ui/src/app/layout/FloatingMiniChat.tsx
+++ b/src/web-ui/src/app/layout/FloatingMiniChat.tsx
@@ -11,7 +11,6 @@
 
 import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Phone } from 'lucide-react';
 
 import { flowChatStore } from '../../flow_chat/store/FlowChatStore';
 import { syncSessionToModernStore } from '../../flow_chat/services/storeSync';
@@ -594,11 +593,21 @@ export const FloatingMiniChat: React.FC = () => {
           aria-expanded={isOpen}
           aria-label={t('toolCards.toolbar.startNewChat')}
           className="bitfun-fmc__button bitfun-fmc__button--hello"
-          leadingIcon={<Phone size={16} aria-hidden="true" />}
           onClick={handleOpen}
           onPointerDown={handleTriggerPointerDown}
         >
-          {tVoice('voiceCall.call.launcherLabel')}
+          <span
+            aria-hidden="true"
+            className="bitfun-fmc__button-label bitfun-fmc__button-label--compact"
+          >
+            {tVoice('voiceCall.call.launcherCompactLabel')}
+          </span>
+          <span
+            aria-hidden="true"
+            className="bitfun-fmc__button-label bitfun-fmc__button-label--expanded"
+          >
+            {tVoice('voiceCall.call.launcherLabel')}
+          </span>
         </LauncherButton>
       )}
 

--- a/src/web-ui/src/app/layout/floatingMiniChatActivity.test.ts
+++ b/src/web-ui/src/app/layout/floatingMiniChatActivity.test.ts
@@ -20,21 +20,22 @@ function readSource(relativePath: string): string {
 }
 
 describe('floating MiniApp chat activity', () => {
-  it('uses the realtime phone icon in the design-system launcher for Hello', () => {
+  it('uses text-only Hi and Hello states in the design-system launcher', () => {
     const component = readSource('./FloatingMiniChat.tsx');
     expect(component).toContain('IconButton, LauncherButton, Tooltip');
     expect(component).toContain('<LauncherButton');
     expect(component).toContain(
       'className="bitfun-fmc__button bitfun-fmc__button--hello"',
     );
-    expect(component).toContain(
-      'leadingIcon={<Phone size={16} aria-hidden="true" />}',
-    );
+    expect(component).not.toContain("from 'lucide-react'");
+    expect(component).not.toContain('leadingIcon=');
+    expect(component).toContain("tVoice('voiceCall.call.launcherCompactLabel')");
     expect(component).toContain("tVoice('voiceCall.call.launcherLabel')");
-    expect(component).not.toContain('className="bitfun-fmc__button-label"');
+    expect(component).toContain('bitfun-fmc__button-label--compact');
+    expect(component).toContain('bitfun-fmc__button-label--expanded');
   });
 
-  it('keeps Hello compact until fine-pointer hover or keyboard focus', () => {
+  it('keeps Hi compact until fine-pointer hover or keyboard focus reveals Hello', () => {
     const stylesheet = readSource('./FloatingMiniChat.scss');
 
     expect(stylesheet).not.toContain('--bf-color-control-launcher');
@@ -47,6 +48,8 @@ describe('floating MiniApp chat activity', () => {
     expect(stylesheet).toContain(
       'inline-size: var(--bf-control-launcher-button-min-inline-size);',
     );
+    expect(stylesheet).toContain('.bitfun-fmc__button-label--compact');
+    expect(stylesheet).toContain('.bitfun-fmc__button-label--expanded');
     expect(stylesheet).toContain('&:focus-visible');
   });
 

--- a/src/web-ui/src/app/scenes/miniapps/components/MiniAppCard.presentation.test.ts
+++ b/src/web-ui/src/app/scenes/miniapps/components/MiniAppCard.presentation.test.ts
@@ -142,6 +142,9 @@ describe('Mini App card presentation', () => {
     expect(stylesheet).toMatch(
       /&__meta \{[\s\S]*?align-self: end;[\s\S]*?block-size: var\(--bf-type-meta-line-height\);/,
     );
+    expect(stylesheet).toMatch(
+      /&__actions \{[\s\S]*?align-self: end;[\s\S]*?align-items: center;/,
+    );
     expect(stylesheet).not.toContain("content: '·';");
   });
 

--- a/src/web-ui/src/app/scenes/miniapps/views/MiniAppLibraryView.scss
+++ b/src/web-ui/src/app/scenes/miniapps/views/MiniAppLibraryView.scss
@@ -255,6 +255,7 @@
 
   &__actions {
     display: flex;
+    align-self: end;
     align-items: center;
     justify-content: flex-end;
     gap: var(--bf-space-2);

--- a/src/web-ui/src/locales/en-US/settings/voice-input.json
+++ b/src/web-ui/src/locales/en-US/settings/voice-input.json
@@ -81,6 +81,7 @@
     "call": {
       "title": "BitFun realtime call",
       "button": "Start a realtime voice call",
+      "launcherCompactLabel": "Hi",
       "launcherLabel": "Hello",
       "switchToVoice": "Switch to realtime voice",
       "switchToChat": "Return to text chat",

--- a/src/web-ui/src/locales/zh-CN/settings/voice-input.json
+++ b/src/web-ui/src/locales/zh-CN/settings/voice-input.json
@@ -81,6 +81,7 @@
     "call": {
       "title": "BitFun 实时通话",
       "button": "开始实时语音通话",
+      "launcherCompactLabel": "Hi",
       "launcherLabel": "Hello",
       "switchToVoice": "切换到实时语音",
       "switchToChat": "返回文字聊天",

--- a/src/web-ui/src/locales/zh-TW/settings/voice-input.json
+++ b/src/web-ui/src/locales/zh-TW/settings/voice-input.json
@@ -81,6 +81,7 @@
     "call": {
       "title": "BitFun 即時通話",
       "button": "開始即時語音通話",
+      "launcherCompactLabel": "Hi",
       "launcherLabel": "Hello",
       "switchToVoice": "切換到即時語音",
       "switchToChat": "返回文字聊天",


### PR DESCRIPTION
## Summary

- refine the floating mini chat launcher behavior, presentation, and localized voice-input copy
- align MiniApp installed/local status pills and the Open action with the bottom metadata row
- extend presentation coverage for the updated layout

## Verification

- `pnpm run check:web`
- `pnpm --dir src/web-ui run test:run src/app/scenes/miniapps/components/MiniAppCard.presentation.test.ts`