### PR TITLE
fix(ci): install Bun for desktop packaging

### DIFF
--- a/.github/workflows/desktop-package.yml
+++ b/.github/workflows/desktop-package.yml
@@ -267,6 +267,12 @@ jobs:
           node-version: 22
           cache: pnpm
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+          no-cache: true
+
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/scripts/check-github-config.test.mjs
+++ b/scripts/check-github-config.test.mjs
@@ -1098,6 +1098,18 @@ test('stages unique release asset names before publishing', () => {
   assert.equal(steps[uploadIndex].with.files, 'release-upload-assets/*');
 });
 
+test('Desktop packaging installs Bun before preparing the OpenCode extension Host', () => {
+  const workflow = yaml.parse(
+    readFileSync(path.join(repoRoot, '.github/workflows/desktop-package.yml'), 'utf8'),
+  );
+  const steps = workflow.jobs.package.steps;
+  const bunIndex = steps.findIndex((step) => step.uses === 'oven-sh/setup-bun@v2');
+  const buildIndex = steps.findIndex((step) => step.name === 'Build desktop app');
+  assert.ok(bunIndex >= 0 && bunIndex < buildIndex);
+  assert.equal(steps[bunIndex].if, undefined, 'every Desktop platform needs Bun');
+  assert.equal(steps[bunIndex].with['bun-version'], '1.3.14');
+});
+
 test('Desktop packaging keeps beta identity explicit and stable-safe', () => {
   const workflow = yaml.parse(
     readFileSync(


### PR DESCRIPTION
## Summary

Desktop packaging failed while preparing the OpenCode extension Host because Bun was unavailable on the runners. Install Bun 1.3.14 for every Desktop platform before building, and add a regression test for the installation step, version, and ordering.

## Type and Areas

Type: CI / bug fix

Areas: Desktop packaging workflow and GitHub configuration tests.

## Motivation / Impact

Restores Windows x64, macOS arm64/x64, and Linux arm64/x64 packaging. No direct user-facing change. Package versions and beta/stable update-channel behavior remain unchanged.

## Verification

- `pnpm run check:github-config`: passed; 21 tests passed, one PowerShell-dependent test skipped because local `pwsh` is unavailable.
- Full fork release run: https://github.com/wgqqqqq/BitFun/actions/runs/33950466407 — all five packaging jobs and the release job succeeded. The publishing job needed one retry after its initial immediate channel readback failed.
- Published https://github.com/wgqqqqq/BitFun/releases/tag/v1.0.0-beta.2 as a prerelease; all 30 assets are accessible and installer/updater signatures are present. The version and beta-channel manifests agree on 1.0.0-beta.2, with download URLs scoped to the fork. The fork's stable latest release remains v0.2.7; official mirror synchronization was skipped.
- `git merge-tree --write-tree upstream/1.0.0-explore HEAD`: no conflicts with the current target branch.

## Reviewer Notes

Only two CI files change. Remote workspace, remote control, peer-device, and detached-dispatch runtime scenarios were not exercised; this change concerns packaging and was validated through the five-platform release workflow.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable (not applicable).
