### PR TITLE
fix(web-ui): prevent long commands from overflowing the permission approval panel

### DIFF
--- a/src/web-ui/src/flow_chat/components/ChatInputApprovalBand.scss
+++ b/src/web-ui/src/flow_chat/components/ChatInputApprovalBand.scss
@@ -6,6 +6,11 @@
   flex-direction: column;
   gap: 5px;
   box-sizing: border-box;
+  // The composer centers its children, so constrain the band before truncating
+  // long resources; otherwise its intrinsic width can exceed the composer.
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
   margin-bottom: 6px;
   padding: 8px 10px;
   border: 1px solid var(--openbitfun-color-status-warning-border);


### PR DESCRIPTION
## Summary

Constrain the permission approval band's width to its composer container so long commands cannot push the panel and action buttons outside the visible area.

## Type and Areas

Type: Bug fix / UI/UX

Areas: Web UI — chat composer permission approval

## Motivation / Impact

The composer centers its children, but the approval band lacked width constraints. Long commands could expand the band beyond the container and obscure its action buttons.

The band now fits within the composer. Long commands retain ellipsis truncation, full-text tooltips, and copying, while approval actions remain visible.

## Verification

- `git diff --check`: passed.
- Local Chromium layout verification using the actual SCSS: checked short commands, long commands, and long unbroken strings at container widths of 320, 600, and 900px. Overflow reproduced before the fix; the panel and buttons remained within the container afterward.
- `pnpm run motion:audit`: completed; no animations added.
- `pnpm run check:web`: could not complete because design-system build artifacts were missing.
- `pnpm --dir src/web-ui run test:run src/flow_chat/components/ChatInputApprovalBand.test.tsx`: tests did not run because the prerequisite build could not resolve `@openbitfun/token-engine`.
- Remote workspace, remote control, Peer Device Mode, and Detached Dispatch scenarios were not exercised.

## Reviewer Notes

This change only adds CSS width constraints to the approval band. Permission handling, protocols, persisted data, and user-facing copy are unchanged. No migration is required.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.