### PR TITLE
fix(nav): prefer connection aliases in remote workspace badges

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceItem.tsx
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceItem.tsx
@@ -252,7 +252,7 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
     return {
       status,
       statusLabel,
-      hostLabel,
+      connectionLabel,
       /** A green dot already reads as "fine"; spell out only the states that need attention. */
       showStatusText: status !== 'connected',
       tooltip: t('nav.workspaces.remote.tooltip', {
@@ -261,7 +261,7 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
         status: statusLabel,
       }),
       ariaLabel: t('nav.workspaces.remote.ariaLabel', {
-        connection: hostLabel,
+        connection: connectionLabel,
         status: statusLabel,
       }),
     };
@@ -1362,7 +1362,7 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
                       aria-hidden="true"
                     />
                     <span className="openbitfun-nav-panel__workspace-item-remote-host">
-                      {remoteMeta.hostLabel}
+                      {remoteMeta.connectionLabel}
                     </span>
                     {remoteMeta.showStatusText ? (
                       <span className="openbitfun-nav-panel__workspace-item-remote-status">

--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSectionLayout.test.ts
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceListSectionLayout.test.ts
@@ -222,7 +222,7 @@ describe('WorkspaceListSection layout styles', () => {
     expect(source).toContain('behavior="marquee"');
     expect(searchIndicatorStart).toBeGreaterThan(remoteNameStart);
     expect(remoteMetaStart).toBeGreaterThan(searchIndicatorStart);
-    expect(remoteMetaMarkup).toContain('remoteMeta.hostLabel');
+    expect(remoteMetaMarkup).toContain('remoteMeta.connectionLabel');
     expect(remoteMetaMarkup.indexOf('workspace-item-status-dot'))
       .toBeLessThan(remoteMetaMarkup.indexOf('workspace-item-remote-host'));
     expect(source).not.toContain('workspace-item-subtitle');


### PR DESCRIPTION
## Summary

A remote workspace badge showed the SSH address even when the saved connection had an alias, while dispatch displayed that alias. Use the existing connection label for the workspace badge and its accessible name: trimmed connection alias first, SSH address next, then connection ID. The tooltip retains the real SSH address and connection status.

## Verification

- `pnpm run check:web` — passed after preparing generated API types and design-system packages in the fresh worktree.
- `pnpm --dir src/web-ui exec vitest run src/app/components/NavPanel/sections/workspaces/WorkspaceListSectionLayout.test.ts src/app/components/NavPanel/sections/sessions/SessionsSectionLayout.test.ts src/app/components/NavPanel/sections/workspaces/WorkspaceItemSessionBatchManagement.test.ts` — 20 passed.
- `git diff --check` — passed.

AI-assisted; focused automated verification completed. This is a frontend label change using existing workspace metadata. Live SSH/Peer Device Mode sessions and mobile remote control were not exercised in this PR; dispatch continues to use its target display name. No styles, persisted shapes, or transport behavior changed.

Please use a merge commit when merging this PR.
