### PR TITLE
Fix SSH workspace status flicker during session navigation

### DIFF
--- a/src/web-ui/src/features/ssh-remote/SSHRemoteProvider.test.tsx
+++ b/src/web-ui/src/features/ssh-remote/SSHRemoteProvider.test.tsx
@@ -392,14 +392,16 @@ describe('SSHRemoteProvider startup restore', () => {
   });
 });
 
-describe('SSHRemoteProvider peer device mode', () => {
+describe('SSHRemoteProvider workspace connection state', () => {
   let container: HTMLDivElement;
   let root: Root;
   let latestStatuses: Record<string, ConnectionStatus>;
+  let statusHistory: Array<Record<string, ConnectionStatus>>;
 
   function StatusProbe() {
     const ctx = React.useContext(SSHContext);
     latestStatuses = ctx?.workspaceStatuses ?? {};
+    statusHistory.push(latestStatuses);
     return null;
   }
 
@@ -424,6 +426,7 @@ describe('SSHRemoteProvider peer device mode', () => {
     vi.clearAllMocks();
     peerModeFlagMock.active = false;
     latestStatuses = {};
+    statusHistory = [];
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
@@ -476,6 +479,59 @@ describe('SSHRemoteProvider peer device mode', () => {
       }
     });
   }
+
+  it.each([true, false])('keeps an established connection green during a session-switch probe (saved profile: %s)', async (hasSavedProfile) => {
+    const workspace = createRemoteWorkspace();
+    workspaceManagerMock.getState.mockReturnValue({
+      loading: false, openedWorkspaces: new Map([[workspace.id, workspace]]), activeWorkspaceId: workspace.id,
+    });
+    sshApiMock.listSavedConnections.mockResolvedValue(hasSavedProfile ? [{
+      id: 'conn-1', name: 'dev-box', host: 'example.com', port: 22, username: 'dev',
+      authType: { type: 'PrivateKey', keyPath: '/tmp/key' },
+    }] : []);
+    sshApiMock.isConnected.mockResolvedValue(true);
+    await renderProvider();
+    expect(latestStatuses['conn-1']).toBe('connected');
+    statusHistory = [];
+
+    let finishProbe!: (connected: boolean) => void;
+    sshApiMock.isConnected.mockImplementationOnce(() => new Promise(resolve => { finishProbe = resolve; }));
+    emitWorkspaceManagerEvent({ type: 'workspace:switched', workspace });
+    await act(async () => { await Promise.resolve(); });
+    expect(finishProbe).toBeTypeOf('function');
+    expect(latestStatuses['conn-1']).toBe('connected');
+    await act(async () => { finishProbe(true); });
+
+    expect(statusHistory.every(statuses => statuses['conn-1'] === 'connected')).toBe(true);
+    expect(sshApiMock.connect).not.toHaveBeenCalled();
+  });
+
+  it('shows connecting after a probe confirms a real disconnect and clears it when reconnection finishes', async () => {
+    const workspace = createRemoteWorkspace();
+    workspaceManagerMock.getState.mockReturnValue({
+      loading: false, openedWorkspaces: new Map([[workspace.id, workspace]]), activeWorkspaceId: workspace.id,
+    });
+    sshApiMock.listSavedConnections.mockResolvedValue([{
+      id: 'conn-1', name: 'dev-box', host: 'example.com', port: 22, username: 'dev',
+      authType: { type: 'PrivateKey', keyPath: '/tmp/key' },
+    }]);
+    sshApiMock.isConnected.mockResolvedValue(true);
+    await renderProvider();
+    expect(latestStatuses['conn-1']).toBe('connected');
+
+    let finishProbe!: (connected: boolean) => void;
+    let finishReconnect!: (result: { success: boolean; connectionId: string }) => void;
+    sshApiMock.isConnected.mockImplementationOnce(() => new Promise(resolve => { finishProbe = resolve; }));
+    sshApiMock.connect.mockImplementationOnce(() => new Promise(resolve => { finishReconnect = resolve; }));
+    emitWorkspaceManagerEvent({ type: 'workspace:switched', workspace });
+    await act(async () => { await Promise.resolve(); });
+    expect(latestStatuses['conn-1']).toBe('connected');
+    await act(async () => { finishProbe(false); });
+    expect(sshApiMock.connect).toHaveBeenCalledTimes(1);
+    expect(latestStatuses['conn-1']).toBe('connecting');
+    await act(async () => { finishReconnect({ success: true, connectionId: 'conn-1' }); });
+    expect(latestStatuses['conn-1']).toBe('connected');
+  });
 
   it('mirrors peer-owned remote workspaces as connected without starting the reconnect timeout', async () => {
     vi.useFakeTimers();

--- a/src/web-ui/src/features/ssh-remote/SSHRemoteProvider.tsx
+++ b/src/web-ui/src/features/ssh-remote/SSHRemoteProvider.tsx
@@ -558,7 +558,10 @@ export const SSHRemoteProvider: React.FC<SSHRemoteProviderProps> = ({ children }
           ? 'error'
           : 'connecting';
       }
-      setWorkspaceStatuses(prev => ({ ...prev, ...initialStatuses }));
+      // A background check is not a reconnect. Keep the last observed state
+      // while the probe is pending, including when session selection checks
+      // every opened workspace again.
+      setWorkspaceStatuses(prev => ({ ...initialStatuses, ...prev }));
 
       type ConnectedEntry = { workspace: RemoteWorkspace; connectionId: string };
       const results = await Promise.all(
@@ -617,6 +620,7 @@ export const SSHRemoteProvider: React.FC<SSHRemoteProviderProps> = ({ children }
             connectionId: workspace.connectionId,
             remotePath: workspace.remotePath,
           });
+          setWorkspaceStatuses(prev => ({ ...prev, [workspace.connectionId]: 'connecting' }));
           const result = await tryReconnectWithRetry(workspace);
 
           if (result !== false) {


### PR DESCRIPTION
## Summary

Selecting an SSH session triggers a background check of opened remote workspaces. That check previously reset every badge to Connecting before asking whether the connection was still alive, producing a green → yellow → green flash.

Keep each workspace's last observed status while the probe runs. Enter Connecting only after a probe confirms a disconnected transport and an actual reconnect starts; confirmed failures and missing-credential errors still update the badge.

## Type and Areas

Type: bug fix, UI/UX, tests.

Areas: shared Web UI SSH remote workspace provider.

## Motivation / Impact

Session navigation no longer presents a healthy SSH connection as reconnecting. Existing connections also remain accurately connected when their saved profile is temporarily unavailable.

## Verification

- `pnpm --dir src/web-ui exec vitest run src/features/ssh-remote/SSHRemoteProvider.test.tsx src/features/ssh-remote/remoteWorkspaceReconnect.test.ts`: 17 tests passed.
- `pnpm --dir src/web-ui exec eslint src/features/ssh-remote/SSHRemoteProvider.tsx src/features/ssh-remote/SSHRemoteProvider.test.tsx`: passed.
- `pnpm run check:web`: passed after preparing the new worktree's design-system dependencies and generated API bindings.
- Focused session lifecycle/state contracts: 38 tests passed.
- Deferred-probe tests inspect intermediate renders, preserve Connected with and without a saved profile, and confirm that a real disconnect still transitions through Connecting to Connected. Existing peer-mode and reconnect/restore contracts remain covered.

## Reviewer Notes

No protocol, persisted shape, theme token, or connection ownership changes. SSH and Peer Device Mode state paths were exercised through the provider tests with mocked transports; this is not a claim of a complete remote scenario matrix. This small follow-up is independent of the communications fixes in #2839.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable (no copy changes).
