### PR TITLE
fix(flow-chat): render turn rail capsules live

### DIFF
--- a/src/crates/assembly/core/src/agentic/persistence/manager.rs
+++ b/src/crates/assembly/core/src/agentic/persistence/manager.rs
@@ -30,7 +30,8 @@ use crate::service::remote_ssh::workspace_state::{
 use crate::service::session::{
     DialogTurnData, SessionMetadata, SessionTranscriptExport, SessionTranscriptExportOptions,
     SessionTurnCatalog, SessionTurnCatalogEntry, SessionTurnWindowResponse, TranscriptLineRange,
-    SESSION_STORAGE_SCHEMA_VERSION, SESSION_TURN_CATALOG_SCHEMA_VERSION,
+    TurnRailCapsulePreview, TurnRailCapsuleSegment, SESSION_STORAGE_SCHEMA_VERSION,
+    SESSION_TURN_CATALOG_SCHEMA_VERSION,
 };
 use crate::service::workspace_runtime::WorkspaceRuntimeService;
 use crate::util::errors::{OpenBitFunError, OpenBitFunResult};
@@ -71,6 +72,10 @@ const COMPRESSION_TRANSCRIPT_CREATE_ATTEMPTS: usize = 32;
 const TOKEN_ANCHOR_SCHEMA_VERSION: u32 = 1;
 const SESSION_TURN_READ_CONCURRENCY: usize = 4;
 const SESSION_TURN_CATALOG_PREVIEW_CHAR_LIMIT: usize = 320;
+const TURN_RAIL_CAPSULE_MAX_SEGMENTS: usize = 64;
+const TURN_RAIL_CAPSULE_TEXT_LIMIT: usize = 320;
+const TURN_RAIL_CAPSULE_LABEL_LIMIT: usize = 160;
+const TURN_RAIL_CAPSULE_TITLE_LIMIT: usize = 320;
 const SESSION_TURN_WINDOW_MAX_BEFORE: usize = 4;
 const SESSION_TURN_WINDOW_MAX_TARGET_AND_AFTER: usize = 12;
 pub const SESSION_REFERENCE_TRANSCRIPT_CHAR_LIMIT: usize = 60_000;
@@ -181,6 +186,57 @@ fn truncate_turn_catalog_preview(content: &str) -> (String, bool) {
     (preview, chars.next().is_some())
 }
 
+fn bounded_display_text(value: &str, limit: usize) -> String {
+    value.chars().take(limit).collect()
+}
+
+fn turn_rail_capsule_preview(turn: &DialogTurnData) -> Option<TurnRailCapsulePreview> {
+    let metadata = turn.user_message.metadata.as_ref()?.as_object()?;
+    let presentation = metadata.get("composerPresentation")?.as_object()?;
+    if presentation.get("version")?.as_u64()? != 1 {
+        return None;
+    }
+    let raw_segments = presentation.get("segments")?.as_array()?;
+    let mut segments = Vec::new();
+    for raw in raw_segments.iter().take(TURN_RAIL_CAPSULE_MAX_SEGMENTS) {
+        let segment = raw.as_object()?;
+        match segment.get("kind")?.as_str()? {
+            "text" => {
+                let text = segment.get("text")?.as_str()?;
+                if !text.is_empty() {
+                    segments.push(TurnRailCapsuleSegment::Text {
+                        text: bounded_display_text(text, TURN_RAIL_CAPSULE_TEXT_LIMIT),
+                    });
+                }
+            }
+            "context" => {
+                let context = segment.get("context")?.as_object()?;
+                let context_type = context.get("type")?.as_str()?;
+                let label = segment.get("label")?.as_str()?;
+                let title = segment
+                    .get("title")
+                    .and_then(serde_json::Value::as_str)
+                    .map(|value| bounded_display_text(value, TURN_RAIL_CAPSULE_TITLE_LIMIT));
+                segments.push(TurnRailCapsuleSegment::Context {
+                    context_type: bounded_display_text(context_type, 40),
+                    label: bounded_display_text(label, TURN_RAIL_CAPSULE_LABEL_LIMIT),
+                    title,
+                });
+            }
+            "inline-token" => {
+                let token_type = segment.get("tokenType")?.as_str()?;
+                let label = segment.get("label")?.as_str()?;
+                segments.push(TurnRailCapsuleSegment::InlineToken {
+                    token_type: bounded_display_text(token_type, 40),
+                    label: bounded_display_text(label, TURN_RAIL_CAPSULE_LABEL_LIMIT),
+                });
+            }
+            _ => return None,
+        }
+    }
+    (!segments.is_empty()).then_some(TurnRailCapsulePreview { segments })
+}
+
 fn turn_catalog_entry(turn: &DialogTurnData, ordinal: usize) -> SessionTurnCatalogEntry {
     let (preview, preview_truncated) =
         truncate_turn_catalog_preview(&transcript_display_user_content(turn));
@@ -190,6 +246,7 @@ fn turn_catalog_entry(turn: &DialogTurnData, ordinal: usize) -> SessionTurnCatal
         turn_id: Some(turn.turn_id.clone()),
         preview: Some(preview),
         preview_truncated,
+        capsule_preview: turn_rail_capsule_preview(turn),
     }
 }
 
