### PR TITLE
fix(editor): preserve Markdown content during rich-text editing

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -453,6 +453,9 @@ importers:
       morphdom:
         specifier: ^2.7.8
         version: 2.7.8
+      parse-entities:
+        specifier: ^4.0.2
+        version: 4.0.2
       partial-json:
         specifier: ^0.1.7
         version: 0.1.7
@@ -507,6 +510,9 @@ importers:
       remark-rehype:
         specifier: ^11.1.2
         version: 11.1.2
+      remark-stringify:
+        specifier: ^11.0.0
+        version: 11.0.0
       unified:
         specifier: ^11.0.5
         version: 11.0.5
@@ -523,6 +529,9 @@ importers:
       '@eslint/js':
         specifier: ^9.24.0
         version: 9.39.4
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.37

--- a/src/web-ui/package.json
+++ b/src/web-ui/package.json
@@ -66,6 +66,7 @@
     "modern-screenshot": "^4.7.0",
     "monaco-editor": "^0.52.2",
     "morphdom": "^2.7.8",
+    "parse-entities": "^4.0.2",
     "partial-json": "^0.1.7",
     "path-browserify": "^1.0.1",
     "pdfjs-dist": "5.4.624",
@@ -84,6 +85,7 @@
     "remark-math": "^6.0.0",
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.2",
+    "remark-stringify": "^11.0.0",
     "unified": "^11.0.5",
     "unist-util-visit": "^5.0.0",
     "yaml": "^2.8.2",
@@ -91,6 +93,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.24.0",
+    "@types/mdast": "^4.0.4",
     "@types/node": "^20.10.0",
     "@types/path-browserify": "^1.0.3",
     "@types/prismjs": "^1.26.5",

--- a/src/web-ui/src/tools/editor/AGENTS.md
+++ b/src/web-ui/src/tools/editor/AGENTS.md
@@ -10,6 +10,7 @@ This directory follows `src/web-ui/AGENTS.md`.
   Unsupported Markdown regions use source-backed embedded blocks; preserve their
   original Markdown when parsing and serializing. HTML rendering uses the shared
   sanitized Markdown renderer.
+- Markdown serialization uses the parser-matched remark extensions. Preserve link titles, code whitespace, and literal syntax; validate emitted inline ranges and use equivalent inline HTML only when Markdown delimiters cannot preserve them. Unsupported block conversions stay local to their source region.
 - Source-backed reference blocks share document-level definitions, numbering,
   and anchors. Preview context is transient and must not enter saved Markdown.
 - Rich text reuses the existing MarkdownRenderer typography and component styles.
@@ -32,7 +33,7 @@ This directory follows `src/web-ui/AGENTS.md`.
 Run from the repository root after Markdown editor changes:
 
 ```bash
-pnpm --dir src/web-ui run test:run src/tools/editor/components/MarkdownEditor.test.tsx src/tools/editor/meditor/components/MEditor.test.tsx src/tools/editor/meditor/utils/tiptapMarkdown.test.ts src/tools/editor/meditor/utils/embeddedSource.test.ts src/tools/editor/meditor/utils/markdownFrontmatter.test.ts src/tools/editor/meditor/components/Preview.test.tsx src/tools/editor/meditor/utils/loadLocalImages.test.ts src/infrastructure/markdown/rehypeSourceRange.test.ts src/infrastructure/markdown/MarkdownRenderer.test.tsx
+pnpm --dir src/web-ui run test:run src/tools/editor/components/MarkdownEditor.test.tsx src/tools/editor/meditor/components/MEditor.test.tsx src/tools/editor/meditor/utils/tiptapMarkdown.test.ts src/tools/editor/meditor/utils/tiptapMarkdown.roundtrip.test.ts src/tools/editor/meditor/utils/embeddedSource.test.ts src/tools/editor/meditor/utils/markdownFrontmatter.test.ts src/tools/editor/meditor/components/Preview.test.tsx src/tools/editor/meditor/utils/loadLocalImages.test.ts src/infrastructure/markdown/rehypeSourceRange.test.ts src/infrastructure/markdown/MarkdownRenderer.test.tsx
 ```
 
 For UI, types, and theme contracts, also follow the parent guide's `check:web`

--- a/src/web-ui/src/tools/editor/meditor/components/MEditor.test.tsx
+++ b/src/web-ui/src/tools/editor/meditor/components/MEditor.test.tsx
@@ -122,6 +122,85 @@ describe('MEditorErrorBoundary', () => {
     expect(container.querySelector('.m-editor-source-block-action')).not.toBeNull();
   });
 
