### PR TITLE
fix(web-ui): keep model test status visible

### DIFF
--- a/src/web-ui/src/infrastructure/config/components/ModelServiceCollapse.presentation.test.ts
+++ b/src/web-ui/src/infrastructure/config/components/ModelServiceCollapse.presentation.test.ts
@@ -80,6 +80,23 @@ describe('model service collapsed presentation', () => {
     expect(modelSettingsSource).toContain('toggleOnRowClick');
   });
 
+  it('keeps model connection test progress and results visible without hover or expansion', () => {
+    const badgeStart = modelSettingsSource.indexOf('const badge = (');
+    const detailsStart = modelSettingsSource.indexOf('const details = (', badgeStart);
+    const badgeSource = modelSettingsSource.slice(badgeStart, detailsStart);
+
+    expect(badgeSource).toContain('{(isTesting || testResult) && (');
+    expect(badgeSource).toContain('openbitfun-model-settings__status-dot');
+    expect(badgeSource).not.toContain('<StatusPill');
+    expect(badgeSource).toContain('role="status"');
+    expect(badgeSource).toContain('aria-live="polite"');
+    expect(badgeSource).toContain('aria-label={testStatusLabel}');
+    expect(badgeSource).toContain("isTesting ? 'is-testing' : testResult?.success ? 'is-success' : 'is-error'");
+    expect(modelSettingsSource).toContain(
+      "isTesting\n      ? t('messages.testing')\n      : testResult?.message.split('\\n', 1)[0]",
+    );
+  });
+
   it('uses the semantic highlight color for each provider model count', () => {
     expect(modelSettingsStyles).toMatch(
       /&__provider-group-count\s*\{[\s\S]*?color:\s*var\(--openbitfun-color-content-required-indicator\)/,

--- a/src/web-ui/src/infrastructure/config/components/ModelSettingsPage.scss
+++ b/src/web-ui/src/infrastructure/config/components/ModelSettingsPage.scss
@@ -313,7 +313,10 @@
     border-radius: 999px;
     margin-left: 4px;
     flex-shrink: 0;
-    background: var(--openbitfun-color-content-muted);
+
+    &.is-testing {
+      background: var(--openbitfun-color-status-warning-emphasis);
+    }
 
     &.is-success {
       background: var(--openbitfun-color-status-success-emphasis);

--- a/src/web-ui/src/infrastructure/config/components/ModelSettingsPage.tsx
+++ b/src/web-ui/src/infrastructure/config/components/ModelSettingsPage.tsx
@@ -3230,6 +3230,9 @@ const ModelSettingsPage: React.FC = () => {
     const providerDisplayName = getProviderDisplayName(config);
     const modelDisplayName = getModelDisplayName(config);
     const modelLabel = config.model_name || modelDisplayName;
+    const testStatusLabel = isTesting
+      ? t('messages.testing')
+      : testResult?.message.split('\n', 1)[0];
 
     const badge = (
       <>
@@ -3240,15 +3243,18 @@ const ModelSettingsPage: React.FC = () => {
         >
           {t(`category.${config.category}`)}
         </span>
-        {testResult && (
+        {(isTesting || testResult) && (
           <span
             data-testid="settings-model-test-status"
             data-config-id={config.id || ''}
             data-model-id={config.model_name}
             data-model-name={config.model_name}
-            data-status={testResult.success ? 'success' : 'error'}
-            className={`openbitfun-model-settings__status-dot ${testResult.success ? 'is-success' : 'is-error'}`}
-            title={testResult.message}
+            data-status={isTesting ? 'testing' : testResult?.success ? 'success' : 'error'}
+            className={`openbitfun-model-settings__status-dot ${isTesting ? 'is-testing' : testResult?.success ? 'is-success' : 'is-error'}`}
+            role="status"
+            aria-live="polite"
+            aria-label={testStatusLabel}
+            title={isTesting ? testStatusLabel : testResult?.message}
           />
         )}
       </>

--- a/src/web-ui/src/locales/en-US/settings/models.json
+++ b/src/web-ui/src/locales/en-US/settings/models.json
@@ -517,6 +517,7 @@
     "referenceCheckFailed": "OpenBitFun could not verify whether other settings still reference this model, so deletion was cancelled",
     "providerReferenceCheckFailed": "OpenBitFun could not verify whether other settings still reference this provider's models, so deletion was cancelled",
     "loadFailed": "Failed to load AI configuration",
+    "testing": "Testing…",
     "testSuccess": "Test successful",
     "testFailed": "Test failed",
     "testUnsupportedOnHost": "Configuration saved; the current CLI device does not support model connection tests",

--- a/src/web-ui/src/locales/zh-CN/settings/models.json
+++ b/src/web-ui/src/locales/zh-CN/settings/models.json
@@ -517,6 +517,7 @@
     "referenceCheckFailed": "无法确认此模型是否仍被其他设置引用，已取消删除",
     "providerReferenceCheckFailed": "无法确认该服务商的模型是否仍被其他设置引用，已取消删除",
     "loadFailed": "加载AI配置失败",
+    "testing": "测试中…",
     "testSuccess": "测试成功",
     "testFailed": "测试失败",
     "testUnsupportedOnHost": "配置已保存，当前 CLI 设备不支持模型连接测试",

--- a/src/web-ui/src/locales/zh-TW/settings/models.json
+++ b/src/web-ui/src/locales/zh-TW/settings/models.json
@@ -517,6 +517,7 @@
     "referenceCheckFailed": "無法確認此模型是否仍被其他設定引用，已取消刪除",
     "providerReferenceCheckFailed": "無法確認該服務商的模型是否仍被其他設定引用，已取消刪除",
     "loadFailed": "載入AI設定失敗",
+    "testing": "測試中…",
     "testSuccess": "測試成功",
     "testFailed": "測試失敗",
     "testUnsupportedOnHost": "設定已儲存，目前 CLI 裝置不支援模型連接測試",


### PR DESCRIPTION
## Summary
- keep model connection test feedback visible without hover or details expansion
- show a compact yellow/green/red status dot for testing/success/failure
- retain localized hover and accessibility labels
- add regression coverage for collapsed model rows

## Verification
- `pnpm --dir src/web-ui exec vitest run src/infrastructure/config/components/ModelServiceCollapse.presentation.test.ts --maxWorkers=50%`
- `pnpm run check:web`