### PR TITLE
fix(flow-chat): Route PDF links to viewer

### DIFF
--- a/src/web-ui/src/infrastructure/markdown/MarkdownRenderer.test.tsx
+++ b/src/web-ui/src/infrastructure/markdown/MarkdownRenderer.test.tsx
@@ -462,6 +462,28 @@ describe('Markdown file links', () => {
     expect(onFileViewRequest).toHaveBeenCalledTimes(4);
   });
 
+  it('routes PDF links through the integrated file viewer instead of the file manager', async () => {
+    const pdfPath = 'D:\\SampleDocs\\Report.PDF';
+
+    await act(async () => {
+      root.render(
+        <MarkdownRenderer
+          content={`[Report.pdf](${pdfPath})`}
+          onFileViewRequest={onFileViewRequest}
+        />,
+      );
+      await Promise.resolve();
+    });
+
+    const link = container.querySelector<HTMLButtonElement>('button.file-link');
+    expect(link).not.toBeNull();
+
+    act(() => link?.click());
+
+    expect(onFileViewRequest).toHaveBeenCalledWith(pdfPath, 'Report.PDF', undefined);
+    expect(mocks.revealInExplorer).not.toHaveBeenCalled();
+  });
+
   it('does not load the math renderer for ordinary markdown', async () => {
     await act(async () => {
       root.render(

--- a/src/web-ui/src/infrastructure/markdown/MarkdownRenderer.tsx
+++ b/src/web-ui/src/infrastructure/markdown/MarkdownRenderer.tsx
@@ -199,7 +199,7 @@ const EDITOR_OPENABLE_EXTENSIONS = new Set([
   'vue', 'svelte',
   'html', 'htm', 'css', 'scss', 'less', 'sass',
   'json', 'jsonc', 'yaml', 'yml', 'toml', 'xml',
-  'md', 'mdx', 'rst', 'txt', 'csv', 'tsv',
+  'md', 'mdx', 'rst', 'txt', 'csv', 'tsv', 'pdf',
   'sh', 'bash', 'zsh', 'fish', 'ps1', 'bat', 'cmd',
   'sql', 'graphql', 'gql', 'proto',
   'ini', 'cfg', 'conf', 'env', 'lock',


### PR DESCRIPTION
Route Markdown PDF links through FlowChat's existing file-view request
so the integrated PDF viewer opens them. Previously, PDF links were
revealed in the system file manager.

- Add PDF to the Markdown link openable-extension set
- Cover case-insensitive PDF routing with a regression test