+  it('edits a native block beside partially bold strikethrough without opening document source', async () => {
+    const markdown = '# Report\n\n- ~~**Remaining**: implementation and tests~~ **Done**\n\nOrdinary text.';
+    const { ref, onSave } = await renderEditor(markdown);
+    expect(getEditor().getJSON().content?.map(node => node.type)).toEqual(['heading', 'bulletList', 'paragraph']);
+    expect(container.querySelector('.m-editor-source-block-action')).toBeNull();
+    expect(ref.current?.getValue()).toBe(markdown);
+    act(() => {
+      getEditor().commands.setTextSelection(getEditor().state.doc.content.size - 1);
+      getEditor().commands.insertContent(' Added.');
+    });
+    expect(ref.current?.getValue()).toBe(`${markdown} Added.`);
+    act(() => container.querySelector('.tiptap')!.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 's', ctrlKey: true, bubbles: true }),
+    ));
+    expect(onSave).toHaveBeenLastCalledWith(`${markdown} Added.`);
+    act(() => { ref.current?.undo?.(); });
+    expect(ref.current?.getValue()).toBe(markdown);
+    act(() => { ref.current?.redo?.(); });
+    expect(ref.current?.getValue()).toBe(`${markdown} Added.`);
+  });
+
+  it('retains link metadata, literal syntax and code spaces across edits, save, undo and reload', async () => {
+    const markdown = '# Before\n\n[label](<https://example.com/a b> "a & title")\n\n\\# literal\n\n``  padded  ``\n\nAfter';
+    const { ref, onSave, setDocumentValue } = await renderEditor(markdown);
+    const assertContent = () => {
+      expect(container.querySelector('.m-editor-source-block-action')).toBeNull();
+      expect(container.querySelector('a')?.getAttribute('title')).toBe('a & title');
+      expect(container.querySelector('code')?.textContent).toBe(' padded ');
+      expect(getEditor().getJSON().content?.map(n => n.type)).toEqual(['heading', 'paragraph', 'paragraph', 'paragraph', 'paragraph']);
+    };
+    assertContent();
+    act(() => {
+      getEditor().commands.setTextSelection(getEditor().state.doc.content.size - 1);
+      getEditor().commands.insertContent(' updated');
+    });
+    const saved = ref.current!.getValue();
+    expect(saved).toContain('"a & title"');
+    expect(saved).toContain('\\# literal');
+    act(() => container.querySelector('.tiptap')!.dispatchEvent(new KeyboardEvent('keydown', { key: 's', ctrlKey: true, bubbles: true })));
+    expect(onSave).toHaveBeenLastCalledWith(saved);
+    act(() => { ref.current?.undo?.(); });
+    expect(ref.current?.getValue()).toBe(markdown);
+    act(() => { ref.current?.redo?.(); });
+    expect(ref.current?.getValue()).toBe(saved);
+    await act(async () => setDocumentValue('# Other document'));
+    await act(async () => setDocumentValue(saved));
+    assertContent();
+    expect(getEditor().getText()).toContain('After updated');
+  });
+
+  it('preserves the built-in underline mark after editing and reloading', async () => {
+    const { ref, setDocumentValue } = await renderEditor('Before <u>underlined</u> after.');
+    expect(container.querySelector('u')?.textContent).toBe('underlined');
+    act(() => {
+      getEditor().commands.setTextSelection(getEditor().state.doc.content.size - 1);
+      getEditor().commands.insertContent(' updated');
+    });
+    const saved = ref.current!.getValue();
+    await act(async () => setDocumentValue('# Other document'));
+    await act(async () => setDocumentValue(saved));
+    expect(container.querySelector('u')?.textContent).toBe('underlined');
+    expect(getEditor().getJSON().content?.[0].type).toBe('paragraph');
+    expect(getEditor().getText()).toBe('Before underlined after. updated');
+  });
+
+  it('limits a source-backed fallback to its block when editing and saving neighbors', async () => {
+    const block = 'Text <b><strong>nested</strong></b> after.';
+    const markdown = '# Before\n\n'+block+'\n\nAfter';
+    const { ref } = await renderEditor(markdown);
+    expect(getEditor().getJSON().content?.map(n => n.type)).toEqual(['heading', 'renderOnlyBlock', 'paragraph']);
+    act(() => {
+      getEditor().commands.setTextSelection(getEditor().state.doc.content.size - 1);
+      getEditor().commands.insertContent(' updated');
+    });
+    expect(ref.current?.getValue()).toBe(markdown+' updated');
+    act(() => { ref.current?.undo?.(); });
+    expect(ref.current?.getValue()).toBe(markdown);
+  });
+
   it('edits an embedded block, saves with the document shortcut, and supports undo/redo', async () => {
     const { ref, onDirtyChange, onSave } = await renderEditor();
     const action = container.querySelector<HTMLButtonElement>('.m-editor-source-block-action')!;

--- a/src/web-ui/src/tools/editor/meditor/components/TiptapEditor.tsx
+++ b/src/web-ui/src/tools/editor/meditor/components/TiptapEditor.tsx
@@ -551,7 +551,11 @@ export const TiptapEditor = React.forwardRef<TiptapEditorHandle, TiptapEditorPro
       TaskItem.configure({
         nested: true,
       }),
-      Link.configure({
+      Link.extend({
+        addAttributes() {
+          return { ...this.parent?.(), title: { default: null } };
+        },
+      }).configure({
         openOnClick: false,
       }),
       // Placeholder decorations keep hints outside the document mutation path.

--- a/src/web-ui/src/tools/editor/meditor/utils/tiptapMarkdown.roundtrip.test.ts
+++ b/src/web-ui/src/tools/editor/meditor/utils/tiptapMarkdown.roundtrip.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from 'vitest';
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkGfm from 'remark-gfm';
+import remarkMath from 'remark-math';
+import remarkRehype from 'remark-rehype';
+import rehypeRaw from 'rehype-raw';
+import type { RootContent, PhrasingContent } from 'mdast';
+import { analyzeMarkdownEditability, markdownToEditableTiptapDoc, markdownToTiptapDoc, tiptapDocToMarkdown } from './tiptapMarkdown';
+
+// Independent source-AST oracle: compare visible text, mark ranges, destinations,
+// titles and block structure, not just the editor DTO (which can omit source data).
+const parser = unified().use(remarkParse).use(remarkGfm).use(remarkMath);
+function inlineFacts(nodes: PhrasingContent[], marks: string[] = []): unknown[] {
+  return nodes.flatMap((node): unknown[] => {
+    if (node.type === 'strong' || node.type === 'emphasis' || node.type === 'delete') {
+      return inlineFacts(node.children, [...marks, node.type]);
+    }
+    if (node.type === 'link') {
+      return inlineFacts(node.children, [...marks, JSON.stringify(['link', node.url, node.title ?? null])]);
+    }
+    if (node.type === 'text' || node.type === 'inlineCode') {
+      const tags = [...marks, ...(node.type === 'inlineCode' ? ['code'] : [])].sort();
+      return Array.from(node.value, character => [character, tags]);
+    }
+    const { position: _position, ...fact } = node;
+    return [{ ...fact, marks: [...marks].sort() }];
+  });
+}
+function blockFacts(node: RootContent): unknown {
+  if (node.type === 'paragraph' || node.type === 'heading' || node.type === 'tableCell') {
+    return { type: node.type, ...('depth' in node ? { depth: node.depth } : {}), content: inlineFacts(node.children) };
+  }
+  const { position: _position, ...fact } = node;
+  if ('children' in node) {
+    const { children: _children, ...attrs } = fact as typeof fact & { children: unknown };
+    delete (attrs as Record<string, unknown>).spread;
+    return { ...attrs, children: node.children.map(child => blockFacts(child as RootContent)) };
+  }
+  return fact;
+}
+function semantics(markdown: string) {
+  return parser.parse(markdown).children.map(blockFacts);
+}
+
+const samples = [
+  '~~**Label**: remaining text~~', '**bold *italic* end**', '*italic **bold** end*',
+  '~~**bold** and *italic*~~', '**a** **b**', '*a* *b*', '**a****b**', '~~a~~~~b~~',
+  '[**bold** normal](https://example.com)', '**[label](https://example.com)**',
+  '[a *b* c](https://example.com)', '[label](https://example.com "Title")',
+  '[label](<https://example.com/a b>)', '[label](https://example.com/a\\)b)',
+  '[label](https://example.com/a(b)c)', '[label](<file:///a b.md> "a \\"quote\\" & title")',
+  '[label](./a\\(b.md "")', '[label](./a.md \'single title\')',
+  '``  padded  ``', '`` `tick` ``', '`plain`', '` `', '`  `', '` a`', '`a `',
+  '``a`b``', '```a``b```', '**`code`**', '~~`code`~~',
+  '**bold**中文', '中文**加粗**内容', '*italic*中文', '~~deleted~~中文',
+  '\\# Heading literal', '\\> quote literal', '\\- item literal', '\\+ item literal',
+  '1\\. item literal', '12\\) item literal', '\\~literal\\~', '\\~~literal\\~~',
+  '&lt;span&gt;', '&amp;copy;', '&#35; literal', '&#x3e; literal',
+  '\\$x\\$', 'x\\*y', 'path\\\\file', 'ordinary\n\\# literal',
+  'ordinary\n\\---', 'ordinary\n\\===', 'line  \nbreak',
+  '![alt](image.png "Title")', '![a \\[b\\]](<a b.png> "a & title")',
+  '**one\nline**', '**one  \nline**', '[one  \ntwo](a.md "title")',
+  'a_b_c', 'a\\@example.com', 'https\\://example.com',
+  '| a | b |\n| --- | --- |\n| text \\| pipe | `a\\|b` |',
+];
+const contexts: Array<[string, (s: string) => string]> = [
+  ['paragraph', s => s], ['blockquote', s => s.split('\n').map(l => '> '+l).join('\n')],
+  ['list', s => '- '+s.replace(/\n/g, '\n  ')],
+  ['ordered list', s => '3. '+s.replace(/\n/g, '\n   ')],
+];
+
+describe('Markdown source semantic preservation', () => {
+  for (const [name, wrap] of contexts) {
+    it.each(samples)(`${name}: %s`, sample => {
+      const markdown = '# Before\n\n'+wrap(sample)+'\n\nAfter';
+      const doc = markdownToEditableTiptapDoc(markdown);
+      expect(semantics(tiptapDocToMarkdown(doc))).toEqual(semantics(markdown));
+      expect(doc.content?.[0].type).toBe('heading');
+      expect(doc.content?.at(-1)?.type).toBe('paragraph');
+    });
+  }
+  it.each(samples.filter(s => !s.startsWith('|')) )('keeps supported inline syntax native: %s', markdown => {
+    expect(analyzeMarkdownEditability(markdown).semanticEqual).toBe(true);
+    expect(markdownToEditableTiptapDoc(markdown)).toMatchObject({ content: [{ type: 'paragraph' }] });
+  });
+  it('retains a link title in the imported document and after an unrelated edit', () => {
+    const doc = markdownToTiptapDoc('[label](./a.md "Title")\n\nAfter');
+    expect(doc.content?.[0].content?.[0].marks).toContainEqual({ type: 'link', attrs: { href: './a.md', title: 'Title' } });
+    doc.content![1].content![0].text = 'Updated';
+    expect(semantics(tiptapDocToMarkdown(doc))).toEqual(semantics('[label](./a.md "Title")\n\nUpdated'));
+  });
+});
+
+const htmlParser = unified().use(remarkParse).use(remarkGfm)
+  .use(remarkRehype, { allowDangerousHtml: true }).use(rehypeRaw);
+function renderedInlineFacts(markdown: string): unknown[] {
+  const tree = htmlParser.runSync(htmlParser.parse(markdown));
+  const paragraphs = tree.children.filter(node => node.type === 'element');
+  expect(paragraphs.map(node => node.type === 'element' ? node.tagName : '')).toEqual(['p']);
+  const walk = (node: (typeof tree.children)[number], marks: string[] = []): unknown[] => {
+    if (node.type === 'text') return Array.from(node.value, character => [character, [...marks].sort()]);
+    if (node.type !== 'element') return [];
+    const tag = ({ strong: 'strong', em: 'emphasis', del: 'delete', code: 'code', u: 'underline' } as Record<string, string>)[node.tagName];
+    return node.children.flatMap(child => walk(child, tag ? [...marks, tag] : marks));
+  };
+  return paragraphs.flatMap(node => walk(node));
+}
+
+const formattingNames = ['bold', 'italic', 'strike', 'code'];
+const semanticNames = ['strong', 'emphasis', 'delete', 'code'];
+function maskMarks(mask: number) {
+  return formattingNames.flatMap((type, bit) => mask & (1 << bit) ? [{ type }] : []);
+}
+const triples = Array.from({ length: 512 }, (_, value) => [value & 7, (value >> 3) & 7, (value >> 6) & 7]);
+describe('rich-text formatting combinations', () => {
+  for (const words of [['a', 'b', 'c'], ['left ', ' middle ', ' right'], ['字', '*_~<&', '文']]) {
+    it.each(triples)(`preserves ${JSON.stringify(words)} with masks %s/%s/%s`, (a, b, c) => {
+      const masks = [a, b, c];
+      const content = words.map((text, index) => ({ type: 'text', text, marks: maskMarks(masks[index]) }));
+      const markdown = tiptapDocToMarkdown({ type: 'doc', content: [{ type: 'paragraph', content }] });
+      const expected = words.flatMap((text, index) => Array.from(text, character => [character,
+        semanticNames.filter((_, bit) => masks[index] & (1 << bit)).sort()]));
+      expect(renderedInlineFacts(markdown), markdown).toEqual(expected);
+      const reloaded = markdownToEditableTiptapDoc(markdown);
+      expect(reloaded.content?.[0].type, markdown).toBe('paragraph');
+      expect(renderedInlineFacts(tiptapDocToMarkdown(reloaded)), markdown).toEqual(expected);
+    });
+  }
+  it.each(Array.from({ length: 256 }, (_, value) => [value & 15, value >> 4]))(
+    'preserves code mixed with formatting %s/%s', (left, right) => {
+      const words = ['a`b', ' c '];
+      const masks = [left, right];
+      const markdown = tiptapDocToMarkdown({ type: 'doc', content: [{ type: 'paragraph',
+        content: words.map((text, index) => ({ type: 'text', text, marks: maskMarks(masks[index]) })),
+      }] });
+      const expected = words.flatMap((text, index) => Array.from(text, character => [character,
+        semanticNames.filter((_, bit) => masks[index] & (1 << bit)).sort()]));
+      expect(renderedInlineFacts(markdown), markdown).toEqual(expected);
+      const reloaded = markdownToEditableTiptapDoc(markdown);
+      expect(reloaded.content?.[0].type, markdown).toBe('paragraph');
+      expect(renderedInlineFacts(tiptapDocToMarkdown(reloaded)), markdown).toEqual(expected);
+    },
+  );
+});
+
+const blockSamples = [
+  '````js\nconst fence = "```";\n````',
+  '~~~~lang`name\n~~~\n~~~~',
+  '- first paragraph\n\n  second paragraph\n\n- next item',
+  '1. first\n\n   another paragraph\n\n2. second',
+  '- item\n\n  > quote\n  >\n  > another\n\n  continuation',
+  '- first\n  - nested\n\n    extra paragraph\n- last',
+  '<p class="note">Styled text</p>',
+  '<div align="center" class="note">\n\nText\n\n</div>',
+  'Text <strong class="note">formatted</strong> after.',
+  '<img src="a.png" width="200">',
+  'Text <a href="a.html" data-id="x">link</a> after.',
+  '- [x] checked\n- plain\n- [ ] pending',
+  '- plain\n- [x] checked\n- last',
+  '> - [x] checked\n> - plain',
+  '- parent\n  - [x] checked\n  - plain',
+  '1. [x] checked\n2. plain',
+  '[a](x)[b](x)',
+  '<details><summary title="tip">Title</summary>\n\nBody\n\n</details>',
+  '[ref][a]\n\n[a]: ./a.md "Title"',
+  'Footnote[^a]\n\n[^a]: Meaning',
+];
+describe('block boundaries and unsupported attributes', () => {
+  it.each(blockSamples)('preserves source semantics and neighboring native blocks: %s', sample => {
+    const source = '# Before\n\n'+sample+'\n\nAfter';
+    const doc = markdownToEditableTiptapDoc(source);
+    expect(doc.content?.[0].type).toBe('heading');
+    expect(doc.content?.at(-1)?.type).toBe('paragraph');
+    expect(semantics(tiptapDocToMarkdown(doc))).toEqual(semantics(source));
+  });
+});
+
+ it('decodes entities when upgrading a simple HTML paragraph', () => {
+  const markdown = tiptapDocToMarkdown(markdownToEditableTiptapDoc('<p>A &amp; B</p>'));
+  expect(renderedInlineFacts(markdown)).toEqual(Array.from('A & B', character => [character, []]));
+});
+
+const destinations = ['./a.md', 'https://example.com/a b', 'a)b', 'a(b)c', 'a\\b', 'a&copy;b', 'a?x=1&y=2', 'a"b', 'a<b>', '', '#part'];
+const titles = [null, '', 'Tooltip', 'a "quote"', "a 'quote'", 'a\\b', '&copy; & <tag>', 'two\nlines'];
+describe('link and image attributes', () => {
+  for (const url of destinations) {
+    it.each(titles)('preserves '+JSON.stringify(url)+' and title %s', title => {
+      const doc = { type: 'doc', content: [{ type: 'paragraph', content: [
+        { type: 'text', text: 'label', marks: [{ type: 'link', attrs: { href: url, title } }] },
+        { type: 'text', text: ' after ' },
+        { type: 'markdownImage', attrs: { src: url, alt: 'alt [x] & text', title } },
+      ] }] };
+      const serialized = tiptapDocToMarkdown(doc);
+      if (title === '') {
+        const tree = htmlParser.runSync(htmlParser.parse(serialized));
+        const paragraph = tree.children.find(n => n.type === 'element');
+        if (paragraph?.type !== 'element') throw new Error('Expected paragraph');
+        expect(paragraph.children.find(n => n.type === 'element' && n.tagName === 'a')).toMatchObject({ properties: { href: url, title: '' } });
+        expect(paragraph.children.find(n => n.type === 'element' && n.tagName === 'img')).toMatchObject({ properties: { src: url, title: '', alt: 'alt [x] & text' } });
+        expect(markdownToEditableTiptapDoc(serialized).content?.[0].type).toBe('paragraph');
+        return;
+      }
+      const parsed = parser.parse(serialized).children[0];
+      expect(parsed.type).toBe('paragraph');
+      if (parsed.type !== 'paragraph') return;
+      expect(parsed.children.find(n => n.type === 'link')).toMatchObject({ url, title });
+      expect(parsed.children.find(n => n.type === 'image')).toMatchObject({ url, title, alt: 'alt [x] & text' });
+    });
+  }
+});
+
+it('isolates an unsafe region while preserving frontmatter and neighboring native blocks', () => {
+  const block = 'Text <b><strong>redundant nested marks</strong></b> after.';
+  expect(analyzeMarkdownEditability(block).mode).toBe('unsafe');
+  const markdown = '---\ntitle: Test\n---\n\n# Before\n\n'+block+'\n\nAfter';
+  const doc = markdownToEditableTiptapDoc(markdown);
+  expect(doc.content?.map(n => n.type)).toEqual(['frontmatter', 'heading', 'renderOnlyBlock', 'paragraph']);
+  expect(doc.content?.[2].attrs?.markdown).toBe(block);
+  doc.content![3].content![0].text = 'Updated';
+  expect(tiptapDocToMarkdown(doc)).toBe(markdown.replace(/After$/, 'Updated'));
+});
+
+it.each(Array.from({ length: 16 }, (_, mask) => mask))('preserves underline with formatting mask %s', mask => {
+  const content = [{ type: 'text', text: ' styled ', marks: [...maskMarks(mask), { type: 'underline' }] }];
+  const markdown = tiptapDocToMarkdown({ type: 'doc', content: [{ type: 'paragraph', content }] });
+  const expected = Array.from(' styled ', character => [character, [...semanticNames.filter((_, bit) => mask & (1 << bit)), 'underline'].sort()]);
+  expect(renderedInlineFacts(markdown)).toEqual(expected);
+  const doc = markdownToEditableTiptapDoc(markdown);
+  expect(doc.content?.[0].type).toBe('paragraph');
+  expect(renderedInlineFacts(tiptapDocToMarkdown(doc))).toEqual(expected);
+});
+
+it('emits literal markup safely when preserving rich-text-only ranges', () => {
+  const text = '<img src=x onerror=alert(1)> &copy;';
+  const doc = { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text, marks: [{ type: 'underline' }] }] }] };
+  const saved = tiptapDocToMarkdown(doc);
+  expect(renderedInlineFacts(saved)).toEqual(Array.from(text, character => [character, ['underline']]));
+  expect(saved).not.toContain('<img');
+});

