### PR TITLE
fix(web): preserve model submenu keyboard focus

### DIFF
--- a/src/web-ui/src/flow_chat/components/ModelSelector.tsx
+++ b/src/web-ui/src/flow_chat/components/ModelSelector.tsx
@@ -1722,6 +1722,12 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
 
     const frameId = window.requestAnimationFrame(() => {
       const menu = portalDropdownRef.current;
+      // The user may already have entered or returned from a submenu before
+      // this initial focus frame runs. Preserve that more recent navigation.
+      if (
+        menu?.contains(document.activeElement)
+        || nativeSubmenuRef.current?.contains(document.activeElement)
+      ) return;
       const selectedItem = menu?.querySelector<HTMLButtonElement>(
         'button[role="menuitemradio"][aria-checked="true"], button[role="menuitem"][data-selected="true"]',
       );

--- a/src/web-ui/src/flow_chat/components/ModelSelectorAcpMode.test.tsx
+++ b/src/web-ui/src/flow_chat/components/ModelSelectorAcpMode.test.tsx
@@ -136,6 +136,7 @@ describe('ModelSelector ACP mode picker', () => {
     act(() => root.unmount());
     container.remove();
     vi.unstubAllGlobals();
+    vi.useRealTimers();
     vi.clearAllMocks();
   });
 
@@ -309,7 +310,8 @@ describe('ModelSelector ACP mode picker', () => {
     expect(container.querySelector('[data-testid="chat-acp-mode-selector-btn"]')).not.toBeNull();
   });
 
-  it('navigates the shared ACP reasoning submenu with the keyboard and restores focus', async () => {
+  it.each(['submenu', 'parent'] as const)('preserves keyboard focus when the opening frame runs in the %s menu', async (frameTarget) => {
+    vi.useFakeTimers({ toFake: ['requestAnimationFrame', 'cancelAnimationFrame'] });
     await renderWithOptions([reasoningOption], modelOptions);
     await click('chat-model-selector-btn');
     const row = document.body.querySelector<HTMLButtonElement>('[data-testid="chat-model-selector-settings-reasoning"]')!;
@@ -318,9 +320,17 @@ describe('ModelSelector ACP mode picker', () => {
       row.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
     });
     expect(document.activeElement?.getAttribute('data-preset-id')).toBe('medium');
+    if (frameTarget === 'submenu') {
+      await act(async () => { vi.advanceTimersToNextFrame(); });
+      expect(document.activeElement?.getAttribute('data-preset-id')).toBe('medium');
+    }
     await act(async () => {
       document.activeElement?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
     });
+    expect(document.activeElement).toBe(row);
+    // Deliver the initial menu-focus frame after the user has already returned
+    // from the submenu, as can happen under a busy browser or CI runner.
+    await act(async () => { vi.advanceTimersToNextFrame(); });
     expect(document.activeElement).toBe(row);
     await act(async () => {
       row.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));


### PR DESCRIPTION
## Summary

When a user enters or leaves a model reasoning submenu before the opening animation-frame callback runs, that delayed callback can move focus back to the first model row. Preserve focus already inside either menu instead of overwriting the user's more recent keyboard navigation.

## Type and Areas

Type: Bug fix / CI regression fix

Areas: Shared desktop/Web UI model selector

## Motivation / Impact

Fixes the intermittent keyboard-focus failure exposed by the `main` CI run after #2834: https://github.com/GCWing/BitFun/actions/runs/34017548212. The PR run passed while the merged run hit the timing race. This change fixes the component behavior and makes both submenu and return-focus regression cases deterministic by controlling animation-frame timing.

## Verification

- Before the fix, explicitly delivering the initial focus frame after returning from the submenu reproduced the CI assertion failure locally.
- After the fix, 79 tests across the model selector, ACP, dispatch, layout, and dropdown positioning suites passed:
  `pnpm --dir src/web-ui exec vitest run src/flow_chat/components/ModelSelectorExternal.test.tsx src/flow_chat/components/ModelSelectorProviderLevels.test.tsx src/flow_chat/components/ModelSelectorAcpMode.test.tsx src/flow_chat/components/ModelSelectorPortalLayer.test.ts src/flow_chat/components/ChatInputWorkspaceStripLayout.test.ts src/flow_chat/components/modelSelectorDropdownPosition.test.ts`
- `pnpm run check:web` — passed.
- `pnpm run motion:audit` — passed (advisory inventory).
- `git diff --check` — passed before commit.

## Reviewer Notes

AI-assisted (Codex); testing level: lightly tested with automated component coverage and deterministic reproduction. No visual styling, backend APIs, persisted data, or wire protocols changed. Remote workspace and dispatch adapter mocks are covered by the focused suites; no live remote workspace, remote control, Peer Device, or detached dispatch end-to-end verification was performed. No visual recording was captured. This PR will be merged only after its GitHub CI passes.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable (no copy changes).
