### PR TITLE
fix(web-ui): make approval commands fully readable

### DIFF
--- a/src/web-ui/src/flow_chat/components/ChatInputApprovalBand.scss
+++ b/src/web-ui/src/flow_chat/components/ChatInputApprovalBand.scss
@@ -6,7 +6,7 @@
   flex-direction: column;
   gap: 5px;
   box-sizing: border-box;
-  // The composer centers its children, so constrain the band before truncating
+  // The composer centers its children, so constrain the band before laying out
   // long resources; otherwise its intrinsic width can exceed the composer.
   width: 100%;
   min-width: 0;
@@ -42,13 +42,15 @@
     color: var(--openbitfun-color-content-secondary);
   }
 
-  // The resource is the part worth the remaining width: which file, which
-  // command. Identity and owner are context and yield first.
-  &__resource {
+  // Keep the full command readable without letting it widen the composer or
+  // push the approval actions out of view. Only the resource body scrolls.
+  .openbitfun-chat-input-approval__resource {
+    flex: none;
     min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    max-height: min(160px, 25vh);
+    overflow: auto;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
   }
 
   &__owner {
@@ -75,6 +77,7 @@
 
   &__note {
     margin: 0;
+    overflow-wrap: anywhere;
     color: var(--openbitfun-color-status-warning-content);
     font-size: var(--openbitfun-type-flow-support-font-size);
 

--- a/src/web-ui/src/flow_chat/components/ChatInputApprovalBand.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInputApprovalBand.tsx
@@ -160,7 +160,7 @@ export const ChatInputApprovalBand: React.FC<ChatInputApprovalBandProps> = ({
     }
   };
 
-  const resourceSummary = request.resources.join(', ');
+  const resourceSummary = request.resources.join('\n');
   const answersAll = effectiveScope === 'all';
   const allowLabel = answersAll
     ? t('permission.allowCurrentAndFollowing')
@@ -195,14 +195,6 @@ export const ChatInputApprovalBand: React.FC<ChatInputApprovalBandProps> = ({
           {permissionActionLabel(request.action, t)}
         </span>
         <span className="openbitfun-chat-input-approval__separator" aria-hidden>·</span>
-        <CopyableTextPreview
-          as="code"
-          text={resourceSummary}
-          emptyText=""
-          className="openbitfun-chat-input-approval__resource copyable-text-preview--theme-font"
-          tooltipContent={request.resources.join('\n') || undefined}
-          tooltipPlacement="top"
-        />
         {request.delegation ? (
           <span className="openbitfun-chat-input-approval__owner">
             {t('permission.subagentOwner', { subagent: request.delegation.subagentType })}
@@ -221,6 +213,16 @@ export const ChatInputApprovalBand: React.FC<ChatInputApprovalBandProps> = ({
           </Tooltip>
         ) : null}
       </div>
+
+      <CopyableTextPreview
+        as="code"
+        text={resourceSummary}
+        emptyText=""
+        className="openbitfun-chat-input-approval__resource copyable-text-preview--theme-font"
+        tooltipContent={resourceSummary || undefined}
+        tooltipPlacement="top"
+        tabIndex={0}
+      />
 
       {/* The risk is the reason to read the band at all, so it keeps its own
           line rather than hiding in a tooltip. */}


### PR DESCRIPTION
## Summary

- Show permission resources on a separate multiline row with wrapping, bounded vertical scrolling, and keyboard access.
- Keep approval actions outside the scrolling content and wrap long risk descriptions.

## Type and Areas

Type: Bug fix / UI/UX

Areas: Web UI, chat composer, permission approvals

## Motivation / Impact

Long commands are reduced to a single truncated line in the approval band, making it difficult to inspect the full operation before answering. The complete command can now be read directly in the band, including its original line breaks, while the approval controls remain accessible in narrow layouts.

## Verification

On the rebased head:

- `pnpm run check:web` — passed, including TypeScript, appearance, typography, and theme governance checks.
- `pnpm --dir src/web-ui run test:run src/flow_chat/components/ChatInputApprovalBand.test.tsx src/flow_chat/components/ChatInputWorkspaceStripLayout.test.ts` — 35 tests passed.
- `git diff --check origin/main...HEAD` — passed.

Manual validation of the UI change:

- Local browser checks at 1024, 560, 360, and 240 px widths: no horizontal overflow and approval actions remained visible.
- Keyboard scrolling reached the end of a long multiline command; narrow-layout batch approval remained usable.
- The Windows x64 Debug build and desktop frontend build passed before rebasing, and the reporter confirmed the fix works. Desktop packaging was not repeated after the rebase.

## Reviewer Notes

- Retains the existing composer width constraints and warning theme tokens. Approval scope, saved grants, reply callbacks, and transport behavior are unchanged.
- Live remote workspace, remote control, Peer Device Mode, and Detached Dispatch scenarios were not exercised; verification covered local rendering and component behavior.
- AI-assisted. Testing level: lightly tested (focused automated checks and local manual validation; no live remote coverage).
- No new user-facing strings or persisted data changes.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.
