### PR TITLE
fix(web): adapt caption buttons to Windows styling

### DIFF
--- a/src/web-ui/src/app/components/SceneTopBar/SceneTopBar.scss
+++ b/src/web-ui/src/app/components/SceneTopBar/SceneTopBar.scss
@@ -13,6 +13,17 @@
   container-type: inline-size;
   user-select: none;
 
+  &:has(.window-controls--windows) {
+    // Extend through the scene surface's right gutter so Close reaches the edge.
+    width: calc(100% + var(--openbitfun-space-4));
+    padding-block: 0;
+    padding-inline-end: 0;
+
+    > [data-openbitfun-part='trailing'] {
+      align-self: stretch;
+    }
+  }
+
   &[data-bordered='true'] {
     &::before,
     &::after {

--- a/src/web-ui/src/app/components/WindowControls/WindowControls.scss
+++ b/src/web-ui/src/app/components/WindowControls/WindowControls.scss
@@ -135,6 +135,38 @@
   }
 }
 
+// Windows caption buttons keep their full hit area even in a narrow window.
+.window-controls--windows {
+  align-items: stretch;
+  gap: 0;
+  height: 100%;
+
+  .window-controls__btn {
+    flex: 0 0 46px;
+    width: 46px;
+    height: 100%;
+    border: 0;
+    border-radius: 0;
+    color: var(--openbitfun-color-content-primary);
+    cursor: default;
+
+    svg {
+      width: 12px;
+      height: 12px;
+      transition: none;
+    }
+
+    &:focus-visible {
+      outline-offset: -2px;
+    }
+
+    &--close:hover:not(:disabled) {
+      background: var(--openbitfun-color-status-danger-content);
+      color: var(--openbitfun-color-content-on-dark);
+    }
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .window-controls__btn {
     transition: none;

--- a/src/web-ui/src/app/components/WindowControls/WindowControls.tsx
+++ b/src/web-ui/src/app/components/WindowControls/WindowControls.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Tooltip } from '@openbitfun/ui';
 import { useTranslation } from 'react-i18next';
+import { isWindowsDesktopRuntime } from '@/infrastructure/runtime';
 import './WindowControls.scss';
 
 export interface WindowControlsProps
@@ -38,6 +39,12 @@ const CloseGlyph = () => (
   </svg>
 );
 
+const WindowsGlyph = ({ d }: { d: string }) => (
+  <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+    <path d={d} stroke="currentColor" strokeWidth="1" />
+  </svg>
+);
+
 /** Desktop-shell window commands. This is product chrome, not a public UI primitive. */
 export const WindowControls: React.FC<WindowControlsProps> = ({
   onMinimize,
@@ -49,6 +56,7 @@ export const WindowControls: React.FC<WindowControlsProps> = ({
   ...props
 }) => {
   const { t } = useTranslation('common');
+  const isWindows = isWindowsDesktopRuntime();
   const maximizeLabel = maximized ? t('window.restore') : t('window.maximize');
 
   const run = (event: React.MouseEvent<HTMLButtonElement>, command: () => void) => {
@@ -60,7 +68,7 @@ export const WindowControls: React.FC<WindowControlsProps> = ({
   return (
     <div
       {...props}
-      className={['window-controls', className].filter(Boolean).join(' ')}
+      className={['window-controls', isWindows && 'window-controls--windows', className].filter(Boolean).join(' ')}
       data-openbitfun-component="window-controls"
       data-openbitfun-part="root"
       data-openbitfun-state={[disabled && 'disabled', maximized && 'maximized'].filter(Boolean).join(' ') || undefined}
@@ -73,7 +81,7 @@ export const WindowControls: React.FC<WindowControlsProps> = ({
           disabled={disabled}
           aria-label={t('window.minimize')}
         >
-          <MinimizeGlyph />
+          {isWindows ? <WindowsGlyph d="M1 6.5h10" /> : <MinimizeGlyph />}
         </button>
       </Tooltip>
 
@@ -85,7 +93,11 @@ export const WindowControls: React.FC<WindowControlsProps> = ({
           disabled={disabled}
           aria-label={maximizeLabel}
         >
-          {maximized ? <RestoreGlyph /> : <MaximizeGlyph />}
+          {isWindows ? (
+            <WindowsGlyph d={maximized
+              ? 'M3.5 3.5v-2h7v7h-2 M1.5 3.5h7v7h-7z'
+              : 'M1.5 1.5h9v9h-9z'} />
+          ) : maximized ? <RestoreGlyph /> : <MaximizeGlyph />}
         </button>
       </Tooltip>
 
@@ -97,7 +109,7 @@ export const WindowControls: React.FC<WindowControlsProps> = ({
           disabled={disabled}
           aria-label={t('window.close')}
         >
-          <CloseGlyph />
+          {isWindows ? <WindowsGlyph d="m1.5 1.5 9 9 m0-9-9 9" /> : <CloseGlyph />}
         </button>
       </Tooltip>
     </div>


### PR DESCRIPTION
## Summary

Give the Windows desktop shell native-style minimize, maximize/restore, and close buttons with 46px rectangular hit areas, Windows-specific glyphs, and a close button aligned with the right window edge. Keep the existing appearance on other platforms.

## Type and Areas

Type: UI/UX bug fix

Areas: Web UI, Windows desktop window chrome

## Motivation / Impact

Windows previously used the compact, rounded shared window controls, leaving the close button inset from the edge. The Windows-only variant fills the title bar height, removes gaps between caption buttons, and uses the existing danger and contrast tokens for the close hover state. Existing command callbacks, localized labels, disabled behavior, and keyboard focus support remain in place.

## Verification

- `pnpm run check:web` — passed, including Web UI type-check, Appearance, theme color, and theme visual contract checks.
- `pnpm --dir src/web-ui exec vitest run src/app/components/SceneTopBar/SceneTopBar.test.tsx src/infrastructure/runtime/environment.test.ts` — 7 tests passed.
- `pnpm run motion:audit` — reviewed the presentation inventory.
- `build-dev.bat` — Windows debug build passed. Launched the built desktop with its packaged frontend in an isolated preview profile and verified the new controls and actual maximize/restore behavior.
- Browser fixture — checked light/dark rendering, 46px button widths, edge alignment, command callbacks, disabled controls, keyboard focus, and maximize/restore glyphs and labels.
- `git diff --check` — passed.

## Reviewer Notes

The new class and glyphs are enabled only by `isWindowsDesktopRuntime()`. The scene layout adjustment is scoped to that Windows class. This changes local window chrome and adds no Tauri commands, transport behavior, persisted shapes, or locale strings.

Remote workspace, remote control, Peer Device Mode, and detached dispatch were not exercised. Native runtime checks were performed on Windows only.

AI-assisted. Testing level: lightly tested through focused automated checks and manual Windows verification; broader platform coverage is left to CI.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable (no string or documentation changes needed).

<img width="2493" height="1056" alt="image" src="https://github.com/user-attachments/assets/2a49fa2e-00ad-4f7c-be23-b9bbd00a8c14" />
