### PR TITLE
fix(computer-use): preserve observation context and stale target integrity

### DIFF
--- a/scripts/fixtures/computer-use-ax.swift
+++ b/scripts/fixtures/computer-use-ax.swift
@@ -1,0 +1,23 @@
+import AppKit
+
+// An isolated, deterministic AX source. It never reads or drives another app.
+let app = NSApplication.shared
+app.setActivationPolicy(.accessory)
+let window = NSWindow(contentRect: NSRect(x: 100, y: 100, width: 500, height: 260),
+                      styleMask: [.titled, .closable], backing: .buffered, defer: false)
+window.title = "OpenBitFun AX context fixture"
+let container = window.contentView!
+for (index, title) in ["Save report", "Delete draft", "Unavailable action"].enumerated() {
+    let button = NSButton(title: title, target: nil, action: nil)
+    button.frame = NSRect(x: 20 + index * 155, y: 170, width: 150, height: 40)
+    button.isEnabled = index != 2
+    container.addSubview(button)
+}
+let field = NSTextField(string: "context-value")
+field.frame = NSRect(x: 20, y: 90, width: 350, height: 32)
+container.addSubview(field)
+window.orderFront(nil)
+DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+    FileHandle.standardOutput.write(Data("READY\n".utf8))
+}
+app.run()

--- a/scripts/test-browser-snapshot.mjs
+++ b/scripts/test-browser-snapshot.mjs
@@ -1,0 +1,137 @@
+// Real Chromium DOM -> production snapshot.js -> compiled Rust presentation.
+import assert from 'node:assert/strict';
+import { readFile, writeFile, mkdtemp, rm } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const root = fileURLToPath(new URL('../', import.meta.url));
+const requireE2e = createRequire(new URL('../tests/e2e/package.json', import.meta.url));
+const requireWdio = createRequire(requireE2e.resolve('@wdio/cli'));
+const puppeteer = requireWdio('puppeteer-core');
+const script = await readFile(new URL('../src/crates/assembly/core/src/agentic/tools/browser_control/snapshot.js', import.meta.url), 'utf8');
+const resolver = await readFile(new URL('../src/crates/assembly/core/src/agentic/tools/browser_control/resolve_element.js', import.meta.url), 'utf8');
+const browser = await puppeteer.launch({
+  ...(process.env.CHROME_PATH ? { executablePath: process.env.CHROME_PATH } : { channel: 'chrome' }),
+  headless: 'new',
+});
+const dir = await mkdtemp(join(tmpdir(), 'openbitfun-dom-context-'));
+try {
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1200, height: 900 });
+  await page.setContent(`<button id="save">保存</button>
+    <label for="search">Search label</label><input id="search" value="current query" disabled>
+    <input id="secret" type="password" value="must-not-appear">
+    <input id="checked" type="checkbox" checked>
+    <textarea id="long-value"></textarea><button id="unicode-label"></button>
+    <div id="shadow"></div>
+    <button id="offscreen" style="position:absolute;top:3000px">Outside</button>
+    <iframe id="outer" style="width:500px;height:300px"></iframe>
+    <iframe id="hidden" style="display:none"></iframe>
+    <iframe id="cross" sandbox srcdoc="<button>Unreachable</button>"></iframe>`);
+  await page.evaluate(async () => {
+    document.querySelector('#long-value').value = '🧪'.repeat(2001);
+    document.querySelector('#unicode-label').textContent = '🧪'.repeat(101);
+    const populate = (frame, html) => new Promise(resolve => {
+      frame.onload = resolve;
+      frame.srcdoc = html;
+    });
+    await populate(document.querySelector('#outer'), '<button id="frame-button">Frame</button><iframe id="nested" style="width:400px;height:150px"></iframe>');
+    await populate(document.querySelector('#outer').contentDocument.querySelector('#nested'), '<button id="deep">Nested</button>');
+    await populate(document.querySelector('#hidden'), '<button id="hidden-button">Hidden frame</button>');
+    const shadow = document.querySelector('#shadow').attachShadow({ mode: 'open' });
+    shadow.innerHTML = '<button id="shadow-button">Shadow</button><iframe id="shadow-frame" style="width:400px;height:100px"></iframe>';
+    await populate(shadow.querySelector('iframe'), '<button id="shadow-deep">Shadow frame</button>');
+  });
+  const snapshot = () => page.evaluate(script).then(JSON.parse);
+  const first = await snapshot();
+  const failures = [];
+  const check = (name, fn) => {
+    try { fn(); console.log(`PASS ${name}`); }
+    catch (error) { failures.push(name); console.error(`FAIL ${name}: ${error.message}`); }
+  };
+  const byId = Object.fromEntries(first.elements.map(e => [e.id, e]));
+  check('DOM names and form states', () => {
+    assert.equal(byId.search.label, 'Search label');
+    assert.equal(byId.search.value, 'current query');
+    assert.equal(byId.search.disabled, true);
+    assert.equal(byId.checked.checked, true);
+    assert(!JSON.stringify(first).includes('must-not-appear'));
+  });
+  check('Unicode truncation is explicit and preserves code points', () => {
+    assert.equal(byId['long-value'].value, '🧪'.repeat(2000));
+    assert.equal(byId['long-value'].value_truncated, true);
+    assert.equal(byId['unicode-label'].text, '🧪'.repeat(100));
+    assert.equal(byId['unicode-label'].text_truncated, true);
+  });
+  check('recursive iframe and shadow traversal', () => {
+    for (const id of ['save', 'frame-button', 'deep', 'shadow-button', 'shadow-deep']) assert(byId[id], `missing ${id}`);
+    assert(byId.deep.frame_path.includes('/'));
+    assert.equal(byId['shadow-button'].scope, 'shadow');
+  });
+  for (const id of ['frame-button', 'deep', 'shadow-button', 'shadow-deep']) {
+    if (!byId[id]) continue;
+    const resolved = await page.evaluate(`(() => {
+      const el = (${resolver})(${JSON.stringify(`[data-cdp-ref="${byId[id].ref}"]`)});
+      el.addEventListener('click', () => el.setAttribute('data-clicked', 'true'), {once:true});
+      el.click();
+      return {id:el.id, clicked:el.getAttribute('data-clicked')};
+    })()`);
+    check(`ref resolves and activates ${id}`, () => assert.deepEqual(resolved, { id, clicked: 'true' }));
+  }
+  check('visibility and inaccessible-context reporting', () => {
+    assert(!byId.offscreen);
+    assert(!byId['hidden-button']);
+    assert(first.offscreen_count > 0);
+    assert.equal(first.cross_origin_frames, 1);
+  });
+  await page.evaluate(() => {
+    document.querySelector('#save').remove();
+    document.querySelector('#outer').contentDocument.querySelector('#nested').contentDocument.querySelector('#deep').style.display = 'none';
+  });
+  const second = await snapshot();
+  check('refresh removes nested stale refs', () => {
+    assert.equal(new Set(second.elements.map(e => e.ref)).size, second.elements.length);
+    assert(!second.elements.some(e => e.id === 'save' || e.id === 'deep'));
+  });
+  const deepRef = await page.evaluate(() => document.querySelector('#outer').contentDocument.querySelector('#nested').contentDocument.querySelector('#deep').getAttribute('data-cdp-ref'));
+  check('hidden nested element has no stale target attribute', () => assert.equal(deepRef, null));
+  if (failures.length) throw new Error(`${failures.length} browser snapshot checks failed`);
+  const fixture = join(dir, 'snapshot.json');
+  await writeFile(fixture, JSON.stringify(first));
+  const code = await new Promise((resolveExit, reject) => {
+    const child = spawn(process.execPath, [join(root, 'scripts/test-computer-use-context.mjs'), 'real_browser_snapshot', '--', '--ignored'], {
+      cwd: root, stdio: 'inherit', windowsHide: true,
+      env: { ...process.env, OPENBITFUN_BROWSER_SNAPSHOT_FIXTURE: fixture },
+    });
+    child.on('error', reject);
+    child.on('close', code => resolveExit(code ?? 1));
+  });
+  assert.equal(code, 0, 'compiled Rust must preserve the actual browser context');
+  if (process.argv.includes('--native-ocr')) {
+    assert.equal(process.platform, 'darwin', 'native fixture currently exercises macOS Vision');
+    await page.setViewport({ width: 800, height: 600 });
+    await page.setContent('<div style="position:absolute;left:100px;top:100px;font:40px Arial;color:black;background:white">Save report</div>');
+    const bytes = await page.screenshot({ type: 'jpeg', quality: 95 });
+    const ocrFixture = join(dir, 'ocr.json');
+    await writeFile(ocrFixture, JSON.stringify({
+      bytes: [...bytes], mime_type: 'image/jpeg', image_width: 800, image_height: 600,
+      native_width: 1600, native_height: 1200, display_origin_x: -1000, display_origin_y: 0,
+      vision_scale: 0.5, image_global_bounds: { left: -500, top: 100, width: 400, height: 300 },
+    }));
+    const nativeCode = await new Promise((resolveExit, reject) => {
+      const child = spawn('cargo', ['test', '-p', 'openbitfun-desktop', '--lib', 'native_vision_reads_rendered_fixture', '--', '--ignored', '--exact', 'computer_use::screen_ocr::native_fixture_tests::native_vision_reads_rendered_fixture'], {
+        cwd: root, stdio: 'inherit', windowsHide: true,
+        env: { ...process.env, OPENBITFUN_OCR_FIXTURE: ocrFixture },
+      });
+      child.on('error', reject);
+      child.on('close', code => resolveExit(code ?? 1));
+    });
+    assert.equal(nativeCode, 0, 'actual macOS OCR must recognize the rendered fixture');
+  }
+} finally {
+  await browser.close();
+  await rm(dir, { recursive: true, force: true });
+}

--- a/scripts/test-computer-use-context.mjs
+++ b/scripts/test-computer-use-context.mjs
@@ -1,0 +1,57 @@
+// Run production data modules without linking Tauri or calling OS automation.
+import { mkdtemp, writeFile, copyFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawn } from 'node:child_process';
+
+const root = fileURLToPath(new URL('../', import.meta.url));
+const dir = await mkdtemp(join(tmpdir(), 'openbitfun-computer-context-'));
+const source = (path) => JSON.stringify(resolve(root, path));
+try {
+  await writeFile(join(dir, 'Cargo.toml'), `[package]
+name = "computer-use-context-tests"
+version = "0.0.0"
+edition = "2021"
+[workspace]
+[lib]
+path = "lib.rs"
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha1 = "0.10"
+`);
+  await copyFile(join(root, 'Cargo.lock'), join(dir, 'Cargo.lock'));
+  // The compatibility path re-exports the actual production DTOs. There are
+  // no replacement algorithms, fake screenshots, or native-host stubs here.
+  await writeFile(join(dir, 'lib.rs'), `#![allow(dead_code)]
+extern crate self as openbitfun_core;
+#[path = ${source('src/crates/execution/tool-contracts/src/computer_use.rs')}]
+pub mod computer_use_contract;
+pub mod agentic { pub mod tools { pub mod computer_use_host {
+    pub use crate::computer_use_contract::*;
+}}}
+mod screen_ocr { pub use crate::computer_use_contract::OcrTextMatch; }
+#[path = ${source('src/apps/desktop/src/computer_use/ocr_context.rs')}]
+mod ocr_context;
+#[path = ${source('src/apps/desktop/src/computer_use/interactive_filter.rs')}]
+mod interactive_filter;
+#[path = ${source('src/apps/desktop/src/computer_use/ax_snapshot_digest.rs')}]
+mod ax_snapshot_digest;
+#[path = ${source('src/crates/assembly/core/src/agentic/tools/browser_control/snapshot_context.rs')}]
+mod snapshot_context;
+`);
+  const code = await new Promise((resolveExit, reject) => {
+    const child = spawn('cargo', ['test', '--offline', '--manifest-path', join(dir, 'Cargo.toml'), '--lib', ...process.argv.slice(2)], {
+      cwd: root,
+      stdio: 'inherit',
+      windowsHide: true,
+      env: { ...process.env, CARGO_TARGET_DIR: join(root, 'target/computer-use-context') },
+    });
+    child.on('error', reject);
+    child.on('close', (code) => resolveExit(code ?? 1));
+  });
+  process.exitCode = code;
+} finally {
+  await rm(dir, { recursive: true, force: true });
+}

--- a/scripts/test-native-ax-context.mjs
+++ b/scripts/test-native-ax-context.mjs
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+assert.equal(process.platform, 'darwin', 'native AX fixture requires macOS');
+const root = fileURLToPath(new URL('../', import.meta.url));
+const dir = await mkdtemp(join(tmpdir(), 'openbitfun-ax-context-'));
+const run = (cmd, args, env = process.env) => new Promise((resolve, reject) => {
+  const child = spawn(cmd, args, { cwd: root, stdio: 'inherit', windowsHide: true, env });
+  child.on('error', reject);
+  child.on('close', code => code === 0 ? resolve() : reject(new Error(`${cmd} exited ${code}`)));
+});
+let fixture;
+try {
+  const executable = join(dir, 'ax-fixture');
+  await run('swiftc', [join(root, 'scripts/fixtures/computer-use-ax.swift'), '-o', executable]);
+  fixture = spawn(executable, [], { cwd: root, stdio: ['ignore', 'pipe', 'inherit'], windowsHide: true });
+  await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error('AX fixture did not become ready')), 15000);
+    fixture.on('error', error => { clearTimeout(timeout); reject(error); });
+    fixture.on('exit', code => { clearTimeout(timeout); reject(new Error(`AX fixture exited ${code}`)); });
+    fixture.stdout.on('data', chunk => { if (String(chunk).includes('READY')) { clearTimeout(timeout); resolve(); } });
+  });
+  await run('cargo', ['test', '-p', 'openbitfun-desktop', '--lib', 'native_ax_fixture_round_trips_tree_and_cached_targets', '--', '--ignored'], {
+    ...process.env, OPENBITFUN_AX_FIXTURE_PID: String(fixture.pid),
+  });
+} finally {
+  if (fixture && fixture.exitCode === null) {
+    await new Promise(resolve => { fixture.once('exit', resolve); fixture.kill('SIGTERM'); });
+  }
+  await rm(dir, { recursive: true, force: true });
+}

--- a/src/apps/desktop/src/computer_use/AGENTS.md
+++ b/src/apps/desktop/src/computer_use/AGENTS.md
@@ -46,6 +46,46 @@ When `PrintWindow` returns a mostly-black bitmap (DirectComposition / UWP):
 
 ## Verification
 
