### PR TITLE
chore(repo): prevent large Git objects from entering history

### DIFF
--- a/.github/workflows/repository-size.yml
+++ b/.github/workflows/repository-size.yml
@@ -1,0 +1,51 @@
+name: Repository Object Sizes
+
+on:
+  pull_request:
+    branches: [main, 1.0.0-explore]
+  push:
+    branches: [main, 1.0.0-explore]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: repository-object-sizes-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Repository Object Sizes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+          filter: blob:none
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: package.json
+          package-manager-cache: false
+
+      - name: Test Git object checks
+        run: node --test scripts/check-git-object-sizes.test.mjs
+
+      - name: Reject oversized objects throughout introduced commits
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          FORCED_PUSH: ${{ github.event.forced }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          args=(--head "$HEAD_SHA")
+          # A rewritten or newly created history has no usable previous base.
+          # Check its complete history, including only the exact approved fonts.
+          if [[ "$FORCED_PUSH" != "true" && -n "$BASE_SHA" && ! "$BASE_SHA" =~ ^0+$ ]]; then
+            args+=(--base "$BASE_SHA")
+          fi
+          node scripts/check-git-object-sizes.mjs "${args[@]}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,6 +144,15 @@ If your work is AI-assisted, please note it in the PR and indicate testing level
 
 Do not commit transient AI prompts, local absolute paths, generated scratch files, pairing secrets, tokens, certificates, or unrelated artifacts. Keep the PR focused on the intended product or maintenance change.
 
+Git objects larger than 5 MiB are rejected by the Repository Object Sizes check,
+including files added in an intermediate commit and deleted before the PR's final
+commit. Keep build artifacts outside Git. Existing bundled Chinese fonts have
+exact-object exceptions in `scripts/git-object-size-policy.json`; changes to those
+exceptions require review. Check a proposed history with
+`node scripts/check-git-object-sizes.mjs --base origin/main --head HEAD`, or omit
+`--base` to check all reachable history. Verify the checker with
+`node --test scripts/check-git-object-sizes.test.mjs`.
+
 ### Branch management
 
 **The `main` branch is the default collaboration branch and accepts feature PRs.** Since this repo encourages product managers and developers to use AI-generated code for rapid validation or idea submission, **please open all PRs targeting the `main` branch**.

--- a/CONTRIBUTING_CN.md
+++ b/CONTRIBUTING_CN.md
@@ -134,6 +134,13 @@ UI 改动请附前后对比截图或短录屏，方便快速评审。
 
 不要提交临时 AI prompt、本地绝对路径、生成的草稿文件、配对密钥、token、证书或无关产物。PR 应聚焦于本次产品或维护改动。
 
+Repository Object Sizes 检查会拒绝超过 5 MiB 的 Git 文件对象，包括在中间提交中加入、
+最终又删除的文件。构建产物应放在 Git 仓库之外。现有内置中文字体在
+`scripts/git-object-size-policy.json` 中按精确对象 ID 列出例外，修改例外需要审查。
+提交前可运行 `node scripts/check-git-object-sizes.mjs --base origin/main --head HEAD`，
+省略 `--base` 则检查全部可达历史。检查器的验证命令为
+`node --test scripts/check-git-object-sizes.test.mjs`。
+
 ### 分支管理
 
 **`main` 分支为默认协作分支，并接受特性 PR。** 本仓库欢迎产品经理、开发者使用 AI 生成代码进行快速验证或提交想法，因此 **所有 PR 请直接提交到 `main` 分支**。

--- a/scripts/check-git-object-sizes.mjs
+++ b/scripts/check-git-object-sizes.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptPath = fileURLToPath(import.meta.url);
+const repositoryRoot = resolve(dirname(scriptPath), '..');
+
+function git(repository, args, input) {
+  return execFileSync('git', ['-c', 'core.quotePath=false', ...args], {
+    cwd: repository,
+    encoding: 'utf8',
+    input,
+    maxBuffer: 64 * 1024 * 1024,
+    windowsHide: true,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }).trimEnd();
+}
+
+export function inspectGitObjectSizes({ repository, head = 'HEAD', base, policy }) {
+  if (!Number.isSafeInteger(policy.maxBlobBytes) || policy.maxBlobBytes <= 0) {
+    throw new Error('maxBlobBytes must be a positive integer.');
+  }
+  const allowed = new Set(policy.allowedBlobs.map((entry) => entry.oid));
+  const headCommit = git(repository, ['rev-parse', '--verify', '--end-of-options', `${head}^{commit}`]);
+  const revisions = [headCommit];
+  if (base) {
+    const baseCommit = git(repository, ['rev-parse', '--verify', '--end-of-options', `${base}^{commit}`]);
+    revisions.push('--not', baseCommit);
+  }
+
+  // Traverse the entire introduced history, including files deleted before HEAD.
+  const entries = git(repository, ['rev-list', '--objects', ...revisions]);
+  if (!entries) return { checkedBlobs: 0, violations: [] };
+  const paths = new Map(entries.split('\n').map((entry) => {
+    const separator = entry.indexOf(' ');
+    return separator < 0 ? [entry, ''] : [entry.slice(0, separator), entry.slice(separator + 1)];
+  }));
+  const metadata = git(repository, ['cat-file', '--batch-check=%(objectname) %(objecttype) %(objectsize)'],
+    `${[...paths.keys()].join('\n')}\n`);
+  let checkedBlobs = 0;
+  const violations = [];
+  for (const line of metadata.split('\n')) {
+    const [oid, type, rawSize] = line.split(' ');
+    const bytes = Number(rawSize);
+    if (!Number.isSafeInteger(bytes)) throw new Error(`Cannot read Git object ${oid}.`);
+    if (type !== 'blob') continue;
+    checkedBlobs += 1;
+    if (bytes > policy.maxBlobBytes && !allowed.has(oid)) {
+      violations.push({ oid, bytes, path: paths.get(oid) });
+    }
+  }
+  return { checkedBlobs, violations };
+}
+
+function main() {
+  const options = { repository: repositoryRoot };
+  const args = process.argv.slice(2);
+  for (let index = 0; index < args.length; index += 2) {
+    const option = args[index];
+    if (!['--base', '--head'].includes(option) || !args[index + 1]) {
+      throw new Error('Usage: node scripts/check-git-object-sizes.mjs [--base COMMIT] [--head COMMIT]');
+    }
+    options[option.slice(2)] = args[index + 1];
+  }
+  const policy = JSON.parse(readFileSync(new URL('./git-object-size-policy.json', import.meta.url), 'utf8'));
+  const result = inspectGitObjectSizes({ ...options, policy });
+  if (result.violations.length > 0) {
+    for (const violation of result.violations) {
+      console.error(`${JSON.stringify(violation.path)}: ${violation.bytes} bytes (${violation.oid}) exceeds the ${policy.maxBlobBytes}-byte Git object limit.`);
+    }
+    throw new Error('Store large build artifacts outside Git. Removing a file only from the latest commit does not remove it from history.');
+  }
+  console.log(`Checked ${result.checkedBlobs} Git blobs; no unapproved objects exceed ${policy.maxBlobBytes} bytes.`);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === scriptPath) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/check-git-object-sizes.test.mjs
+++ b/scripts/check-git-object-sizes.test.mjs
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, relative } from 'node:path';
+import test from 'node:test';
+import { inspectGitObjectSizes } from './check-git-object-sizes.mjs';
+
+const policy = { maxBlobBytes: 64, allowedBlobs: [] };
+
+function repositoryFixture(t) {
+  const temporaryRoot = tmpdir();
+  const repository = mkdtempSync(join(temporaryRoot, 'openbitfun-git-object-size-'));
+  t.after(() => {
+    const relativePath = relative(temporaryRoot, repository);
+    assert.match(relativePath, /^openbitfun-git-object-size-[^\\/]+$/);
+    rmSync(repository, { recursive: true, force: true });
+  });
+  const git = (...args) => execFileSync('git', ['-c', 'commit.gpgsign=false', ...args], {
+    cwd: repository, encoding: 'utf8', windowsHide: true, stdio: ['pipe', 'pipe', 'pipe'],
+  }).trim();
+  git('init', '--quiet');
+  git('config', 'user.name', 'Object Size Test');
+  git('config', 'user.email', 'object-size-test@example.invalid');
+  writeFileSync(join(repository, 'source.txt'), 'initial source\n');
+  git('add', 'source.txt');
+  git('commit', '--quiet', '-m', 'Initial source');
+  const base = git('rev-parse', 'HEAD');
+  function commitFile(name, content) {
+    writeFileSync(join(repository, name), content);
+    git('add', '--', name);
+    git('commit', '--quiet', '-m', `Update ${name}`);
+    return git('rev-parse', `HEAD:${name}`);
+  }
+  return { repository, base, git, commitFile };
+}
+
+test('rejects a large blob added and then deleted within the proposed history', (t) => {
+  const fixture = repositoryFixture(t);
+  const oid = fixture.commitFile('temporary binary.bin', Buffer.alloc(65, 1));
+  fixture.git('rm', '--', 'temporary binary.bin');
+  fixture.git('commit', '--quiet', '-m', 'Remove temporary binary');
+  const result = inspectGitObjectSizes({ ...fixture, policy });
+  assert.deepEqual(result.violations, [{ oid, bytes: 65, path: 'temporary binary.bin' }]);
+});
+
+test('does not charge an unchanged object already reachable from the base', (t) => {
+  const fixture = repositoryFixture(t);
+  fixture.commitFile('existing.bin', Buffer.alloc(65, 2));
+  const base = fixture.git('rev-parse', 'HEAD');
+  fixture.commitFile('source.txt', 'updated source\n');
+  const result = inspectGitObjectSizes({ ...fixture, base, policy });
+  assert.equal(result.violations.length, 0);
+  assert.equal(result.checkedBlobs, 1);
+});
+
+test('allows an exact approved object but rejects replacement bytes at the same path', (t) => {
+  const fixture = repositoryFixture(t);
+  const oid = fixture.commitFile('font.ttf', Buffer.alloc(65, 3));
+  const fontPolicy = { ...policy, allowedBlobs: [{ oid }] };
+  assert.equal(inspectGitObjectSizes({ ...fixture, policy: fontPolicy }).violations.length, 0);
+  const replacement = fixture.commitFile('font.ttf', Buffer.alloc(65, 4));
+  assert.deepEqual(inspectGitObjectSizes({ ...fixture, policy: fontPolicy }).violations.map((entry) => entry.oid), [replacement]);
+});
+
+test('full-history checks include existing large objects and invalid bases fail', (t) => {
+  const fixture = repositoryFixture(t);
+  fixture.commitFile('existing.bin', Buffer.alloc(65, 5));
+  const result = inspectGitObjectSizes({ repository: fixture.repository, policy });
+  assert.equal(result.violations.length, 1);
+  assert.throws(() => inspectGitObjectSizes({ ...fixture, base: 'missing-base', policy }));
+});

