### PR TITLE
fix(ssh): align parent directory row layout

### DIFF
--- a/src/web-ui/src/features/ssh-remote/RemoteFileBrowser.tsx
+++ b/src/web-ui/src/features/ssh-remote/RemoteFileBrowser.tsx
@@ -549,9 +549,11 @@ export const RemoteFileBrowser: React.FC<RemoteFileBrowserProps> = ({
                     }}
                     className="remote-file-browser__row remote-file-browser__row--parent"
                   >
-                    <td colSpan={3}>
-                      <Icon name="folder" size="md" className="remote-file-browser__entry-icon remote-file-browser__entry-icon--parent" />
-                      <span>..</span>
+                    <td colSpan={3} className="remote-file-browser__td remote-file-browser__td--name">
+                      <div className="remote-file-browser__name-cell">
+                        <Icon name="folder" size="md" className="remote-file-browser__entry-icon remote-file-browser__entry-icon--parent" />
+                        <span className="remote-file-browser__name">..</span>
+                      </div>
                     </td>
                   </tr>
                 )}


### PR DESCRIPTION
## Summary

Fix the cramped icon and `..` label in the remote workspace directory picker by reusing the existing name-cell layout and typography.

## Type and Areas

Type: Bug fix / UI/UX

Areas: Web UI, SSH remote file browser

## Motivation / Impact

The parent-directory row omitted the flex wrapper and name styling used by ordinary directory entries, leaving its icon and label without the intended spacing and vertical alignment. Apply those shared styles while preserving the smaller navigation icon, spanning cell, and existing parent-directory navigation behavior.

## Verification

- `pnpm run type-check:web` — passed after rebasing onto the latest `main`.
- `pnpm run check:web:appearance` — passed after refreshing the local design-system build outputs.
- `git diff --check origin/main...HEAD` — passed.

## Reviewer Notes

Only `RemoteFileBrowser.tsx` changes. No path handling, SSH operations, persistence, or user-facing strings change.

Verification is local and static. Live remote workspace, remote control, Peer Device Mode, and Detached Dispatch scenarios were not exercised. The development application was not launched.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable (no changes required).
