### PR TITLE
fix(web-ui): stabilize workspace and session menu positioning

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.tsx
+++ b/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.tsx
@@ -56,7 +56,7 @@ import type {
   BackgroundSubagentActivity,
   BackgroundSubagentActivityItem,
 } from '@/flow_chat/utils/backgroundSubagentActivity';
-import { computeFixedPopoverPosition } from '@/shared/utils/fixedPopoverViewport';
+import { useSideAnchoredPopoverPosition } from '@/shared/utils/useSideAnchoredPopoverPosition';
 import { exportSessionToMarkdown } from '@/flow_chat/services/sessionMarkdownExport';
 import type { TranscriptExportScope } from '@/flow_chat/utils/dialogTranscriptExport';
 import { confirmDanger } from '@/infrastructure/confirm-dialog';
@@ -285,7 +285,6 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
   }));
   const [aggregateReloadRequestId, setAggregateReloadRequestId] = useState(0);
   const [openMenuSessionId, setOpenMenuSessionId] = useState<string | null>(null);
-  const [sessionMenuPosition, setSessionMenuPosition] = useState<{ top: number; left: number } | null>(null);
   /** Second level of the session menu: pick what a Markdown export includes. */
   const [isExportScopeMenu, setIsExportScopeMenu] = useState(false);
   const [exportingSessionId, setExportingSessionId] = useState<string | null>(null);
@@ -295,6 +294,13 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
   const editInputRef = useRef<HTMLInputElement>(null);
   const sessionMenuPopoverRef = useRef<HTMLDivElement>(null);
   const sessionMenuAnchorRef = useRef<HTMLButtonElement>(null);
+  const sessionMenuPosition = useSideAnchoredPopoverPosition({
+    open: openMenuSessionId !== null,
+    anchorRef: sessionMenuAnchorRef,
+    popoverRef: sessionMenuPopoverRef,
+    gap: 4,
+    layoutRevision: `${openMenuSessionId}:${isExportScopeMenu}`,
+  });
   const metadataLoadRequestIdRef = useRef(0);
   /** User-driven metadata loads still running; background loads yield to them. */
   const foregroundLoadCountRef = useRef(0);