--- a/scripts/git-object-size-policy.json
+++ b/scripts/git-object-size-policy.json
@@ -1,0 +1,20 @@
+{
+  "maxBlobBytes": 5242880,
+  "allowedBlobs": [
+    {
+      "oid": "5c925d1fb1f1eccc85a1c7c78cc71a50ef9cc2db",
+      "path": "src/web-ui/src/assets/fonts/harmonyos-sans/sc/HarmonyOS_Sans_SC_Bold.ttf",
+      "reason": "Existing offline Simplified Chinese font, verified by scripts/web-font-profile.mjs. Any replacement requires explicit review."
+    },
+    {
+      "oid": "350f6a004d0fed6abf0cbb99bee2b5c027b7f7d5",
+      "path": "src/web-ui/src/assets/fonts/harmonyos-sans/sc/HarmonyOS_Sans_SC_Medium.ttf",
+      "reason": "Existing offline Simplified Chinese font, verified by scripts/web-font-profile.mjs. Any replacement requires explicit review."
+    },
+    {
+      "oid": "aff150a137831c29d4d3cba994ac1b8e3a9940fa",
+      "path": "src/web-ui/src/assets/fonts/harmonyos-sans/sc/HarmonyOS_Sans_SC_Regular.ttf",
+      "reason": "Existing offline Simplified Chinese font, verified by scripts/web-font-profile.mjs. Any replacement requires explicit review."
+    }
+  ]
+}


### PR DESCRIPTION
Large files introduced anywhere in a PR remain in Git history even when deleted before the final commit. Add a dedicated Repository Object Sizes workflow covering every path, including `png/`, to reject newly reachable blobs larger than 5 MiB. Keep exact-object exceptions for the three existing offline Chinese fonts; replacement bytes require review.

The checker also supports full-history verification after a history rewrite and fails when an expected base cannot be resolved. English and Chinese contributor guides document the policy and focused commands.

Validation: 4 real Git repository tests passed, including intermediate add/delete detection and exact-object exceptions; GitHub configuration audit and all 22 existing configuration tests passed; repository hygiene and diff checks passed. The committed change introduces six small blobs and passes its own incremental check.

AI-assisted implementation with focused automated validation. No product runtime or visual changes.
