### PR TITLE
fix(installer): remove obsolete bundled migrator requirement

### DIFF
--- a/OpenBitFun-Installer/AGENTS.md
+++ b/OpenBitFun-Installer/AGENTS.md
@@ -50,6 +50,13 @@ pnpm --dir OpenBitFun-Installer run type-check                            # fron
 cargo check --manifest-path OpenBitFun-Installer/src-tauri/Cargo.toml      # Tauri/Rust changes
 ```
 
+For installer payload validation and the independent Data Migrator boundary, run:
+
+```bash
+node --test OpenBitFun-Installer/scripts/build-installer.test.cjs scripts/data-migrator-tauri-build.test.mjs
+cargo test --manifest-path OpenBitFun-Installer/src-tauri/Cargo.toml --lib installer::commands::tests
+```
+
 Run the full installer build only for packaging, payload, native bundling,
 install/uninstall flow, registry, shortcut, or extraction changes:
 

--- a/OpenBitFun-Installer/README.md
+++ b/OpenBitFun-Installer/README.md
@@ -14,7 +14,7 @@ Instead of relying on the generic NSIS wizard UI from Tauri's built-in bundler, 
 ## Legacy data migration
 
 Data Migrator is distributed separately and is not included in this installer.
-To import older BitFun data, download and run the [standalone Data Migrator](../src/apps/data-migrator/README.md) after closing both applications.
+To import legacy data, download and run the [standalone Data Migrator](../src/apps/data-migrator/README.md) after closing both applications.
 
 ## Common tasks
 

--- a/OpenBitFun-Installer/README.md
+++ b/OpenBitFun-Installer/README.md
@@ -11,6 +11,11 @@ Instead of relying on the generic NSIS wizard UI from Tauri's built-in bundler, 
 - **Full control** — Custom installation logic, right-click context menu, PATH integration
 - **Cross-platform potential** — Same codebase can target Windows, macOS, and Linux
 
+## Legacy data migration
+
+Data Migrator is distributed separately and is not included in this installer.
+To import older BitFun data, download and run the [standalone Data Migrator](../src/apps/data-migrator/README.md) after closing both applications.
+
 ## Common tasks
 
 Requires Node.js 22.12+ and pnpm 10.15.0, matching the workspace baseline.

--- a/OpenBitFun-Installer/scripts/build-installer.cjs
+++ b/OpenBitFun-Installer/scripts/build-installer.cjs
@@ -28,7 +28,6 @@ const STRICT_PAYLOAD_VALIDATION = !isDev;
 const MIN_APP_EXE_BYTES = 5 * 1024 * 1024;
 const REQUIRED_PAYLOAD_FILES = [
   "openbitfun-desktop.exe",
-  "openbitfun-data-migrator.exe",
   "frontend/dist/index.html",
   "mobile-web/dist/index.html",
   "resources/ext-host/extension-host.js",

--- a/OpenBitFun-Installer/scripts/build-installer.test.cjs
+++ b/OpenBitFun-Installer/scripts/build-installer.test.cjs
@@ -103,36 +103,30 @@ test("all Installer validators share the required runtime file contract", () => 
     path.join(installerRoot, "src-tauri", "src", "installer", "commands.rs"),
     "utf8"
   );
-  const installerModRs = fs.readFileSync(
-    path.join(installerRoot, "src-tauri", "src", "installer", "mod.rs"),
-    "utf8"
-  );
+  for (const source of [buildRs, commandsRs]) {
+    const declaration = source.match(/const REQUIRED_PAYLOAD_FILES: \[&str; (\d+)\] = \[([\s\S]*?)\];/);
+    assert.equal(Number(declaration[1]), REQUIRED_PAYLOAD_FILES.length);
+    const files = [...declaration[2].matchAll(/"([^"]+)"|MAIN_APP_EXE/g)]
+      .map((match) => match[1] || "openbitfun-desktop.exe");
+    assert.deepEqual(files, REQUIRED_PAYLOAD_FILES);
+  }
   for (const relativePath of REQUIRED_PAYLOAD_FILES) {
     assert.match(buildRs, new RegExp(escapeRegExp(relativePath)));
     if (relativePath === "openbitfun-desktop.exe") {
       assert.match(commandsRs, /MAIN_APP_EXE/);
-    } else if (relativePath === "openbitfun-data-migrator.exe") {
-      assert.match(installerModRs, new RegExp(escapeRegExp(relativePath)));
-      assert.match(commandsRs, /DATA_MIGRATOR_EXE/);
     } else {
       assert.match(commandsRs, new RegExp(escapeRegExp(relativePath)));
     }
   }
 });
 
-test("Data Migrator launch resolves only the registered installation", () => {
-  const commandsRs = fs.readFileSync(
-    path.join(installerRoot, "src-tauri", "src", "installer", "commands.rs"),
-    "utf8"
-  );
-  const commandStart = commandsRs.indexOf("pub(crate) fn launch_legacy_data_migrator");
-  const commandEnd = commandsRs.indexOf("/// Close the installer window.", commandStart);
-  assert.notEqual(commandStart, -1);
-  assert.notEqual(commandEnd, -1);
-  const commandSource = commandsRs.slice(commandStart, commandEnd);
-  assert.doesNotMatch(commandSource, /request\.install_path/);
-  assert.match(commandSource, /read_existing_install_from_uninstall_registry/);
-  assert.match(commandSource, /read_tauri_install_location/);
+test("standalone Data Migrator is not required by the installer", () => {
+  assert.ok(!REQUIRED_PAYLOAD_FILES.includes("openbitfun-data-migrator.exe"));
+  const commandsRs = fs.readFileSync(path.join(installerRoot, "src-tauri/src/installer/commands.rs"), "utf8");
+  assert.doesNotMatch(commandsRs, /DATA_MIGRATOR_EXE|HandoffStore|launch_trusted_executable/);
+  assert.match(commandsRs, /Data Migrator is distributed separately/);
+  const themeSetup = fs.readFileSync(path.join(installerRoot, "src/pages/ThemeSetup.tsx"), "utf8");
+  assert.doesNotMatch(themeSetup, /migrateLegacyData|onLaunchMigration/);
 });
 
 function minorLine(version) {

--- a/OpenBitFun-Installer/src-tauri/Cargo.toml
+++ b/OpenBitFun-Installer/src-tauri/Cargo.toml
@@ -30,9 +30,6 @@ zip = "0.6"
 openbitfun-core-types = { path = "../../src/crates/contracts/core-types" }
 openbitfun-ai-adapters = { path = "../../src/crates/adapters/ai-adapters" }
 openbitfun-services-core = { path = "../../src/crates/services/services-core", features = ["json-io"] }
-openbitfun-legacy-migration = { path = "../../src/crates/services/legacy-migration" }
-openbitfun-product-domains = { path = "../../src/crates/contracts/product-domains", features = ["legacy-migration"] }
-uuid = { version = "1", features = ["v4"] }
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.52"

--- a/OpenBitFun-Installer/src-tauri/build.rs
+++ b/OpenBitFun-Installer/src-tauri/build.rs
@@ -5,9 +5,8 @@ use std::path::{Path, PathBuf};
 use zip::write::FileOptions;
 use zip::{CompressionMethod, ZipWriter};
 
-const REQUIRED_PAYLOAD_FILES: [&str; 7] = [
+const REQUIRED_PAYLOAD_FILES: [&str; 6] = [
     "openbitfun-desktop.exe",
-    "openbitfun-data-migrator.exe",
     "frontend/dist/index.html",
     "mobile-web/dist/index.html",
     "resources/ext-host/extension-host.js",

--- a/OpenBitFun-Installer/src-tauri/src/installer/commands.rs
+++ b/OpenBitFun-Installer/src-tauri/src/installer/commands.rs
@@ -6,23 +6,12 @@ use super::types::{
     ConnectionTestResult, DiskSpaceInfo, InstallOptions, InstallProgress, ModelConfig,
     RemoteModelInfo,
 };
-use super::{DATA_MIGRATOR_EXE, MAIN_APP_EXE};
+use super::MAIN_APP_EXE;
 use openbitfun_core_types::{
     installer_config_handoff::{
         InstallerConfigHandoff, InstallerModelHandoff, INSTALLER_CONFIG_HANDOFF_FILE_NAME,
     },
-    product_identity::{data_namespace, hidden_data_directory, product_id},
-};
-#[cfg(target_os = "windows")]
-use openbitfun_legacy_migration::{
-    launch_trusted_executable, probe_legacy_source, HandoffStore, MigrationOnboardingStore,
-    MigrationRoots, ProbeLimits, TrustedInstallationResolver,
-};
-#[cfg(target_os = "windows")]
-use openbitfun_product_domains::legacy_migration::{
-    MigrationPromptChoice, MigrationSelection, MigratorHandoffRequest,
-    MigratorProtocolCapabilities, MigratorRequestMode, MigratorRequestOrigin,
-    CURRENT_MIGRATION_FORMAT_VERSION,
+    product_identity::{data_namespace, hidden_data_directory},
 };
 use openbitfun_services_core::json_store::JsonFileStore;
 use serde::{Deserialize, Serialize};
@@ -33,8 +22,6 @@ use std::fs::File;
 use std::io::{Cursor, Read};
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
-#[cfg(target_os = "windows")]
-use std::time::{SystemTime, UNIX_EPOCH};
 use tauri::{Emitter, Manager, Window};
 
 #[cfg(target_os = "windows")]
@@ -48,9 +35,8 @@ struct WindowsInstallState {
 
 const MIN_WINDOWS_APP_EXE_BYTES: u64 = 5 * 1024 * 1024;
 const PAYLOAD_MANIFEST_FILE: &str = "payload-manifest.json";
-const REQUIRED_PAYLOAD_FILES: [&str; 7] = [
+const REQUIRED_PAYLOAD_FILES: [&str; 6] = [
     MAIN_APP_EXE,
-    DATA_MIGRATOR_EXE,
     "frontend/dist/index.html",
     "mobile-web/dist/index.html",
     "resources/ext-host/extension-host.js",
@@ -58,13 +44,6 @@ const REQUIRED_PAYLOAD_FILES: [&str; 7] = [
     "flashgrep/flashgrep-x86_64-pc-windows-msvc.exe",
 ];
 const INSTALLER_STATE_FILE: &str = "installer-state.json";
-#[cfg(target_os = "windows")]
-const MIGRATOR_HANDOFF_LIFETIME_MS: i64 = 10 * 60 * 1000;
-#[cfg(target_os = "windows")]
-const RELEASE_CHANNEL: &str = match option_env!("OPENBITFUN_RELEASE_CHANNEL") {
-    Some(value) => value,
-    None => "stable",
-};
 const EMBEDDED_PAYLOAD_ZIP: &[u8] =
     include_bytes!(concat!(env!("OUT_DIR"), "/embedded_payload.zip"));
 
@@ -858,9 +837,7 @@ pub(crate) fn launch_application(install_path: String) -> Result<(), String> {
     Ok(())
 }
 
-/// Create an Installer-origin onboarding handoff and launch the installed
-/// standalone Data Migrator. The Installer never reads or writes migrated
-/// product data itself.
+/// Retain the old command as an explicit unsupported response for older clients.
 #[derive(Debug, Default, Deserialize)]
 #[serde(default, deny_unknown_fields, rename_all = "camelCase")]
 pub(crate) struct LaunchLegacyDataMigratorRequest {}
@@ -869,98 +846,8 @@ pub(crate) struct LaunchLegacyDataMigratorRequest {}
 pub(crate) fn launch_legacy_data_migrator(
     request: LaunchLegacyDataMigratorRequest,
 ) -> Result<bool, String> {
-    #[cfg(not(target_os = "windows"))]
-    {
-        let _ = request;
-        return Err(
-            "Legacy data migration is not supported by this Installer platform.".to_string(),
-        );
-    }
-
-    #[cfg(target_os = "windows")]
-    {
-        let _ = request;
-        let roots = MigrationRoots::resolve_current_user()
-            .map_err(|_| "Could not resolve the current-user migration storage.".to_string())?;
-        let Some(source) = probe_legacy_source(&roots, ProbeLimits::default())
-            .map_err(|_| "Could not safely inspect older data.".to_string())?
-        else {
-            return Ok(false);
-        };
-        if !source.supported {
-            return Err(
-                "The discovered legacy data format is not supported by this Data Migrator."
-                    .to_string(),
-            );
-        }
-
-        let now_ms = migration_now_ms();
-        let capabilities = MigratorProtocolCapabilities::current();
-        let handoff = MigratorHandoffRequest {
-            protocol_version: capabilities.protocol_version,
-            mode: MigratorRequestMode::Onboarding,
-            origin: MigratorRequestOrigin::Installer,
-            run_id: uuid::Uuid::new_v4().to_string(),
-            nonce: uuid::Uuid::new_v4().to_string(),
-            source_id: Some(source.source_id.clone()),
-            source_fingerprint: Some(source.source_fingerprint.clone()),
-            selection: MigrationSelection::all(),
-            caller_process_id: std::process::id(),
-            product_id: product_id().to_string(),
-            release_channel: RELEASE_CHANNEL.to_string(),
-            created_at_ms: now_ms,
-            expires_at_ms: now_ms.saturating_add(MIGRATOR_HANDOFF_LIFETIME_MS),
-            required_capabilities: capabilities.capabilities,
-        };
-        HandoffStore::new(roots.clone(), product_id(), RELEASE_CHANNEL)
-            .write_request(&handoff, now_ms)
-            .map_err(|_| "Could not create a safe Data Migrator handoff.".to_string())?;
-        MigrationOnboardingStore::new(roots)
-            .update(|state| {
-                state.format_version = CURRENT_MIGRATION_FORMAT_VERSION;
-                state.source_fingerprint = source.source_fingerprint.clone();
-                state.detected_at_ms.get_or_insert(now_ms);
-                state.choice = MigrationPromptChoice::Unset;
-                state.last_prompted_version = Some(env!("CARGO_PKG_VERSION").to_string());
-                state.run_id = Some(handoff.run_id.clone());
-                state.handled_run_id = None;
-            })
-            .map_err(|_| "Could not persist the Data Migrator handoff state.".to_string())?;
-
-        let registered_install_path = super::registry::read_existing_install_from_uninstall_registry()
-            .map(|registration| registration.install_location)
-            .or_else(super::registry::read_tauri_install_location)
-            .ok_or_else(|| {
-                "The registered OpenBitFun installation could not be found. Repair the installation before starting Data Migrator."
-                    .to_string()
-            })?;
-        let desktop = PathBuf::from(registered_install_path).join(MAIN_APP_EXE);
-        let executable = TrustedInstallationResolver::resolve_sibling(
-            &desktop,
-            MAIN_APP_EXE,
-            DATA_MIGRATOR_EXE,
-        )
-        .map_err(|_| {
-            "The installed Data Migrator is missing or failed installation layout checks. Repair the OpenBitFun installation."
-                .to_string()
-        })?;
-        launch_trusted_executable(
-            &executable,
-            &[std::ffi::OsStr::new(handoff.run_id.as_str())],
-        )
-        .map_err(|_| "Could not launch the installed Data Migrator.".to_string())?;
-        Ok(true)
-    }
-}
-
-#[cfg(target_os = "windows")]
-fn migration_now_ms() -> i64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis()
-        .try_into()
-        .unwrap_or(i64::MAX)
+    let _ = request;
+    Err("Data Migrator is distributed separately. Download and run OpenBitFun Data Migrator to import legacy data.".to_string())
 }
 
 /// Close the installer window.
@@ -2004,6 +1891,13 @@ mod tests {
     };
     use std::io::{Cursor, Write};
     use zip::write::FileOptions;
+
+    #[test]
+    fn legacy_migration_command_reports_the_independent_distribution() {
+        let result =
+            super::launch_legacy_data_migrator(super::LaunchLegacyDataMigratorRequest::default());
+        assert!(result.unwrap_err().contains("distributed separately"));
+    }
 
     #[test]
     fn language_alias_priority_is_descending_and_stable_for_equal_lengths() {

--- a/OpenBitFun-Installer/src-tauri/src/installer/mod.rs
+++ b/OpenBitFun-Installer/src-tauri/src/installer/mod.rs
@@ -6,7 +6,6 @@ mod types;
 
 /// Windows main binary file name — must match `src/apps/desktop` `[[bin]]` and Tauri NSIS output.
 const MAIN_APP_EXE: &str = "openbitfun-desktop.exe";
-const DATA_MIGRATOR_EXE: &str = "openbitfun-data-migrator.exe";
 
 #[cfg(target_os = "windows")]
 mod registry;

--- a/OpenBitFun-Installer/src/App.tsx
+++ b/OpenBitFun-Installer/src/App.tsx
@@ -90,7 +90,6 @@ function App() {
             options={installer.options}
             setOptions={installer.setOptions}
             onLaunch={installer.launchApp}
-            onLaunchMigration={installer.launchLegacyDataMigrator}
             onClose={installer.closeInstaller}
           />
         );

--- a/OpenBitFun-Installer/src/hooks/useInstaller.ts
+++ b/OpenBitFun-Installer/src/hooks/useInstaller.ts
@@ -38,7 +38,6 @@ export interface UseInstallerReturn {
   saveModelConfig: () => Promise<void>;
   testModelConnection: (modelConfig: ModelConfig) => Promise<ConnectionTestResult>;
   launchApp: () => Promise<void>;
-  launchLegacyDataMigrator: () => Promise<boolean>;
   closeInstaller: () => void;
   refreshDiskSpace: (path: string) => Promise<void>;
   clearInstallError: () => void;
@@ -334,12 +333,6 @@ export function useInstaller(): UseInstallerReturn {
     await invoke('launch_application', { installPath: options.installPath });
   }, [options.installPath]);
 
-  const launchLegacyDataMigrator = useCallback(async () => {
-    return invoke<boolean>('launch_legacy_data_migrator', {
-      request: {},
-    });
-  }, []);
-
   const closeInstaller = useCallback(() => {
     invoke('close_installer');
   }, []);
@@ -386,7 +379,7 @@ export function useInstaller(): UseInstallerReturn {
     progress, isInstalling, installationCompleted, error, diskSpace,
     existingInstall, launchRegisteredUninstaller,
     install, canConfirmProgress, confirmProgress, retryInstall, backToOptions,
-    saveModelConfig, testModelConnection, launchApp, launchLegacyDataMigrator, closeInstaller, refreshDiskSpace, clearInstallError,
+    saveModelConfig, testModelConnection, launchApp, closeInstaller, refreshDiskSpace, clearInstallError,
     isUninstallMode, isUninstalling, uninstallCompleted, uninstallError, uninstallProgress, startUninstall,
   };
 }

--- a/OpenBitFun-Installer/src/pages/ThemeSetup.tsx
+++ b/OpenBitFun-Installer/src/pages/ThemeSetup.tsx
@@ -10,11 +10,10 @@ interface ThemeSetupProps {
   options: InstallOptions;
   setOptions: React.Dispatch<React.SetStateAction<InstallOptions>>;
   onLaunch: () => Promise<void>;
-  onLaunchMigration: () => Promise<boolean>;
   onClose: () => void;
 }
 
-export function ThemeSetup({ options, setOptions, onLaunch, onLaunchMigration, onClose }: ThemeSetupProps) {
+export function ThemeSetup({ options, setOptions, onLaunch, onClose }: ThemeSetupProps) {
   const { t } = useTranslation();
   const [isFinishing, setIsFinishing] = useState(false);
   const [finishError, setFinishError] = useState<string | null>(null);
@@ -58,10 +57,7 @@ export function ThemeSetup({ options, setOptions, onLaunch, onLaunchMigration, o
         console.warn('Failed to persist theme preference:', err);
       }
 
-      const migratorLaunched = options.migrateLegacyData
-        ? await onLaunchMigration()
-        : false;
-      if (!migratorLaunched && options.launchAfterInstall) {
+      if (options.launchAfterInstall) {
         await onLaunch();
       }
       onClose();
@@ -127,18 +123,6 @@ export function ThemeSetup({ options, setOptions, onLaunch, onLaunchMigration, o
           </div>
 
           <div style={{ width: '100%', marginBottom: 14 }}>
-            <Checkbox
-              checked={options.migrateLegacyData}
-              onChange={(checked) => setOptions((prev) => ({ ...prev, migrateLegacyData: checked }))}
-              label={t('complete.migrateLegacyData')}
-            />
-            <p style={{
-              margin: '6px 0 12px 26px',
-              color: 'var(--openbitfun-color-content-secondary)',
-              fontSize: 'var(--openbitfun-type-body-xs-font-size)',
-            }}>
-              {t('complete.migrateLegacyDataDescription')}
-            </p>
             <Checkbox
               checked={options.launchAfterInstall}
               onChange={(checked) => setOptions((prev) => ({ ...prev, launchAfterInstall: checked }))}

--- a/OpenBitFun-Installer/src/types/installer.ts
+++ b/OpenBitFun-Installer/src/types/installer.ts
@@ -83,7 +83,6 @@ export interface InstallOptions {
   desktopShortcut: boolean;
   startMenu: boolean;
   launchAfterInstall: boolean;
-  migrateLegacyData: boolean;
   appLanguage: AppLanguage;
   themePreference: ThemePreferenceId;
   modelConfig: ModelConfig | null;
@@ -110,7 +109,6 @@ export const DEFAULT_OPTIONS: InstallOptions = {
   desktopShortcut: true,
   startMenu: true,
   launchAfterInstall: true,
-  migrateLegacyData: false,
   appLanguage: 'zh-CN',
   themePreference: SYSTEM_THEME_ID,
   modelConfig: null,


### PR DESCRIPTION
Windows beta packaging fails because Installer still requires `openbitfun-data-migrator.exe` after Data Migrator became an independent distribution. Align the build/runtime payload validators with the standalone design, remove the obsolete migration checkbox and handoff dependencies, and keep the old command returning a clear unsupported response for older clients. No existing user data is removed.

Validation: 40 product/build-script tests, 8 installer packaging tests, 6 native installer tests, Installer type check and frontend build, all 23 color-audit surfaces, and core-boundary check passed. The payload regression now compares the full JS/Rust required-file lists and their declared lengths. Windows packaging will be verified by the beta build after merge.

Remote scenarios: none exercised; this change is confined to the local Installer. Remote Workspace, Remote Control, Peer Device Mode, and Detached Dispatch runtime behavior is unchanged.

Reproduced by Desktop Package run 34226341448 (Windows); macOS/Linux jobs succeeded.