@@ -721,56 +727,20 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
 
   const closeSessionMenu = useCallback(() => {
     setOpenMenuSessionId(null);
-    setSessionMenuPosition(null);
     setIsExportScopeMenu(false);
   }, []);
 
   useEffect(() => {
     if (!openMenuSessionId) return;
     const handleOutside = (event: MouseEvent) => {
-      if (!sessionMenuPopoverRef.current?.contains(event.target as Node)) {
+      if (!sessionMenuPopoverRef.current?.contains(event.target as Node)
+        && !sessionMenuAnchorRef.current?.contains(event.target as Node)) {
         closeSessionMenu();
       }
     };
     document.addEventListener('mousedown', handleOutside);
     return () => document.removeEventListener('mousedown', handleOutside);
   }, [closeSessionMenu, openMenuSessionId]);
-
-  const updateSessionMenuPosition = useCallback(() => {
-    const anchor = sessionMenuAnchorRef.current;
-    if (!anchor || !openMenuSessionId) return;
-    const rect = anchor.getBoundingClientRect();
-    const viewportPadding = 8;
-    const gap = 4;
-    const fallbackWidth = 160;
-    const fallbackHeight = 96;
-
-    const apply = () => {
-      const menuEl = sessionMenuPopoverRef.current;
-      const w = menuEl?.offsetWidth ?? fallbackWidth;
-      const h = menuEl?.offsetHeight ?? fallbackHeight;
-      setSessionMenuPosition(computeFixedPopoverPosition(rect, w, h, gap, viewportPadding));
-    };
-
-    apply();
-    requestAnimationFrame(apply);
-  }, [openMenuSessionId]);
-
-  useEffect(() => {
-    if (!openMenuSessionId) return;
-
-    // The second menu level has a different height; re-anchor on switch.
-    updateSessionMenuPosition();
-
-    const handleViewportChange = () => updateSessionMenuPosition();
-    window.addEventListener('resize', handleViewportChange);
-    window.addEventListener('scroll', handleViewportChange, true);
-
-    return () => {
-      window.removeEventListener('resize', handleViewportChange);
-      window.removeEventListener('scroll', handleViewportChange, true);
-    };
-  }, [isExportScopeMenu, openMenuSessionId, updateSessionMenuPosition]);
 
   // Clear unread completion mark after the switched session renders
   useEffect(() => {
@@ -1230,10 +1200,6 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
         closeSessionMenu();
         return;
       }
-      const btn = e.currentTarget as HTMLElement;
-      const rect = btn.getBoundingClientRect();
-      const { top, left } = computeFixedPopoverPosition(rect, 160, 120, 4, 8);
-      setSessionMenuPosition({ top, left });
       setIsExportScopeMenu(false);
       setOpenMenuSessionId(sessionId);
     },
@@ -1868,14 +1834,18 @@ const SessionsSection: React.FC<SessionsSectionProps> = ({
                       <Icon name="more" size="xs" />
                     </button>
                   </div>
-                  {openMenuSessionId === session.sessionId && sessionMenuPosition && createPortal(
+                  {openMenuSessionId === session.sessionId && createPortal(
                     <Menu
                       ref={sessionMenuPopoverRef}
                       className="openbitfun-nav-panel__inline-item-menu-popover"
                       data-openbitfun-component="sessions-section"
                       data-openbitfun-part="menu"
                       data-openbitfun-state="menuOpen"
-                      style={{ top: `${sessionMenuPosition.top}px`, left: `${sessionMenuPosition.left}px` }}
+                      style={{
+                        top: sessionMenuPosition?.top ?? 0,
+                        left: sessionMenuPosition?.left ?? 0,
+                        visibility: sessionMenuPosition ? 'visible' : 'hidden',
+                      }}
                       data-testid="nav-session-menu"
                       data-session-id={session.sessionId}
                     >

--- a/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceItem.tsx
+++ b/src/web-ui/src/app/components/NavPanel/sections/workspaces/WorkspaceItem.tsx
@@ -52,7 +52,7 @@ import {
 import { SSHContext } from '@/features/ssh-remote/SSHRemoteContext';
 import { useWorkspaceSearchIndex } from '@/tools/file-explorer';
 import { WORKSPACE_SEARCH_AVAILABLE } from '@/infrastructure/config/workspaceSearchAvailability';
-import { computeFixedPopoverPosition } from '@/shared/utils/fixedPopoverViewport';
+import { useSideAnchoredPopoverPosition } from '@/shared/utils/useSideAnchoredPopoverPosition';
 import { scheduleAfterStartupSignal } from '@/shared/utils/startupTaskScheduling';
 import {
   getWorkspaceGitBasicInfoOptions,
@@ -150,7 +150,12 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
   const menuPopoverRef = useRef<HTMLDivElement>(null);
   const acpSubmenuRef = useRef<HTMLDivElement>(null);
   const cardRef = useRef<HTMLDivElement>(null);
-  const [menuPosition, setMenuPosition] = useState<{ top: number; left: number } | null>(null);
+  const menuPosition = useSideAnchoredPopoverPosition({
+    open: menuOpen,
+    anchorRef: menuAnchorRef,
+    popoverRef: menuPopoverRef,
+    layoutRevision: `${acpClientsLoading}:${acpClients.length}`,
+  });
   const isDefaultAssistantWorkspace =
     workspace.workspaceKind === WorkspaceKind.Assistant &&
     (workspace.id === primaryAssistantWorkspaceId ||
@@ -440,27 +445,6 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
     );
   }, [tFiles, workspaceSearchIndex]);
 
-  const updateMenuPosition = useCallback(() => {
-    const anchor = menuAnchorRef.current;
-    if (!anchor) return;
-
-    const rect = anchor.getBoundingClientRect();
-    const viewportPadding = 8;
-    const gap = 6;
-    const fallbackWidth = 240;
-    const fallbackHeight = 260;
-
-    const apply = () => {
-      const menuEl = menuPopoverRef.current;
-      const w = menuEl?.offsetWidth ?? fallbackWidth;
-      const h = menuEl?.offsetHeight ?? fallbackHeight;
-      setMenuPosition(computeFixedPopoverPosition(rect, w, h, gap, viewportPadding));
-    };
-
-    apply();
-    requestAnimationFrame(apply);
-  }, []);
-
   const handleMenuTriggerClick = useCallback(() => {
     setMenuOpen(open => !open);
   }, []);
@@ -479,21 +463,6 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
     document.addEventListener('mousedown', handleOutside);
     return () => document.removeEventListener('mousedown', handleOutside);
   }, [menuOpen]);
-
-  useEffect(() => {
-    if (!menuOpen) return;
-
-    updateMenuPosition();
-
-    const handleViewportChange = () => updateMenuPosition();
-    window.addEventListener('resize', handleViewportChange);
-    window.addEventListener('scroll', handleViewportChange, true);
-
-    return () => {
-      window.removeEventListener('resize', handleViewportChange);
-      window.removeEventListener('scroll', handleViewportChange, true);
-    };
-  }, [menuOpen, updateMenuPosition]);
 
   useEffect(() => {
     if (!menuOpen) {
@@ -923,11 +892,15 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
               </button>
             </div>
 
-            {menuOpen && menuPosition && createPortal(
+            {menuOpen && createPortal(
               <Menu
                 ref={menuPopoverRef}
                 className="openbitfun-nav-panel__workspace-item-menu-popover"
-                style={{ top: `${menuPosition.top}px`, left: `${menuPosition.left}px` }}
+                style={{
+                  top: menuPosition?.top ?? 0,
+                  left: menuPosition?.left ?? 0,
+                  visibility: menuPosition ? 'visible' : 'hidden',
+                }}
                 data-testid="nav-workspace-item-menu"
                 data-workspace-id={workspace.id}
               >
@@ -1397,11 +1370,15 @@ const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
               </button>
             </div>
 
-            {menuOpen && menuPosition && createPortal(
+            {menuOpen && createPortal(
               <Menu
                 ref={menuPopoverRef}
                 className="openbitfun-nav-panel__workspace-item-menu-popover"
-                style={{ top: `${menuPosition.top}px`, left: `${menuPosition.left}px` }}
+                style={{
+                  top: menuPosition?.top ?? 0,
+                  left: menuPosition?.left ?? 0,
+                  visibility: menuPosition ? 'visible' : 'hidden',
+                }}
                 data-testid="nav-workspace-item-menu"
                 data-workspace-id={workspace.id}
               >

--- a/src/web-ui/src/shared/utils/useSideAnchoredPopoverPosition.test.tsx
+++ b/src/web-ui/src/shared/utils/useSideAnchoredPopoverPosition.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+import React, { act, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { createRoot, type Root } from 'react-dom/client';
+import { Menu, MenuItem } from '@openbitfun/ui';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useSideAnchoredPopoverPosition } from './useSideAnchoredPopoverPosition';
+
+function Harness({ revision = 0 }: { revision?: number }) {
+  const [open, setOpen] = useState(false);
+  const anchorRef = useRef<HTMLButtonElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const layout = useSideAnchoredPopoverPosition({ open, anchorRef, popoverRef, layoutRevision: revision });
+  return <>
+    <button ref={anchorRef} onClick={() => setOpen(value => !value)}>Menu</button>
+    {open && createPortal(
+      <Menu ref={popoverRef} style={{
+        position: 'fixed', top: layout?.top ?? 0, left: layout?.left ?? 0,
+        visibility: layout ? 'visible' : 'hidden',
+      }}>
+        <MenuItem>Action</MenuItem>
+      </Menu>, document.body,
+    )}
+  </>;
+}
+
+describe('side anchored menu positioning', () => {
+  let root: Root;
+  let container: HTMLDivElement;
+  let anchor: DOMRect;
+  let width: number;
+  let height: number;
+  let scale: number;
+  let notifyResize: () => void;
+  const observed = new Set<Element>();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    vi.stubGlobal('innerWidth', 900);
+    vi.stubGlobal('innerHeight', 600);
+    anchor = new DOMRect(250, 510, 24, 24);
+    width = 240;
+    height = 400;
+    scale = 1;
+    observed.clear();
+    vi.stubGlobal('ResizeObserver', class {
+      constructor(callback: () => void) { notifyResize = callback; }
+      observe(element: Element) { observed.add(element); }
+      disconnect() { observed.clear(); }
+    });
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (this: HTMLElement) {
+      return this.getAttribute('role') === 'menu'
+        ? new DOMRect(0, 0, width * scale, height * scale)
+        : anchor;
+    });
+    vi.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockImplementation(function (this: HTMLElement) {
+      return this.getAttribute('role') === 'menu' ? width : anchor.width;
+    });
+    vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockImplementation(function (this: HTMLElement) {
+      return this.getAttribute('role') === 'menu' ? height : anchor.height;
+    });
+    container = document.createElement('div');
+    document.body.append(container);
+    root = createRoot(container);
+    act(() => root.render(<Harness />));
+  });
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+  const toggle = () => act(() => container.querySelector('button')!.click());
+  const menu = () => document.querySelector<HTMLElement>('[role="menu"]')!;
+
+  it('opens to the right above the footer on the first click using the full animated size', () => {
+    scale = 0.98;
+    toggle();
+    // No animation frame or second click should be needed to reach the final geometry.
+    expect(menu().style.visibility).toBe('visible');
+    expect(menu().style.left).toBe('280px');
+    expect(menu().style.top).toBe('134px');
+    expect(Number.parseFloat(menu().style.top) + height).toBe(anchor.bottom);
+    toggle();
+    scale = 1;
+    toggle();
+    expect(menu().style.top).toBe('134px');
+    expect(menu().style.left).toBe('280px');
+  });
+
+  it('flips left only when the right side lacks space without covering the trigger', () => {
+    anchor = new DOMRect(850, 100, 24, 24);
+    toggle();
+    expect(menu().style.left).toBe('604px');
+    expect(menu().style.top).toBe('100px');
+    expect(Number.parseFloat(menu().style.left) + width).toBeLessThan(anchor.left);
+  });
+
+  it('repositions when async menu content grows', () => {
+    height = 80;
+    toggle();
+    expect(menu().style.top).toBe('510px');
+    expect(observed.has(menu())).toBe(true);
+    height = 400;
+    act(() => { notifyResize(); vi.advanceTimersByTime(20); });
+    expect(menu().style.top).toBe('134px');
+    expect(menu().style.left).toBe('280px');
+  });
+
+  it('remeasures a changed menu level before displaying it', () => {
+    toggle();
+    height = 80;
+    act(() => root.render(<Harness revision={1} />));
+    expect(menu().style.top).toBe('510px');
+  });
+
+  it('tracks scrolling and viewport changes and clears observers on close', () => {
+    toggle();
+    anchor = new DOMRect(300, 80, 24, 24);
+    act(() => {
+      container.dispatchEvent(new Event('scroll'));
+      vi.advanceTimersByTime(20);
+    });
+    expect(menu().style.left).toBe('330px');
+    expect(menu().style.top).toBe('80px');
+    vi.stubGlobal('innerHeight', 430);
+    act(() => { window.dispatchEvent(new Event('resize')); vi.advanceTimersByTime(20); });
+    expect(Number.parseFloat(menu().style.top)).toBeGreaterThanOrEqual(8);
+    expect(Number.parseFloat(menu().style.top) + height).toBeLessThanOrEqual(422);
+    toggle();
+    expect(observed.size).toBe(0);
+    expect(menu()).toBeNull();
+  });
+});

--- a/src/web-ui/src/shared/utils/useSideAnchoredPopoverPosition.ts
+++ b/src/web-ui/src/shared/utils/useSideAnchoredPopoverPosition.ts
@@ -55,8 +55,10 @@ export function useSideAnchoredPopoverPosition({
 
     const anchorBounds = anchor.getBoundingClientRect();
     const popoverBounds = popover.getBoundingClientRect();
-    const popoverWidth = popoverBounds.width || popover.offsetWidth || popover.scrollWidth;
-    const popoverHeight = popoverBounds.height || popover.offsetHeight || popover.scrollHeight;
+    // Opening animations can scale the painted bounds. Position against the
+    // layout dimensions so the fully expanded menu still clears the viewport.
+    const popoverWidth = popover.offsetWidth || popoverBounds.width || popover.scrollWidth;
+    const popoverHeight = popover.offsetHeight || popoverBounds.height || popover.scrollHeight;
     const rightLeft = anchorBounds.right + gap;
     const leftLeft = anchorBounds.left - gap - popoverWidth;
     const fitsRight = rightLeft + popoverWidth <= window.innerWidth - padding;


### PR DESCRIPTION
## Summary

- Position workspace and session menus beside their triggers, preferring the right side and flipping left when necessary.
- Measure mounted menus before making them visible, avoiding incorrect placement on the first open.
- Use unscaled layout dimensions so opening animations do not underestimate menu size.
- Reposition menus when content changes, the page scrolls, or the viewport resizes.
- Keep session menu trigger clicks from immediately reopening a closing menu.

## Type and Areas

Type: Bug fix / UI/UX / Test

Areas: Web UI, workspace and session navigation, shared popover positioning.

## Motivation / Impact

Menus near the bottom of the sidebar could initially extend behind the footer, jump into position only after reopening, or appear above and overlap their triggers.

This change gives both menu types consistent side placement and correct geometry on their first open.

## Verification

Passed:

```bash
pnpm run check:web
git diff --cached --check
pnpm --dir src/web-ui exec vitest run \
  src/shared/utils/useSideAnchoredPopoverPosition.test.tsx \
  src/flow_chat/components/ChatInputBoostSubmenu.test.tsx \
  src/flow_chat/components/HarnessProfileSelector.test.tsx \
  src/app/components/NavPanel/sections/workspaces/WorkspaceAcpSessionSubmenu.test.tsx \
  src/app/components/NavPanel/sections/workspaces/WorkspaceItemSessionBatchManagement.test.ts \
  src/app/components/NavPanel/sections/sessions/SessionsSectionLayout.test.ts \
  src/app/components/NavPanel/sections/sessions/sessionActionConfirmation.test.ts
```

All 43 tests across 7 files passed. Coverage includes first-open positioning during animation, left-side fallback, asynchronous content growth, menu-level changes, scrolling, resizing, and observer cleanup.

## Reviewer Notes

- Reuses the existing shared side-positioning hook.
- Geometry was verified with mocked DOM measurements; desktop and remote scenarios were not tested manually.
- No persisted data, protocols, user-facing strings, or locale resources changed.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.