### PR TITLE
fix(ci): fetch full history efficiently for repository size audits

### DIFF
--- a/.github/workflows/repository-size.yml
+++ b/.github/workflows/repository-size.yml
@@ -24,7 +24,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
-          filter: blob:none
+          # Full-history verification needs blob sizes without thousands of
+          # individual lazy fetches; partial clones are useful for PR deltas.
+          filter: ${{ github.event_name == 'pull_request' && 'blob:none' || '' }}
 
       - uses: actions/setup-node@v5
         with:


### PR DESCRIPTION
Full-history object-size verification needs every historical blob's size. A blobless checkout can turn that into thousands of individual lazy fetches after a forced history update. Use a regular fetch for push/manual full-history verification, retaining partial clones for PR deltas.

Validation: GitHub configuration audit passed; the existing checker and its four real-repository tests are unchanged. AI-assisted workflow-only correction.
