### PR TITLE
refactor(agents): remove obsolete mode entry reminders

### DIFF
--- a/src/crates/assembly/agent-content/prompts/agents/agentic_mode_first_entry_reminder.md
+++ b/src/crates/assembly/agent-content/prompts/agents/agentic_mode_first_entry_reminder.md
@@ -1,1 +1,0 @@
-You have entered agentic mode.

--- a/src/crates/assembly/agent-content/prompts/agents/creative_mode.md
+++ b/src/crates/assembly/agent-content/prompts/agents/creative_mode.md
@@ -1,5 +1,6 @@
 You are OpenBitFun in Creative mode. Help the user reshape the running installed
 client and create, inspect, update, and delete its MiniApps through prompts.
+Product-creation capabilities are intentionally isolated in this mode.
 The user has a packaged application, not necessarily the OpenBitFun source
 repository or development tools. Complete the requested product change and
 verify the owner result; do not substitute a mockup, instructions, workspace
@@ -25,7 +26,12 @@ Choose the actual owner before editing:
    slots and semantic selectors. No build is required. Do not edit the user's
    workspace, install OpenBitFun source dependencies, or modify minified bundles
    to implement a client customization. Apply the exact draftId and read its
-   final confirmed/rolled_back outcome. Never bypass readiness or recovery.
+   final confirmed/rolled_back outcome. Applying is a two-phase transaction:
+   OpenBitFun loads a provisional candidate, then unlocks Keep and starts the
+   15-second countdown only after the real app shell reports readiness. The
+   `apply` call returns the final outcome. Never claim the change was kept from
+   a navigation request or by reading internal state files. Never bypass
+   readiness or recovery.
 4. Reusable runtime capabilities: use the same activation API to register
    namespaced commands with parameter declarations, persistent JSON state, and
    event subscriptions. UI and commands can compose the same state and events;

--- a/src/crates/assembly/agent-content/prompts/agents/creative_mode_first_entry_reminder.md
+++ b/src/crates/assembly/agent-content/prompts/agents/creative_mode_first_entry_reminder.md
@@ -1,6 +1,0 @@
-You have entered Creative mode. Product-creation capabilities are intentionally isolated here.
-
-- For MiniApps, load `miniapp-dev` and discover the structured CRUD operations with `OpenBitFunControl get` on `feature.miniapps`. Inspect installed apps before updating or deleting them. For local file-based work, `InitMiniApp` and `FinalizeMiniApp` remain available. Call `PublishMiniApp` only when explicitly asked to publish externally.
-- For existing UI settings/actions use `OpenBitFunControl`. For custom UI, load `openbitfun-frontend-dev`, call `FrontendWorkbench prepare`, read its packaged UI API reference, edit only its CSS/JS/creation-assets, then apply that draft id. This needs no repository or build.
-- Applying a frontend is a two-phase transaction. OpenBitFun first loads the provisional candidate, unlocks Keep and starts the 15-second countdown only after the real app shell reports readiness, then makes `apply` return the final `confirmed` or `rolled_back` outcome. Never claim it was kept from a navigation request or by reading internal state files.
-- Frontend customization requires a visible local Desktop surface. It is unavailable for remote workspaces, remote mobile/bot turns, Peer Device control, and headless dispatch; never substitute a controller-local path.

--- a/src/crates/assembly/agent-content/tests/prompt_catalog_contracts.rs
+++ b/src/crates/assembly/agent-content/tests/prompt_catalog_contracts.rs
@@ -14,10 +14,6 @@ const CATALOG_PROMPT_SOURCES: &[(&str, &[u8])] = &[
         include_bytes!("../prompts/agents/agentic_mode.md"),
     ),
     (
-        "agentic_mode_first_entry_reminder",
-        include_bytes!("../prompts/agents/agentic_mode_first_entry_reminder.md"),
-    ),
-    (
         "claw_mode",
         include_bytes!("../prompts/agents/claw_mode.md"),
     ),
@@ -34,8 +30,8 @@ const CATALOG_PROMPT_SOURCES: &[(&str, &[u8])] = &[
         include_bytes!("../prompts/agents/cowork_mode.md"),
     ),
     (
-        "creative_mode_first_entry_reminder",
-        include_bytes!("../prompts/agents/creative_mode_first_entry_reminder.md"),
+        "creative_mode",
+        include_bytes!("../prompts/agents/creative_mode.md"),
     ),
     (
         "deep_research_agent",

--- a/src/crates/assembly/core/src/agentic/agents/definitions/modes/agentic.rs
+++ b/src/crates/assembly/core/src/agentic/agents/definitions/modes/agentic.rs
@@ -1,19 +1,13 @@
 //! Agentic Mode
 //!
-//! Shared coding modes inherit the agentic baseline for
-//! `SHARED_CODING_MODE_PROMPT_TEMPLATE`, `shared_coding_mode_tools()`,
-//! `shared_coding_mode_tool_exposure_overrides()`, and
-//! `shared_coding_mode_user_context_policy()`. Across the four coding modes,
-//! only the reminder content differs.
+//! Uses the shared coding prompt, tools, exposure policy, and user context.
 
 use crate::agentic::agents::{
-    get_embedded_prompt, shared_coding_mode_tool_exposure_overrides, shared_coding_mode_tools,
+    shared_coding_mode_tool_exposure_overrides, shared_coding_mode_tools,
     shared_coding_mode_user_context_policy, Agent, AgentToolPolicyOverrides, UserContextPolicy,
     SHARED_CODING_MODE_PROMPT_TEMPLATE,
 };
 use async_trait::async_trait;
-
-const AGENTIC_MODE_FIRST_ENTRY_REMINDER_TEMPLATE: &str = "agentic_mode_first_entry_reminder";
 
 pub struct AgenticMode {
     default_tools: Vec<String>,
@@ -32,20 +26,6 @@ impl AgenticMode {
             default_tools: shared_coding_mode_tools(),
             tool_exposure_overrides: shared_coding_mode_tool_exposure_overrides(),
         }
-    }
-
-    fn load_reminder_template(
-        &self,
-        template_name: &str,
-    ) -> crate::util::errors::OpenBitFunResult<String> {
-        get_embedded_prompt(template_name)
-            .map(str::to_string)
-            .ok_or_else(|| {
-                crate::util::errors::OpenBitFunError::Agent(format!(
-                    "{} not found in embedded files",
-                    template_name
-                ))
-            })
     }
 }
 
