### PR TITLE
feat(flowchat): accept file drops across the conversation pane

### DIFF
--- a/src/web-ui/src/app/scenes/session/ChatPane.scss
+++ b/src/web-ui/src/app/scenes/session/ChatPane.scss
@@ -22,3 +22,35 @@
   width: 100%;
   height: 100%;
 }
+
+// A pane-sized target without intercepting drops or changing transcript geometry.
+.openbitfun-chat-pane__drop-overlay {
+  position: absolute;
+  inset: var(--openbitfun-space-2);
+  z-index: var(--openbitfun-layer-overlay);
+  pointer-events: none;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--openbitfun-color-accent-default);
+  border-radius: var(--openbitfun-radius-lg);
+  background: color-mix(in srgb, var(--openbitfun-color-accent-default) 9%, transparent);
+}
+
+.openbitfun-chat-pane__drop-hint {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--openbitfun-space-2);
+  padding: var(--openbitfun-space-3) var(--openbitfun-space-4);
+  margin: var(--openbitfun-space-4);
+  border: 1px solid var(--openbitfun-color-border-default);
+  border-radius: var(--openbitfun-radius-lg);
+  background: var(--openbitfun-color-surface-scene);
+  color: var(--openbitfun-color-content-primary);
+  box-shadow: var(--openbitfun-shadow-sm);
+  font-family: var(--openbitfun-type-label-md-font-family);
+  font-size: var(--openbitfun-type-label-md-font-size);
+  font-weight: var(--openbitfun-type-label-md-font-weight);
+  line-height: var(--openbitfun-type-label-md-line-height);
+
+  .openbitfun-icon { color: var(--openbitfun-color-accent-default); }
+}

--- a/src/web-ui/src/app/scenes/session/ChatPane.tsx
+++ b/src/web-ui/src/app/scenes/session/ChatPane.tsx
@@ -5,7 +5,9 @@
  * Renamed from panels/CenterPanel. All logic preserved.
  */
 
-import React, { useCallback, memo, useEffect, useRef } from 'react';
+import React, { useCallback, memo, useEffect, useRef, useState } from 'react';
+import { Icon } from '@openbitfun/ui';
+import { useI18n } from '@/infrastructure/i18n';
 import { ModernFlowChatContainer as FlowChatContainer } from '../../../flow_chat/components/modern/ModernFlowChatContainer';
 import { ChatInput } from '../../../flow_chat/components/ChatInput';
 import type { ChatInputRegistration } from '../../../flow_chat/components/chatInputRegistration';