@@ -203,6 +260,7 @@ fn placeholder_turn_catalog_entry(
         turn_id: None,
         preview: None,
         preview_truncated: false,
+        capsule_preview: None,
     }
 }
 
@@ -5259,6 +5317,59 @@ mod tests {
         let (preview, truncated) = truncate_turn_catalog_preview(&exact);
         assert_eq!(preview, exact);
         assert!(!truncated);
+    }
+
+    #[test]
+    fn turn_rail_capsule_preview_keeps_only_display_facts() {
+        let mut turn = DialogTurnData::new(
+            "turn-capsule".to_string(),
+            0,
+            "session-capsule".to_string(),
+            UserMessageData {
+                id: "user-capsule".to_string(),
+                content: "[$pdf] #file: auth.ts".to_string(),
+                timestamp: 0,
+                metadata: Some(serde_json::json!({
+                    "composerPresentation": {
+                        "version": 1,
+                        "segments": [
+                            { "kind": "inline-token", "token": "[$pdf]", "tokenType": "skill", "label": "pdf" },
+                            { "kind": "text", "text": " " },
+                            {
+                                "kind": "context",
+                                "context": {
+                                    "id": "file-1",
+                                    "type": "file",
+                                    "filePath": "E:/workspace/auth.ts",
+                                    "fileName": "auth.ts",
+                                    "selectedText": "large secret payload that must not enter catalog"
+                                },
+                                "tag": "#file: auth.ts",
+                                "label": "auth.ts",
+                                "title": "E:/workspace/auth.ts"
+                            }
+                        ]
+                    }
+                })),
+            },
+        );
+        let entry = turn_catalog_entry(&turn, 0);
+        let preview = entry.capsule_preview.expect("capsule preview");
+        assert_eq!(preview.segments.len(), 3);
+        let encoded = serde_json::to_string(&preview).expect("preview should serialize");
+        let encoded_json: serde_json::Value =
+            serde_json::from_str(&encoded).expect("preview JSON should parse");
+        assert_eq!(encoded_json["segments"][0]["kind"], "inlineToken");
+        assert_eq!(encoded_json["segments"][0]["tokenType"], "skill");
+        assert!(encoded_json["segments"][0].get("token_type").is_none());
+        assert_eq!(encoded_json["segments"][2]["kind"], "context");
+        assert_eq!(encoded_json["segments"][2]["contextType"], "file");
+        assert!(encoded_json["segments"][2].get("context_type").is_none());
+        assert!(encoded.contains("auth.ts"));
+        assert!(!encoded.contains("large secret payload"));
+        assert!(!encoded.contains("filePath"));
+        turn.user_message.metadata = None;
+        assert!(turn_catalog_entry(&turn, 0).capsule_preview.is_none());
     }
 
     #[tokio::test]

