### PR TITLE
fix(web-ui): keep long-command approval actions reachable

### DIFF
--- a/src/web-ui/src/app/components/RemoteConnectDialog/RemoteConnectDialog.status.test.tsx
+++ b/src/web-ui/src/app/components/RemoteConnectDialog/RemoteConnectDialog.status.test.tsx
@@ -298,13 +298,13 @@ describe('Remote Connect shared status through the real dialog and sidebar', () 
     const devices = element('[data-testid="nav-device-status-connected-devices"]');
     expect(devices.querySelector('[data-openbitfun-device-kind="mobile"] strong')?.textContent).toBe('remoteConnect.mobileBrowserTitle');
     expect(devices.querySelector('[data-openbitfun-device-kind="message-app"] strong')?.textContent).toBe('remoteConnect.weixin');
-    const service = element('[data-testid="nav-device-connection-service"]');
-    expect(service.getAttribute('data-openbitfun-service-kind')).toBe('self-hosted');
-    expect(service.textContent).toContain('relay.example.test');
-    await click(element('[data-testid="nav-footer-device-status"]'));
-    await click(element('[data-testid="reopen-remote-connect"]'));
+    expect(document.querySelector('[data-testid="nav-device-connection-service"]')).toBeNull();
+    await click(element('[data-testid="nav-device-status-manage"]'));
+    expect(document.querySelector('[data-testid="nav-device-status-popover"]')).toBeNull();
     expect(overviewNetwork().textContent).toContain('remoteConnect.stateConnected');
     await openNetwork();
+    expect(element('#remote-connect-network-tab-custom_server').getAttribute('aria-selected')).toBe('true');
+    expect((element('input[type="url"]') as HTMLInputElement).value).toBe(relayA);
     expect(cardStatus()).toBe('remoteConnect.stateConnected');
     expect(dialog().textContent).not.toContain('remoteConnect.disconnect');
     await clickText('remoteConnect.showConnectionCode');

--- a/src/web-ui/src/flow_chat/components/ChatInputApprovalBand.scss
+++ b/src/web-ui/src/flow_chat/components/ChatInputApprovalBand.scss
@@ -1,34 +1,31 @@
-// The approval band normally sits in the composer stack, directly above the
-// capsule. Embedded child-session panels reuse the same compact surface when
-// no child composer exists.
+// Keep the band within both the centered composer stack and embedded panels.
+// Only the resource scrolls; approval actions remain outside that viewport.
 .openbitfun-chat-input-approval {
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  flex-shrink: 0;
   box-sizing: border-box;
-  margin-bottom: 6px;
-  padding: 8px 10px;
-  border: 1px solid var(--openbitfun-color-status-warning-border);
-  border-radius: 12px;
-  background: var(--openbitfun-color-status-warning-surface);
+  margin-bottom: var(--openbitfun-layout-card-gap-sm);
   color: var(--openbitfun-color-content-primary);
   font-size: var(--openbitfun-type-flow-control-font-size);
-  animation: openbitfun-chat-input-approval-in 160ms cubic-bezier(0.23, 1, 0.32, 1);
 
   &__request {
     display: flex;
     min-width: 0;
     align-items: center;
-    gap: 5px;
+    gap: var(--openbitfun-layout-card-gap-sm);
   }
 
   &__icon {
     flex: none;
-    color: var(--openbitfun-color-status-warning-emphasis);
+    color: var(--openbitfun-color-content-secondary);
   }
 
   &__action {
-    flex: none;
+    min-width: 0;
+    overflow-wrap: anywhere;
+    color: var(--openbitfun-color-content-primary);
     font-weight: var(--openbitfun-type-label-selected-font-weight);
   }
 
@@ -37,17 +34,35 @@
     color: var(--openbitfun-color-content-secondary);
   }
 
-  // The resource is the part worth the remaining width: which file, which
-  // command. Identity and owner are context and yield first.
   &__resource {
     min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    max-height: min(10rem, 25dvh);
+    overflow: auto;
+    overscroll-behavior: contain;
+    margin: 0;
+    padding: var(--openbitfun-layout-card-padding-sm);
+    border-radius: var(--openbitfun-layout-card-radius-sm);
+    background: var(--openbitfun-color-surface-canvas);
+    color: var(--openbitfun-color-content-primary);
+    font-family: var(--openbitfun-type-code-md-font-family);
+    font-size: var(--openbitfun-type-code-md-font-size);
+    line-height: var(--openbitfun-type-code-md-line-height);
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+
+    code {
+      font: inherit;
+      white-space: inherit;
+    }
+
+    &:focus-visible {
+      outline: var(--openbitfun-focus-width) solid var(--openbitfun-color-focus-ring);
+      outline-offset: var(--openbitfun-focus-offset);
+    }
   }
 
   &__owner {
-    flex: 0 1 auto;
+    flex: 1 1 auto;
     min-width: 0;
     overflow: hidden;
     color: var(--openbitfun-color-content-secondary);
@@ -58,18 +73,14 @@
 
   &__count {
     flex: none;
-    margin-left: auto;
-    padding: 1px 6px;
-    border-radius: 8px;
-    color: var(--openbitfun-color-content-on-light);
-    background: var(--openbitfun-color-status-warning-emphasis);
+    color: var(--openbitfun-color-content-secondary);
     font-size: var(--openbitfun-type-flow-support-font-size);
-    font-weight: var(--openbitfun-type-heading-page-font-weight);
     cursor: default;
   }
 
   &__note {
     margin: 0;
+    overflow-wrap: anywhere;
     color: var(--openbitfun-color-status-warning-content);
     font-size: var(--openbitfun-type-flow-support-font-size);
 
@@ -80,9 +91,10 @@
 
   &__actions {
     display: flex;
+    min-width: 0;
     flex-wrap: wrap;
     align-items: center;
-    gap: 6px;
+    gap: var(--openbitfun-layout-card-footer-gap);
   }
 
   &__spacer {
@@ -90,61 +102,6 @@
   }
 
   &__scope {
-    display: inline-flex;
-    flex: none;
-    align-items: center;
-    padding: 2px;
-    border: 1px solid var(--openbitfun-color-border-default);
-    border-radius: 7px;
-    background: var(--openbitfun-color-surface-canvas);
-  }
-
-  &__scope-option {
-    min-height: 20px;
-    padding: 1px 7px;
-    border: none;
-    border-radius: 5px;
-    color: var(--openbitfun-color-content-secondary);
-    background: transparent;
-    font-size: var(--openbitfun-type-flow-support-font-size);
-    cursor: pointer;
-
-    &--active {
-      color: var(--openbitfun-color-content-primary);
-      background: color-mix(in srgb, var(--openbitfun-color-status-warning-emphasis) 18%, transparent);
-    }
-
-    &:focus-visible {
-      outline: 2px solid var(--openbitfun-color-status-warning-emphasis);
-      outline-offset: 1px;
-    }
-  }
-
-}
-
-// A narrow composer drops secondary identity information while the shared
-// buttons wrap as complete, readable actions.
-@media (max-width: 560px) {
-  .openbitfun-chat-input-approval {
-    &__owner {
-      display: none;
-    }
-  }
-}
-
-@keyframes openbitfun-chat-input-approval-in {
-  from {
-    opacity: 0;
-    transform: translateY(3px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .openbitfun-chat-input-approval {
-    animation: none;
+    min-width: 0;
   }
 }

--- a/src/web-ui/src/flow_chat/components/ChatInputApprovalBand.test.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInputApprovalBand.test.tsx
@@ -1,6 +1,10 @@
 // @vitest-environment jsdom
 
 import React, { act } from 'react';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { compileString } from 'sass';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { PermissionRequest } from '@/infrastructure/api/service-api/AgentAPI';
@@ -23,7 +27,8 @@ const TRANSLATIONS: Record<string, string> = {
   'permission.scopeAll': 'All',
 };
 
-vi.mock('react-i18next', () => ({
+vi.mock('react-i18next', async importOriginal => ({
+  ...await importOriginal<typeof import('react-i18next')>(),
   useTranslation: () => ({
     t: (key: string, values?: Record<string, string>) => {
       if (key === 'permission.subagentOwner') return `${values?.subagent} subagent`;
@@ -43,11 +48,6 @@ vi.mock('@openbitfun/ui', async importOriginal => ({
   Tooltip: ({ children }: { children: React.ReactElement }) => <>{children}</>,
 }));
 
-vi.mock('./CopyableTextPreview', () => ({
-  CopyableTextPreview: ({ text, className }: { text: string; className?: string }) => (
-    <code className={className}>{text}</code>
-  ),
-}));
 
 function request(overrides: Partial<PermissionRequest> = {}): PermissionRequest {
   return {
@@ -70,8 +70,15 @@ function request(overrides: Partial<PermissionRequest> = {}): PermissionRequest 
 describe('ChatInputApprovalBand', () => {
   let container: HTMLDivElement;
   let root: Root;
+  let stylesheet: HTMLStyleElement;
 
   beforeEach(() => {
+    stylesheet = document.createElement('style');
+    const filename = 'ChatInputApprovalBand.scss';
+    stylesheet.textContent = compileString(readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), filename), 'utf8',
+    )).css;
+    document.head.appendChild(stylesheet);
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
@@ -80,14 +87,16 @@ describe('ChatInputApprovalBand', () => {
   afterEach(() => {
     act(() => root.unmount());
     container.remove();
+    stylesheet.remove();
     vi.clearAllMocks();
   });
 
   const click = async (testId: string) => {
     await act(async () => {
-      container
-        .querySelector<HTMLButtonElement>(`[data-testid="${testId}"]`)
-        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      const button = container.querySelector<HTMLButtonElement>(`[data-testid="${testId}"]`);
+      expect(button).not.toBeNull();
+      expect(button!.disabled).toBe(false);
+      button!.click();
     });
   };
 
@@ -152,7 +161,7 @@ describe('ChatInputApprovalBand', () => {
     });
 
     // A lone request has nothing to scope, so the toggle stays out of the way.
-    expect(container.querySelector('[data-testid="chat-input-approval-scope-all"]')).toBeNull();
+    expect(container.querySelector('[role="radio"][data-openbitfun-value="all"]')).toBeNull();
     expect(container.querySelector('[data-testid="chat-input-approval-pending-count"]')).toBeNull();
 
     await click('chat-input-approval-allow');
@@ -182,7 +191,15 @@ describe('ChatInputApprovalBand', () => {
         ?.dataset.approvalScope,
     ).toBe('this');
 
-    await click('chat-input-approval-scope-all');
+    const currentScope = container.querySelector<HTMLButtonElement>(
+      '[role="radio"][data-openbitfun-value="this"]',
+    );
+    expect(currentScope).not.toBeNull();
+    await act(async () => {
+      currentScope!.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    });
+    expect(container.querySelector('[role="radio"][data-openbitfun-value="all"]')
+      ?.getAttribute('aria-checked')).toBe('true');
     const band = container.querySelector<HTMLElement>('[data-testid="chat-input-approval-band"]');
     expect(band?.dataset.approvalScope).toBe('all');
     expect(band?.textContent).toContain('Reject all');
@@ -268,6 +285,56 @@ describe('ChatInputApprovalBand', () => {
     expect(
       container.querySelector<HTMLButtonElement>('[data-testid="chat-input-approval-allow"]')?.disabled,
     ).toBe(false);
+  });
+
+  it.each([
+    ['unbroken command', `printf '${'x'.repeat(40000)}'`],
+    ['multiline command', Array.from({ length: 300 }, (_, index) => `printf 'line ${index}\n'`).join('\n')],
+  ])('keeps the full %s separate from answer controls and copies it intact', async (_, command) => {
+    const writeText = vi.fn(async () => undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+    const onRespond = vi.fn(async () => undefined);
+    await act(async () => {
+      root.render(
+        <ChatInputApprovalBand
+          requests={[request({ action: 'bash', resources: [command] })]}
+          onRespond={onRespond}
+          onRespondBatch={vi.fn(async () => undefined)}
+        />,
+      );
+    });
+
+    const band = container.querySelector<HTMLElement>('[data-testid="chat-input-approval-band"]')!;
+    const resource = band.querySelector<HTMLElement>('[role="region"]')!;
+    const actions = band.querySelector<HTMLElement>('[data-openbitfun-part="actions"]')!;
+    expect(resource.textContent).toBe(command);
+    expect(resource.tabIndex).toBe(0);
+    expect(resource.contains(actions)).toBe(false);
+    expect(band.querySelector('[data-openbitfun-component="card"]')?.getAttribute('data-appearance'))
+      .toBe('subtle');
+
+    // jsdom checks the compiled containment rules; real viewport layout is a
+    // separate manual check, since jsdom does not calculate element geometry.
+    const bandStyle = getComputedStyle(band);
+    expect(bandStyle.width).toBe('100%');
+    expect(bandStyle.maxWidth).toBe('100%');
+    expect(bandStyle.minWidth).toBe('0px');
+    const resourceStyle = getComputedStyle(resource);
+    expect(resourceStyle.whiteSpace).toBe('pre-wrap');
+    expect(resourceStyle.overflowWrap).toBe('anywhere');
+    expect(resourceStyle.overflow).toBe('auto');
+    expect(resourceStyle.maxHeight).toBe('min(10rem, 25dvh)');
+    expect(getComputedStyle(actions).flexWrap).toBe('wrap');
+
+    await click('chat-input-approval-copy');
+    expect(writeText).toHaveBeenCalledWith(command);
+    await click('chat-input-approval-allow');
+    expect(onRespond).toHaveBeenLastCalledWith('request-1', 'once', undefined);
+    await click('chat-input-approval-reject');
+    expect(onRespond).toHaveBeenLastCalledWith('request-1', 'reject', undefined);
   });
 
   it('renders nothing when there is nothing to approve', async () => {

--- a/src/web-ui/src/flow_chat/components/ChatInputApprovalBand.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInputApprovalBand.tsx
@@ -12,15 +12,14 @@
  */
 
 import React, { useState } from 'react';
-import { Button } from '@openbitfun/ui';
+import { Button, Card, Icon, IconButton, SegmentedControl, Tooltip } from '@openbitfun/ui';
 import { ShieldAlert } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { Tooltip, Icon } from '@openbitfun/ui';
 import type {
   PermissionReplyKind,
   PermissionRequest,
 } from '@/infrastructure/api/service-api/AgentAPI';
-import { CopyableTextPreview } from './CopyableTextPreview';
+import { useCopyTextAction } from '../hooks/useCopyTextAction';
 import './ChatInputApprovalBand.scss';
 
 export interface ChatInputApprovalBandProps {
@@ -130,6 +129,14 @@ export const ChatInputApprovalBand: React.FC<ChatInputApprovalBandProps> = ({
   const effectiveScope: ApprovalScope = canAnswerAll ? scope : 'this';
   const reason = rejectReason.trim();
 
+  const resourceText = request?.resources.join('\n') ?? '';
+  const { copied, copy } = useCopyTextAction({
+    getText: () => resourceText,
+    successMessage: t('toolCards.common.copied'),
+    failureMessage: t('toolCards.common.copyFailed'),
+    showSuccessNotification: false,
+  });
+
   if (!request) return null;
 
   const risk = permissionRisk(request, t);
@@ -160,7 +167,6 @@ export const ChatInputApprovalBand: React.FC<ChatInputApprovalBandProps> = ({
     }
   };
 
-  const resourceSummary = request.resources.join(', ');
   const answersAll = effectiveScope === 'all';
   const allowLabel = answersAll
     ? t('permission.allowCurrentAndFollowing')
@@ -180,167 +186,167 @@ export const ChatInputApprovalBand: React.FC<ChatInputApprovalBandProps> = ({
       data-testid="chat-input-approval-band"
       data-approval-scope={effectiveScope}
     >
-      <div
-        data-openbitfun-component="permission-request-panel"
-        data-openbitfun-part="request"
-        className="openbitfun-chat-input-approval__request"
-      >
-        <ShieldAlert
-          className="openbitfun-chat-input-approval__icon"
-          size={14}
-          strokeWidth={2.1}
-          aria-hidden
-        />
-        <span className="openbitfun-chat-input-approval__action">
-          {permissionActionLabel(request.action, t)}
-        </span>
-        <span className="openbitfun-chat-input-approval__separator" aria-hidden>·</span>
-        <CopyableTextPreview
-          as="code"
-          text={resourceSummary}
-          emptyText=""
-          className="openbitfun-chat-input-approval__resource copyable-text-preview--theme-font"
-          tooltipContent={request.resources.join('\n') || undefined}
-          tooltipPlacement="top"
-        />
-        {request.delegation ? (
-          <span className="openbitfun-chat-input-approval__owner">
-            {t('permission.subagentOwner', { subagent: request.delegation.subagentType })}
+      <Card appearance="subtle" padding="sm" gap="sm">
+        <div
+          data-openbitfun-component="permission-request-panel"
+          data-openbitfun-part="request"
+          className="openbitfun-chat-input-approval__request"
+        >
+          <ShieldAlert
+            className="openbitfun-chat-input-approval__icon"
+            size={14}
+            strokeWidth={2.1}
+            aria-hidden
+          />
+          <span className="openbitfun-chat-input-approval__action">
+            {permissionActionLabel(request.action, t)}
           </span>
-        ) : (
-          <span className="openbitfun-chat-input-approval__owner">{request.source.identity}</span>
-        )}
-        {canAnswerAll ? (
-          <Tooltip content={t('permission.batchCount', { count: pendingCount })} placement="top">
-            <span
-              className="openbitfun-chat-input-approval__count"
-              data-testid="chat-input-approval-pending-count"
-            >
-              +{pendingCount - 1}
+          <span className="openbitfun-chat-input-approval__separator" aria-hidden>·</span>
+          {request.delegation ? (
+            <span className="openbitfun-chat-input-approval__owner">
+              {t('permission.subagentOwner', { subagent: request.delegation.subagentType })}
             </span>
-          </Tooltip>
-        ) : null}
-      </div>
-
-      {/* The risk is the reason to read the band at all, so it keeps its own
-          line rather than hiding in a tooltip. */}
-      {error ? (
-        <p
-          data-openbitfun-component="permission-request-panel"
-          data-openbitfun-part="error"
-          className="openbitfun-chat-input-approval__note openbitfun-chat-input-approval__note--error"
-          role="alert"
-        >
-          {t('permission.responseFailed')}
-        </p>
-      ) : risk ? (
-        <p
-          data-openbitfun-component="permission-request-panel"
-          data-openbitfun-part="risk"
-          className="openbitfun-chat-input-approval__note"
-        >
-          {risk}
-        </p>
-      ) : null}
-
-      <div
-        data-openbitfun-component="permission-request-panel"
-        data-openbitfun-part="actions"
-        className="openbitfun-chat-input-approval__actions"
-      >
-        {canAnswerAll ? (
-          <div
-            data-openbitfun-component="permission-request-panel"
-            data-openbitfun-part="scope"
-            className="openbitfun-chat-input-approval__scope"
-            role="radiogroup"
-            aria-label={t('permission.scopeLabel')}
-          >
-            {(['this', 'all'] as const).map(option => (
-              <button
-                key={option}
-                type="button"
-                role="radio"
-                aria-checked={effectiveScope === option}
-                className={[
-                  'openbitfun-chat-input-approval__scope-option',
-                  effectiveScope === option && 'openbitfun-chat-input-approval__scope-option--active',
-                ]
-                  .filter(Boolean)
-                  .join(' ')}
-                disabled={responding}
-                data-testid={`chat-input-approval-scope-${option}`}
-                onClick={() => setScope(option)}
+          ) : (
+            <span className="openbitfun-chat-input-approval__owner">{request.source.identity}</span>
+          )}
+          {canAnswerAll ? (
+            <Tooltip content={t('permission.batchCount', { count: pendingCount })} placement="top">
+              <span
+                className="openbitfun-chat-input-approval__count"
+                data-testid="chat-input-approval-pending-count"
               >
-                {option === 'this' ? t('permission.scopeThis') : t('permission.scopeAll')}
-              </button>
-            ))}
-          </div>
+                +{pendingCount - 1}
+              </span>
+            </Tooltip>
+          ) : null}
+          <IconButton
+            variant="quiet"
+            size="sm"
+            aria-label={copied ? t('toolCards.common.copied') : t('toolCards.common.copy')}
+            icon={<Icon name={copied ? 'check-line' : 'duplicate'} size="sm" />}
+            onClick={copy}
+            data-testid="chat-input-approval-copy"
+          />
+        </div>
+
+        <pre
+          className="openbitfun-chat-input-approval__resource"
+          role="region"
+          aria-label={permissionActionLabel(request.action, t)}
+          tabIndex={0}
+        ><code>{resourceText}</code></pre>
+
+        {/* The risk is the reason to read the band at all, so it keeps its own
+            line rather than hiding in a tooltip. */}
+        {error ? (
+          <p
+            data-openbitfun-component="permission-request-panel"
+            data-openbitfun-part="error"
+            className="openbitfun-chat-input-approval__note openbitfun-chat-input-approval__note--error"
+            role="alert"
+          >
+            {t('permission.responseFailed')}
+          </p>
+        ) : risk ? (
+          <p
+            data-openbitfun-component="permission-request-panel"
+            data-openbitfun-part="risk"
+            className="openbitfun-chat-input-approval__note"
+          >
+            {risk}
+          </p>
         ) : null}
 
-        <span className="openbitfun-chat-input-approval__spacer" />
+        <div
+          data-openbitfun-component="permission-request-panel"
+          data-openbitfun-part="actions"
+          className="openbitfun-chat-input-approval__actions"
+        >
+          {canAnswerAll ? (
+            <div
+              data-openbitfun-component="permission-request-panel"
+              data-openbitfun-part="scope"
+              className="openbitfun-chat-input-approval__scope"
+            >
+              <SegmentedControl
+                aria-label={t('permission.scopeLabel')}
+                size="sm"
+                tone="neutral"
+                value={effectiveScope}
+                disabled={responding}
+                options={[
+                  { value: 'this', label: t('permission.scopeThis') },
+                  { value: 'all', label: t('permission.scopeAll') },
+                ]}
+                onValueChange={value => setScope(value as ApprovalScope)}
+              />
+            </div>
+          ) : null}
 
-        {/* Rejecting is the safe answer, so it leads and never depends on
-            anything else being in the right state. */}
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          leadingIcon={<Icon name="xmark" size="lg" style={{ width: 13, height: 13 }} />}
-          disabled={responding}
-          data-testid="chat-input-approval-reject"
-          onClick={() => void answer('reject', false)}
-        >
-          {rejectLabel}
-        </Button>
-        {/* The composer is the reason field. It is offered rather than assumed,
-            so a half-typed next message cannot become a rejection reason and
-            typing one cannot block the allow buttons. */}
-        {reason ? (
-          <Tooltip content={t('permission.rejectWithReasonTooltip')} placement="top">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              leadingIcon={<Icon name="xmark" size="lg" style={{ width: 13, height: 13 }} />}
-              disabled={responding}
-              data-testid="chat-input-approval-reject-with-reason"
-              onClick={() => void answer('reject', true)}
-            >
-              {t('permission.rejectWithReason')}
-            </Button>
-          </Tooltip>
-        ) : null}
-        <Button
-          type="button"
-          variant="fill"
-          size="sm"
-          leadingIcon={<Icon name="check-line" size="lg" style={{ width: 13, height: 13 }} />}
-          disabled={responding}
-          data-testid="chat-input-approval-allow"
-          onClick={() => void answer('once', false)}
-        >
-          {allowLabel}
-        </Button>
-        {/* "Always" writes a saved grant, so it is only offered when this
-            request has a scope to save, and only for the request in front of
-            the reader — a saved grant is not something to apply in bulk to
-            requests they have not read. */}
-        {request.saveResources?.length && !answersAll ? (
-          <Tooltip content={alwaysAllowTooltip} placement="top">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              disabled={responding}
-              data-testid="chat-input-approval-allow-always"
-              onClick={() => void answer('always', false)}
-            >
-              {t('permission.allowAlways')}
-            </Button>
-          </Tooltip>
-        ) : null}
-      </div>
+          <span className="openbitfun-chat-input-approval__spacer" />
+
+          {/* Rejecting is the safe answer, so it leads and never depends on
+              anything else being in the right state. */}
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            leadingIcon={<Icon name="xmark" size="lg" style={{ width: 13, height: 13 }} />}
+            disabled={responding}
+            data-testid="chat-input-approval-reject"
+            onClick={() => void answer('reject', false)}
+          >
+            {rejectLabel}
+          </Button>
+          {/* The composer is the reason field. It is offered rather than assumed,
+              so a half-typed next message cannot become a rejection reason and
+              typing one cannot block the allow buttons. */}
+          {reason ? (
+            <Tooltip content={t('permission.rejectWithReasonTooltip')} placement="top">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                leadingIcon={<Icon name="xmark" size="lg" style={{ width: 13, height: 13 }} />}
+                disabled={responding}
+                data-testid="chat-input-approval-reject-with-reason"
+                onClick={() => void answer('reject', true)}
+              >
+                {t('permission.rejectWithReason')}
+              </Button>
+            </Tooltip>
+          ) : null}
+          <Button
+            type="button"
+            variant="fill"
+            size="sm"
+            leadingIcon={<Icon name="check-line" size="lg" style={{ width: 13, height: 13 }} />}
+            disabled={responding}
+            data-testid="chat-input-approval-allow"
+            onClick={() => void answer('once', false)}
+          >
+            {allowLabel}
+          </Button>
+          {/* "Always" writes a saved grant, so it is only offered when this
+              request has a scope to save, and only for the request in front of
+              the reader — a saved grant is not something to apply in bulk to
+              requests they have not read. */}
+          {request.saveResources?.length && !answersAll ? (
+            <Tooltip content={alwaysAllowTooltip} placement="top">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={responding}
+                data-testid="chat-input-approval-allow-always"
+                onClick={() => void answer('always', false)}
+              >
+                {t('permission.allowAlways')}
+              </Button>
+            </Tooltip>
+          ) : null}
+        </div>
+      </Card>
     </div>
   );
 };

--- a/tests/e2e/page-objects/ApprovalBandPage.ts
+++ b/tests/e2e/page-objects/ApprovalBandPage.ts
@@ -1,0 +1,48 @@
+import { $, browser, expect } from '@wdio/globals';
+
+export class ApprovalBandPage {
+  get band() { return $('[data-testid="chat-input-approval-band"]'); }
+  get allow() { return $('[data-testid="chat-input-approval-allow"]'); }
+  get reject() { return $('[data-testid="chat-input-approval-reject"]'); }
+  get resource() { return $('.openbitfun-chat-input-approval__resource'); }
+
+  async assertContained() {
+    await this.band.waitForDisplayed({ timeout: 45000 });
+    const layout = await browser.execute(() => {
+      const band = document.querySelector<HTMLElement>('[data-testid="chat-input-approval-band"]')!;
+      const resource = band.querySelector<HTMLElement>('.openbitfun-chat-input-approval__resource')!;
+      const container = band.parentElement!;
+      const rect = band.getBoundingClientRect();
+      const parent = container.getBoundingClientRect();
+      const buttons = ['allow', 'reject'].map(action => {
+        const button = band.querySelector<HTMLElement>(`[data-testid="chat-input-approval-${action}"]`)!;
+        const box = button.getBoundingClientRect();
+        const hit = document.elementFromPoint(box.x + box.width / 2, box.y + box.height / 2);
+        return {
+          action, rect: { x: box.x, y: box.y, width: box.width, height: box.height }, visible: box.left >= 0 && box.right <= innerWidth && box.top >= 0 && box.bottom <= innerHeight,
+          hit: !!hit && button.contains(hit),
+          outsideResource: !resource.contains(button),
+        };
+      });
+      return {
+        viewportWidth: innerWidth,
+        bounded: rect.left >= parent.left - 1 && rect.right <= parent.right + 1,
+        noHorizontalOverflow: document.documentElement.scrollWidth <= innerWidth + 1,
+        scrollable: resource.scrollHeight > resource.clientHeight,
+        resourceHeight: resource.clientHeight,
+        viewportHeight: innerHeight,
+        buttons,
+      };
+    });
+    expect(layout.bounded).toBe(true);
+    expect(layout.noHorizontalOverflow).toBe(true);
+    expect(layout.scrollable).toBe(true);
+    expect(layout.resourceHeight).toBeLessThanOrEqual(layout.viewportHeight * .25 + 32);
+    for (const button of layout.buttons) {
+      expect(button.visible).toBe(true);
+      expect(button.hit).toBe(true);
+      expect(button.outsideResource).toBe(true);
+    }
+    return layout;
+  }
+}

--- a/tests/e2e/specs/l1-approval-long-command.spec.ts
+++ b/tests/e2e/specs/l1-approval-long-command.spec.ts
@@ -1,0 +1,166 @@
+import { $, browser, expect } from '@wdio/globals';
+import { createServer, type Server } from 'node:http';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { ApprovalBandPage } from '../page-objects/ApprovalBandPage';
+import { openWorkspaceThroughFrontend } from '../helpers/workspace-helper';
+
+async function invoke<T>(command: string, request: Record<string, unknown>): Promise<T> {
+  return browser.execute(async (name, payload) => {
+    return window.__TAURI__!.core!.invoke!(name, { request: payload }) as Promise<T>;
+  }, command, request);
+}
+
+// Only the model endpoint is deterministic. Sessions, tool execution, approval
+// requests, UI events, replies, and audit storage use the real desktop runtime.
+describe('L1 long-command approval', () => {
+  const page = new ApprovalBandPage();
+  const screenshots = path.resolve('reports/screenshots/approval-long-command');
+  const workspace = mkdtempSync(path.join(tmpdir(), 'approval-ui-e2e-'));
+  let endpoint: Server;
+  let commands: string[] = [];
+  let delivered = false;
+  let modelResult = '';
+  let sessionId = '';
+  let workspaceId = '';
+  const measurements: unknown[] = [];
+
+  before(async () => {
+    if (process.env.OPENBITFUN_E2E_STORAGE_GUARD !== '1') throw new Error('Isolated profile required');
+    mkdirSync(screenshots, { recursive: true });
+    endpoint = createServer(async (request, response) => {
+      let body = '';
+      for await (const chunk of request) body += chunk;
+      const input = JSON.parse(body || '{}');
+      const toolResults = (input.messages || []).filter((message: any) => message.role === 'tool');
+      const tools = input.tools || [];
+      const wireName = tools.map((tool: any) => tool.function?.name)
+        .find((name: string) => /^(ExecCommand|Bash)$/.test(name));
+      const delta: any = { role: 'assistant' };
+      let finishReason = 'stop';
+      if (!delivered && wireName) {
+        delivered = true;
+        delta.tool_calls = commands.map((command, index) => ({
+          index, id: `call_approval_${index}_${Date.now()}`, type: 'function',
+          function: { name: wireName, arguments: JSON.stringify(wireName === 'Bash'
+            ? { command } : { cmd: command, workdir: workspace, yield_time_ms: 1000 }) },
+        }));
+        finishReason = 'tool_calls';
+      } else {
+        if (toolResults.length) modelResult = JSON.stringify(toolResults);
+        delta.content = toolResults.length ? '审批流程已完成，执行结果已收到。' : '长命令审批测试';
+      }
+      response.writeHead(200, { 'content-type': 'text/event-stream', 'cache-control': 'no-cache' });
+      const chunk = (value: unknown, reason: string | null) => JSON.stringify({
+        id: 'chatcmpl-approval-e2e', object: 'chat.completion.chunk', created: 1,
+        model: 'approval-e2e', choices: [{ index: 0, delta: value, finish_reason: reason }],
+      });
+      response.write(`data: ${chunk(delta, null)}\n\n`);
+      response.end(`data: ${chunk({}, finishReason)}\n\ndata: [DONE]\n\n`);
+    });
+    await new Promise<void>(resolve => endpoint.listen(0, '127.0.0.1', resolve));
+    const address = endpoint.address();
+    if (!address || typeof address === 'string') throw new Error('Missing endpoint');
+    await invoke('set_config', { path: 'ai.models', value: [{
+      id: 'approval-e2e', name: 'Approval UI E2E', provider: 'openai', model_name: 'approval-e2e',
+      base_url: `http://127.0.0.1:${address.port}/v1`, api_key: 'local-fixture',
+      context_window: 128000, max_tokens: 4096, enabled: true,
+      category: 'general_chat', capabilities: ['text_chat', 'function_calling'],
+    }] });
+    await invoke('set_config', { path: 'ai.default_models', value: { primary: 'approval-e2e', fast: 'approval-e2e' } });
+    await openWorkspaceThroughFrontend(workspace);
+    const current = await invoke<{ id: string }>('get_current_workspace', {});
+    workspaceId = current.id;
+  });
+
+  async function viewport(width: number, height: number) {
+    // The embedded macOS driver reports native pixels, while layout uses CSS pixels.
+    const ratio = await browser.execute(() => devicePixelRatio);
+    await browser.setWindowSize(Math.round(width * ratio), Math.round(height * ratio));
+    await browser.waitUntil(async () => {
+      const actual = await browser.execute(() => ({ width: innerWidth, height: innerHeight }));
+      return Math.abs(actual.width - width) <= 2 && Math.abs(actual.height - height) <= 2;
+    }, { timeout: 5000, timeoutMsg: 'Native window did not reach the requested CSS viewport' });
+  }
+
+  async function start(label: string, nextCommands: string[]) {
+    commands = nextCommands;
+    delivered = false;
+    modelResult = '';
+    sessionId = randomUUID();
+    await invoke('create_session', {
+      sessionId, sessionName: label, agentType: 'agentic', workspacePath: workspace,
+      config: { modelName: 'approval-e2e' },
+    });
+    await browser.refresh();
+    const item = await $(`[data-testid="nav-session-item"][data-session-id="${sessionId}"]`);
+    await item.waitForDisplayed({ timeout: 30000 });
+    await item.click();
+    await invoke('start_dialog_turn', {
+      sessionId, userInput: label, agentType: 'agentic', workspacePath: workspace,
+    });
+    await page.band.waitForDisplayed({ timeout: 45000 });
+  }
+
+  async function screenshot(name: string) {
+    // Let the shared segmented-control selection transition settle before capture.
+    await browser.pause(250);
+    await browser.saveScreenshot(path.join(screenshots, `${name}.png`));
+    await page.band.saveScreenshot(path.join(screenshots, `${name}-detail.png`));
+  }
+
+  async function assertReply(reply: string, count = 1) {
+    await browser.waitUntil(async () => {
+      const { records } = await invoke<{ records: any[] }>('list_project_permission_audit', { workspaceId });
+      return records.filter(record => record.request.sessionId === sessionId
+        && record.event.event === 'replied' && record.event.reply.reply === reply).length === count;
+    }, { timeout: 15000, timeoutMsg: `Missing ${reply} audit record` });
+    await page.band.waitForDisplayed({ reverse: true, timeout: 15000 });
+    await browser.waitUntil(() => modelResult.length > 0, { timeout: 15000 });
+  }
+
+  it('keeps reject reachable with a long multiline command and records rejection', async () => {
+    await viewport(1280, 800);
+    const command = Array.from({ length: 16 }, (_, i) => `printf '%s\\n' 'approval-ui-line-${i}: Android / HarmonyOS build configuration and tracked files'`).join('\n');
+    await start('检查长命令审批布局', [command]);
+    measurements.push({ case: 'multiline-desktop', ...await page.assertContained() });
+    expect(await page.resource.getText()).toBe(command);
+    await screenshot('01-desktop-long-command');
+    await page.reject.click();
+    await assertReply('reject');
+    expect(modelResult).toMatch(/reject|denied|拒绝/i);
+  });
+
+  it('keeps allow reachable with an unbroken command at a narrower window and executes it', async () => {
+    await viewport(800, 700);
+    await start('验证窄窗口允许执行', [`printf 'approval-e2e-executed'; # ${'long-command-'.repeat(2500)}`]);
+    measurements.push({ case: 'unbroken-narrow', ...await page.assertContained() });
+    await screenshot('02-narrow-long-command');
+    await page.allow.click();
+    await assertReply('once');
+    expect(modelResult).toContain('approval-e2e-executed');
+  });
+
+  it('uses the shared scope control to reject all pending commands', async () => {
+    await viewport(1000, 750);
+    await start('验证批量审批', [
+      `printf 'batch-one'; # ${'review-command '.repeat(200)}`,
+      "printf 'batch-two'",
+    ]);
+    measurements.push({ case: 'batch', ...await page.assertContained() });
+    const all = await $('[data-openbitfun-component="segmented-control"] [data-openbitfun-value="all"]');
+    await all.click();
+    expect(await all.getAttribute('aria-checked')).toBe('true');
+    await screenshot('03-batch-approval');
+    await page.reject.click();
+    await assertReply('reject', 2);
+  });
+
+  after(async () => {
+    writeFileSync(path.join(screenshots, 'layout-measurements.json'), JSON.stringify(measurements, null, 2));
+    endpoint?.closeAllConnections();
+    if (endpoint?.listening) await new Promise<void>(resolve => endpoint.close(() => resolve()));
+  });
+});


### PR DESCRIPTION
## Summary

Long or unbroken commands could expand the composer approval band beyond its container and put Allow/Reject outside the visible window. Constrain the band to the composer width and show the complete command in a bounded, scrollable preview, with approval actions in a separate wrapping row.

Use the local design system's `Card`, `IconButton`, `Button`, and neutral `SegmentedControl`, together with semantic surface, typography, spacing, and focus tokens. The command remains copyable in full.

## Type and Areas

Type: Bug fix / UI / test

Areas: Desktop and shared Web UI approval composer; native desktop E2E

## Motivation / Impact

The remote-connection integration test now follows the current device card: connected controllers remain visible, and the Manage Devices action reopens the dialog with the correct self-hosted relay selected. This replaces assertions for the service card removed by upstream commit `04af44bd4`; product behavior is unchanged by this test correction.

Users can review and answer very long permission requests without the command pushing approval buttons offscreen. The approval panel also follows the existing neutral component styling. Single-request, saved-grant, batch, rejection-reason, and retry behavior are preserved.

## Verification

- `pnpm --dir src/web-ui run test:run` — all 673 test files and 4,946 tests passed after the CI test correction.
- Focused approval, layout, device card, and remote-connection suites — 63 tests passed after the CI test correction.
- `pnpm run check:web` — passed, including TypeScript, typography, Appearance contracts, all 22 theme/color surfaces, and theme visual governance.
- `pnpm --dir src/web-ui exec vitest run src/flow_chat/components/ChatInputApprovalBand.test.tsx src/flow_chat/components/ChatInputWorkspaceStripLayout.test.ts` — 37 tests passed on the latest upstream base.
- `OPENBITFUN_E2E_APP_PATH=/path/to/existing/debug/openbitfun-desktop OPENBITFUN_E2E_APP_MODE=debug OPENBITFUN_E2E_STORAGE_ROOT=/tmp/openbitfun-approval-ui-pr-e2e E2E_LOG_LEVEL=warn pnpm --dir tests/e2e exec wdio run ./config/wdio.conf.ts --spec ./specs/l1-approval-long-command.spec.ts` — 3 native macOS E2E cases passed: reject a multiline command, allow and execute an approximately 32 KB unbroken command at an 800 px window, and reject both pending commands using the shared scope control.
- E2E uses an isolated temporary profile/workspace and a deterministic local model endpoint. Sessions, approval requests/replies, audit storage, and shell execution use the real desktop backend. Assertions check button hit targets, viewport containment, scrolling, audit records, and tool results.
- `git diff --check` — passed.

## Reviewer Notes

AI-assisted implementation; focused unit and native desktop E2E testing completed. The E2E runner uses the current branch's frontend with an existing local debug desktop binary; no Rust code changes are included.

Screenshots are generated by the spec under `tests/e2e/reports/screenshots/approval-long-command/` (full-window and approval-panel detail for all three cases), alongside `layout-measurements.json`. Generated local evidence is excluded from the commit.

Remote workspace, remote control, Peer Device Mode, and Detached Dispatch were not exercised; no permission protocol or backend policy changes are included. No new strings, token keys, or persisted shapes are introduced.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable (existing strings reused).

