### PR TITLE
fix(web-ui): improve session archive feedback and cleanup

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.tsx
+++ b/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.tsx
@@ -1304,11 +1304,12 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
       try {
         await flowChatManager.archiveChatSession(sessionId);
         window.dispatchEvent(new CustomEvent('openbitfun:session-archived'));
+        notificationService.success(t('nav.sessions.archivedAll', { count: 1 }), { duration: 3000 });
       } catch (err) {
         log.error('Failed to archive session', err);
       }
     },
-    []
+    [t]
   );
 
   const handleCopySessionId = useCallback(

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.test.ts
@@ -1207,7 +1207,10 @@ describe('SessionModule historical session coordination', () => {
     expect(persistenceMocks.cleanupSaveState).toHaveBeenCalledWith(context, 'active-1');
   });
 
-  it('cancels a speculative history-open transition when deleting its target', async () => {
+  it.each([
+    ['deleting', deleteChatSession],
+    ['archiving', archiveChatSession],
+  ] as const)('cancels a speculative history-open transition when %s its target', async (_action, removeSession) => {
     const historicalSession = createSession({
       sessionId: 'history-delete',
       isHistorical: true,
@@ -1223,7 +1226,7 @@ describe('SessionModule historical session coordination', () => {
       sessionId: historicalSession.sessionId,
     });
 
-    await deleteChatSession(context, historicalSession.sessionId);
+    await removeSession(context, historicalSession.sessionId);
 
     expect(getHistorySessionOpenTransitionSnapshot()).toBeNull();
   });

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/SessionModule.ts
@@ -898,6 +898,13 @@ export async function archiveChatSession(
       && removedSessionIdSet.has(stateBeforeArchive.activeSessionId)
     );
 
+    // Match deletion: a removed session must not leave a pending history-open
+    // shield or navigation intent behind while the archive request settles.
+    removedSessionIds.forEach(removedSessionId => {
+      clearRecentHistorySessionOpenIntent(removedSessionId);
+      clearHistorySessionOpenTransition(removedSessionId);
+    });
+
     await driverForSession(sessionId, session).archiveSession(context, sessionId, {
       removedSessionIds,
       removedActiveSession,

--- a/src/web-ui/src/locales/en-US/common.json
+++ b/src/web-ui/src/locales/en-US/common.json
@@ -404,7 +404,7 @@
       "restore": "Restore",
       "restoreSucceeded": "Restored “{{name}}” in {{workspace}}.",
       "restoreRefreshFailed": "The session was restored, but the session list could not refresh. Refresh the workspace manually.",
-      "archivedAll": "{{count}} sessions archived",
+      "archivedAll": "Archived {{count}} sessions. View them in Settings → Archived Sessions.",
       "restoreFailed": "Failed to restore session",
       "deleteArchivedFailed": "Failed to delete session",
       "deleteAllArchivedFailed": "Failed to delete all archived sessions",

--- a/src/web-ui/src/locales/zh-CN/common.json
+++ b/src/web-ui/src/locales/zh-CN/common.json
@@ -404,7 +404,7 @@
       "restore": "恢复",
       "restoreSucceeded": "已恢复“{{name}}”（{{workspace}}）。",
       "restoreRefreshFailed": "会话已恢复，但会话列表刷新失败；请手动刷新工作区。",
-      "archivedAll": "已归档 {{count}} 个会话",
+      "archivedAll": "已归档 {{count}} 个会话，可在设置 → 已归档会话中查看。",
       "restoreFailed": "恢复会话失败",
       "deleteArchivedFailed": "删除会话失败",
       "deleteAllArchivedFailed": "删除全部已归档会话失败",

--- a/src/web-ui/src/locales/zh-TW/common.json
+++ b/src/web-ui/src/locales/zh-TW/common.json
@@ -404,7 +404,7 @@
       "restore": "恢復",
       "restoreSucceeded": "已恢復「{{name}}」（{{workspace}}）。",
       "restoreRefreshFailed": "會話已恢復，但會話列表重新整理失敗；請手動重新整理工作區。",
-      "archivedAll": "已歸檔 {{count}} 個會話",
+      "archivedAll": "已歸檔 {{count}} 個會話，可在設定 → 已歸檔會話中檢視。",
       "restoreFailed": "恢復會話失敗",
       "deleteArchivedFailed": "刪除會話失敗",
       "deleteAllArchivedFailed": "刪除全部已歸檔會話失敗",


### PR DESCRIPTION
## Summary

- Show a success notification after archiving a single session.
- Tell users where to find archived sessions: Settings → Archived Sessions, for both single and bulk actions.
- Clear pending session-open intents and transitions during archiving, matching deletion behavior.
- Update English, Simplified Chinese, and Traditional Chinese notification text.

## Type and Areas

Type: Bug fix / UI/UX

Areas: Web UI, session management, internationalization

## Motivation / Impact

Provide clear feedback after archiving and help users locate archived sessions. Prevent stale session-open state from affecting the UI while preserving immediate, confirmation-free archiving.

## Verification

- `pnpm --dir src/web-ui run test:run src/app/services/sessionSceneLifecycle.test.ts src/flow_chat/services/sessionActivation.test.ts src/flow_chat/services/storeSync.test.ts src/app/stores/sceneStore.test.ts src/flow_chat/services/flow-chat-manager/SessionModule.test.ts src/app/components/NavPanel/sections/sessions/sessionActionConfirmation.test.ts`
  - Passed: 6 test files, 88 tests.
- `pnpm run check:web`: passed.
- `pnpm run i18n:audit`: passed with 0 warnings.
- `git diff --check`: passed.

## Reviewer Notes

- Changes are limited to frontend feedback and state cleanup. No backend protocol or persisted format changes.
- Remote workspace, remote control, Peer Device Mode, and Detached Dispatch scenarios were not verified on live devices.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.