### PR TITLE
fix(settings): preserve model detail contrast

### DIFF
--- a/src/web-ui/src/infrastructure/config/components/ModelServiceCollapse.presentation.test.ts
+++ b/src/web-ui/src/infrastructure/config/components/ModelServiceCollapse.presentation.test.ts
@@ -51,6 +51,9 @@ describe('model service collapsed presentation', () => {
     expect(modelSettingsStyles).toMatch(
       /&__provider-group-header\s*\{[^}]*background:\s*transparent/,
     );
+    expect(modelSettingsStyles).toMatch(
+      /\.openbitfun-collection-item__details\s*\{[^}]*background:\s*transparent/,
+    );
   });
 
   it('draws one consistent divider between provider headers and model rows', () => {

--- a/src/web-ui/src/infrastructure/config/components/ModelSettingsPage.scss
+++ b/src/web-ui/src/infrastructure/config/components/ModelSettingsPage.scss
@@ -235,6 +235,11 @@
 
     .openbitfun-collection-item__details {
       border-top: 1px solid var(--openbitfun-color-border-subtle);
+      // The provider group owns the persistent surface. Reusing the shared
+      // translucent details tint here makes the dark-theme composite nearly
+      // identical to the surrounding scene, leaving a page-colored gutter
+      // around the dashed inset section.
+      background: transparent;
     }
 
     .openbitfun-collection-item__details-toggle {


### PR DESCRIPTION
Keep expanded model details on the provider group's persistent surface
instead of applying the shared translucent details tint.

In the dark theme, that tint nearly matched the settings scene, making
the area around the dashed detail section appear detached.

Add a presentation assertion to prevent the background from regressing.