--- a/src/crates/services/services-core/src/session/types.rs
+++ b/src/crates/services/services-core/src/session/types.rs
@@ -392,6 +392,36 @@ pub struct SessionTurnCatalogEntry {
     pub preview: Option<String>,
     #[serde(default)]
     pub preview_truncated: bool,
+    /// Small, read-only projection used to render Turn Rail tooltips without
+    /// copying executable context payloads into the navigation catalog.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capsule_preview: Option<TurnRailCapsulePreview>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TurnRailCapsulePreview {
+    pub segments: Vec<TurnRailCapsuleSegment>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum TurnRailCapsuleSegment {
+    Text {
+        text: String,
+    },
+    Context {
+        #[serde(rename = "contextType")]
+        context_type: String,
+        label: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        title: Option<String>,
+    },
+    InlineToken {
+        #[serde(rename = "tokenType")]
+        token_type: String,
+        label: String,
+    },
 }
 
 /// Lightweight navigation catalog for a persisted Session.

--- a/src/web-ui/src/flow_chat/components/modern/FlowChatTurnRail.scss
+++ b/src/web-ui/src/flow_chat/components/modern/FlowChatTurnRail.scss
@@ -121,6 +121,7 @@
     white-space: pre-wrap;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 5;
+
   }
 }
 

