### PR TITLE
fix(flow-chat): Balance user message spacing

### DIFF
--- a/src/web-ui/src/flow_chat/components/modern/FlowChatRhythm.test.ts
+++ b/src/web-ui/src/flow_chat/components/modern/FlowChatRhythm.test.ts
@@ -63,7 +63,7 @@ describe('FlowChat transcript rhythm', () => {
     const userMessageStyles = readSource('./UserMessageItem.scss');
 
     expect(rendererStyles).toMatch(
-      /\[data-item-type='user-message'\]:not\(\[data-virtual-index='0'\]\)\s*\{\s*padding-top: var\(--openbitfun-control-flow-chat-turn-gap\);/,
+      /\[data-item-type='user-message'\]:not\(\[data-virtual-index='0'\]\)\s*\{\s*padding-top: calc\(var\(--openbitfun-control-flow-chat-turn-gap\) \+ var\(--openbitfun-space-4\)\);/,
     );
     expect(rendererStyles).toContain(
       "&[data-turn-boundary-after='true']",

--- a/src/web-ui/src/flow_chat/components/modern/VirtualItemRenderer.scss
+++ b/src/web-ui/src/flow_chat/components/modern/VirtualItemRenderer.scss
@@ -22,16 +22,17 @@
   padding: 0;
 
   // A regular user message starts a new Turn. Give it a clear boundary from
-  // the preceding Turn while keeping the first message aligned to the list
-  // header and steering messages grouped with the active Turn.
+  // the preceding Turn, balancing the reserved action row below its bubble.
+  // Keep the first message aligned to the list header and steering messages
+  // grouped with the active Turn.
   &[data-item-type='user-message']:not([data-virtual-index='0']) {
-    padding-top: var(--openbitfun-control-flow-chat-turn-gap);
+    padding-top: calc(var(--openbitfun-control-flow-chat-turn-gap) + var(--openbitfun-space-4));
   }
 
   /* Turn spacing has one owner: this virtual-row boundary. Remove only the
    * trailing leaf margin immediately before the next user Turn so text,
    * thinking, compact/expanded tools, notices, and completed-round footers all
-   * resolve to the same `turnGap` instead of stacking two unrelated gaps. */
+   * resolve to the same boundary spacing instead of stacking unrelated gaps. */
   &[data-turn-boundary-after='true'] {
     > .user-message-item-shell,
     > .turn-completion-notice,


### PR DESCRIPTION
Increase spacing above new-turn user messages by 16px to balance
the reserved action row below each bubble.

Preserve first-message alignment and hover-stable action spacing,
and update the transcript rhythm regression test.