--- a/src/web-ui/src/tools/editor/meditor/utils/tiptapMarkdown.test.ts
+++ b/src/web-ui/src/tools/editor/meditor/utils/tiptapMarkdown.test.ts
@@ -10,6 +10,27 @@ import {
 } from './tiptapMarkdown';
 
 describe('tiptap markdown compatibility', () => {
+  it.each([
+    '~~**Label**: remaining text~~',
+    '~~*Label*: remaining text~~',
+    '**~~Label~~: remaining text**',
+    '*~~Label~~: remaining text*',
+    '***Label**: remaining text*',
+    '~~before **middle** after~~',
+    '~~**Label**: remaining text~~ **Done**',
+    '~~***Label***: remaining text~~',
+  ])('preserves nested formatting ranges: %s', markdown => {
+    expect(analyzeMarkdownEditability(markdown).semanticEqual).toBe(true);
+    expect(markdownToEditableTiptapDoc(markdown).content?.[0].type).toBe('paragraph');
+  });
+
+  it('keeps a report with partially bold strikethrough editable as separate blocks', () => {
+    const markdown = '# Report\n\n- ~~**Remaining**: implementation and tests~~ **Done**\n\n## Results\n\nOrdinary text.';
+    const doc = markdownToEditableTiptapDoc(markdown);
+    expect(doc.content?.map(node => node.type)).toEqual(['heading', 'bulletList', 'heading', 'paragraph']);
+    expect(tiptapDocToMarkdown(doc)).toBe(markdown);
+  });
+
   it('supports gfm tables without falling back', () => {
     const markdown = [
       '| name | value |',
@@ -76,7 +97,7 @@ describe('tiptap markdown compatibility', () => {
     expect(emailNode?.text).toBe('support@example.com');
     expect(slashEmailNode).toBeUndefined();
     expect(tiptapDocToMarkdown(doc)).toBe(
-      'Contact [support@example.com](mailto:support@example.com) or see /admin@example.com.'
+      'Contact [support@example.com](mailto:support@example.com) or see /admin\\@example.com.'
     );
   });
 
@@ -375,8 +396,9 @@ describe('tiptap markdown compatibility', () => {
     const serialized = tiptapDocToMarkdown(doc);
     const analysis = analyzeMarkdownEditability(markdown);
 
-    expect(serialized).toBe(markdown);
-    expect(analysis.mode).toBe('lossless');
+    expect(serialized).toBe(markdown.replace(/x86_64(?=:| \()/g, 'x86\\_64'));
+    expect(analysis.semanticEqual).toBe(true);
+    expect(analysis.mode).toBe('canonicalizable');
     expect(analysis.containsRenderOnlyBlocks).toBe(false);
     expect(analysis.containsRawHtmlBlocks).toBe(false);
     expect(doc.content?.[0]?.type).toBe('details');

--- a/src/web-ui/src/tools/editor/meditor/utils/tiptapMarkdown.ts
+++ b/src/web-ui/src/tools/editor/meditor/utils/tiptapMarkdown.ts
@@ -3,6 +3,9 @@ import remarkGfm from 'remark-gfm';
 import remarkParse from 'remark-parse';
 import remarkMath from 'remark-math';
 import remarkRehype from 'remark-rehype';
+import remarkStringify from 'remark-stringify';
+import { parseEntities } from 'parse-entities';
+import type { PhrasingContent, Root, Strong, Emphasis, Delete, Link as MarkdownLink } from 'mdast';
 import rehypeRaw from 'rehype-raw';
 import type { JSONContent } from '@tiptap/core';
 import { createBlockId } from './blockId';
@@ -303,7 +306,7 @@ function parseHtmlAttributes(raw: string): Record<string, string> {
       continue;
     }
 
-    attributes[name.toLowerCase()] = doubleQuoted ?? singleQuoted ?? unquoted ?? '';
+    attributes[name.toLowerCase()] = parseEntities(doubleQuoted ?? singleQuoted ?? unquoted ?? '', { attribute: true });
   }
 
   return attributes;
@@ -409,12 +412,19 @@ function convertHtmlInlineTokens(
 
   for (const token of tokens) {
     if (token.kind === 'text') {
-      appendText(token.value);
+      appendText(parseEntities(token.value));
+      continue;
+    }
+
+    const supportedAttrs = token.tagName === 'a' ? ['href', 'title']
+      : token.tagName === 'img' ? ['src', 'alt', 'title'] : [];
+    if (Object.keys(token.attrs).some(name => !supportedAttrs.includes(name))) {
+      appendRawHtml(token.raw);
       continue;
     }
 
     if (token.kind === 'self' && token.tagName === 'br') {
-      content.push({ type: 'hardBreak' });
+      content.push({ type: 'hardBreak', ...(activeMarks.length > 0 ? { marks: activeMarks } : {}) });
       continue;
     }
 
@@ -429,6 +439,18 @@ function convertHtmlInlineTokens(
         ...(activeMarks.length > 0 ? { marks: activeMarks } : {}),
       });
       continue;
+    }
+
+    if (['del', 's', 'strike', 'u'].includes(token.tagName)) {
+      const type = token.tagName === 'u' ? 'underline' : 'strike';
+      if (token.kind === 'open') {
+        activeMarks = [...activeMarks, { type }];
+        continue;
+      }
+      if (token.kind === 'close') {
+        const nextMarks = removeLastMatchingMark(activeMarks, mark => mark.type === type);
+        if (nextMarks) { activeMarks = nextMarks; continue; }
+      }
     }
 
     if (token.kind === 'open' && HTML_BOLD_TAGS.has(token.tagName)) {
@@ -488,8 +510,8 @@ function convertHtmlInlineTokens(
     }
 
     if (token.tagName === 'a') {
-      if (token.kind === 'open' && token.attrs.href) {
-        activeMarks = [...activeMarks, { type: 'link', attrs: { href: token.attrs.href } }];
+      if (token.kind === 'open' && Object.prototype.hasOwnProperty.call(token.attrs, 'href')) {
+        activeMarks = [...activeMarks, { type: 'link', attrs: { href: token.attrs.href, ...(token.attrs.title !== undefined ? { title: token.attrs.title } : {}) } }];
         continue;
       }
 
@@ -570,11 +592,11 @@ function convertInlineNodes(nodes: MdastNode[], marks: Mark[] = []): JSONContent
       case 'link':
         content.push(...convertInlineNodes(node.children ?? [], [
           ...activeMarks,
-          { type: 'link', attrs: { href: node.url ?? '' } },
+          { type: 'link', attrs: { href: node.url ?? '', ...(node.title !== null && node.title !== undefined ? { title: node.title } : {}) } },
         ]));
         return;
       case 'break':
-        content.push({ type: 'hardBreak' });
+        content.push({ type: 'hardBreak', ...(activeMarks.length > 0 ? { marks: activeMarks } : {}) });
         return;
       default:
         content.push(...convertInlineNodes(node.children ?? [], activeMarks));
@@ -595,6 +617,12 @@ function isTaskList(node: MdastNode): boolean {
 }
 
 function convertList(node: MdastNode): JSONContent[] {
+  const hasTasks = node.children?.some(item => typeof item.checked === 'boolean');
+  if (hasTasks && (node.ordered || !isTaskList(node)) && node.source !== undefined) {
+    // Native task lists cannot represent unchecked-vs-non-task membership or
+    // ordered task markers. Preserve just this list, including nested lists.
+    return [createRenderOnlyBlock(node.source, 'list')];
+  }
   if (isTaskList(node)) {
     return [{
       type: 'taskList',
@@ -694,61 +722,12 @@ function convertBlock(node: MdastNode): JSONContent[] {
   }
 }
 
-function escapeMarkdownPlainText(text: string): string {
-  return text
-    .replace(/\\/g, '\\\\')
-    .replace(/([`*[\]|])/g, '\\$1')
-    .replace(/_/g, (match, offset, input) => {
-      const previous = input[offset - 1] ?? '';
-      const next = input[offset + 1] ?? '';
-      const isWordBoundaryUnderscore = /[A-Za-z0-9]/.test(previous) && /[A-Za-z0-9]/.test(next);
-      return isWordBoundaryUnderscore ? match : `\\${match}`;
-    });
-}
-
-function wrapInlineCodeText(text: string): string {
-  const runs = text.match(/`+/g) ?? [];
-  const longestRun = runs.reduce((max, run) => Math.max(max, run.length), 0);
-  const fence = '`'.repeat(longestRun + 1);
-  const needsPadding = text.startsWith('`') || text.endsWith('`');
-  const normalizedText = needsPadding ? ` ${text} ` : text;
-  return `${fence}${normalizedText}${fence}`;
-}
-
-function applyLinkMarks(markdown: string, marks: Mark[] = []): string {
-  return marks
-    .filter(mark => mark.type === 'link')
-    .reduce((result, mark) => `[${result}](${String(mark.attrs?.href ?? '')})`, markdown);
-}
-
-function escapeMarkdownImageText(value: string): string {
-  return value
-    .replace(/\\/g, '\\\\')
-    .replace(/[[\]]/g, '\\$&');
-}
-
-function escapeMarkdownUrl(value: string): string {
-  return value
-    .replace(/\\/g, '\\\\')
-    .replace(/([()])/g, '\\$1');
-}
-
 function escapeHtmlText(value: string): string {
   return value
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;');
-}
-
-function renderMarkdownImageBase(node: JSONContent): string {
-  const alt = escapeMarkdownImageText(String(node.attrs?.alt ?? ''));
-  const src = escapeMarkdownUrl(String(node.attrs?.src ?? ''));
-  const title = typeof node.attrs?.title === 'string' && node.attrs.title
-    ? ` "${node.attrs.title.replace(/"/g, '\\"')}"`
-    : '';
-
-  return `![${alt}](${src}${title})`;
 }
 
 function walkMdast(node: MdastNode | null | undefined, visit: (current: MdastNode) => void): void {
@@ -769,7 +748,7 @@ function parseMarkdownTree(markdown: string): MdastNode {
     .use(remarkMath)
     .parse(markdown) as MdastNode;
   walkMdast(tree, node => {
-    if (node.type === 'inlineMath' || node.type === 'math' || node.type === 'code') {
+    if (node.type === 'inlineMath' || node.type === 'math' || node.type === 'code' || node.type === 'list') {
       const raw = markdown.slice(node.position?.start?.offset, node.position?.end?.offset);
       const indent = Math.max(0, (node.position?.start?.column ?? 1) - 1);
       node.source = raw.split('\n').map((line, index) => index === 0 ? line
@@ -819,7 +798,21 @@ function normalizeComparableJson(
 }
 
 function normalizeTiptapDoc(doc: JSONContent): ComparableJsonValue {
-  return normalizeComparableJson(doc as ComparableJsonValue, new Set(['blockId', 'alignGroup']));
+  const normalized = normalizeComparableJson(doc as ComparableJsonValue, new Set(['blockId', 'alignGroup'])) as JSONContent;
+  const mergeTextRuns = (node: JSONContent): JSONContent => {
+    if (!node.content) return node;
+    const content: JSONContent[] = [];
+    for (const child of node.content.map(mergeTextRuns)) {
+      const last = content.at(-1);
+      if (last?.type === 'text' && child.type === 'text' &&
+          JSON.stringify(last.marks ?? []) === JSON.stringify(child.marks ?? []) &&
+          JSON.stringify(last.attrs) === JSON.stringify(child.attrs)) {
+        last.text = (last.text ?? '') + (child.text ?? '');
+      } else content.push(child);
+    }
+    return { ...node, content };
+  };
+  return mergeTextRuns(normalized) as ComparableJsonValue;
 }
 
 function walkTiptapDoc(
@@ -956,7 +949,8 @@ function parseSingleHtmlElement(
 
 function convertStructuredHtmlBlock(html: string): JSONContent[] | null {
   const tagToken = parseSingleHtmlTagToken(html.trim());
-  if (tagToken && tagToken.kind === 'self' && tagToken.tagName === 'img') {
+  if (tagToken && tagToken.kind === 'self' && tagToken.tagName === 'img' &&
+      Object.keys(tagToken.attrs).every(name => ['src', 'alt', 'title'].includes(name))) {
     return [createParagraph([{
       type: 'markdownImage',
       attrs: {
@@ -972,7 +966,7 @@ function convertStructuredHtmlBlock(html: string): JSONContent[] | null {
     return null;
   }
 
-  if (element.tagName !== 'p') {
+  if (element.tagName !== 'p' || Object.keys(element.attrs).some(name => name !== 'align')) {
     return null;
   }
 
@@ -1120,6 +1114,8 @@ function convertDetailsSummaryInlineChildren(
       return null;
     }
 
+    const allowedProperties = node.tagName === 'a' ? ['href', 'title'] : [];
+    if (Object.keys(node.properties ?? {}).some(key => !allowedProperties.includes(key))) return null;
     const childNodes = node.children ?? [];
 
     switch (node.tagName) {
@@ -1138,6 +1134,12 @@ function convertDetailsSummaryInlineChildren(
         if (!next) {
           return null;
         }
+        content.push(...next);
+        continue;
+      }
+      case 'u': {
+        const next = convertDetailsSummaryInlineChildren(childNodes, [...marks, { type: 'underline' }]);
+        if (!next) return null;
         content.push(...next);
         continue;
       }
@@ -1161,7 +1163,7 @@ function convertDetailsSummaryInlineChildren(
 
         const next = convertDetailsSummaryInlineChildren(childNodes, [
           ...marks,
-          { type: 'link', attrs: { href } },
+          { type: 'link', attrs: { href, ...(typeof node.properties?.title === 'string' ? { title: node.properties.title } : {}) } },
         ]);
         if (!next) {
           return null;
@@ -1198,6 +1200,7 @@ function convertDetailsMarkdownRegion(markdown: string): JSONContent | null {
 
   const { attrSource, bodyRaw } = matchedRegion;
   const { summaryNode } = detailsAst;
+  if (Object.keys(summaryNode.properties ?? {}).length > 0) return createRenderOnlyBlock(markdown, 'details');
   const attrs = parseHtmlAttributes(attrSource);
   const attrNames = Object.keys(attrs);
   if (attrNames.some(name => name !== 'open')) {
@@ -1327,96 +1330,145 @@ export function canRoundTripMarkdownWithTiptap(markdown: string): boolean {
   return analyzeMarkdownEditability(markdown).mode === 'lossless';
 }
 
-function getTextFormattingMarks(marks: Mark[] = []): string[] {
-  return ['bold', 'italic', 'strike'].filter(type => marks.some(mark => mark.type === type));
+// Use the same syntax extensions as the parser. Context-aware escaping belongs
+// to the Markdown serializer, including destinations, entities and code padding.
+const inlineMarkdownSerializer = unified()
+  .use(remarkGfm)
+  .use(remarkMath)
+  .use(remarkStringify, {
+    emphasis: '*',
+    strong: '*',
+    resourceLink: true,
+    handlers: { break: () => '  \n' },
+  });
+
+type InlineContainer = Strong | Emphasis | Delete | MarkdownLink;
+
+function markdownFormattingMarks(node: JSONContent): Mark[] {
+  const marks = (node.marks as Mark[] | undefined) ?? [];
+  return ['link', 'bold', 'italic', 'strike'].flatMap(type => {
+    const mark = marks.find(candidate => candidate.type === type);
+    return mark ? [{ type, ...(type === 'link' ? { attrs: {
+      href: String(mark.attrs?.href ?? ''),
+      title: typeof mark.attrs?.title === 'string' ? mark.attrs.title : null,
+    } } : {}) }] : [];
+  });
 }
 
-function openFormattingMark(type: string, value: string): string {
-  switch (type) {
-    case 'bold':
-      return `${value}**`;
-    case 'italic':
-      return `${value}*`;
-    case 'strike':
-      return `${value}~~`;
-    default:
-      return value;
-  }
+function inlineSemanticKey(content: JSONContent[]): string {
+  const runs: Array<{ type: string; text?: string; marks: string; attrs?: unknown }> = [];
+  content.forEach(node => {
+    const marks = [...markdownFormattingMarks(node),
+      ...['code', 'underline'].flatMap(type => node.marks?.some(mark => mark.type === type) ? [{ type }] : [])]
+      .map(mark => JSON.stringify(mark)).sort().join('|');
+    const last = runs.at(-1);
+    if (node.type === 'text' && last?.type === 'text' && last.marks === marks) {
+      last.text += node.text ?? '';
+    } else {
+      runs.push({ type: node.type ?? '', ...(node.type === 'text' ? { text: node.text ?? '' } : { attrs: node.attrs }), marks });
+    }
+  });
+  return JSON.stringify(runs);
 }
 
-function closeFormattingMark(type: string, value: string): string {
-  switch (type) {
-    case 'bold':
-      return `${value}**`;
-    case 'italic':
-      return `${value}*`;
-    case 'strike':
-      return `${value}~~`;
-    default:
-      return value;
-  }
+// Markdown delimiters cannot represent every range produced by rich-text edits.
+// Use equivalent inline HTML only when the emitted Markdown fails a range check.
+// Encode literal syntax and whitespace so Markdown inside HTML stays literal.
+function renderInlineSourceHtml(content: JSONContent[]): string {
+  return content.map(node => {
+    let value: string;
+    if (node.type === 'text') {
+      value = Array.from(node.text ?? '', character => /[\s&<>"`*_~$\[\]\\]/.test(character)
+        ? `&#${character.codePointAt(0)};` : character).join('');
+    } else if (node.type === 'hardBreak') {
+      value = '<br>';
+    } else if (node.type === 'markdownImage') {
+      value = `<img src="${escapeHtmlText(String(node.attrs?.src ?? ''))}" alt="${escapeHtmlText(String(node.attrs?.alt ?? ''))}"${
+        typeof node.attrs?.title === 'string' ? ` title="${escapeHtmlText(node.attrs.title)}"` : ''}>`;
+    } else if (node.type === 'inlineMath') {
+      value = String(node.attrs?.markdown ?? '');
+    } else if (node.type === 'rawHtmlInline') {
+      value = String(node.attrs?.html ?? '');
+    } else {
+      value = renderInlineSourceHtml(node.content ?? []);
+    }
+    for (const [mark, tag] of [['code', 'code'], ['bold', 'strong'], ['italic', 'em'], ['strike', 'del'], ['underline', 'u']]) {
+      if (node.marks?.some(candidate => candidate.type === mark)) value = `<${tag}>${value}</${tag}>`;
+    }
+    const link = node.marks?.find(mark => mark.type === 'link');
+    if (link) {
+      const title = typeof link.attrs?.title === 'string' ? ` title="${escapeHtmlText(link.attrs.title)}"` : '';
+      value = `<a href="${escapeHtmlText(String(link.attrs?.href ?? ''))}"${title}>${value}</a>`;
+    }
+    return value;
+  }).join('');
 }
 
 function renderInline(content: JSONContent[] = []): string {
-  let result = '';
-  const activeFormatting: string[] = [];
+  const children: PhrasingContent[] = [];
+  const formatting = content.map(node => markdownFormattingMarks(node).map(mark => ({
+    mark, key: JSON.stringify(mark),
+  })));
+  const ends: Map<string, number>[] = new Array(content.length);
+  for (let index = content.length - 1; index >= 0; index -= 1) {
+    ends[index] = new Map(formatting[index].map(({ key }) => [
+      key, ends[index + 1]?.get(key) ?? index + 1,
+    ]));
+  }
+  const active: Array<{ key: string; node: InlineContainer }> = [];
+  const currentChildren = (): PhrasingContent[] => active.length
+    ? active[active.length - 1].node.children as PhrasingContent[] : children;
 
-  const syncFormatting = (nextFormatting: string[]) => {
-    while (activeFormatting.length > 0 && !nextFormatting.includes(activeFormatting[activeFormatting.length - 1])) {
-      const last = activeFormatting.pop();
-      if (last) {
-        result = closeFormattingMark(last, result);
-      }
-    }
-
-    nextFormatting.forEach((format) => {
-      if (!activeFormatting.includes(format)) {
-        result = openFormattingMark(format, result);
-        activeFormatting.push(format);
-      }
+  content.forEach((node, index) => {
+    const next = formatting[index];
+    const firstEnded = active.findIndex(entry => !next.some(mark => mark.key === entry.key));
+    if (firstEnded >= 0) active.splice(firstEnded);
+    // Long-lived ranges are outermost. Closing an outer range also closes
+    // its inner ranges; continuing ranges reopen rather than leaking marks.
+    next.sort((a, b) => ends[index].get(b.key)! - ends[index].get(a.key)!);
+    next.forEach(({ mark, key }) => {
+      if (active.some(entry => entry.key === key)) return;
+      const wrapper: InlineContainer = mark.type === 'link'
+        ? { type: 'link', url: String(mark.attrs?.href ?? ''), title: mark.attrs?.title as string | null, children: [] }
+        : { type: mark.type === 'bold' ? 'strong' : mark.type === 'italic' ? 'emphasis' : 'delete', children: [] };
+      currentChildren().push(wrapper);
+      active.push({ key, node: wrapper });
     });
-  };
 
-  content.forEach((node: JSONContent) => {
-    const marks = (node.marks as Mark[] | undefined) ?? [];
-    const formattingMarks = getTextFormattingMarks(marks);
-    syncFormatting(formattingMarks);
-
-    if (node.type === 'text') {
-      const hasCodeMark = marks.some(mark => mark.type === 'code');
-      const baseText = hasCodeMark
-        ? wrapInlineCodeText(node.text ?? '')
-        : escapeMarkdownPlainText(node.text ?? '');
-
-      result += applyLinkMarks(baseText, marks);
-      return;
+    let leaf: PhrasingContent;
+    switch (node.type) {
+      case 'text':
+        leaf = { type: node.marks?.some(mark => mark.type === 'code') ? 'inlineCode' : 'text', value: node.text ?? '' };
+        break;
+      case 'hardBreak':
+        leaf = { type: 'break' };
+        break;
+      case 'inlineMath':
+        leaf = { type: 'html', value: String(node.attrs?.markdown ?? '') };
+        break;
+      case 'rawHtmlInline':
+        leaf = { type: 'html', value: String(node.attrs?.html ?? '') };
+        break;
+      case 'markdownImage':
+        leaf = { type: 'image', url: String(node.attrs?.src ?? ''), alt: String(node.attrs?.alt ?? ''),
+          title: typeof node.attrs?.title === 'string' ? node.attrs.title : null };
+        break;
+      default:
+        leaf = { type: 'html', value: renderInline(node.content ?? []) };
     }
-
-    if (node.type === 'hardBreak') {
-      result += '  \n';
-      return;
-    }
-
-    if (node.type === 'inlineMath') {
-      result += applyLinkMarks(String(node.attrs?.markdown ?? ''), marks);
-      return;
-    }
-
-    if (node.type === 'rawHtmlInline') {
-      result += String(node.attrs?.html ?? '');
-      return;
-    }
-
-    if (node.type === 'markdownImage') {
-      result += applyLinkMarks(renderMarkdownImageBase(node), marks);
-      return;
-    }
-
-    result += renderInline(node.content ?? []);
+    const siblings = currentChildren();
+    const previous = siblings.at(-1);
+    if ((leaf.type === 'text' || leaf.type === 'inlineCode') && previous?.type === leaf.type) {
+      (previous as typeof leaf).value += leaf.value;
+    } else siblings.push(leaf);
   });
-
-  syncFormatting([]);
-  return result;
+  const tree: Root = { type: 'root', children: [{ type: 'paragraph', children }] };
+  const markdown = inlineMarkdownSerializer.stringify(tree).replace(/\n$/, '');
+  const parsed = parseMarkdownTree(markdown).children ?? [];
+  const recovered = parsed.length === 1 && parsed[0].type === 'paragraph'
+    ? convertInlineNodes(parsed[0].children ?? []) : [];
+  return inlineSemanticKey(recovered) === inlineSemanticKey(content)
+    ? markdown : renderInlineSourceHtml(content);
 }
 
 function renderInlineHtml(content: JSONContent[] = []): string {
@@ -1437,10 +1489,12 @@ function renderInlineHtml(content: JSONContent[] = []): string {
       if (marks.some(mark => mark.type === 'strike')) {
         result = `<del>${result}</del>`;
       }
+      if (marks.some(mark => mark.type === 'underline')) result = `<u>${result}</u>`;
 
       const linkMarks = marks.filter(mark => mark.type === 'link');
       linkMarks.forEach((mark) => {
-        result = `<a href="${escapeHtmlText(String(mark.attrs?.href ?? ''))}">${result}</a>`;
+        const title = typeof mark.attrs?.title === 'string' ? ` title="${escapeHtmlText(mark.attrs.title)}"` : '';
+        result = `<a href="${escapeHtmlText(String(mark.attrs?.href ?? ''))}"${title}>${result}</a>`;
       });
 
       return result;
@@ -1456,6 +1510,10 @@ function renderInlineHtml(content: JSONContent[] = []): string {
 
 function parseAlignmentDirective(html: string, state: AlignmentState): boolean {
   const tagPattern = /<\/?div\b[^>]*>/gi;
+  if ((html.match(tagPattern) ?? []).some(raw => {
+    const token = parseSingleHtmlTagToken(raw);
+    return !token || Object.keys(token.attrs).some(name => name !== 'align');
+  })) return false;
   let matched = false;
   let cursor = 0;
   let match: RegExpExecArray | null;
@@ -1666,11 +1724,12 @@ function renderListItem(
   const [first, ...rest] = children;
   const firstRendered = first.type === 'paragraph'
     ? renderInline(first.content ?? [])
-    : renderBlock(first, depth + 1);
+    : renderBlock(first, 0);
 
-  const lines: string[] = [`${indent}${marker}${firstRendered}`];
+  const lines: string[] = [`${indent}${marker}${firstRendered.replace(/\n/g, `\n${continuationIndent}`)}`];
 
   rest.forEach((child: JSONContent) => {
+    if (child.type === 'paragraph') lines.push('');
     lines.push(prefixMarkdownLines(renderBlock(child, 0), continuationIndent));
   });
 
@@ -1703,7 +1762,10 @@ function renderBlock(node: JSONContent, depth = 0): string {
       const text = (node.content ?? [])
         .map((child: JSONContent) => (child.type === 'text' ? child.text ?? '' : renderInline(child.content ?? [])))
         .join('');
-      return `\`\`\`${language}\n${text}\n\`\`\``;
+      const marker = language.includes('`') ? '~' : '`';
+      const runs = text.match(marker === '`' ? /`+/g : /~+/g) ?? [];
+      const fence = marker.repeat(runs.reduce((length, run) => Math.max(length, run.length + 1), 3));
+      return `${fence}${language}\n${text}\n${fence}`;
     }
     case 'horizontalRule':
       return '---';
@@ -1785,16 +1847,38 @@ export function markdownToTiptapDoc(markdown: string): JSONContent {
   };
 }
 
-/** Last-resort source-backed block for documents whose structure cannot round-trip.
- * Rendered blocks remain editable; never feed lossy conversion into the editor.
+/** Keep conversion failures local to their source region. The global analysis
+ * remains strict; a problem in one block must not turn unrelated text into source.
  */
 export function markdownToEditableTiptapDoc(markdown: string): JSONContent {
-  if (analyzeMarkdownEditability(markdown).mode === 'unsafe') {
-    return { type: 'doc', content: withTopLevelBlockIds([
-      createRenderOnlyBlock(markdown, 'markdown'),
-    ]) };
+  if (analyzeMarkdownEditability(markdown).mode !== 'unsafe') {
+    return markdownToTiptapDoc(markdown);
   }
-  return markdownToTiptapDoc(markdown);
+  const frontmatter = splitMarkdownFrontmatter(markdown);
+  const body = frontmatter ? frontmatter.body : markdown;
+  const children = parseMarkdownTree(body).children ?? [];
+  const content: JSONContent[] = frontmatter
+    ? [createFrontmatterBlock(frontmatter, getLeadingBlankLines(body))] : [];
+  for (let index = 0; index < children.length; index += 1) {
+    const child = children[index];
+    // HTML containers and alignment wrappers are indivisible source regions;
+    // splitting them could change the meaning of their descendants.
+    const region = consumeRawHtmlRegion(children, index, body);
+    const last = region ? region.nextIndex - 1 : index;
+    const start = getNodeStartOffset(child);
+    const end = getNodeEndOffset(children[last]);
+    if (start === null || end === null) {
+      throw new Error('Markdown parser omitted source positions');
+    }
+    const source = body.slice(start, end);
+    if (analyzeMarkdownEditability(source).mode === 'unsafe') {
+      content.push(createRenderOnlyBlock(source, child.type ?? 'markdown'));
+    } else {
+      content.push(...(markdownToTiptapDoc(source).content ?? []));
+    }
+    index = last;
+  }
+  return { type: 'doc', content: withTopLevelBlockIds(content) };
 }
 
 export function tiptapDocToMarkdown(

--- a/tests/e2e/browser/markdown-editor.spec.ts
+++ b/tests/e2e/browser/markdown-editor.spec.ts
@@ -14,6 +14,50 @@ describe('Markdown rich text browser E2E', () => {
 
   });
 
+  it('preserves escaped text, link titles and code spaces after a native edit, save and reload', async () => {
+    const source = '# Edge cases\n\n[label](<https://example.com/a b> "a & title")\n\n\\# literal\n\n``  padded  ``\n\n~~**Remaining**: work~~\n\nAfter';
+    await editor.mode(1);
+    await editor.source.setValue(source);
+    await editor.mode(0);
+    await expect($$('[data-testid="md-embed-block"]')).toBeElementsArrayOfSize(0);
+    await expect(editor.richText.$('a')).toHaveAttribute('title', 'a & title');
+    expect(await editor.richText.$('code').getProperty('textContent')).toBe(' padded ');
+    await editor.richText.$(':scope > p:last-child').click();
+    await browser.keys([modifier, 'ArrowRight']);
+    await browser.keys(' updated');
+    await expect(editor.dirty).toHaveText('Unsaved');
+    await editor.save();
+    const saved = await editor.savedSource();
+    expect(saved).toContain('"a & title"');
+    expect(saved).toContain('\\# literal');
+    expect(saved).toContain('After updated');
+    await browser.refresh();
+    await editor.richText.waitForDisplayed();
+    await expect(editor.richText.$('a')).toHaveAttribute('title', 'a & title');
+    expect(await editor.richText.$('code').getProperty('textContent')).toBe(' padded ');
+    await expect(editor.richText.$(':scope > p:last-child')).toHaveText('After updated');
+    await expect($$('[data-testid="md-embed-block"]')).toBeElementsArrayOfSize(0);
+  });
+
+  it('edits neighbors of an isolated source block without rewriting that block', async () => {
+    const block = 'Text <b><strong>nested</strong></b> after.';
+    const source = '# Before\n\n'+block+'\n\nAfter';
+    await editor.mode(1);
+    await editor.source.setValue(source);
+    await editor.mode(0);
+    await expect($$('[data-testid="md-embed-block"]')).toBeElementsArrayOfSize(1);
+    await expect(editor.richText.$('h1')).toHaveText('Before');
+    await editor.richText.$(':scope > p:last-child').click();
+    await browser.keys([modifier, 'ArrowRight']);
+    await browser.keys(' updated');
+    await editor.save();
+    expect(await editor.savedSource()).toBe(source+' updated');
+    await browser.refresh();
+    await editor.richText.waitForDisplayed();
+    await expect($$('[data-testid="md-embed-block"]')).toBeElementsArrayOfSize(1);
+    await expect(editor.richText.$(':scope > p:last-child')).toHaveText('After updated');
+  });
+
   it('sanitizes loaded and edited details summaries without changing their Markdown source', async () => {
     const heading = '# Untrusted document\n\n';
     const details = '<details open>\n<summary>'


### PR DESCRIPTION
## Summary

Fix Markdown rich-text editing that can turn an entire document into a single source block or silently change formatting after saving. Serialize inline content with `remark-stringify`, validate formatting ranges, and preserve unsupported content in a localized source block while neighboring blocks remain editable.

## Type and Areas

Type: Bug fix, regression coverage

Areas: Web UI Markdown editor and browser E2E tests

## Motivation / Impact

Clicking a paragraph in a document containing partially bold strikethrough text could open the entire document as Markdown source because the custom serializer changed mark boundaries and triggered document-wide fallback. The same serialization path could lose link titles, underline, task markers, or literal punctuation.

This change preserves nested formatting, link and image attributes, inline-code whitespace, escaped syntax, HTML entities, mixed lists, and code fences. Unsupported HTML attributes and unsafe regions retain their original source. Undo continues to restore the original imported bytes; no persisted schema or transport changes are introduced.

## Verification

Test level: focused unit/component tests and local browser integration.

- Focused editor suite: 10 test files, **2,349 tests passed**, including generated formatting combinations and independent Markdown/HTML semantic checks. Command: `pnpm --dir src/web-ui exec vitest run src/tools/editor/components/MarkdownEditor.test.tsx src/tools/editor/meditor/components/MEditor.test.tsx src/tools/editor/meditor/utils/tiptapMarkdown.test.ts src/tools/editor/meditor/utils/tiptapMarkdown.roundtrip.test.ts src/tools/editor/meditor/utils/embeddedSource.test.ts src/tools/editor/meditor/utils/markdownFrontmatter.test.ts src/tools/editor/meditor/components/Preview.test.tsx src/tools/editor/meditor/utils/loadLocalImages.test.ts src/infrastructure/markdown/rehypeSourceRange.test.ts src/infrastructure/markdown/MarkdownRenderer.test.tsx`.
- `pnpm run check:web` and `pnpm --dir src/web-ui exec tsc --noEmit`: passed.
- `pnpm --dir tests/e2e exec wdio run ./config/wdio.markdown-browser.ts`: 12 passed; one new test initially selected a nested paragraph. After restricting its selector to a top-level paragraph, `pnpm --dir tests/e2e exec wdio run ./config/wdio.markdown-browser.ts --mochaOpts.grep 'preserves escaped text|edits neighbors'` passed both new scenarios. All 13 distinct flows were exercised successfully across these runs.
- Read-only reproduction with the reported document: 30 native blocks, no document-wide source block, semantic equality after round trip. The private document is not included in this PR.
- `git diff --check`: passed, including after a conflict-free cherry-pick onto current upstream/main. Runtime checks above ran before that cherry-pick; upstream did not modify these files.
- Remote workspace, remote control, Peer Device Mode, and Detached Dispatch were not exercised live. Packaged native desktop integration was not rerun; browser tests use local IO adapters.

## Reviewer Notes

AI-assisted implementation and tests. Adds direct dependencies on `remark-stringify` and `parse-entities`, and the `@types/mdast` development dependency; these packages were already present transitively in the lockfile. Equivalent inline HTML is used when Markdown cannot safely express a mark combination, and unsupported regions remain source-backed.

This PR contains only Markdown changes. The non-Git content-search fix remains separately tracked in #2950.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.