--- a/src/web-ui/src/flow_chat/components/modern/FlowChatTurnRail.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/FlowChatTurnRail.test.tsx
@@ -23,6 +23,7 @@ vi.mock('react-i18next', () => ({
 }));
 
 vi.mock('@openbitfun/ui', () => ({
+  Icon: ({ name }: { name: string }) => <span data-testid={`icon-${name}`} />,
   Tooltip: ({
     children,
     content,
@@ -253,6 +254,39 @@ describe('FlowChatTurnRail', () => {
     expect(tooltip?.textContent).toContain('Turn 1');
     expect(tooltip?.textContent).toContain('First user message');
     expect(tooltip?.querySelector('.flowchat-turn-rail__tooltip-time')).toBeNull();
+  });
+
+  it('renders catalog-only capsule previews without the raw prompt markers', () => {
+    act(() => {
+      root.render(
+        <FlowChatTurnRail
+          turns={[{
+            ...turns[0],
+            content: '[$pdf] #file: src/auth.ts',
+            capsulePreview: {
+              segments: [
+                { kind: 'inlineToken', tokenType: 'skill', label: 'pdf' },
+                { kind: 'text', text: ' ' },
+                { kind: 'context', contextType: 'file', label: 'auth.ts', title: 'src/auth.ts' },
+              ],
+            },
+          }]}
+          currentTurnId="turn-1"
+          visibleTurnIds={['turn-1']}
+          onNavigate={vi.fn()}
+        />,
+      );
+    });
+
+    const tooltip = container.querySelector('[data-testid="tooltip-content"]');
+    expect(tooltip?.textContent).toContain('pdf');
+    expect(tooltip?.textContent).toContain('auth.ts');
+    expect(tooltip?.textContent).not.toContain('[$pdf]');
+    expect(tooltip?.textContent).not.toContain('#file:');
+    expect(tooltip?.querySelectorAll('.user-message-item__reference')).toHaveLength(2);
+    expect(tooltip?.querySelector('[data-testid="icon-extension"]')).not.toBeNull();
+    expect(tooltip?.querySelector('[data-testid="icon-extension"]')?.closest('.message-reference-capsule')
+      ?.textContent).toContain('pdf');
   });
 
   it('delegates clicks to the shared turn navigation callback', () => {

--- a/src/web-ui/src/flow_chat/components/modern/FlowChatTurnRail.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/FlowChatTurnRail.tsx
@@ -1,6 +1,8 @@
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Tooltip } from '@openbitfun/ui';
+import type { TurnRailCapsulePreview } from '@/shared/types/session-history';
+import { MessageReferenceCapsule } from './MessageReferenceCapsule';
 import { observeElementResize } from '@/shared/utils/sharedResizeObserver';
 import {
   FLOWCHAT_TURN_RAIL_ROW_HEIGHT_PX,
@@ -17,6 +19,7 @@ export interface FlowChatTurnRailItem {
   ordinal: number;
   turnIndex: number;
   content: string | null;
+  capsulePreview?: TurnRailCapsulePreview;
 }
 
 interface FlowChatTurnRailProps {
@@ -275,6 +278,7 @@ export const FlowChatTurnRail: React.FC<FlowChatTurnRailProps> = ({
             const content = turn.content === null
               ? null
               : turn.content.trim() || untitledTurnLabel;
+            const capsulePreview = turn.capsulePreview;
 
             return (
               <Tooltip
@@ -285,7 +289,26 @@ export const FlowChatTurnRail: React.FC<FlowChatTurnRailProps> = ({
                 content={(
                   <span className="flowchat-turn-rail__tooltip-content" data-openbitfun-component="flow-chat-turn-rail" data-openbitfun-part="tooltipContent">
                     <span className="flowchat-turn-rail__tooltip-turn" data-openbitfun-component="flow-chat-turn-rail" data-openbitfun-part="tooltipTurn">{turnLabel}</span>
-                    {content !== null ? (
+                    {capsulePreview ? (
+                      <span className="flowchat-turn-rail__tooltip-message" data-openbitfun-component="flow-chat-turn-rail" data-openbitfun-part="tooltipMessage">
+                        {capsulePreview.segments.map((segment, index) => segment.kind === 'text' ? (
+                          <React.Fragment key={`text-${index}`}>{segment.text}</React.Fragment>
+                        ) : segment.kind === 'inlineToken' ? (
+                          <MessageReferenceCapsule
+                            key={`token-${index}`}
+                            type={segment.tokenType}
+                            label={segment.label}
+                          />
+                        ) : (
+                          <MessageReferenceCapsule
+                            key={`context-${index}`}
+                            type={segment.contextType}
+                            label={segment.label}
+                            title={segment.title}
+                          />
+                        ))}
+                      </span>
+                    ) : content !== null ? (
                       <span className="flowchat-turn-rail__tooltip-message" data-openbitfun-component="flow-chat-turn-rail" data-openbitfun-part="tooltipMessage">{content}</span>
                     ) : null}
                   </span>

--- a/src/web-ui/src/flow_chat/components/modern/MessageReferenceCapsule.scss
+++ b/src/web-ui/src/flow_chat/components/modern/MessageReferenceCapsule.scss
@@ -1,0 +1,35 @@
+.message-reference-capsule,
+.user-message-item__reference {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.28rem;
+  max-width: min(100%, 18rem);
+  margin: 0.08rem 0.14rem;
+  padding: 0.08rem 0.38rem;
+  vertical-align: text-bottom;
+  border: 1px solid var(--openbitfun-color-border-subtle);
+  border-radius: var(--openbitfun-radius-sm);
+  background: var(--openbitfun-color-action-neutral-surface-hover);
+  color: var(--openbitfun-color-content-secondary);
+  font-size: var(--openbitfun-type-flow-control-font-size);
+  font-weight: var(--openbitfun-type-label-sm-font-weight);
+  line-height: var(--openbitfun-type-meta-line-height);
+  white-space: nowrap;
+  user-select: none;
+
+  svg,
+  [data-openbitfun-component='icon'] {
+    flex: 0 0 auto;
+  }
+}
+
+.message-reference-capsule--session-reference,
+.user-message-item__reference--session-reference {
+  color: var(--openbitfun-color-content-primary);
+}
+
+.message-reference-capsule__label,
+.user-message-item__reference-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/src/web-ui/src/flow_chat/components/modern/MessageReferenceCapsule.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/MessageReferenceCapsule.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { Icon } from '@openbitfun/ui';
+import { AtSign, Code2, File, MessageCircle } from 'lucide-react';
+import type { ContextType } from '@/shared/types/context';
+import './MessageReferenceCapsule.scss';
+
+export function messageContextIcon(type: ContextType | string): React.ReactNode {
+  switch (type) {
+    case 'session-reference': return <MessageCircle size={13} aria-hidden />;
+    case 'file':
+    case 'image': return <File size={13} aria-hidden />;
+    case 'directory': return <Icon name="folder" size="lg" style={{ width: 13, height: 13 }} aria-hidden />;
+    case 'code-snippet':
+    case 'mermaid-node':
+    case 'mermaid-diagram': return <Code2 size={13} aria-hidden />;
+    case 'pull-request':
+    case 'git-ref': return <Icon name="git" size="lg" style={{ width: 13, height: 13 }} aria-hidden />;
+    case 'terminal-command': return <Icon name="terminal" size="lg" style={{ width: 13, height: 13 }} aria-hidden />;
+    case 'url': return <Icon name="link" size="lg" style={{ width: 13, height: 13 }} aria-hidden />;
+    default: return <AtSign size={13} aria-hidden />;
+  }
+}
+
+/**
+ * Returns the icon used for composer inline tokens. Keeping this projection
+ * shared means persisted Turn Rail previews render the same visual language as
+ * the already-sent user message.
+ */
+export function messageInlineTokenIcon(tokenType: string): React.ReactNode {
+  switch (tokenType) {
+    case 'skill':
+      return <Icon name="extension" size="lg" style={{ width: 13, height: 13 }} aria-hidden />;
+    case 'widget':
+    default:
+      return <AtSign size={13} aria-hidden />;
+  }
+}
+
+export const MessageReferenceCapsule: React.FC<{
+  className?: string;
+  type: string;
+  label: string;
+  title?: string;
+  children?: React.ReactNode;
+}> = ({ className = '', type, label, title, children }) => {
+
+  return (
+    <span
+      className={`message-reference-capsule message-reference-capsule--${type} user-message-item__reference user-message-item__reference--${type} ${className}`.trim()}
+      data-openbitfun-component="user-message-item"
+      data-openbitfun-part="content"
+      data-openbitfun-state={type}
+      title={title ?? label}
+    >
+      {children ?? (type === 'skill' || type === 'widget'
+        ? messageInlineTokenIcon(type)
+        : messageContextIcon(type))}
+      <span className="message-reference-capsule__label user-message-item__reference-label">{label}</span>
+    </span>
+  );
+};

--- a/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModernFlowChatContainer.tsx
@@ -20,6 +20,7 @@ import {
 } from './FlowChatHeader';
 import type { SessionTreeSelection } from './SessionTreePopover';
 import { FlowChatTurnRail, type FlowChatTurnRailItem } from './FlowChatTurnRail';
+import { composerPresentationToTurnRailPreview, parseComposerPresentation } from '../../utils/composerPresentation';
 import { BackgroundCommandInputDialog } from '../background-command/BackgroundCommandInputDialog';
 import { WelcomePanel } from '../WelcomePanel';
 import { HistorySessionPlaceholder } from './HistorySessionPlaceholder';
@@ -1009,11 +1010,17 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
       ...(historyView?.loadedRanges.flatMap(range => range.turns) ?? []),
     ];
     const dialogTurnById = new Map(loadedTurns.map(turn => [turn.id, turn]));
-    const loadedByStorageIndex = new Map<number, { turnId: string; content: string }>();
-    const loadedByOrdinal = new Map<number, { turnId: string; content: string }>();
+    const loadedByStorageIndex = new Map<number, { turnId: string; content: string; capsulePreview?: FlowChatTurnRailItem['capsulePreview'] }>();
+    const loadedByOrdinal = new Map<number, { turnId: string; content: string; capsulePreview?: FlowChatTurnRailItem['capsulePreview'] }>();
     for (const range of historyView?.loadedRanges ?? []) {
       range.turns.forEach((turn, index) => {
-        const loaded = { turnId: turn.id, content: turn.userMessage?.content ?? '' };
+        const loaded = {
+          turnId: turn.id,
+          content: turn.userMessage?.content ?? '',
+          capsulePreview: composerPresentationToTurnRailPreview(
+            parseComposerPresentation(turn.userMessage?.metadata?.composerPresentation),
+          ),
+        };
         loadedByOrdinal.set(range.startOrdinal + index, loaded);
         const storageTurnIndex = turn.storageTurnIndex ?? turn.backendTurnIndex;
         if (typeof storageTurnIndex === 'number') {
@@ -1022,9 +1029,13 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
       });
     }
     for (const summary of absoluteRenderedTurnSummaries) {
+      const dialogTurn = dialogTurnById.get(summary.turnId);
       const loaded = {
         turnId: summary.turnId,
-        content: dialogTurnById.get(summary.turnId)?.userMessage?.content ?? '',
+        content: dialogTurn?.userMessage?.content ?? '',
+        capsulePreview: composerPresentationToTurnRailPreview(
+          parseComposerPresentation(dialogTurn?.userMessage?.metadata?.composerPresentation),
+        ),
       };
       loadedByOrdinal.set(Math.max(0, summary.turnIndex - 1), loaded);
       if (typeof summary.storageTurnIndex === 'number') {
@@ -1047,6 +1058,9 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
         ?? (catalogEntry?.turnId && catalogDialogTurn ? {
           turnId: catalogEntry.turnId,
           content: catalogDialogTurn.userMessage?.content ?? '',
+          capsulePreview: composerPresentationToTurnRailPreview(
+            parseComposerPresentation(catalogDialogTurn.userMessage?.metadata?.composerPresentation),
+          ),
         } : undefined)
         ?? loadedByOrdinal.get(ordinal);
       const turnId = loaded?.turnId ?? catalogEntry?.turnId ?? null;
@@ -1059,6 +1073,7 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
         ordinal,
         turnIndex: ordinal + 1,
         content: loaded?.content ?? catalogEntry?.preview ?? null,
+        capsulePreview: loaded?.capsulePreview ?? catalogEntry?.capsulePreview,
       };
     });
 
@@ -1074,6 +1089,9 @@ export const ModernFlowChatContainer: React.FC<ModernFlowChatContainerProps> = (
         ordinal: Math.max(0, summary.turnIndex - 1),
         turnIndex: summary.turnIndex,
         content: dialogTurnById.get(summary.turnId)?.userMessage?.content ?? '',
+        capsulePreview: composerPresentationToTurnRailPreview(
+          parseComposerPresentation(dialogTurnById.get(summary.turnId)?.userMessage?.metadata?.composerPresentation),
+        ),
       });
     }
 

--- a/src/web-ui/src/flow_chat/components/modern/UserMessageItem.scss
+++ b/src/web-ui/src/flow_chat/components/modern/UserMessageItem.scss
@@ -175,39 +175,6 @@
   transition: none;
 }
 
-.user-message-item__reference {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.28rem;
-  max-width: min(100%, 18rem);
-  margin: 0.08rem 0.14rem;
-  padding: 0.08rem 0.38rem;
-  vertical-align: text-bottom;
-  border: 1px solid var(--openbitfun-color-border-subtle);
-  border-radius: var(--openbitfun-radius-sm);
-  background: var(--openbitfun-color-action-neutral-surface-hover);
-  color: var(--openbitfun-color-content-secondary);
-  font-size: var(--openbitfun-type-flow-control-font-size);
-  font-weight: var(--openbitfun-type-label-sm-font-weight);
-  line-height: var(--openbitfun-type-meta-line-height);
-  white-space: nowrap;
-  user-select: none;
-
-  svg,
-  [data-openbitfun-component='icon'] {
-    flex: 0 0 auto;
-  }
-}
-
-.user-message-item__reference--session-reference {
-  color: var(--openbitfun-color-content-primary);
-}
-
-.user-message-item__reference-label {
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
 // Expanded state (outer scroll area).
 .user-message-item--expanded {
   max-height: 60vh;

--- a/src/web-ui/src/flow_chat/components/modern/UserMessagePresentationContent.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/UserMessagePresentationContent.tsx
@@ -1,46 +1,6 @@
 import React from 'react';
-import { Icon } from '@openbitfun/ui';
-import {
-  AtSign,
-  Code2,
-  File,
-  MessageCircle,
-} from 'lucide-react';
-import type { ContextItem } from '@/shared/types/context';
 import type { ComposerPresentation } from '../../utils/composerPresentation';
-
-const catalogIcon = (name: 'extension' | 'folder' | 'git' | 'link' | 'terminal') => (
-  <Icon name={name} size="lg" style={{ width: 13, height: 13 }} aria-hidden />
-);
-
-function contextIcon(type: ContextItem['type']): React.ReactNode {
-  switch (type) {
-    case 'session-reference':
-      return <MessageCircle size={13} aria-hidden />;
-    case 'file':
-    case 'image':
-      return <File size={13} aria-hidden />;
-    case 'directory':
-      return catalogIcon('folder');
-    case 'code-snippet':
-    case 'mermaid-node':
-    case 'mermaid-diagram':
-      return <Code2 size={13} aria-hidden />;
-    case 'pull-request':
-    case 'git-ref':
-      return catalogIcon('git');
-    case 'terminal-command':
-      return catalogIcon('terminal');
-    case 'url':
-      return catalogIcon('link');
-    case 'web-element':
-      return <AtSign size={13} aria-hidden />;
-    default: {
-      const exhaustive: never = type;
-      return exhaustive;
-    }
-  }
-}
+import { MessageReferenceCapsule, messageInlineTokenIcon } from './MessageReferenceCapsule';
 
 export const UserMessagePresentationContent: React.FC<{
   presentation: ComposerPresentation;
@@ -52,30 +12,23 @@ export const UserMessagePresentationContent: React.FC<{
       }
 
       if (segment.kind === 'inline-token') {
-        const icon = segment.tokenType === 'skill'
-          ? catalogIcon('extension')
-          : <AtSign size={13} aria-hidden />;
         return (
-          <span
+          <MessageReferenceCapsule
             key={`token-${index}`}
-            className={`user-message-item__reference user-message-item__reference--${segment.tokenType}`}
+            type={segment.tokenType}
             title={segment.label}
-          >
-            {icon}
-            <span className="user-message-item__reference-label">{segment.label}</span>
-          </span>
+            label={segment.label}
+          >{messageInlineTokenIcon(segment.tokenType)}</MessageReferenceCapsule>
         );
       }
 
       return (
-        <span
+        <MessageReferenceCapsule
           key={`context-${index}`}
-          className={`user-message-item__reference user-message-item__reference--${segment.context.type}`}
+          type={segment.context.type}
           title={segment.title}
-        >
-          {contextIcon(segment.context.type)}
-          <span className="user-message-item__reference-label">{segment.label}</span>
-        </span>
+          label={segment.label}
+        />
       );
     })}
   </>

--- a/src/web-ui/src/flow_chat/utils/composerPresentation.ts
+++ b/src/web-ui/src/flow_chat/utils/composerPresentation.ts
@@ -1,4 +1,5 @@
 import type { ContextItem, SessionReferenceContext } from '@/shared/types/context';
+import type { TurnRailCapsulePreview } from '@/shared/types/session-history';
 
 export const COMPOSER_PRESENTATION_VERSION = 1;
 
@@ -79,6 +80,26 @@ export function hasComposerPresentationReferences(
   return Boolean(
     presentation?.segments.some(segment => segment.kind !== 'text'),
   );
+}
+
+/** Reduce a full presentation to the read-only facts needed by Turn Rail. */
+export function composerPresentationToTurnRailPreview(
+  presentation: ComposerPresentation | null | undefined,
+): TurnRailCapsulePreview | undefined {
+  if (!presentation || !hasComposerPresentationReferences(presentation)) return undefined;
+  const segments = presentation.segments.map(segment => {
+    if (segment.kind === 'text') return { kind: 'text' as const, text: segment.text };
+    if (segment.kind === 'inline-token') {
+      return { kind: 'inlineToken' as const, tokenType: segment.tokenType, label: segment.label };
+    }
+    return {
+      kind: 'context' as const,
+      contextType: segment.context.type,
+      label: segment.label,
+      ...(segment.title ? { title: segment.title } : {}),
+    };
+  });
+  return segments.length > 0 ? { segments } : undefined;
 }
 
 export function composerPresentationToEditorText(

--- a/src/web-ui/src/shared/types/session-history.ts
+++ b/src/web-ui/src/shared/types/session-history.ts
@@ -174,6 +174,15 @@ export interface SessionTurnCatalogEntry {
   turnId?: string;
   preview?: string;
   previewTruncated: boolean;
+  capsulePreview?: TurnRailCapsulePreview;
+}
+
+export interface TurnRailCapsulePreview {
+  segments: Array<
+    | { kind: 'text'; text: string }
+    | { kind: 'context'; contextType: string; label: string; title?: string }
+    | { kind: 'inlineToken'; tokenType: string; label: string }
+  >;
 }
 
 export interface SessionTurnCatalog {


### PR DESCRIPTION
Render Turn Rail tooltips with the same compact reference capsules used by
sent user messages.

- Persist bounded capsule previews for unloaded historical turns
- Serialize catalog segment fields as camelCase at the Rust wire boundary
- Reuse skill, file, and session reference icon mappings
- Generate previews for newly submitted in-memory turns immediately
- Keep large context payloads out of the navigation catalog
