### PR TITLE
fix(desktop): focus window from notification clicks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1137,6 +1137,7 @@ dependencies = [
  "libc",
  "log",
  "mime_guess",
+ "notify-rust",
  "objc2 0.6.4",
  "objc2-app-kit",
  "objc2-foundation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -209,6 +209,7 @@ tauri-plugin-notification = "2.3"
 tauri-plugin-updater = "2.10"
 tauri-plugin-single-instance = "2.4"
 tauri-plugin-window-state = "2.4"
+notify-rust = { version = "4.18", default-features = false }
 tauri-build = { version = "2.6", features = [] }
 keepawake = "0.6.0"
 

--- a/src/apps/desktop/Cargo.toml
+++ b/src/apps/desktop/Cargo.toml
@@ -103,6 +103,7 @@ objc2-app-kit = { workspace = true }
 objc2-vision = { workspace = true, features = ["std", "VNRecognizeTextRequest", "VNRequest", "VNObservation", "VNRequestHandler", "VNUtils", "VNTypes", "objc2-core-foundation"] }
 
 [target.'cfg(windows)'.dependencies]
+notify-rust = { workspace = true }
 win32job = { workspace = true }
 windows = { workspace = true, features = [
   "Foundation",

--- a/src/apps/desktop/src/api/system_api.rs
+++ b/src/apps/desktop/src/api/system_api.rs
@@ -898,17 +898,135 @@ pub async fn send_system_notification(
     app: tauri::AppHandle,
     request: SendNotificationRequest,
 ) -> Result<(), String> {
-    use tauri_plugin_notification::NotificationExt;
-
-    let mut builder = app.notification().builder().title(&request.title);
-    if let Some(body) = &request.body {
-        builder = builder.body(body);
+    #[cfg(target_os = "windows")]
+    {
+        // The Tauri notification plugin drops notify-rust's response handle after
+        // showing a Windows toast, so its body-click activation cannot be observed.
+        return send_clickable_windows_notification(app, request);
     }
-    builder.show().map_err(|e| e.to_string())
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        use tauri_plugin_notification::NotificationExt;
+
+        let mut builder = app.notification().builder().title(&request.title);
+        if let Some(body) = &request.body {
+            builder = builder.body(body);
+        }
+        builder.show().map_err(|e| e.to_string())
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn send_clickable_windows_notification(
+    app: tauri::AppHandle,
+    request: SendNotificationRequest,
+) -> Result<(), String> {
+    let mut notification = notify_rust::Notification::new();
+    notification.summary(&request.title);
+    if let Some(body) = &request.body {
+        notification.body(body);
+    }
+
+    if should_use_configured_notification_app_id() {
+        notification.app_id(&app.config().identifier);
+    }
+
+    let handle = notification.show().map_err(|error| error.to_string())?;
+    // Waiting for a toast click is blocking; keep it off both the UI thread and
+    // the async executor while retaining the response handle until dismissal.
+    tauri::async_runtime::spawn_blocking(move || {
+        if let Err(error) =
+            handle.wait_for_response(move |response: &notify_rust::NotificationResponse| {
+                if !notification_response_activates_main_window(response) {
+                    return;
+                }
+
+                let app_for_window = app.clone();
+                if let Err(error) = app.run_on_main_thread(move || {
+                    activate_main_window_from_notification(&app_for_window);
+                }) {
+                    log::warn!(
+                        "Failed to schedule main window activation from notification: {}",
+                        error
+                    );
+                }
+            })
+        {
+            log::warn!("Failed to observe Windows notification response: {}", error);
+        }
+    });
+
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn should_use_configured_notification_app_id() -> bool {
+    use std::path::MAIN_SEPARATOR;
+
+    // Match the Tauri plugin's development behavior. A Cargo-built executable
+    // has no installed Windows shortcut that registers BitFun's AppUserModelID.
+    let Ok(executable) = tauri::utils::platform::current_exe() else {
+        return false;
+    };
+    let Some(executable_dir) = executable.parent() else {
+        return false;
+    };
+    let executable_dir = executable_dir.display().to_string();
+
+    !executable_dir.ends_with(format!("{MAIN_SEPARATOR}target{MAIN_SEPARATOR}debug").as_str())
+        && !executable_dir
+            .ends_with(format!("{MAIN_SEPARATOR}target{MAIN_SEPARATOR}release").as_str())
+}
+
+#[cfg(target_os = "windows")]
+fn notification_response_activates_main_window(
+    response: &notify_rust::NotificationResponse,
+) -> bool {
+    matches!(
+        response,
+        notify_rust::NotificationResponse::Default
+            | notify_rust::NotificationResponse::Action(_)
+            | notify_rust::NotificationResponse::Reply(_)
+    )
+}
+
+#[cfg(target_os = "windows")]
+fn activate_main_window_from_notification(app: &tauri::AppHandle) {
+    let Some(window) = app.get_webview_window("main") else {
+        log::warn!("Failed to activate main window from notification: main window not found");
+        return;
+    };
+
+    if let Err(error) = window.unminimize() {
+        log::warn!(
+            "Failed to unminimize main window from notification: {}",
+            error
+        );
+    }
+    if let Err(error) = window.show() {
+        log::warn!("Failed to show main window from notification: {}", error);
+    }
+    if let Err(error) = window.set_focus() {
+        log::warn!("Failed to focus main window from notification: {}", error);
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn notification_body_click_activates_main_window_but_dismissal_does_not() {
+        use notify_rust::{CloseReason, NotificationResponse};
+
+        assert!(super::notification_response_activates_main_window(
+            &NotificationResponse::Default
+        ));
+        assert!(!super::notification_response_activates_main_window(
+            &NotificationResponse::Closed(CloseReason::Dismissed)
+        ));
+    }
+
     /// The probe reads `platforms[<key>].url` out of `latest.json`; if this key
     /// stops matching what scripts/generate-tauri-latest-json.mjs emits, every
     /// probe silently scores 0 and ranking degrades to the configured order.


### PR DESCRIPTION
## Summary

- Preserve the Windows notification response handle so notification clicks can be observed.
- Restore the BitFun main window by unminimizing, showing, and focusing it when a notification is activated.
- Avoid stealing focus when the notification is dismissed or expires.
- Keep the existing notification implementation unchanged on non-Windows platforms.
- Add regression coverage for notification activation versus dismissal.

## Type and Areas

Type:

Regression fix

Areas:

Desktop/Tauri, Windows notifications, dependency configuration

## Motivation / Impact

When BitFun completed a task while its window was minimized, hidden in the system tray, or unfocused, clicking the Windows notification did not return the user to BitFun.

Task completion notifications now restore and focus the main BitFun window when clicked.

## Verification

- `pnpm run fmt:rs` — passed
- `pnpm run check:build-prereqs` — passed
- `cargo check -p bitfun-desktop` — passed
- `cargo test -p bitfun-desktop notification_body_click_activates_main_window_but_dismissal_does_not --lib --no-run` — passed
- `pnpm run check:core-boundaries` — passed
- `git diff --check` — passed
- The focused test execution was attempted, but the Windows test harness exited before entering the test runner with the repository's known Tauri #13419 `STATUS_ENTRYPOINT_NOT_FOUND` loader issue.

## Reviewer Notes

- The new direct `notify-rust` dependency is Windows-only and reuses the version already selected by the Tauri notification plugin.
- Non-Windows notification behavior is unchanged.
- No persisted data, protocol, localization, or migration changes are involved.
- Remote workspace, remote control, Peer Device Mode, and Detached Dispatch were not exercised. Existing remote-surface registry declarations are unchanged.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.