@@ -83,59 +63,7 @@ impl Agent for AgenticMode {
         shared_coding_mode_user_context_policy()
     }
 
-    async fn get_system_reminder(
-        &self,
-        previous_agent_type: Option<&str>,
-        _workspace: Option<&crate::agentic::WorkspaceBinding>,
-    ) -> crate::util::errors::OpenBitFunResult<String> {
-        if previous_agent_type == Some(self.id()) {
-            Ok(String::new())
-        } else {
-            self.load_reminder_template(AGENTIC_MODE_FIRST_ENTRY_REMINDER_TEMPLATE)
-        }
-    }
-
     fn is_readonly(&self) -> bool {
         false
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::AgenticMode;
-    use crate::agentic::agents::Agent;
-    use crate::agentic::tools::framework::ToolExposure;
-
-    #[test]
-    fn agentic_mode_enables_review_platform_by_default() {
-        let tools = AgenticMode::new().default_tools();
-
-        assert!(tools.contains(&"ReviewPlatform".to_string()));
-    }
-
-    #[test]
-    fn agentic_mode_expands_web_research_tools() {
-        let mode = AgenticMode::new();
-        let overrides = mode.tool_exposure_overrides();
-
-        assert_eq!(overrides.get("WebSearch"), Some(&ToolExposure::Direct));
-        assert_eq!(overrides.get("WebFetch"), Some(&ToolExposure::Direct));
-        assert!(mode.default_tools().contains(&"WebSearch".to_string()));
-        assert!(mode.default_tools().contains(&"WebFetch".to_string()));
-    }
-
-    #[tokio::test]
-    async fn returns_first_entry_reminder_only_when_entering_agentic_mode() {
-        let mode = AgenticMode::new();
-
-        assert_eq!(
-            mode.get_system_reminder(None, None).await.unwrap(),
-            "You have entered agentic mode."
-        );
-        assert!(mode
-            .get_system_reminder(Some("agentic"), None)
-            .await
-            .unwrap()
-            .is_empty());
     }
 }

--- a/src/crates/assembly/core/src/agentic/agents/definitions/modes/creative.rs
+++ b/src/crates/assembly/core/src/agentic/agents/definitions/modes/creative.rs
@@ -4,12 +4,10 @@
 //! default tool manifests of general coding, office, or assistant modes.
 
 use crate::agentic::agents::{
-    get_embedded_prompt, shared_coding_mode_tool_exposure_overrides, shared_coding_mode_tools,
+    shared_coding_mode_tool_exposure_overrides, shared_coding_mode_tools,
     shared_coding_mode_user_context_policy, Agent, AgentToolPolicyOverrides, UserContextPolicy,
 };
 use async_trait::async_trait;
-
-const CREATIVE_MODE_FIRST_ENTRY_REMINDER_TEMPLATE: &str = "creative_mode_first_entry_reminder";
 
 pub struct CreativeMode {
     default_tools: Vec<String>,
@@ -76,24 +74,6 @@ impl Agent for CreativeMode {
         shared_coding_mode_user_context_policy()
     }
 
-    async fn get_system_reminder(
-        &self,
-        previous_agent_type: Option<&str>,
-        _workspace: Option<&crate::agentic::WorkspaceBinding>,
-    ) -> crate::util::errors::OpenBitFunResult<String> {
-        if previous_agent_type == Some(self.id()) {
-            return Ok(String::new());
-        }
-        get_embedded_prompt(CREATIVE_MODE_FIRST_ENTRY_REMINDER_TEMPLATE)
-            .map(str::to_string)
-            .ok_or_else(|| {
-                crate::util::errors::OpenBitFunError::Agent(format!(
-                    "{} not found in embedded files",
-                    CREATIVE_MODE_FIRST_ENTRY_REMINDER_TEMPLATE
-                ))
-            })
-    }
-
     fn is_readonly(&self) -> bool {
         false
     }
@@ -129,20 +109,5 @@ mod tests {
             .join(" ")
             .contains("installed client"));
         assert!(prompt.contains("FrontendWorkbench"));
-    }
-
-    #[tokio::test]
-    async fn creative_reminder_is_only_injected_on_entry() {
-        let mode = CreativeMode::new();
-        assert!(mode
-            .get_system_reminder(None, None)
-            .await
-            .expect("reminder")
-            .contains("FrontendWorkbench"));
-        assert!(mode
-            .get_system_reminder(Some("Creative"), None)
-            .await
-            .expect("ongoing reminder")
-            .is_empty());
     }
 }


### PR DESCRIPTION
- Remove Agentic and Creative entry reminder templates and overrides
- Merge Creative confirmation safeguards into its system prompt
- Preserve the Agent reminder interface and default behavior
- Update the prompt catalog contract and remove obsolete tests
