### PR TITLE
fix(web): retire session tabs when their workspace closes

### DIFF
--- a/src/web-ui/src/app/services/sessionSceneLifecycle.test.ts
+++ b/src/web-ui/src/app/services/sessionSceneLifecycle.test.ts
@@ -1,12 +1,14 @@
 // @vitest-environment jsdom
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flowChatStore } from '@/flow_chat/store/FlowChatStore';
 import { useModernFlowChatStore } from '@/flow_chat/store/modernFlowChatStore';
 import type { Session } from '@/flow_chat/types/flow-chat';
 import { activateSurface, LOCAL_SURFACE_ID } from '@/infrastructure/peer-device/deviceSurface';
 import { selectActiveSceneId, useSceneStore } from '../stores/sceneStore';
 import { resolveSessionSceneTarget } from './sessionSceneTarget';
+import { workspaceManager, type WorkspaceEventListener } from '@/infrastructure/services/business/workspaceManager';
+import type { WorkspaceInfo } from '@/shared/types';
 import { startSessionSceneLifecycle } from './sessionSceneLifecycle';
 
 function session(sessionId: string, overrides: Partial<Session> = {}): Session {
@@ -46,6 +48,7 @@ describe('Session scene resource lifetime with real stores', () => {
   afterEach(() => {
     stop?.();
     stop = undefined;
+    vi.restoreAllMocks();
     activateSurface(LOCAL_SURFACE_ID);
     select([], null);
     useModernFlowChatStore.getState().clear();
@@ -139,6 +142,50 @@ describe('Session scene resource lifetime with real stores', () => {
     expect(flowChatStore.getActiveSession()?.sessionId).toBe('b');
     expect(useSceneStore.getState().navHistory).not.toContain(firstTabId);
   });
+
+  it.each(['legacy', 'bound', 'worktree', 'remote'] as const)(
+    'retires a closed %s workspace tab without reactivating its cached session', kind => {
+      stop?.();
+      const workspace = {
+        id: 'closing', rootPath: '/projects/a',
+        ...(kind === 'remote' ? { connectionId: 'ssh-a', sshHost: 'host-a' } : {}),
+      } as WorkspaceInfo;
+      const first = session('a', {
+        workspacePath: kind === 'worktree' ? '/worktrees/a' : workspace.rootPath,
+        ...(kind === 'bound' ? { workspaceId: workspace.id } : {}),
+        ...(kind === 'worktree' ? { projectWorkspacePath: workspace.rootPath } : {}),
+        ...(kind === 'remote' ? { remoteConnectionId: 'ssh-a', remoteSshHost: 'host-a' } : {}),
+      });
+      const workspaceState = {
+        ...workspaceManager.getState(), currentWorkspace: workspace,
+        activeWorkspaceId: workspace.id, openedWorkspaces: new Map([[workspace.id, workspace]]),
+      };
+      let onWorkspaceEvent: WorkspaceEventListener = () => {};
+      vi.spyOn(workspaceManager, 'getState').mockImplementation(() => workspaceState);
+      vi.spyOn(workspaceManager, 'addEventListener').mockImplementation(listener => {
+        onWorkspaceEvent = listener;
+        return () => {};
+      });
+      select([first], first.sessionId);
+      stop = startSessionSceneLifecycle();
+      useSceneStore.getState().openScene('settings');
+      useSceneStore.getState().openScene('session');
+      const tabId = useSceneStore.getState().activeTabId;
+      const open = vi.spyOn(useSceneStore.getState(), 'openSessionScene');
+
+      workspaceState.openedWorkspaces = new Map();
+      onWorkspaceEvent({ type: 'workspace:closed', workspaceId: workspace.id });
+
+      expect(open).not.toHaveBeenCalled();
+      expect(useSceneStore.getState().openTabs.map(tab => tab.id)).toEqual(['settings']);
+      expect(useSceneStore.getState().activeTabId).toBe('settings');
+      expect(useSceneStore.getState().navHistory).not.toContain(tabId);
+      expect(flowChatStore.getState().sessions.get(first.sessionId)).toBe(first);
+      // The active session may lag the workspace update until hydrate completes.
+      select([{ ...first, title: 'Late update' }], first.sessionId);
+      expect(useSceneStore.getState().openTabs.map(tab => tab.id)).toEqual(['settings']);
+    },
+  );
 
   it('does not reopen a closed tab when its session is updated in the background', () => {
     const first = session('a');

--- a/src/web-ui/src/app/services/sessionSceneLifecycle.ts
+++ b/src/web-ui/src/app/services/sessionSceneLifecycle.ts
@@ -1,6 +1,6 @@
 import { flowChatStore } from '@/flow_chat/store/FlowChatStore';
 import { startAutoSync } from '@/flow_chat/services/storeSync';
-import { workspaceManager } from '@/infrastructure/services/business/workspaceManager';
+import { workspaceManager, type WorkspaceEvent } from '@/infrastructure/services/business/workspaceManager';
 import { getActiveSurfaceId, isSurfaceChangedError } from '@/infrastructure/peer-device/deviceSurface';
 import { createLogger } from '@/shared/utils/logger';
 import { registerSessionSceneNavigation, useSceneStore } from '../stores/sceneStore';
@@ -49,8 +49,9 @@ export function startSessionSceneLifecycle(): () => void {
 
   let previousSelection = current();
   let previousSurface = getActiveSurfaceId();
+  let previousWorkspaces = new Map(workspaceManager.getState().openedWorkspaces);
   let reconciling = false;
-  const reconcile = () => {
+  const reconcile = (event?: WorkspaceEvent) => {
     if (reconciling) return;
     reconciling = true;
     try {
@@ -58,11 +59,16 @@ export function startSessionSceneLifecycle(): () => void {
       if (surfaceId !== previousSurface) {
         previousSurface = surfaceId;
         previousSelection = current();
+        previousWorkspaces = new Map(workspaceManager.getState().openedWorkspaces);
         useSceneStore.getState().resetForPeerSwitch();
       }
+      const closedWorkspace = event?.type === 'workspace:closed' || event?.type === 'workspace:removed'
+        ? previousWorkspaces.get(event.workspaceId) : undefined;
+      if (event) previousWorkspaces = new Map(workspaceManager.getState().openedWorkspaces);
       const selected = current();
-      const selectionChanged = selected?.sessionId !== previousSelection?.sessionId
-        || selected?.workspaceKey !== previousSelection?.workspaceKey;
+      // Identity enrichment (or a closed workspace falling back to a path) is
+      // reconciled below. It is not a request to activate the session again.
+      const selectionChanged = selected?.sessionId !== previousSelection?.sessionId;
       previousSelection = selected;
       const scenes = useSceneStore.getState();
       // The pending navigation owns the upcoming selection. Bootstrap/hydrate
@@ -79,6 +85,9 @@ export function startSessionSceneLifecycle(): () => void {
       for (const tab of useSceneStore.getState().openTabs) {
         const session = tab.session?.surfaceId === surfaceId
           ? source.sessions.get(tab.session.sessionId) : undefined;
+        // Retire only explicitly closed workspace tabs. Cached sessions remain
+        // recoverable, and an offline remote workspace is not a close event.
+        if (session && closedWorkspace && resolveSessionSceneWorkspace(session, [closedWorkspace])) continue;
         if (session) targets.set(session.sessionId, scenes.pendingTabId && tab.session
           // Keep the transaction's identity until it commits. Metadata may
           // acquire a workspace id while activation is awaiting the host.
@@ -93,8 +102,8 @@ export function startSessionSceneLifecycle(): () => void {
     }
   };
 
-  const unsubscribeSessions = flowChatStore.subscribe(reconcile);
-  const unsubscribeScenes = useSceneStore.subscribe(reconcile);
+  const unsubscribeSessions = flowChatStore.subscribe(() => reconcile());
+  const unsubscribeScenes = useSceneStore.subscribe(() => reconcile());
   const unsubscribeWorkspaces = workspaceManager.addEventListener(reconcile);
   reconcile();
 

--- a/src/web-ui/src/app/stores/sceneStore.test.ts
+++ b/src/web-ui/src/app/stores/sceneStore.test.ts
@@ -77,6 +77,29 @@ describe('sceneStore transition snapshots', () => {
     } finally { stop(); }
   });
 
+  it('invalidates pending activation when its workspace tab is retired', async () => {
+    useSceneStore.getState().openSessionScene(sessionTarget);
+    useSceneStore.getState().openScene('terminal');
+    let complete!: (activated: boolean) => void;
+    const activation = new Promise<boolean>(resolve => { complete = resolve; });
+    let isCurrent = () => true;
+    const stop = registerSessionSceneNavigation({
+      current: () => null,
+      isActive: () => false,
+      activate: (_target, current) => { isCurrent = current; return activation; },
+    });
+    try {
+      useSceneStore.getState().activateScene(sessionTabId);
+      useSceneStore.getState().reconcileSessionScenes(new Map());
+      expect(isCurrent()).toBe(false);
+      expect(useSceneStore.getState().pendingTabId).toBeNull();
+      complete(true);
+      await activation;
+      expect(useSceneStore.getState().activeTabId).toBe('terminal');
+      expect(useSceneStore.getState().openTabs.map(tab => tab.id)).toEqual(['terminal']);
+    } finally { stop(); }
+  });
+
   it('keeps recoverable tabs when resource activation is unsuccessful', async () => {
     useSceneStore.getState().openSessionScene(sessionTarget);
     useSceneStore.getState().openScene('terminal');

--- a/src/web-ui/src/app/stores/sceneStore.ts
+++ b/src/web-ui/src/app/stores/sceneStore.ts
@@ -202,7 +202,12 @@ export const useSceneStore = create<SceneState>((set, get) => ({
     const retainedActiveId = activeId && tabs.has(activeId) ? activeId : null;
     const mappedHistory = state.navHistory.map(id => remapped.get(id) ?? id);
     const navHistory = mappedHistory.filter(id => tabs.has(id));
+    const retiredPendingTab = state.pendingTabId !== null
+      && state.openTabs.some(tab => tab.id === state.pendingTabId)
+      && !remapped.has(state.pendingTabId);
+    if (retiredPendingTab) navigationRequest++;
     set({
+      ...(retiredPendingTab ? { pendingTabId: null } : {}),
       openTabs: nextTabs,
       activeTabId: retainedActiveId,
       navHistory,


### PR DESCRIPTION
## Summary
Closing an active workspace could show “This session’s workspace is not open” even though the close succeeded. The cached session’s tab identity fell back from a workspace ID to a path, which the scene lifecycle incorrectly treated as a new session selection.

Treat identity changes as tab reconciliation instead of activation. Retire tabs on explicit workspace close/removal events while retaining cached session records, and invalidate pending navigation to retired tabs so delayed activation cannot reopen them. Temporary remote unavailability is not treated as a workspace close.

## Validation
- 55 focused tests passed across session scene lifecycle, session activation, store synchronization, and scene store contracts.
- Added closure regression coverage for legacy path-only sessions, bound workspace IDs, worktree sessions, and remote host/connection bindings, plus delayed activation after tab retirement.
- `pnpm run check:web` passed; final TypeScript check and focused lifecycle rerun also passed.
- `git diff --check` passed.

Validation ran in the development checkout with the same four-file patch. Local desktop logs identified the original failure; the dev server serves the fix. Native interaction and remote workspace/Peer Device scenarios have not been verified end to end. Remote control and Detached Dispatch behavior is unchanged.
