### PR TITLE
fix(ci): Disable migrator signing job cache

### DIFF
--- a/.github/workflows/data-migrator-package.yml
+++ b/.github/workflows/data-migrator-package.yml
@@ -82,6 +82,8 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: '22.18.0'
+          # Signing uses Node built-ins only; pnpm is not installed in this job.
+          package-manager-cache: false
       - uses: actions/download-artifact@v7
         with:
           pattern: data-migrator-*


### PR DESCRIPTION
Disable automatic package manager caching in the draft-release job.
The signing scripts use only Node built-ins, so pnpm is not installed
and setup-node must not try to query its cache directory.
