### PR TITLE
fix(flow-chat): Clarify file edit guidance errors

### DIFF
--- a/design-system/packages/ui/src/flow-chat/tool-cards/FileOperationToolCard.module.css
+++ b/design-system/packages/ui/src/flow-chat/tool-cards/FileOperationToolCard.module.css
@@ -81,6 +81,8 @@
   }
 
   .errorMessage {
+    max-block-size: 20rem;
+    overflow-y: auto;
     color: var(--openbitfun-color-content-muted);
     white-space: pre-wrap;
     overflow-wrap: anywhere;

--- a/design-system/packages/ui/src/flow-chat/tool-cards/FileOperationToolCard.tsx
+++ b/design-system/packages/ui/src/flow-chat/tool-cards/FileOperationToolCard.tsx
@@ -39,7 +39,7 @@ export interface FileOperationToolCardAction {
 export interface FileOperationToolCardError {
   guidance?: boolean;
   message: ReactNode;
-  title: ReactNode;
+  title?: ReactNode;
 }
 
 export interface FileOperationToolCardProps
@@ -146,10 +146,12 @@ export function FileOperationToolCard({
 
   const errorContent = error ? (
     <div className={styles.error} data-guidance={error.guidance ? "true" : "false"}>
-      <div className={styles.errorTitle}>
-        {error.guidance ? <Info aria-hidden="true" /> : <XCircle aria-hidden="true" />}
-        <span>{error.title}</span>
-      </div>
+      {error.title != null && (
+        <div className={styles.errorTitle}>
+          {error.guidance ? <Info aria-hidden="true" /> : <XCircle aria-hidden="true" />}
+          <span>{error.title}</span>
+        </div>
+      )}
       <div className={styles.errorMessage}>{error.message}</div>
     </div>
   ) : undefined;
@@ -211,7 +213,7 @@ export function FileOperationToolCard({
               />
             ) : undefined}
             icon={<Icon aria-hidden="true" />}
-            statusIcon={failed
+            statusIcon={failed && !error?.guidance
               ? (
                 <TriangleAlert
                   aria-hidden="true"

--- a/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.test.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.test.tsx
@@ -877,7 +877,8 @@ describe('FileOperationToolCard', () => {
       );
     });
 
-    expect(container.textContent).toContain('toolCards.file.guidanceHint');
+    expect(container.textContent).not.toContain('toolCards.file.guidanceHint');
+    expect(container.querySelector('[data-openbitfun-icon="warning"]')).toBeNull();
     expect(container.textContent).not.toContain('toolCards.file.failed');
     expect(container.textContent).toContain('report.md');
     expect(container.textContent).not.toContain(
@@ -894,6 +895,8 @@ describe('FileOperationToolCard', () => {
       'Use Read to load the current contents of docs/report.md before calling Write on it.',
     );
     expect(container.querySelector('[data-openbitfun-part="error"] [data-guidance="true"]')).not.toBeNull();
+    expect(container.textContent).not.toContain('toolCards.file.guidanceTitle');
+    expect(container.querySelector('[data-openbitfun-icon="warning"]')).toBeNull();
   });
 
   it('renders edit guardrail blocks as guidance instead of hard failure', async () => {
@@ -938,7 +941,8 @@ describe('FileOperationToolCard', () => {
       );
     });
 
-    expect(container.textContent).toContain('toolCards.file.guidanceHint');
+    expect(container.textContent).not.toContain('toolCards.file.guidanceHint');
+    expect(container.querySelector('[data-openbitfun-icon="warning"]')).toBeNull();
     expect(container.textContent).not.toContain('toolCards.file.failed');
     expect(container.textContent).toContain('main.rs');
     expect(container.textContent).not.toContain(
@@ -955,6 +959,8 @@ describe('FileOperationToolCard', () => {
       'Use Read to load the current contents of src/main.rs before calling Edit on it.',
     );
     expect(container.querySelector('[data-openbitfun-part="error"] [data-guidance="true"]')).not.toBeNull();
+    expect(container.textContent).not.toContain('toolCards.file.guidanceTitle');
+    expect(container.querySelector('[data-openbitfun-icon="warning"]')).toBeNull();
   });
 
   it('shows receiving content label while write content streams before file_path', async () => {

--- a/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/FileOperationToolCard.tsx
@@ -808,7 +808,7 @@ const GenericFileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
     ? `${t('toolCards.file.delete')}${isFailed ? t('toolCards.file.failed') : ''}`
     : isFailed
       ? isFileGuidanceBlocked
-        ? `${toolDisplayName}${t('toolCards.file.guidanceHint')}`
+        ? `${toolDisplayName}:`
         : `${toolDisplayName}${t('toolCards.file.failed')}`
       : `${toolDisplayName}:`;
 
@@ -838,7 +838,7 @@ const GenericFileOperationToolCard: React.FC<FileOperationToolCardProps> = ({
           guidance: isFileGuidanceBlocked,
           message: getDisplayMessage(),
           title: isFileGuidanceBlocked
-            ? t('toolCards.file.guidanceTitle')
+            ? undefined
             : `${toolDisplayName}${t('toolCards.file.failed')}`,
         } : undefined}
         isExpanded={isCardContentExpanded}

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -1636,8 +1636,6 @@
       "delete": "Delete File",
       "deletedLabel": "Deleted",
       "failed": "Failed",
-      "guidanceHint": " · Needs attention",
-      "guidanceTitle": "Action required before retrying",
       "parsingPath": "Parsing file path...",
       "receivingContent": "Receiving file content...",
       "unknownFile": "Unknown file",

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -1636,8 +1636,6 @@
       "delete": "删除文件",
       "deletedLabel": "删除",
       "failed": "失败",
-      "guidanceHint": " · 需要处理",
-      "guidanceTitle": "重试前需要处理",
       "parsingPath": "解析文件路径中...",
       "receivingContent": "接收文件内容中...",
       "unknownFile": "未知文件",

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -1636,8 +1636,6 @@
       "delete": "刪除檔案",
       "deletedLabel": "刪除",
       "failed": "失敗",
-      "guidanceHint": " · 需要處理",
-      "guidanceTitle": "重試前需要處理",
       "parsingPath": "解析檔案路徑中...",
       "receivingContent": "接收檔案內容中...",
       "unknownFile": "未知檔案",


### PR DESCRIPTION
Edit failures such as old_string mismatches can be handled by the
agent. The action-required labels and warning icon misleadingly
suggested that users needed to intervene.

- Remove guidance labels and the header warning icon from file cards.
- Preserve error details for manual expansion and ordinary failure UI.
- Limit error details to 20rem with vertical scrolling for long output.
- Remove unused translations and update guidance rendering assertions.