### PR TITLE
fix(search): use filesystem search for non-Git folders

### DIFF
--- a/src/apps/desktop/AGENTS.md
+++ b/src/apps/desktop/AGENTS.md
@@ -99,6 +99,8 @@ cargo check -p openbitfun-desktop && cargo test -p openbitfun-desktop
 
 For skill discovery response compatibility and timeouts, use
 `cargo test -p openbitfun-desktop --lib api::skill_api::tests`.
+For content-search routing and remote fallback protection, use
+`cargo test --locked -p openbitfun-desktop --lib api::search_api::tests`.
 For staged application-update cache and signature behavior, use
 `cargo test -p openbitfun-desktop --lib api::update_api::tests`.
 For peer system-info response compatibility, run

--- a/src/apps/desktop/src/api/search_api.rs
+++ b/src/apps/desktop/src/api/search_api.rs
@@ -112,6 +112,14 @@ async fn workspace_search_unavailable_message(
         );
     }
 
+    if !openbitfun_services_integrations::workspace_search::workspace_search_supports_local_root(
+        root_path,
+    )
+    .await
+    {
+        return Some(NON_GIT_WORKSPACE_MESSAGE.to_string());
+    }
+
     None
 }
 

--- a/src/crates/services/services-integrations/AGENTS.md
+++ b/src/crates/services/services-integrations/AGENTS.md
@@ -121,6 +121,7 @@ cargo test -p openbitfun-services-integrations --no-default-features --features 
 cargo test --locked -p openbitfun-services-integrations --no-default-features --features remote-ssh-concrete --lib remote_ssh::relay_deploy::tests::
 cargo test --locked -p openbitfun-services-integrations --no-default-features --features remote-connect --lib remote_connect::relay_client::tests::
 cargo test -p openbitfun-services-integrations --no-default-features --features file-watch --test file_watch_contracts
+cargo test --locked -p openbitfun-services-integrations --no-default-features --features workspace-search --test workspace_search_contracts
 cargo test --locked -p openbitfun-services-integrations --no-default-features --features deep-research --lib deep_research::tests::
 cargo test --locked -p openbitfun-services-integrations --no-default-features --features review-platform --lib review_platform
 pnpm run check:core-boundaries

--- a/src/crates/services/services-integrations/src/workspace_search/auto_index.rs
+++ b/src/crates/services/services-integrations/src/workspace_search/auto_index.rs
@@ -43,6 +43,16 @@ pub(crate) async fn evaluate(repo_root: PathBuf, policy: AutoIndexPolicy) -> Aut
     }
 }
 