+For observation payloads, OCR projection, AX filtering/digests, and browser
+snapshot context, use the isolated compiler harness first. It compiles the
+production Rust files by path, with the actual DTO source and no replacement
+algorithms or native-host mocks. Cargo dependencies must already be cached
+(`cargo fetch --locked` on a fresh machine).
+
+```bash
+node scripts/test-computer-use-context.mjs
+cargo test -p openbitfun-desktop --lib context_integrity_tests
+```
+
+Native black-box fixtures use only a dedicated test window / rendered image:
+
+```bash
+# Node 22/24 and installed workspace dependencies; installed Chrome required.
+# CHROME_PATH can select another Chromium executable.
+node scripts/test-browser-snapshot.mjs --native-ocr
+# macOS + Accessibility permission; creates and closes its own AppKit window.
+node scripts/test-native-ax-context.mjs
+```
+
+The browser fixture runs production snapshot/resolver JavaScript in Chromium,
+then passes the actual DOM payload to compiled Rust presentation tests. The
+optional OCR step compiles the Desktop test target and invokes macOS Vision on
+the rendered JPEG. The AX fixture compiles the Desktop test target and checks
+native AX nodes, text, states, parent indices, cache entries, filtering, and DTO
+round trips. These are local macOS checks, not Windows/Linux or remote evidence.
+
+Observation invariants:
+
+- Rectangle containment does not prove two controls have the same action.
+- Projection uses content padding and authoritative global bounds; invalid
+  geometry and OCR matches outside the content are not actionable coordinates.
+- AX snapshot digests cover state and geometry as well as labels. A state-only
+  change must not be mistaken for a failed action and trigger duplicate input.
+- Stale interactive/visual indices must be returned to the caller for a fresh
+  choice, never silently reused after rebuilding a different view.
+- Element-budget omissions are reported in `omitted_element_count`, including
+  when text rendering is disabled; focused controls survive budget selection.
+
 ```bash
 cargo check -p openbitfun-desktop
 cargo test -p openbitfun-desktop

--- a/src/apps/desktop/src/computer_use/ax_snapshot_digest.rs
+++ b/src/apps/desktop/src/computer_use/ax_snapshot_digest.rs
@@ -1,0 +1,57 @@
+//! Canonical AX observation digest shared by the native host adapters.
+use openbitfun_core::agentic::tools::computer_use_host::AxNode;
+use sha1::{Digest, Sha1};
+
+/// Hash the complete observed payload, including enabled/focus/selection and
+/// geometry. Omitting those facts can misclassify a successful action as a no-op
+/// and cause a second input dispatch. Digests are opaque observation tokens;
+/// an older host's token simply requires a fresh observation after upgrade.
+pub(super) fn compute_digest(nodes: &[AxNode]) -> String {
+    let bytes = serde_json::to_vec(nodes).expect("AX node DTO serialization");
+    format!("{:x}", Sha1::digest(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn node() -> AxNode {
+        serde_json::from_value(json!({
+            "idx":0, "role":"AXButton", "title":"Save", "enabled":true,
+            "focused":false, "frame_global":[10.0,20.0,30.0,40.0], "actions":["AXPress"]
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn state_geometry_and_content_changes_are_observable() {
+        let original = node();
+        let baseline = compute_digest(&[original.clone()]);
+        for (key, value) in [
+            ("enabled", json!(false)),
+            ("focused", json!(true)),
+            ("selected", json!(true)),
+            ("expanded", json!(false)),
+            ("value", json!("saved")),
+            ("url", json!("https://example.test")),
+            ("frame_global", json!([50.0, 20.0, 30.0, 40.0])),
+            ("actions", json!([])),
+            ("role_description", json!("submit button")),
+        ] {
+            let mut value_json = serde_json::to_value(&original).unwrap();
+            value_json[key] = value;
+            let changed = serde_json::from_value(value_json).unwrap();
+            assert_ne!(compute_digest(&[changed]), baseline, "lost {key} change");
+        }
+        assert_eq!(compute_digest(&[original]), baseline);
+    }
+
+    #[test]
+    fn optional_fields_survive_old_payload_round_trip() {
+        let original = node();
+        let restored: AxNode =
+            serde_json::from_value(serde_json::to_value(&original).unwrap()).unwrap();
+        assert_eq!(compute_digest(&[original]), compute_digest(&[restored]));
+    }
+}

--- a/src/apps/desktop/src/computer_use/desktop_host/ax_orchestration.rs
+++ b/src/apps/desktop/src/computer_use/desktop_host/ax_orchestration.rs
@@ -39,6 +39,65 @@ use openbitfun_core::util::errors::{OpenBitFunError, OpenBitFunResult};
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 use std::time::{Duration, Instant};
 
+#[cfg(all(test, any(target_os = "macos", target_os = "windows")))]
+mod context_integrity_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn stale_view_actions_do_not_rebuild_and_retarget_old_indices() {
+        let host = DesktopComputerUseHost::new();
+        // No running app is involved. A stale request must fail before capture
+        // or OS input, leaving the cached observation untouched.
+        let pid = i32::MAX;
+        {
+            let mut state = host.state.lock().unwrap();
+            state.interactive_view_cache.insert(
+                pid,
+                CachedInteractiveView {
+                    digest: "current-observation".into(),
+                    elements: vec![],
+                },
+            );
+            state.visual_mark_cache.insert(
+                pid,
+                CachedVisualMarkView {
+                    digest: "current-observation".into(),
+                    marks: vec![],
+                    screenshot_id: None,
+                },
+            );
+        }
+        let interactive = serde_json::from_value(serde_json::json!({
+            "i":0, "before_view_digest":"previous-observation"
+        }))
+        .unwrap();
+        let error = host
+            .interactive_click_impl(AppSelector::by_pid(pid), interactive)
+            .await
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("STALE_INTERACTIVE_VIEW"),
+            "{error}"
+        );
+        let visual = serde_json::from_value(serde_json::json!({
+            "i":0, "before_view_digest":"previous-observation"
+        }))
+        .unwrap();
+        let error = host
+            .visual_click_impl(AppSelector::by_pid(pid), visual)
+            .await
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("STALE_VISUAL_MARK_VIEW"),
+            "{error}"
+        );
+        assert_eq!(
+            host.state.lock().unwrap().interactive_view_cache[&pid].digest,
+            "current-observation"
+        );
+    }
+}
+
 impl DesktopComputerUseHost {
     pub(super) async fn app_click_impl(
         &self,
@@ -891,16 +950,24 @@ impl DesktopComputerUseHost {
                 max_elements,
                 clip_to_image_bounds: opts.focus_window_only,
             };
-            let elements = crate::computer_use::interactive_filter::build_interactive_elements(
-                &snap.nodes,
-                snap.screenshot.as_ref(),
-                &filter_opts,
-            );
-            let tree_text = if opts.include_tree_text {
+            let (elements, eligible_count) =
+                crate::computer_use::interactive_filter::build_interactive_elements_with_count(
+                    &snap.nodes,
+                    snap.screenshot.as_ref(),
+                    &filter_opts,
+                );
+            let omitted_element_count = eligible_count.saturating_sub(elements.len()) as u32;
+            let mut tree_text = if opts.include_tree_text {
                 crate::computer_use::interactive_filter::render_element_tree_text(&elements)
             } else {
                 String::new()
             };
+            if opts.include_tree_text && omitted_element_count > 0 {
+                tree_text.push_str(&format!(
+                    "Note: {} additional controls omitted by max_elements; request a larger view budget or use get_app_state/locate to inspect them.\n",
+                    omitted_element_count
+                ));
+            }
             let digest = compute_interactive_view_digest(&elements);
 
             let mut screenshot_out: Option<ComputerScreenshot> = None;
@@ -940,6 +1007,7 @@ impl DesktopComputerUseHost {
                 app: snap.app.clone(),
                 window_title: snap.window_title.clone(),
                 elements: elements.clone(),
+                omitted_element_count,
                 tree_text,
                 digest: digest.clone(),
                 captured_at_ms,
@@ -979,43 +1047,11 @@ impl DesktopComputerUseHost {
     ) -> OpenBitFunResult<InteractiveActionResult> {
         #[cfg(any(target_os = "macos", target_os = "windows"))]
         {
-            // Resolve `i → node_idx` against the cached interactive view.
-            // On `STALE_INTERACTIVE_VIEW` we transparently rebuild the
-            // view ONCE and retry — this turns the most common UI-changed
-            // failure into an internal recovery instead of a hard error
-            // the model has to handle. Idempotency is preserved by
-            // capping at one rebuild + one retry.
-            let mut auto_rebuilt = false;
-            let node_idx = match self
+            // A rebuilt view can assign this index to a different control.
+            // Preserve stale-view errors so the caller observes and chooses again.
+            let node_idx = self
                 .resolve_interactive_index(&app, params.i, params.before_view_digest.as_deref())
-                .await
-            {
-                Ok(idx) => idx,
-                Err(err) if is_stale_interactive_view_error(&err) => {
-                    warn!(
-                        target: "computer_use::interactive_view",
-                        "interactive_click: STALE view detected, rebuilding once and retrying (i={}): {}",
-                        params.i, err
-                    );
-                    let rebuilt = self
-                        .build_interactive_view(app.clone(), InteractiveViewOpts::default())
-                        .await?;
-                    if rebuilt.elements.iter().any(|e| e.i == params.i) {
-                        auto_rebuilt = true;
-                        // Use the rebuilt view's digest, not the stale one
-                        // the caller passed in.
-                        self.resolve_interactive_index(&app, params.i, Some(&rebuilt.digest))
-                            .await?
-                    } else {
-                        return Err(OpenBitFunError::tool(format!(
-                            "INTERACTIVE_INDEX_OUT_OF_RANGE: i={} not in rebuilt view (len={}); the UI has changed under you, re-call `build_interactive_view` and pick a fresh `i`",
-                            params.i,
-                            rebuilt.elements.len()
-                        )));
-                    }
-                }
-                Err(other) => return Err(other),
-            };
+                .await?;
 
             // Look up the cached element's image-pixel center as a
             // pointer fallback. Always available when `frame_image` was
@@ -1075,9 +1111,6 @@ impl DesktopComputerUseHost {
                 None
             };
             let mut note = format!("index_resolved_via_node_idx({})", node_idx);
-            if auto_rebuilt {
-                note.push_str(",auto_rebuilt_view_after_stale");
-            }
             if fallback_used {
                 note.push_str(",fallback_image_xy");
             }
@@ -1202,33 +1235,10 @@ impl DesktopComputerUseHost {
     ) -> OpenBitFunResult<VisualActionResult> {
         #[cfg(any(target_os = "macos", target_os = "windows"))]
         {
-            let mut auto_rebuilt = false;
-            let mark = match self
+            // Visual indices are also tied to the view the caller actually saw.
+            let mark = self
                 .resolve_visual_mark(&app, params.i, params.before_view_digest.as_deref())
-                .await
-            {
-                Ok(mark) => mark,
-                Err(err) if is_stale_visual_mark_view_error(&err) => {
-                    warn!(
-                        target: "computer_use::visual_mark_view",
-                        "visual_click: STALE visual mark view detected, rebuilding once and retrying (i={}): {}",
-                        params.i, err
-                    );
-                    let rebuilt = self
-                        .build_visual_mark_view(app.clone(), VisualMarkViewOpts::default())
-                        .await?;
-                    let Some(mark) = rebuilt.marks.iter().find(|m| m.i == params.i).cloned() else {
-                        return Err(OpenBitFunError::tool(format!(
-                            "VISUAL_INDEX_OUT_OF_RANGE: i={} not in rebuilt view (len={}); re-call `build_visual_mark_view` and pick a fresh `i`",
-                            params.i,
-                            rebuilt.marks.len()
-                        )));
-                    };
-                    auto_rebuilt = true;
-                    mark
-                }
-                Err(other) => return Err(other),
-            };
+                .await?;
 
             let screenshot_id = {
                 let pid = resolve_pid(self, &app).await?;
@@ -1264,10 +1274,7 @@ impl DesktopComputerUseHost {
             } else {
                 None
             };
-            let mut note = format!("visual_mark_image_xy({},{})", mark.x, mark.y);
-            if auto_rebuilt {
-                note.push_str(",auto_rebuilt_view_after_stale");
-            }
+            let note = format!("visual_mark_image_xy({},{})", mark.x, mark.y);
             Ok(VisualActionResult {
                 snapshot,
                 view,
@@ -1875,16 +1882,6 @@ fn top_regular_positions(
 /// error text rather than introducing a typed error enum because every
 /// `OpenBitFunError::tool` is already string-based throughout the host
 /// surface; adding a new variant would ripple through ~40 callers.
-#[cfg(any(target_os = "macos", target_os = "windows"))]
-fn is_stale_interactive_view_error(err: &OpenBitFunError) -> bool {
-    err.to_string().contains("STALE_INTERACTIVE_VIEW")
-}
-
-#[cfg(any(target_os = "macos", target_os = "windows"))]
-fn is_stale_visual_mark_view_error(err: &OpenBitFunError) -> bool {
-    err.to_string().contains("STALE_VISUAL_MARK_VIEW")
-}
-
 impl DesktopComputerUseHost {
     /// Return the image-pixel center `(x, y)` of the cached interactive
     /// element with the given `i`, when its `frame_image` is known. Used

--- a/src/apps/desktop/src/computer_use/interactive_filter.rs
+++ b/src/apps/desktop/src/computer_use/interactive_filter.rs
@@ -24,8 +24,8 @@ use openbitfun_core::agentic::tools::computer_use_host::{
 /// Per-host filter knobs.
 #[derive(Debug, Clone)]
 pub(crate) struct FilterOpts {
-    /// Hard cap on emitted elements. The filter keeps the largest-area
-    /// elements when exceeded so the overlay stays legible.
+    /// Hard cap on emitted elements. Keep focused controls first, then the
+    /// largest-area elements when exceeded so the overlay stays legible.
     pub max_elements: usize,
     /// When `true`, only elements whose frame intersects the focused
     /// window's image rectangle are kept. The host passes the rectangle
@@ -51,6 +51,16 @@ pub(crate) fn build_interactive_elements(
     screenshot: Option<&ComputerScreenshot>,
     opts: &FilterOpts,
 ) -> Vec<InteractiveElement> {
+    build_interactive_elements_with_count(nodes, screenshot, opts).0
+}
+
+/// Also return the eligible count before the caller's display budget, so
+/// truncation can be disclosed without confusing it with absent controls.
+pub(crate) fn build_interactive_elements_with_count(
+    nodes: &[AxNode],
+    screenshot: Option<&ComputerScreenshot>,
+    opts: &FilterOpts,
+) -> (Vec<InteractiveElement>, usize) {
     let mut staged: Vec<Staged> = Vec::with_capacity(nodes.len() / 4);
 
     for n in nodes {
@@ -61,12 +71,11 @@ pub(crate) fn build_interactive_elements(
             continue;
         };
         let (gx, gy, gw, gh) = frame;
-        if gw < 4.0 || gh < 4.0 {
+        if ![gx, gy, gw, gh].iter().all(|v| v.is_finite()) || gw < 4.0 || gh < 4.0 {
             continue;
         }
 
-        let frame_image = screenshot
-            .and_then(|s| project_global_to_image(s, gx, gy, gw, gh, opts.clip_to_image_bounds));
+        let frame_image = screenshot.and_then(|s| project_global_to_image(s, gx, gy, gw, gh));
 
         // When clipping is requested and the host provided bounds, drop
         // anything that falls entirely outside the captured rectangle.
@@ -97,37 +106,8 @@ pub(crate) fn build_interactive_elements(
         });
     }
 
-    // Card-merge heuristic: when an actionable container (AXCell / AXRow /
-    // AXButton / AXLink / AXGroup-with-AXPress) geometrically contains
-    // smaller actionable children that are themselves actionable, drop
-    // the children. Without this the SoM overlay shows 3-5 stacked
-    // numbers on a single card (icon + label + cell) and the model has
-    // to guess which one actually fires the navigation. Keep the card.
-    //
-    // Containment rule: parent area is at least 1.5x the child, and the
-    // child rectangle is fully (with 2pt slop) inside the parent.
-    if staged.len() > 1 {
-        let originals = staged.clone();
-        staged.retain(|child| {
-            let (cx, cy, cw, ch) = child.frame_global;
-            !originals.iter().any(|parent| {
-                if parent.node_idx == child.node_idx {
-                    return false;
-                }
-                if !is_card_container(&parent.role) {
-                    return false;
-                }
-                if parent.area < child.area * 1.5 {
-                    return false;
-                }
-                let (px, py, pw, ph) = parent.frame_global;
-                cx + 2.0 >= px
-                    && cy + 2.0 >= py
-                    && cx + cw <= px + pw + 2.0
-                    && cy + ch <= py + ph + 2.0
-            })
-        });
-    }
+    // Overlapping bounds do not imply equivalent actions. In particular,
+    // cards can contain independent buttons and editable fields; retain them.
 
     // Stable deterministic sort: top-to-bottom, then left-to-right.
     // Buckets of 16pt eliminate jitter from baseline differences between
@@ -142,15 +122,18 @@ pub(crate) fn build_interactive_elements(
             .then_with(|| a.node_idx.cmp(&b.node_idx))
     });
 
+    let eligible_count = staged.len();
     if staged.len() > opts.max_elements {
         // Keep the largest-area elements so the overlay stays readable on
         // dense pages. We still preserve the deterministic display order
         // afterwards by re-sorting the kept slice.
         let mut by_area = staged;
         by_area.sort_by(|a, b| {
-            b.area
-                .partial_cmp(&a.area)
-                .unwrap_or(std::cmp::Ordering::Equal)
+            b.focused.cmp(&a.focused).then_with(|| {
+                b.area
+                    .partial_cmp(&a.area)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
         });
         by_area.truncate(opts.max_elements);
         by_area.sort_by(|a, b| {
@@ -165,7 +148,7 @@ pub(crate) fn build_interactive_elements(
         staged = by_area;
     }
 
-    staged
+    let elements = staged
         .into_iter()
         .enumerate()
         .map(|(i, s)| InteractiveElement {
@@ -180,7 +163,8 @@ pub(crate) fn build_interactive_elements(
             focused: s.focused,
             ax_actionable: s.ax_actionable,
         })
-        .collect()
+        .collect();
+    (elements, eligible_count)
 }
 
 /// Render a compact one-line-per-element text rendering used in the model
@@ -190,7 +174,12 @@ pub(crate) fn render_element_tree_text(elements: &[InteractiveElement]) -> Strin
     for e in elements {
         let label = e.label.as_deref().unwrap_or("");
         let role = display_role(&e.role, e.subrole.as_deref());
-        let mut line = format!("[{}] {} \"{}\"", e.i, role, label);
+        let mut line = format!(
+            "[{}] {} {}",
+            e.i,
+            role,
+            serde_json::to_string(label).expect("string serialization")
+        );
         if e.focused {
             line.push_str(" [focused]");
         }
@@ -204,23 +193,6 @@ pub(crate) fn render_element_tree_text(elements: &[InteractiveElement]) -> Strin
         out.push('\n');
     }
     out
-}
-
-/// Roles eligible to "absorb" smaller actionable descendants in the SoM
-/// overlay. Anything else (text fields, sliders, menu items …) keeps its
-/// children visible — those tend to need direct interaction at the leaf.
-fn is_card_container(role: &str) -> bool {
-    matches!(
-        role,
-        "AXCell"
-            | "AXRow"
-            | "AXOutlineRow"
-            | "AXButton"
-            | "AXMenuButton"
-            | "AXPopUpButton"
-            | "AXLink"
-            | "AXGroup"
-    )
 }
 
 #[derive(Clone)]
@@ -327,15 +299,42 @@ fn project_global_to_image(
     gy: f64,
     gw: f64,
     gh: f64,
-    require_intersection: bool,
 ) -> Option<(u32, u32, u32, u32)> {
     let bounds = shot.image_global_bounds.as_ref()?;
-    if bounds.width <= 0.0 || bounds.height <= 0.0 {
+    if ![
+        bounds.left,
+        bounds.top,
+        bounds.width,
+        bounds.height,
+        gx,
+        gy,
+        gw,
+        gh,
+    ]
+    .iter()
+    .all(|v| v.is_finite())
+        || bounds.width <= 0.0
+        || bounds.height <= 0.0
+        || gw <= 0.0
+        || gh <= 0.0
+    {
         return None;
     }
 
-    let scale_x = shot.image_width as f64 / bounds.width;
-    let scale_y = shot.image_height as f64 / bounds.height;
+    let (left, top, width, height) = shot
+        .image_content_rect
+        .as_ref()
+        .map(|r| (r.left, r.top, r.width, r.height))
+        .unwrap_or((0, 0, shot.image_width, shot.image_height));
+    if width == 0
+        || height == 0
+        || left.checked_add(width)? > shot.image_width
+        || top.checked_add(height)? > shot.image_height
+    {
+        return None;
+    }
+    let scale_x = width as f64 / bounds.width;
+    let scale_y = height as f64 / bounds.height;
 
     // Clip the global rectangle to the image rectangle.
     let lx = gx.max(bounds.left);
@@ -343,31 +342,20 @@ fn project_global_to_image(
     let rx = (gx + gw).min(bounds.left + bounds.width);
     let by = (gy + gh).min(bounds.top + bounds.height);
     if rx <= lx || by <= ty {
-        if require_intersection {
-            return None;
-        }
-        // No intersection but caller wants a best-effort projection — fall
-        // through using the unclipped rectangle so the overlay can decide
-        // whether to draw a clipped marker.
-        let ix = ((gx - bounds.left) * scale_x).round();
-        let iy = ((gy - bounds.top) * scale_y).round();
-        let iw = (gw * scale_x).round().max(1.0);
-        let ih = (gh * scale_y).round().max(1.0);
-        return Some((ix.max(0.0) as u32, iy.max(0.0) as u32, iw as u32, ih as u32));
+        // The caller can retain the global target when clipping is disabled,
+        // but there is no corresponding overlay rectangle in this image.
+        return None;
     }
 
-    let ix = ((lx - bounds.left) * scale_x).round();
-    let iy = ((ty - bounds.top) * scale_y).round();
-    let iw = ((rx - lx) * scale_x).round().max(1.0);
-    let ih = ((by - ty) * scale_y).round().max(1.0);
-
-    let max_x = shot.image_width.saturating_sub(1) as f64;
-    let max_y = shot.image_height.saturating_sub(1) as f64;
+    let ix = left + (((lx - bounds.left) * scale_x).floor() as u32).min(width - 1);
+    let iy = top + (((ty - bounds.top) * scale_y).floor() as u32).min(height - 1);
+    let right = left + (((rx - bounds.left) * scale_x).ceil() as u32).min(width);
+    let bottom = top + (((by - bounds.top) * scale_y).ceil() as u32).min(height);
     Some((
-        ix.max(0.0).min(max_x) as u32,
-        iy.max(0.0).min(max_y) as u32,
-        iw as u32,
-        ih as u32,
+        ix,
+        iy,
+        right.saturating_sub(ix).max(1),
+        bottom.saturating_sub(iy).max(1),
     ))
 }
 
@@ -476,44 +464,21 @@ mod tests {
 
     #[test]
     fn caps_at_max_elements() {
-        let nodes: Vec<_> = (0..10)
+        let mut nodes: Vec<_> = (0..10)
             .map(|k| node(k, "AXButton", Some((k as f64 * 50.0, 10.0, 30.0, 20.0))))
             .collect();
+        nodes[9].focused = true;
         let opts = FilterOpts {
             max_elements: 4,
             ..FilterOpts::default()
         };
-        let out = build_interactive_elements(&nodes, Some(&screenshot()), &opts);
+        let (out, eligible) =
+            build_interactive_elements_with_count(&nodes, Some(&screenshot()), &opts);
         assert_eq!(out.len(), 4);
-    }
-
-    #[test]
-    fn card_container_absorbs_contained_actionable_children() {
-        // Outer cell (large) + inner button + inner static-text-as-button,
-        // all actionable. Card-merge should keep the cell only.
-        let cell = node(10, "AXCell", Some((0.0, 0.0, 300.0, 80.0)));
-        let inner_btn = node(11, "AXButton", Some((10.0, 10.0, 60.0, 60.0)));
-        let inner_btn2 = node(12, "AXButton", Some((100.0, 20.0, 100.0, 30.0)));
-        // Sibling button outside the cell stays.
-        let outside = node(13, "AXButton", Some((400.0, 0.0, 50.0, 30.0)));
-        let nodes = vec![cell, inner_btn, inner_btn2, outside];
-        let out = build_interactive_elements(&nodes, Some(&screenshot()), &FilterOpts::default());
-        let kept_idx: Vec<u32> = out.iter().map(|e| e.node_idx).collect();
-        assert!(kept_idx.contains(&10), "cell must survive: {:?}", kept_idx);
+        assert_eq!(eligible - out.len(), 6);
         assert!(
-            kept_idx.contains(&13),
-            "outside btn must survive: {:?}",
-            kept_idx
-        );
-        assert!(
-            !kept_idx.contains(&11),
-            "inner btn 11 must be absorbed: {:?}",
-            kept_idx
-        );
-        assert!(
-            !kept_idx.contains(&12),
-            "inner btn 12 must be absorbed: {:?}",
-            kept_idx
+            out.iter().any(|e| e.node_idx == 9),
+            "focused control must survive truncation"
         );
     }
 
@@ -529,5 +494,74 @@ mod tests {
         let mut lines = text.lines();
         assert_eq!(lines.next(), Some("[0] Button \"label-0\""));
         assert_eq!(lines.next(), Some("[1] TextField \"label-1\""));
+    }
+
+    #[test]
+    fn preserves_independent_controls_inside_cards_and_overlapping_siblings() {
+        let mut button = node(11, "AXButton", Some((10.0, 10.0, 60.0, 30.0)));
+        button.parent_idx = Some(10);
+        let mut field = node(12, "AXTextField", Some((100.0, 20.0, 100.0, 30.0)));
+        field.parent_idx = Some(10);
+        let nodes = vec![
+            node(10, "AXCell", Some((0.0, 0.0, 300.0, 80.0))),
+            button,
+            field,
+            node(13, "AXLink", Some((200.0, 50.0, 50.0, 20.0))),
+        ];
+        let out = build_interactive_elements(&nodes, Some(&screenshot()), &FilterOpts::default());
+        assert_eq!(
+            out.len(),
+            4,
+            "geometry does not establish equivalent actions"
+        );
+    }
+
+    #[test]
+    fn projection_respects_padding_negative_origin_and_partial_intersection() {
+        let mut shot = screenshot();
+        shot.image_content_rect = Some(
+            openbitfun_core::agentic::tools::computer_use_host::ComputerUseImageContentRect {
+                left: 100,
+                top: 80,
+                width: 800,
+                height: 640,
+            },
+        );
+        shot.image_global_bounds.as_mut().unwrap().left = -500.0;
+        assert_eq!(
+            project_global_to_image(&shot, -550.0, 50.0, 100.0, 50.0),
+            Some((100, 160, 80, 80))
+        );
+    }
+
+    #[test]
+    fn rejects_nonfinite_geometry_and_escapes_multiline_labels() {
+        let mut valid = node(1, "AXButton", Some((10.0, 10.0, 30.0, 20.0)));
+        valid.title = Some("Save\n[99] \"Delete\"".into());
+        let nodes = vec![
+            valid,
+            node(2, "AXButton", Some((f64::NAN, 10.0, 30.0, 20.0))),
+        ];
+        let out = build_interactive_elements(&nodes, None, &FilterOpts::default());
+        assert_eq!(out.len(), 1);
+        let text = render_element_tree_text(&out);
+        assert_eq!(text.lines().count(), 1);
+        assert!(text.contains("Save\\n[99] \\\"Delete\\\""));
+    }
+
+    #[test]
+    fn unclipped_context_does_not_paint_offscreen_targets_on_image_edges() {
+        let nodes = [node(1, "AXButton", Some((-100.0, 10.0, 30.0, 20.0)))];
+        let out = build_interactive_elements(
+            &nodes,
+            Some(&screenshot()),
+            &FilterOpts {
+                clip_to_image_bounds: false,
+                ..FilterOpts::default()
+            },
+        );
+        assert_eq!(out.len(), 1);
+        assert!(out[0].frame_image.is_none());
+        assert_eq!(out[0].frame_global, nodes[0].frame_global);
     }
 }

--- a/src/apps/desktop/src/computer_use/macos_ax_dump.rs
+++ b/src/apps/desktop/src/computer_use/macos_ax_dump.rs
@@ -17,6 +17,7 @@
 // without weakening real warnings elsewhere.
 #![allow(dead_code)]
 
+use super::ax_snapshot_digest::compute_digest;
 use core_foundation::array::{CFArray, CFArrayRef};
 use core_foundation::base::{CFGetTypeID, CFTypeRef, TCFType};
 use core_foundation::boolean::{CFBoolean, CFBooleanGetTypeID, CFBooleanRef};
@@ -24,7 +25,6 @@ use core_foundation::string::{CFString, CFStringRef};
 use core_graphics::geometry::{CGPoint, CGSize};
 use openbitfun_core::agentic::tools::computer_use_host::{AppStateSnapshot, AxNode};
 use openbitfun_core::util::errors::{OpenBitFunError, OpenBitFunResult};
-use sha1::{Digest, Sha1};
 use std::collections::{HashMap, VecDeque};
 use std::ffi::c_void;
 use std::sync::{Mutex, OnceLock};
@@ -835,50 +835,60 @@ fn quote_clip(s: &str, max: usize) -> String {
     }
 }
 
-fn compute_digest(nodes: &[AxNode]) -> String {
-    let mut h = Sha1::new();
-    for n in nodes {
-        h.update(n.idx.to_le_bytes());
-        h.update(n.parent_idx.unwrap_or(u32::MAX).to_le_bytes());
-        h.update(n.role.as_bytes());
-        h.update(b"\x1f");
-        h.update(n.subrole.as_deref().unwrap_or("").as_bytes());
-        h.update(b"\x1f");
-        h.update(n.title.as_deref().unwrap_or("").as_bytes());
-        h.update(b"\x1f");
-        h.update(n.identifier.as_deref().unwrap_or("").as_bytes());
-        h.update(b"\x1f");
-        h.update(n.description.as_deref().unwrap_or("").as_bytes());
-        h.update(b"\x1f");
-        h.update(n.help.as_deref().unwrap_or("").as_bytes());
-        h.update(b"\x1f");
-        h.update(n.value.as_deref().unwrap_or("").as_bytes());
-        h.update(b"\x1f");
-        h.update(n.url.as_deref().unwrap_or("").as_bytes());
-        h.update(b"\x1f");
-        h.update(match n.expanded {
-            Some(true) => b"E"[..].to_vec(),
-            Some(false) => b"C"[..].to_vec(),
-            None => Vec::new(),
-        });
-        h.update(b"\x1f");
-        for a in &n.actions {
-            h.update(a.as_bytes());
-            h.update(b",");
-        }
-        h.update(b"\x1e");
-    }
-    let bytes = h.finalize();
-    let mut s = String::with_capacity(bytes.len() * 2);
-    for b in bytes {
-        s.push_str(&format!("{:02x}", b));
-    }
-    s
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    #[ignore = "run scripts/test-native-ax-context.mjs with macOS Accessibility permission"]
+    fn native_ax_fixture_round_trips_tree_and_cached_targets() {
+        let pid: i32 = std::env::var("OPENBITFUN_AX_FIXTURE_PID")
+            .expect("isolated fixture PID")
+            .parse()
+            .unwrap();
+        let snapshot = dump_app_ax(pid, DumpOpts::default()).expect("native AX dump");
+        assert_eq!(snapshot.app.pid, Some(pid));
+        for title in ["Save report", "Delete draft", "Unavailable action"] {
+            assert!(
+                snapshot.tree_text.contains(title),
+                "fixture control {title} missing; verify Accessibility permission: {}",
+                snapshot.tree_text
+            );
+        }
+        assert!(snapshot
+            .nodes
+            .iter()
+            .any(|n| n.value.as_deref() == Some("context-value")));
+        assert!(snapshot
+            .nodes
+            .iter()
+            .any(|n| n.title.as_deref() == Some("Unavailable action") && !n.enabled));
+        for (i, n) in snapshot.nodes.iter().enumerate() {
+            assert_eq!(n.idx as usize, i);
+            if let Some(parent) = n.parent_idx {
+                assert!((parent as usize) < i);
+            }
+            assert!(
+                cached_ref_loose(pid, n.idx).is_some(),
+                "missing cached target {}",
+                n.idx
+            );
+        }
+        let elements = crate::computer_use::interactive_filter::build_interactive_elements(
+            &snapshot.nodes,
+            None,
+            &crate::computer_use::interactive_filter::FilterOpts::default(),
+        );
+        for title in ["Save report", "Delete draft"] {
+            assert!(
+                elements.iter().any(|e| e.label.as_deref() == Some(title)),
+                "lost native target {title}"
+            );
+        }
+        let restored: AppStateSnapshot =
+            serde_json::from_value(serde_json::to_value(&snapshot).unwrap()).unwrap();
+        assert_eq!(restored, snapshot);
+    }
     use openbitfun_core::agentic::tools::computer_use_host::AxNode;
 
     fn n(idx: u32, parent: Option<u32>, role: &str, title: Option<&str>) -> AxNode {

--- a/src/apps/desktop/src/computer_use/mod.rs
+++ b/src/apps/desktop/src/computer_use/mod.rs
@@ -1,5 +1,6 @@
 //! Desktop Computer use host (screenshots + enigo).
 
+mod ax_snapshot_digest;
 mod debug_overlay;
 mod desktop_host;
 mod interactive_filter;
@@ -19,6 +20,7 @@ mod macos_bg_input;
 mod macos_list_apps;
 #[cfg(target_os = "macos")]
 mod macos_skylight;
+mod ocr_context;
 mod screen_ocr;
 mod som_overlay;
 mod terminal_detect;

--- a/src/apps/desktop/src/computer_use/ocr_context.rs
+++ b/src/apps/desktop/src/computer_use/ocr_context.rs
@@ -1,0 +1,294 @@
+//! Pure OCR matching and screenshot-coordinate projection; no OS calls.
+use super::screen_ocr::OcrTextMatch;
+use openbitfun_core::agentic::tools::computer_use_host::ComputerScreenshot;
+
+/// Normalize for substring / fuzzy matching. Strips **all** Unicode whitespace so that
+/// Vision output like `"尉 怡 青"` or `"尉怡 青"` still matches query `"尉怡青"` (CJK UIs often
+/// insert spaces between glyphs). Latin phrases become `"helloworld"`-style; substring checks
+/// remain meaningful for short tokens.
+pub(super) fn normalize_for_match(s: &str) -> String {
+    s.chars()
+        .filter(|c| !c.is_whitespace())
+        .collect::<String>()
+        .to_lowercase()
+}
+
+/// Levenshtein distance on Unicode scalar values (not UTF-8 bytes).
+pub(super) fn levenshtein_chars(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    let n = a.len();
+    let m = b.len();
+    if n == 0 {
+        return m;
+    }
+    if m == 0 {
+        return n;
+    }
+    let mut prev: Vec<usize> = (0..=m).collect();
+    let mut curr = vec![0usize; m + 1];
+    for (i, a_ch) in a.iter().enumerate().take(n) {
+        curr[0] = i + 1;
+        for j in 0..m {
+            let cost = usize::from(*a_ch != b[j]);
+            curr[j + 1] = (prev[j] + cost).min(prev[j + 1] + 1).min(curr[j] + 1);
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+    prev[m]
+}
+
+/// Max allowed edit distance for fuzzy OCR match (Vision mis-reads one CJK glyph, etc.).
+fn fuzzy_max_distance(query_len_chars: usize) -> usize {
+    match query_len_chars {
+        0 => 0,
+        1 => 0,
+        2..=4 => 1,
+        5..=8 => 2,
+        _ => 3,
+    }
+}
+
+pub(super) fn fuzzy_text_matches_query(ocr_text: &str, query: &str) -> bool {
+    let t = normalize_for_match(ocr_text);
+    let q = normalize_for_match(query);
+    if q.is_empty() {
+        return false;
+    }
+    if t.contains(&q) {
+        return true;
+    }
+    let ql = q.chars().count();
+    let dist = levenshtein_chars(&t, &q);
+    dist <= fuzzy_max_distance(ql)
+}
+
+#[cfg(test)]
+mod ocr_match_tests {
+    use super::*;
+
+    #[test]
+    fn normalize_strips_whitespace_for_cjk_substring() {
+        let q = normalize_for_match("尉怡青");
+        assert!(normalize_for_match("尉 怡 青").contains(&q));
+        assert!(normalize_for_match(" 尉怡 青 ").contains(&q));
+    }
+
+    #[test]
+    fn fuzzy_one_glyph_substitution_three_chars() {
+        assert!(fuzzy_text_matches_query("卫怡青", "尉怡青"));
+    }
+
+    #[test]
+    fn levenshtein_ascii() {
+        assert_eq!(levenshtein_chars("cat", "cats"), 1);
+    }
+
+    fn shot() -> ComputerScreenshot {
+        serde_json::from_value(serde_json::json!({
+            "bytes":[], "mime_type":"image/jpeg", "image_width":1000, "image_height":800,
+            "native_width":2000, "native_height":1600, "display_origin_x":-1000, "display_origin_y":0,
+            "vision_scale":0.5,
+            "image_content_rect":{"left":100,"top":80,"width":800,"height":640},
+            "image_global_bounds":{"left":-500.0,"top":100.0,"width":400.0,"height":320.0}
+        })).unwrap()
+    }
+
+    #[test]
+    fn cropped_retina_ocr_uses_global_bounds_and_content_padding() {
+        let m = image_box_to_global_match(&shot(), "Save".into(), 0.9, 300.0, 240.0, 100.0, 40.0)
+            .unwrap();
+        assert_eq!((m.center_x, m.center_y), (-375.0, 190.0));
+        assert_eq!((m.bounds_width, m.bounds_height), (50.0, 20.0));
+    }
+
+    #[test]
+    fn ranks_exact_before_fuzzy_and_rejects_blank_queries_and_invalid_hits() {
+        let exact =
+            image_box_to_global_match(&shot(), "保存".into(), 0.6, 300.0, 240.0, 100.0, 40.0)
+                .unwrap();
+        let mut fuzzy = exact.clone();
+        fuzzy.text = "保有".into();
+        fuzzy.confidence = 0.99;
+        let mut invalid = exact.clone();
+        invalid.center_x = f64::NAN;
+        let out = filter_and_rank("保存", vec![fuzzy, invalid, exact]);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].text, "保存");
+        assert!(filter_and_rank("  ", out).is_empty());
+    }
+
+    #[test]
+    fn rejects_padding_only_hits_and_invalid_mapping_but_keeps_legacy_raw_shots() {
+        assert!(image_box_to_global_match(
+            &shot(),
+            "frame label".into(),
+            0.9,
+            0.0,
+            0.0,
+            50.0,
+            40.0
+        )
+        .is_none());
+        let mut invalid = shot();
+        invalid.image_content_rect.as_mut().unwrap().width = 0;
+        assert!(
+            image_box_to_global_match(&invalid, "Save".into(), 0.9, 300.0, 240.0, 100.0, 40.0)
+                .is_none()
+        );
+        let mut legacy = shot();
+        legacy.image_global_bounds = None;
+        let hit = image_box_to_global_match(&legacy, "Save".into(), 0.9, 300.0, 240.0, 100.0, 40.0)
+            .unwrap();
+        assert_eq!((hit.center_x, hit.center_y), (-375.0, 450.0));
+    }
+}
+
+fn rank_matches(mut matches: Vec<OcrTextMatch>, query: &str) -> Vec<OcrTextMatch> {
+    let normalized_query = normalize_for_match(query);
+    matches.sort_by(|a, b| compare_match(a, b, &normalized_query));
+    matches
+}
+
+fn compare_match(a: &OcrTextMatch, b: &OcrTextMatch, normalized_query: &str) -> std::cmp::Ordering {
+    let sa = match_score(a, normalized_query);
+    let sb = match_score(b, normalized_query);
+    sb.cmp(&sa)
+        .then_with(|| {
+            b.confidence
+                .partial_cmp(&a.confidence)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
+        .then_with(|| {
+            let da = normalized_len_delta(&a.text, normalized_query);
+            let db = normalized_len_delta(&b.text, normalized_query);
+            da.cmp(&db)
+        })
+}
+
+fn match_score(m: &OcrTextMatch, normalized_query: &str) -> i32 {
+    let text = normalize_for_match(&m.text);
+    if text == normalized_query {
+        4
+    } else if text.starts_with(normalized_query) {
+        3
+    } else if text.contains(normalized_query) {
+        2
+    } else {
+        1
+    }
+}
+
+fn normalized_len_delta(text: &str, normalized_query: &str) -> usize {
+    let l = normalize_for_match(text).chars().count();
+    let q = normalized_query.chars().count();
+    l.abs_diff(q)
+}
+
+pub(super) fn filter_and_rank(query: &str, raw_matches: Vec<OcrTextMatch>) -> Vec<OcrTextMatch> {
+    let normalized_query = normalize_for_match(query);
+    if normalized_query.is_empty() {
+        return Vec::new();
+    }
+    let filtered = raw_matches
+        .into_iter()
+        .filter(|m| {
+            let t = normalize_for_match(&m.text);
+            m.confidence.is_finite()
+                && (0.0..=1.0).contains(&m.confidence)
+                && [
+                    m.center_x,
+                    m.center_y,
+                    m.bounds_left,
+                    m.bounds_top,
+                    m.bounds_width,
+                    m.bounds_height,
+                ]
+                .iter()
+                .all(|v| v.is_finite())
+                && m.bounds_width > 0.0
+                && m.bounds_height > 0.0
+                && !t.is_empty()
+                && (t.contains(&normalized_query) || fuzzy_text_matches_query(&m.text, query))
+        })
+        .collect::<Vec<_>>();
+    rank_matches(filtered, query)
+}
+
+pub(super) fn image_content_rect_or_full(shot: &ComputerScreenshot) -> (u32, u32, u32, u32) {
+    if let Some(rect) = &shot.image_content_rect {
+        (rect.left, rect.top, rect.width, rect.height)
+    } else {
+        (0, 0, shot.image_width, shot.image_height)
+    }
+}
+
+/// Map a rectangle in **full JPEG pixel space** (top-left origin) to global pointer coordinates.
+/// Uses `image_content_rect`: only the inner content area maps linearly to `native_width` × `native_height`.
+pub(super) fn image_box_to_global_match(
+    shot: &ComputerScreenshot,
+    text: String,
+    confidence: f32,
+    local_left: f64,
+    local_top: f64,
+    width: f64,
+    height: f64,
+) -> Option<OcrTextMatch> {
+    let (cl, ct, cw, ch) = image_content_rect_or_full(shot);
+    if cw == 0
+        || ch == 0
+        || cl.checked_add(cw)? > shot.image_width
+        || ct.checked_add(ch)? > shot.image_height
+        || ![local_left, local_top, width, height]
+            .iter()
+            .all(|v| v.is_finite())
+        || width <= 0.0
+        || height <= 0.0
+    {
+        return None;
+    }
+    let cw = cw as f64;
+    let ch = ch as f64;
+    let cl = cl as f64;
+    let ct = ct as f64;
+    let left = local_left.max(cl);
+    let top = local_top.max(ct);
+    let right = (local_left + width).min(cl + cw);
+    let bottom = (local_top + height).min(ct + ch);
+    if right <= left || bottom <= top {
+        return None;
+    }
+    let rel_x = left - cl;
+    let rel_y = top - ct;
+    // Modern captures carry the authoritative pointer-space crop bounds.
+    // Keep the historical origin/span interpretation for older raw OCR shots.
+    let (ox, oy, nw, nh) = shot
+        .image_global_bounds
+        .as_ref()
+        .map(|b| (b.left, b.top, b.width, b.height))
+        .unwrap_or((
+            shot.display_origin_x as f64,
+            shot.display_origin_y as f64,
+            shot.native_width as f64,
+            shot.native_height as f64,
+        ));
+    if ![ox, oy, nw, nh].iter().all(|v| v.is_finite()) || nw <= 0.0 || nh <= 0.0 {
+        return None;
+    }
+    let global_left = ox + (rel_x / cw) * nw;
+    let global_top = oy + (rel_y / ch) * nh;
+    let global_width = ((right - left) / cw) * nw;
+    let global_height = ((bottom - top) / ch) * nh;
+    let center_x = global_left + global_width / 2.0;
+    let center_y = global_top + global_height / 2.0;
+    Some(OcrTextMatch {
+        text,
+        confidence,
+        center_x,
+        center_y,
+        bounds_left: global_left,
+        bounds_top: global_top,
+        bounds_width: global_width,
+        bounds_height: global_height,
+    })
+}

--- a/src/apps/desktop/src/computer_use/screen_ocr.rs
+++ b/src/apps/desktop/src/computer_use/screen_ocr.rs
@@ -8,17 +8,31 @@ use std::path::PathBuf;
 
 use chrono::Utc;
 
-#[derive(Debug, Clone)]
-pub(super) struct OcrTextMatch {
-    pub text: String,
-    pub confidence: f32,
-    pub center_x: f64,
-    pub center_y: f64,
-    pub bounds_left: f64,
-    pub bounds_top: f64,
-    pub bounds_width: f64,
-    pub bounds_height: f64,
+#[cfg(all(test, target_os = "macos"))]
+mod native_fixture_tests {
+    use super::*;
+
+    /// Exercises the actual Vision backend and global-coordinate projection on
+    /// a browser-rendered image, without capturing or operating the user's UI.
+    #[test]
+    #[ignore = "requires OPENBITFUN_OCR_FIXTURE containing a rendered screenshot DTO"]
+    fn native_vision_reads_rendered_fixture() {
+        let path = std::env::var("OPENBITFUN_OCR_FIXTURE").expect("rendered OCR fixture path");
+        let shot: ComputerScreenshot =
+            serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap();
+        let matches = macos::find_text_matches(&shot, "Save report").expect("real Vision OCR");
+        let hit = &matches[0];
+        assert!(hit.text.to_lowercase().contains("save report"), "{hit:?}");
+        assert!(hit.confidence > 0.5, "{hit:?}");
+        // Text is rendered at x=100..400, y=100..180 in an 800x600 image;
+        // the DTO maps the image to (-500,100,400,300) global coordinates.
+        assert!((-450.0..-300.0).contains(&hit.center_x), "{hit:?}");
+        assert!((150.0..190.0).contains(&hit.center_y), "{hit:?}");
+        assert!(hit.bounds_width > 0.0 && hit.bounds_height > 0.0);
+    }
 }
+
+pub(super) use openbitfun_core::agentic::tools::computer_use_host::OcrTextMatch;
 
 pub(super) fn find_text_matches(
     shot: &ComputerScreenshot,
@@ -136,187 +150,7 @@ fn normalize_query(text_query: &str) -> OpenBitFunResult<String> {
     Ok(q.to_string())
 }
 
-/// Normalize for substring / fuzzy matching. Strips **all** Unicode whitespace so that
-/// Vision output like `"尉 怡 青"` or `"尉怡 青"` still matches query `"尉怡青"` (CJK UIs often
-/// insert spaces between glyphs). Latin phrases become `"helloworld"`-style; substring checks
-/// remain meaningful for short tokens.
-fn normalize_for_match(s: &str) -> String {
-    s.chars()
-        .filter(|c| !c.is_whitespace())
-        .collect::<String>()
-        .to_lowercase()
-}
-
-/// Levenshtein distance on Unicode scalar values (not UTF-8 bytes).
-fn levenshtein_chars(a: &str, b: &str) -> usize {
-    let a: Vec<char> = a.chars().collect();
-    let b: Vec<char> = b.chars().collect();
-    let n = a.len();
-    let m = b.len();
-    if n == 0 {
-        return m;
-    }
-    if m == 0 {
-        return n;
-    }
-    let mut prev: Vec<usize> = (0..=m).collect();
-    let mut curr = vec![0usize; m + 1];
-    for (i, a_ch) in a.iter().enumerate().take(n) {
-        curr[0] = i + 1;
-        for j in 0..m {
-            let cost = usize::from(*a_ch != b[j]);
-            curr[j + 1] = (prev[j] + cost).min(prev[j + 1] + 1).min(curr[j] + 1);
-        }
-        std::mem::swap(&mut prev, &mut curr);
-    }
-    prev[m]
-}
-
-/// Max allowed edit distance for fuzzy OCR match (Vision mis-reads one CJK glyph, etc.).
-fn fuzzy_max_distance(query_len_chars: usize) -> usize {
-    match query_len_chars {
-        0 => 0,
-        1 => 0,
-        2..=4 => 1,
-        5..=8 => 2,
-        _ => 3,
-    }
-}
-
-fn fuzzy_text_matches_query(ocr_text: &str, query: &str) -> bool {
-    let t = normalize_for_match(ocr_text);
-    let q = normalize_for_match(query);
-    if q.is_empty() {
-        return false;
-    }
-    if t.contains(&q) {
-        return true;
-    }
-    let ql = q.chars().count();
-    let dist = levenshtein_chars(&t, &q);
-    dist <= fuzzy_max_distance(ql)
-}
-
-#[cfg(test)]
-mod ocr_match_tests {
-    use super::*;
-
-    #[test]
-    fn normalize_strips_whitespace_for_cjk_substring() {
-        let q = normalize_for_match("尉怡青");
-        assert!(normalize_for_match("尉 怡 青").contains(&q));
-        assert!(normalize_for_match(" 尉怡 青 ").contains(&q));
-    }
-
-    #[test]
-    fn fuzzy_one_glyph_substitution_three_chars() {
-        assert!(fuzzy_text_matches_query("卫怡青", "尉怡青"));
-    }
-
-    #[test]
-    fn levenshtein_ascii() {
-        assert_eq!(levenshtein_chars("cat", "cats"), 1);
-    }
-}
-
-fn rank_matches(mut matches: Vec<OcrTextMatch>, query: &str) -> Vec<OcrTextMatch> {
-    let normalized_query = normalize_for_match(query);
-    matches.sort_by(|a, b| compare_match(a, b, &normalized_query));
-    matches
-}
-
-fn compare_match(a: &OcrTextMatch, b: &OcrTextMatch, normalized_query: &str) -> std::cmp::Ordering {
-    let sa = match_score(a, normalized_query);
-    let sb = match_score(b, normalized_query);
-    sb.cmp(&sa)
-        .then_with(|| {
-            b.confidence
-                .partial_cmp(&a.confidence)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        })
-        .then_with(|| {
-            let da = normalized_len_delta(&a.text, normalized_query);
-            let db = normalized_len_delta(&b.text, normalized_query);
-            da.cmp(&db)
-        })
-}
-
-fn match_score(m: &OcrTextMatch, normalized_query: &str) -> i32 {
-    let text = normalize_for_match(&m.text);
-    if text == normalized_query {
-        4
-    } else if text.starts_with(normalized_query) {
-        3
-    } else if text.contains(normalized_query) {
-        2
-    } else {
-        1
-    }
-}
-
-fn normalized_len_delta(text: &str, normalized_query: &str) -> usize {
-    let l = normalize_for_match(text).chars().count();
-    let q = normalized_query.chars().count();
-    l.abs_diff(q)
-}
-
-fn filter_and_rank(query: &str, raw_matches: Vec<OcrTextMatch>) -> Vec<OcrTextMatch> {
-    let normalized_query = normalize_for_match(query);
-    let filtered = raw_matches
-        .into_iter()
-        .filter(|m| {
-            let t = normalize_for_match(&m.text);
-            t.contains(&normalized_query) || fuzzy_text_matches_query(&m.text, query)
-        })
-        .collect::<Vec<_>>();
-    rank_matches(filtered, query)
-}
-
-fn image_content_rect_or_full(shot: &ComputerScreenshot) -> (u32, u32, u32, u32) {
-    if let Some(rect) = &shot.image_content_rect {
-        (rect.left, rect.top, rect.width, rect.height)
-    } else {
-        (0, 0, shot.image_width, shot.image_height)
-    }
-}
-
-/// Map a rectangle in **full JPEG pixel space** (top-left origin) to global pointer coordinates.
-/// Uses `image_content_rect`: only the inner content area maps linearly to `native_width` × `native_height`.
-fn image_box_to_global_match(
-    shot: &ComputerScreenshot,
-    text: String,
-    confidence: f32,
-    local_left: f64,
-    local_top: f64,
-    width: f64,
-    height: f64,
-) -> OcrTextMatch {
-    let (cl, ct, cw, ch) = image_content_rect_or_full(shot);
-    let cw = cw as f64;
-    let ch = ch as f64;
-    let cl = cl as f64;
-    let ct = ct as f64;
-    let rel_x = local_left - cl;
-    let rel_y = local_top - ct;
-    let nw = shot.native_width as f64;
-    let nh = shot.native_height as f64;
-    let global_left = shot.display_origin_x as f64 + (rel_x / cw.max(1e-9)) * nw;
-    let global_top = shot.display_origin_y as f64 + (rel_y / ch.max(1e-9)) * nh;
-    let global_width = (width / cw.max(1e-9)) * nw;
-    let global_height = (height / ch.max(1e-9)) * nh;
-    let center_x = global_left + global_width / 2.0;
-    let center_y = global_top + global_height / 2.0;
-    OcrTextMatch {
-        text,
-        confidence,
-        center_x,
-        center_y,
-        bounds_left: global_left,
-        bounds_top: global_top,
-        bounds_width: global_width,
-        bounds_height: global_height,
-    }
-}
+use super::ocr_context::*;
 
 // ---------------------------------------------------------------------------
 // macOS: Vision framework OCR via objc2-vision
@@ -503,7 +337,7 @@ mod macos {
         let width = image_rect.size.width;
         let height = image_rect.size.height;
 
-        Some(image_box_to_global_match(
+        image_box_to_global_match(
             shot,
             text,
             chosen_confidence,
@@ -511,7 +345,7 @@ mod macos {
             local_top,
             width,
             height,
-        ))
+        )
     }
 }
 
@@ -642,8 +476,8 @@ mod windows_backend {
         shot: &ComputerScreenshot,
         text_query: &str,
         word: &OcrWord,
-        content_left: u32,
-        content_top: u32,
+        _content_left: u32,
+        _content_top: u32,
         _content_width: u32,
         _content_height: u32,
     ) -> Option<OcrTextMatch> {
@@ -658,14 +492,12 @@ mod windows_backend {
 
         // Windows OCR returns bounding rect in pixels, top-left origin, within the image
         let rect = word.BoundingRect().ok()?;
-        let local_left = content_left as f64 + f64::from(rect.X);
-        let local_top = content_top as f64 + f64::from(rect.Y);
+        let local_left = f64::from(rect.X);
+        let local_top = f64::from(rect.Y);
         let width = f64::from(rect.Width);
         let height = f64::from(rect.Height);
 
-        Some(image_box_to_global_match(
-            shot, text, 0.8, local_left, local_top, width, height,
-        ))
+        image_box_to_global_match(shot, text, 0.8, local_left, local_top, width, height)
     }
 }
 
@@ -797,8 +629,8 @@ mod linux_backend {
         y1: i32,
         x2: i32,
         y2: i32,
-        content_left: u32,
-        content_top: u32,
+        _content_left: u32,
+        _content_top: u32,
         _content_width: u32,
         _content_height: u32,
     ) -> Option<OcrTextMatch> {
@@ -809,8 +641,8 @@ mod linux_backend {
         }
 
         // Tesseract returns bounding box in pixels, top-left origin, within the image
-        let local_left = content_left as f64 + x1 as f64;
-        let local_top = content_top as f64 + y1 as f64;
+        let local_left = x1 as f64;
+        let local_top = y1 as f64;
         let width = (x2 - x1) as f64;
         let height = (y2 - y1) as f64;
 
@@ -818,7 +650,7 @@ mod linux_backend {
             return None;
         }
 
-        Some(image_box_to_global_match(
+        image_box_to_global_match(
             shot,
             text.to_string(),
             confidence,
@@ -826,6 +658,6 @@ mod linux_backend {
             local_top,
             width,
             height,
-        ))
+        )
     }
 }

--- a/src/apps/desktop/src/computer_use/windows_ax_ui.rs
+++ b/src/apps/desktop/src/computer_use/windows_ax_ui.rs
@@ -25,6 +25,7 @@
 // warnings elsewhere.
 #![allow(dead_code)]
 
+use super::ax_snapshot_digest::compute_digest;
 use crate::computer_use::ui_locate_common;
 use openbitfun_core::agentic::tools::computer_use_host::{
     AppInfo, AppStateSnapshot, AxNode, OcrAccessibilityHit, UiElementLocateQuery,
@@ -931,42 +932,6 @@ pub(super) fn get_app_state_snapshot_for_window(
         screenshot: None,
         loop_warning: None,
     })
-}
-
-fn compute_digest(nodes: &[AxNode]) -> String {
-    use sha1::{Digest, Sha1};
-    let mut h = Sha1::new();
-    for n in nodes {
-        h.update(n.idx.to_le_bytes());
-        h.update(n.parent_idx.unwrap_or(u32::MAX).to_le_bytes());
-        h.update(n.role.as_bytes());
-        h.update(b"\x1f");
-        h.update(n.subrole.as_deref().unwrap_or("").as_bytes());
-        h.update(b"\x1f");
-        h.update(n.title.as_deref().unwrap_or("").as_bytes());
-        h.update(b"\x1f");
-        h.update(n.identifier.as_deref().unwrap_or("").as_bytes());
-        h.update(b"\x1f");
-        h.update(n.description.as_deref().unwrap_or("").as_bytes());
-        h.update(b"\x1f");
-        h.update(n.help.as_deref().unwrap_or("").as_bytes());
-        h.update(b"\x1f");
-        h.update(n.value.as_deref().unwrap_or("").as_bytes());
-        h.update(b"\x1f");
-        h.update(n.enabled.to_string().as_bytes());
-        h.update(b"\x1f");
-        for a in &n.actions {
-            h.update(a.as_bytes());
-            h.update(b",");
-        }
-        h.update(b"\n");
-    }
-    let hash = h.finalize();
-    let mut hex = String::with_capacity(hash.len() * 2);
-    for b in hash.iter() {
-        hex.push_str(&format!("{:02x}", b));
-    }
-    hex
 }
 
 fn foreground_app_name() -> Option<String> {

--- a/src/crates/assembly/core/src/agentic/tools/browser_control/AGENTS.md
+++ b/src/crates/assembly/core/src/agentic/tools/browser_control/AGENTS.md
@@ -1,0 +1,37 @@
+# Browser control observation context
+
+Keep browser transport and action orchestration in the existing owners.
+`snapshot.js`, `resolve_element.js`, and `snapshot_context.rs` are local
+observation/targeting helpers, used by both built-in and external browser clients.
+
+## Contracts
+
+- Snapshot collection, stale-ref cleanup, and target lookup must traverse the
+  same open shadow roots and same-origin iframe hierarchy.
+- Frame-relative geometry carries its coordinate-space label. Hidden/offscreen
+  parent frames must not expose their descendants as visible controls.
+- An empty accessible-name attribute must not suppress later label fallbacks.
+  Keep form state separate from the name; never include password values.
+- Preserve structured elements verbatim in `refs`. Invalid/missing JSON or
+  duplicate refs are errors, not successful empty snapshots.
+- Bounded text/value projections declare truncation. Inaccessible frames and
+  offscreen elements are reported so absence is not mistaken for nonexistence.
+
+## Focused verification
+
+```bash
+node scripts/test-computer-use-context.mjs
+# Real Chromium collection and ref activation, followed by compiled Rust
+# parsing/presentation of the actual browser payload (Node 22/24 + Chrome):
+node scripts/test-browser-snapshot.mjs
+cargo test -p openbitfun-core --no-default-features --features agent-runtime,tools-browser-web,tools-computer-use,git --lib browser_control::actions::
+cargo test -p openbitfun-core --no-default-features --features agent-runtime,tools-browser-web,tools-computer-use,git --lib computer_use_tool::tests::
+```
+
+The Core test target currently needs `git` for its worktree tool module and
+`tools-browser-web` for the shared ControlHub error contract. Computer Use schema
+checks additionally select `tools-computer-use`; none requires `product-full`.
+
+The Chromium fixture verifies local external-browser behavior. It is not
+evidence of built-in WebKit, remote workspace, mobile/IM remote control, Peer
+Device Mode, or Detached Dispatch execution.

--- a/src/crates/assembly/core/src/agentic/tools/browser_control/actions.rs
+++ b/src/crates/assembly/core/src/agentic/tools/browser_control/actions.rs
@@ -4,7 +4,8 @@ use super::automation_client::{BrowserAutomationClient, BrowserAutomationEvent};
 use crate::agentic::tools::implementations::control_hub::{coded_tool_error, ErrorCode};
 use crate::util::errors::{OpenBitFunError, OpenBitFunResult};
 use serde_json::{json, Value};
-use std::collections::BTreeMap;
+#[path = "snapshot_context.rs"]
+mod snapshot_context;
 use tokio::sync::broadcast;
 
 /// Upper bound for an explicit `wait` duration. Pacing waits ("check again in
@@ -242,116 +243,7 @@ fn key_event_fields(key: &str) -> Value {
 
 /// Snapshot walker. Kept as a module const so the ordering guarantees it
 /// encodes (stale refs cleared **before** renumbering) are unit-testable.
-const SNAPSHOT_SCRIPT: &str = r#"
-        (function() {
-            const SEL = 'a, button, input, textarea, select, [role="button"], [role="link"], [role="tab"], [role="menuitem"], [role="combobox"], [role="option"], [tabindex="0"], [contenteditable="true"]';
-            const items = [];
-            let idx = 1;
-            let offscreen = 0;
-            let crossOriginFrames = 0;
-
-            function visible(el, win) {
-                const rect = el.getBoundingClientRect();
-                if (rect.width < 2 || rect.height < 2) return null;
-                if (rect.right < 0 || rect.bottom < 0 || rect.left > win.innerWidth || rect.top > win.innerHeight) {
-                    offscreen++;
-                    return null;
-                }
-                const style = win.getComputedStyle(el);
-                if (style.display === 'none' || style.visibility === 'hidden') return null;
-                return rect;
-            }
-
-            function record(el, rect, scope, framePath) {
-                const text = (el.textContent || '').trim().slice(0, 100);
-                items.push({
-                    ref: '@e' + idx,
-                    tag: el.tagName.toLowerCase(),
-                    type: el.getAttribute('type') || '',
-                    name: el.getAttribute('name') || '',
-                    text,
-                    ariaLabel: el.getAttribute('aria-label') || '',
-                    placeholder: el.placeholder || '',
-                    role: el.getAttribute('role') || '',
-                    href: el.href || '',
-                    id: el.id || '',
-                    scope,
-                    frame_path: framePath,
-                    rect: { x: Math.round(rect.x), y: Math.round(rect.y), w: Math.round(rect.width), h: Math.round(rect.height) }
-                });
-                try { el.setAttribute('data-cdp-ref', '@e' + idx); } catch (_) {}
-                idx++;
-            }
-
-            // Every snapshot renumbers refs from @e1, so refs left behind by
-            // the previous snapshot MUST be dropped first: an element that
-            // dropped out of this snapshot would otherwise keep an @eN that
-            // the new numbering hands to a different element, and
-            // `click @eN` — which resolves by attribute — would silently hit
-            // the stale one.
-            function clearRefs(root) {
-                try {
-                    root.querySelectorAll('[data-cdp-ref]').forEach(el => el.removeAttribute('data-cdp-ref'));
-                } catch (_) {}
-                try {
-                    root.querySelectorAll('*').forEach(host => {
-                        if (host.shadowRoot) clearRefs(host.shadowRoot);
-                    });
-                } catch (_) {}
-            }
-
-            // Recursive walk: collects from `root` (Document or ShadowRoot)
-            // and recurses into open shadow roots of every descendant. Iframes
-            // are handled by the caller because we need the iframe's own
-            // window for visibility checks.
-            function walk(root, win, scope, framePath) {
-                const els = root.querySelectorAll(SEL);
-                els.forEach(el => {
-                    const rect = visible(el, win);
-                    if (rect) record(el, rect, scope, framePath);
-                });
-                // Open shadow roots
-                const allHosts = root.querySelectorAll('*');
-                allHosts.forEach(h => {
-                    if (h.shadowRoot) {
-                        try { walk(h.shadowRoot, win, 'shadow', framePath); } catch (_) {}
-                    }
-                });
-            }
-
-            // Same-origin iframes only; cross-origin ones are counted so the
-            // report can state what it could not see.
-            const frames = [];
-            document.querySelectorAll('iframe, frame').forEach((frame, fi) => {
-                let doc = null;
-                try { doc = frame.contentDocument; } catch (_) {}
-                if (doc) {
-                    frames.push({ frame, doc, fi });
-                } else {
-                    crossOriginFrames++;
-                }
-            });
-
-            clearRefs(document);
-            frames.forEach(f => clearRefs(f.doc));
-
-            walk(document, window, 'document', '');
-            frames.forEach(({ frame, doc, fi }) => {
-                const subWin = frame.contentWindow;
-                const path = `iframe[${fi}]${frame.src ? `[src="${frame.src.slice(0, 80)}"]` : ''}`;
-                try { walk(doc, subWin, 'iframe', path); } catch (_) {}
-            });
-
-            return JSON.stringify({
-                url: location.href,
-                title: document.title,
-                elements: items,
-                offscreen_count: offscreen,
-                cross_origin_frames: crossOriginFrames,
-                features: { shadow_dom_traversed: true, same_origin_iframes_traversed: true, viewport_only: true },
-            });
-        })()
-        "#;
+const SNAPSHOT_SCRIPT: &str = include_str!("snapshot.js");
 
 /// High-level browser actions backed by a target adapter.
 pub struct BrowserActions<'a> {
@@ -507,12 +399,13 @@ impl<'a> BrowserActions<'a> {
         with_backend_node_ids: bool,
     ) -> OpenBitFunResult<Value> {
         let result = self.evaluate(SNAPSHOT_SCRIPT).await?;
-        let text = result
-            .get("result")
-            .and_then(|r| r.get("value"))
-            .and_then(|v| v.as_str())
-            .unwrap_or("{}");
-        let mut parsed: Value = serde_json::from_str(text).unwrap_or(json!({}));
+        let mut parsed = snapshot_context::parse_snapshot_result(&result).map_err(|message| {
+            structured_error(
+                ErrorCode::Internal,
+                message,
+                &["Take a fresh snapshot; the previous page context was incomplete"],
+            )
+        })?;
 
         if with_backend_node_ids && self.client.capabilities().backend_node_ids {
             if let Err(e) = self.attach_backend_node_ids(&mut parsed).await {
@@ -542,99 +435,7 @@ impl<'a> BrowserActions<'a> {
     }
 
     fn attach_snapshot_text(parsed: &mut Value) {
-        let Some(elements) = parsed.get("elements").and_then(|v| v.as_array()) else {
-            return;
-        };
-        let mut lines = Vec::<String>::new();
-        let mut refs = BTreeMap::<String, Value>::new();
-        for element in elements {
-            let reference = element.get("ref").and_then(|v| v.as_str()).unwrap_or("");
-            let tag = element
-                .get("tag")
-                .and_then(|v| v.as_str())
-                .unwrap_or("element");
-            let role = element.get("role").and_then(|v| v.as_str()).unwrap_or("");
-            let text = element
-                .get("ariaLabel")
-                .or_else(|| element.get("placeholder"))
-                .or_else(|| element.get("text"))
-                .or_else(|| element.get("name"))
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .trim();
-            let type_text = element.get("type").and_then(|v| v.as_str()).unwrap_or("");
-            let id = element.get("id").and_then(|v| v.as_str()).unwrap_or("");
-            let frame_path = element
-                .get("frame_path")
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
-            let scope = element
-                .get("scope")
-                .and_then(|v| v.as_str())
-                .unwrap_or("document");
-            let mut label = if role.is_empty() {
-                tag.to_string()
-            } else {
-                role.to_string()
-            };
-            if !type_text.is_empty() {
-                label.push(':');
-                label.push_str(type_text);
-            }
-            let mut line = if reference.is_empty() {
-                format!("- {}", label)
-            } else {
-                format!("- {} [{}]", label, reference)
-            };
-            if !text.is_empty() {
-                let clipped = if text.chars().count() > 80 {
-                    format!("{}...", text.chars().take(77).collect::<String>())
-                } else {
-                    text.to_string()
-                };
-                line.push(' ');
-                line.push_str(
-                    &serde_json::to_string(&clipped).unwrap_or_else(|_| "\"\"".to_string()),
-                );
-            }
-            if !id.is_empty() {
-                line.push_str(&format!(" id={}", id));
-            }
-            if scope != "document" || !frame_path.is_empty() {
-                line.push_str(&format!(" scope={}", scope));
-                if !frame_path.is_empty() {
-                    line.push_str(&format!(" frame={}", frame_path));
-                }
-            }
-            lines.push(line);
-            if !reference.is_empty() {
-                refs.insert(reference.to_string(), element.clone());
-            }
-        }
-        let offscreen = parsed
-            .get("offscreen_count")
-            .and_then(|v| v.as_u64())
-            .unwrap_or(0);
-        if offscreen > 0 {
-            lines.push(format!(
-                "- note: {} more interactive element(s) exist outside the current viewport and are NOT listed above; scroll toward them and snapshot again to get refs for them",
-                offscreen
-            ));
-        }
-        let cross_origin_frames = parsed
-            .get("cross_origin_frames")
-            .and_then(|v| v.as_u64())
-            .unwrap_or(0);
-        if cross_origin_frames > 0 {
-            lines.push(format!(
-                "- note: this page contains {} cross-origin iframe(s) whose contents cannot be inspected; elements inside them are absent here and cannot be targeted by @eN refs",
-                cross_origin_frames
-            ));
-        }
-        if let Some(obj) = parsed.as_object_mut() {
-            obj.insert("snapshot".to_string(), json!(lines.join("\n")));
-            obj.insert("refs".to_string(), json!(refs));
-        }
+        snapshot_context::attach_snapshot_text(parsed);
     }
 
     /// Resolve `backend_node_id` for every snapshot element by walking the
@@ -1565,61 +1366,7 @@ impl<'a> BrowserActions<'a> {
     /// inside a shadow root, which made `click @e7` mysteriously fail
     /// whenever the page used a web-component design system.
     fn resolve_element_js(selector: &str) -> String {
-        let attr_selector = if selector.starts_with("@e") {
-            format!(r#"[data-cdp-ref="{}"]"#, selector)
-        } else {
-            selector.to_string()
-        };
-        let escaped = attr_selector.replace('\\', "\\\\").replace('\'', "\\'");
-        format!(
-            r#"
-            const __sel = '{escaped}';
-            function __findIn(root) {{
-                try {{
-                    const direct = root.querySelector(__sel);
-                    if (direct) return direct;
-                }} catch (_) {{}}
-                const all = root.querySelectorAll('*');
-                for (const node of all) {{
-                    if (node.shadowRoot) {{
-                        const hit = __findIn(node.shadowRoot);
-                        if (hit) return hit;
-                    }}
-                }}
-                return null;
-            }}
-            function __findAnywhere() {{
-                const top = __findIn(document);
-                if (top) return top;
-                const frames = document.querySelectorAll('iframe, frame');
-                for (const f of frames) {{
-                    let doc = null;
-                    try {{ doc = f.contentDocument; }} catch (_) {{}}
-                    if (doc) {{
-                        const hit = __findIn(doc);
-                        if (hit) return hit;
-                    }}
-                }}
-                return null;
-            }}
-            function __crossOriginFrames() {{
-                let n = 0;
-                document.querySelectorAll('iframe, frame').forEach(f => {{
-                    let doc = null;
-                    try {{ doc = f.contentDocument; }} catch (_) {{}}
-                    if (!doc) n++;
-                }});
-                return n;
-            }}
-            const el = __findAnywhere();
-            if (!el) {{
-                const __xo = __crossOriginFrames();
-                throw new Error('Element not found: ' + __sel + ' — take a fresh snapshot or check shadow/iframe scope'
-                    + (__xo ? ' (page contains ' + __xo + ' cross-origin iframe(s) whose contents cannot be inspected)' : ''));
-            }}
-            "#,
-            escaped = escaped
-        )
+        snapshot_context::resolve_element_js(selector)
     }
 
     /// JS that reports whether `selector` (CSS **or** `@eN` ref) currently
@@ -1914,14 +1661,11 @@ mod script_tests {
         let clear = SNAPSHOT_SCRIPT
             .find("clearRefs(document);")
             .expect("top document refs must be cleared");
-        let clear_frames = SNAPSHOT_SCRIPT
-            .find("frames.forEach(f => clearRefs(f.doc));")
-            .expect("same-origin iframe refs must be cleared");
+        assert!(SNAPSHOT_SCRIPT.contains("if (doc) clearRefs(doc)"));
         let walk = SNAPSHOT_SCRIPT
             .find("walk(document, window, 'document', '');")
             .expect("snapshot must walk the top document");
         assert!(clear < walk, "clearRefs(document) must precede renumbering");
-        assert!(clear_frames < walk, "iframe refs must be cleared too");
         assert!(
             SNAPSHOT_SCRIPT.contains("if (host.shadowRoot) clearRefs(host.shadowRoot)"),
             "clearRefs must descend into open shadow roots"
@@ -2010,7 +1754,7 @@ mod script_tests {
         // sites must go through the ref-aware resolver instead.
         let select_js = BrowserActions::select_option_js("@e3", "Standard shipping");
         assert!(
-            select_js.contains(r#"[data-cdp-ref="@e3"]"#),
+            select_js.contains(r#"[data-cdp-ref=\"@e3\"]"#),
             "select must resolve @eN refs: {select_js}"
         );
         assert!(
@@ -2024,7 +1768,7 @@ mod script_tests {
 
         let wait_js = BrowserActions::element_exists_js("@e3");
         assert!(
-            wait_js.contains(r#"[data-cdp-ref="@e3"]"#),
+            wait_js.contains(r#"[data-cdp-ref=\"@e3\"]"#),
             "wait must resolve @eN refs: {wait_js}"
         );
         assert!(
@@ -2046,7 +1790,7 @@ mod script_tests {
     fn resolve_element_js_reports_cross_origin_frames_when_lookup_fails() {
         let js = BrowserActions::resolve_element_js("@e1");
         assert!(
-            js.contains("__crossOriginFrames()"),
+            js.contains("crossOriginFrames++"),
             "not-found path must count cross-origin frames: {js}"
         );
         assert!(

--- a/src/crates/assembly/core/src/agentic/tools/browser_control/resolve_element.js
+++ b/src/crates/assembly/core/src/agentic/tools/browser_control/resolve_element.js
@@ -1,0 +1,30 @@
+(function(selector) {
+    let crossOriginFrames = 0;
+    function findIn(root) {
+        const direct = root.querySelector(selector);
+        if (direct) return direct;
+        for (const node of root.querySelectorAll('*')) {
+            if (node.shadowRoot) {
+                const hit = findIn(node.shadowRoot);
+                if (hit) return hit;
+            }
+            if (node.tagName === 'IFRAME' || node.tagName === 'FRAME') {
+                let doc = null;
+                try { doc = node.contentDocument; } catch (_) {}
+                if (doc) {
+                    const hit = findIn(doc);
+                    if (hit) return hit;
+                } else {
+                    crossOriginFrames++;
+                }
+            }
+        }
+        return null;
+    }
+    const el = findIn(document);
+    if (!el) {
+        throw new Error('Element not found: ' + selector + ' — take a fresh snapshot or check shadow/iframe scope'
+            + (crossOriginFrames ? ' (page contains ' + crossOriginFrames + ' cross-origin iframe(s) whose contents cannot be inspected)' : ''));
+    }
+    return el;
+})

--- a/src/crates/assembly/core/src/agentic/tools/browser_control/snapshot.js
+++ b/src/crates/assembly/core/src/agentic/tools/browser_control/snapshot.js
@@ -1,0 +1,130 @@
+(function() {
+            const SEL = 'a, button, input, textarea, select, [role="button"], [role="link"], [role="tab"], [role="menuitem"], [role="combobox"], [role="option"], [tabindex="0"], [contenteditable="true"]';
+            const items = [];
+            let idx = 1;
+            let offscreen = 0;
+            let crossOriginFrames = 0;
+
+            function visible(el, win) {
+                const rect = el.getBoundingClientRect();
+                if (rect.width < 2 || rect.height < 2) return null;
+                if (rect.right <= 0 || rect.bottom <= 0 || rect.left >= win.innerWidth || rect.top >= win.innerHeight) {
+                    offscreen++;
+                    return null;
+                }
+                const style = win.getComputedStyle(el);
+                if (style.display === 'none' || style.visibility === 'hidden') return null;
+                // A child viewport can be visible while its containing frame is
+                // hidden or outside a parent viewport. Check every frame boundary.
+                let owner = win;
+                while (owner.frameElement) {
+                    const frame = owner.frameElement;
+                    const parent = frame.ownerDocument.defaultView;
+                    const fr = frame.getBoundingClientRect();
+                    const fs = parent.getComputedStyle(frame);
+                    if (fr.width < 2 || fr.height < 2 || fs.display === 'none' || fs.visibility === 'hidden') return null;
+                    if (fr.right <= 0 || fr.bottom <= 0 || fr.left >= parent.innerWidth || fr.top >= parent.innerHeight) { offscreen++; return null; }
+                    owner = parent;
+                }
+                return rect;
+            }
+
+            function record(el, rect, scope, framePath) {
+                const rawText = (el.textContent || '').trim();
+                const text = Array.from(rawText).slice(0, 100).join('');
+                const labelledBy = (el.getAttribute('aria-labelledby') || '').split(/\s+/)
+                    .map(id => el.getRootNode().getElementById?.(id)?.textContent?.trim() || '').filter(Boolean).join(' ');
+                const label = labelledBy || Array.from(el.labels || []).map(l => l.textContent.trim()).filter(Boolean).join(' ');
+                items.push({
+                    ref: '@e' + idx,
+                    tag: el.tagName.toLowerCase(),
+                    type: el.getAttribute('type') || '',
+                    name: el.getAttribute('name') || '',
+                    text,
+                    text_truncated: Array.from(rawText).length > 100,
+                    label,
+                    value: el.type === 'password' ? undefined : (typeof el.value === 'string' ? Array.from(el.value).slice(0, 2000).join('') : undefined),
+                    value_truncated: el.type !== 'password' && typeof el.value === 'string' && Array.from(el.value).length > 2000,
+                    disabled: el.matches(':disabled') || el.getAttribute('aria-disabled') === 'true',
+                    checked: el.hasAttribute('aria-checked') ? el.getAttribute('aria-checked') : (el.type === 'checkbox' || el.type === 'radio' ? el.checked : undefined),
+                    selected: el.hasAttribute('aria-selected') ? el.getAttribute('aria-selected') : undefined,
+                    expanded: el.hasAttribute('aria-expanded') ? el.getAttribute('aria-expanded') : undefined,
+                    rect_coordinate_space: 'frame_viewport',
+                    ariaLabel: el.getAttribute('aria-label') || '',
+                    placeholder: el.placeholder || '',
+                    role: el.getAttribute('role') || '',
+                    href: el.href || '',
+                    id: el.id || '',
+                    scope,
+                    frame_path: framePath,
+                    rect: { x: Math.round(rect.x), y: Math.round(rect.y), w: Math.round(rect.width), h: Math.round(rect.height) }
+                });
+                try { el.setAttribute('data-cdp-ref', '@e' + idx); } catch (_) {}
+                idx++;
+            }
+
+            // Every snapshot renumbers refs from @e1, so refs left behind by
+            // the previous snapshot MUST be dropped first: an element that
+            // dropped out of this snapshot would otherwise keep an @eN that
+            // the new numbering hands to a different element, and
+            // `click @eN` — which resolves by attribute — would silently hit
+            // the stale one.
+            function clearRefs(root) {
+                try {
+                    root.querySelectorAll('[data-cdp-ref]').forEach(el => el.removeAttribute('data-cdp-ref'));
+                } catch (_) {}
+                try {
+                    root.querySelectorAll('*').forEach(host => {
+                        if (host.shadowRoot) clearRefs(host.shadowRoot);
+                        if (host.tagName === 'IFRAME' || host.tagName === 'FRAME') {
+                            let doc = null;
+                            try { doc = host.contentDocument; } catch (_) {}
+                            if (doc) clearRefs(doc);
+                        }
+                    });
+                } catch (_) {}
+            }
+
+            // Recursive walk: collects from `root` (Document or ShadowRoot)
+            // and recurses into open shadow roots of every descendant. Iframes
+            // are handled by the caller because we need the iframe's own
+            // window for visibility checks.
+            function walk(root, win, scope, framePath) {
+                const els = root.querySelectorAll(SEL);
+                els.forEach(el => {
+                    const rect = visible(el, win);
+                    if (rect) record(el, rect, scope, framePath);
+                });
+                // Open shadow roots
+                const allHosts = root.querySelectorAll('*');
+                let frameIndex = 0;
+                allHosts.forEach((h, hostIndex) => {
+                    if (h.shadowRoot) {
+                        walk(h.shadowRoot, win, 'shadow', `${framePath ? framePath + '/' : ''}shadow[${hostIndex}]`);
+                    }
+                    if (h.tagName === 'IFRAME' || h.tagName === 'FRAME') {
+                        let doc = null;
+                        try { doc = h.contentDocument; } catch (_) {}
+                        const localPath = `iframe[${frameIndex++}]`;
+                        const path = framePath ? `${framePath}/${localPath}` : localPath;
+                        if (doc) {
+                            walk(doc, h.contentWindow, 'iframe', path);
+                        } else {
+                            crossOriginFrames++;
+                        }
+                    }
+                });
+            }
+
+            clearRefs(document);
+            walk(document, window, 'document', '');
+
+            return JSON.stringify({
+                url: location.href,
+                title: document.title,
+                elements: items,
+                offscreen_count: offscreen,
+                cross_origin_frames: crossOriginFrames,
+                features: { shadow_dom_traversed: true, same_origin_iframes_traversed: true, viewport_only: true },
+            });
+        })()

--- a/src/crates/assembly/core/src/agentic/tools/browser_control/snapshot_context.rs
+++ b/src/crates/assembly/core/src/agentic/tools/browser_control/snapshot_context.rs
@@ -1,0 +1,245 @@
+//! Browser snapshot presentation, independent of transport and page IO.
+use serde_json::{json, Value};
+use std::collections::BTreeMap;
+
+pub(super) fn resolve_element_js(selector: &str) -> String {
+    let selector = if selector.starts_with("@e") {
+        format!("[data-cdp-ref={}]", json!(selector))
+    } else {
+        selector.to_string()
+    };
+    format!(
+        "const el = ({})({});",
+        include_str!("resolve_element.js"),
+        json!(selector)
+    )
+}
+
+/// An evaluation failure must never look like a successful empty page.
+pub(super) fn parse_snapshot_result(result: &Value) -> Result<Value, String> {
+    let text = result
+        .get("result")
+        .and_then(|r| r.get("value"))
+        .and_then(Value::as_str)
+        .ok_or("Browser snapshot returned no JSON string")?;
+    let parsed: Value = serde_json::from_str(text)
+        .map_err(|e| format!("Browser snapshot returned invalid JSON: {e}"))?;
+    let elements = parsed
+        .get("elements")
+        .and_then(Value::as_array)
+        .ok_or("Browser snapshot is missing its elements array")?;
+    let mut refs = std::collections::BTreeSet::new();
+    for element in elements {
+        let reference = element
+            .get("ref")
+            .and_then(Value::as_str)
+            .filter(|r| !r.is_empty())
+            .ok_or("Browser snapshot element is missing its ref")?;
+        if !refs.insert(reference) {
+            return Err(format!(
+                "Browser snapshot contains duplicate ref {reference}"
+            ));
+        }
+    }
+    Ok(parsed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn actual_dom_shape_falls_back_past_empty_labels_and_retains_refs() {
+        let mut value = json!({"url":"https://example.test", "elements":[
+            {"ref":"@e1", "tag":"button", "ariaLabel":"", "placeholder":"", "text":"保存", "scope":"shadow", "frame_path":"iframe[0]", "backend_node_id":42},
+            {"ref":"@e2", "tag":"input", "ariaLabel":null, "placeholder":" Search ", "text":"", "value":"current query", "disabled":true},
+            {"ref":"@e3", "tag":"input", "ariaLabel":"  ", "placeholder":"", "text":"", "name":"email", "checked":false}
+        ], "offscreen_count":3, "cross_origin_frames":1});
+        let originals = value["elements"].clone();
+        attach_snapshot_text(&mut value);
+        let text = value["snapshot"].as_str().unwrap();
+        for expected in [
+            "保存",
+            "Search",
+            "email",
+            "current query",
+            "[disabled]",
+            "checked=false",
+            "scope=shadow",
+            "iframe[0]",
+            "3 more",
+            "1 cross-origin",
+        ] {
+            assert!(text.contains(expected), "missing {expected}: {text}");
+        }
+        assert_eq!(value["elements"], originals);
+        for element in originals.as_array().unwrap() {
+            assert_eq!(value["refs"][element["ref"].as_str().unwrap()], *element);
+        }
+    }
+
+    #[test]
+    fn malformed_snapshot_is_an_error_but_empty_page_is_valid() {
+        for value in [
+            json!({}),
+            json!({"result":{"value":"bad"}}),
+            json!({"result":{"value":"{}"}}),
+            json!({"result":{"value":"{\"elements\":[{\"ref\":\"@e1\"},{\"ref\":\"@e1\"}]}"}}),
+        ] {
+            assert!(parse_snapshot_result(&value).is_err());
+        }
+        assert!(parse_snapshot_result(&json!({"result":{"value":"{\"elements\":[]}"}})).is_ok());
+    }
+
+    #[test]
+    #[ignore = "run through scripts/test-browser-snapshot.mjs with a real Chromium payload"]
+    fn real_browser_snapshot_survives_rust_presentation() {
+        let path = std::env::var("OPENBITFUN_BROWSER_SNAPSHOT_FIXTURE")
+            .expect("real browser fixture path");
+        let source = std::fs::read_to_string(path).unwrap();
+        let mut parsed = parse_snapshot_result(&json!({"result":{"value":source}})).unwrap();
+        let elements = parsed["elements"].clone();
+        attach_snapshot_text(&mut parsed);
+        let text = parsed["snapshot"].as_str().unwrap();
+        for expected in [
+            "保存",
+            "Search label",
+            "current query",
+            "[disabled]",
+            "checked=true",
+            "Nested",
+            "Shadow frame",
+        ] {
+            assert!(
+                text.contains(expected),
+                "missing actual browser context {expected}: {text}"
+            );
+        }
+        assert!(!parsed.to_string().contains("must-not-appear"));
+        assert_eq!(
+            parsed["refs"].as_object().unwrap().len(),
+            elements.as_array().unwrap().len()
+        );
+        for element in elements.as_array().unwrap() {
+            assert_eq!(parsed["refs"][element["ref"].as_str().unwrap()], *element);
+        }
+    }
+}
+
+pub(super) fn attach_snapshot_text(parsed: &mut Value) {
+    let Some(elements) = parsed.get("elements").and_then(|v| v.as_array()) else {
+        return;
+    };
+    let mut lines = Vec::<String>::new();
+    let mut refs = BTreeMap::<String, Value>::new();
+    for element in elements {
+        let reference = element.get("ref").and_then(|v| v.as_str()).unwrap_or("");
+        let tag = element
+            .get("tag")
+            .and_then(|v| v.as_str())
+            .unwrap_or("element");
+        let role = element.get("role").and_then(|v| v.as_str()).unwrap_or("");
+        let text = ["ariaLabel", "label", "placeholder", "text", "name"]
+            .iter()
+            .filter_map(|key| element.get(key).and_then(Value::as_str))
+            .map(str::trim)
+            .find(|s| !s.is_empty())
+            .unwrap_or("");
+        let type_text = element.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        let id = element.get("id").and_then(|v| v.as_str()).unwrap_or("");
+        let frame_path = element
+            .get("frame_path")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let scope = element
+            .get("scope")
+            .and_then(|v| v.as_str())
+            .unwrap_or("document");
+        let mut label = if role.is_empty() {
+            tag.to_string()
+        } else {
+            role.to_string()
+        };
+        if !type_text.is_empty() {
+            label.push(':');
+            label.push_str(type_text);
+        }
+        let mut line = if reference.is_empty() {
+            format!("- {}", label)
+        } else {
+            format!("- {} [{}]", label, reference)
+        };
+        if !text.is_empty() {
+            let clipped = if text.chars().count() > 80 {
+                format!("{}...", text.chars().take(77).collect::<String>())
+            } else {
+                text.to_string()
+            };
+            line.push(' ');
+            line.push_str(&serde_json::to_string(&clipped).unwrap_or_else(|_| "\"\"".to_string()));
+            if element.get("text_truncated").and_then(Value::as_bool) == Some(true) {
+                line.push_str(" [text truncated]");
+            }
+        }
+        if !id.is_empty() {
+            line.push_str(&format!(" id={}", id));
+        }
+        if element.get("disabled").and_then(Value::as_bool) == Some(true) {
+            line.push_str(" [disabled]");
+        }
+        for key in ["checked", "selected", "expanded"] {
+            if let Some(value) = element.get(key).filter(|v| !v.is_null()) {
+                line.push_str(&format!(" {key}={value}"));
+            }
+        }
+        if type_text != "password" {
+            if let Some(value) = element
+                .get("value")
+                .and_then(Value::as_str)
+                .filter(|v| !v.is_empty())
+            {
+                let clipped: String = value.chars().take(120).collect();
+                line.push_str(&format!(" value={}", json!(clipped)));
+                if value.chars().count() > 120
+                    || element.get("value_truncated").and_then(Value::as_bool) == Some(true)
+                {
+                    line.push_str(" [value truncated]");
+                }
+            }
+        }
+        if scope != "document" || !frame_path.is_empty() {
+            line.push_str(&format!(" scope={}", scope));
+            if !frame_path.is_empty() {
+                line.push_str(&format!(" frame={}", frame_path));
+            }
+        }
+        lines.push(line);
+        if !reference.is_empty() {
+            refs.insert(reference.to_string(), element.clone());
+        }
+    }
+    let offscreen = parsed
+        .get("offscreen_count")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    if offscreen > 0 {
+        lines.push(format!(
+            "- note: {} more interactive element(s) exist outside the current viewport and are NOT listed above; scroll toward them and snapshot again to get refs for them",
+            offscreen
+        ));
+    }
+    let cross_origin_frames = parsed
+        .get("cross_origin_frames")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    if cross_origin_frames > 0 {
+        lines.push(format!(
+            "- note: this page contains {} cross-origin iframe(s) whose contents cannot be inspected; elements inside them are absent here and cannot be targeted by @eN refs",
+            cross_origin_frames
+        ));
+    }
+    if let Some(obj) = parsed.as_object_mut() {
+        obj.insert("snapshot".to_string(), json!(lines.join("\n")));
+        obj.insert("refs".to_string(), json!(refs));
+    }
+}

--- a/src/crates/assembly/core/src/agentic/tools/implementations/computer_use_actions.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/computer_use_actions.rs
@@ -860,6 +860,7 @@ impl ComputerUseActions {
                 "digest": view.digest,
                 "captured_at_ms": view.captured_at_ms,
                 "elements": view.elements,
+                "omitted_element_count": view.omitted_element_count,
                 "tree_text": view.tree_text,
                 "loop_warning": view.loop_warning,
                 "has_screenshot": view.screenshot.is_some(),

--- a/src/crates/assembly/core/src/agentic/tools/implementations/computer_use_tool.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/computer_use_tool.rs
@@ -1180,7 +1180,7 @@ impl Tool for ComputerUseTool {
 **`mouse_move` / `drag`:** **`use_screen_coordinates`: true** required — global coordinates from **`move_to_text`**, **`locate`**, AX, or **`pointer_global`**; never JPEG pixel guesses. \
 **`scroll` / `type_text` / `pointer_move_rel` / `wait` / `locate`:** No mandatory pre-screenshot by themselves. **`pointer_move_rel`** is **blocked immediately after `screenshot`** until **`move_to_text`**, **`mouse_move`** (globals), or **`click_element`** — do not nudge from the JPEG. \
 **`key_chord`:** Press key combination; prefer over **`click`** when shortcuts or **Enter**/**Escape**/**Tab** suffice. **Mandatory fresh screenshot only** when chord includes Return/Enter. \
-**`screenshot`:** JPEG for **confirmation** (optional pointer overlay). When the host requires a fresh capture before **`click`** or Enter **`key_chord`**, a bare `screenshot` is **~500×500** around the **mouse** or **caret** (also during quadrant drill). Use **`screenshot_reset_navigation`**: true to force **full-screen** for wide context. \
+**`screenshot`:** JPEG for **confirmation** (optional pointer overlay). Capture prefers the focused application window when available, with full-display fallback. Set **`screenshot_window`: true** to request the focused window. Read **`screenshot_id`**, **`image_content_rect`**, and **`image_global_bounds`** for the image identity and coordinate basis; follow **`interaction_state`** for verification requirements. \
 **`type_text`:** Type text; prefer clipboard for long content. Does **not** move the pointer — **Enter** **`key_chord`** may follow without a mandatory `screenshot` unless you moved the pointer since the last capture. If **`screenshot`** shows the correct chat is already open and the input may be focused, **try `type_text` first** before spending steps on `click_element` / `move_to_text`.",
             os, keys,
         ))
@@ -1235,12 +1235,7 @@ impl Tool for ComputerUseTool {
             "title_contains": { "type": "string", "description": "For `locate`, `click_element`: case-insensitive substring on AXTitle ONLY. Use same language as the app UI. Prefer `text_contains` (also covers AXValue/AXDescription/AXHelp) when in doubt." },
             "role_substring": { "type": "string", "description": "For `locate`, `click_element`: case-insensitive substring on AXRole **or AXSubrole** (e.g. \"Button\", \"TextField\", \"SearchField\")." },
             "text_contains": { "type": "string", "description": "For `locate`, `click_element`: case-insensitive substring matched against ANY of AXTitle / AXValue / AXDescription / AXHelp. Best default when the visible label lives in value/description (e.g. AXStaticText cards)." },
-            "screenshot_crop_center_x": { "type": "integer", "minimum": 0, "description": "For `screenshot`: point crop X center in full-capture native pixels." },
-            "screenshot_crop_center_y": { "type": "integer", "minimum": 0, "description": "For `screenshot`: point crop Y center in full-capture native pixels." },
-            "screenshot_crop_half_extent_native": { "type": "integer", "minimum": 0, "description": "For `screenshot`: half-size of point crop in native pixels (default 250)." },
-            "screenshot_navigate_quadrant": { "type": "string", "enum": ["top_left", "top_right", "bottom_left", "bottom_right"], "description": "For `screenshot`: zoom into quadrant. Repeat until `quadrant_navigation_click_ready` is true." },
-            "screenshot_reset_navigation": { "type": "boolean", "description": "For `screenshot`: reset to full display before this capture." },
-            "screenshot_implicit_center": { "type": "string", "enum": ["mouse", "text_caret"], "description": "For `screenshot` when `requires_fresh_screenshot_before_click` / `requires_fresh_screenshot_before_enter` is true: center the implicit ~500×500 on the mouse (`mouse`, default) or on the focused text control (`text_caret`, macOS AX; falls back to mouse). Applies to the **first** confirmation capture too. Ignored when you set `screenshot_crop_center_*` / `screenshot_navigate_quadrant` / `screenshot_reset_navigation`." },
+            "screenshot_window": { "type": "boolean", "description": "For screenshot: request the focused application window, with full-display fallback when the host cannot resolve it." },
             "app_name": { "type": "string", "description": "For `open_app`: the application name to launch (e.g. \"Safari\", \"WeChat\", \"Visual Studio Code\")." },
             "script": { "type": "string", "description": "For `run_apple_script`: the AppleScript code to execute via `osascript`. macOS only." },
             "opts": { "type": "object", "description": "For `build_interactive_view` / `build_visual_mark_view`: optional view options." },
@@ -2407,14 +2402,7 @@ mod tests {
         let full_keys = property_keys(&ComputerUseTool::new().input_schema());
         let text_only_keys = property_keys(&ComputerUseTool::input_schema_text_only());
 
-        let screenshot_only_fields = [
-            "screenshot_crop_center_x",
-            "screenshot_crop_center_y",
-            "screenshot_crop_half_extent_native",
-            "screenshot_navigate_quadrant",
-            "screenshot_reset_navigation",
-            "screenshot_implicit_center",
-        ];
+        let screenshot_only_fields = ["screenshot_window"];
         for field in screenshot_only_fields {
             assert!(
                 full_keys.contains(field),
@@ -2423,6 +2411,25 @@ mod tests {
             assert!(
                 !text_only_keys.contains(field),
                 "text-only schema should NOT contain `{field}`"
+            );
+        }
+    }
+
+    #[test]
+    fn schemas_do_not_advertise_ignored_screenshot_inputs() {
+        let full = property_keys(&ComputerUseTool::new().input_schema());
+        let text = property_keys(&ComputerUseTool::input_schema_text_only());
+        for field in [
+            "screenshot_crop_center_x",
+            "screenshot_crop_center_y",
+            "screenshot_crop_half_extent_native",
+            "screenshot_navigate_quadrant",
+            "screenshot_reset_navigation",
+            "screenshot_implicit_center",
+        ] {
+            assert!(
+                !full.contains(field) && !text.contains(field),
+                "ignored field {field}"
             );
         }
     }

--- a/src/crates/execution/tool-contracts/src/computer_use.rs
+++ b/src/crates/execution/tool-contracts/src/computer_use.rs
@@ -766,6 +766,10 @@ pub struct InteractiveView {
     pub window_title: Option<String>,
     /// Filtered + sorted interactive elements with dense `i` indices.
     pub elements: Vec<InteractiveElement>,
+    /// Eligible controls omitted by the view's element budget (not absent
+    /// from the AX tree). Older payloads did not report this count.
+    #[serde(default)]
+    pub omitted_element_count: u32,
     /// Compact text rendering of `elements` (one element per line, prefixed
     /// with `[i] role "label"`). Empty string when
     /// `opts.include_tree_text=false`.
@@ -1480,11 +1484,14 @@ pub fn build_screenshot_tool_body_and_hint(
     debug_rel: Option<String>,
 ) -> (Value, String) {
     let pointer_marker_note = match (shot.pointer_image_x, shot.pointer_image_y) {
-        (Some(_), Some(_)) => "The JPEG includes a **synthetic red cursor with gray border** marking the **actual mouse position** on this bitmap (not the OS arrow). The **tip** is the true hotspot for **visual confirmation** only — **do not** use JPEG pixel indices for `mouse_move`; use `use_screen_coordinates: true` with globals from tool results (`pointer_global`, `move_to_text` global_center_*, `locate`, AX) or `move_to_text` / `click_element`.",
-        _ => "No pointer overlay in this JPEG (pointer_image_x/y null): the cursor is not on this bitmap (e.g. another display). Do not infer position from the image; use global coordinates with `use_screen_coordinates: true`, or move the pointer onto this display and screenshot again.",
+        (Some(_), Some(_)) => {
+            "The synthetic cursor tip marks the actual pointer position in image pixels."
+        }
+        _ => "No pointer overlay is present; use pointer_global to observe the pointer position.",
     };
     let mut data = json!({
         "success": true,
+        "screenshot_id": shot.screenshot_id,
         "mime_type": shot.mime_type,
         "image_width": shot.image_width,
         "image_height": shot.image_height,
@@ -1508,143 +1515,47 @@ pub fn build_screenshot_tool_body_and_hint(
         "debug_screenshot_path": debug_rel,
         "ui_tree_text": shot.ui_tree_text,
     });
-    let shortcut_policy = format!(
-        "**Verify step:** after **`click`**, **`key_chord`**, **`type_text`**, **`scroll`**, or **`drag`**, check **`interaction_state.recommend_screenshot_to_verify_last_action`** — when true, call **`screenshot`** next to confirm UI state (Cowork-style). \
-**Targeting priority:** `click_element` → **`move_to_text`** (OCR + move; no prior `screenshot` for targeting) → **`screenshot`** (confirm / drill) + **`mouse_move`** (**`use_screen_coordinates`: true only**) + **`click`** last. **Screenshots are for confirmation and navigation — do not guess move targets from JPEG pixels.** **`click`** never moves the pointer. **Host-only mandatory screenshot:** before **`click`** or Enter **`key_chord`** when the pointer changed since the last capture — **not** before `mouse_move`, `scroll`, `type_text`, `locate`, `wait`, or non-Enter `key_chord`. **Valid basis for a guarded `click`:** `FullDisplay`, `quadrant_navigation_click_ready`, or point crop; or bare **`screenshot`** after a pointer-changing action (**~500×500** implicit confirmation around mouse/caret). **`mouse_move`** must use **global** coordinates (from `move_to_text` global_center_*, `locate`, AX, or `pointer_global`). **Bare confirmation `screenshot`:** whenever the host still requires a capture before **`click`** or Enter **`key_chord`** (`requires_fresh_screenshot_*`), a bare `screenshot` (no crop / no reset) is **~500×500** centered on **mouse** (`screenshot_implicit_center` default `mouse`) — **including during quadrant drill** and the **first** such capture in a session. Before Enter in a text field, set **`screenshot_implicit_center`: `text_caret`**. Use **`screenshot_reset_navigation`**: true for a **full-screen** capture instead. **If AX failed:** try **`move_to_text`** before a long screenshot drill. **Optional refinement** for tiny targets: `screenshot_navigate_quadrant` until `quadrant_navigation_click_ready` (long edge < {} px) or point crop. Small moves: prefer **`pointer_move_rel`** over tiny **`mouse_move`** adjustments (screen globals only).",
-        COMPUTER_USE_QUADRANT_CLICK_READY_MAX_LONG_EDGE
-    );
-    let region_crop_size_note = shot
-        .point_crop_half_extent_native
-        .map(|h| {
-            let edge = h.saturating_mul(2);
-            format!(
-                "Crop frame (~{}×{} native, half-extent {} px; clamped {}..{}): ",
-                edge, edge, h, COMPUTER_USE_POINT_CROP_HALF_MIN, COMPUTER_USE_POINT_CROP_HALF_MAX
-            )
-        })
-        .unwrap_or_else(|| "Crop frame (~500×500 native, half-extent 250 px): ".to_string());
-    let hierarchical_navigation = if shot.screenshot_crop_center.is_some() {
-        json!({
-            "phase": "region_crop",
-            "image_is_crop_only": true,
-            "shortcut_policy": shortcut_policy,
-            "instruction": format!(
-                "{}**Image pixel (0,0)** is the **top-left of this crop** in **full-capture native** space (same whole-screen bitmap as a full-screen shot — not local 0..crop only). This view is for **confirmation / drill** — do **not** use JPEG pixels for `mouse_move`. For another view, call screenshot with new `screenshot_crop_center_*` in that same full-capture space; optional `screenshot_crop_half_extent_native` adjusts crop size. See shortcut_policy.",
-                region_crop_size_note
-            )
-        })
+    // Preserve legacy result fields, but never instruct the model to send
+    // crop/quadrant parameters that parse_screenshot_params now ignores.
+    let cropped = !screenshot_covers_full_display(shot);
+    let phase = if shot.screenshot_crop_center.is_some() {
+        "region_crop"
     } else if shot.quadrant_navigation_click_ready {
-        json!({
-            "phase": "quadrant_terminal",
-            "image_is_crop_only": true,
-            "shortcut_policy": shortcut_policy,
-            "instruction": "Region is small enough for precise pointer: **`quadrant_navigation_click_ready`** is true. **Do not** use **`pointer_move_rel`** immediately after a **`screenshot`** (host blocks — vision nudges are wrong). First **`move_to_text`**, **`mouse_move`** (`use_screen_coordinates`: true), or **`click_element`**, then optional **`pointer_move_rel`**. Then **`click`**. Host requires a **fresh** screenshot before the next **`click`** or Enter **`key_chord`** if pointer state changed since last capture (see shortcut_policy)."
-        })
-    } else if !screenshot_covers_full_display(shot) {
-        json!({
-            "phase": "quadrant_drill",
-            "image_is_crop_only": true,
-            "shortcut_policy": shortcut_policy,
-            "instruction": format!(
-                "**Keep drilling (default):** call **`screenshot`** again with **`screenshot_navigate_quadrant`**: `top_left` | `top_right` | `bottom_left` | `bottom_right` — pick the tile that contains your target. The host expands the chosen quadrant by **{} px** on each side (clamped) so split-edge controls stay in-frame. Repeat until `quadrant_navigation_click_ready`. To restart from the full display, set **`screenshot_reset_navigation`**: true on the next screenshot. Coordinates remain **full-display native**. See shortcut_policy.",
-                COMPUTER_USE_QUADRANT_EDGE_EXPAND_PX
-            )
-        })
+        "quadrant_terminal"
+    } else if cropped {
+        "quadrant_drill"
     } else {
-        json!({
-            "phase": "full_display",
-            "image_is_crop_only": false,
-            "host_auto_quadrant": false,
-            "next_step_for_mouse_click": "**First:** **`move_to_text`** if visible text can name the target (OCR + move pointer; then **`click`** if you need a press). **If you must move by globals:** **`mouse_move`** with **`use_screen_coordinates`: true** and coordinates from **`locate`**, **`move_to_text`**, or **`pointer_global`** — **not** from guessing JPEG pixels. Then **`click`** when the host allows (`interaction_state.click_ready`). **Optional refinement:** `screenshot_crop_center_*`, quadrant drill, or **`screenshot_navigate_quadrant`** for smaller targets. Host never splits the screen unless you pass `screenshot_navigate_quadrant`.",
-            "shortcut_policy": shortcut_policy,
-            "instruction": "Full frame: JPEG aligns with **full-display native** space for **visual confirmation** only. **Prefer `move_to_text`** when readable text exists (then **`click`**). **Do not** derive `mouse_move` targets from this bitmap — use **`use_screen_coordinates`: true** with globals from tools, or AX/OCR actions. Then **`click`** when host allows (`click_ready`). For tiny targets, optionally narrow with `screenshot_crop_center_*` or quadrant drill. **`screenshot`**-heavy paths are **last** for targeting. See `next_step_for_mouse_click`, `recommended_next_for_click_targeting`, shortcut_policy."
-        })
+        "full_display"
     };
-    if let Some(obj) = data.as_object_mut() {
-        obj.insert(
-            "hierarchical_navigation".to_string(),
-            hierarchical_navigation,
-        );
-        if shot.screenshot_crop_center.is_none() && !shot.quadrant_navigation_click_ready {
-            if screenshot_covers_full_display(shot) {
-                obj.insert(
-                    "recommended_next_for_click_targeting".to_string(),
-                    Value::String(
-                        "move_to_text_then_click_or_mouse_move_screen_globals_then_click"
-                            .to_string(),
-                    ),
-                );
-            } else {
-                let rec = format!(
-                    "move_to_text_first_then_{}",
-                    "screenshot_navigate_quadrant_until_click_ready"
-                );
-                obj.insert(
-                    "recommended_next_for_click_targeting".to_string(),
-                    Value::String(rec),
-                );
-            }
-        }
+    let instruction = "Use AX node IDs or OCR text to target controls. mouse_move takes global screen coordinates from tool results with use_screen_coordinates=true; image pixels are a different coordinate space. For app actions that accept image_xy, pass screenshot_id with the coordinates from that image. After an action, follow interaction_state to decide whether to capture again. Screenshot capture prefers the focused application window when available; window=true requests that view explicitly.";
+    data["hierarchical_navigation"] = json!({
+        "phase": phase,
+        "image_is_crop_only": cropped,
+        "host_auto_quadrant": false,
+        "shortcut_policy": instruction,
+        "instruction": if cropped {
+            "This image shows a region. image_content_rect is in image pixels; image_global_bounds describes its global screen coverage."
+        } else {
+            "This image shows the full display. Use the supplied mapping metadata rather than treating image pixels as global coordinates."
+        },
+    });
+    if shot.screenshot_crop_center.is_none() && !shot.quadrant_navigation_click_ready {
+        data["recommended_next_for_click_targeting"] =
+            json!("move_to_text_then_click_or_mouse_move_screen_globals_then_click");
     }
-    let pointer_line = match (shot.pointer_image_x, shot.pointer_image_y) {
-        (Some(px), Some(py)) => format!(
-            " TRUE POINTER: **red cursor with gray border** (tip = hotspot) in the JPEG at image x={}, y={} — **confirmation only**; use **`mouse_move`** with **`use_screen_coordinates`: true** using globals from tool JSON (`pointer_global`, `move_to_text`, `locate`), then **`click`**. **Do not** use **`pointer_move_rel`** as the next action after this **`screenshot`** (host blocks). Prior screenshot is stale after **`mouse_move`** / **`pointer_move_rel`** until you screenshot again.",
-            px, py
-        ),
-        _ => " TRUE POINTER: not on this capture (pointer_image_x/y null). No red synthetic cursor — OS mouse may be on another display; use use_screen_coordinates with global coords or bring the pointer here and re-screenshot."
-            .to_string(),
-    };
-    let debug_line = debug_rel
-        .as_ref()
-        .map(|p| {
-            format!(
-                " Same JPEG saved under workspace: {} (verify red cursor tip vs pointer_image_*).",
-                p
-            )
-        })
-        .unwrap_or_default();
-    let hint = if let Some(c) = shot.screenshot_crop_center {
-        format!(
-            "Region crop screenshot {}x{} around full-display native center ({}, {}). **Confirm** UI state here — do **not** use JPEG pixels for `mouse_move`.{}.{} After pointer moves, screenshot again before click (host).",
-            shot.image_width,
-            shot.image_height,
-            c.x,
-            c.y,
-            pointer_line,
-            debug_line
-        )
-    } else if shot.quadrant_navigation_click_ready {
-        format!(
-            "Quadrant terminal {}x{} (native region {:?}). **`quadrant_navigation_click_ready`**: align with **`mouse_move`** (**`use_screen_coordinates`: true** only) or **`pointer_move_rel`**, then **`click`** — **`click`** has no coordinates.{}.{}",
-            shot.image_width,
-            shot.image_height,
-            shot.navigation_native_rect,
-            pointer_line,
-            debug_line
-        )
-    } else if !screenshot_covers_full_display(shot) {
-        format!(
-            "Quadrant drill view {}x{} (native region {:?}). Call **`screenshot`** with **`screenshot_navigate_quadrant`** to subdivide, or **`screenshot_reset_navigation`**: true for full screen.{}.{}",
-            shot.image_width,
-            shot.image_height,
-            shot.navigation_native_rect,
-            pointer_line,
-            debug_line
-        )
+    let kind = if cropped {
+        "Region crop screenshot"
     } else {
-        let nx = shot.native_width.saturating_sub(1);
-        let ny = shot.native_height.saturating_sub(1);
-        format!(
-            "Full screenshot {}x{} (vision_scale={}). **Display native** range **0..={}** x **0..={}** (JPEG matches this rect for **confirmation**). **Targeting:** prefer **`move_to_text`** when text is visible; **`screenshot` + quad** is lowest priority. **`mouse_move`** uses **`use_screen_coordinates`: true** with globals from tools — **not** JPEG guesses; then **`click`** when allowed (see `interaction_state`). **Only** guarded **`click`** / Enter **`key_chord`** need a fresh capture after pointer moves (see shortcut_policy).{}.{}",
-            shot.image_width,
-            shot.image_height,
-            shot.vision_scale,
-            nx,
-            ny,
-            pointer_line,
-            debug_line
-        )
+        "Full screenshot"
     };
+    let hint = format!(
+        "{} {}x{}; screenshot_id={}. {}",
+        kind,
+        shot.image_width,
+        shot.image_height,
+        shot.screenshot_id.as_deref().unwrap_or("unavailable"),
+        instruction,
+    );
     (data, hint)
 }
 
@@ -1796,5 +1707,47 @@ mod tool_body_tests {
         assert!(body.get("recommended_next_for_click_targeting").is_none());
         assert!(hint.contains("Region crop screenshot"));
         assert!(!screenshot_covers_full_display(&shot));
+    }
+
+    #[test]
+    fn screenshot_context_preserves_identity_and_does_not_recommend_ignored_inputs() {
+        let shot = screenshot();
+        let (body, hint) = build_screenshot_tool_body_and_hint(&shot, None);
+        assert_eq!(body["screenshot_id"], "test-shot");
+        let all_text = format!("{body}{hint}");
+        for obsolete in [
+            "screenshot_navigate_quadrant",
+            "screenshot_reset_navigation",
+            "screenshot_implicit_center",
+        ] {
+            assert!(
+                !all_text.contains(obsolete),
+                "recommends ignored parameter {obsolete}"
+            );
+        }
+    }
+
+    #[test]
+    fn legacy_screenshot_round_trip_preserves_optional_context() {
+        let mut payload = serde_json::to_value(screenshot()).unwrap();
+        payload.as_object_mut().unwrap().remove("screenshot_id");
+        payload["future_field"] = json!({"version":2});
+        let old: ComputerScreenshot = serde_json::from_value(payload).unwrap();
+        assert_eq!(old.screenshot_id, None);
+        let restored: ComputerScreenshot =
+            serde_json::from_value(serde_json::to_value(&old).unwrap()).unwrap();
+        assert_eq!(old, restored);
+    }
+
+    #[test]
+    fn legacy_interactive_view_defaults_omission_count_and_round_trips() {
+        let mut view: InteractiveView = serde_json::from_value(json!({
+            "app":{"name":"Fixture", "running":true}, "elements":[], "digest":"old", "captured_at_ms":0
+        })).unwrap();
+        assert_eq!(view.omitted_element_count, 0);
+        view.omitted_element_count = 12;
+        let restored: InteractiveView =
+            serde_json::from_value(serde_json::to_value(&view).unwrap()).unwrap();
+        assert_eq!(view, restored);
     }
 }


### PR DESCRIPTION
## Summary

Computer Use observations could lose nested controls, misproject OCR coordinates, omit state-only AX changes, or reuse a stale element index after rebuilding a view. This fixes those paths and adds compiled production-module tests plus real Chromium, macOS Vision, and native AX fixtures.

- Preserve independent AX controls, focused elements, full state digests, and explicit element-budget omissions; reject stale interactive/visual targets before input.
- Project OCR hits using screenshot content bounds, reject invalid/padded geometry, and retain legacy raw-screenshot coordinate behavior.
- Traverse nested same-origin frames and open shadow roots consistently for DOM collection, cleanup, and target resolution. Preserve labels and form states, omit password values, report truncation/inaccessible contexts, and reject malformed snapshots.
- Return screenshot IDs and align the advertised Computer Use schema with supported inputs.

## Type and Areas

Type: Bug fix, test, internal refactor, documentation.

Areas: Desktop Computer Use, Core browser/tool orchestration, tool contracts.

## Motivation / Impact

For example, a child button inside a larger clickable control remains independently addressable; a state-only AX change refreshes the observation digest; and an expired numbered target returns a stale-view error so the caller can select from a fresh observation. Extracted helpers remain in their existing owners and are shared by production and test code.

## Verification

All commands below passed locally on macOS. Counts overlap across the isolated and owning-crate suites; they are not a total of unique tests.

| Command | Result |
| --- | --- |
| `node scripts/test-computer-use-context.mjs` | Compiles actual production Rust files and DTOs: 35 passed, 1 fixture-dependent test ignored and exercised below |
| `cargo test -p openbitfun-desktop --lib -- computer_use::interactive_filter:: computer_use::ocr_context:: computer_use::ax_snapshot_digest:: context_integrity_tests::` | 18 passed |
| `cargo test -p openbitfun-core --no-default-features --features agent-runtime,browser-control,tools-browser-web,tools-computer-use,git --lib browser_control::actions::` | 23 passed, 1 fixture-dependent test ignored and exercised below |
| `cargo test -p openbitfun-core --no-default-features --features agent-runtime,browser-control,tools-browser-web,tools-computer-use,git --lib computer_use_tool::tests::` | 22 passed |
| `pnpm --package=node@22 dlx node scripts/test-browser-snapshot.mjs --native-ocr` | 10 real Chromium checks; actual browser payload through compiled Rust: 1 passed; real macOS Vision OCR on rendered image: 1 passed |
| `node scripts/test-native-ax-context.mjs` | Compiled AppKit fixture and production Desktop AX capture/filter/cache/DTO checks: 1 passed |
| `cargo build -p openbitfun-desktop` | Passed |
| `pnpm run fmt:rs` | Passed |
| `pnpm run check:repo-hygiene` | Passed |
| `pnpm run check:core-boundaries` | Passed |
| `git diff --check` | Passed |

The native fixtures use their own window/rendered image. This is runtime testing in addition to white-box coverage, not source-text assertions. Focused commands and observation invariants are documented in the owning module guides.

## Reviewer Notes

- `omitted_element_count` defaults during deserialization, with legacy payload/round-trip coverage. Legacy action inputs remain tolerated even where no longer advertised. AX digests are opaque observation tokens and now include complete node state.
- No runtime ownership migration or Cargo dependency changes.
- Windows/Linux native paths and built-in WebKit were not executed. Remote workspace, mobile/IM remote control, Peer Device Mode, and Detached Dispatch were not exercised; local results are not remote evidence.
- AI-assisted implementation, with the compilation and local runtime checks recorded above.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.
