### PR TITLE
fix(web-ui): isolate sidebar navigation stacking

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/NavPanel.scss
+++ b/src/web-ui/src/app/components/NavPanel/NavPanel.scss
@@ -58,6 +58,9 @@ $_section-header-height: 22px;
       flex: 1 1 auto;
       min-width: 0;
       max-width: 100%;
+      // Keep sticky headers below SceneNav even when reduced motion removes
+      // the transform that otherwise establishes this stacking context.
+      isolation: isolate;
       opacity: 1;
       transform: translate3d(0, 0, 0);
       transition: none;


### PR DESCRIPTION
## Summary

Add `isolation: isolate` to the main sidebar navigation layer so sticky session headers remain below the file navigation overlay when reduced motion removes the layer's transform.

## Type and Areas

Type: Bug fix

Areas: Shared Web UI / sidebar navigation

## Motivation / Impact

The file navigation overlay keeps the main navigation mounted to preserve session-list state. Its sticky headers have a higher z-index than the overlay, so they can paint above the file tree when reduced motion removes the transform that previously contained them. An explicit stacking context keeps the overlay on top while preserving sticky positioning, navigation transitions, and scroll state.

## Verification

After rebasing onto `origin/main` at `8f6ddaf8a`:

- `pnpm --dir src/web-ui run test:run src/app/components/NavPanel/NavPanelLayout.test.ts src/app/components/NavPanel/components/StickySectionHeader.test.tsx` — 11 tests passed.
- `pnpm run check:web` — passed.
- Chromium fixture using the actual compiled NavPanel SCSS — all 8 combinations of light/dark, normal/reduced motion, and pointer/keyboard navigation passed. Removing the fix reproduced header overlap in all 4 reduced-motion combinations. Returning to main navigation preserved sticky positioning and scroll offset.
- `git diff origin/main...HEAD --check` — passed.

Before rebase, the desktop frontend build and Windows Debug build also passed. The Debug linker reported a non-fatal `LNK4098` warning. Those builds were not repeated against the new base; the application and `build-dev.bat` were not launched.

## Reviewer Notes

This is a shared presentation-layer fix; no transport, persisted state, or protocol changes are involved. Browser checks are local style-fixture evidence. Live remote workspace, Remote Connect, Peer Device Mode, and Detached Dispatch scenarios were not exercised.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable. No copy changes are needed.
