### PR TITLE
fix(ios): keep QR capture work off main thread

### DIFF
--- a/src/apps/mobile/ios/OpenBitFun/Features/Pairing/PairingSheet.swift
+++ b/src/apps/mobile/ios/OpenBitFun/Features/Pairing/PairingSheet.swift
@@ -37,16 +37,19 @@ struct PairingSheet: View {
             }
         }
         .fullScreenCover(isPresented: $scannerOpen) {
-            QRCodeScannerView { code in
-                pairingURL = code
-                scannerOpen = false
-                if PairingLinkHintsKt.inspectPairingLink(url: code).requiresAccount {
-                    manualOpen = true
-                    focused = true
-                } else {
-                    model.submitPairing(url: code)
-                }
-            }
+            QRCodeScannerView(
+                onCode: { code in
+                    pairingURL = code
+                    scannerOpen = false
+                    if PairingLinkHintsKt.inspectPairingLink(url: code).requiresAccount {
+                        manualOpen = true
+                        focused = true
+                    } else {
+                        model.submitPairing(url: code)
+                    }
+                },
+                onCancel: { scannerOpen = false }
+            )
             .ignoresSafeArea()
         }
     }

--- a/src/apps/mobile/ios/OpenBitFun/Infrastructure/Platform/QRCodeScannerView.swift
+++ b/src/apps/mobile/ios/OpenBitFun/Infrastructure/Platform/QRCodeScannerView.swift
@@ -4,10 +4,12 @@ import UIKit
 
 struct QRCodeScannerView: UIViewControllerRepresentable {
     let onCode: (String) -> Void
+    let onCancel: () -> Void
 
     func makeUIViewController(context: Context) -> QRScannerController {
         let controller = QRScannerController()
         controller.onCode = onCode
+        controller.onCancel = onCancel
         return controller
     }
 
@@ -15,9 +17,13 @@ struct QRCodeScannerView: UIViewControllerRepresentable {
 }
 
 final class QRScannerController: UIViewController, AVCaptureMetadataOutputObjectsDelegate {
-    private let session = AVCaptureSession()
+    private let sessionQueue = DispatchQueue(label: "com.openbitfun.mobile.ios.qr-session")
+    private lazy var session = AVCaptureSession()
     private var previewLayer: AVCaptureVideoPreviewLayer?
+    private var captureConfigured = false
+    private var emittedCode = false
     var onCode: ((String) -> Void)?
+    var onCancel: (() -> Void)?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -27,7 +33,10 @@ final class QRScannerController: UIViewController, AVCaptureMetadataOutputObject
         close.tintColor = UIColor(OpenBitFunTheme.contentOnAction)
         close.backgroundColor = UIColor(OpenBitFunTheme.mediaControlBackground)
         close.layer.cornerRadius = 22
-        close.addAction(UIAction { [weak self] _ in self?.dismiss(animated: true) }, for: .touchUpInside)
+        close.addAction(UIAction { [weak self] _ in
+            self?.stopCapture()
+            self?.onCancel?()
+        }, for: .touchUpInside)
         close.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(close)
         NSLayoutConstraint.activate([
@@ -37,11 +46,22 @@ final class QRScannerController: UIViewController, AVCaptureMetadataOutputObject
             close.heightAnchor.constraint(equalToConstant: 44),
         ])
 
-        guard AVCaptureDevice.authorizationStatus(for: .video) != .denied else { return }
-        AVCaptureDevice.requestAccess(for: .video) { [weak self] granted in
-            guard granted else { return }
-            DispatchQueue.main.async { self?.configureCapture() }
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized:
+            configureCaptureAsync()
+        case .notDetermined:
+            AVCaptureDevice.requestAccess(for: .video) { [weak self] granted in
+                guard granted else { return }
+                self?.configureCaptureAsync()
+            }
+        default:
+            break
         }
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        stopCapture()
     }
 
     override func viewDidLayoutSubviews() {
@@ -49,21 +69,42 @@ final class QRScannerController: UIViewController, AVCaptureMetadataOutputObject
         previewLayer?.frame = view.bounds
     }
 
+    private func configureCaptureAsync() {
+        sessionQueue.async { [weak self] in
+            self?.configureCapture()
+        }
+    }
+
     private func configureCapture() {
+        guard !captureConfigured else { return }
         guard let device = AVCaptureDevice.default(for: .video),
               let input = try? AVCaptureDeviceInput(device: device),
               session.canAddInput(input) else { return }
         let output = AVCaptureMetadataOutput()
         guard session.canAddOutput(output) else { return }
+        session.beginConfiguration()
         session.addInput(input)
         session.addOutput(output)
-        output.setMetadataObjectsDelegate(self, queue: .main)
+        output.setMetadataObjectsDelegate(self, queue: sessionQueue)
         output.metadataObjectTypes = [.qr]
-        let layer = AVCaptureVideoPreviewLayer(session: session)
-        layer.videoGravity = .resizeAspectFill
-        view.layer.insertSublayer(layer, at: 0)
-        previewLayer = layer
+        session.commitConfiguration()
+        captureConfigured = true
+        DispatchQueue.main.async { [weak self] in
+            guard let self, self.previewLayer == nil else { return }
+            let layer = AVCaptureVideoPreviewLayer(session: self.session)
+            layer.videoGravity = .resizeAspectFill
+            layer.frame = self.view.bounds
+            self.view.layer.insertSublayer(layer, at: 0)
+            self.previewLayer = layer
+        }
         session.startRunning()
+    }
+
+    private func stopCapture() {
+        sessionQueue.async { [weak self] in
+            guard let self, self.session.isRunning else { return }
+            self.session.stopRunning()
+        }
     }
 
     func metadataOutput(
@@ -72,9 +113,14 @@ final class QRScannerController: UIViewController, AVCaptureMetadataOutputObject
         from connection: AVCaptureConnection,
     ) {
         guard let value = (metadataObjects.first as? AVMetadataMachineReadableCodeObject)?.stringValue,
-              !value.isEmpty else { return }
-        session.stopRunning()
-        onCode?(value)
-        dismiss(animated: true)
+              !value.isEmpty,
+              !emittedCode else { return }
+        emittedCode = true
+        if session.isRunning {
+            session.stopRunning()
+        }
+        DispatchQueue.main.async { [weak self] in
+            self?.onCode?(value)
+        }
     }
 }


### PR DESCRIPTION
## Problem

Scanning a pairing QR code could freeze the iOS UI because `AVCaptureSession.startRunning()` and `stopRunning()` executed synchronously on the main thread. The scanner also let UIKit and SwiftUI dismiss the same cover independently.

## Changes

- create and operate the capture session on a dedicated serial queue
- deliver QR results to the main thread only after capture stops
- ignore duplicate metadata callbacks
- stop capture when the scanner disappears
- make SwiftUI the single owner of scanner dismissal

## Validation

- iPhone 16 Pro simulator Debug build
- signed generic iOS device Debug build
- `./Testing/run-pure-swift-tests.sh`
- `git diff --check upstream/main...HEAD`
- iPhone 13 Pro, iOS 26.3: QR recognition stopped capture off the main thread, pairing requests returned HTTP 200, subsequent 15-second heartbeats succeeded, the process stayed alive, and no crash report was produced

The live device run verified the queue and dismissal fix. The final lazy-initialization refinement was then device-build verified after the log exposed a separate capture-session initialization stall.