+/// Checks the local indexed-search prerequisite without opening a daemon session
+/// or counting files. Callers must route remote paths before using this probe.
+/// A negative result lets content-search callers use their local filesystem backend.
+pub async fn workspace_search_supports_local_root(repo_root: impl AsRef<Path>) -> bool {
+    let repo_root = repo_root.as_ref().to_path_buf();
+    spawn_blocking(move || git_worktree_root(&repo_root).is_ok())
+        .await
+        .unwrap_or(false)
+}
+
 fn evaluate_blocking(repo_root: &Path, policy: AutoIndexPolicy) -> AutoIndexDecision {
     if policy.min_indexable_files == 0 {
         return AutoIndexDecision::Eligible {

--- a/src/crates/services/services-integrations/src/workspace_search/mod.rs
+++ b/src/crates/services/services-integrations/src/workspace_search/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod result_mapping;
 mod service;
 mod types;
 
+pub use auto_index::workspace_search_supports_local_root;
 pub use index_queue::WorkspaceSearchAutoIndexPriority;
 pub use service::{
     resolve_workspace_search_daemon_program_path, workspace_search_daemon_available,

--- a/src/crates/services/services-integrations/tests/workspace_search_contracts.rs
+++ b/src/crates/services/services-integrations/tests/workspace_search_contracts.rs
@@ -9,12 +9,95 @@ use openbitfun_services_integrations::workspace_search::{
     ContentSearchOutputMode, ContentSearchRequest, WorkspaceSearchService,
 };
 
+#[tokio::test]
+async fn indexed_search_requires_a_local_worktree_with_a_commit() {
+    use openbitfun_services_integrations::workspace_search::workspace_search_supports_local_root;
+
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let root = directory.path();
+    std::fs::write(root.join("example.txt"), "Cas fixture\n").unwrap();
+    assert!(!workspace_search_supports_local_root(root).await);
+
+    git(root, &["init", "--quiet"]);
+    assert!(!workspace_search_supports_local_root(root).await);
+
+    git(root, &["add", "."]);
+    git(
+        root,
+        &[
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.invalid",
+            "-c",
+            "commit.gpgsign=false",
+            "commit",
+            "-m",
+            "fixture",
+        ],
+    );
+    assert!(workspace_search_supports_local_root(root).await);
+
+    let subdirectory = root.join("nested");
+    std::fs::create_dir(&subdirectory).unwrap();
+    assert!(workspace_search_supports_local_root(&subdirectory).await);
+
+    let linked = root.join("linked");
+    git(
+        root,
+        &["worktree", "add", "--detach", linked.to_str().unwrap()],
+    );
+    assert!(workspace_search_supports_local_root(&linked).await);
+
+    let bare = root.join("bare.git");
+    git(root, &["clone", "--bare", ".", bare.to_str().unwrap()]);
+    assert!(!workspace_search_supports_local_root(&bare).await);
+}
+
 #[test]
 fn daemon_binary_contract_lists_current_platform_candidate() {
     let primary = workspace_search_daemon_binary_name();
 
     assert!(!primary.is_empty());
     assert!(workspace_search_daemon_binary_names().contains(&primary));
+}
+
+#[tokio::test]
+async fn non_indexable_folders_can_search_contents_without_a_daemon() {
+    use openbitfun_services_core::filesystem::{FileSearchOptions, FileSystemService};
+    use openbitfun_services_integrations::workspace_search::workspace_search_supports_local_root;
+
+    let directory = tempfile::tempdir().unwrap();
+    let root = directory.path();
+    std::fs::write(root.join("example.txt"), "Cas fixture\n").unwrap();
+    let filesystem = FileSystemService::default();
+    for initialized in [false, true] {
+        if initialized {
+            git(root, &["init", "--quiet"]);
+        }
+        assert!(!workspace_search_supports_local_root(root).await);
+        let result = filesystem
+            .search_file_contents_with_progress(
+                root.to_str().unwrap(),
+                "Cas",
+                FileSearchOptions {
+                    include_content: true,
+                    include_directories: false,
+                    max_results: Some(100),
+                    ..Default::default()
+                },
+                None,
+                None,
+            )
+            .await
+            .expect("ordinary folders and unborn repositories remain searchable");
+        assert_eq!(result.results.len(), 1);
+        assert_eq!(result.results[0].line_number, Some(1));
+        assert_eq!(
+            result.results[0].matched_content.as_deref(),
+            Some("Cas fixture")
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fix content search in ordinary folders such as Downloads when Flashgrep is enabled. Check the local Git worktree/HEAD prerequisite before selecting indexed search, so ordinary folders and repositories without a first commit use the existing filesystem content search.

## Type and Areas

Type: Bug fix

Areas: Desktop/Tauri search routing, workspace-search integration, regression tests

## Motivation / Impact

Previously the file manager sent these folders to Flashgrep and displayed a protocol error requiring a Git worktree with a HEAD commit. The shared availability check now covers all three desktop content-search entry points and index actions. The probe reuses existing Git discovery on a blocking worker without starting a daemon or counting files.

## Verification

- `cargo test --locked -p openbitfun-services-integrations --no-default-features --features workspace-search --test workspace_search_contracts` — 5 passed; 1 existing live-daemon test ignored.
- `cargo test --locked -p openbitfun-desktop --lib api::search_api::tests` — 3 passed.
- `pnpm run fmt:rs` and `git diff --check` — passed.
- Regression coverage: ordinary folders, unborn repositories, committed repositories, nested directories, linked worktrees, bare repositories, and actual filesystem content matches in ordinary/unborn folders.

## Reviewer Notes

AI-assisted; testing level: focused automated tests. No manual desktop UI verification. Remote workspace, remote control, Peer Device Mode, and Detached Dispatch were not exercised end to end. Remote-path refusal still runs before the local probe; its refusal-message test passes. No persisted shapes or wire contracts change.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.
