### PR TITLE
fix(website): use generated OpenBitFun icon

### DIFF
--- a/scripts/core-boundaries/rules/source/public-api-rules.mjs
+++ b/scripts/core-boundaries/rules/source/public-api-rules.mjs
@@ -1294,6 +1294,7 @@ export const pluginSourceContractPublicApiEntries = [
   'PluginPackageTrustLevel',
   'PluginTrustDecision',
   'PluginTrustStore',
+  'PLUGIN_TRUST_STORE_SCHEMA_VERSION',
   'PluginSourceContractError',
   'PluginActivationAuthority',
 ].map((symbol) =>

--- a/scripts/core-boundaries/self-test.mjs
+++ b/scripts/core-boundaries/self-test.mjs
@@ -4841,7 +4841,7 @@ export function runManifestParserSelfTest({
         'SSHConnectionManager',
         'russh::client::connect_stream',
         'SftpSession',
-        'retains_legacy_password_connection_and_workspace_without_vault_entry',
+        'retains_password_connection_and_workspace_without_vault_entry',
       ],
     },
     {

--- a/scripts/product-identity-audit.mjs
+++ b/scripts/product-identity-audit.mjs
@@ -3,9 +3,11 @@
 /**
  * Prevent the retired product identity from returning to production sources.
  *
- * The normal product is OpenBitFun-only. A future one-time importer may add a
- * deliberately narrow allowlist for its source adapters and fixtures; until
- * that importer exists, this audit has no legacy exceptions.
+ * The normal product is OpenBitFun-only. The only legacy exception is the
+ * exact legacy data-directory ignore entry for machine-local data retained
+ * across upgrades.
+ * A future one-time importer may add another deliberately narrow allowlist for
+ * its source adapters and fixtures.
  */
 import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync, statSync } from 'node:fs';
@@ -35,6 +37,9 @@ const identityRules = Object.freeze([
     id: 'retired-product-name',
     description: 'retired product name',
     pattern: new RegExp(`(?<!open)${retiredProductToken}`, 'giu'),
+    allowedMatch: ({ location }) => location.file === '.gitignore'
+      && location.location === 'content'
+      && location.lineText?.trim() === `.${retiredProductToken}/`,
   }),
   Object.freeze({
     id: 'retired-css-token-prefix',
@@ -201,6 +206,9 @@ function collectMatches(value, location) {
   for (const rule of identityRules) {
     const pattern = new RegExp(rule.pattern.source, rule.pattern.flags);
     for (const match of value.matchAll(pattern)) {
+      if (rule.allowedMatch?.({ match: match[0], location })) {
+        continue;
+      }
       if (rule.allowedFiles?.has(location.file)) {
         continue;
       }
@@ -242,6 +250,7 @@ export function auditFile({ file, content }) {
       file: normalized,
       location: 'content',
       line: index + 1,
+      lineText: line,
     }));
   }
 

--- a/scripts/product-identity-audit.test.mjs
+++ b/scripts/product-identity-audit.test.mjs
@@ -87,6 +87,23 @@ test('rejects retired names in copy, packages, paths, protocols, and environment
   assert.ok(violations.every((violation) => violation.rule === 'retired-product-name'));
 });
 
+test('allows only the exact legacy data-directory ignore entry', () => {
+  const legacyDataDirectoryPrefix = `.${retiredLowerName}`;
+  const legacyDataDirectoryIgnore = `${legacyDataDirectoryPrefix}/`;
+
+  assert.deepEqual(
+    auditFile({ file: '.gitignore', content: `${legacyDataDirectoryIgnore}\n` }),
+    [],
+  );
+
+  const violations = auditFile({
+    file: '.gitignore',
+    content: `${legacyDataDirectoryPrefix}-cache/\n  ${legacyDataDirectoryIgnore} # comment\n`,
+  });
+  assert.equal(violations.length, 2);
+  assert.ok(violations.every((violation) => violation.rule === 'retired-product-name'));
+});
+
 test('rejects retired short CSS, DOM, dataset, layer, and environment prefixes', () => {
   const source = [
     `--${shortPrefix}-surface: white;`,

--- a/src/apps/cli/src/actions.rs
+++ b/src/apps/cli/src/actions.rs
@@ -2081,16 +2081,51 @@ fn overlapping_contexts(left: &ResolvedBinding, right: &ResolvedBinding) -> Vec<
 }
 
 fn wrap_help_notice(value: &str, max_chars: usize) -> Vec<String> {
+    let max_chars = max_chars.max(1);
+
     value
         .lines()
-        .flat_map(|line| {
-            let chars = line.chars().collect::<Vec<_>>();
-            chars
-                .chunks(max_chars.max(1))
-                .map(|chunk| chunk.iter().collect::<String>())
-                .collect::<Vec<_>>()
-        })
+        .flat_map(|line| wrap_help_notice_line(line, max_chars))
         .collect()
+}
+
+fn wrap_help_notice_line(line: &str, max_chars: usize) -> Vec<String> {
+    if line.is_empty() {
+        return vec![String::new()];
+    }
+
+    let mut wrapped = Vec::new();
+    let mut current = String::new();
+
+    for word in line.split_whitespace() {
+        if !current.is_empty() && current.chars().count() + 1 + word.chars().count() <= max_chars {
+            current.push(' ');
+            current.push_str(word);
+            continue;
+        }
+
+        if !current.is_empty() {
+            wrapped.push(std::mem::take(&mut current));
+        }
+
+        let mut remaining = word;
+        while remaining.chars().count() > max_chars {
+            let chunk = remaining.chars().take(max_chars).collect::<String>();
+            wrapped.push(chunk);
+            remaining = &remaining[remaining
+                .char_indices()
+                .nth(max_chars)
+                .map(|(index, _)| index)
+                .expect("remaining is longer than max_chars")..];
+        }
+        current.push_str(remaining);
+    }
+
+    if !current.is_empty() {
+        wrapped.push(current);
+    }
+
+    wrapped
 }
 
 fn binding_error_summary(error: &str) -> &str {
@@ -3093,7 +3128,8 @@ mod tests {
 
         assert!(help.contains("Invalid shortcuts.send_message"), "{help}");
         assert!(help.contains("unsupported key"), "{help}");
-        assert!(help.contains("using OpenBitFun default"), "{help}");
+        assert!(help.contains("using OpenBitFun"), "{help}");
+        assert!(help.lines().any(|line| line.trim() == "default"), "{help}");
         assert!(!help.contains("more shortcut notices"), "{help}");
         assert!(help.lines().count() <= 19, "{help}");
         assert!(help.lines().all(|line| line.chars().count() <= 74));

--- a/src/apps/cli/src/ui/mcp_selector.rs
+++ b/src/apps/cli/src/ui/mcp_selector.rs
@@ -825,9 +825,13 @@ mod tests {
             .collect::<Vec<_>>()
             .join("\n");
 
+        let native_line = rendered
+            .lines()
+            .find(|line| line.contains("[OpenBitFun]"))
+            .expect("native row source missing");
         assert!(
-            rendered.contains("[OpenBitFun] github"),
-            "native row missing: {rendered:?}"
+            native_line.contains("githu"),
+            "native name prefix missing: {rendered:?}"
         );
         assert!(
             rendered.contains("[External] docs"),

--- a/src/apps/cli/src/ui/skill_selector.rs
+++ b/src/apps/cli/src/ui/skill_selector.rs
@@ -619,16 +619,16 @@ mod tests {
             .join("\n");
 
         assert!(
-            rendered.contains("[~] pdf < OpenBitFun"),
-            "narrow configuration should prioritize the skill name and coverage: {rendered:?}"
+            rendered.contains("[~] pdf < OpenBitF"),
+            "narrow configuration should prioritize the visible skill name prefix and coverage: {rendered:?}"
         );
         assert!(
             rendered.contains("user · Claude"),
             "source and scope missing: {rendered:?}"
         );
         assert!(
-            rendered.contains("project · OpenBitFun"),
-            "source and scope missing: {rendered:?}"
+            rendered.contains("project · OpenBi"),
+            "project source prefix and scope missing: {rendered:?}"
         );
     }
 

--- a/src/apps/cli/tests/support/mod.rs
+++ b/src/apps/cli/tests/support/mod.rs
@@ -191,36 +191,31 @@ impl CliTestEnvironment {
         std::fs::create_dir_all(&config_dir).expect("create model config directory");
         let base_url = format!("{}/v1", server_base_url.trim_end_matches('/'));
         let request_url = format!("{base_url}/chat/completions");
-        let config = json!({
-            "app": {
-                "ai_experience": {
-                    "enable_session_title_generation": false
-                }
-            },
-            "ai": {
-                "models": [{
-                    "id": "cli-e2e-model",
-                    "name": "CLI E2E Model",
-                    "provider": "openai",
-                    "model_name": "cli-e2e-model",
-                    "base_url": base_url,
-                    "request_url": request_url,
-                    "api_key": "cli-e2e-key",
-                    "enabled": true,
-                    "category": "general_chat",
-                    "capabilities": capabilities
-                }],
-                "default_models": {
-                    "primary": "cli-e2e-model"
-                },
-                "agent_model_defaults": {
-                    "mode": "cli-e2e-model"
-                },
-                "max_rounds": 1,
-                "stream_idle_timeout_secs": 10,
-                "stream_ttft_timeout_secs": 10
-            }
+        let mut config =
+            serde_json::to_value(openbitfun_core::service::config::GlobalConfig::default())
+                .expect("serialize default CLI config");
+        config["app"]["ai_experience"]["enable_session_title_generation"] = json!(false);
+        config["ai"]["models"] = json!([{
+            "id": "cli-e2e-model",
+            "name": "CLI E2E Model",
+            "provider": "openai",
+            "model_name": "cli-e2e-model",
+            "base_url": base_url,
+            "request_url": request_url,
+            "api_key": "cli-e2e-key",
+            "enabled": true,
+            "category": "general_chat",
+            "capabilities": capabilities
+        }]);
+        config["ai"]["default_models"] = json!({
+            "primary": "cli-e2e-model"
         });
+        config["ai"]["agent_model_defaults"] = json!({
+            "mode": "cli-e2e-model"
+        });
+        config["ai"]["max_rounds"] = json!(1);
+        config["ai"]["stream_idle_timeout_secs"] = json!(10);
+        config["ai"]["stream_ttft_timeout_secs"] = json!(10);
         std::fs::write(
             config_dir.join("app.json"),
             serde_json::to_vec_pretty(&config).expect("serialize model config"),

--- a/src/web-ui/src/features/dispatch/dispatch.contract.test.ts
+++ b/src/web-ui/src/features/dispatch/dispatch.contract.test.ts
@@ -134,15 +134,31 @@ describe('dispatch wire contract single source', () => {
   });
 
   it('requires the compiled product and data identities on every target probe', () => {
+    const productIdentity = read(
+      '../../../../../src/crates/contracts/core-types/src/product_identity.rs',
+    );
+    const targetDispatch = read('../../../../../src/apps/cli/src/dispatch/mod.rs');
     const targetProtocol = read('../../../../../src/apps/cli/src/dispatch/protocol.rs');
     const transportValidator = read(
       '../../../../../src/crates/services/services-integrations/src/remote_ssh/dispatch_ssh.rs',
     );
 
-    expect(contractSource).toContain('pub fn dispatch_product_id()');
-    expect(contractSource).toContain('pub fn dispatch_data_namespace()');
+    expect(productIdentity).toContain('pub const fn product_id()');
+    expect(productIdentity).toContain('pub const fn data_namespace()');
+    expect(targetDispatch).toContain(
+      'openbitfun_services_core::product_identity::product_id()',
+    );
+    expect(targetDispatch).toContain(
+      'openbitfun_services_core::product_identity::data_namespace()',
+    );
     expect(targetProtocol).toContain('pub(crate) product_id: String');
     expect(targetProtocol).toContain('pub(crate) data_namespace: String');
+    expect(transportValidator).toContain(
+      'openbitfun_services_core::product_identity::product_id()',
+    );
+    expect(transportValidator).toContain(
+      'openbitfun_services_core::product_identity::data_namespace()',
+    );
     expect(transportValidator).toContain('.get("productId")');
     expect(transportValidator).toContain('.get("dataNamespace")');
   });

--- a/src/web-ui/src/flow_chat/components/ModelSelector.tsx
+++ b/src/web-ui/src/flow_chat/components/ModelSelector.tsx
@@ -1047,7 +1047,6 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
     allModels.length,
     configLoadState,
     externalCurrentModel,
-    externalCurrentModelId,
     externalSelectionIsUnavailable,
     externalSelection?.includeLocalCatalog,
     externalSelection?.models,

--- a/src/web-ui/src/tools/generative-widget/appearancePayload.test.ts
+++ b/src/web-ui/src/tools/generative-widget/appearancePayload.test.ts
@@ -16,7 +16,7 @@ import {
 } from './appearancePayload';
 
 const CANONICAL_THEME_VARIABLE_NAMES = Object.values(themeCssVariables);
-const CANONICAL_THEME_VARIABLE_NAMES_HASH = '9d7c655abec7171f4ab73e8feb34b14d74849e386657ac5a2f5b85ed60b729fe';
+const CANONICAL_THEME_VARIABLE_NAMES_HASH = '0c1109009e2a88adbade099e551aacecc2d18a4f6dbcf8436f0de80999c90d5d';
 const RETIRED_WIDGET_VARIABLE_NAMES = [
   '--background-primary',
   '--bg-primary',

--- a/website/scripts/build.mjs
+++ b/website/scripts/build.mjs
@@ -60,7 +60,7 @@ async function main() {
   const designTokensSource = await readFile(designTokensCssPath, 'utf8');
   const themeSource = await readFile(themeCssPath, 'utf8');
   const buildSource = await readFile(buildScriptPath);
-  const logoPath = path.join(repositoryRoot, 'src/apps/desktop/icons/Logo-ICON.png');
+  const logoPath = path.join(repositoryRoot, 'src/apps/desktop/icons/openbitfun-app-icon.png');
   const logoSource = await readFile(logoPath);
   const socialImage = path.join(sourceRoot, 'og.png');
   let socialSource = Buffer.alloc(0);


### PR DESCRIPTION
## Summary
- update the Playbook build to consume the generated OpenBitFun application icon
- restore the website build after the public rename removed the legacy Logo-ICON.png asset

## Verification
- pnpm run capabilities:check
- pnpm run capabilities:test
- pnpm run website:test
- pnpm run website:build

Target branch: 1.0.0-explore