### PR TITLE
fix(desktop): align macOS traffic lights with toolbar icons

### DIFF
--- a/src/apps/desktop/src/appearance.rs
+++ b/src/apps/desktop/src/appearance.rs
@@ -651,7 +651,9 @@ pub fn create_main_window(
         builder = builder
             .decorations(true)
             .title_bar_style(tauri::TitleBarStyle::Overlay)
-            .traffic_light_position(tauri::LogicalPosition::new(12.0, 15.0))
+            // Match the 45px toolbar row (layout.toolbar.mdHeight) used by
+            // NavBar and SceneTopBar, including when the sidebar is collapsed.
+            .traffic_light_position(tauri::LogicalPosition::new(12.0, 22.5))
             .hidden_title(true);
     }
 


### PR DESCRIPTION
## Summary

Adjust the macOS native traffic-light vertical position from 15 to 22.5 logical pixels to align with the 45px toolbar row.

Related issue: N/A.

## Type and Areas

Type: Bug fix / UI/UX

Areas: Desktop / Tauri (macOS)

## Motivation / Impact

The native close, minimize, and fullscreen buttons appear above the other toolbar icons on macOS. Move them down by 7.5 logical pixels while preserving their horizontal spacing.

## Verification

- `pnpm run fmt:rs` — passed.
- `git diff --check` — passed.
- `cargo check -p openbitfun-desktop --offline` — passed on Windows.
- `pnpm --dir src/web-ui exec vitest run src/app/layout/WorkspaceBody.presentation.test.ts` — 4 tests passed.
- The standard test script was blocked during its design-system prebuild by a missing `@openbitfun/token-engine` workspace dependency; the focused tests passed when invoked directly.
- macOS visual verification remains pending. Windows checks do not validate native macOS button placement.
- Remote workspace, remote control, Peer Device Mode, and Detached Dispatch were not exercised.

## Reviewer Notes

- AI-assisted; lightly tested.
- The change is limited to the macOS native window creation configuration.
- Rebuild and restart on macOS to verify alignment with both expanded and collapsed sidebars. Frontend hot reload does not apply this change.
- No persisted data, protocols, or user-facing strings changed.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.