### PR TITLE
fix(harmony): stabilize QR and account device connections

### DIFF
--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/viewmodel/DeviceDirectoryViewModel.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/viewmodel/DeviceDirectoryViewModel.ets
@@ -236,7 +236,8 @@ export class DeviceDirectoryViewModel {
       return created;
     });
     this.state.replace(next);
-    if (this.state.find(this.state.selectedDeviceId)) {
+    if (this.state.find(this.state.selectedDeviceId) ||
+      (this.state.selectedDeviceId === activeId && activeId.length > 0 && activeConnected)) {
       return;
     }
     // A live control target is transport state, not a user selection in the
@@ -253,17 +254,27 @@ export class DeviceDirectoryViewModel {
   }
 
   async selectDevice(deviceId: string): Promise<void> {
-    const entry = this.state.find(deviceId);
+    const target = deviceId.trim();
+    const entry = this.state.find(target);
     if (!entry) {
+      // A QR-paired desktop is projected into the sidebar without belonging to
+      // the account directory. It is still a real selectable disclosure row
+      // while its control link is live; accepting only directory entries made
+      // that row render normally but ignore every tap.
+      if (target.length > 0 && target === this.hooks.activeDeviceId().trim() &&
+        this.hooks.activeDeviceConnected()) {
+        this.state.select(target);
+        RemoteLogger.info(`device directory select active projection device=${target}`);
+      }
       return;
     }
-    this.state.select(deviceId);
-    RemoteLogger.info(`device directory select device=${deviceId}`);
+    this.state.select(target);
+    RemoteLogger.info(`device directory select device=${target}`);
     if (this.shouldFetch(entry)) {
       entry.status = 'loading';
       entry.errorText = '';
     }
-    await this.ensureLoaded(deviceId);
+    await this.ensureLoaded(target);
   }
 
   async retryDevice(deviceId: string): Promise<void> {

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/viewmodel/RemoteConnectionController.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/viewmodel/RemoteConnectionController.ets
@@ -181,7 +181,9 @@ export class RemoteConnectionController {
       // list that is already on screen. Its own failures are logged inside.
       void this.loadRecentWorkspaces();
       this.pageState.setLoadingHome(false);
-      RemoteLogger.info('connect success');
+      RemoteLogger.info(
+        `connect success sessions=${initialSync.sessions.length} has_more=${initialSync.hasMoreSessions ? '1' : '0'}`
+      );
     } catch (err) {
       if (!this.connection.isCurrentRequest()) {
         return;

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/viewmodel/SettingsController.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/viewmodel/SettingsController.ets
@@ -554,7 +554,14 @@ export class SettingsController {
       return;
     }
     const selectionVersion = ++this.accountDeviceSelectionVersion;
-    if (deviceId === cloud.remoteState.controlTargetDeviceId && cloud.remoteState.connectionState === 'connected') {
+    // A QR room and an account-device link can identify the same physical
+    // desktop. Only short-circuit when the active transport is already the
+    // account path the user selected; otherwise this tap is an intentional
+    // room -> account migration and must replace the transport and persist the
+    // account target for the next launch.
+    if (cloud.remoteState.controlTargetType === 'account_device' &&
+      deviceId === cloud.remoteState.controlTargetDeviceId &&
+      cloud.remoteState.connectionState === 'connected') {
       cloud.hooks.closeConnectSheet();
       if (navigateHome) {
         cloud.hooks.navigateRemoteHome();

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/services/RemoteSessionManager.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/services/RemoteSessionManager.ets
@@ -49,12 +49,21 @@ export interface ProvisionedPeerDevice {
 const ACCOUNT_HANDSHAKE_TIMEOUT_MS: number = 15000;
 
 export class RemoteSessionManager implements RemoteChatCommandClient, RemoteFileDownloadClient, RemoteModelClient, RemoteSessionClient, RemoteToolActionClient {
-  private readonly roomClient: RelayHttpClient = new RelayHttpClient();
+  private readonly roomClient: RelayHttpClient;
   private transport?: RemoteCommandTransport;
   private transportGeneration: number = 0;
   private crypto?: RemoteCrypto;
   private workspace?: WorkspaceInfo;
   private roomRelayUrl: string = '';
+  private readonly cryptoFactory: () => RemoteCrypto;
+
+  constructor(
+    roomClient: RelayHttpClient = new RelayHttpClient(),
+    cryptoFactory: () => RemoteCrypto = () => new RemoteCrypto()
+  ) {
+    this.roomClient = roomClient;
+    this.cryptoFactory = cryptoFactory;
+  }
 
   reset(): void {
     this.transportGeneration += 1;
@@ -68,15 +77,21 @@ export class RemoteSessionManager implements RemoteChatCommandClient, RemoteFile
 
   async connect(descriptor: RemoteDescriptor, identity: PairIdentity, deviceId: string): Promise<InitialSyncResult> {
     this.transportGeneration += 1;
-    this.crypto = new RemoteCrypto();
-    this.roomRelayUrl = descriptor.relayUrl;
-    this.roomClient.bind(descriptor, this.crypto);
+    // A previous room transport owns this same RelayHttpClient. Reset it before
+    // binding the newly scanned descriptor; resetting afterwards would erase
+    // the new room and make every retry fail before the pairing HTTP request.
     this.transport?.reset();
+    this.crypto = undefined;
+    this.workspace = undefined;
+    this.roomRelayUrl = '';
+    this.crypto = this.cryptoFactory();
+    this.roomClient.bind(descriptor, this.crypto);
     this.transport = new RoomRemoteCommandTransport(this.roomClient);
     const initialSync = await this.roomClient.pair(deviceId, identity);
     // Account inheritance is optional for room pairing. A desktop without an
     // account, or an older desktop build, must not make normal QR control fail.
     await this.roomClient.requestDelegatedIdentity();
+    this.roomRelayUrl = descriptor.relayUrl;
     this.workspace = RemoteResponseMapper.workspaceFromInitialSync(initialSync);
     return {
       workspace: this.workspace,
@@ -141,6 +156,11 @@ export class RemoteSessionManager implements RemoteChatCommandClient, RemoteFile
   ): Promise<InitialSyncResult> {
     this.transportGeneration += 1;
     this.transport?.reset();
+    // Account-device RPC replaces the room channel. Do not leave a failed or
+    // previous QR room advertised as usable after the transport has changed.
+    this.crypto = undefined;
+    this.workspace = undefined;
+    this.roomRelayUrl = '';
     this.transport = new AccountDeviceCommandTransport(accountClient, relayUrl, session, targetDeviceId);
     let workspaceResponse: WorkspaceInfoResponse;
     try {

--- a/src/apps/mobile/harmonyos/entry/src/test/DeviceDirectoryUnit.test.ets
+++ b/src/apps/mobile/harmonyos/entry/src/test/DeviceDirectoryUnit.test.ets
@@ -189,6 +189,23 @@ export default function deviceDirectoryUnitTest() {
   });
 
   describe('DeviceDirectoryViewModel', () => {
+    it('selects a live QR device projected outside the account directory', 0, async () => {
+      const state = new DeviceDirectoryState();
+      const viewModel = new DeviceDirectoryViewModel(state, {
+        credentials: () => undefined,
+        activeDeviceId: () => 'qr-desktop',
+        activeDeviceConnected: () => true
+      });
+
+      await viewModel.selectDevice('qr-desktop');
+      expect(state.selectedDeviceId).assertEqual('qr-desktop');
+
+      // An account-directory refresh has no row for a scan-only target, but it
+      // must not collapse the disclosure while that target is still connected.
+      viewModel.syncDevices([]);
+      expect(state.selectedDeviceId).assertEqual('qr-desktop');
+    });
+
     it('does not issue RPC for an offline device', 0, async () => {
       let credentialCalls = 0;
       const state = new DeviceDirectoryState();

--- a/src/apps/mobile/harmonyos/entry/src/test/TransportAndGeneralChatUnit.test.ets
+++ b/src/apps/mobile/harmonyos/entry/src/test/TransportAndGeneralChatUnit.test.ets
@@ -71,6 +71,7 @@ import {
   RemoteModelPreferenceStore
 } from '../main/ets/services/RemoteModelController';
 import { RemotePairingPolicy } from '../main/ets/services/RemotePairingPolicy';
+import { PairIdentity, RelayHttpClient } from '../main/ets/services/RelayHttpClient';
 import { RemoteResponseMapper } from '../main/ets/services/RemoteResponseMapper';
 import { RemoteSessionClient, RemoteSessionController } from '../main/ets/services/RemoteSessionController';
 import { RemoteSessionManager } from '../main/ets/services/RemoteSessionManager';
@@ -120,6 +121,7 @@ import { TimeFormat } from '../main/ets/services/TimeFormat';
 import { X25519 } from '../main/ets/services/X25519';
 import {
   ChatMessage,
+  CommandStatusResponse,
   FileInfo,
   ImageAttachment,
   PollSessionResult,
@@ -129,8 +131,11 @@ import {
   RemoteImageContext,
   RemoteQuestionAnswerPayload,
   InitialSyncResult,
+  InitialSyncResponse,
+  RemoteDescriptor,
   RemoteModelCatalog,
   ReadFileResult,
+  RemoteCommand,
   RemoteSession,
   SelectedImageAttachment,
   SessionItemResponse,
@@ -322,6 +327,64 @@ class ScriptedAccountSessionManager extends RemoteSessionManager {
   reset(): void {
     this.resets += 1;
     super.reset();
+  }
+}
+
+class RecordingRoomClient extends RelayHttpClient {
+  readonly events: string[] = [];
+  private descriptorReady: boolean = false;
+
+  bind(descriptor: RemoteDescriptor, _crypto: RemoteCrypto): void {
+    this.descriptorReady = true;
+    this.events.push(`bind:${descriptor.roomId}`);
+  }
+
+  reset(): void {
+    this.descriptorReady = false;
+    this.events.push('reset');
+  }
+
+  async pair(_deviceId: string, _identity: PairIdentity): Promise<InitialSyncResponse> {
+    if (!this.descriptorReady) {
+      throw new Error('Remote descriptor is not configured.');
+    }
+    this.events.push('pair');
+    return {
+      resp: 'initial_sync',
+      has_workspace: true,
+      path: '/workspace',
+      project_name: 'workspace',
+      sessions: [{
+        session_id: 'session-after-retry',
+        name: 'Recovered session',
+        agent_type: 'agentic'
+      }]
+    };
+  }
+
+  async requestDelegatedIdentity(_force: boolean = false): Promise<boolean> {
+    return false;
+  }
+}
+
+class RecordingAccountDeviceClient extends CloudAccountClient {
+  async deviceRpc<T extends CommandStatusResponse>(
+    _relayUrl: string,
+    _session: CloudAccountSession,
+    _targetDeviceId: string,
+    command: RemoteCommand,
+    _timeoutMs: number = 130000
+  ): Promise<T> {
+    if (command.cmd === 'get_workspace_info') {
+      return JSON.parse(
+        '{"resp":"workspace_info","has_workspace":true,"workspace_path":"/account-workspace",' +
+        '"workspace_name":"Account workspace"}'
+      ) as T;
+    }
+    return JSON.parse(
+      '{"resp":"session_list","sessions":[{"session_id":"account-device-session",' +
+      '"name":"Account device session","agent_type":"agentic"}],"has_more":false}'
+    ) as T;
   }
 }
 
@@ -559,6 +622,74 @@ export default function transportAndGeneralChatUnitTest() {
         didThrow = true;
       }
       expect(didThrow).assertEqual(true);
+    });
+  });
+
+  describe('RemoteSessionManager room reconnect', () => {
+    it('keeps the newly scanned descriptor and its initial sessions after a prior room transport', 0, async () => {
+      const roomClient = new RecordingRoomClient();
+      const manager = new RemoteSessionManager(roomClient, () => new RemoteCrypto({
+        cipher: new FakeRemoteCryptoCipher(),
+        keyPair: {
+          privateKey: new Uint8Array(32),
+          publicKey: new Uint8Array(32)
+        },
+        randomBytes: fixedRandomBytes
+      }));
+      const identity: PairIdentity = { userId: 'harmony-device' };
+      const first: RemoteDescriptor = {
+        relayUrl: 'https://relay.example.com',
+        roomId: 'expired-room',
+        publicKey: 'expired-key',
+        accountAuth: false,
+        accountUsername: ''
+      };
+      const replacement: RemoteDescriptor = {
+        relayUrl: 'https://relay.example.com',
+        roomId: 'fresh-room',
+        publicKey: 'fresh-key',
+        accountAuth: false,
+        accountUsername: ''
+      };
+
+      await manager.connect(first, identity, 'harmony-device');
+      const result = await manager.connect(replacement, identity, 'harmony-device');
+
+      expect(roomClient.events.join(','))
+        .assertEqual('bind:expired-room,pair,reset,bind:fresh-room,pair');
+      expect(result.sessions.length).assertEqual(1);
+      expect(result.sessions[0].id).assertEqual('session-after-retry');
+    });
+
+    it('replaces room state and loads sessions when switching to an account device', 0, async () => {
+      const roomClient = new RecordingRoomClient();
+      const manager = new RemoteSessionManager(roomClient, () => new RemoteCrypto({
+        cipher: new FakeRemoteCryptoCipher(),
+        keyPair: {
+          privateKey: new Uint8Array(32),
+          publicKey: new Uint8Array(32)
+        },
+        randomBytes: fixedRandomBytes
+      }));
+      await manager.connect({
+        relayUrl: 'https://relay.example.com',
+        roomId: 'room-before-account',
+        publicKey: 'room-key',
+        accountAuth: false,
+        accountUsername: ''
+      }, { userId: 'harmony-device' }, 'harmony-device');
+
+      const result = await manager.connectAccountDevice(
+        new RecordingAccountDeviceClient(),
+        'https://relay.example.com',
+        { token: 'token', userId: 'account-user', masterKey: new Uint8Array(32) },
+        'desktop-device'
+      );
+
+      expect(manager.hasRoomChannel()).assertFalse();
+      expect(result.workspace.path).assertEqual('/account-workspace');
+      expect(result.sessions.length).assertEqual(1);
+      expect(result.sessions[0].id).assertEqual('account-device-session');
     });
   });
 
@@ -1341,6 +1472,21 @@ export default function transportAndGeneralChatUnitTest() {
       expect(harness.remoteState.activeSession.sessionId).assertEqual('');
       expect(harness.remoteState.statusText).assertEqual('');
       expect(harness.timelineResets).assertEqual(1);
+    });
+
+    it('migrates the same desktop from a QR room to the account transport', 0, async () => {
+      const harness = new AccountDeviceSwitchHarness();
+      harness.remoteState.setControlTarget('room', 'desk-a', 'Desktop A');
+      harness.remoteState.setConnectionState('connected');
+
+      await harness.controller.selectCloudAccountDevice(harness.device('desk-a'), false);
+
+      expect(harness.sessionManager.dialled.join(',')).assertEqual('desk-a');
+      expect(harness.remoteState.controlTargetType).assertEqual('account_device');
+      expect(harness.remoteState.controlTargetDeviceId).assertEqual('desk-a');
+      expect(harness.remoteState.connectionState).assertEqual('connected');
+      expect(harness.sessionStore.saved.length).assertEqual(1);
+      expect(harness.sessionStore.saved[0].targetDeviceId).assertEqual('desk-a');
     });
 
     it('puts the phone back on the previous desktop when a device switch fails', 0, async () => {


### PR DESCRIPTION
## Summary

- reset the previous room transport before binding a newly scanned QR descriptor so retries keep the new room
- make live scan-only device rows selectable and preserve their expanded state during account-directory refreshes
- migrate a connected QR room to account-device RPC when the same physical desktop is selected after login
- log the initial session count and add regression coverage for all three transitions

## Verification

- HarmonyOS LocalTest suite
- pnpm run harmony:architecture
- signed HarmonyOS HAP build
- USB real-device verification: QR pairing loaded sessions and workspaces, selecting the same signed-in desktop switched to account RPC, and a cold restart restored the account-device target without retrying QR pairing

Remote scenario exercised: HarmonyOS phone remote control to the desktop relay. Remote workspace, Peer Device Mode, and Detached Dispatch were not involved.