### PR TITLE
fix(web-ui): remove archived sessions filter menu option

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/components/WorkspaceSessionFilterMenu.tsx
+++ b/src/web-ui/src/app/components/NavPanel/components/WorkspaceSessionFilterMenu.tsx
@@ -260,17 +260,6 @@ const WorkspaceSessionFilterMenu: React.FC = () => {
           {row('worktree', undefined, view.filters.hiddenWorktrees.length > 0)}
           {row('environment', undefined, view.filters.hiddenEnvironments.length > 0)}
           {row('source', undefined, view.filters.hiddenSources.length > 0)}
-          <MenuItem
-          role="menuitemcheckbox"
-            checked={!view.filters.hideArchived}
-            metadata={!view.filters.hideArchived ? <Icon name="check-line" size="sm" aria-hidden="true" /> : null}
-            onClick={() => {
-              setActiveSubmenu(null);
-              view.toggleArchived();
-            }}
-          >
-            {t('nav.sessions.viewMenu.archived')}
-          </MenuItem>
         </MenuSection>
         <MenuSeparator />
         {view.grouping === 'grouped' ? (


### PR DESCRIPTION
## Summary

Remove the Archived sessions checkbox from the session filter menu.

## Type and Areas

Type: UI/UX / bug fix

Areas: Web UI, shared desktop frontend session navigation

## Motivation / Impact

The session filter menu no longer exposes the Archived sessions option. This is a focused menu change; existing session archive actions, persisted preferences, and archive management remain unchanged.

## Verification

Re-run after rebasing onto upstream/main:

- `pnpm --dir src/web-ui run test:run src/app/components/NavPanel/components/WorkspaceSessionFilterMenu.test.tsx` — passed, 3 tests.
- `pnpm run check:web` — passed, with existing Appearance contract warnings in unrelated files.
- `git diff --check upstream/main...HEAD` — passed.

## Reviewer Notes

One frontend component changed, removing 11 lines. No new copy, locale changes, host APIs, or data migrations are required.

Validation was local. Remote workspace, remote control, Peer Device Mode, and Detached Dispatch were not manually exercised.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable. No copy or locale changes are required.
