### PR TITLE
fix(config): accept OpenBitFun 1.0 prerelease configurations

### DIFF
--- a/src/crates/assembly/core/src/service/config/manager.rs
+++ b/src/crates/assembly/core/src/service/config/manager.rs
@@ -29,11 +29,11 @@ fn invalid_config_error(context: &str, result: &ConfigValidationResult) -> OpenB
 
 const MIN_OPENBITFUN_CONFIG_VERSION: (u64, u64, u64) = (1, 0, 0);
 
-fn parse_semver_floor(version: &str) -> Option<((u64, u64, u64), bool)> {
+fn parse_semver_floor(version: &str) -> Option<(u64, u64, u64)> {
     let without_build = version.split_once('+').map_or(version, |(value, _)| value);
-    let (core, has_prerelease) = without_build
+    let core = without_build
         .split_once('-')
-        .map_or((without_build, false), |(value, _)| (value, true));
+        .map_or(without_build, |(value, _)| value);
     let mut parts = core.split('.');
     let parsed = (
         parts.next()?.parse().ok()?,
@@ -43,7 +43,7 @@ fn parse_semver_floor(version: &str) -> Option<((u64, u64, u64), bool)> {
     if parts.next().is_some() {
         return None;
     }
-    Some((parsed, has_prerelease))
+    Some(parsed)
 }
 
 pub(crate) fn validate_openbitfun_product_version(
@@ -58,14 +58,14 @@ pub(crate) fn validate_openbitfun_product_version(
         )));
     }
 
-    let Some((parsed, has_prerelease)) = parse_semver_floor(version) else {
+    let Some(parsed) = parse_semver_floor(version) else {
         return Err(OpenBitFunError::validation(format!(
             "{context} version '{version}' is not a valid OpenBitFun version"
         )));
     };
-    if parsed < MIN_OPENBITFUN_CONFIG_VERSION
-        || (parsed == MIN_OPENBITFUN_CONFIG_VERSION && has_prerelease)
-    {
+    // This floor separates product generations, not release-channel precedence.
+    // OpenBitFun 1.0 prereleases write the same product identity and schema.
+    if parsed < MIN_OPENBITFUN_CONFIG_VERSION {
         return Err(OpenBitFunError::validation(format!(
             "{context} version '{version}' predates OpenBitFun 1.0.0"
         )));
@@ -931,6 +931,30 @@ mod tests {
             invalid.as_object_mut().unwrap().remove(field);
             let error = validate_current_config_value(&invalid, "test config").unwrap_err();
             assert!(error.to_string().contains(field), "{error}");
+        }
+    }
+
+    #[test]
+    fn current_config_contract_accepts_openbitfun_prerelease_versions() {
+        for version in [
+            "1.0.0-beta.1",
+            "1.0.0-beta.2+build.7",
+            "1.0.0-nightly.20260906",
+            "1.0.0-rc.1",
+            "1.0.0",
+            "1.0.1-beta.1",
+        ] {
+            let mut current = serde_json::to_value(GlobalConfig::default()).unwrap();
+            current["version"] = serde_json::json!(version);
+            validate_current_config_value(&current, "test config")
+                .unwrap_or_else(|error| panic!("{version}: {error}"));
+        }
+
+        for version in ["0.2.19", "0.9.9-beta.1", "0.9.9+build.7"] {
+            let mut legacy = serde_json::to_value(GlobalConfig::default()).unwrap();
+            legacy["version"] = serde_json::json!(version);
+            let error = validate_current_config_value(&legacy, "test config").unwrap_err();
+            assert!(error.to_string().contains("predates OpenBitFun 1.0.0"));
         }
     }
 

--- a/src/crates/assembly/core/src/service/config/service.rs
+++ b/src/crates/assembly/core/src/service/config/service.rs
@@ -1044,6 +1044,62 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn prerelease_config_survives_load_save_and_restart() {
+        for version in ["1.0.0-beta.1", "1.0.0-nightly.20260906"] {
+            let name = "prerelease-config-restart";
+            let (service, dir) = test_service(name).await;
+            let mut config: GlobalConfig = service.get_config(None).await.unwrap();
+            config.version = version.to_string();
+            config.app.language = "zh-CN".to_string();
+            drop(service);
+
+            let config_file = dir.path().join(name).join("config").join("app.json");
+            let original = serde_json::to_string_pretty(&config).unwrap();
+            tokio::fs::write(&config_file, &original).await.unwrap();
+            let service = restart_test_service(&dir, name).await;
+            let loaded: GlobalConfig = service.get_config(None).await.unwrap();
+            assert_eq!(loaded.version, version);
+            assert_eq!(loaded.app.language, "zh-CN");
+            assert_eq!(
+                tokio::fs::read_to_string(&config_file).await.unwrap(),
+                original
+            );
+
+            service.set_config("app.language", &"en-US").await.unwrap();
+            drop(service);
+            let restarted = restart_test_service(&dir, name).await;
+            let saved: GlobalConfig = restarted.get_config(None).await.unwrap();
+            assert_eq!(saved.version, env!("CARGO_PKG_VERSION"));
+            assert_eq!(saved.app.language, "en-US");
+        }
+    }
+
+    #[tokio::test]
+    async fn prerelease_exports_support_explicit_import_and_account_settings() {
+        for version in ["1.0.0-beta.1", "1.0.0-nightly.20260906"] {
+            for account_sync in [false, true] {
+                let (service, _dir) = test_service("prerelease-config-import").await;
+                let mut export = current_export(GlobalConfig::default());
+                export.version = version.to_string();
+                export.config.version = version.to_string();
+                export.config.app.language = "zh-CN".to_string();
+                let export: ConfigExport =
+                    serde_json::from_str(&serde_json::to_string(&export).unwrap()).unwrap();
+
+                let imported = if account_sync {
+                    service.import_account_settings(export).await.unwrap()
+                } else {
+                    service.import_config(export).await.unwrap()
+                };
+                assert!(imported.success, "{:?}", imported.errors);
+                let config: GlobalConfig = service.get_config(None).await.unwrap();
+                assert_eq!(config.app.language, "zh-CN");
+                assert_eq!(config.version, env!("CARGO_PKG_VERSION"));
+            }
+        }
+    }
+
+    #[tokio::test]
     async fn pre_1_0_exports_are_rejected_without_changing_current_config() {
         for account_sync in [false, true] {
             let (service, _dir) = test_service("pre-1-export-rejected").await;


### PR DESCRIPTION
## Summary

Allow valid OpenBitFun 1.0 prerelease configurations to load by applying the product-generation floor to the numeric version core. Add regression coverage for beta/nightly load-save-restart cycles, explicit imports, and account-settings imports.

Related issue: none filed.

## Type and Areas

Type: Bug fix / regression test

Areas: Rust core configuration; desktop startup

## Motivation / Impact

OpenBitFun 1.0 beta builds persist their actual version, such as `1.0.0-beta.1`, but the configuration reader rejects that value as older than OpenBitFun 1.0.0. A configuration written by the application can therefore prevent its next startup or fail an import. The reader now accepts the same product generation across stable and prerelease builds.

## Verification

- `cargo test -p openbitfun-core --no-default-features --lib service::config::`: 122 passed with source version `1.0.0`, and 122 passed with the actual Cargo package version projected to `1.0.0-beta.1`.
- `node --test scripts/release-channel.test.mjs OpenBitFun-Installer/scripts/build-installer.test.cjs`: 12 passed.
- `build-installer.bat`: the complete local Windows release build passed with version `1.0.0-beta.1`.
- Verified the embedded payload against the installer executable and all 1,068 manifest entries by SHA-256; opened the installer UI successfully.
- Ran the exact extracted desktop payload with isolated storage: fresh startup, settings save, graceful exit, and restart passed; the persisted version remained `1.0.0-beta.1`, and language/theme settings survived restart.
- Confirmed that a `0.9.9` configuration is still rejected without changing its bytes. The existing user configuration remained unchanged.
- `git diff --check`: passed.

## Reviewer Notes

The product identity, schema, protected metadata, retired-field rejection, and pre-1.0 floor remain enforced. Saves still record the actual package version. Release-channel validation and updater version ordering are unchanged; no configuration migration or reset is introduced.

AI-assisted. Testing level: fully tested for the focused configuration behavior and Windows packaged runtime described above. Installer installation/upgrade actions, macOS/Linux runtime behavior, and live remote workspace, remote control, peer-device, and detached-dispatch scenarios were not exercised. Account-settings import is covered by feature-free Core fixtures.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable (no changes required).