@@ -56,6 +58,9 @@ const ChatPaneInner: React.FC<ChatPaneProps> = ({
   chatInputRegistration,
 }) => {
   const addTab = useCanvasStore(state => state.addTab);
+  const fileDropTargetRef = useRef<HTMLDivElement>(null);
+  const [isFileDragOver, setIsFileDragOver] = useState(false);
+  const { t } = useI18n('flow-chat');
   const deferredTaskDetailTimersRef = useRef<number[]>([]);
   const deferredTaskDetailIdleCallbacksRef = useRef<number[]>([]);
 
@@ -157,6 +162,7 @@ const ChatPaneInner: React.FC<ChatPaneProps> = ({
 
   return (
     <div data-openbitfun-component="chat-pane" data-openbitfun-part="root"
+      ref={fileDropTargetRef}
       className="openbitfun-chat-pane__content"
       data-shortcut-scope="chat"
       data-fullscreen={isFullscreen}
@@ -176,9 +182,20 @@ const ChatPaneInner: React.FC<ChatPaneProps> = ({
       />
       {showChatInput && (
         <ChatInput
+          fileDropTargetRef={fileDropTargetRef}
+          onFileDragOverChange={setIsFileDragOver}
           isSceneActive={isSceneActive}
           registration={chatInputRegistration}
         />
+      )}
+      {showChatInput && isSceneActive && isFileDragOver && (
+        <div className="openbitfun-chat-pane__drop-overlay" role="status"
+          data-testid="chat-pane-drop-overlay">
+          <span className="openbitfun-chat-pane__drop-hint">
+            <Icon name="upload" size="md" />
+            {t('context.dropToAdd')}
+          </span>
+        </div>
       )}
     </div>
   );

--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -1,3 +1,4 @@
+import { ChatInputImagePreview } from './ChatInputImagePreview';
 /**
  * Standalone chat input component
  * Separated from bottom bar, supports session-level state awareness
@@ -274,6 +275,9 @@ const log = createLogger('ChatInput');
 export interface ChatInputProps {
   className?: string;
   isSceneActive?: boolean;
+  /** The host conversation area that accepts files for this composer. */
+  fileDropTargetRef?: React.RefObject<HTMLElement | null>;
+  onFileDragOverChange?: (isOver: boolean) => void;
   /**
    * Optional content and transport registration for hosts that embed the
    * standard composer. The registration never replaces ChatInput's UI.
@@ -481,6 +485,8 @@ interface ExternalFileIntakeRequest {
 export const ChatInput: React.FC<ChatInputProps> = ({
   className = '',
   isSceneActive = true,
+  fileDropTargetRef,
+  onFileDragOverChange,
   registration,
 }) => {
   const deviceSurfaceScope = getActiveSurfaceScope();
@@ -503,6 +509,8 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   const richTextInputRef = useRef<RichTextInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const externalFileDropTargetRef = useRef<HTMLDivElement>(null);
+  const [nativeFileDragOver, setNativeFileDragOver] = useState(false);
+  const [contextFileDragOver, setContextFileDragOver] = useState(false);
   const inputAreaAnchorRef = useRef<HTMLDivElement>(null);
   const agentBoostRef = useRef<HTMLDivElement>(null);
   const boostTriggerRef = useRef<HTMLSpanElement>(null);
@@ -4789,12 +4797,21 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   }, [addClipboardImageFiles, captureExternalFileIntakeRequest, enqueueExternalFileIntake]);
 
   useLocalFileDrop({
-    targetRef: externalFileDropTargetRef,
-    enabled: !isWindowsDesktopRuntime()
+    targetRef: fileDropTargetRef ?? externalFileDropTargetRef,
+    enabled: isSceneActive && !isWindowsDesktopRuntime()
       && !caps.transferInFlight
       && !isInterruptedTurnRecoveryInFlight,
     onDropPaths: paths => intakeExternalPaths('drop', paths),
+    onDragOver: setNativeFileDragOver,
   });
+
+  useEffect(() => {
+    onFileDragOverChange?.(isSceneActive && !caps.transferInFlight
+      && !isInterruptedTurnRecoveryInFlight && (nativeFileDragOver || contextFileDragOver));
+  }, [onFileDragOverChange, isSceneActive, caps.transferInFlight,
+    isInterruptedTurnRecoveryInFlight, nativeFileDragOver, contextFileDragOver]);
+
+  useEffect(() => () => onFileDragOverChange?.(false), [onFileDragOverChange]);
 
   const handleRecoverInterruptedTurn = useCallback(async () => {
     const candidate = interruptedTurnRecovery;
@@ -5858,9 +5875,11 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     <>
       {deepReviewConsentDialog}
       <ContextDropZone
+        extendedTargetRef={fileDropTargetRef}
+        onDragStateChange={setContextFileDragOver}
         acceptedTypes={['file', 'directory', 'image', 'code-snippet', 'mermaid-diagram']}
         className="openbitfun-chat-input-drop-zone"
-        disabled={isInterruptedTurnRecoveryInFlight}
+        disabled={!isSceneActive || caps.transferInFlight || isInterruptedTurnRecoveryInFlight}
         onExternalFilesDrop={
           isWindowsDesktopRuntime() && !caps.transferInFlight
             ? files => { void handleHtmlExternalFilesDrop(files); }
@@ -5976,26 +5995,13 @@ export const ChatInput: React.FC<ChatInputProps> = ({
                   data-testid="chat-input-image-strip"
                 >
                   {imageContexts.map(image => {
-                    const previewUrl = image.thumbnailUrl || image.dataUrl;
                     return (
                       <div data-openbitfun-component="chat-input" data-openbitfun-part="image"
                         key={image.id}
                         className="openbitfun-chat-input__image-chip"
                         title={image.imageName}
                       >
-                        {previewUrl ? (
-                          <img
-                            className="openbitfun-chat-input__image-chip-thumb"
-                            data-openbitfun-component="chat-input"
-                            data-openbitfun-part="imagePreview"
-                            src={previewUrl}
-                            alt={image.imageName}
-                          />
-                        ) : (
-                          <div className="openbitfun-chat-input__image-chip-thumb openbitfun-chat-input__image-chip-thumb--placeholder" data-openbitfun-component="chat-input" data-openbitfun-part="imagePreview">
-                            <Icon name="image" size="sm" />
-                          </div>
-                        )}
+                        <ChatInputImagePreview image={image} surfaceEpoch={deviceSurfaceScope.epoch} />
                         <button
                           type="button"
                           className="openbitfun-chat-input__image-chip-remove"

--- a/src/web-ui/src/flow_chat/components/ChatInputImagePreview.test.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInputImagePreview.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatInputImagePreview } from './ChatInputImagePreview';
+import type { ImageContext } from '@/types/context';
+vi.mock('@/infrastructure/peer-device/deviceSurface', () => ({ getActiveSurfaceScope: () => ({ epoch: 1 }) }));
+
+const { readFileContent } = vi.hoisted(() => ({ readFileContent: vi.fn() }));
+vi.mock('@/infrastructure/api/service-api/WorkspaceAPI', () => ({ workspaceAPI: { readFileContent } }));
+vi.mock('@/infrastructure/i18n', () => ({ useI18n: () => ({ t: (_key: string, values: { message: string }) => `Load failed: ${values.message}` }) }));
+vi.mock('@/shared/utils/logger', () => ({ createLogger: () => ({ warn: vi.fn(), debug: vi.fn(), info: vi.fn(), error: vi.fn() }) }));
+
+const image = { id: 'image', imageName: 'Photo.png', imagePath: '/Lark images/Photo.png', mimeType: 'image/png' } as ImageContext;
+
+describe('ChatInputImagePreview', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    readFileContent.mockReset();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+  afterEach(() => { act(() => root.unmount()); container.remove(); });
+  const render = async (element: React.ReactNode) => { await act(async () => { root.render(element); }); };
+
+
+  it('reads path-only dropped screenshots through the host transport', async () => {
+    readFileContent.mockResolvedValue('aW1hZ2U=');
+    await render(<ChatInputImagePreview image={image} surfaceEpoch={1} />);
+    const thumbnail = container.querySelector('img')!;
+    expect(readFileContent).toHaveBeenCalledWith(image.imagePath, 'base64');
+    expect(thumbnail.getAttribute('src')).toBe('data:image/png;base64,aW1hZ2U=');
+  });
+
+  it('uses embedded clipboard data without reading a host file', async () => {
+    await render(<ChatInputImagePreview image={{ ...image, dataUrl: 'data:image/png;base64,AA==' }} surfaceEpoch={1} />);
+    expect(container.querySelector('img')!.getAttribute('src')).toBe('data:image/png;base64,AA==');
+    expect(readFileContent).not.toHaveBeenCalled();
+  });
+
+  it('displays read failures without falling back to controller-local URLs', async () => {
+    readFileContent.mockRejectedValue(new Error('Host offline'));
+    await render(<ChatInputImagePreview image={image} surfaceEpoch={1} />);
+    expect(container.querySelector('[role=img]')!.getAttribute('aria-label')).toContain('Host offline');
+    expect(container.querySelector('img')).toBeNull();
+    expect(readFileContent).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a stale image read after the attachment changes', async () => {
+    let finishOld!: (content: string) => void;
+    readFileContent.mockImplementationOnce(() => new Promise<string>(resolve => { finishOld = resolve; }));
+    readFileContent.mockResolvedValueOnce('NEW');
+    await render(<ChatInputImagePreview image={image} surfaceEpoch={1} />);
+    await render(<ChatInputImagePreview image={{ ...image, imagePath: '/new.png' }} surfaceEpoch={1} />);
+    expect(container.querySelector('img')!.getAttribute('src')).toBe('data:image/png;base64,NEW');
+    await act(async () => { finishOld('OLD'); });
+    expect(container.querySelector('img')!.getAttribute('src')).toBe('data:image/png;base64,NEW');
+  });
+});

--- a/src/web-ui/src/flow_chat/components/ChatInputImagePreview.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInputImagePreview.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react';
+import { Icon } from '@openbitfun/ui';
+import { workspaceAPI } from '@/infrastructure/api/service-api/WorkspaceAPI';
+import { getActiveSurfaceScope } from '@/infrastructure/peer-device/deviceSurface';
+import { useI18n } from '@/infrastructure/i18n';
+import type { ImageContext } from '@/types/context';
+import { getMimeTypeFromFilename } from '../utils/imageUtils';
+
+export function ChatInputImagePreview({ image, surfaceEpoch }: {
+  image: ImageContext;
+  surfaceEpoch: number;
+}) {
+  const { t } = useI18n('tools');
+  const embedded = image.thumbnailUrl || image.dataUrl;
+  const path = image.imagePath;
+  const [loaded, setLoaded] = useState<{ path: string; epoch: number; source: string } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const source = embedded || (loaded?.path === path && loaded.epoch === surfaceEpoch ? loaded.source : undefined);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoaded(null);
+    setError(null);
+    if (!embedded && path) {
+      // Paths belong to the runtime host, just like sent-message attachments.
+      // Read through the transport; never turn them into controller asset URLs.
+      void workspaceAPI.readFileContent(path, 'base64').then(content => {
+        if (!cancelled && getActiveSurfaceScope().epoch === surfaceEpoch) {
+          setLoaded({ path, epoch: surfaceEpoch,
+            source: `data:${image.mimeType || getMimeTypeFromFilename(path)};base64,${content}` });
+        }
+      }).catch(cause => {
+        if (!cancelled && getActiveSurfaceScope().epoch === surfaceEpoch) setError(String(cause));
+      });
+    }
+    return () => { cancelled = true; };
+  }, [embedded, path, image.mimeType, surfaceEpoch]);
+
+  return source && !error ? (
+    <img className="openbitfun-chat-input__image-chip-thumb"
+      data-openbitfun-component="chat-input" data-openbitfun-part="imagePreview"
+      src={source} alt={image.imageName} onError={() => setError(image.imageName)} />
+  ) : (
+    <div className="openbitfun-chat-input__image-chip-thumb openbitfun-chat-input__image-chip-thumb--placeholder"
+      data-openbitfun-component="chat-input" data-openbitfun-part="imagePreview"
+      role={error ? 'img' : undefined}
+      aria-label={error ? t('editor.imageViewer.loadImageFailedWithMessage', { message: error }) : undefined}
+      title={error ? t('editor.imageViewer.loadImageFailedWithMessage', { message: error }) : image.imageName}>
+      <Icon name="image" size="sm" />
+    </div>
+  );
+}

--- a/src/web-ui/src/infrastructure/files/useLocalFileDrop.test.ts
+++ b/src/web-ui/src/infrastructure/files/useLocalFileDrop.test.ts
@@ -34,6 +34,32 @@ describe('local file drop controller', () => {
     expect(onDropPaths).toHaveBeenCalledOnce();
   });
 
+  it('shows hover on entry, clears it outside the pane and after a drop', async () => {
+    const { controller, onDragOver } = setup();
+    await controller.handle({ type: 'enter', paths: ['/tmp/a'], position: { x: 20, y: 20 } });
+    expect(onDragOver).toHaveBeenLastCalledWith(true);
+    await controller.handle({ type: 'over', position: { x: 100, y: 100 } });
+    expect(onDragOver).toHaveBeenLastCalledWith(false);
+    await controller.handle({ type: 'over', position: { x: 20, y: 20 } });
+    await controller.handle({ type: 'drop', paths: ['/tmp/a'], position: { x: 20, y: 20 } });
+    expect(onDragOver).toHaveBeenLastCalledWith(false);
+  });
+
+  it('does not restore hover when a delayed hit test finishes after leave', async () => {
+    let resolveScale!: (scale: number) => void;
+    const scale = new Promise<number>(resolve => { resolveScale = resolve; });
+    const onDragOver = vi.fn();
+    const controller = createLocalFileDropController({
+      getTarget: () => target, getScaleFactor: () => scale,
+      isEnabled: () => true, onDragOver, onDropPaths: vi.fn(),
+    });
+    const entering = controller.handle({ type: 'enter', paths: ['/tmp/a'], position: { x: 20, y: 20 } });
+    await controller.handle({ type: 'leave' });
+    resolveScale(1);
+    await entering;
+    expect(onDragOver).toHaveBeenCalledExactlyOnceWith(false);
+  });
+
   it('clears hover state on leave', async () => {
     const { controller, onDragOver } = setup();
     await controller.handle({ type: 'over', position: { x: 20, y: 20 } });

--- a/src/web-ui/src/infrastructure/files/useLocalFileDrop.ts
+++ b/src/web-ui/src/infrastructure/files/useLocalFileDrop.ts
@@ -31,6 +31,7 @@ export function createLocalFileDropController(
 ): LocalFileDropController {
   let enterPaths: string[] = [];
   let disposed = false;
+  let hoverGeneration = 0;
   let lastDrop: { signature: string; at: number } | null = null;
 
   const clear = () => {
@@ -40,6 +41,7 @@ export function createLocalFileDropController(
 
   return {
     async handle(payload) {
+      const generation = ++hoverGeneration;
       const enabled = options.isEnabled();
       if (disposed) return;
       if (payload.type === 'leave') {
@@ -52,13 +54,14 @@ export function createLocalFileDropController(
       }
       if (payload.type === 'enter') {
         enterPaths = [...payload.paths];
-        return;
       }
 
       const scaleFactor = await options.getScaleFactor();
       const target = options.getTarget();
       const hit = isDragPositionOverElement(payload.position, scaleFactor, target);
-      if (payload.type === 'over') {
+      if (disposed || !options.isEnabled()) return;
+      if (payload.type === 'over' || payload.type === 'enter') {
+        if (generation !== hoverGeneration) return;
         options.onDragOver?.(hit);
         return;
       }

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -624,6 +624,7 @@
     "codeBlock": "Code Block",
     "image": "Image",
     "url": "URL",
+    "dropToAdd": "Drop to add to message",
     "dragHint": "Drop files here to add context"
   },
   "agent": {

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -624,6 +624,7 @@
     "codeBlock": "代码块",
     "image": "图片",
     "url": "URL",
+    "dropToAdd": "松开即可添加",
     "dragHint": "拖放文件到此处添加上下文"
   },
   "agent": {

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -624,6 +624,7 @@
     "codeBlock": "代碼塊",
     "image": "圖片",
     "url": "URL",
+    "dropToAdd": "放開即可新增",
     "dragHint": "拖放檔案到此處新增上下文"
   },
   "agent": {

--- a/src/web-ui/src/shared/context-system/drag-drop/ContextDropZone.test.tsx
+++ b/src/web-ui/src/shared/context-system/drag-drop/ContextDropZone.test.tsx
@@ -1,0 +1,85 @@
+/** @vitest-environment jsdom */
+import React, { act, useRef } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+const mocks = vi.hoisted(() => ({ payload: null as unknown, addContext: vi.fn(), updateValidation: vi.fn() }));
+vi.mock('../../services/DragManager', () => ({ dragManager: {
+  registerTarget: () => () => {}, getCurrentPayload: () => mocks.payload,
+  handleDragEnter: vi.fn(), handleDragLeave: vi.fn(), handleDragOver: vi.fn(),
+  handleDrop: (target: { canAccept: (p: unknown) => boolean; onDrop: (p: unknown) => void }) => {
+    if (target.canAccept(mocks.payload)) target.onDrop(mocks.payload);
+  },
+} }));
+vi.mock('../../services/ContextRegistry', () => ({ contextRegistry: { getAllTypes: () => ['file'] } }));
+vi.mock('../../stores/contextStore', () => ({ useContextStore: (selector: (state: typeof mocks) => unknown) => selector(mocks) }));
+import { ContextDropZone } from './ContextDropZone';
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+const container = document.createElement('div');
+document.body.appendChild(container);
+let root: ReturnType<typeof createRoot>;
+afterEach(() => { act(() => root.unmount()); mocks.payload = null; vi.clearAllMocks(); });
+function mount(onFiles = vi.fn(), disabled = false, onContextAdded = vi.fn(), onDragStateChange = vi.fn()) {
+  function Pane() {
+    const ref = useRef<HTMLDivElement>(null);
+    return <><div ref={ref}>
+      <div data-testid="transcript">History</div>
+      <ContextDropZone extendedTargetRef={ref} disabled={disabled} onDragStateChange={onDragStateChange} onExternalFilesDrop={onFiles} onContextAdded={onContextAdded}>
+        <div data-testid="composer">Input</div>
+      </ContextDropZone>
+    </div><div data-testid="other-pane">Editor</div></>;
+  }
+  root = createRoot(container);
+  act(() => root.render(<Pane />));
+  return onFiles;
+}
+function drag(target: string, type: string, types: string[], files: File[] = []) {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperty(event, 'dataTransfer', { value: { types, files, dropEffect: 'none' } });
+  act(() => { container.querySelector(`[data-testid="${target}"]`)!.dispatchEvent(event); });
+  return event;
+}
+describe('conversation area drops', () => {
+  it('handles transcript files, adds composer drops once, and excludes other panes', () => {
+    const onFiles = mount(); const file = new File(['hello'], 'notes.txt');
+    expect(drag('transcript', 'dragover', ['Files']).defaultPrevented).toBe(true);
+    drag('transcript', 'drop', ['Files'], [file]);
+    expect(onFiles).toHaveBeenCalledExactlyOnceWith([file]);
+    drag('composer', 'drop', ['Files'], [file]);
+    expect(onFiles).toHaveBeenCalledTimes(2);
+    drag('other-pane', 'drop', ['Files'], [file]);
+    expect(onFiles).toHaveBeenCalledTimes(2);
+  });
+  it('routes internal workspace files through context insertion', () => {
+    const onAdded = vi.fn(); mount(vi.fn(), false, onAdded);
+    const context = { id: 'file-1', type: 'file', path: '/project/notes.txt' };
+    mocks.payload = { dataType: 'file', data: context };
+    drag('transcript', 'dragenter', ['application/openbitfun-context']);
+    drag('transcript', 'drop', ['application/openbitfun-context']);
+    expect(mocks.addContext).toHaveBeenCalledExactlyOnceWith(context);
+    expect(onAdded).toHaveBeenCalledExactlyOnceWith(context);
+  });
+  it('shows accepted drag feedback and clears it on leave, drop and cancellation', () => {
+    const onDragStateChange = vi.fn();
+    mount(vi.fn(), false, vi.fn(), onDragStateChange);
+    drag('transcript', 'dragenter', ['Files']);
+    expect(onDragStateChange).toHaveBeenLastCalledWith(true);
+    drag('transcript', 'dragleave', ['Files']);
+    expect(onDragStateChange).toHaveBeenLastCalledWith(false);
+    drag('transcript', 'dragenter', ['Files']);
+    drag('transcript', 'drop', ['Files']);
+    expect(onDragStateChange).toHaveBeenLastCalledWith(false);
+    drag('transcript', 'dragenter', ['Files']);
+    act(() => window.dispatchEvent(new Event('dragend')));
+    expect(onDragStateChange).toHaveBeenLastCalledWith(false);
+    drag('transcript', 'dragenter', ['Files']);
+    act(() => window.dispatchEvent(new Event('blur')));
+    expect(onDragStateChange).toHaveBeenLastCalledWith(false);
+  });
+  it('blocks disabled drops without consuming ordinary text drags', () => {
+    const onFiles = mount(vi.fn(), true);
+    drag('transcript', 'drop', ['Files'], [new File(['x'], 'x.txt')]);
+    expect(onFiles).not.toHaveBeenCalled();
+    expect(drag('transcript', 'dragover', ['text/plain']).defaultPrevented).toBe(false);
+    expect(drag('transcript', 'drop', ['text/plain']).defaultPrevented).toBe(false);
+  });
+});

--- a/src/web-ui/src/shared/context-system/drag-drop/ContextDropZone.tsx
+++ b/src/web-ui/src/shared/context-system/drag-drop/ContextDropZone.tsx
@@ -15,7 +15,14 @@ export interface ContextDropZoneProps {
   onContextAdded?: (context: ContextItem) => void;
   onExternalFilesDrop?: (files: File[]) => void;
   disabled?: boolean;
+  /** Also accept drops in this enclosing surface; feedback stays on the composer. */
+  extendedTargetRef?: React.RefObject<HTMLElement | null>;
+  onDragStateChange?: (canDrop: boolean) => void;
 }
+
+type DropEvent = React.DragEvent | DragEvent;
+const nativeDragEvent = (event: DropEvent): DragEvent =>
+  'nativeEvent' in event ? event.nativeEvent : event;
 
 export const ContextDropZone: React.FC<ContextDropZoneProps> = ({
   acceptedTypes,
@@ -24,6 +31,8 @@ export const ContextDropZone: React.FC<ContextDropZoneProps> = ({
   onContextAdded,
   onExternalFilesDrop,
   disabled = false,
+  extendedTargetRef,
+  onDragStateChange,
 }) => {
   const [isDragOver, setIsDragOver] = useState(false);
   const [canAccept, setCanAccept] = useState(false);
@@ -31,6 +40,24 @@ export const ContextDropZone: React.FC<ContextDropZoneProps> = ({
   const dragCounterRef = useRef(0); 
   const addContext = useContextStore(state => state.addContext);
   const updateValidation = useContextStore(state => state.updateValidation);
+
+  useEffect(() => {
+    onDragStateChange?.(isDragOver && canAccept && !disabled);
+  }, [isDragOver, canAccept, disabled, onDragStateChange]);
+
+  useEffect(() => {
+    const reset = () => {
+      dragCounterRef.current = 0;
+      setIsDragOver(false);
+      setCanAccept(false);
+    };
+    window.addEventListener('dragend', reset);
+    window.addEventListener('blur', reset);
+    return () => {
+      window.removeEventListener('dragend', reset);
+      window.removeEventListener('blur', reset);
+    };
+  }, []);
   
   
   const acceptedTypesArray = React.useMemo(() => 
@@ -100,7 +127,8 @@ export const ContextDropZone: React.FC<ContextDropZoneProps> = ({
   }, [dropTarget]);
   
    
-  const handleDragEnter = useCallback((e: React.DragEvent) => {
+  const handleDragEnter = useCallback((e: DropEvent) => {
+    if (!e.dataTransfer) return;
     e.preventDefault();
     e.stopPropagation();
 
@@ -118,12 +146,13 @@ export const ContextDropZone: React.FC<ContextDropZoneProps> = ({
         const accepted = dropTargetRef.current.canAccept(payload);
         setIsDragOver(true);
         setCanAccept(accepted);
-        dragManager.handleDragEnter(dropTargetRef.current, e.nativeEvent);
+        dragManager.handleDragEnter(dropTargetRef.current, nativeDragEvent(e));
       }
     }
   }, [disabled, onExternalFilesDrop]);
   
-  const handleDragOver = useCallback((e: React.DragEvent) => {
+  const handleDragOver = useCallback((e: DropEvent) => {
+    if (!e.dataTransfer) return;
     e.preventDefault();
     e.stopPropagation();
 
@@ -135,30 +164,32 @@ export const ContextDropZone: React.FC<ContextDropZoneProps> = ({
     const payload = dragManager.getCurrentPayload();
     if (payload && dropTargetRef.current.canAccept(payload)) {
       e.dataTransfer.dropEffect = 'copy';
-      dragManager.handleDragOver(dropTargetRef.current, e.nativeEvent);
+      dragManager.handleDragOver(dropTargetRef.current, nativeDragEvent(e));
     } else {
       e.dataTransfer.dropEffect = 'none';
     }
   }, [disabled, onExternalFilesDrop]);
   
-  const handleDragLeave = useCallback((e: React.DragEvent) => {
+  const handleDragLeave = useCallback((e: DropEvent) => {
+    if (!e.dataTransfer) return;
     e.preventDefault();
     e.stopPropagation();
     const containsExternalFiles = Array.from(e.dataTransfer.types).includes('Files');
     
-    dragCounterRef.current--;
+    dragCounterRef.current = Math.max(0, dragCounterRef.current - 1);
     
     if (dragCounterRef.current === 0) {
       
       setIsDragOver(false);
       setCanAccept(false);
       if (!containsExternalFiles) {
-        dragManager.handleDragLeave(dropTargetRef.current, e.nativeEvent);
+        dragManager.handleDragLeave(dropTargetRef.current, nativeDragEvent(e));
       }
     }
   }, []);
   
-  const handleDrop = useCallback((e: React.DragEvent) => {
+  const handleDrop = useCallback((e: DropEvent) => {
+    if (!e.dataTransfer) return;
     e.preventDefault();
     e.stopPropagation();
     
@@ -173,8 +204,34 @@ export const ContextDropZone: React.FC<ContextDropZoneProps> = ({
       }
       return;
     }
-    dragManager.handleDrop(dropTargetRef.current, e.nativeEvent);
+    dragManager.handleDrop(dropTargetRef.current, nativeDragEvent(e));
   }, [disabled, onExternalFilesDrop]);
+
+  useEffect(() => {
+    const target = extendedTargetRef?.current;
+    if (!target) return;
+    const outsideComposer = (handler: (event: DropEvent) => void) => (event: DragEvent) => {
+      // The composer's existing React handlers own drops inside it. Do not
+      // consume text/tab drags in the transcript or add an attachment twice.
+      if (event.target instanceof Node && dropZoneRef.current?.contains(event.target)) return;
+      if (!event.dataTransfer?.types.includes('Files') && !dragManager.getCurrentPayload()) return;
+      handler(event);
+    };
+    const enter = outsideComposer(handleDragEnter);
+    const over = outsideComposer(handleDragOver);
+    const leave = outsideComposer(handleDragLeave);
+    const drop = outsideComposer(handleDrop);
+    target.addEventListener('dragenter', enter);
+    target.addEventListener('dragover', over);
+    target.addEventListener('dragleave', leave);
+    target.addEventListener('drop', drop);
+    return () => {
+      target.removeEventListener('dragenter', enter);
+      target.removeEventListener('dragover', over);
+      target.removeEventListener('dragleave', leave);
+      target.removeEventListener('drop', drop);
+    };
+  }, [extendedTargetRef, handleDragEnter, handleDragOver, handleDragLeave, handleDrop]);
   
   return (
     <div


### PR DESCRIPTION
## Summary

Allow files to be dropped anywhere in the active FlowChat conversation pane, including the transcript and empty space, to add them to the composer. Accepted drags show a theme-aware pane highlight and a “Drop to add to message” hint without changing transcript geometry or intercepting pointer events.

Also load path-only image attachments through the host file API so dropped screenshots have composer thumbnails. The existing sent-message preview fix did not cover the composer.

## Type and Areas

Type: Feature / bug fix / UI/UX

Areas: Web UI FlowChat, context drag-and-drop, desktop file intake, image previews, locales.

## Motivation / Impact

Users no longer need to hit the input box precisely when attaching files. Internal context drags and native file drops reuse existing intake paths; drops in the composer are handled once, adjacent panes remain outside the target, and inactive or busy composers reject intake.

Drag feedback clears after leaving, dropping or cancelling. Delayed native hover checks cannot restore a highlight after the pointer has left. Image previews use transport-routed host reads, preserve embedded clipboard data, and ignore stale attachment reads instead of constructing local asset URLs.

## Verification

- `pnpm --dir src/web-ui exec vitest run src/shared/context-system/drag-drop/ContextDropZone.test.tsx src/infrastructure/files/useLocalFileDrop.test.ts src/flow_chat/components/ChatInputImagePreview.test.tsx src/flow_chat/components/modern/UserMessageImage.test.tsx src/flow_chat/utils/externalFileIntake.test.ts` — focused regression coverage for intake, deduplication, scope, drag feedback, cancellation and image preview loading.
- `pnpm run check:web` — passed during implementation, including type and appearance/theme contracts.
- `pnpm run i18n:audit` — passed with zero warnings; English, Simplified Chinese and Traditional Chinese copy updated.
- `git diff upstream/main --check` — passed.
- Desktop dev build launched successfully. Isolated visual previews checked light/dark themes and narrow/wide pane sizes. Native OS drag interactions and remote scenarios have not been verified end to end.

## Reviewer Notes

Remote workspace and Peer Device paths retain existing capability restrictions and transport routing; no controller-local file fallback is added. Remote control and Detached Dispatch are not extended. Screenshot reads are covered with mocked host responses, not a live remote host.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.
