### PR TITLE
fix(editor): restore document editing and source-preserving undo

### DIFF
--- a/src/web-ui/src/infrastructure/markdown/Markdown.scss
+++ b/src/web-ui/src/infrastructure/markdown/Markdown.scss
@@ -402,7 +402,8 @@
   margin-bottom: 0;
 }
 
-.markdown-renderer details {
+.markdown-renderer details,
+.markdown-renderer [data-type='details'] {
   margin: calc(var(--markdown-block-gap) * 1.2) 0;
   padding: 0.62rem 0.72rem;
   border: 1px solid var(--openbitfun-color-border-subtle);
@@ -419,6 +420,10 @@
 
 .markdown-renderer details[open] > summary {
   margin-bottom: var(--markdown-block-gap);
+}
+
+.markdown-renderer [data-type='details'] [data-type='detailsContent'] {
+  padding-top: var(--markdown-block-gap);
 }
 
 .markdown-renderer hr {
@@ -540,6 +545,19 @@
 }
 
 .markdown-renderer .table-wrapper tbody tr:hover {
+  background: var(--markdown-table-row-hover);
+}
+
+// Tiptap keeps the header in tbody; offset striping to match rendered data rows.
+.markdown-renderer.ProseMirror table[data-type='markdown-table'] tbody tr:nth-child(2n) {
+  background: var(--markdown-table-row-base);
+}
+
+.markdown-renderer.ProseMirror table[data-type='markdown-table'] tbody tr:nth-child(2n + 3) {
+  background: var(--markdown-table-row-stripe);
+}
+
+.markdown-renderer.ProseMirror table[data-type='markdown-table'] tbody tr:hover {
   background: var(--markdown-table-row-hover);
 }
 

--- a/src/web-ui/src/infrastructure/markdown/MarkdownMathRenderer.tsx
+++ b/src/web-ui/src/infrastructure/markdown/MarkdownMathRenderer.tsx
@@ -9,6 +9,7 @@ import rehypeSanitize from 'rehype-sanitize';
 import type { Options as RehypeSanitizeOptions } from 'rehype-sanitize';
 import type { Pluggable } from 'unified';
 import 'katex/dist/katex.min.css';
+import { rehypeSourceRange, type MarkdownSourceRange } from './rehypeSourceRange';
 
 interface MarkdownMathRendererProps {
   markdownContent: string;
@@ -16,6 +17,7 @@ interface MarkdownMathRendererProps {
   sanitizeSchema: RehypeSanitizeOptions;
   remarkAutolinkComputerFileLinks: Pluggable;
   urlTransform: (value: string) => string;
+  sourceRange?: MarkdownSourceRange;
 }
 
 export const MarkdownMathRenderer: React.FC<MarkdownMathRendererProps> = ({
@@ -24,11 +26,12 @@ export const MarkdownMathRenderer: React.FC<MarkdownMathRendererProps> = ({
   sanitizeSchema,
   remarkAutolinkComputerFileLinks,
   urlTransform,
+  sourceRange,
 }) => (
   <div data-openbitfun-component="markdown" data-openbitfun-part="math">
     <ReactMarkdown
       remarkPlugins={[remarkGfm, remarkMath, remarkAutolinkComputerFileLinks]}
-      rehypePlugins={[rehypeRaw, [rehypeSanitize, sanitizeSchema], rehypeKatex]}
+      rehypePlugins={[rehypeRaw, [rehypeSanitize, sanitizeSchema], [rehypeSourceRange, sourceRange], rehypeKatex]}
       urlTransform={urlTransform}
       components={components}
     >

--- a/src/web-ui/src/infrastructure/markdown/MarkdownRenderer.test.tsx
+++ b/src/web-ui/src/infrastructure/markdown/MarkdownRenderer.test.tsx
@@ -138,6 +138,24 @@ describe('Markdown file links', () => {
     expect(mocks.getCurrentWorkspacePath).not.toHaveBeenCalled();
   });
 
+  it('renders separate footnote regions and follows their shared anchors', async () => {
+    const reference = 'Text[^a].';
+    const definition = '[^a]: Definition';
+    const content = `${reference}\n\n${definition}`;
+    await act(async () => root.render(<>
+      <MarkdownRenderer content={content} sourceRange={{ start: 0, end: reference.length, idPrefix: 'test-editor-' }} />
+      <MarkdownRenderer content={content} sourceRange={{ start: reference.length + 2, end: content.length, idPrefix: 'test-editor-' }} />
+    </>));
+    const link = container.querySelector<HTMLAnchorElement>('[data-footnote-ref]')!;
+    const target = document.getElementById(link.hash.slice(1))!;
+    const scrollIntoView = vi.fn();
+    target.scrollIntoView = scrollIntoView;
+    expect(container.querySelectorAll('section[data-footnotes] li')).toHaveLength(1);
+    expect(target.textContent).toContain('Definition');
+    act(() => link.click());
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: 'nearest' });
+  });
+
   it.each([
     '[Open Canvas](openbitfun-canvas://session/session_1/canvas/canvas_1)',
     'openbitfun-canvas://session/session_1/canvas/canvas_1',

--- a/src/web-ui/src/infrastructure/markdown/MarkdownRenderer.tsx
+++ b/src/web-ui/src/infrastructure/markdown/MarkdownRenderer.tsx
@@ -31,6 +31,7 @@ import {
 } from '@/shared/utils/startupTrace';
 import path from 'path-browserify';
 import './Markdown.scss';
+import { rehypeSourceRange, type MarkdownSourceRange } from './rehypeSourceRange';
 
 const log = createLogger('Markdown');
 const COMPUTER_LINK_PREFIX = 'computer://';
@@ -823,6 +824,8 @@ const CopyButton: React.FC<{ code: string }> = ({ code }) => {
 
 export interface MarkdownRendererProps {
   content: string;
+  /** Display a region while resolving Markdown references against all content. */
+  sourceRange?: MarkdownSourceRange;
   basePath?: string;
   remoteConnectionId?: string;
   remoteSshHost?: string;
@@ -844,6 +847,7 @@ function useLiveValueRef<T>(value: T): React.MutableRefObject<T> {
 
 export const MarkdownRenderer = React.memo<MarkdownRendererProps>(({
   content, 
+  sourceRange,
   basePath,
   remoteConnectionId,
   remoteSshHost,
@@ -874,6 +878,7 @@ export const MarkdownRenderer = React.memo<MarkdownRendererProps>(({
   const onTabOpenRef = useLiveValueRef(onTabOpen);
   const onHttpLinkClickRef = useLiveValueRef(onHttpLinkClick);
   const traceContextRef = useLiveValueRef(traceContext);
+  const sourceRangeRef = useLiveValueRef(sourceRange);
   
   const syntaxTheme = useMemo(() => buildMarkdownPrismStyle(isLight), [isLight]);
   const syntaxThemeRef = useLiveValueRef(syntaxTheme);
@@ -1512,6 +1517,11 @@ export const MarkdownRenderer = React.memo<MarkdownRendererProps>(({
           {...props}
           onClick={(e) => {
             e.preventDefault();
+            if (isHashLink && sourceRangeRef.current) {
+              const target = document.getElementById(hrefValue.slice(1));
+              target?.scrollIntoView({ block: 'nearest' });
+              target?.focus({ preventScroll: true });
+            }
           }}
           style={{ cursor: 'pointer' }}
         >
@@ -1592,13 +1602,14 @@ export const MarkdownRenderer = React.memo<MarkdownRendererProps>(({
     remoteSshHostRef,
     syntaxThemeRef,
     traceContextRef,
+    sourceRangeRef,
   ]);
   
   const wrapperClassName = `markdown-renderer ${className}`.trim();
   const basicMarkdownRenderer = (
     <ReactMarkdown
       remarkPlugins={[remarkGfm, remarkAutolinkInternalLinks]}
-      rehypePlugins={[rehypeRaw, [rehypeSanitize, sanitizeSchema]]}
+      rehypePlugins={[rehypeRaw, [rehypeSanitize, sanitizeSchema], [rehypeSourceRange, sourceRange]]}
       urlTransform={markdownUrlTransform}
       components={components}
     >
@@ -1618,7 +1629,7 @@ export const MarkdownRenderer = React.memo<MarkdownRendererProps>(({
           traceContext={traceContext}
         />
       )}
-      <MarkdownErrorBoundary fallbackContent={markdownContent}>
+      <MarkdownErrorBoundary fallbackContent={sourceRange ? markdownContent.slice(sourceRange.start, sourceRange.end) : markdownContent}>
         {shouldUseMathRenderer ? (
           <React.Suspense fallback={basicMarkdownRenderer}>
             <MarkdownMathRenderer
@@ -1627,6 +1638,7 @@ export const MarkdownRenderer = React.memo<MarkdownRendererProps>(({
               sanitizeSchema={sanitizeSchema}
               remarkAutolinkComputerFileLinks={remarkAutolinkInternalLinks}
               urlTransform={markdownUrlTransform}
+              sourceRange={sourceRange}
             />
           </React.Suspense>
         ) : basicMarkdownRenderer}

--- a/src/web-ui/src/infrastructure/markdown/rehypeSourceRange.test.ts
+++ b/src/web-ui/src/infrastructure/markdown/rehypeSourceRange.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkGfm from 'remark-gfm';
+import remarkRehype from 'remark-rehype';
+import rehypeSanitize from 'rehype-sanitize';
+import rehypeRaw from 'rehype-raw';
+import { rehypeSourceRange } from './rehypeSourceRange';
+
+function renderRegions(regions: string[], idPrefix = 'editor-1-') {
+  const content = regions.join('\n\n');
+  let start = 0;
+  return regions.map(region => {
+    const processor = unified().use(remarkParse).use(remarkGfm).use(remarkRehype)
+      .use(rehypeRaw).use(rehypeSanitize).use(rehypeSourceRange, { start, end: start + region.length, idPrefix });
+    start += region.length + 2;
+    return processor.runSync(processor.parse(content));
+  });
+}
+
+function elements(tree: any, predicate: (node: any) => boolean): any[] {
+  return [ ...(predicate(tree) ? [tree] : []), ...(tree.children ?? []).flatMap((node: any) => elements(node, predicate)) ];
+}
+
+describe('Markdown source region rendering', () => {
+  it('shares numbering and matching anchors without duplicating footnote bodies', () => {
+    const regions = ['First[^b].', 'Second[^a] and again[^b].', '[^a]: Alpha', '[^b]: Beta'];
+    const trees = renderRegions(regions);
+    const refs = trees.flatMap(tree => elements(tree, node => node.properties?.dataFootnoteRef !== undefined));
+    expect(refs.map(node => node.children[0].value)).toEqual(['1', '2', '1']);
+    const definitions = trees.flatMap(tree => elements(tree, node => node.tagName === 'li'));
+    expect(definitions).toHaveLength(2);
+    expect(definitions.map(node => node.properties.value)).toEqual([2, 1]);
+    const allIds = trees.flatMap(tree => elements(tree, node => typeof node.properties?.id === 'string'))
+      .map(node => node.properties.id);
+    expect(new Set(allIds).size).toBe(allIds.length);
+    const links = trees.flatMap(tree => elements(tree, node => node.tagName === 'a'));
+    links.forEach(node => expect(allIds).toContain(node.properties.href.slice(1)));
+    expect(elements(trees[0], node => node.tagName === 'section')).toHaveLength(0);
+    expect(JSON.stringify(trees[2])).not.toContain('Beta');
+    expect(JSON.stringify(trees[3])).not.toContain('Alpha');
+    const otherIds = renderRegions(regions, 'editor-2-').flatMap(tree =>
+      elements(tree, node => typeof node.properties?.id === 'string')).map(node => node.properties.id);
+    expect(otherIds.some(id => allIds.includes(id))).toBe(false);
+  });
+
+  it('resolves reference links and images from definitions outside the region', () => {
+    const [tree] = renderRegions(['[Guide][g] ![Image][img]', '[g]: https://example.com', '[img]: photo.png']);
+    expect(elements(tree, node => node.tagName === 'a')[0].properties.href).toBe('https://example.com');
+    expect(elements(tree, node => node.tagName === 'img')[0].properties.src).toBe('photo.png');
+  });
+});

--- a/src/web-ui/src/infrastructure/markdown/rehypeSourceRange.ts
+++ b/src/web-ui/src/infrastructure/markdown/rehypeSourceRange.ts
@@ -1,0 +1,68 @@
+/** Render one source region after resolving references against the whole document. */
+export interface MarkdownSourceRange {
+  start: number;
+  end: number;
+  idPrefix: string;
+}
+
+type HtmlNode = {
+  type: string;
+  tagName?: string;
+  properties?: Record<string, unknown>;
+  position?: { start: { offset?: number }; end: { offset?: number } };
+  children?: HtmlNode[];
+};
+
+export function rehypeSourceRange(range?: MarkdownSourceRange) {
+  return (tree: HtmlNode) => {
+    if (!range) return;
+    const inside = (node: HtmlNode) => {
+      const start = node.position?.start.offset;
+      const end = node.position?.end.offset;
+      return start !== undefined && end !== undefined && start >= range.start && end <= range.end;
+    };
+    const walk = (node: HtmlNode, visit: (node: HtmlNode) => void) => {
+      visit(node);
+      node.children?.forEach(child => walk(child, visit));
+    };
+
+    // Namespace all anchors consistently across independent render roots. Run
+    // after sanitization and account for its user-content- clobber protection.
+    const ids = new Map<string, string>();
+    walk(tree, node => {
+      const id = node.properties?.id;
+      if (typeof id === 'string') ids.set(id, `${range.idPrefix}${id}`);
+    });
+    walk(tree, node => {
+      const props = node.properties;
+      if (!props) return;
+      if (typeof props.id === 'string') props.id = ids.get(props.id);
+      if (typeof props.href === 'string' && props.href.startsWith('#')) {
+        const id = props.href.slice(1);
+        const target = ids.get(id) ?? ids.get(`user-content-${id}`);
+        if (target) props.href = `#${target}`;
+      }
+      if (Array.isArray(props.ariaDescribedBy)) {
+        props.ariaDescribedBy = props.ariaDescribedBy.map(id =>
+          ids.get(String(id)) ?? ids.get(`user-content-${id}`) ?? id);
+      }
+    });
+
+    tree.children = (tree.children ?? []).flatMap(node => {
+      if (inside(node)) return [node];
+      if (node.tagName !== 'section' || node.properties?.dataFootnotes === undefined) return [];
+      const list = node.children?.find(child => child.tagName === 'ol');
+      const items = list?.children?.filter(child => child.tagName === 'li') ?? [];
+      const selected = items.filter(inside);
+      if (!list || selected.length === 0) return [];
+      selected.forEach(item => {
+        item.properties = { ...item.properties, value: items.indexOf(item) + 1 };
+      });
+      list.children = selected;
+      // Each definition is rendered once, with one shared heading and globally
+      // ordered numbers, even when definitions live in separate editor blocks.
+      if (!selected.includes(items[0])) node.children = [list];
+      return [node];
+    });
+  };
+}

--- a/src/web-ui/src/locales/en-US/tools.json
+++ b/src/web-ui/src/locales/en-US/tools.json
@@ -68,6 +68,19 @@
       "switchToSideBySide": "Switch to side-by-side view"
     },
     "markdownEditor": {
+      "blockTypes": {
+        "math": "Equation",
+        "code": "Code block",
+        "reference": "Link reference",
+        "footnote": "Footnote"
+      },
+      "finishBlockEdit": "Done editing",
+      "editImage": "Edit image",
+      "imageAddress": "Image address",
+      "imageAltText": "Alternative text",
+      "imageTitle": "Image title",
+      "richText": "Document",
+      "editBlockSource": "Edit block source",
       "loadingFile": "Loading file...",
       "placeholder": "Start writing Markdown...",
       "source": "Source",
@@ -75,9 +88,9 @@
       "preview": "Preview",
       "copyMarkdown": "Copy Markdown",
       "copiedMarkdown": "Copied Markdown",
-      "viewModeLabel": "Markdown and preview mode",
+      "viewModeLabel": "Document and source mode",
       "notice": {
-        "sourcePreviewFallback": "This document contains syntax that is not safely editable in visual mode. Edit in source mode or switch to preview."
+        "sourcePreviewFallback": "Rich text could not load. You can continue editing the Markdown source."
       }
     },
     "planViewer": {

--- a/src/web-ui/src/locales/zh-CN/tools.json
+++ b/src/web-ui/src/locales/zh-CN/tools.json
@@ -68,6 +68,19 @@
       "switchToSideBySide": "切换到并排视图"
     },
     "markdownEditor": {
+      "blockTypes": {
+        "math": "公式",
+        "code": "代码块",
+        "reference": "链接引用",
+        "footnote": "脚注"
+      },
+      "finishBlockEdit": "完成编辑",
+      "editImage": "编辑图片",
+      "imageAddress": "图片地址",
+      "imageAltText": "替代文本",
+      "imageTitle": "图片标题",
+      "richText": "文档",
+      "editBlockSource": "编辑此块源码",
       "loadingFile": "正在加载文件...",
       "placeholder": "开始编写 Markdown 内容...",
       "source": "源码",
@@ -75,9 +88,9 @@
       "preview": "预览",
       "copyMarkdown": "复制 Markdown",
       "copiedMarkdown": "已复制 Markdown",
-      "viewModeLabel": "Markdown 与预览模式",
+      "viewModeLabel": "文档与源码模式",
       "notice": {
-        "sourcePreviewFallback": "该文档包含无法在可视化模式中安全编辑的语法。请在源码模式中编辑，或切换到预览模式查看。"
+        "sourcePreviewFallback": "富文本加载失败，你可以继续编辑 Markdown 源码。"
       }
     },
     "planViewer": {

--- a/src/web-ui/src/locales/zh-TW/tools.json
+++ b/src/web-ui/src/locales/zh-TW/tools.json
@@ -68,6 +68,19 @@
       "switchToSideBySide": "切換到並排視圖"
     },
     "markdownEditor": {
+      "blockTypes": {
+        "math": "公式",
+        "code": "程式碼區塊",
+        "reference": "連結參照",
+        "footnote": "註腳"
+      },
+      "finishBlockEdit": "完成編輯",
+      "editImage": "編輯圖片",
+      "imageAddress": "圖片位址",
+      "imageAltText": "替代文字",
+      "imageTitle": "圖片標題",
+      "richText": "文件",
+      "editBlockSource": "編輯此區塊原始碼",
       "loadingFile": "正在載入檔案...",
       "placeholder": "開始編寫 Markdown 內容...",
       "source": "源碼",
@@ -75,9 +88,9 @@
       "preview": "預覽",
       "copyMarkdown": "複製 Markdown",
       "copiedMarkdown": "已複製 Markdown",
-      "viewModeLabel": "Markdown 與預覽模式",
+      "viewModeLabel": "文件與源碼模式",
       "notice": {
-        "sourcePreviewFallback": "該文檔包含無法在可視化模式中安全編輯的語法。請在源碼模式中編輯，或切換到預覽模式查看。"
+        "sourcePreviewFallback": "富文字載入失敗，你可以繼續編輯 Markdown 原始碼。"
       }
     },
     "planViewer": {

--- a/src/web-ui/src/tools/editor/AGENTS.md
+++ b/src/web-ui/src/tools/editor/AGENTS.md
@@ -1,0 +1,67 @@
+# Editor
+
+This directory follows `src/web-ui/AGENTS.md`.
+
+## Markdown editing
+
+- File editing exposes rich text (`ir`) and source (`edit`). Pure preview is
+  reserved for explicit viewer consumers, never an automatic compatibility mode.
+- Keep ordinary blocks editable when a document contains special syntax.
+  Unsupported Markdown regions use source-backed embedded blocks; preserve their
+  original Markdown when parsing and serializing. HTML rendering uses the shared
+  sanitized Markdown renderer.
+- Rich text reuses the existing MarkdownRenderer typography and component styles.
+  Preserve the pre-existing preview appearance; do not add an editor-specific
+  visual redesign.
+- Outside local editing, embeds keep their original rendered appearance. Show
+  additional source-editing labels and completion controls only while that embed
+  is being edited.
+- Embedded changes participate in the document's dirty state, save shortcuts,
+  undo/redo, and explicit readonly policy. Changing modes or editability must
+  not clear unsaved changes or emit a document edit.
+- Keep imported Markdown bytes associated with their rich document state. Undo
+  back to that state must restore the exact source; do not hide source-formatting
+  edits by weakening the owner's comparison with the last saved bytes.
+- File access, conflict dialogs, local image loading, and peer disk synchronization
+  continue through existing infrastructure adapters.
+
+## Focused verification
+
+Run from the repository root after Markdown editor changes:
+
+```bash
+pnpm --dir src/web-ui run test:run src/tools/editor/components/MarkdownEditor.test.tsx src/tools/editor/meditor/components/MEditor.test.tsx src/tools/editor/meditor/utils/tiptapMarkdown.test.ts src/tools/editor/meditor/utils/embeddedSource.test.ts src/tools/editor/meditor/utils/markdownFrontmatter.test.ts src/tools/editor/meditor/components/Preview.test.tsx
+```
+
+For UI, types, and theme contracts, also follow the parent guide's `check:web`
+command. Local DOM tests do not establish remote workspace, Remote Connect,
+Peer Device Mode, or Detached Dispatch behavior.
+
+For rich-text interaction changes, run the focused browser E2E from the root:
+
+```bash
+pnpm --dir tests/e2e exec wdio run ./config/wdio.markdown-browser.ts
+```
+
+This runs Chrome against the production MarkdownEditor with a test filesystem
+adapter backed by a temporary file. It checks local block editing, live rendering,
+keyboard completion, undo/redo, rich/source switching, readonly and save/reload.
+The runner owns localhost ports 1447/1450, isolates browser state, removes its
+temporary file, and writes screenshots to `tests/e2e/reports/markdown-browser`.
+It does not test Tauri, relay, SSH, peer transport, or detached dispatch.
+
+For actual desktop integration, build the current desktop and frontend, then run:
+
+```bash
+cargo build -p openbitfun-desktop
+pnpm run build:web
+pnpm --dir tests/e2e exec wdio run ./config/wdio.markdown-native.ts
+```
+
+The native spec opens a temporary workspace in OpenBitFun, opens its Markdown file
+from the file tree, edits native and embedded blocks, saves via the production
+Tauri transport, and closes/reopens the file. Packaged frontend mode prevents
+accidentally testing another checkout's Vite server. The focused runner uses a
+fresh application profile on every run and removes it on completion. Screenshots
+go to `tests/e2e/reports/screenshots`.
+This covers a local desktop workspace; remote scenarios still require live hosts.

--- a/src/web-ui/src/tools/editor/AGENTS.md
+++ b/src/web-ui/src/tools/editor/AGENTS.md
@@ -10,6 +10,8 @@ This directory follows `src/web-ui/AGENTS.md`.
   Unsupported Markdown regions use source-backed embedded blocks; preserve their
   original Markdown when parsing and serializing. HTML rendering uses the shared
   sanitized Markdown renderer.
+- Source-backed reference blocks share document-level definitions, numbering,
+  and anchors. Preview context is transient and must not enter saved Markdown.
 - Rich text reuses the existing MarkdownRenderer typography and component styles.
   Preserve the pre-existing preview appearance; do not add an editor-specific
   visual redesign.
@@ -30,7 +32,7 @@ This directory follows `src/web-ui/AGENTS.md`.
 Run from the repository root after Markdown editor changes:
 
 ```bash
-pnpm --dir src/web-ui run test:run src/tools/editor/components/MarkdownEditor.test.tsx src/tools/editor/meditor/components/MEditor.test.tsx src/tools/editor/meditor/utils/tiptapMarkdown.test.ts src/tools/editor/meditor/utils/embeddedSource.test.ts src/tools/editor/meditor/utils/markdownFrontmatter.test.ts src/tools/editor/meditor/components/Preview.test.tsx
+pnpm --dir src/web-ui run test:run src/tools/editor/components/MarkdownEditor.test.tsx src/tools/editor/meditor/components/MEditor.test.tsx src/tools/editor/meditor/utils/tiptapMarkdown.test.ts src/tools/editor/meditor/utils/embeddedSource.test.ts src/tools/editor/meditor/utils/markdownFrontmatter.test.ts src/tools/editor/meditor/components/Preview.test.tsx src/tools/editor/meditor/utils/loadLocalImages.test.ts src/infrastructure/markdown/rehypeSourceRange.test.ts src/infrastructure/markdown/MarkdownRenderer.test.tsx
 ```
 
 For UI, types, and theme contracts, also follow the parent guide's `check:web`

--- a/src/web-ui/src/tools/editor/components/MarkdownEditor.appearance.ts
+++ b/src/web-ui/src/tools/editor/components/MarkdownEditor.appearance.ts
@@ -6,7 +6,7 @@ export const markdownEditorAppearanceDescriptor: AppearanceSurfaceDescriptor = {
     { id: 'root' }, { id: 'loading' }, { id: 'error' },
     { id: 'toolbar' }, { id: 'actions' }, { id: 'body' },
   ],
-  facets: [{ id: 'view', attribute: 'data-openbitfun-view', values: ['preview', 'markdown', 'source'] }],
+  facets: [{ id: 'view', attribute: 'data-openbitfun-view', values: ['preview', 'markdown', 'source', 'ir'] }],
   states: [
     { id: 'loading', selector: { kind: 'self', suffix: '[data-openbitfun-state~="loading"]' } },
     { id: 'error', selector: { kind: 'self', suffix: '[data-openbitfun-state~="error"]' } },

--- a/src/web-ui/src/tools/editor/components/MarkdownEditor.test.tsx
+++ b/src/web-ui/src/tools/editor/components/MarkdownEditor.test.tsx
@@ -129,19 +129,22 @@ describe('MarkdownEditor', () => {
     expect(html).toContain('data-component="icon-button"');
   });
 
-  it('uses preview mode for markdown rendering', () => {
+  it('opens Mermaid documents in rich text mode', () => {
     const html = renderToStaticMarkup(
       <MarkdownEditor initialContent="```mermaid\ngraph TD\n  A-->B\n```" />,
     );
 
-    expect(html).toContain('data-mode="preview"');
+    expect(html).toContain('data-mode="ir"');
   });
 
-  it('does not show the IR fallback warning in the preview/source file UI', () => {
+  it('offers only rich text and source modes', () => {
     const html = renderToStaticMarkup(
       <MarkdownEditor initialContent="# Ordinary Markdown" />,
     );
 
-    expect(html).not.toContain('IR fallback warning');
+    expect(html).toContain('editor.markdownEditor.richText');
+    expect(html).toContain('editor.markdownEditor.source');
+    expect(html).not.toContain('editor.markdownEditor.preview');
+    expect(html.match(/role="radio"/g)).toHaveLength(2);
   });
 });

--- a/src/web-ui/src/tools/editor/components/MarkdownEditor.tsx
+++ b/src/web-ui/src/tools/editor/components/MarkdownEditor.tsx
@@ -9,7 +9,6 @@ import { Button, Icon, IconButton, SegmentedControl } from '@openbitfun/ui';
 import React, { useEffect, useState, useCallback, useRef } from 'react';
 import { MEditor } from '../meditor';
 import type { EditorInstance } from '../meditor';
-import { analyzeMarkdownEditability, type MarkdownEditabilityAnalysis } from '../meditor/utils/tiptapMarkdown';
 import { AlertCircle } from 'lucide-react';
 import { createLogger } from '@/shared/utils/logger';
 import { sendDebugProbe } from '@/shared/utils/debugProbe';
@@ -22,7 +21,6 @@ import {
 } from '@/infrastructure/peer-device/peerModeFlag';
 import { LoadingState } from '@openbitfun/ui';
 import { useI18n } from '@/infrastructure/i18n';
-import CodeEditor from './CodeEditor';
 import {
   diskVersionFromMetadata,
   diskVersionsDiffer,
@@ -81,7 +79,6 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
   filePath,
   initialContent = '',
   workspacePath,
-  fileName,
   readOnly = false,
   className = '',
   onContentChange,
@@ -94,12 +91,10 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
   const { t } = useI18n('tools');
   const [content, setContent] = useState<string>(initialContent);
   const [hasChanges, setHasChanges] = useState(false);
-  const [viewMode, setViewMode] = useState<'preview' | 'markdown'>('preview');
-  const [unsafeViewMode, setUnsafeViewMode] = useState<'source' | 'preview'>('source');
+  const [viewMode, setViewMode] = useState<'ir' | 'source'>('ir');
   const [loading, setLoading] = useState(!!filePath);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
-  const [editability, setEditability] = useState<MarkdownEditabilityAnalysis>(() => analyzeMarkdownEditability(initialContent));
   const editorRef = useRef<EditorInstance>(null);
   const isUnmountedRef = useRef(false);
   const diskVersionRef = useRef<DiskFileVersion | null>(null);
@@ -109,21 +104,11 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
   const onContentChangeRef = useRef(onContentChange);
   const contentRef = useRef(content);
   const lastReportedDirtyRef = useRef<boolean | null>(null);
-  const unsafeViewModeRef = useRef(unsafeViewMode);
-  unsafeViewModeRef.current = unsafeViewMode;
   const lastReportedMissingRef = useRef<boolean | undefined>(undefined);
 
   const reportFileMissingFromDisk = useCallback(
     (missing: boolean) => {
       if (!onFileMissingFromDiskChange) {
-        return;
-      }
-      const isUnsafeSplit =
-        !!filePath &&
-        (editability.mode === 'unsafe' ||
-          editability.containsRenderOnlyBlocks ||
-          editability.containsRawHtmlInlines);
-      if (isUnsafeSplit && unsafeViewModeRef.current === 'source') {
         return;
       }
       if (lastReportedMissingRef.current === missing) {
@@ -132,7 +117,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
       lastReportedMissingRef.current = missing;
       onFileMissingFromDiskChange(missing);
     },
-    [editability.containsRawHtmlInlines, editability.containsRenderOnlyBlocks, editability.mode, filePath, onFileMissingFromDiskChange]
+    [onFileMissingFromDiskChange]
   );
 
   onContentChangeRef.current = onContentChange;
@@ -141,13 +126,6 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
   useEffect(() => {
     hasChangesRef.current = hasChanges;
   }, [hasChanges]);
-
-  const toNormalizedMarkdown = useCallback((raw: string) => {
-    const nextEditability = analyzeMarkdownEditability(raw);
-    const nextContent =
-      nextEditability.mode === 'unsafe' ? raw : nextEditability.canonicalMarkdown;
-    return { nextEditability, nextContent };
-  }, []);
 
   const basePath = React.useMemo(() => {
     if (!filePath) return undefined;
@@ -169,8 +147,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
   }, []);
 
   useEffect(() => {
-    setViewMode('preview');
-    setUnsafeViewMode('source');
+    setViewMode('ir');
   }, [filePath, initialContent]);
 
   const fetchFileMetadata = useCallback(async () => {
@@ -212,9 +189,8 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
       }
 
       if (!isUnmountedRef.current) {
-        const { nextEditability, nextContent } = toNormalizedMarkdown(fileContent);
+        const nextContent = fileContent;
 
-        setEditability(nextEditability);
         setContent(nextContent);
         setHasChanges(false);
         lastReportedDirtyRef.current = false;
@@ -245,7 +221,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
         setLoading(false);
       }
     }
-  }, [fetchFileMetadata, filePath, reportFileMissingFromDisk, t, toNormalizedMarkdown]);
+  }, [fetchFileMetadata, filePath, reportFileMissingFromDisk, t]);
 
   // Initial file load - only run once when filePath changes
   const loadFileContentCalledRef = useRef(false);
@@ -262,12 +238,8 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
         loadFileContent();
       }
     } else if (initialContent !== undefined) {
-      const nextEditability = analyzeMarkdownEditability(initialContent);
-      const nextContent = nextEditability.mode === 'unsafe'
-        ? initialContent
-        : nextEditability.canonicalMarkdown;
+      const nextContent = initialContent;
 
-      setEditability(nextEditability);
       setContent(nextContent);
       setHasChanges(false);
       lastReportedDirtyRef.current = false;
@@ -328,7 +300,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
         outcome = 'editor-changed-before-read';
         return;
       }
-      const { nextEditability, nextContent } = toNormalizedMarkdown(raw);
+      const nextContent = raw;
       if (nextContent === contentRef.current) {
         diskVersionRef.current = currentVersion;
         outcome = 'content-match';
@@ -352,7 +324,6 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
       }
 
       if (!isUnmountedRef.current) {
-        setEditability(nextEditability);
         setContent(nextContent);
         contentRef.current = nextContent;
         setHasChanges(false);
@@ -397,21 +368,14 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
       }
       isCheckingDiskRef.current = false;
     }
-  }, [fetchFileMetadata, filePath, isActiveTab, reportFileMissingFromDisk, t, toNormalizedMarkdown]);
+  }, [fetchFileMetadata, filePath, isActiveTab, reportFileMissingFromDisk, t]);
 
   const checkMarkdownDisk = useCallback(async () => {
     await syncMarkdownFromDisk('poll');
   }, [syncMarkdownFromDisk]);
 
-  const isUnsafeSplitUi =
-    !!filePath &&
-    (editability.mode === 'unsafe' ||
-      editability.containsRenderOnlyBlocks ||
-      editability.containsRawHtmlInlines);
-  const pollMarkdownDisk = !isUnsafeSplitUi || unsafeViewMode !== 'source';
-
   useEffect(() => {
-    if (!filePath || !isActiveTab || !pollMarkdownDisk) {
+    if (!filePath || !isActiveTab) {
       return;
     }
     const tick = () => {
@@ -443,10 +407,10 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
       }
       window.removeEventListener('peer-mode:changed', onPeerModeChanged);
     };
-  }, [checkMarkdownDisk, filePath, isActiveTab, pollMarkdownDisk]);
+  }, [checkMarkdownDisk, filePath, isActiveTab]);
 
   useEffect(() => {
-    if (!filePath || !pollMarkdownDisk) {
+    if (!filePath) {
       return;
     }
 
@@ -456,7 +420,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
       }
       void syncMarkdownFromDisk('event');
     });
-  }, [filePath, pollMarkdownDisk, syncMarkdownFromDisk]);
+  }, [filePath, syncMarkdownFromDisk]);
 
   const saveFileContent = useCallback(async () => {
     if (!hasChanges || isUnmountedRef.current) return;
@@ -487,9 +451,8 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
           });
           if (!overwrite) {
             const raw = await workspaceAPI.readFileContent(filePath);
-            const { nextEditability, nextContent } = toNormalizedMarkdown(raw);
+            const nextContent = raw;
             if (!isUnmountedRef.current) {
-              setEditability(nextEditability);
               setContent(nextContent);
               contentRef.current = nextContent;
               setHasChanges(false);
@@ -553,7 +516,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
         setError(t('editor.common.saveFailedWithMessage', { message: errorMessage }));
       }
     }
-  }, [content, fetchFileMetadata, filePath, hasChanges, onSave, reportFileMissingFromDisk, t, toNormalizedMarkdown, workspacePath]);
+  }, [content, fetchFileMetadata, filePath, hasChanges, onSave, reportFileMissingFromDisk, t, workspacePath]);
 
   const handleContentChange = useCallback((newContent: string) => {
     contentRef.current = newContent;
@@ -618,12 +581,6 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
     return () => clearTimeout(timer);
   }, [jumpToLine, jumpToColumn, filePath, loading, content]);
 
-  const shouldUseSourcePreviewFallback = !!filePath && (
-    editability.mode === 'unsafe' ||
-    editability.containsRenderOnlyBlocks ||
-    editability.containsRawHtmlInlines
-  );
-
   if (loading) {
     return (
       <div className={`openbitfun-markdown-editor-loading ${className}`} data-openbitfun-component="markdown-editor" data-openbitfun-part="loading" data-openbitfun-state="loading">
@@ -648,88 +605,6 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
     );
   }
 
-  if (shouldUseSourcePreviewFallback) {
-    return (
-      <div className={`openbitfun-markdown-editor ${className}`} data-openbitfun-component="markdown-editor" data-openbitfun-part="root" data-openbitfun-view={unsafeViewMode}>
-        <div className="openbitfun-markdown-editor__mode-toolbar" data-openbitfun-component="markdown-editor" data-openbitfun-part="toolbar">
-          <SegmentedControl
-            className="openbitfun-markdown-editor__mode-toggle"
-            aria-label={t('editor.markdownEditor.viewModeLabel')}
-            options={[
-              { value: 'source', label: t('editor.markdownEditor.markdown') },
-              { value: 'preview', label: t('editor.markdownEditor.preview') },
-            ]}
-            value={unsafeViewMode}
-            onValueChange={(value) => setUnsafeViewMode(value as 'source' | 'preview')}
-          />
-          <div className="openbitfun-markdown-editor__toolbar-actions" data-openbitfun-component="markdown-editor" data-openbitfun-part="actions">
-            <IconButton
-              type="button"
-              size="sm"
-              onClick={() => void handleCopyMarkdown()}
-              aria-label={copied
-                ? t('editor.markdownEditor.copiedMarkdown')
-                : t('editor.markdownEditor.copyMarkdown')}
-              icon={copied ? <Icon name="check-line" size="lg" /> : <Icon name="duplicate" size="lg" />}
-              title={copied
-                ? t('editor.markdownEditor.copiedMarkdown')
-                : t('editor.markdownEditor.copyMarkdown')}
-            />
-          </div>
-        </div>
-        <div className="openbitfun-markdown-editor__unsafe-body" data-openbitfun-component="markdown-editor" data-openbitfun-part="body">
-          {unsafeViewMode === 'source' ? (
-            <CodeEditor
-              filePath={filePath}
-              workspacePath={workspacePath}
-              fileName={filePath.split(/[/\\]/).pop() || fileName}
-              language="markdown"
-              readOnly={readOnly}
-              showLineNumbers={true}
-              showMinimap={true}
-              jumpToLine={jumpToLine}
-              jumpToColumn={jumpToColumn}
-              isActiveTab={isActiveTab}
-              onFileMissingFromDiskChange={onFileMissingFromDiskChange}
-              onContentChange={(newContent, dirty) => {
-                contentRef.current = newContent;
-                setContent(newContent);
-                setHasChanges(dirty);
-                if (lastReportedDirtyRef.current === dirty) {
-                  return;
-                }
-
-                lastReportedDirtyRef.current = dirty;
-                onContentChangeRef.current?.(newContent, dirty);
-              }}
-              onSave={(_savedContent) => {
-                setHasChanges(false);
-                lastReportedDirtyRef.current = false;
-                onContentChangeRef.current?.(contentRef.current, false);
-              }}
-            />
-          ) : (
-            <MEditor
-              ref={editorRef}
-              value={content}
-              onChange={handleContentChange}
-              onSave={handleSave}
-              onDirtyChange={handleDirtyChange}
-              mode="preview"
-              height="100%"
-              width="100%"
-              placeholder={t('editor.markdownEditor.placeholder')}
-              readonly={true}
-              toolbar={false}
-              filePath={filePath}
-              basePath={basePath}
-            />
-          )}
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div className={`openbitfun-markdown-editor ${className}`} data-openbitfun-component="markdown-editor" data-openbitfun-part="root" data-openbitfun-view={viewMode}>
       <div className="openbitfun-markdown-editor__mode-toolbar" data-openbitfun-component="markdown-editor" data-openbitfun-part="toolbar">
@@ -737,11 +612,11 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
           className="openbitfun-markdown-editor__mode-toggle"
           aria-label={t('editor.markdownEditor.viewModeLabel')}
           options={[
-            { value: 'preview', label: t('editor.markdownEditor.preview') },
-            { value: 'markdown', label: t('editor.markdownEditor.markdown') },
+            { value: 'ir', label: t('editor.markdownEditor.richText') },
+            { value: 'source', label: t('editor.markdownEditor.source') },
           ]}
           value={viewMode}
-          onValueChange={(value) => setViewMode(value as 'preview' | 'markdown')}
+          onValueChange={(value) => setViewMode(value as 'ir' | 'source')}
         />
         <div className="openbitfun-markdown-editor__toolbar-actions" data-openbitfun-component="markdown-editor" data-openbitfun-part="actions">
           <IconButton
@@ -765,7 +640,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
           onChange={handleContentChange}
           onSave={handleSave}
           onDirtyChange={handleDirtyChange}
-          mode={viewMode === 'preview' ? 'preview' : 'edit'}
+          mode={viewMode === 'ir' ? 'ir' : 'edit'}
           height="100%"
           width="100%"
           placeholder={t('editor.markdownEditor.placeholder')}

--- a/src/web-ui/src/tools/editor/meditor/components/EditArea.tsx
+++ b/src/web-ui/src/tools/editor/meditor/components/EditArea.tsx
@@ -24,7 +24,7 @@ export const EditArea = forwardRef<HTMLTextAreaElement, EditAreaProps>(
     }
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      if (e.key === 'Tab') {
+      if (!readonly && e.key === 'Tab') {
         e.preventDefault()
         const textarea = e.currentTarget
         const start = textarea.selectionStart

--- a/src/web-ui/src/tools/editor/meditor/components/MEditor.test.tsx
+++ b/src/web-ui/src/tools/editor/meditor/components/MEditor.test.tsx
@@ -1,11 +1,18 @@
 // @vitest-environment jsdom
 
-import React, { act } from 'react'
+import React, { act, createRef, useState } from 'react'
+import type { Editor } from '@tiptap/core'
+import { closeHistory } from '@tiptap/pm/history'
+import type { EditorInstance } from '../types'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   logError: vi.fn(),
+}))
+
+vi.mock('@/infrastructure/markdown', () => ({
+  MarkdownRenderer: ({ content }: { content: string }) => <div data-testid="block-renderer">{content}</div>,
 }))
 
 vi.mock('@/shared/utils/logger', () => ({
@@ -30,6 +37,8 @@ describe('MEditorErrorBoundary', () => {
 
   beforeEach(() => {
     globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    Range.prototype.getClientRects = () => [] as unknown as DOMRectList;
+    Range.prototype.getBoundingClientRect = () => new DOMRect();
     container = document.createElement('div')
     document.body.appendChild(container)
     root = createRoot(container)
@@ -68,21 +77,300 @@ describe('MEditorErrorBoundary', () => {
     )
   })
 
-  it('shows the compatibility warning only when IR mode requests a fallback', () => {
-    act(() => {
-      root.render(
-        <MEditor value={'Mix <span data-x="1">inline</span> HTML.'} mode="preview" />
-      )
-    })
-    expect(container.textContent).not.toContain('IR fallback warning')
+  const sourceMarkdown = '# Before\n\n```mermaid\ngraph TD\n  A-->B\n```\n\nAfter';
 
+  function getEditor(): Editor {
+    return (container.querySelector('.ProseMirror') as HTMLElement & { editor: Editor }).editor;
+  }
+
+  async function renderEditor(markdown = sourceMarkdown, readonly = false) {
+    const ref = createRef<EditorInstance>();
+    const onDirtyChange = vi.fn();
+    const onSave = vi.fn();
+    let setDocumentValue: (value: string) => void;
+    function Document() {
+      const [value, setValue] = useState(markdown);
+      setDocumentValue = setValue;
+      const [mode, setMode] = useState<'ir' | 'edit'>('ir');
+      const [locked, setLocked] = useState(readonly);
+      return <>
+        <button id="readonly" onClick={() => setLocked(!locked)}>Toggle readonly</button>
+        <button id="reload" onClick={() => setValue('# Reloaded')}>Reload</button>
+        <button id="mode" onClick={() => setMode(mode === 'ir' ? 'edit' : 'ir')}>Switch</button>
+        <MEditor ref={ref} value={value} onChange={setValue} onDirtyChange={onDirtyChange}
+          onSave={onSave} mode={mode} readonly={locked} />
+      </>;
+    }
+    await act(async () => root.render(<Document />));
+    await act(async () => { await new Promise(resolve => setTimeout(resolve, 0)); });
+    return { ref, onDirtyChange, onSave, setDocumentValue: (next: string) => setDocumentValue(next) };
+  }
+
+  it.each([
+    sourceMarkdown,
+    '# Before\n\n<div data-custom="yes">HTML</div>\n\nAfter',
+    '# Before\n\nMix <span data-x="1">inline</span> HTML.\n\nAfter',
+    '# Before\n\nFootnote[^a].\n\n[^a]: Definition\n\nAfter',
+    '# Before\n\n$$\nx^2\n$$\n\nAfter',
+  ])('keeps surrounding paragraphs editable and special content in source-backed blocks: %s', async markdown => {
+    await renderEditor(markdown);
+    expect(container.querySelector('.m-editor-mode-ir')).not.toBeNull();
+    expect(container.querySelector('.m-editor-mode-split, .m-editor-mode-preview')).toBeNull();
+    expect(getEditor().isEditable).toBe(true);
+    expect(getEditor().getJSON().content?.[0].type).toBe('heading');
+    expect(getEditor().getJSON().content?.at(-1)?.type).toBe('paragraph');
+    expect(container.querySelector('.m-editor-source-block-action')).not.toBeNull();
+  });
+
+  it('edits an embedded block, saves with the document shortcut, and supports undo/redo', async () => {
+    const { ref, onDirtyChange, onSave } = await renderEditor();
+    const action = container.querySelector<HTMLButtonElement>('.m-editor-source-block-action')!;
+    expect(container.querySelector<HTMLElement>('.m-editor-embed-toolbar')?.hidden).toBe(true);
+    act(() => container.querySelector<HTMLElement>('[data-testid="md-embed-preview"]')!.click());
+    const textarea = container.querySelector<HTMLTextAreaElement>('.m-editor-render-only-block__textarea')!;
+    expect(textarea.closest('[data-editing]')?.getAttribute('data-editing')).toBe('true');
     act(() => {
-      root.render(
-        <MEditor value={'Mix <span data-x="1">inline</span> HTML.'} mode="ir" />
-      )
-    })
-    expect(container.textContent).toContain('IR fallback warning')
-  })
+      textarea.value = 'graph TD\n  A-->C';
+      textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    expect(ref.current?.getValue()).toContain('A-->C');
+    expect(onDirtyChange).toHaveBeenLastCalledWith(true);
+    act(() => textarea.dispatchEvent(new KeyboardEvent('keydown', { key: 's', ctrlKey: true, bubbles: true })));
+    expect(onSave).toHaveBeenLastCalledWith(sourceMarkdown.replace('A-->B', 'A-->C'));
+    act(() => action.click());
+    expect(textarea.closest('[data-editing]')?.getAttribute('data-editing')).toBe('false');
+    expect(container.querySelector('[data-testid="block-renderer"]')?.textContent).toContain('A-->C');
+    expect(container.querySelector<HTMLElement>('.m-editor-embed-toolbar')?.hidden).toBe(true);
+    act(() => { ref.current?.undo?.(); });
+    expect(ref.current?.getValue()).toBe(sourceMarkdown);
+    act(() => { ref.current?.redo?.(); });
+    expect(ref.current?.getValue()).toContain('A-->C');
+  });
+
+  it('edits inline math without replacing the surrounding paragraph', async () => {
+    const { ref } = await renderEditor('Before $x^2$ after.');
+    expect(getEditor().getJSON().content?.[0].type).toBe('paragraph');
+    const preview = container.querySelector<HTMLElement>('.m-editor-inline-math__preview')!;
+    act(() => preview.click());
+    const source = container.querySelector<HTMLTextAreaElement>('.m-editor-inline-math__textarea')!;
+    expect(source.value).toBe('x^2');
+    act(() => {
+      source.value = 'y^2';
+      source.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    expect(ref.current?.getValue()).toBe('Before $y^2$ after.');
+    act(() => document.body.dispatchEvent(new Event('click', { bubbles: true })));
+    expect(preview.closest('[data-editing]')?.getAttribute('data-editing')).toBe('false');
+  });
+
+  it('completes a final embed with the keyboard and creates an editable following paragraph', async () => {
+    const { ref } = await renderEditor('$$\nx^2\n$$');
+    act(() => container.querySelector<HTMLElement>('[data-testid="md-embed-preview"]')!.click());
+    const source = container.querySelector<HTMLTextAreaElement>('[data-testid="md-embed-source"]')!;
+    expect(source.value).toBe('x^2');
+    act(() => source.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', ctrlKey: true, bubbles: true })));
+    expect(getEditor().state.selection.$from.parent.type.name).toBe('paragraph');
+    act(() => { getEditor().commands.insertContent('Following text'); });
+    expect(ref.current?.getValue()).toContain('$$\nx^2\n$$\n\nFollowing text');
+  });
+
+  it('preserves dirty state through source/rich text switches', async () => {
+    const { ref, onDirtyChange } = await renderEditor('# Original');
+    act(() => getEditor().commands.insertContentAt(1, 'Changed '));
+    const edited = ref.current?.getValue();
+    expect(ref.current?.isDirty).toBe(true);
+    act(() => container.querySelector<HTMLButtonElement>('#mode')!.click());
+    expect(container.querySelector('textarea')?.value).toBe(edited);
+    await act(async () => container.querySelector<HTMLButtonElement>('#mode')!.click());
+    expect(ref.current?.getValue()).toBe(edited);
+    expect(ref.current?.isDirty).toBe(true);
+    expect(onDirtyChange).toHaveBeenLastCalledWith(true);
+  });
+
+  it('reports the first edit after an external reload', async () => {
+    const { ref, onDirtyChange } = await renderEditor('# Original');
+    // The document owner supplies new content and explicitly marks its disk baseline.
+    await act(async () => container.querySelector<HTMLButtonElement>('#reload')!.click());
+    act(() => { ref.current?.setInitialContent?.('# Reloaded'); });
+    act(() => getEditor().commands.insertContentAt(1, 'First '));
+    expect(ref.current?.getValue()).toBe('# First Reloaded');
+    expect(ref.current?.isDirty).toBe(true);
+    expect(onDirtyChange).toHaveBeenLastCalledWith(true);
+  });
+
+  it.each([
+    '# Undo test\n\n* item\n',
+    '#  Undo test\n\n\nText\n\n',
+    '# Undo test\r\n\r\nText\r\n',
+    '# Undo test\n\n__bold__ and _italic_\n',
+  ])('restores the exact imported source and clean state after undo: %s', async raw => {
+    const { ref, onDirtyChange } = await renderEditor(raw);
+    act(() => getEditor().commands.insertContentAt(1, 'Changed '));
+    const edited = ref.current!.getValue();
+    expect(ref.current?.isDirty).toBe(true);
+    act(() => { ref.current?.undo?.(); });
+    expect(ref.current?.getValue()).toBe(raw);
+    expect(ref.current?.isDirty).toBe(false);
+    expect(onDirtyChange).toHaveBeenLastCalledWith(false);
+    act(() => { ref.current?.redo?.(); });
+    expect(ref.current?.getValue()).toBe(edited);
+    expect(ref.current?.isDirty).toBe(true);
+  });
+
+  it('compares undo and redo with the latest successful save', async () => {
+    const raw = '# Undo test\n\n* item\n';
+    const { ref } = await renderEditor(raw);
+    act(() => getEditor().commands.insertContentAt(1, 'Changed '));
+    const saved = ref.current!.getValue();
+    act(() => { ref.current?.markSaved?.(); });
+    expect(ref.current?.isDirty).toBe(false);
+    act(() => { ref.current?.undo?.(); });
+    expect(ref.current?.getValue()).toBe(raw);
+    expect(ref.current?.isDirty).toBe(true);
+    act(() => { ref.current?.redo?.(); });
+    expect(ref.current?.getValue()).toBe(saved);
+    expect(ref.current?.isDirty).toBe(false);
+  });
+
+  it('stays dirty after partial undo and clears only after all content changes are undone', async () => {
+    const raw = '# Undo test\n\n* item\n';
+    const { ref } = await renderEditor(raw);
+    act(() => getEditor().commands.insertContentAt(1, 'First '));
+    const firstEdit = ref.current!.getValue();
+    act(() => {
+      const editor = getEditor();
+      editor.view.dispatch(closeHistory(editor.state.tr));
+      editor.commands.insertContentAt(editor.state.doc.content.size, {
+        type: 'paragraph', content: [{ type: 'text', text: 'New block' }],
+      });
+    });
+    act(() => { ref.current?.undo?.(); });
+    expect(ref.current?.getValue()).toBe(firstEdit);
+    expect(ref.current?.isDirty).toBe(true);
+    act(() => { ref.current?.undo?.(); });
+    expect(ref.current?.getValue()).toBe(raw);
+    expect(ref.current?.isDirty).toBe(false);
+  });
+
+  it('preserves source-only changes through rich editing and undo', async () => {
+    const raw = '# Undo test\n\n- item\n';
+    const changed = '# Undo test\n\n* item\n\n';
+    const { ref, setDocumentValue } = await renderEditor(raw);
+    act(() => container.querySelector<HTMLButtonElement>('#mode')!.click());
+    act(() => { setDocumentValue(changed); });
+    await act(async () => container.querySelector<HTMLButtonElement>('#mode')!.click());
+    expect(ref.current?.isDirty).toBe(true);
+    act(() => getEditor().commands.insertContentAt(1, 'Changed '));
+    act(() => { ref.current?.undo?.(); });
+    expect(ref.current?.getValue()).toBe(changed);
+    expect(ref.current?.isDirty).toBe(true);
+    act(() => { ref.current?.markSaved?.(); });
+    act(() => getEditor().commands.insertContentAt(1, 'Again '));
+    act(() => { ref.current?.undo?.(); });
+    expect(ref.current?.getValue()).toBe(changed);
+    expect(ref.current?.isDirty).toBe(false);
+  });
+
+  it('replaces the source snapshot when disk content is reloaded', async () => {
+    const raw = '#  Reloaded\n\n* item\n\n';
+    const { ref, setDocumentValue } = await renderEditor('# Original');
+    act(() => { setDocumentValue(raw); ref.current?.setInitialContent?.(raw); });
+    act(() => getEditor().commands.insertContentAt(1, 'Changed '));
+    act(() => { ref.current?.undo?.(); });
+    expect(ref.current?.getValue()).toBe(raw);
+    expect(ref.current?.isDirty).toBe(false);
+  });
+
+  it.each([
+    '**Token** and *emphasis* with `code`.',
+    '> Token',
+    '- Token\n- Another item',
+    '1. Token\n2. Another item',
+    '- [ ] Token\n- [x] Done',
+    '| Header |\n| --- |\n| Token |',
+    '```typescript\nconst Token = 1;\n```',
+    '<details>\n<summary>Title</summary>\n\nToken\n\n</details>',
+    '[Token](https://example.com)',
+  ])('edits native rich text without turning the document into an embed: %s', async markdown => {
+    const { ref } = await renderEditor(markdown);
+    let position = -1;
+    getEditor().state.doc.descendants((node, pos) => {
+      if (node.isText && node.text?.includes('Token')) position = pos + node.text.indexOf('Token');
+    });
+    expect(position).toBeGreaterThanOrEqual(0);
+    act(() => getEditor().commands.insertContentAt(position, 'Updated '));
+    expect(ref.current?.getValue()).toContain('Updated Token');
+    expect(ref.current?.isDirty).toBe(true);
+    expect(container.querySelector('.m-editor-mode-preview, .m-editor-mode-split')).toBeNull();
+  });
+
+  it('edits image attributes in place and includes them in document saves', async () => {
+    const { ref, onSave } = await renderEditor('Before ![Original](https://example.com/photo.png) after.');
+    act(() => container.querySelector<HTMLElement>('.m-editor-image img')!.click());
+    const fields = container.querySelector('.m-editor-image-fields')!;
+    expect(fields.hasAttribute('hidden')).toBe(false);
+    const alt = fields.querySelectorAll('input')[1];
+    act(() => {
+      alt.value = 'Updated description';
+      alt.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    expect(ref.current?.getValue()).toBe('Before ![Updated description](https://example.com/photo.png) after.');
+    act(() => alt.dispatchEvent(new KeyboardEvent('keydown', { key: 's', metaKey: true, bubbles: true })));
+    expect(onSave).toHaveBeenLastCalledWith(ref.current?.getValue());
+    act(() => { ref.current?.undo?.(); });
+    expect(ref.current?.getValue()).toContain('![Original]');
+  });
+
+  it('edits frontmatter without losing its delimiters or surrounding content', async () => {
+    const { ref } = await renderEditor('---\ntitle: Original\n---\n\n# Body');
+    act(() => container.querySelector<HTMLElement>('.m-editor-frontmatter [data-testid="md-embed-preview"]')!.click());
+    const textarea = container.querySelector<HTMLTextAreaElement>('.m-editor-frontmatter__textarea')!;
+    act(() => {
+      textarea.value = 'title: Updated';
+      textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    expect(ref.current?.getValue()).toBe('---\ntitle: Updated\n---\n\n# Body');
+  });
+
+  it('keeps the document editable if its renderer fails', async () => {
+    const onChange = vi.fn();
+    act(() => root.render(
+      <MEditorErrorBoundary editorProps={{ value: '# Recoverable', onChange }} forwardedRef={null}>
+        <UnsupportedMarkdownRenderer />
+      </MEditorErrorBoundary>,
+    ));
+    const textarea = container.querySelector('textarea')!;
+    expect(textarea.readOnly).toBe(false);
+  });
+
+  it('does not rewrite or dirty a document just by opening it or changing permissions', async () => {
+    const raw = '#  Original\n\nText\n\n';
+    const { ref } = await renderEditor(raw);
+    expect(ref.current?.getValue()).toBe(raw);
+    expect(ref.current?.isDirty).toBe(false);
+    await act(async () => container.querySelector<HTMLButtonElement>('#readonly')!.click());
+    expect(ref.current?.getValue()).toBe(raw);
+    expect(ref.current?.isDirty).toBe(false);
+  });
+
+  it('updates embedded block permissions when the document becomes readonly', async () => {
+    await renderEditor();
+    await act(async () => container.querySelector<HTMLButtonElement>('#readonly')!.click());
+    expect(getEditor().isEditable).toBe(false);
+    expect(container.querySelector<HTMLButtonElement>('.m-editor-source-block-action')?.hidden).toBe(true);
+    expect(container.querySelector<HTMLTextAreaElement>('.m-editor-render-only-block__textarea')?.readOnly).toBe(true);
+    await act(async () => container.querySelector<HTMLButtonElement>('#readonly')!.click());
+    expect(container.querySelector<HTMLButtonElement>('.m-editor-source-block-action')?.hidden).toBe(false);
+    expect(container.querySelector<HTMLTextAreaElement>('.m-editor-render-only-block__textarea')?.readOnly).toBe(false);
+  });
+
+  it('honors explicit readonly documents without enabling embedded edits', async () => {
+    await renderEditor(sourceMarkdown, true);
+    expect(getEditor().isEditable).toBe(false);
+    expect(container.querySelector<HTMLButtonElement>('.m-editor-source-block-action')?.hidden).toBe(true);
+    expect(container.querySelector<HTMLTextAreaElement>('.m-editor-render-only-block__textarea')?.readOnly).toBe(true);
+  });
+
 })
 
 vi.mock('@/infrastructure/i18n', () => ({

--- a/src/web-ui/src/tools/editor/meditor/components/MEditor.tsx
+++ b/src/web-ui/src/tools/editor/meditor/components/MEditor.tsx
@@ -4,7 +4,6 @@ import React, {
   useCallback,
   useEffect,
   useImperativeHandle,
-  useMemo,
   useRef,
   useState,
   type ErrorInfo,
@@ -19,8 +18,6 @@ import { TiptapEditor, TiptapEditorHandle } from './TiptapEditor'
 import { Preview } from './Preview'
 import type { EditorOptions, EditorInstance } from '../types'
 import { useI18n } from '@/infrastructure/i18n'
-import { analyzeMarkdownEditability } from '../utils/tiptapMarkdown'
-import { AlertCircle } from 'lucide-react'
 import './MEditor.scss'
 
 const log = createLogger('MEditor')
@@ -51,6 +48,7 @@ function executeTextareaAction(
 }
 
 const MEditorSourceFallback = forwardRef<EditorInstance, MEditorProps>((props, ref) => {
+  const { t } = useI18n('tools')
   const {
     value: controlledValue,
     defaultValue = '',
@@ -147,6 +145,9 @@ const MEditorSourceFallback = forwardRef<EditorInstance, MEditorProps>((props, r
         }
       }}
     >
+      <div className="m-editor-notice" data-openbitfun-component="m-editor" data-openbitfun-part="notice" role="status">
+        {t('editor.markdownEditor.notice.sourcePreviewFallback')}
+      </div>
       <textarea
         ref={textareaRef}
         className="m-editor-source-fallback"
@@ -257,18 +258,10 @@ const MEditorInner = forwardRef<EditorInstance, MEditorProps>((props, ref) => {
     setMode,
     textareaRef,
     editorInstance
-  } = useEditor(controlledValue ?? defaultValue, onChange)
+  } = useEditor(controlledValue ?? defaultValue, onChange, initialMode)
 
   const tiptapEditorRef = useRef<TiptapEditorHandle>(null)
-  const editability = useMemo(() => analyzeMarkdownEditability(value), [value])
-  const irNeedsSourceFallback = mode === 'ir' && (
-    editability.mode === 'unsafe' ||
-    editability.containsRenderOnlyBlocks ||
-    editability.containsRawHtmlInlines
-  )
-  const effectiveMode = irNeedsSourceFallback
-    ? (readonly ? 'preview' : 'split')
-    : mode
+  const effectiveMode = mode
 
   useEffect(() => {
     currentValueRef.current = value
@@ -372,10 +365,6 @@ const MEditorInner = forwardRef<EditorInstance, MEditorProps>((props, ref) => {
     setInitialContent: (content: string) => {
       if (effectiveMode === 'ir' && tiptapEditorRef.current) {
         tiptapEditorRef.current.setInitialContent(content)
-        currentValueRef.current = content
-        savedValueRef.current = content
-        onDirtyChange?.(false)
-        return
       }
       currentValueRef.current = content
       savedValueRef.current = content
@@ -383,9 +372,6 @@ const MEditorInner = forwardRef<EditorInstance, MEditorProps>((props, ref) => {
       onDirtyChange?.(false)
     },
     get isDirty() {
-      if (effectiveMode === 'ir' && tiptapEditorRef.current) {
-        return tiptapEditorRef.current.isDirty
-      }
       return currentValueRef.current !== savedValueRef.current
     }
   }), [editorInstance, effectiveMode, onDirtyChange, textareaRef])
@@ -394,9 +380,9 @@ const MEditorInner = forwardRef<EditorInstance, MEditorProps>((props, ref) => {
     if ((e.ctrlKey || e.metaKey) && e.key === 's') {
       e.preventDefault()
       e.stopPropagation()  // Prevent event bubbling; avoids other listeners handling it.
-      onSave?.(value)
+      onSave?.(currentValueRef.current)
     }
-  }, [value, onSave])
+  }, [onSave])
 
   const handleFocusCapture = useCallback(() => {
     if (effectiveMode === 'ir' || effectiveMode === 'preview') {
@@ -443,12 +429,6 @@ const MEditorInner = forwardRef<EditorInstance, MEditorProps>((props, ref) => {
       tabIndex={-1}
     >
       {toolbar && <div data-openbitfun-component="m-editor" data-openbitfun-part="toolbar" className="m-editor-toolbar">{t('editor.meditor.toolbarPlaceholder')}</div>}
-      {irNeedsSourceFallback && (
-        <div className="m-editor-notice" data-openbitfun-component="m-editor" data-openbitfun-part="notice">
-          <AlertCircle className="m-editor-notice__icon" />
-          <span>{t('editor.markdownEditor.notice.sourcePreviewFallback')}</span>
-        </div>
-      )}
       
       <div data-openbitfun-component="m-editor" data-openbitfun-part="content" className="m-editor-content">
         {effectiveMode === 'preview' && (
@@ -498,7 +478,6 @@ const MEditorInner = forwardRef<EditorInstance, MEditorProps>((props, ref) => {
               onChange={handleEditorChange}
               onFocus={onFocus}
               onBlur={onBlur}
-              onDirtyChange={onDirtyChange}
               placeholder={placeholder}
               readonly={readonly}
               autofocus={autofocus}

--- a/src/web-ui/src/tools/editor/meditor/components/TiptapEditor.scss
+++ b/src/web-ui/src/tools/editor/meditor/components/TiptapEditor.scss
@@ -1,7 +1,5 @@
 @use '@/shared/styles/surface-recipes' as surfaces;
 @use '@/infrastructure/markdown/code' as markdownCode;
-@use '@/infrastructure/markdown/table' as markdownTable;
-@use '../../styles/markdown-editor-layout' as markdownLayout;
 
 .m-editor-tiptap {
   position: relative;
@@ -19,442 +17,27 @@
     box-shadow: none !important;
   }
 
+  // Share the existing MarkdownRenderer appearance; only editing behavior is local.
   .ProseMirror {
     min-height: 100%;
     outline: none;
-    color: var(--openbitfun-color-content-secondary);
-    font-size: var(--openbitfun-type-label-md-font-size);
-    line-height: var(--openbitfun-type-body-lg-line-height);
-
-    /* blockId lives on <hr> itself — do not use paragraph chrome (padding + radius + hover fill) on hr */
-    > [data-block-id]:not(hr) {
-      margin-bottom: var(--openbitfun-space-2);
-      padding: var(--openbitfun-space-2);
-      border-radius: 0;
-      transition: background var(--openbitfun-motion-duration-base) var(--openbitfun-motion-easing-standard);
-
-      &:hover {
-        background: var(--openbitfun-color-surface-subtle);
-      }
-
-      &.m-editor-tiptap-block-highlighted {
-        background: color-mix(in srgb, var(--openbitfun-color-status-warning-content) 15%, transparent);
-      }
+    .m-editor-tiptap-block-highlighted {
+      background: color-mix(in srgb, var(--openbitfun-color-status-warning-content) 15%, transparent);
     }
-
-    > p.is-empty {
-      position: relative;
-      min-height: calc(var(--openbitfun-type-label-md-font-size) * var(--openbitfun-type-body-lg-line-height));
-    }
-
+    > .m-editor-frontmatter + * { margin-top: 0; }
+    > p.is-empty { position: relative; }
     > p.is-empty::before {
       content: attr(data-placeholder);
       color: var(--openbitfun-color-content-disabled);
       float: left;
       height: 0;
-      font-size: var(--openbitfun-type-label-md-font-size);
-      letter-spacing: var(--openbitfun-type-body-sm-letter-spacing);
-      white-space: nowrap;
-      opacity: 0;
       pointer-events: none;
-      transition: opacity var(--openbitfun-motion-duration-fast) var(--openbitfun-motion-easing-standard);
     }
+    [data-align='center'] { text-align: center; }
+    [data-align='right'] { text-align: right; }
+    li[data-checked] > div,
+    li[data-checked] > div > p:first-child { display: inline; }
 
-    > p.is-empty::before {
-      opacity: 1;
-    }
-
-    > p.is-editor-empty:first-child.is-empty::before {
-      white-space: normal;
-    }
-
-    p {
-      margin: 0;
-    }
-
-    [data-align='center'] {
-      text-align: center;
-    }
-
-    [data-align='right'] {
-      text-align: right;
-    }
-
-    h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6 {
-      margin: 0;
-      color: var(--openbitfun-color-content-primary);
-      font-weight: var(--openbitfun-type-label-selected-font-weight);
-    }
-
-    h1 {
-      font-size: var(--openbitfun-type-heading-dialog-font-size);
-      color: var(--openbitfun-color-content-primary);
-      text-align: center;
-    }
-
-    h2 {
-      font-size: var(--openbitfun-type-flow-section-title-font-size);
-    }
-
-    h3 {
-      font-size: var(--openbitfun-type-flow-title-font-size);
-    }
-
-    h4 {
-      font-size: var(--openbitfun-type-body-lg-font-size);
-    }
-
-    h5 {
-      font-size: var(--openbitfun-type-body-md-font-size);
-    }
-
-    h6 {
-      font-size: var(--openbitfun-type-label-md-font-size);
-      letter-spacing: var(--openbitfun-type-modifier-tracking-wide-letter-spacing);
-      text-transform: uppercase;
-    }
-
-    blockquote {
-      margin: markdownCode.$bq-margin;
-      padding: markdownCode.$bq-padding;
-      font-style: italic;
-      color: markdownCode.$bq-fg;
-      background: markdownCode.$bq-bg;
-      border-left: 3px solid markdownCode.$bq-border;
-      border-radius: markdownCode.$bq-radius;
-    }
-
-    pre {
-      margin: 0.25rem 0.3rem;
-      padding: markdownCode.$pre-padding;
-      overflow-x: auto;
-      font-size: var(--openbitfun-type-flow-code-font-size);
-      line-height: var(--openbitfun-type-body-sm-line-height);
-      font-family:var(--openbitfun-type-code-md-font-family);
-      color: markdownCode.$pre-code-fg;
-      background: markdownCode.$pre-bg;
-      border: 1px dashed markdownCode.$pre-border;
-      border-radius: var(--openbitfun-control-flow-chat-card-radius);
-      box-shadow: markdownCode.$pre-shadow;
-      transition:
-        border-color 0.3s ease,
-        box-shadow 0.3s ease;
-
-      &:hover {
-        border-style: solid;
-        border-color: markdownCode.$pre-hover-border;
-        box-shadow: markdownCode.$pre-hover-shadow;
-      }
-    }
-
-    code {
-      padding: 0.1em 0.4em;
-      margin: 0 0.05em;
-      font-size: var(--openbitfun-type-label-md-font-size);
-      font-weight: var(--openbitfun-type-label-sm-font-weight);
-      line-height: var(--openbitfun-type-modifier-leading-ui-line-height);
-      vertical-align: baseline;
-      white-space: nowrap;
-      font-family:var(--openbitfun-type-code-md-font-family);
-      color: markdownCode.$inline-code-fg;
-      background: markdownCode.$inline-code-bg;
-      border: 1px solid markdownCode.$inline-code-border;
-      border-radius: 4px;
-      transition:
-        background-color 0.15s ease,
-        border-color 0.15s ease,
-        color 0.15s ease;
-      box-decoration-break: clone;
-      -webkit-box-decoration-break: clone;
-
-      &:hover {
-        background: markdownCode.$inline-code-hover-bg;
-        border-color: markdownCode.$inline-code-hover-border;
-        color: markdownCode.$inline-code-hover-fg;
-      }
-    }
-
-    pre code {
-      display: block;
-      padding: 0;
-      margin: 0;
-      font-size: var(--openbitfun-type-flow-code-font-size);
-      font-weight: inherit;
-      white-space: pre-wrap;
-      word-break: break-word;
-      color: inherit;
-      background: transparent;
-      border: none;
-      border-radius: 0;
-      box-shadow: none;
-
-      &:hover {
-        background: transparent !important;
-        border: none !important;
-        color: inherit !important;
-      }
-    }
-
-    hr {
-      display: block;
-      height: 0;
-      margin: var(--openbitfun-space-4) 0;
-      padding: 0;
-      border: 0;
-      border-top: 1px solid var(--openbitfun-color-border-subtle);
-      background: none;
-      background-color: transparent;
-      overflow: visible;
-      box-shadow: none;
-      border-radius: 0;
-
-      &[data-block-id] {
-        margin-bottom: var(--openbitfun-space-2);
-      }
-
-      &[data-block-id].m-editor-tiptap-block-highlighted {
-        border-top-color: color-mix(in srgb, var(--openbitfun-color-status-warning-content) 55%, transparent);
-      }
-    }
-
-    /* Same palette as flow chat `.markdown-renderer .table-wrapper` (see flowchat-markdown-table-vars.scss) */
-    table {
-      width: 100%;
-      border-collapse: collapse;
-      border-spacing: 0;
-      margin: var(--openbitfun-space-4) 0;
-      table-layout: fixed;
-      font-size: var(--openbitfun-type-body-md-font-size);
-      border: 1px solid markdownTable.$border;
-      border-radius: var(--openbitfun-control-flow-chat-card-radius);
-      background: markdownTable.$surface;
-      box-shadow: markdownTable.$shadow;
-      overflow: hidden;
-    }
-
-    th,
-    td {
-      padding: var(--openbitfun-space-3) var(--openbitfun-space-4);
-      border: none;
-      border-bottom: 1px solid markdownTable.$cell-border;
-      vertical-align: top;
-      min-width: 5rem;
-      word-break: break-word;
-      overflow-wrap: anywhere;
-      text-align: left;
-      background: transparent;
-      transition: background-color var(--openbitfun-motion-duration-fast) var(--openbitfun-motion-easing-standard);
-    }
-
-    th {
-      font-weight: var(--openbitfun-type-label-selected-font-weight);
-      background: markdownTable.$th-bg;
-      color: markdownTable.$th-fg;
-    }
-
-    td {
-      color: var(--openbitfun-color-content-primary);
-    }
-
-    th + th,
-    td + td,
-    th + td {
-      border-left: 1px solid markdownTable.$col-divider;
-    }
-
-    tbody tr:last-child td,
-    tbody tr:last-child th {
-      border-bottom: none;
-    }
-
-    tbody tr {
-      background: markdownTable.$row-base;
-    }
-
-    tbody tr:nth-child(2n) {
-      background: markdownTable.$row-stripe;
-    }
-
-    tbody tr:hover {
-      background: markdownTable.$hover;
-    }
-
-    thead tr:hover {
-      background: markdownTable.$hover;
-    }
-
-    thead tr:hover th,
-    tbody tr:hover th,
-    tbody tr:hover td {
-      background: transparent;
-    }
-
-    tbody tr:first-child th:first-child,
-    thead th:first-child {
-      border-top-left-radius: var(--openbitfun-control-flow-chat-card-radius);
-    }
-
-    tbody tr:first-child th:last-child,
-    thead th:last-child {
-      border-top-right-radius: var(--openbitfun-control-flow-chat-card-radius);
-    }
-
-    tbody tr:last-child td:first-child,
-    tbody tr:last-child th:first-child {
-      border-bottom-left-radius: var(--openbitfun-control-flow-chat-card-radius);
-    }
-
-    tbody tr:last-child td:last-child,
-    tbody tr:last-child th:last-child {
-      border-bottom-right-radius: var(--openbitfun-control-flow-chat-card-radius);
-    }
-
-    tbody tr:first-child th:only-child {
-      border-radius: var(--openbitfun-control-flow-chat-card-radius) var(--openbitfun-control-flow-chat-card-radius) 0 0;
-    }
-
-    tbody tr:last-child td:only-child {
-      border-radius: 0 0 var(--openbitfun-control-flow-chat-card-radius) var(--openbitfun-control-flow-chat-card-radius);
-    }
-
-    th code,
-    td code {
-      white-space: normal;
-      word-break: break-word;
-      overflow-wrap: anywhere;
-      max-width: 100%;
-    }
-
-    th pre code,
-    td pre code {
-      white-space: pre-wrap;
-      word-break: break-word;
-      max-width: 100%;
-    }
-
-    > ul:not([data-type='taskList']),
-    > ol:not([data-type='taskList']) {
-      margin: 0;
-      padding-left: 0;
-    }
-
-    > ul:not([data-type='taskList']) > li,
-    > ol:not([data-type='taskList']) > li {
-      list-style: none;
-      position: relative;
-      margin-bottom: var(--openbitfun-space-1);
-      padding-left: calc(#{markdownLayout.$list-marker-width} + #{markdownLayout.$list-gap});
-    }
-
-    > ul:not([data-type='taskList']) > li::before,
-    > ol:not([data-type='taskList']) > li::before {
-      position: absolute;
-      left: 0;
-      top: 0;
-      width: markdownLayout.$list-marker-width;
-      color: var(--openbitfun-color-content-primary);
-      font-weight: var(--openbitfun-type-label-sm-font-weight);
-    }
-
-    > ul:not([data-type='taskList']) > li::before {
-      content: '•';
-      text-align: center;
-    }
-
-    > ol:not([data-type='taskList']) {
-      counter-reset: m-editor-ordered-list;
-    }
-
-    > ol:not([data-type='taskList']) > li {
-      counter-increment: m-editor-ordered-list;
-    }
-
-    > ol:not([data-type='taskList']) > li::before {
-      content: counter(m-editor-ordered-list) '.';
-      text-align: left;
-    }
-
-    li > ul:not([data-type='taskList']),
-    li > ol:not([data-type='taskList']) {
-      margin-top: var(--openbitfun-space-1);
-      margin-bottom: 0;
-      padding-left: markdownLayout.$list-indent;
-    }
-
-    > ul[data-type='taskList'] {
-      margin: 0;
-      padding-left: 0;
-      list-style: none;
-    }
-
-    > ul[data-type='taskList'] > li {
-      display: grid;
-      grid-template-columns: markdownLayout.$list-marker-width 1fr;
-      column-gap: markdownLayout.$list-gap;
-      align-items: start;
-      margin-bottom: var(--openbitfun-space-1);
-    }
-
-    > ul[data-type='taskList'] > li > label {
-      width: markdownLayout.$list-marker-width;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      padding-top: 0.15rem;
-    }
-
-    > ul[data-type='taskList'] > li > label > input[type='checkbox'] {
-      margin: 0;
-      width: markdownLayout.$task-checkbox-size;
-      height: markdownLayout.$task-checkbox-size;
-    }
-
-    > ul[data-type='taskList'] > li > label > span {
-      display: none;
-    }
-
-    > ul[data-type='taskList'] > li > div {
-      flex: 1 1 auto;
-      min-width: 0;
-    }
-
-    ul[data-type='taskList'] li > ul,
-    ul[data-type='taskList'] li > ol {
-      margin-top: var(--openbitfun-space-1);
-      margin-bottom: 0;
-      padding-left: markdownLayout.$list-indent;
-    }
-
-    li > p {
-      margin: 0;
-      display: block;
-    }
-
-    li > p + p {
-      margin-top: var(--openbitfun-space-2);
-    }
-
-    a {
-      color: var(--openbitfun-color-accent-default);
-      text-decoration: none;
-
-      &:hover {
-        text-decoration: underline;
-      }
-    }
-
-    img {
-      max-width: 100%;
-      box-sizing: content-box;
-      background-color: transparent;
-      border-radius: var(--openbitfun-radius-base);
-      vertical-align: middle;
-    }
   }
 
   .m-editor-inline-ai {
@@ -765,6 +348,108 @@
     font-size: var(--openbitfun-type-label-sm-font-size);
   }
 
+  .m-editor-image { display: inline-block; max-width: 100%; }
+
+  .m-editor-image-fields {
+    display: grid;
+    gap: var(--openbitfun-space-2);
+    padding: var(--openbitfun-space-2);
+    font-size: var(--openbitfun-type-label-sm-font-size);
+
+    &[hidden] { display: none; }
+    label { display: grid; gap: var(--openbitfun-space-1); }
+    input {
+      min-width: 0;
+      color: var(--openbitfun-color-content-primary);
+      background: var(--openbitfun-color-surface-scene);
+      border: 1px solid var(--openbitfun-color-border-default);
+      border-radius: var(--openbitfun-radius-base);
+      padding: var(--openbitfun-space-1);
+      font: inherit;
+    }
+  }
+
+  .m-editor-source-block-action {
+    display: block;
+    margin: 0;
+    padding: var(--openbitfun-space-1) var(--openbitfun-space-2);
+    border: 1px solid var(--openbitfun-color-border-default);
+    border-radius: var(--openbitfun-radius-base);
+    color: var(--openbitfun-color-content-secondary);
+    background: var(--openbitfun-color-surface-scene);
+    font: inherit;
+    cursor: pointer;
+
+    &[hidden] { display: none; }
+  }
+
+  .m-editor-embed-toolbar {
+    &[hidden] { display: none; }
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--openbitfun-space-3);
+    padding: var(--openbitfun-space-2) var(--openbitfun-space-3);
+    font-size: var(--openbitfun-type-label-sm-font-size);
+    line-height: var(--openbitfun-type-label-sm-line-height);
+    user-select: none;
+  }
+
+  .m-editor-embed-label {
+    color: var(--openbitfun-color-content-muted);
+    font-family: var(--openbitfun-type-code-md-font-family);
+  }
+
+  .m-editor-source-block-action:hover,
+  .m-editor-source-block-action:focus-visible {
+    background: var(--openbitfun-color-action-quiet-hover);
+    color: var(--openbitfun-color-content-primary);
+    outline: 1px solid var(--openbitfun-color-border-default);
+  }
+
+  .m-editor-inline-math {
+    display: inline-block;
+    position: relative;
+    vertical-align: baseline;
+    cursor: pointer;
+
+    &__pane--preview,
+    &__preview,
+    &__preview .markdown-body,
+    &__preview [data-openbitfun-part='math'],
+    &__preview p { display: inline; margin: 0; }
+
+    &__pane--editor {
+      position: absolute;
+      z-index: 10;
+      top: 100%;
+      left: 0;
+      display: block;
+      width: min(26rem, calc(100vw - 40px));
+      border: 1px solid var(--openbitfun-color-border-default);
+      border-radius: var(--openbitfun-radius-base);
+      background: var(--openbitfun-color-surface-scene);
+    }
+
+    &[data-editing='false'] .m-editor-inline-math__pane--editor { display: none; }
+    &__textarea {
+      display: block;
+      box-sizing: border-box;
+      width: 100%;
+      min-height: 64px;
+      padding: var(--openbitfun-space-3);
+      border: 0;
+      border-top: 1px solid var(--openbitfun-color-border-default);
+      color: var(--openbitfun-color-content-primary);
+      background: transparent;
+      font-family: var(--openbitfun-type-code-md-font-family);
+      font-size: var(--openbitfun-type-code-md-font-size);
+      resize: vertical;
+    }
+    &__source-fallback { display: none; }
+    &[data-preview-empty='true'] .m-editor-inline-math__source-fallback { display: inline; }
+  }
+
   .m-editor-render-only-block,
   .m-editor-raw-html-block,
   .m-editor-frontmatter {
@@ -774,6 +459,26 @@
     border-radius: var(--openbitfun-radius-base);
     background: var(--openbitfun-color-action-quiet-hover);
     color: var(--openbitfun-color-content-secondary);
+  }
+
+  // Embedded content has document appearance until its local editor is open.
+  .m-editor-render-only-block[data-editing='false'],
+  .m-editor-raw-html-block[data-editing='false'] {
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    overflow: visible;
+    margin: 0;
+  }
+
+  .m-editor-frontmatter {
+    margin: 0 0 var(--openbitfun-space-4);
+    .m-editor-embed-toolbar { border-bottom: 1px solid var(--openbitfun-color-border-default); }
+    .m-editor-embed-label {
+      font-family: inherit;
+      font-weight: var(--openbitfun-type-label-selected-font-weight);
+      color: var(--openbitfun-color-content-secondary);
+    }
   }
 
   .m-editor-frontmatter__header {
@@ -812,6 +517,10 @@
   }
 
   .m-editor-raw-html-inline__source {
+    max-width: 100%;
+    color: inherit;
+    background: transparent;
+    border: 0;
     margin: 0;
     font-family:var(--openbitfun-type-code-md-font-family);
     font-size: var(--openbitfun-type-label-sm-font-size);
@@ -841,8 +550,6 @@
     padding: 0;
   }
 
-  .m-editor-render-only-block[data-editing='true'] .m-editor-render-only-block__pane--preview,
-  .m-editor-raw-html-block[data-editing='true'] .m-editor-raw-html-block__pane--preview,
   .m-editor-frontmatter[data-editing='true'] .m-editor-frontmatter__pane--preview {
     display: none;
   }
@@ -861,7 +568,7 @@
     font-size: var(--openbitfun-type-label-md-font-size);
     display: block;
     width: 100%;
-    min-height: 180px;
+    min-height: 100px;
     resize: vertical;
     border: 1px solid color-mix(in srgb, var(--openbitfun-color-content-primary) 12%, transparent);
     border-radius: var(--openbitfun-radius-base);
@@ -884,7 +591,7 @@
   .m-editor-render-only-block__preview,
   .m-editor-raw-html-block__preview,
   .m-editor-frontmatter__preview {
-    min-height: 180px;
+    min-height: 0;
     cursor: text;
     user-select: text;
     -webkit-user-select: text;
@@ -1021,11 +728,6 @@
     grid-template-columns: 20px minmax(0, 1fr);
     align-items: start;
     gap: var(--openbitfun-space-2);
-    margin: var(--openbitfun-space-3) 0;
-    padding: var(--openbitfun-space-2) var(--openbitfun-space-3);
-    border: 1px solid color-mix(in srgb, var(--openbitfun-color-content-primary) 10%, transparent);
-    border-radius: var(--openbitfun-radius-base);
-    background: color-mix(in srgb, var(--openbitfun-color-surface-scene) 88%, var(--openbitfun-color-content-on-dark));
   }
 
   [data-type='details'] > button {
@@ -1056,19 +758,12 @@
   [data-type='details'] summary {
     display: block;
     list-style: none;
-    color: var(--openbitfun-color-content-primary);
-    font-size: var(--openbitfun-type-label-md-font-size);
-    font-weight: var(--openbitfun-type-label-sm-font-weight);
     outline: none;
   }
 
   [data-type='details'] summary::marker,
   [data-type='details'] summary::-webkit-details-marker {
     display: none;
-  }
-
-  [data-type='details'] [data-type='detailsContent'] {
-    padding-top: var(--openbitfun-space-3);
   }
 
   [data-type='details'] [data-type='detailsContent'] > :first-child {
@@ -1140,79 +835,7 @@
 :root[data-openbitfun-appearance-mode="light"] .m-editor-tiptap,
 [data-openbitfun-appearance-mode="light"] .m-editor-tiptap,
 .light .m-editor-tiptap {
-  .ProseMirror {
-    blockquote {
-      color: markdownCode.$bq-fg-light;
-      background: markdownCode.$bq-bg-light;
-      border-left-color: markdownCode.$bq-border-light;
-    }
 
-    pre {
-      color: markdownCode.$pre-code-fg-light;
-      background: markdownCode.$pre-bg-light;
-      border-color: markdownCode.$pre-border-light;
-      box-shadow: markdownCode.$pre-shadow-light;
-
-      &:hover {
-        border-color: markdownCode.$pre-hover-border-light;
-        box-shadow: markdownCode.$pre-hover-shadow-light;
-      }
-    }
-
-    code {
-      color: markdownCode.$inline-code-fg-light;
-      background: markdownCode.$inline-code-bg-light;
-      border-color: markdownCode.$inline-code-border-light;
-
-      &:hover {
-        background: markdownCode.$inline-code-hover-bg-light;
-        border-color: markdownCode.$inline-code-hover-border-light;
-        color: markdownCode.$inline-code-hover-fg-light;
-      }
-    }
-
-    pre code,
-    pre code:hover {
-      color: inherit;
-      background: transparent !important;
-      border: none !important;
-    }
-
-    table {
-      border-color: markdownTable.$border-light;
-      background: markdownTable.$surface-light;
-      box-shadow: markdownTable.$shadow-light;
-    }
-
-    th,
-    td {
-      border-bottom-color: markdownTable.$cell-border-light;
-    }
-
-    th {
-      background: markdownTable.$th-bg-light;
-      color: markdownTable.$th-fg-light;
-    }
-
-    th + th,
-    td + td,
-    th + td {
-      border-left-color: markdownTable.$col-divider-light;
-    }
-
-    tbody tr {
-      background: markdownTable.$row-base-light;
-    }
-
-    tbody tr:nth-child(2n) {
-      background: markdownTable.$row-stripe-light;
-    }
-
-    tbody tr:hover,
-    thead tr:hover {
-      background: markdownTable.$hover-light;
-    }
-  }
 
   .m-editor-inline-ai-rendered__content.markdown-body blockquote {
     color: markdownCode.$bq-fg-light;

--- a/src/web-ui/src/tools/editor/meditor/components/TiptapEditor.tsx
+++ b/src/web-ui/src/tools/editor/meditor/components/TiptapEditor.tsx
@@ -2,7 +2,6 @@ import React, {
   useCallback,
   useEffect,
   useImperativeHandle,
-  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -38,7 +37,7 @@ import {
   InlineAiPreviewExtension,
 } from '../extensions/InlineAiPreviewExtension';
 import { inlineAiPreviewPluginKey } from '../extensions/InlineAiPreviewPluginKey';
-import { Frontmatter, RawHtmlBlock, RawHtmlInline, RenderOnlyBlock } from '../extensions/RawHtmlExtensions';
+import { Frontmatter, InlineMath, RawHtmlBlock, RawHtmlInline, RenderOnlyBlock } from '../extensions/RawHtmlExtensions';
 import { getBlockIndexForLine } from '../utils/markdownBlocks';
 import {
   buildInlineContinuePrompt,
@@ -48,7 +47,8 @@ import {
 } from '../utils/inlineAi';
 import { getCachedLocalImageDataUrl, loadLocalImages } from '../utils/loadLocalImages';
 import { isLocalPath, resolveImagePath } from '../utils/rehype-local-images';
-import { markdownToTiptapDoc, tiptapDocToMarkdown, tiptapDocToTopLevelMarkdownBlocks } from '../utils/tiptapMarkdown';
+import { markdownToEditableTiptapDoc, tiptapDocToMarkdown, tiptapDocToTopLevelMarkdownBlocks } from '../utils/tiptapMarkdown';
+import '@/infrastructure/markdown/Markdown.scss';
 import './TiptapEditor.scss';
 
 const log = createLogger('TiptapEditor');
@@ -106,54 +106,6 @@ function getTopLevelBlockIds(doc: JSONContent | null | undefined): string[] {
   return (doc?.content ?? [])
     .map((node: JSONContent) => (typeof node.attrs?.blockId === 'string' ? node.attrs.blockId : null))
     .filter((value: string | null): value is string => typeof value === 'string');
-}
-
-function syncInlineAiHints(
-  instance: TiptapEditorInstance,
-  root: HTMLDivElement | null,
-  hintText: string
-): void {
-  if (!root) {
-    return;
-  }
-
-  root.querySelectorAll<HTMLElement>('[data-inline-ai-hint]').forEach(element => {
-    element.removeAttribute('data-inline-ai-hint');
-  });
-  root.querySelectorAll<HTMLElement>('[data-inline-ai-active]').forEach(element => {
-    element.removeAttribute('data-inline-ai-active');
-  });
-
-  const { selection } = instance.state;
-  const activeBlockId =
-    selection.empty &&
-    selection.$from.depth === 1 &&
-    selection.$from.parent.type.name === 'paragraph' &&
-    selection.$from.parent.textContent.trim().length === 0 &&
-    typeof selection.$from.parent.attrs?.blockId === 'string'
-      ? selection.$from.parent.attrs.blockId
-      : null;
-
-  instance.state.doc.forEach((node) => {
-    if (node.type.name !== 'paragraph' || node.textContent.trim().length > 0) {
-      return;
-    }
-
-    const blockId = typeof node.attrs?.blockId === 'string' ? node.attrs.blockId : null;
-    if (!blockId) {
-      return;
-    }
-
-    const element = root.querySelector<HTMLElement>(`[data-block-id="${blockId}"]`);
-    if (!element) {
-      return;
-    }
-
-    element.setAttribute('data-inline-ai-hint', hintText);
-    if (blockId === activeBlockId) {
-      element.setAttribute('data-inline-ai-active', 'true');
-    }
-  });
 }
 
 async function resolveEditorLocalImages(
@@ -424,10 +376,15 @@ function replaceEditorContentWithoutHistory(
   instance
     .chain()
     .setMeta('addToHistory', false)
-    .setContent(markdownToTiptapDoc(markdown), {
+    .setContent(markdownToEditableTiptapDoc(markdown), {
       emitUpdate: false,
     })
     .run();
+}
+
+function getSourceDocumentKey(doc: JSONContent): string {
+  // Generated block identities are editor bookkeeping, not Markdown content.
+  return JSON.stringify(doc, (key, value) => key === 'blockId' ? undefined : value);
 }
 
 export const TiptapEditor = React.forwardRef<TiptapEditorHandle, TiptapEditorProps>(({
@@ -451,15 +408,16 @@ export const TiptapEditor = React.forwardRef<TiptapEditorHandle, TiptapEditorPro
   const editorRef = useRef<TiptapEditorInstance | null>(null);
   const savedContentRef = useRef(value);
   const currentMarkdownRef = useRef(value);
+  const lastReceivedValueRef = useRef(value);
+  const sourceSnapshotRef = useRef<{ source: string; documentKey: string } | null>(null);
   const preserveTrailingNewlineRef = useRef(value.endsWith('\n'));
-  const applyingExternalValueRef = useRef(false);
   const highlightTimerRef = useRef<number | null>(null);
   const targetIdRef = useRef(`markdown-ir-tiptap-${Math.random().toString(36).slice(2, 10)}`);
   const inlineAiInputRef = useRef<HTMLInputElement | null>(null);
   const inlineAiInputComposingRef = useRef(false);
   const [inlineAiState, setInlineAiState] = useState<InlineAiState | null>(null);
 
-  const initialContent = useMemo(() => markdownToTiptapDoc(value), [value]);
+  const [initialContent] = useState(() => markdownToEditableTiptapDoc(value));
   const inlineAiTriggerHint = t('editor.meditor.inlineAi.triggerHint');
 
   useEffect(() => {
@@ -487,11 +445,22 @@ export const TiptapEditor = React.forwardRef<TiptapEditorHandle, TiptapEditorPro
     readonlyRef.current = readonly;
   }, [readonly]);
 
-  const serializeEditorMarkdown = useCallback((instance: TiptapEditorInstance): string => (
-    tiptapDocToMarkdown(instance.getJSON(), {
+  const rememberSource = useCallback((instance: TiptapEditorInstance, source: string) => {
+    sourceSnapshotRef.current = { source, documentKey: getSourceDocumentKey(instance.getJSON()) };
+  }, []);
+
+  const serializeEditorMarkdown = useCallback((instance: TiptapEditorInstance): string => {
+    const doc = instance.getJSON();
+    const snapshot = sourceSnapshotRef.current;
+    // Undo restores document nodes, not Markdown spelling. Recover the exact
+    // imported source at that state, including whitespace and list delimiters.
+    // This snapshot may itself be unsaved (for example after a source-mode edit);
+    // the document owner still compares the returned bytes with its saved value.
+    if (snapshot && getSourceDocumentKey(doc) === snapshot.documentKey) return snapshot.source;
+    return tiptapDocToMarkdown(doc, {
       preserveTrailingNewline: preserveTrailingNewlineRef.current,
-    })
-  ), []);
+    });
+  }, []);
 
   const closeInlineAi = useCallback((options?: { cancelRequest?: boolean; focusEditor?: boolean }) => {
     const shouldCancel = options?.cancelRequest ?? false;
@@ -548,7 +517,7 @@ export const TiptapEditor = React.forwardRef<TiptapEditorHandle, TiptapEditorPro
       return false;
     }
 
-    const content = markdownToTiptapDoc(normalized).content ?? [];
+    const content = markdownToEditableTiptapDoc(normalized).content ?? [];
     if (content.length === 0) {
       return false;
     }
@@ -572,6 +541,8 @@ export const TiptapEditor = React.forwardRef<TiptapEditorHandle, TiptapEditorPro
     editable: !readonly,
     extensions: [
       StarterKit.configure({
+        link: false,
+        code: { HTMLAttributes: { class: 'inline-code' } },
         heading: {
           levels: [1, 2, 3, 4, 5, 6],
         },
@@ -583,6 +554,8 @@ export const TiptapEditor = React.forwardRef<TiptapEditorHandle, TiptapEditorPro
       Link.configure({
         openOnClick: false,
       }),
+      // Placeholder decorations keep hints outside the document mutation path.
+      // Direct paragraph DOM changes can reparse and destroy active embed editors.
       Placeholder.configure({
         placeholder: ({ node, hasAnchor }) => {
           if (!hasAnchor || node.type.name !== 'paragraph') {
@@ -595,6 +568,11 @@ export const TiptapEditor = React.forwardRef<TiptapEditorHandle, TiptapEditorPro
       MarkdownAlignmentExtension,
       BlockIdExtension,
       MarkdownImage.configure({
+        editLabel: t('editor.markdownEditor.editImage'),
+        doneLabel: t('editor.markdownEditor.finishBlockEdit'),
+        srcLabel: t('editor.markdownEditor.imageAddress'),
+        altLabel: t('editor.markdownEditor.imageAltText'),
+        titleLabel: t('editor.markdownEditor.imageTitle'),
         basePath,
       }),
       Details.configure({
@@ -603,13 +581,35 @@ export const TiptapEditor = React.forwardRef<TiptapEditorHandle, TiptapEditorPro
       DetailsSummary,
       DetailsContent,
       Frontmatter.configure({
+        editLabel: t('editor.markdownEditor.editBlockSource'),
+        doneLabel: t('editor.markdownEditor.finishBlockEdit'),
         label: t('editor.meditor.frontmatter.label'),
+      }),
+      InlineMath.configure({
+        label: t('editor.markdownEditor.blockTypes.math'),
+        editLabel: t('editor.markdownEditor.editBlockSource'),
+        doneLabel: t('editor.markdownEditor.finishBlockEdit'),
       }),
       // Keep raw/render-only fallbacks for HTML we still can't round-trip safely.
       RenderOnlyBlock.configure({
+        typeLabels: {
+          math: t('editor.markdownEditor.blockTypes.math'),
+          mermaid: 'Mermaid',
+          code: t('editor.markdownEditor.blockTypes.code'),
+          markdown: 'Markdown',
+          paragraph: 'Markdown',
+          html: 'HTML',
+          definition: t('editor.markdownEditor.blockTypes.reference'),
+          footnoteDefinition: t('editor.markdownEditor.blockTypes.footnote'),
+        },
+        editLabel: t('editor.markdownEditor.editBlockSource'),
+        doneLabel: t('editor.markdownEditor.finishBlockEdit'),
         basePath,
       }),
       RawHtmlBlock.configure({
+        label: 'HTML',
+        editLabel: t('editor.markdownEditor.editBlockSource'),
+        doneLabel: t('editor.markdownEditor.finishBlockEdit'),
         basePath,
       }),
       RawHtmlInline.configure({
@@ -622,6 +622,7 @@ export const TiptapEditor = React.forwardRef<TiptapEditorHandle, TiptapEditorPro
       InlineAiPreviewExtension,
     ],
     editorProps: {
+      attributes: { class: 'markdown-renderer' },
       handleKeyDown: (_view, event) => {
         if (readonlyRef.current || inlineAiStateRef.current?.isOpen) {
           return false;
@@ -661,19 +662,16 @@ export const TiptapEditor = React.forwardRef<TiptapEditorHandle, TiptapEditorPro
     onCreate: ({ editor: instance }: { editor: TiptapEditorInstance }) => {
       editorRef.current = instance;
       preserveTrailingNewlineRef.current = value.endsWith('\n');
-      const markdown = serializeEditorMarkdown(instance);
-      currentMarkdownRef.current = markdown;
-      savedContentRef.current = markdown;
-      syncInlineAiHints(instance, rootRef.current, inlineAiTriggerHint);
+      rememberSource(instance, value);
+      currentMarkdownRef.current = value;
+      savedContentRef.current = value;
       onDirtyChange?.(false);
     },
-    onFocus: ({ editor: instance }: { editor: TiptapEditorInstance }) => {
+    onFocus: () => {
       activeEditTargetService.setActiveTarget(targetIdRef.current);
-      syncInlineAiHints(instance, rootRef.current, inlineAiTriggerHint);
       onFocus?.();
     },
-    onBlur: ({ editor: instance }: { editor: TiptapEditorInstance }) => {
-      syncInlineAiHints(instance, rootRef.current, inlineAiTriggerHint);
+    onBlur: () => {
       window.setTimeout(() => {
         const root = rootRef.current;
         const activeElement = typeof document !== 'undefined' ? document.activeElement : null;
@@ -685,18 +683,10 @@ export const TiptapEditor = React.forwardRef<TiptapEditorHandle, TiptapEditorPro
       }, 0);
       onBlur?.();
     },
-    onSelectionUpdate: ({ editor: instance }: { editor: TiptapEditorInstance }) => {
-      syncInlineAiHints(instance, rootRef.current, inlineAiTriggerHint);
-    },
-    onUpdate: ({ editor: instance }: { editor: TiptapEditorInstance }) => {
+    onUpdate: ({ editor: instance, transaction }) => {
+      if (!transaction.docChanged) return;
       const markdown = serializeEditorMarkdown(instance);
       currentMarkdownRef.current = markdown;
-      syncInlineAiHints(instance, rootRef.current, inlineAiTriggerHint);
-
-      if (applyingExternalValueRef.current) {
-        applyingExternalValueRef.current = false;
-        return;
-      }
 
       onChange(markdown);
       onDirtyChange?.(markdown !== savedContentRef.current);
@@ -711,14 +701,6 @@ export const TiptapEditor = React.forwardRef<TiptapEditorHandle, TiptapEditorPro
     editorRef.current = editor;
     editor.setEditable(!readonly);
   }, [editor, readonly]);
-
-  useEffect(() => {
-    if (!editor) {
-      return;
-    }
-
-    syncInlineAiHints(editor, rootRef.current, inlineAiTriggerHint);
-  }, [editor, inlineAiTriggerHint]);
 
   useEffect(() => {
     if (!editor) {
@@ -784,17 +766,18 @@ export const TiptapEditor = React.forwardRef<TiptapEditorHandle, TiptapEditorPro
   }, [basePath, editor, value]);
 
   useEffect(() => {
-    if (!editor || value === currentMarkdownRef.current) {
-      return;
-    }
+    if (!editor || value === lastReceivedValueRef.current) return;
+    lastReceivedValueRef.current = value;
+    // Tiptap can render a transaction before React delivers the parent's new
+    // value. Reapplying that unchanged, older prop destroys active NodeViews.
+    if (value === currentMarkdownRef.current) return;
 
-    applyingExternalValueRef.current = true;
     preserveTrailingNewlineRef.current = value.endsWith('\n');
     currentMarkdownRef.current = value;
     replaceEditorContentWithoutHistory(editor, value);
-    syncInlineAiHints(editor, rootRef.current, inlineAiTriggerHint);
+    rememberSource(editor, value);
     onDirtyChange?.(value !== savedContentRef.current);
-  }, [editor, inlineAiTriggerHint, value, onDirtyChange]);
+  }, [editor, inlineAiTriggerHint, value, onDirtyChange, rememberSource]);
 
   useEffect(() => {
     if (!editor) {
@@ -1192,14 +1175,14 @@ export const TiptapEditor = React.forwardRef<TiptapEditorHandle, TiptapEditorPro
         return;
       }
 
-      applyingExternalValueRef.current = true;
       replaceEditorContentWithoutHistory(editor, content);
+      rememberSource(editor, content);
       onDirtyChange?.(false);
     },
     get isDirty() {
       return currentMarkdownRef.current !== savedContentRef.current;
     },
-  }), [editor, focusBlockByIndex, onDirtyChange]);
+  }), [editor, focusBlockByIndex, onDirtyChange, rememberSource]);
 
   const isInlineBusy =
     inlineAiState?.status === 'submitting' || inlineAiState?.status === 'streaming';

--- a/src/web-ui/src/tools/editor/meditor/extensions/MarkdownImageExtension.ts
+++ b/src/web-ui/src/tools/editor/meditor/extensions/MarkdownImageExtension.ts
@@ -51,6 +51,7 @@ export const MarkdownImage = Node.create<MarkdownImageOptions>({
     return ({ editor, node, getPos }) => {
       let currentNode = node;
       let editing = false;
+      let lastSource: string | undefined;
       const dom = document.createElement('span');
       dom.className = 'm-editor-image';
       dom.dataset.testid = 'md-image';
@@ -88,10 +89,18 @@ export const MarkdownImage = Node.create<MarkdownImageOptions>({
       dom.append(image, action, fields);
       const sync = () => {
         const src = String(currentNode.attrs.src ?? '');
-        const resolvedSrc = src && isLocalPath(src)
-          ? getCachedLocalImageDataUrl(resolveImagePath(src, this.options.basePath)) ?? src
-          : src;
-        if (image.getAttribute('src') !== resolvedSrc) image.setAttribute('src', resolvedSrc);
+        if (src !== lastSource) {
+          lastSource = src;
+          delete image.dataset.localResolved;
+          image.removeAttribute('data-local-image');
+          image.removeAttribute('data-local-path');
+          image.removeAttribute('data-original-src');
+          image.classList.remove('local-image-loading', 'local-image-loaded', 'local-image-error');
+          const resolvedSrc = src && isLocalPath(src)
+            ? getCachedLocalImageDataUrl(resolveImagePath(src, this.options.basePath)) ?? src
+            : src;
+          image.setAttribute('src', resolvedSrc);
+        }
         image.alt = String(currentNode.attrs.alt ?? '');
         image.title = String(currentNode.attrs.title ?? '');
         if (!editor.isEditable) editing = false;

--- a/src/web-ui/src/tools/editor/meditor/extensions/MarkdownImageExtension.ts
+++ b/src/web-ui/src/tools/editor/meditor/extensions/MarkdownImageExtension.ts
@@ -1,9 +1,15 @@
 import { mergeAttributes, Node } from '@tiptap/core';
+import { closeHistory } from '@tiptap/pm/history';
 import { getCachedLocalImageDataUrl } from '../utils/loadLocalImages';
 import { isLocalPath, resolveImagePath } from '../utils/rehype-local-images';
 
 type MarkdownImageOptions = {
   basePath?: string;
+  editLabel?: string;
+  doneLabel?: string;
+  srcLabel?: string;
+  altLabel?: string;
+  titleLabel?: string;
 };
 
 export const MarkdownImage = Node.create<MarkdownImageOptions>({
@@ -42,28 +48,121 @@ export const MarkdownImage = Node.create<MarkdownImageOptions>({
   },
 
   addNodeView() {
-    return ({ node }) => {
-      const dom = document.createElement('img');
-      const src = typeof node.attrs.src === 'string' ? node.attrs.src : '';
-      const alt = typeof node.attrs.alt === 'string' ? node.attrs.alt : '';
-      const title = typeof node.attrs.title === 'string' ? node.attrs.title : '';
-
-      if (alt) {
-        dom.setAttribute('alt', alt);
+    return ({ editor, node, getPos }) => {
+      let currentNode = node;
+      let editing = false;
+      const dom = document.createElement('span');
+      dom.className = 'm-editor-image';
+      dom.dataset.testid = 'md-image';
+      dom.contentEditable = 'false';
+      const image = document.createElement('img');
+      image.tabIndex = 0;
+      const action = document.createElement('button');
+      action.type = 'button';
+      action.className = 'm-editor-source-block-action';
+      action.dataset.testid = 'md-image-edit';
+      const fields = document.createElement('span');
+      fields.className = 'm-editor-image-fields';
+      const inputs = new Map<string, HTMLInputElement>();
+      for (const [attr, text] of [
+        ['src', this.options.srcLabel],
+        ['alt', this.options.altLabel],
+        ['title', this.options.titleLabel],
+      ]) {
+        const label = document.createElement('label');
+        label.textContent = text ?? attr ?? '';
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.dataset.testid = `md-image-${attr}`;
+        input.addEventListener('input', () => {
+          const pos = getPos();
+          if (!editor.isEditable || typeof pos !== 'number' || !attr) return;
+          editor.view.dispatch(editor.state.tr.setNodeMarkup(pos, undefined, {
+            ...currentNode.attrs, [attr]: input.value,
+          }));
+        });
+        if (attr) inputs.set(attr, input);
+        label.append(input);
+        fields.append(label);
       }
-      if (title) {
-        dom.setAttribute('title', title);
-      }
-
-      if (src && isLocalPath(src)) {
-        const absolutePath = resolveImagePath(src, this.options.basePath);
-        const cachedDataUrl = getCachedLocalImageDataUrl(absolutePath);
-        dom.setAttribute('src', cachedDataUrl ?? src);
-      } else {
-        dom.setAttribute('src', src);
-      }
-
-      return { dom };
+      dom.append(image, action, fields);
+      const sync = () => {
+        const src = String(currentNode.attrs.src ?? '');
+        const resolvedSrc = src && isLocalPath(src)
+          ? getCachedLocalImageDataUrl(resolveImagePath(src, this.options.basePath)) ?? src
+          : src;
+        if (image.getAttribute('src') !== resolvedSrc) image.setAttribute('src', resolvedSrc);
+        image.alt = String(currentNode.attrs.alt ?? '');
+        image.title = String(currentNode.attrs.title ?? '');
+        if (!editor.isEditable) editing = false;
+        action.hidden = !editor.isEditable || !editing;
+        action.textContent = editing ? this.options.doneLabel ?? '' : this.options.editLabel ?? '';
+        action.setAttribute('aria-expanded', String(editing));
+        fields.hidden = !editing;
+        inputs.forEach((input, attr) => {
+          const value = String(currentNode.attrs[attr] ?? '');
+          if (input.value !== value) input.value = value;
+          input.readOnly = !editor.isEditable;
+        });
+      };
+      const toggle = (event: Event) => {
+        if (!editor.isEditable) return;
+        event.preventDefault();
+        event.stopPropagation();
+        editor.view.dispatch(closeHistory(editor.state.tr));
+        editing = !editing;
+        sync();
+        if (editing) inputs.get('src')?.focus();
+        else image.focus();
+      };
+      const finish = (focus = false) => {
+        editing = false;
+        sync();
+        if (focus) image.focus();
+      };
+      const finishOutside = (event: Event) => {
+        if (editing && event.target instanceof globalThis.Node && !dom.contains(event.target)) finish();
+      };
+      document.addEventListener('click', finishOutside, true);
+      dom.addEventListener('keydown', event => {
+        if (event.key === 'Tab') window.setTimeout(() => {
+          if (dom.isConnected && !dom.contains(document.activeElement)) finish();
+        }, 0);
+      }, true);
+      image.addEventListener('keydown', event => {
+        if (event.key === 'Enter' || event.key === ' ') toggle(event);
+      });
+      action.addEventListener('click', toggle);
+      image.addEventListener('click', toggle);
+      fields.addEventListener('keydown', event => {
+        if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 's') return;
+        if ((event.key === 'Escape' || event.key === 'Enter') && !event.isComposing) {
+          event.preventDefault();
+          finish(true);
+        } else if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'z') {
+          event.preventDefault();
+          if (event.shiftKey) editor.commands.redo();
+          else editor.commands.undo();
+        }
+        event.stopPropagation();
+      });
+      sync();
+      editor.on('update', sync);
+      return {
+        dom,
+        update: updatedNode => {
+          if (updatedNode.type !== currentNode.type) return false;
+          currentNode = updatedNode;
+          sync();
+          return true;
+        },
+        stopEvent: event => event.target instanceof HTMLElement && !!event.target.closest('input, button'),
+        ignoreMutation: () => true,
+        destroy: () => {
+          editor.off('update', sync);
+          document.removeEventListener('click', finishOutside, true);
+        },
+      };
     };
   },
 });

--- a/src/web-ui/src/tools/editor/meditor/extensions/MarkdownTableExtensions.ts
+++ b/src/web-ui/src/tools/editor/meditor/extensions/MarkdownTableExtensions.ts
@@ -44,7 +44,8 @@ export const MarkdownTable = Node.create({
   },
 
   renderHTML({ HTMLAttributes }) {
-    return ['table', mergeAttributes(HTMLAttributes, { 'data-type': 'markdown-table' }), ['tbody', 0]];
+    return ['div', { class: 'table-wrapper' },
+      ['table', mergeAttributes(HTMLAttributes, { 'data-type': 'markdown-table' }), ['tbody', 0]]];
   },
 });
 

--- a/src/web-ui/src/tools/editor/meditor/extensions/RawHtmlExtensions.ts
+++ b/src/web-ui/src/tools/editor/meditor/extensions/RawHtmlExtensions.ts
@@ -1,12 +1,18 @@
 import React from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { Node } from '@tiptap/core';
+import { Selection, TextSelection } from '@tiptap/pm/state';
+import { closeHistory } from '@tiptap/pm/history';
+import { embeddedSource } from '../utils/embeddedSource';
 import { MarkdownRenderer } from '@/infrastructure/markdown';
 import { activeEditTargetService } from '@/tools/editor/services/ActiveEditTargetService';
 
 type SourceBackedBlockOptions = {
   basePath?: string;
   label?: string;
+  editLabel?: string;
+  doneLabel?: string;
+  typeLabels?: Record<string, string>;
 };
 
 type RawHtmlInlineOptions = {
@@ -209,10 +215,12 @@ function createSourceBackedBlock(
   valueAttr: 'html' | 'markdown' | 'yaml',
   className: string,
   metadataAttrs: readonly string[] = [],
+  inline = false,
 ) {
   return Node.create<SourceBackedBlockOptions>({
     name,
-    group: 'block',
+    group: inline ? 'inline' : 'block',
+    inline,
     atom: true,
     isolating: true,
     selectable: true,
@@ -240,7 +248,7 @@ function createSourceBackedBlock(
 
     parseHTML() {
       return [{
-        tag: `div[data-type="${name}"]`,
+        tag: `${inline ? 'span' : 'div'}[data-type="${name}"]`,
         getAttrs: element => ({
           [valueAttr]: element.getAttribute(`data-${valueAttr}`) ?? '',
           ...Object.fromEntries(metadataAttrs.map(attr => [
@@ -259,7 +267,7 @@ function createSourceBackedBlock(
         : null;
 
       return [
-        'div',
+        inline ? 'span' : 'div',
         {
           'data-type': name,
           [`data-${valueAttr}`]: value,
@@ -284,21 +292,26 @@ function createSourceBackedBlock(
         const textareaTargetId = `${name}-textarea-${++sourceBackedBlockTextareaTargetCounter}`;
         let unbindEditTarget: (() => void) | null = null;
 
-        const dom = document.createElement('div');
+        const tag = inline ? 'span' : 'div';
+        const dom: HTMLElement = document.createElement(tag);
         dom.className = className;
+        dom.contentEditable = 'false';
+        dom.dataset.testid = inline ? 'md-inline-math' : 'md-embed-block';
         dom.draggable = false;
         dom.setAttribute('draggable', 'false');
 
-        const body = document.createElement('div');
+        const body = document.createElement(tag);
         body.className = `${className}__body`;
         body.draggable = false;
         body.setAttribute('draggable', 'false');
 
-        const editorPane = document.createElement('div');
+        const editorPane = document.createElement(tag);
         editorPane.className = `${className}__pane ${className}__pane--editor`;
 
         const textarea = document.createElement('textarea');
         textarea.className = `${className}__textarea`;
+        textarea.dataset.testid = 'md-embed-source';
+        textarea.id = textareaTargetId;
         textarea.spellcheck = false;
         textarea.wrap = 'off';
         textarea.draggable = false;
@@ -315,14 +328,15 @@ function createSourceBackedBlock(
 
         editorPane.append(textarea);
 
-        const previewPane = document.createElement('div');
+        const previewPane = document.createElement(tag);
         previewPane.className = `${className}__pane ${className}__pane--preview`;
 
-        const preview = document.createElement('div');
+        const preview: HTMLElement = document.createElement(tag);
         preview.className = `${className}__preview markdown-body`;
         preview.draggable = false;
         preview.setAttribute('draggable', 'false');
         preview.tabIndex = 0;
+        preview.dataset.testid = 'md-embed-preview';
         previewRoot = createRoot(preview);
 
         const sourceFallback = document.createElement('pre');
@@ -331,19 +345,31 @@ function createSourceBackedBlock(
         previewPane.append(preview, sourceFallback);
         body.append(editorPane, previewPane);
 
-        if (this.options.label) {
-          const header = document.createElement('div');
-          header.className = `${className}__header`;
+        const header = document.createElement(tag);
+        header.className = 'm-editor-embed-toolbar';
+        const label = document.createElement('span');
+        label.className = 'm-editor-embed-label';
+        header.append(label);
 
-          const label = document.createElement('span');
-          label.className = `${className}__label`;
-          label.textContent = this.options.label;
-
-          header.append(label);
-          dom.append(header);
+        const editButton = document.createElement('button');
+        editButton.type = 'button';
+        editButton.className = 'm-editor-source-block-action';
+        editButton.contentEditable = 'false';
+        textarea.setAttribute('aria-label', this.options.editLabel ?? this.options.label ?? name);
+        editButton.dataset.testid = 'md-embed-edit';
+        editButton.setAttribute('aria-controls', textareaTargetId);
+        header.append(editButton);
+        if (inline) {
+          editorPane.prepend(header);
+          dom.append(body);
+        } else {
+          dom.append(header, body);
         }
 
-        dom.append(body);
+        const sourceModel = () => embeddedSource(
+          String(currentNode.attrs[valueAttr] ?? ''),
+          inline ? 'inlineMath' : name === 'rawHtmlBlock' ? 'html' : currentNode.attrs.kind,
+        );
 
         const applyAttrs = (attrs: Record<string, unknown>) => {
           const pos = typeof getPos === 'function' ? getPos() : null;
@@ -361,7 +387,15 @@ function createSourceBackedBlock(
 
         const syncEditingState = () => {
           dom.setAttribute('data-editing', isEditing ? 'true' : 'false');
-          preview.tabIndex = editor.isEditable ? -1 : 0;
+          header.hidden = !isEditing && name !== 'frontmatter';
+          preview.tabIndex = 0;
+          const language = name === 'frontmatter' ? 'yaml' : sourceModel().language;
+          dom.dataset.language = language;
+          label.textContent = this.options.label ?? this.options.typeLabels?.[language] ?? language;
+          preview.setAttribute('aria-label', label.textContent);
+          editButton.hidden = !editor.isEditable || (name === 'frontmatter' && !isEditing);
+          editButton.textContent = isEditing ? this.options.doneLabel ?? 'Done' : this.options.editLabel ?? 'Edit';
+          editButton.setAttribute('aria-expanded', String(isEditing));
         };
 
         const setEditing = (nextEditing: boolean, options?: { focus?: boolean }) => {
@@ -377,6 +411,8 @@ function createSourceBackedBlock(
             frontmatterEditingMinHeight = previewPane.getBoundingClientRect().height;
           }
 
+          // Separate two block-edit sessions in document undo history.
+          editor.view.dispatch(closeHistory(editor.state.tr));
           isEditing = resolvedEditing;
           syncEditingState();
 
@@ -394,9 +430,34 @@ function createSourceBackedBlock(
           }
         };
 
-        const exitEditing = () => {
+        const exitEditing = (focus = true) => {
           setEditing(false);
+          activeEditTargetService.clearActiveTarget(textareaTargetId);
+          if (focus) preview.focus();
         };
+
+        const moveOutside = (direction: -1 | 1) => {
+          const pos = getPos();
+          if (typeof pos !== 'number') return;
+          exitEditing(false);
+          const edge = pos + (direction === 1 ? currentNode.nodeSize : 0);
+          const state = editor.state;
+          if (inline) {
+            editor.view.dispatch(state.tr.setSelection(TextSelection.create(state.doc, edge)));
+          } else {
+            const boundary = state.doc.resolve(edge);
+            const adjacent = direction === 1 ? boundary.nodeAfter : boundary.nodeBefore;
+            const selection = adjacent?.isTextblock ? Selection.findFrom(boundary, direction, true) : null;
+            if (selection) editor.view.dispatch(state.tr.setSelection(selection));
+            else {
+              if (!editor.isEditable) return;
+              const tr = state.tr.insert(edge, state.schema.nodes.paragraph.create());
+              editor.view.dispatch(tr.setSelection(TextSelection.create(tr.doc, edge + 1)));
+            }
+          }
+          editor.view.focus();
+        };
+
 
         const renderPreview = (markdown: string) => {
           if (name === 'frontmatter') {
@@ -414,14 +475,7 @@ function createSourceBackedBlock(
 
           const kind = typeof currentNode.attrs.kind === 'string' ? currentNode.attrs.kind : null;
           const detailsSource = kind === 'details' ? parseDetailsSource(markdown) : null;
-          const shouldCheckPreviewVisibility = name === 'rawHtmlBlock' || kind === 'details';
-
           const syncPreviewVisibility = (fallbackToMarkdownRenderer = false) => {
-            if (!shouldCheckPreviewVisibility) {
-              dom.setAttribute('data-preview-empty', 'false');
-              return;
-            }
-
             if (previewCheckTimer !== null) {
               window.clearTimeout(previewCheckTimer);
             }
@@ -513,8 +567,9 @@ function createSourceBackedBlock(
 
           dom.setAttribute('data-readonly', editable ? 'false' : 'true');
 
-          if (valueChanged && textarea.value !== value) {
-            textarea.value = value;
+          const payload = sourceModel().source;
+          if (valueChanged && textarea.value !== payload) {
+            textarea.value = payload;
           }
 
           syncFrontmatterTextareaHeight();
@@ -545,15 +600,39 @@ function createSourceBackedBlock(
         };
 
         const handleTextareaKeyDown = (event: KeyboardEvent) => {
-          if (isSelectAllShortcut(event)) {
+          if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 's') {
+            return; // Let the document owner save, including this block's changes.
+          }
+          if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'z') {
+            event.preventDefault();
+            if (event.shiftKey) editor.commands.redo();
+            else editor.commands.undo();
+          } else if (isSelectAllShortcut(event)) {
             event.preventDefault();
             textarea.select();
+          } else if (event.key === 'Enter' && (event.ctrlKey || event.metaKey) && !event.isComposing) {
+            event.preventDefault();
+            moveOutside(1);
+          } else if (event.key === 'Escape' && !event.isComposing) {
+            event.preventDefault();
+            exitEditing();
           }
-
           event.stopPropagation();
         };
 
         const handlePreviewKeyDown = (event: KeyboardEvent) => {
+          if (event.target !== preview) return;
+          if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 's') return;
+          if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
+            event.preventDefault();
+            moveOutside(1);
+          } else if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
+            event.preventDefault();
+            moveOutside(-1);
+          } else if (editor.isEditable && (event.key === 'Enter' || event.key === ' ')) {
+            event.preventDefault();
+            enterEditing();
+          }
           if (isSelectAllShortcut(event)) {
             event.preventDefault();
             selectElementContent(preview);
@@ -573,7 +652,7 @@ function createSourceBackedBlock(
           }
         };
 
-        const handlePreviewMouseDown = (event: MouseEvent) => {
+        const handlePreviewMouseDown = (event: Event) => {
           if (!editor.isEditable) {
             focusElementWithoutScroll(preview);
           }
@@ -581,13 +660,13 @@ function createSourceBackedBlock(
           event.stopPropagation();
         };
 
-        const handlePreviewDoubleClick = (event: MouseEvent) => {
+        const handlePreviewEdit = (event: Event) => {
           const target = event.target;
-          if (!(target instanceof HTMLElement)) {
+          if (!(target instanceof Element)) {
             return;
           }
 
-          if (target.closest('a, summary')) {
+          if (target.closest('a, summary, button, input, video, audio, select, textarea')) {
             event.stopPropagation();
             return;
           }
@@ -621,13 +700,19 @@ function createSourceBackedBlock(
         textarea.addEventListener('click', stopPropagation);
         textarea.addEventListener('keydown', handleTextareaKeyDown);
         textarea.addEventListener('focus', handleTextareaFocus);
-        textarea.addEventListener('blur', exitEditing);
         textarea.addEventListener('blur', handleTextareaBlur);
 
         preview.addEventListener('mousedown', handlePreviewMouseDown);
         preview.addEventListener('click', handlePreviewClickCapture, true);
         preview.addEventListener('click', stopPropagation);
-        preview.addEventListener('dblclick', handlePreviewDoubleClick);
+        preview.addEventListener('click', handlePreviewEdit);
+        sourceFallback.addEventListener('click', handlePreviewEdit);
+        editButton.addEventListener('mousedown', event => event.preventDefault());
+        editButton.addEventListener('click', event => {
+          event.stopPropagation();
+          if (isEditing) exitEditing();
+          else enterEditing();
+        });
         preview.addEventListener('keydown', handlePreviewKeyDown);
 
         [dom, body, textarea, preview].forEach((element) => {
@@ -635,7 +720,8 @@ function createSourceBackedBlock(
         });
 
         textarea.addEventListener('input', () => {
-          const nextValue = textarea.value;
+          if (!editor.isEditable) return;
+          const nextValue = sourceModel().wrap(textarea.value);
           lastSyncedValue = nextValue;
           syncFrontmatterTextareaHeight();
           applyAttrs({ [valueAttr]: nextValue });
@@ -652,8 +738,8 @@ function createSourceBackedBlock(
             const activeElement = typeof document !== 'undefined' ? document.activeElement : null;
             return activeElement === textarea;
           },
-          undo: () => executeTextareaAction(textarea, 'undo'),
-          redo: () => executeTextareaAction(textarea, 'redo'),
+          undo: () => editor.commands.undo(),
+          redo: () => editor.commands.redo(),
           cut: () => executeTextareaAction(textarea, 'cut'),
           copy: () => executeTextareaAction(textarea, 'copy'),
           paste: () => executeTextareaAction(textarea, 'paste'),
@@ -661,7 +747,19 @@ function createSourceBackedBlock(
           containsElement: (element) => element === textarea,
         });
 
+        const finishOutside = (event: Event) => {
+          if (isEditing && event.target instanceof globalThis.Node && !dom.contains(event.target)) {
+            exitEditing(false);
+          }
+        };
+        document.addEventListener('click', finishOutside, true);
+        dom.addEventListener('keydown', event => {
+          if (event.key === 'Tab') window.setTimeout(() => {
+            if (dom.isConnected && !dom.contains(document.activeElement)) exitEditing(false);
+          }, 0);
+        }, true);
         sync();
+        editor.on('update', sync);
 
         return {
           dom,
@@ -681,7 +779,7 @@ function createSourceBackedBlock(
 
             const target = event.target;
             return target instanceof HTMLElement && dom.contains(target) && (
-              !!target.closest('textarea') ||
+              !!target.closest('textarea, button') ||
               !!target.closest(`.${className}__preview`)
             );
           },
@@ -690,6 +788,8 @@ function createSourceBackedBlock(
             return target instanceof globalThis.Node && dom.contains(target);
           },
           destroy: () => {
+            editor.off('update', sync);
+            document.removeEventListener('click', finishOutside, true);
             activeEditTargetService.clearActiveTarget(textareaTargetId);
             unbindEditTarget?.();
             unbindEditTarget = null;
@@ -697,14 +797,18 @@ function createSourceBackedBlock(
               window.clearTimeout(previewCheckTimer);
               previewCheckTimer = null;
             }
-            previewRoot?.unmount();
+            const root = previewRoot;
             previewRoot = null;
+            // NodeViews can be destroyed during the parent React commit.
+            queueMicrotask(() => root?.unmount());
           },
         };
       };
     },
   });
 }
+
+export const InlineMath = createSourceBackedBlock('inlineMath', 'markdown', 'm-editor-inline-math', [], true);
 
 export const RenderOnlyBlock = createSourceBackedBlock(
   'renderOnlyBlock',
@@ -773,11 +877,49 @@ export const RawHtmlInline = Node.create<RawHtmlInlineOptions>({
   },
 
   addNodeView() {
-    return ({ node }) => ({
-      dom: createRawHtmlInlinePreviewNode(
-        String(node.attrs.html ?? ''),
-        this.options.label,
-      ),
-    });
+    return ({ editor, node, getPos }) => {
+      let currentNode = node;
+      const dom = createRawHtmlInlinePreviewNode(String(node.attrs.html ?? ''), this.options.label);
+      const source = dom.querySelector('code')!;
+      const input = document.createElement('input');
+      input.className = 'm-editor-raw-html-inline__source';
+      input.setAttribute('aria-label', this.options.label);
+      const sync = () => {
+        input.value = String(currentNode.attrs.html ?? '');
+        input.readOnly = !editor.isEditable;
+        input.size = Math.max(1, Math.min(input.value.length, 50));
+      };
+      source.replaceWith(input);
+      input.addEventListener('input', () => {
+        const pos = getPos();
+        if (!editor.isEditable || typeof pos !== 'number') return;
+        editor.view.dispatch(editor.state.tr.setNodeMarkup(pos, undefined, {
+          ...currentNode.attrs, html: input.value,
+        }));
+      });
+      input.addEventListener('keydown', event => {
+        if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 's') return;
+        if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'z') {
+          event.preventDefault();
+          if (event.shiftKey) editor.commands.redo();
+          else editor.commands.undo();
+        }
+        event.stopPropagation();
+      });
+      sync();
+      editor.on('update', sync);
+      return {
+        dom,
+        update: updatedNode => {
+          if (updatedNode.type !== currentNode.type) return false;
+          currentNode = updatedNode;
+          sync();
+          return true;
+        },
+        stopEvent: event => event.target === input,
+        ignoreMutation: () => true,
+        destroy: () => { editor.off('update', sync); },
+      };
+    };
   },
 });

--- a/src/web-ui/src/tools/editor/meditor/extensions/RawHtmlExtensions.ts
+++ b/src/web-ui/src/tools/editor/meditor/extensions/RawHtmlExtensions.ts
@@ -4,6 +4,7 @@ import { Node } from '@tiptap/core';
 import { Selection, TextSelection } from '@tiptap/pm/state';
 import { closeHistory } from '@tiptap/pm/history';
 import { embeddedSource } from '../utils/embeddedSource';
+import { sourceBlockPreview } from '../utils/sourceBlockPreview';
 import { MarkdownRenderer } from '@/infrastructure/markdown';
 import { activeEditTargetService } from '@/tools/editor/services/ActiveEditTargetService';
 
@@ -20,6 +21,8 @@ type RawHtmlInlineOptions = {
 };
 
 let sourceBackedBlockTextareaTargetCounter = 0;
+let referencePreviewCounter = 0;
+const referencePreviewPrefixes = new WeakMap<object, string>();
 
 function createRawHtmlInlinePreviewNode(
   html: string,
@@ -282,10 +285,16 @@ function createSourceBackedBlock(
 
     addNodeView() {
       return ({ editor, node, getPos }) => {
+        if (!referencePreviewPrefixes.has(editor)) {
+          referencePreviewPrefixes.set(editor, `md-reference-${++referencePreviewCounter}-`);
+        }
+        const referencePrefix = referencePreviewPrefixes.get(editor)!;
         let currentNode = node;
         let isEditing = false;
         let lastSyncedValue: string | null = null;
         let lastEditableState = editor.isEditable;
+        let lastReferenceContent: string | undefined;
+        let lastReferenceStart: number | undefined;
         let previewRoot: Root | null = null;
         let previewCheckTimer: number | null = null;
         let frontmatterEditingMinHeight = 0;
@@ -460,6 +469,10 @@ function createSourceBackedBlock(
 
 
         const renderPreview = (markdown: string) => {
+          const pos = getPos();
+          const referencePreview = name === 'renderOnlyBlock' || name === 'rawHtmlBlock'
+            ? typeof pos === 'number' ? sourceBlockPreview(editor.state.doc, pos, referencePrefix) : undefined
+            : undefined;
           if (name === 'frontmatter') {
             previewRoot?.render(
               React.createElement(
@@ -549,6 +562,7 @@ function createSourceBackedBlock(
           previewRoot?.render(
             React.createElement(MarkdownRenderer, {
               content: markdown,
+              ...referencePreview,
               basePath: this.options.basePath,
               className: `${className}__markdown`,
             }),
@@ -564,6 +578,11 @@ function createSourceBackedBlock(
           const editable = editor.isEditable;
           const valueChanged = lastSyncedValue !== value;
           const editableChanged = lastEditableState !== editable;
+          const pos = getPos();
+          const referencePreview = (name === 'renderOnlyBlock' || name === 'rawHtmlBlock') && typeof pos === 'number'
+            ? sourceBlockPreview(editor.state.doc, pos, referencePrefix) : undefined;
+          const referencesChanged = lastReferenceContent !== referencePreview?.content ||
+            lastReferenceStart !== referencePreview?.sourceRange.start;
 
           dom.setAttribute('data-readonly', editable ? 'false' : 'true');
 
@@ -580,12 +599,14 @@ function createSourceBackedBlock(
           }
           syncEditingState();
 
-          if (valueChanged || editableChanged) {
+          if (valueChanged || editableChanged || referencesChanged) {
             renderPreview(value);
           }
 
           lastSyncedValue = value;
           lastEditableState = editable;
+          lastReferenceContent = referencePreview?.content;
+          lastReferenceStart = referencePreview?.sourceRange.start;
         };
 
         const enterEditing = () => {
@@ -760,6 +781,7 @@ function createSourceBackedBlock(
         }, true);
         sync();
         editor.on('update', sync);
+        editor.on('transaction', sync);
 
         return {
           dom,
@@ -789,6 +811,7 @@ function createSourceBackedBlock(
           },
           destroy: () => {
             editor.off('update', sync);
+            editor.off('transaction', sync);
             document.removeEventListener('click', finishOutside, true);
             activeEditTargetService.clearActiveTarget(textareaTargetId);
             unbindEditTarget?.();

--- a/src/web-ui/src/tools/editor/meditor/hooks/useEditor.ts
+++ b/src/web-ui/src/tools/editor/meditor/hooks/useEditor.ts
@@ -6,10 +6,11 @@ import type { EditorInstance, EditorMode } from '../types'
  */
 export function useEditor(
   initialValue: string = '',
-  onChange?: (value: string) => void
+  onChange?: (value: string) => void,
+  initialMode: EditorMode = 'ir',
 ) {
   const [value, setValue] = useState(initialValue)
-  const [mode, setMode] = useState<EditorMode>('ir')
+  const [mode, setMode] = useState<EditorMode>(initialMode)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
 
   const handleChange = useCallback((newValue: string) => {

--- a/src/web-ui/src/tools/editor/meditor/utils/embeddedSource.test.ts
+++ b/src/web-ui/src/tools/editor/meditor/utils/embeddedSource.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { embeddedSource } from './embeddedSource';
+
+describe('embedded source payloads', () => {
+  it.each([
+    ['```mermaid\ngraph TD\n  A-->B\n```', 'code', 'graph TD\n  A-->B'],
+    ['~~~js title="sample"\r\nconst x = 1;\r\n~~~~', 'code', 'const x = 1;'],
+    ['$$\nx^2\n$$', 'math', 'x^2'],
+    ['$x^2$', 'inlineMath', 'x^2'],
+    ['<div>HTML</div>', 'html', '<div>HTML</div>'],
+  ])('retains wrappers and metadata: %s', (markdown, kind, source) => {
+    const payload = embeddedSource(markdown, kind);
+    expect(payload.source).toBe(source);
+    expect(payload.wrap(source)).toBe(markdown);
+  });
+
+  it('lengthens a code fence when the edited content contains a closing fence', () => {
+    const payload = embeddedSource('```md\nold\n```', 'code');
+    expect(payload.wrap('```\nnew')).toBe('````md\n```\nnew\n````');
+  });
+});

--- a/src/web-ui/src/tools/editor/meditor/utils/embeddedSource.ts
+++ b/src/web-ui/src/tools/editor/meditor/utils/embeddedSource.ts
@@ -1,0 +1,34 @@
+/** Present the editable payload while retaining the Markdown wrapper on disk. */
+export function embeddedSource(markdown: string, kind?: string | null) {
+  const fenced = markdown.match(/^( {0,3})(`{3,}|~{3,})([^\r\n]*)(\r?\n)([\s\S]*?)(\r?\n)( {0,3})(`{3,}|~{3,})([ \t]*)$/);
+  if (fenced && fenced[2][0] === fenced[8][0] && fenced[8].length >= fenced[2].length) {
+    const [, indent, fence, info, openingNewline, source, closingNewline, closingIndent, closingFence, trailing] = fenced;
+    return {
+      source,
+      language: info.trim().split(/\s/)[0] || 'code',
+      wrap: (value: string) => {
+        // Pasting a fence into a code block must not terminate that block.
+        const runs = value.match(fence[0] === '`' ? /^ {0,3}`{3,}/gm : /^ {0,3}~{3,}/gm) ?? [];
+        const length = Math.max(fence.length, ...runs.map(run => run.trim().length + 1));
+        const opening = fence[0].repeat(length);
+        const closing = fence[0].repeat(Math.max(closingFence.length, length));
+        return `${indent}${opening}${info}${openingNewline}${value}${closingNewline}${closingIndent}${closing}${trailing}`;
+      },
+    };
+  }
+  if (kind === 'math' || kind === 'inlineMath') {
+    const math = markdown.match(/^(\${1,})([\s\S]*?)\1$/);
+    if (math) {
+      const [, delimiter, body] = math;
+      const opening = body.match(/^\r?\n/)?.[0] ?? '';
+      const closing = body.match(/\r?\n$/)?.[0] ?? '';
+      const source = body.slice(opening.length, closing ? -closing.length : undefined);
+      return {
+        source,
+        language: 'math',
+        wrap: (value: string) => `${delimiter}${opening}${value}${closing}${delimiter}`,
+      };
+    }
+  }
+  return { source: markdown, language: kind ?? 'markdown', wrap: (value: string) => value };
+}

--- a/src/web-ui/src/tools/editor/meditor/utils/loadLocalImages.test.ts
+++ b/src/web-ui/src/tools/editor/meditor/utils/loadLocalImages.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { loadLocalImages } from './loadLocalImages';
+
+const { readFileContent } = vi.hoisted(() => ({ readFileContent: vi.fn() }));
+vi.mock('@/infrastructure/api', () => ({ workspaceAPI: { readFileContent } }));
+vi.mock('@/infrastructure/i18n', () => ({ i18nService: { t: (key: string) => key } }));
+vi.mock('@/shared/utils/logger', () => ({
+  createLogger: () => ({ warn: vi.fn(), error: vi.fn() }),
+}));
+
+describe('local image source changes', () => {
+  it.each(['resolve', 'reject'] as const)('ignores a stale request that later %ss', async outcome => {
+    let resolveOld!: (value: string) => void;
+    let rejectOld!: (error: Error) => void;
+    const oldPath = `/workspace/${outcome}-old.png`;
+    const newPath = `/workspace/${outcome}-new.png`;
+    const oldRead = new Promise<string>((resolve, reject) => { resolveOld = resolve; rejectOld = reject; });
+    readFileContent.mockImplementation((path: string) => path === oldPath ? oldRead : Promise.resolve('bmV3'));
+    const container = document.createElement('div');
+    const image = document.createElement('img');
+    container.append(image);
+    image.dataset.localImage = 'true';
+    image.dataset.localPath = oldPath;
+    const oldLoad = loadLocalImages(container);
+    await vi.waitFor(() => expect(readFileContent).toHaveBeenCalledWith(oldPath));
+    image.dataset.localPath = newPath;
+    image.alt = 'New image';
+    await loadLocalImages(container);
+    if (outcome === 'resolve') resolveOld('b2xk');
+    else rejectOld(new Error('Old request failed'));
+    await oldLoad;
+    expect(image.getAttribute('src')).toBe('data:image/png;base64,bmV3');
+    expect(image.alt).toBe('New image');
+    expect(image.classList.contains('local-image-error')).toBe(false);
+  });
+});

--- a/src/web-ui/src/tools/editor/meditor/utils/loadLocalImages.ts
+++ b/src/web-ui/src/tools/editor/meditor/utils/loadLocalImages.ts
@@ -77,8 +77,11 @@ export async function loadLocalImages(container: HTMLElement): Promise<void> {
     
     try {
       const dataUrl = await getLocalImageDataUrl(localPath);
+      // The same image element may now point at another source.
+      if (img.getAttribute('data-local-path') !== localPath) return;
       markLocalImageLoaded(img, dataUrl);
     } catch (error) {
+      if (img.getAttribute('data-local-path') !== localPath) return;
       log.error('Failed to load local image', { path: localPath, error });
       
       img.classList.remove('local-image-loading');

--- a/src/web-ui/src/tools/editor/meditor/utils/sourceBlockPreview.ts
+++ b/src/web-ui/src/tools/editor/meditor/utils/sourceBlockPreview.ts
@@ -1,0 +1,52 @@
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkGfm from 'remark-gfm';
+import type { MarkdownSourceRange } from '@/infrastructure/markdown/rehypeSourceRange';
+
+type SourceRegion = { start: number; end: number };
+type ReferenceNode = {
+  type: string;
+  position?: { start: { offset?: number }; end: { offset?: number } };
+  children?: ReferenceNode[];
+};
+const referenceTypes = new Set([
+  'definition', 'linkReference', 'imageReference', 'footnoteDefinition', 'footnoteReference',
+]);
+const contexts = new WeakMap<ProseMirrorNode, { content: string; regions: Map<number, SourceRegion> }>();
+
+/** Source-backed nodes share reference facts, while native editor blocks stay native. */
+export function sourceBlockPreview(doc: ProseMirrorNode, pos: number, idPrefix: string): {
+  content: string;
+  sourceRange: MarkdownSourceRange;
+} | undefined {
+  let context = contexts.get(doc);
+  if (!context) {
+    let content = '';
+    const candidates = new Map<number, SourceRegion>();
+    doc.descendants((node, offset) => {
+      if (node.type.name !== 'renderOnlyBlock' && node.type.name !== 'rawHtmlBlock') return;
+      const source = String(node.attrs.markdown ?? node.attrs.html ?? '');
+      if (content) content += '\n\n';
+      const start = content.length;
+      content += source;
+      candidates.set(offset, { start, end: content.length });
+    });
+    const references: SourceRegion[] = [];
+    const visit = (node: ReferenceNode) => {
+      const start = node.position?.start.offset;
+      const end = node.position?.end.offset;
+      if (referenceTypes.has(node.type) && start !== undefined && end !== undefined) {
+        references.push({ start, end });
+      }
+      node.children?.forEach(visit);
+    };
+    if (content) visit(unified().use(remarkParse).use(remarkGfm).parse(content));
+    const regions = new Map([...candidates].filter(([, region]) =>
+      references.some(ref => ref.start >= region.start && ref.end <= region.end)));
+    context = { content, regions };
+    contexts.set(doc, context);
+  }
+  const region = context.regions.get(pos);
+  return region ? { content: context.content, sourceRange: { ...region, idPrefix } } : undefined;
+}

--- a/src/web-ui/src/tools/editor/meditor/utils/tiptapMarkdown.test.ts
+++ b/src/web-ui/src/tools/editor/meditor/utils/tiptapMarkdown.test.ts
@@ -4,6 +4,7 @@ import {
   canRoundTripMarkdownWithTiptap,
   getUnsupportedTiptapMarkdownFeatures,
   markdownToTiptapDoc,
+  markdownToEditableTiptapDoc,
   tiptapDocToMarkdown,
   tiptapDocToTopLevelMarkdownBlocks,
 } from './tiptapMarkdown';
@@ -288,7 +289,7 @@ describe('tiptap markdown compatibility', () => {
     expect(analysis.containsRawHtmlBlocks).toBe(false);
   });
 
-  it('preserves inline raw html fragments inside markdown paragraphs', () => {
+  it('preserves paragraphs with raw inline HTML as editable embedded blocks', () => {
     const markdown = 'Mix <span data-x="1">inline</span> HTML into markdown.';
 
     const doc = markdownToTiptapDoc(markdown);
@@ -297,7 +298,8 @@ describe('tiptap markdown compatibility', () => {
 
     expect(serialized).toBe(markdown);
     expect(analysis.mode).toBe('lossless');
-    expect(analysis.containsRawHtmlInlines).toBe(true);
+    expect(analysis.containsRawHtmlInlines).toBe(false);
+    expect(analysis.containsRenderOnlyBlocks).toBe(true);
     expect(analysis.containsRawHtmlBlocks).toBe(false);
   });
 
@@ -398,5 +400,45 @@ describe('tiptap markdown compatibility', () => {
     expect(analysis.mode).toBe('lossless');
     expect(analysis.containsRawHtmlBlocks).toBe(true);
     expect(doc.content?.[0]?.type).toBe('rawHtmlBlock');
+  });
+});
+
+
+describe('editable embedded Markdown blocks', () => {
+  it.each([
+    '```mermaid\ngraph TD\n  A-->B\n```',
+    '~~~mermaid\ngraph TD\n  A-->B\n~~~',
+    '<div data-custom="yes">HTML</div>',
+    'Text <span data-x="1">inline</span>.',
+    'Footnote[^a].\n\n[^a]: Definition',
+    '[Link][ref]\n\n[ref]: https://example.com',
+    '$$\nx^2\n$$',
+    '```js title="example"\nconst x = 1;\n```',
+  ])('keeps the original embedded source on a round trip: %s', block => {
+    const markdown = '# Before\n\n' + block + '\n\nAfter';
+    const doc = markdownToEditableTiptapDoc(markdown);
+    expect(doc.content?.[0].type).toBe('heading');
+    expect(doc.content?.at(-1)?.type).toBe('paragraph');
+    expect(tiptapDocToMarkdown(doc)).toBe(markdown);
+    const embedded = doc.content?.find(node => node.type === 'renderOnlyBlock' || node.type === 'rawHtmlBlock');
+    expect(embedded).toBeDefined();
+  });
+});
+
+describe('inline and nested special content', () => {
+  it.each(['Before $x^2$ after.', '**Before $x$ after.**', 'Before $$x + y$$ after.'])('keeps inline formulas inside editable paragraphs: %s', markdown => {
+    const doc = markdownToEditableTiptapDoc(markdown);
+    expect(doc.content?.[0].type).toBe('paragraph');
+    expect(doc.content?.[0].content?.some(node => node.type === 'inlineMath')).toBe(true);
+    expect(tiptapDocToMarkdown(doc)).toBe(markdown);
+  });
+  it('preserves native list text around nested Mermaid', () => {
+    const markdown = '- Editable item\n  \n  ```mermaid\n  graph TD\n    A-->B\n  ```';
+    const doc = markdownToEditableTiptapDoc(markdown);
+    expect(doc.content?.[0].type).toBe('bulletList');
+    expect(doc.content?.[0].content?.[0].content?.map(node => node.type)).toEqual(['paragraph', 'renderOnlyBlock']);
+    const serialized = tiptapDocToMarkdown(doc);
+    expect(serialized).toContain('  ```mermaid\n  graph TD\n    A-->B\n  ```');
+    expect(markdownToEditableTiptapDoc(serialized).content?.[0].type).toBe('bulletList');
   });
 });

--- a/src/web-ui/src/tools/editor/meditor/utils/tiptapMarkdown.ts
+++ b/src/web-ui/src/tools/editor/meditor/utils/tiptapMarkdown.ts
@@ -1,6 +1,7 @@
 import { unified } from 'unified';
 import remarkGfm from 'remark-gfm';
 import remarkParse from 'remark-parse';
+import remarkMath from 'remark-math';
 import remarkRehype from 'remark-rehype';
 import rehypeRaw from 'rehype-raw';
 import type { JSONContent } from '@tiptap/core';
@@ -10,8 +11,10 @@ import { serializeMarkdownFrontmatter, splitMarkdownFrontmatter } from './markdo
 type MdastNode = {
   type?: string;
   value?: string;
+  source?: string;
   depth?: number;
   lang?: string | null;
+  meta?: string | null;
   url?: string;
   alt?: string | null;
   title?: string | null;
@@ -23,6 +26,7 @@ type MdastNode = {
   position?: {
     start?: {
       offset?: number;
+      column?: number;
     };
     end?: {
       offset?: number;
@@ -97,6 +101,14 @@ type HastNode = {
   properties?: Record<string, unknown>;
   children?: HastNode[];
 };
+
+// Unsupported syntax stays in the smallest containing Markdown block, rather
+// than disabling rich text for the whole document or dropping unknown nodes.
+const NATIVE_MARKDOWN_TYPES = new Set([
+  'paragraph', 'heading', 'text', 'html', 'inlineCode', 'image', 'strong',
+  'emphasis', 'delete', 'link', 'break', 'blockquote', 'list', 'listItem',
+  'table', 'tableRow', 'tableCell', 'code', 'thematicBreak', 'inlineMath',
+]);
 
 const TOP_LEVEL_BLOCK_TYPES = new Set([
   'paragraph',
@@ -528,6 +540,10 @@ function convertInlineNodes(nodes: MdastNode[], marks: Mark[] = []): JSONContent
         activeMarks = htmlFragment.activeMarks;
         return;
       }
+      case 'inlineMath':
+        content.push({ type: 'inlineMath', attrs: { markdown: node.source ?? `$${node.value ?? ''}$`, kind: 'inlineMath' },
+          ...(activeMarks.length ? { marks: activeMarks } : {}) });
+        return;
       case 'inlineCode':
         content.push(...createTextNode(node.value ?? '', [...activeMarks, { type: 'code' }]));
         return;
@@ -629,6 +645,10 @@ function convertTable(node: MdastNode): JSONContent[] {
 }
 
 function convertBlock(node: MdastNode): JSONContent[] {
+  if (node.source && (node.type === 'math' || (node.type === 'code' &&
+      (node.lang?.toLowerCase() === 'mermaid' || node.meta)))) {
+    return [createRenderOnlyBlock(node.source, node.type)];
+  }
   switch (node.type) {
     case 'paragraph': {
       const inline = convertInlineNodes(node.children ?? []);
@@ -743,10 +763,20 @@ function walkMdast(node: MdastNode | null | undefined, visit: (current: MdastNod
 }
 
 function parseMarkdownTree(markdown: string): MdastNode {
-  return unified()
+  const tree = unified()
     .use(remarkParse)
     .use(remarkGfm)
+    .use(remarkMath)
     .parse(markdown) as MdastNode;
+  walkMdast(tree, node => {
+    if (node.type === 'inlineMath' || node.type === 'math' || node.type === 'code') {
+      const raw = markdown.slice(node.position?.start?.offset, node.position?.end?.offset);
+      const indent = Math.max(0, (node.position?.start?.column ?? 1) - 1);
+      node.source = raw.split('\n').map((line, index) => index === 0 ? line
+        : line.replace(new RegExp(`^[ \t>]{0,${indent}}`), '')).join('\n');
+    }
+  });
+  return tree;
 }
 
 function normalizeComparableJson(
@@ -1261,15 +1291,6 @@ export function analyzeMarkdownEditability(markdown: string): MarkdownEditabilit
     softIssues.add('multipleTrailingBlankLines');
   }
 
-  const frontmatter = splitMarkdownFrontmatter(markdown);
-  const tree = parseMarkdownTree(frontmatter?.body ?? markdown);
-
-  walkMdast(tree, (node) => {
-    if (node.type === 'footnoteDefinition' || node.type === 'footnoteReference') {
-      hardIssues.add('footnote');
-    }
-  });
-
   if (!textEqual) {
     softIssues.add('roundTripMismatch');
   }
@@ -1373,6 +1394,11 @@ function renderInline(content: JSONContent[] = []): string {
 
     if (node.type === 'hardBreak') {
       result += '  \n';
+      return;
+    }
+
+    if (node.type === 'inlineMath') {
+      result += applyLinkMarks(String(node.attrs?.markdown ?? ''), marks);
       return;
     }
 
@@ -1514,7 +1540,40 @@ function convertRootMarkdownChildren(children: MdastNode[], markdown: string): J
       }
     }
 
-    const nextNodes = convertBlock(child).map(node => withBlockAttrs(
+    let needsSourceBlock = false;
+    walkMdast(child, node => {
+      // Container children can host their own source-backed blocks.
+      if ((child.type === 'list' || child.type === 'blockquote') &&
+          (node.type === 'math' || node.type === 'code')) return;
+      if (!NATIVE_MARKDOWN_TYPES.has(node.type ?? '') ||
+          (node.type === 'code' && (node.lang?.toLowerCase() === 'mermaid' || node.meta))) {
+        needsSourceBlock = true;
+      }
+    });
+    if (needsSourceBlock) {
+      const start = getNodeStartOffset(child);
+      const end = getNodeEndOffset(child);
+      if (start !== null && end !== null) {
+        content.push(withBlockAttrs(
+          createRenderOnlyBlock(markdown.slice(start, end), child.type ?? 'markdown'),
+          alignmentState.activeAlign,
+          alignmentState.activeGroupId,
+        ));
+        continue;
+      }
+    }
+
+    const converted = convertBlock(child);
+    let containsRawInline = false;
+    converted.forEach(node => walkTiptapDoc(node, descendant => {
+      if (descendant.type === 'rawHtmlInline') containsRawInline = true;
+    }));
+    const start = getNodeStartOffset(child);
+    const end = getNodeEndOffset(child);
+    const editableNodes = containsRawInline && start !== null && end !== null
+      ? [createRenderOnlyBlock(markdown.slice(start, end), 'html')]
+      : converted;
+    const nextNodes = editableNodes.map(node => withBlockAttrs(
       node,
       alignmentState.activeAlign,
       alignmentState.activeGroupId,
@@ -1724,6 +1783,18 @@ export function markdownToTiptapDoc(markdown: string): JSONContent {
     type: 'doc',
     content: content.length > 0 ? content : [createParagraph()],
   };
+}
+
+/** Last-resort source-backed block for documents whose structure cannot round-trip.
+ * Rendered blocks remain editable; never feed lossy conversion into the editor.
+ */
+export function markdownToEditableTiptapDoc(markdown: string): JSONContent {
+  if (analyzeMarkdownEditability(markdown).mode === 'unsafe') {
+    return { type: 'doc', content: withTopLevelBlockIds([
+      createRenderOnlyBlock(markdown, 'markdown'),
+    ]) };
+  }
+  return markdownToTiptapDoc(markdown);
 }
 
 export function tiptapDocToMarkdown(

--- a/src/web-ui/tests/e2e/image.svg
+++ b/src/web-ui/tests/e2e/image.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="64" viewBox="0 0 160 64"><rect width="160" height="64" fill="none" stroke="currentColor"/><text x="12" y="36" fill="currentColor">Image fixture</text></svg>

--- a/src/web-ui/tests/e2e/markdown-editor.html
+++ b/src/web-ui/tests/e2e/markdown-editor.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<html lang="en-US">
+<head><meta charset="utf-8"><!-- OPENBITFUN_FONT_PROFILE_STYLESHEET --><title>Markdown editor E2E</title></head>
+<body><div id="root"></div><script type="module" src="./markdown-editor.tsx"></script></body>
+</html>

--- a/src/web-ui/tests/e2e/markdown-editor.tsx
+++ b/src/web-ui/tests/e2e/markdown-editor.tsx
@@ -1,0 +1,41 @@
+import React, { useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import '@openbitfun/ui/styles.css';
+import '@openbitfun/design-tokens/tokens.css';
+import '@openbitfun/theme-openbitfun/default.css';
+import '../../src/app/styles/index.scss';
+import { I18nProvider, i18nService } from '../../src/infrastructure/i18n';
+import { OpenBitFunDesignSystemProvider } from '../../src/infrastructure/design-system';
+import { appearanceRuntime, buildBuiltinAppearance, openBitFunDarkPalette } from '../../src/infrastructure/appearance';
+import { workspaceAPI } from '../../src/infrastructure/api';
+import MarkdownEditor from '../../src/tools/editor/components/MarkdownEditor';
+import { Preview } from '../../src/tools/editor/meditor/components/Preview';
+
+// Only the filesystem boundary is replaced. The production file editor, parser,
+// renderer, dirty tracking, disk polling and save/conflict flow all run normally.
+const endpoint = 'http://127.0.0.1:1450';
+workspaceAPI.readFileContent = async () => (await fetch(`${endpoint}/file`)).text();
+workspaceAPI.getFileMetadata = async () => (await fetch(`${endpoint}/metadata`)).json();
+workspaceAPI.writeFileContent = async (_workspace, _file, content) => {
+  const response = await fetch(`${endpoint}/file`, { method: 'PUT', body: content });
+  if (!response.ok) throw new Error('Fixture file write failed');
+};
+await i18nService.initialize();
+await appearanceRuntime.initialize(buildBuiltinAppearance(openBitFunDarkPalette));
+
+const showReference = new URLSearchParams(location.search).has('reference');
+const referenceContent = showReference ? await workspaceAPI.readFileContent('/workspace/test.md') : '';
+
+function Fixture() {
+  const [dirty, setDirty] = useState(false);
+  const [readonly, setReadonly] = useState(false);
+  return <I18nProvider><OpenBitFunDesignSystemProvider>
+    <div style={{ height: '100vh', display: 'flex', flexDirection: 'column', maxWidth: 960, margin: 'auto' }}>
+      <div><button data-testid="readonly" onClick={() => setReadonly(!readonly)}>Toggle readonly</button>
+        <output data-testid="dirty">{dirty ? 'Unsaved' : 'Saved'}</output></div>
+      {showReference ? <Preview value={referenceContent} /> : <MarkdownEditor filePath="/workspace/test.md" workspacePath="/workspace" readOnly={readonly}
+        onContentChange={(_content, changed) => setDirty(changed)} />}
+    </div>
+  </OpenBitFunDesignSystemProvider></I18nProvider>;
+}
+createRoot(document.getElementById('root')!).render(<Fixture />);

--- a/tests/e2e/AGENTS.md
+++ b/tests/e2e/AGENTS.md
@@ -37,3 +37,18 @@ pnpm --dir tests/e2e exec wdio run ./config/wdio.conf.ts --spec "./specs/<file>.
 ## Verification
 
 Prefer the narrowest relevant spec first, then broaden only if needed.
+
+Markdown editor browser interaction tests (no desktop binary required):
+
+```bash
+pnpm --dir tests/e2e exec wdio run ./config/wdio.markdown-browser.ts
+```
+
+This focused runner mounts the production file editor with temporary file IO
+through a test adapter; it does not replace desktop or remote transport coverage.
+See `src/web-ui/src/tools/editor/AGENTS.md` for scope and output locations.
+
+For the real desktop Markdown workflow, build the desktop and current frontend,
+then run `pnpm --dir tests/e2e exec wdio run ./config/wdio.markdown-native.ts`
+from the repository root. This focused runner uses packaged frontend assets and
+a fresh temporary application profile; it does not use another checkout's dev server.

--- a/tests/e2e/browser/MarkdownEditorPage.ts
+++ b/tests/e2e/browser/MarkdownEditorPage.ts
@@ -1,0 +1,29 @@
+import { $, $$, browser, expect } from '@wdio/globals';
+
+export class MarkdownEditorPage {
+  get richText() { return $('.ProseMirror'); }
+  get source() { return $('.m-editor-textarea'); }
+  get dirty() { return $('[data-testid="dirty"]'); }
+  block(language: string) { return $(`[data-testid="md-embed-block"][data-language="${language}"]`); }
+  async mode(index: number) { await (await $$('.openbitfun-markdown-editor__mode-toggle [role="radio"]'))[index].click(); }
+  async open() {
+    await browser.url('/tests/e2e/markdown-editor.html');
+    await this.richText.waitForDisplayed();
+    await expect(this.dirty).toHaveText('Saved');
+  }
+  async editBlock(language: string, value: string) {
+    const block = this.block(language);
+    await block.$('[data-testid="md-embed-preview"]').click();
+    const source = block.$('[data-testid="md-embed-source"]');
+    await source.waitForDisplayed();
+    await source.setValue(value);
+    return block;
+  }
+  async save() {
+    // Chromium on macOS uses Meta; other hosts use Control.
+    const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+    await browser.keys([modifier, 's']);
+    await expect(this.dirty).toHaveText('Saved');
+  }
+  async savedSource() { return (await fetch('http://127.0.0.1:1450/file')).text(); }
+}

--- a/tests/e2e/browser/markdown-editor.spec.ts
+++ b/tests/e2e/browser/markdown-editor.spec.ts
@@ -1,0 +1,191 @@
+import { readFile } from 'node:fs/promises';
+import { browser, $, $$, expect } from '@wdio/globals';
+import { MarkdownEditorPage } from './MarkdownEditorPage';
+
+const editor = new MarkdownEditorPage();
+const fixture = await readFile(new URL('./markdown-fixture.md', import.meta.url), 'utf8');
+const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+
+describe('Markdown rich text browser E2E', () => {
+  beforeEach(async () => {
+    await browser.url('about:blank');
+    await fetch('http://127.0.0.1:1450/file', { method: 'PUT', body: fixture });
+    await editor.open();
+
+  });
+
+  it('retains the original standard preview typography and embedded appearance', async () => {
+    // The math renderer adds an asynchronous wrapper. Compare the standard
+    // document layout here; formula editing/rendering has separate coverage.
+    await browser.url('about:blank');
+    await fetch('http://127.0.0.1:1450/file', { method: 'PUT', body: fixture
+      .replace('$x^2$', 'formula').replace('$$\na^2+b^2=c^2\n$$', 'Equation') });
+    await editor.open();
+    const styles = async (reference: boolean) => browser.execute((isReference: boolean) => {
+      const root = document.querySelector(isReference ? '.m-editor-preview .markdown-renderer' : '.ProseMirror')!;
+      const definitions: Record<string, [string, string[]]> = {
+        body: [':scope', ['fontFamily', 'fontSize', 'lineHeight', 'color']],
+        heading: ['h1', ['fontSize', 'fontWeight', 'lineHeight', 'marginTop', 'marginBottom', 'paddingLeft']],
+        paragraph: ['p', ['fontSize', 'lineHeight', 'paddingTop', 'paddingLeft', 'marginTop', 'marginBottom']],
+        table: ['.table-wrapper', ['borderRadius', 'borderTopWidth', 'backgroundColor']],
+        cell: ['td', ['fontSize', 'lineHeight', 'paddingTop', 'paddingLeft']],
+        mermaid: ['.mermaid-block', ['borderRadius', 'borderTopWidth', 'backgroundColor']],
+        diagram: ['.mermaid-block__diagram', ['paddingTop', 'paddingLeft']],
+        details: [isReference ? 'details' : '[data-type="details"]', ['borderRadius', 'borderTopWidth', 'paddingTop', 'backgroundColor']],
+      };
+      const appearance = Object.fromEntries(Object.entries(definitions).map(([key, [selector, properties]]) => {
+        const element = selector === ':scope' ? root : root.querySelector(selector)!;
+        if (!element) throw new Error(`Missing ${key} (${selector}): ${root.innerHTML.slice(0, 500)}`);
+        const style = getComputedStyle(element);
+        return [key, Object.fromEntries(properties.map(property => [property, style[property as keyof CSSStyleDeclaration]]))];
+      }));
+      const checkbox = root.querySelector<HTMLInputElement>('input[type="checkbox"]')!;
+      const walker = document.createTreeWalker(checkbox.closest('li')!, NodeFilter.SHOW_TEXT);
+      let text = walker.nextNode();
+      while (text && !text.textContent?.trim()) text = walker.nextNode();
+      const range = document.createRange();
+      range.selectNodeContents(text!);
+      const line = range.getBoundingClientRect();
+      const box = checkbox.getBoundingClientRect();
+      return { ...appearance, taskOnOneLine: box.top < line.bottom && box.bottom > line.top };
+    }, reference);
+    await editor.block('mermaid').$('svg').waitForDisplayed();
+    const rich = await styles(false);
+    expect(rich.taskOnOneLine).toBe(true);
+    await browser.url('/tests/e2e/markdown-editor.html?reference=1');
+    await $('.m-editor-preview .mermaid-block svg').waitForDisplayed();
+    const original = await styles(true);
+    expect(rich).toEqual(original);
+  });
+
+  it('keeps source formatting edits dirty while undoing later rich edits exactly', async () => {
+    const changedSource = fixture.replace('# Editable document', '#  Editable document') + '\n';
+    await editor.mode(1);
+    await editor.source.setValue(changedSource);
+    await expect(editor.dirty).toHaveText('Unsaved');
+    await editor.mode(0);
+    await editor.editBlock('mermaid', 'graph TD\n A[Changed] --> B[Source]');
+    await browser.keys([modifier, 'z']);
+    await expect(editor.dirty).toHaveText('Unsaved');
+    await editor.mode(1);
+    await expect(editor.source).toHaveValue(changedSource, { trim: false });
+    await editor.source.click();
+    await editor.save();
+    expect(await editor.savedSource()).toBe(changedSource);
+    await editor.mode(0);
+    await editor.editBlock('mermaid', 'graph TD\n A[Changed] --> B[Saved]');
+    await browser.keys([modifier, 'z']);
+    await expect(editor.dirty).toHaveText('Saved');
+    await editor.mode(1);
+    await expect(editor.source).toHaveValue(changedSource, { trim: false });
+  });
+
+  it('edits Mermaid with live rendering and saves across source switches and reload', async () => {
+    await expect($$('.openbitfun-markdown-editor__mode-toggle [role="radio"]')).toBeElementsArrayOfSize(2);
+    const block = await editor.editBlock('mermaid', 'graph TD\n  A[Start] --> B[Edited]');
+    await expect(block.$('svg')).toHaveText(expect.stringContaining('Edited'));
+    await expect(block.$('[data-testid="md-embed-source"]')).toHaveValue('graph TD\n  A[Start] --> B[Edited]');
+    await expect(editor.dirty).toHaveText('Unsaved');
+    await editor.save();
+    expect(await editor.savedSource()).toContain('```mermaid\ngraph TD\n  A[Start] --> B[Edited]\n```');
+    await block.$('[data-testid="md-embed-edit"]').click();
+    await expect(block.$('[data-testid="md-embed-source"]')).not.toBeDisplayed();
+    await expect(block.$('.m-editor-embed-toolbar')).not.toBeDisplayed();
+    expect((await block.getCSSProperty('border-top-width')).value).toBe('0px');
+    await editor.mode(1);
+    await expect(editor.source).toHaveValue(expect.stringContaining('B[Edited]'));
+    await editor.mode(0);
+    await browser.refresh();
+    await expect(editor.block('mermaid').$('svg')).toHaveText(expect.stringContaining('Edited'));
+    await expect(editor.dirty).toHaveText('Saved');
+  });
+
+  it('edits an inline equation while surrounding text stays native and closes outside', async () => {
+    const math = $('[data-testid="md-inline-math"]');
+    await math.$('.m-editor-inline-math__preview').click();
+    const source = math.$('[data-testid="md-embed-source"]');
+    await source.setValue('y^3');
+    await expect(math.$('.katex')).toBeDisplayed();
+    await $('.ProseMirror > h1').click();
+    await expect(source).not.toBeDisplayed();
+    const paragraph = $('.ProseMirror > p');
+    await paragraph.click();
+    await browser.keys('End');
+    await browser.keys(' Changed.');
+    await editor.save();
+    expect(await editor.savedSource()).toContain('$y^3$');
+    expect(await editor.savedSource()).toContain('Changed.');
+    await expect($$('.ProseMirror > p [data-testid="md-inline-math"]')).toBeElementsArrayOfSize(1);
+  });
+
+  it('keeps HTML and block equations editable and supports keyboard completion and undo', async () => {
+    const html = await editor.editBlock('html', '<div data-example="embed">Updated HTML</div>');
+    await expect(html.$('.markdown-body')).toHaveText(expect.stringContaining('Updated HTML'));
+    await browser.keys([modifier, 'Enter']);
+    await expect(html.$('[data-testid="md-embed-source"]')).not.toBeDisplayed();
+    await editor.editBlock('math', 'E=mc^2');
+    await expect(editor.block('math').$('.katex')).toBeDisplayed();
+    await browser.keys([modifier, 'z']);
+    await expect(editor.block('math').$('[data-testid="md-embed-source"]')).toHaveValue('a^2+b^2=c^2');
+    await browser.keys([modifier, 'Shift', 'z']);
+    await expect(editor.block('math').$('[data-testid="md-embed-source"]')).toHaveValue('E=mc^2');
+    await browser.keys('Escape');
+    await expect(editor.block('math').$('[data-testid="md-embed-source"]')).not.toBeDisplayed();
+    await editor.save();
+    expect(await editor.savedSource()).toContain('$$\nE=mc^2\n$$');
+    expect(await editor.savedSource()).toContain('Updated HTML');
+  });
+
+  it('edits tasks tables and nested content and preserves unsupported syntax on save', async () => {
+    await $('.ProseMirror input[type="checkbox"]').click();
+    const cell = $('.ProseMirror td:last-child');
+    await cell.click();
+    await browser.keys('Home');
+    await browser.keys('Updated ');
+    const nested = $('[data-type="detailsContent"] p');
+    await nested.click();
+    await browser.keys('End');
+    await browser.keys(' edited');
+    await $('[data-type="details"] > button').click();
+    await expect(nested).not.toBeDisplayed();
+    await $('[data-type="details"] > button').click();
+    await expect(nested).toHaveText(expect.stringContaining('edited'));
+    await expect($('.ProseMirror li [data-language="mermaid"]')).toBeDisplayed();
+    await editor.save();
+    const source = await editor.savedSource();
+    expect(source).toContain('- [x] Finish editing');
+    expect(source).toContain('Updated');
+    expect(source).toContain('[^test]: Preserved definition');
+  });
+
+  it('edits image properties locally with keyboard completion and persistent saves', async () => {
+    const image = $('[data-testid="md-image"]');
+    await image.$('img').click();
+    await image.$('[data-testid="md-image-alt"]').setValue('Updated description');
+    await image.$('[data-testid="md-image-title"]').setValue('Updated title');
+    await browser.keys('Enter');
+    await expect(image.$('[data-testid="md-image-alt"]')).not.toBeDisplayed();
+    await expect(image.$('img')).toHaveAttribute('alt', 'Updated description');
+    await editor.save();
+    expect(await editor.savedSource()).toContain('![Updated description]');
+    expect(await editor.savedSource()).toContain('"Updated title"');
+    await browser.refresh();
+    await expect($('[data-testid="md-image"] img')).toHaveAttribute('title', 'Updated title');
+  });
+
+  it('recovers from invalid Mermaid and locks all embedded editors in readonly mode', async () => {
+    const block = await editor.editBlock('mermaid', 'this is not valid mermaid');
+    await expect(block.$('[data-testid="md-embed-source"]')).toBeDisplayed();
+    await expect(editor.richText).toHaveAttribute('contenteditable', 'true');
+    await block.$('[data-testid="md-embed-source"]').setValue('graph TD\n A-->Recovered');
+    await expect(block.$('svg')).toHaveText(expect.stringContaining('Recovered'));
+    await $('[data-testid="readonly"]').click();
+    await expect(editor.richText).toHaveAttribute('contenteditable', 'false');
+    await expect(block.$('[data-testid="md-embed-edit"]')).not.toBeDisplayed();
+    await expect(block.$('[data-testid="md-embed-source"]')).not.toBeDisplayed();
+    await $('[data-testid="readonly"]').click();
+    await expect(editor.dirty).toHaveText('Unsaved');
+    await block.$('[data-testid="md-embed-preview"]').click();
+    await expect(block.$('[data-testid="md-embed-source"]')).toHaveValue('graph TD\n A-->Recovered');
+  });
+});

--- a/tests/e2e/browser/markdown-editor.spec.ts
+++ b/tests/e2e/browser/markdown-editor.spec.ts
@@ -173,6 +173,64 @@ describe('Markdown rich text browser E2E', () => {
     await expect($('[data-testid="md-image"] img')).toHaveAttribute('title', 'Updated title');
   });
 
+
+  it('renders footnotes with shared numbering, anchors and live definition updates', async () => {
+    const markdown = '# Notes\n\nText[^a] and again[^a].\n\nOther[^b] with $x^2$.\n\n[^a]: Definition\n\n[^b]: Another definition';
+    await browser.url('about:blank');
+    await fetch('http://127.0.0.1:1450/file', { method: 'PUT', body: markdown });
+    await editor.open();
+    await expect($$('.ProseMirror [data-footnote-ref]')).toBeElementsArrayOfSize(3);
+    await expect($('.ProseMirror [data-footnote-ref]')).toHaveText('1');
+    await expect($$('.ProseMirror section[data-footnotes] li')).toBeElementsArrayOfSize(2);
+    const anchors = await browser.execute(() => {
+      const root = document.querySelector('.ProseMirror')!;
+      const ids = [...root.querySelectorAll('[id]')].map(node => node.id);
+      const links = [...root.querySelectorAll<HTMLAnchorElement>('[data-footnote-ref], [data-footnote-backref]')];
+      return { unique: new Set(ids).size === ids.length, resolved: links.every(link => ids.includes(link.hash.slice(1))) };
+    });
+    expect(anchors).toEqual({ unique: true, resolved: true });
+    await expect($('.ProseMirror > h1')).toHaveText('Notes');
+    const block = editor.block('footnoteDefinition');
+    await block.$('[data-testid="md-embed-preview"]').click();
+    await block.$('[data-testid="md-embed-source"]').setValue('[^a]: Updated definition');
+    await expect(block.$('section[data-footnotes]')).toHaveText(expect.stringContaining('Updated definition'));
+    await browser.keys('Escape');
+    await editor.save();
+    expect(await editor.savedSource()).toBe(markdown.replace('[^a]: Definition', '[^a]: Updated definition'));
+    await browser.refresh();
+    await expect($$('.ProseMirror [data-footnote-ref]')).toBeElementsArrayOfSize(3);
+    await expect($('.ProseMirror section[data-footnotes]')).toHaveText(expect.stringContaining('Updated definition'));
+  });
+
+  it('loads edited local image addresses through the workspace file adapter', async () => {
+    await browser.url('about:blank');
+    await fetch('http://127.0.0.1:1450/file', { method: 'PUT', body: '# Image\n\n![test](http://127.0.0.1:1447/tests/e2e/image.svg)' });
+    await editor.open();
+    await browser.execute(async () => {
+      // Track only the fixture filesystem boundary; use the production image loader.
+      const { workspaceAPI } = await import('/src/infrastructure/api/index.ts');
+      (window as any).__imageReads = [];
+      const original = workspaceAPI.readFileContent;
+      workspaceAPI.readFileContent = async (path: string) => {
+        (window as any).__imageReads.push(path);
+        if (path.endsWith('.png')) return 'iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAFElEQVR4nGNoIBEwjGoY1TB8NQAAJYSAEGy7FvQAAAAASUVORK5CYII=';
+        return original(path);
+      };
+    });
+    for (const name of ['new.png', 'another.png']) {
+      await $('[data-testid="md-image"] img').click();
+      await $('[data-testid="md-image-src"]').setValue(`./${name}`);
+      await browser.keys('Enter');
+      await browser.waitUntil(async () => browser.execute((path: string) =>
+        (window as any).__imageReads.includes(path), `/workspace/${name}`));
+      await expect($('[data-testid="md-image"] img')).toHaveAttribute('src', expect.stringContaining('data:image/png;base64,'));
+      await browser.waitUntil(async () => browser.execute(() =>
+        document.querySelector<HTMLImageElement>('[data-testid="md-image"] img')?.naturalWidth === 16));
+    }
+    await editor.save();
+    expect(await editor.savedSource()).toContain('![test](./another.png)');
+  });
+
   it('recovers from invalid Mermaid and locks all embedded editors in readonly mode', async () => {
     const block = await editor.editBlock('mermaid', 'this is not valid mermaid');
     await expect(block.$('[data-testid="md-embed-source"]')).toBeDisplayed();

--- a/tests/e2e/browser/markdown-fixture.md
+++ b/tests/e2e/browser/markdown-fixture.md
@@ -1,0 +1,50 @@
+---
+title: Block editing
+---
+
+# Editable document
+
+Before $x^2$ after.
+
+```mermaid
+graph TD
+  A[Start] --> B[Original]
+```
+
+<div data-example="embed">Original HTML</div>
+
+$$
+a^2+b^2=c^2
+$$
+
+- [ ] Finish editing
+- [x] Existing task
+
+| Type | Status |
+| --- | --- |
+| Table cell | Original |
+
+<details open>
+<summary>Toggle test</summary>
+
+Editable nested text
+
+</details>
+
+> [!NOTE]
+> Editable callout text
+
+- Editable parent
+
+  ```mermaid
+  graph TD
+    Parent --> Child
+  ```
+
+Footnote[^test].
+
+[^test]: Preserved definition
+
+![Original description](http://127.0.0.1:1447/tests/e2e/image.svg "Original title")
+
+Last paragraph.

--- a/tests/e2e/config/wdio.markdown-browser.ts
+++ b/tests/e2e/config/wdio.markdown-browser.ts
@@ -1,0 +1,70 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { createServer, type Server } from 'node:http';
+import { mkdtemp, readFile, writeFile, stat, rm, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, resolve, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { Options } from '@wdio/types';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+let vite: ChildProcess;
+let files: Server;
+let storage: string;
+
+export const config: Options.Testrunner = {
+  runner: 'local',
+  specs: ['../browser/markdown-editor.spec.ts'],
+  maxInstances: 1,
+  capabilities: [{ browserName: 'chrome', 'goog:chromeOptions': { args: ['--headless=new', '--window-size=1280,900'] } }],
+  framework: 'mocha', reporters: ['spec'], logLevel: 'warn',
+  mochaOpts: { timeout: 60000 }, waitforTimeout: 15000,
+  baseUrl: 'http://127.0.0.1:1447',
+  async onPrepare() {
+    storage = await mkdtemp(join(tmpdir(), 'openbitfun-markdown-e2e-'));
+    const file = join(storage, 'test.md');
+    await writeFile(file, await readFile(join(root, 'tests/e2e/browser/markdown-fixture.md')));
+    files = createServer(async (request, response) => {
+      response.setHeader('Access-Control-Allow-Origin', 'http://127.0.0.1:1447');
+      response.setHeader('Access-Control-Allow-Methods', 'GET, PUT, OPTIONS');
+      if (request.method === 'OPTIONS') { response.end(); return; }
+      try {
+        if (request.url === '/file' && request.method === 'PUT') {
+          const chunks = [];
+          for await (const chunk of request) chunks.push(chunk);
+          await writeFile(file, Buffer.concat(chunks));
+          response.end();
+        } else if (request.url === '/file' && request.method === 'GET') {
+          response.end(await readFile(file));
+        } else if (request.url === '/metadata') {
+          const info = await stat(file);
+          response.setHeader('Content-Type', 'application/json');
+          response.end(JSON.stringify({ path: '/workspace/test.md', modified: info.mtimeMs, size: info.size, isFile: true, isDir: false }));
+        } else { response.statusCode = 404; response.end(); }
+      } catch (error) { response.statusCode = 500; response.end(String(error)); }
+    });
+    await new Promise<void>((done, reject) => { files.once('error', reject); files.listen(1450, '127.0.0.1', done); });
+    vite = spawn('pnpm', ['exec', 'vite', '--host', '127.0.0.1', '--port', '1447', '--strictPort'], {
+      cwd: join(root, 'src/web-ui'), windowsHide: true, stdio: 'pipe',
+    });
+    let output = '';
+    vite.stdout?.on('data', chunk => { output += chunk; });
+    vite.stderr?.on('data', chunk => { output += chunk; });
+    for (let attempt = 0; attempt < 100; attempt++) {
+      if (vite.exitCode !== null) throw new Error(output);
+      try { if ((await fetch('http://127.0.0.1:1447/tests/e2e/markdown-editor.html')).ok) return; } catch { /* wait for Vite */ }
+      await new Promise(done => setTimeout(done, 200));
+    }
+    throw new Error(`Markdown fixture server did not start: ${output}`);
+  },
+  async afterTest(test, _context, { passed }) {
+    const { browser } = await import('@wdio/globals');
+    const directory = join(root, 'tests/e2e/reports/markdown-browser');
+    await mkdir(directory, { recursive: true });
+    await browser.saveScreenshot(join(directory, `${passed ? 'pass' : 'fail'}-${test.title.replace(/[^a-z0-9]+/gi, '-')}.png`));
+  },
+  async onComplete() {
+    vite?.kill('SIGTERM');
+    if (files) await new Promise<void>(done => files.close(() => done()));
+    if (storage) await rm(storage, { recursive: true, force: true });
+  },
+};

--- a/tests/e2e/config/wdio.markdown-native.ts
+++ b/tests/e2e/config/wdio.markdown-native.ts
@@ -1,0 +1,33 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { Options } from '@wdio/types';
+import { createEmbeddedConfig } from './embedded-driver';
+
+// Worker processes inherit this root; each runner invocation starts fresh.
+const runtimeRoot = process.env.OPENBITFUN_MARKDOWN_E2E_ROOT
+  ?? mkdtempSync(join(tmpdir(), 'openbitfun-markdown-profile-'));
+process.env.OPENBITFUN_MARKDOWN_E2E_ROOT = runtimeRoot;
+Object.assign(process.env, {
+  OPENBITFUN_E2E_STORAGE_ROOT: runtimeRoot,
+  OPENBITFUN_E2E_USER_ROOT: join(runtimeRoot, 'user'),
+  OPENBITFUN_USER_ROOT: join(runtimeRoot, 'user'),
+  OPENBITFUN_E2E_HOME: join(runtimeRoot, 'home'),
+  OPENBITFUN_HOME: join(runtimeRoot, 'home'),
+  OPENBITFUN_E2E_LOG_DIR: join(runtimeRoot, 'logs'),
+  OPENBITFUN_E2E_STORAGE_GUARD: '1',
+  OPENBITFUN_E2E_PACKAGED_FRONTEND: '1',
+  OPENBITFUN_E2E_FRONTEND_DIR: resolve(fileURLToPath(new URL('../../../dist', import.meta.url))),
+});
+const base = createEmbeddedConfig(['../specs/markdown-native.spec.ts'], 'Markdown native');
+export const config: Options.Testrunner = {
+  ...base,
+  async onComplete(...args) {
+    try {
+      if (typeof base.onComplete === 'function') await base.onComplete(...args);
+    } finally {
+      rmSync(runtimeRoot, { recursive: true, force: true });
+    }
+  },
+};

--- a/tests/e2e/specs/markdown-native.spec.ts
+++ b/tests/e2e/specs/markdown-native.spec.ts
@@ -1,0 +1,181 @@
+import { mkdtemp, readFile, writeFile, copyFile, rm, realpath } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { $, $$, browser, expect } from '@wdio/globals';
+import { openWorkspace } from '../helpers/workspace-helper';
+import { saveScreenshot } from '../helpers/screenshot-utils';
+
+/** Real desktop WebView, production transport and a temporary on-disk workspace. */
+class NativeMarkdownPage {
+  get richText() { return $('.ProseMirror'); }
+  get source() { return $('.m-editor-textarea'); }
+  get tab() { return $('[data-tab-title="editor-test.md"]'); }
+  block(kind: string) { return $(`[data-testid="md-embed-block"][data-language="${kind}"]`); }
+  async waitForDiagram() {
+    const block = this.block('mermaid');
+    await expect(block.$('svg')).toHaveProperty('textContent', expect.stringContaining('Desktop'));
+    await browser.waitUntil(async () => (await block.$('.mermaid-block__diagram').getCSSProperty('opacity')).value === 1
+      || (await block.$('.mermaid-block__diagram').getCSSProperty('opacity')).value === '1', { timeout: 10000 });
+  }
+  async editBlock(kind: string, source: string) {
+    const block = this.block(kind);
+    await block.$('[data-testid="md-embed-preview"]').click();
+    await block.$('[data-testid="md-embed-source"]').setValue(source);
+    return block;
+  }
+  async typeAtStart(selector: string, text: string) {
+    await $(selector).click();
+    // The embedded driver dispatches synthetic clicks, which do not place a
+    // native WebKit caret. Set only the selection, then type through WebDriver.
+    await browser.execute((query: string) => {
+      const element = document.querySelector(query)!;
+      (element.closest('[contenteditable="true"]') as HTMLElement).focus();
+      const range = document.createRange();
+      range.selectNodeContents(element);
+      range.collapse(true);
+      const selection = window.getSelection()!;
+      selection.removeAllRanges();
+      selection.addRange(range);
+      document.dispatchEvent(new Event('selectionchange'));
+    }, selector);
+    await browser.keys(text);
+    await expect($(selector)).toHaveText(expect.stringContaining(text.trim()));
+  }
+  async mode(index: number) {
+    await (await $$('.openbitfun-markdown-editor__mode-toggle [role="radio"]'))[index].click();
+  }
+  async openFile(file: string) {
+    const row = $(`.openbitfun-file-viewer-nav [data-file-path="${file}"]`);
+    await row.waitForDisplayed({ timeout: 20000 });
+    await row.click();
+    try {
+      await this.richText.waitForDisplayed({ timeout: 20000 });
+    } catch (error) {
+      await saveScreenshot('markdown-native-open-failure', { includeTimestamp: false });
+      console.log('Desktop open state:', await browser.execute(() => document.body.innerText.slice(-6000)));
+      throw error;
+    }
+  }
+}
+
+const page = new NativeMarkdownPage();
+const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+let workspace: string;
+let file: string;
+
+describe('Native desktop Markdown editing', () => {
+  before(async () => {
+    workspace = await realpath(await mkdtemp(join(tmpdir(), 'openbitfun-markdown-native-')));
+    file = join(workspace, 'editor-test.md');
+    const fixture = (await readFile(new URL('../browser/markdown-fixture.md', import.meta.url), 'utf8'))
+      .replace('# Editable document', '#  Editable document')
+      .replace('http://127.0.0.1:1447/tests/e2e/image.svg', './image.svg');
+    await writeFile(file, fixture);
+    await copyFile(new URL('../../../src/web-ui/tests/e2e/image.svg', import.meta.url), join(workspace, 'image.svg'));
+    expect(await openWorkspace(workspace)).toBe(true);
+    await browser.execute(() => window.dispatchEvent(new CustomEvent('scene:open', {
+      detail: { sceneId: 'file-viewer' },
+    })));
+    await page.openFile(file);
+  });
+
+  after(async () => { if (workspace) await rm(workspace, { recursive: true, force: true }); });
+
+  it('restores original source and dirty state through undo, redo, and saving', async () => {
+    const original = await readFile(file, 'utf8');
+    await page.typeAtStart('.ProseMirror h1', 'Changed ');
+    await expect(page.tab).toHaveAttribute('data-openbitfun-state', expect.stringContaining('dirty'));
+    await browser.keys([modifier, 'z']);
+    await expect($('.ProseMirror h1')).toHaveText('Editable document');
+    await expect(page.tab).not.toHaveAttribute('data-openbitfun-state', expect.stringContaining('dirty'));
+    await browser.keys([modifier, 'Shift', 'z']);
+    await expect(page.tab).toHaveAttribute('data-openbitfun-state', expect.stringContaining('dirty'));
+    await browser.keys([modifier, 's']);
+    await expect(page.tab).not.toHaveAttribute('data-openbitfun-state', expect.stringContaining('dirty'));
+    const saved = await readFile(file, 'utf8');
+    expect(saved).toContain('Changed Editable document');
+    await browser.keys([modifier, 'z']);
+    await expect(page.tab).toHaveAttribute('data-openbitfun-state', expect.stringContaining('dirty'));
+    await browser.keys([modifier, 'Shift', 'z']);
+    await expect(page.tab).not.toHaveAttribute('data-openbitfun-state', expect.stringContaining('dirty'));
+    await browser.keys([modifier, 'z']);
+    await page.mode(1);
+    await expect(page.source).toHaveValue(original, { trim: false });
+    await page.source.click();
+    await browser.keys([modifier, 's']);
+    await expect(page.tab).not.toHaveAttribute('data-openbitfun-state', expect.stringContaining('dirty'));
+    expect(await readFile(file, 'utf8')).toBe(original);
+    await page.mode(0);
+  });
+
+  it('edits native blocks and embedded source, saves through Tauri, and reopens the same file', async () => {
+    expect(await browser.execute(() => Boolean(window.__TAURI__?.core?.invoke))).toBe(true);
+    await expect($$('.openbitfun-markdown-editor__mode-toggle [role="radio"]')).toBeElementsArrayOfSize(2);
+    await expect(page.richText).toHaveAttribute('contenteditable', 'true');
+
+    const mermaid = await page.editBlock('mermaid', 'graph TD\n A[Desktop] --> B[Saved]');
+    await expect(mermaid.$('svg')).toHaveProperty('textContent', expect.stringContaining('Desktop'));
+    await browser.keys([modifier, 'Enter']);
+    await expect(mermaid.$('[data-testid="md-embed-source"]')).not.toBeDisplayed();
+    await expect(mermaid.$('.m-editor-embed-toolbar')).not.toBeDisplayed();
+    expect((await mermaid.getCSSProperty('border-top-width')).value).toBe('0px');
+
+    const html = await page.editBlock('html', '<div>Native HTML edited</div>');
+    await expect(html.$('.markdown-body')).toHaveText(expect.stringContaining('Native HTML edited'));
+    await browser.keys([modifier, 'Enter']);
+    const math = await page.editBlock('math', 'E=mc^2');
+    await expect(math.$('.katex')).toBeDisplayed();
+    await browser.keys([modifier, 'z']);
+    await expect(math.$('[data-testid="md-embed-source"]')).toHaveValue('a^2+b^2=c^2');
+    await browser.keys([modifier, 'Shift', 'z']);
+    await expect(math.$('[data-testid="md-embed-source"]')).toHaveValue('E=mc^2');
+    await browser.keys('Escape');
+
+    const inlineMath = $('[data-testid="md-inline-math"]');
+    await inlineMath.$('.m-editor-inline-math__preview').click();
+    await inlineMath.$('[data-testid="md-embed-source"]').setValue('y^3');
+    await $('.ProseMirror > h1').click();
+    await expect(inlineMath.$('[data-testid="md-embed-source"]')).not.toBeDisplayed();
+
+    const image = $('[data-testid="md-image"]');
+    await image.$('img').click();
+    await image.$('[data-testid="md-image-alt"]').setValue('Desktop image description');
+    await image.$('[data-testid="md-image-title"]').setValue('Desktop title');
+    await browser.keys('Enter');
+    await expect(image.$('img')).toHaveAttribute('alt', 'Desktop image description');
+    await expect(image.$('img')).toHaveAttribute('src', expect.stringContaining('data:image/'));
+
+    await $('.ProseMirror input[type="checkbox"]').click();
+    await page.typeAtStart('.ProseMirror td:last-child', 'Desktop cell ');
+    await page.typeAtStart('[data-type="detailsContent"] p', 'Desktop nested ');
+    await expect($('.ProseMirror li [data-language="mermaid"]')).toBeDisplayed();
+
+    await page.mode(1);
+    await expect(page.source).toHaveValue(expect.stringContaining('Native HTML edited'));
+    await page.mode(0);
+    await page.richText.click();
+    await browser.keys([modifier, 's']);
+    await browser.waitUntil(async () => (await readFile(file, 'utf8')).includes('Desktop image description'), {
+      timeout: 15000, timeoutMsg: 'Desktop save did not reach the actual file',
+    });
+    const saved = await readFile(file, 'utf8');
+    for (const value of ['A[Desktop]', 'Native HTML edited', '$y^3$', 'E=mc^2', '- [x] Finish editing', 'Desktop cell', 'Desktop nested', '[^test]: Preserved definition']) {
+      expect(saved).toContain(value);
+    }
+    await expect(page.tab).not.toHaveAttribute('data-openbitfun-state', expect.stringContaining('dirty'));
+    await page.waitForDiagram();
+    await saveScreenshot('markdown-native-edited', { includeTimestamp: false });
+
+    await page.tab.$('.canvas-tab__close-btn').click();
+    await expect(page.richText).not.toBeExisting();
+    await page.openFile(file);
+    await expect(page.block('mermaid').$('svg')).toHaveProperty('textContent', expect.stringContaining('Desktop'));
+    await expect($('[data-testid="md-image"] img')).toHaveAttribute('title', 'Desktop title');
+    await page.mode(1);
+    await expect(page.source).toHaveValue(saved, { trim: false });
+    await page.mode(0);
+    await page.waitForDiagram();
+    await page.block('mermaid').scrollIntoView({ block: 'center' });
+    await saveScreenshot('markdown-native-reopened', { includeTimestamp: false });
+  });
+});


### PR DESCRIPTION
## Summary

Restore editable Markdown documents with two modes: **Document / Source** (文档 / 源码). Ordinary text stays directly editable when the document contains embedded syntax, and the document view reuses the existing preview typography and component styles.

- Edit Mermaid, HTML, equations, frontmatter, image properties, and unsupported Markdown regions through local source editors; keep their original rendered appearance outside editing.
- Preserve dirty state, save shortcuts, readonly behavior, and undo/redo across native and embedded editing. Renderer failures leave an editable source fallback.
- Associate imported Markdown bytes with their rich document state. Undoing back to that state restores the original source, including list delimiters, whitespace, and line endings, so formatting normalization does not leave a false dirty marker.

- Reload local images through the workspace file adapter when their source changes; ignore stale image requests so they cannot overwrite a newer image.
- Resolve source-backed reference blocks against shared document context, preserving footnote numbering, definitions, and navigation without duplicating bodies or changing saved Markdown.

## Type and Areas

Type: regression fix / UI/UX / tests

Areas: Web UI Markdown editor; shared Markdown presentation; local desktop integration tests; locales.

## Motivation / Impact

Markdown files had regressed to preview plus source editing. This restores document editing without redesigning their appearance or forcing an entire document into preview because of special syntax.

For example, opening a file containing `* item`, editing its heading, and undoing previously regenerated `- item`: the visible content was restored, but the tab remained dirty. The editor now returns the exact imported source at the restored document state. Partial undo and intentional source-formatting edits remain dirty, and undo/redo after saving is compared with the latest saved bytes.

## Verification

Validation for the image-loading and footnote-context fixes in `c9670e187`:

- Focused editor and shared Markdown suites listed in `src/web-ui/src/tools/editor/AGENTS.md` — 104 tests passed across 9 files. Coverage includes stale image request success/failure, shared footnote numbering, unique anchors, reference links/images, and navigation across render regions.
- `pnpm --dir tests/e2e exec wdio run ./config/wdio.markdown-browser.ts` — 10 tests passed. Added browser coverage for editing footnote definitions and save/reload, and changing image addresses through the production workspace image loader. The image test was also re-run with a valid PNG and an assertion that the browser actually decoded it.
- `pnpm run check:web` — passed, including types and appearance/theme checks. `pnpm --dir src/web-ui exec tsc --noEmit` was re-run after the final production changes and passed.
- `git diff --check` — passed.

Earlier validation of the original document-editing implementation:

- `pnpm run i18n:audit` — passed with no warnings.
- `pnpm run check:repo-hygiene` — passed.
- `pnpm run build:web` — passed before the rebase onto `upstream/1.0.0-explore` at `11788537f`.
- `OPENBITFUN_E2E_WEBDRIVER_PORT=4447 E2E_LOG_LEVEL=warn pnpm --dir tests/e2e exec wdio run ./config/wdio.markdown-native.ts` — 2 tests passed before the rebase, covering actual desktop WebView editing, dirty markers, production Tauri save, close/reopen, and exact disk content.

Native desktop integration was not re-run for the latest fixes. Remote workspace, Remote Connect, Peer Device Mode, and Detached Dispatch were not exercised.

## Reviewer Notes

The native runner uses packaged frontend assets, an isolated temporary application profile, and a temporary workspace. Browser fixtures replace only the filesystem boundary and are not production entrypoints.

Existing appearance mode values remain accepted for compatibility. File access and synchronization continue through existing infrastructure adapters; there are no persisted-format, Tauri-command, or remote-protocol changes.

The latest fixes were exercised in the local browser. Earlier native desktop coverage is recorded separately above; it does not establish remote behavior.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.

