### PR TITLE
Expose web tools directly and fix card link contrast

### DIFF
--- a/design-system/packages/ui/src/flow-chat/tool-cards/SearchResultsToolCards.module.css
+++ b/design-system/packages/ui/src/flow-chat/tool-cards/SearchResultsToolCards.module.css
@@ -89,7 +89,7 @@
   }
 
   .resultButton:is(:hover, :focus-visible) {
-    color: var(--openbitfun-color-action-primary-content);
+    color: var(--openbitfun-color-accent-hover);
     text-decoration: underline;
     text-underline-offset: 0.16em;
   }

--- a/design-system/packages/ui/src/flow-chat/tool-cards/StandardAmbientToolCards.module.css
+++ b/design-system/packages/ui/src/flow-chat/tool-cards/StandardAmbientToolCards.module.css
@@ -102,7 +102,7 @@
     appearance: none;
     padding: 0;
     border: 0;
-    color: var(--openbitfun-color-action-primary-content);
+    color: var(--openbitfun-color-accent-default);
     background: transparent;
     font: inherit;
     font-size: var(--openbitfun-type-body-sm-font-size);
@@ -119,6 +119,10 @@
   .openLinkText {
     min-inline-size: 0;
     overflow-wrap: anywhere;
+  }
+
+  .openLink:is(:hover, :focus-visible) {
+    color: var(--openbitfun-color-accent-hover);
   }
 
   .openLink:is(:hover, :focus-visible) .openLinkText {

--- a/src/crates/assembly/core/src/agentic/agents/definitions/modes/cowork.rs
+++ b/src/crates/assembly/core/src/agentic/agents/definitions/modes/cowork.rs
@@ -2,13 +2,11 @@
 //!
 //! A collaborative mode that prioritizes early clarification and lightweight progress tracking.
 
-use crate::agentic::agents::{Agent, AgentToolPolicyOverrides, UserContextPolicy};
-use crate::agentic::tools::framework::ToolExposure;
+use crate::agentic::agents::{Agent, UserContextPolicy};
 use async_trait::async_trait;
 
 pub struct CoworkMode {
     default_tools: Vec<String>,
-    tool_exposure_overrides: AgentToolPolicyOverrides,
 }
 
 impl Default for CoworkMode {
@@ -19,13 +17,7 @@ impl Default for CoworkMode {
 
 impl CoworkMode {
     pub fn new() -> Self {
-        // Cowork is the office/research mode; web research is baseline there,
-        // so keep WebSearch/WebFetch expanded (same as DeepResearch).
-        let mut tool_exposure_overrides = AgentToolPolicyOverrides::default();
-        tool_exposure_overrides.insert("WebSearch".to_string(), ToolExposure::Direct);
-        tool_exposure_overrides.insert("WebFetch".to_string(), ToolExposure::Direct);
         Self {
-            tool_exposure_overrides,
             default_tools: vec![
                 // Clarification + planning helpers
                 "AskUserQuestion".to_string(),
@@ -94,10 +86,6 @@ impl Agent for CoworkMode {
 
     fn default_tools(&self) -> Vec<String> {
         self.default_tools.clone()
-    }
-
-    fn tool_exposure_overrides(&self) -> &AgentToolPolicyOverrides {
-        &self.tool_exposure_overrides
     }
 
     fn user_context_policy(&self) -> UserContextPolicy {

--- a/src/crates/assembly/core/src/agentic/agents/definitions/modes/creative.rs
+++ b/src/crates/assembly/core/src/agentic/agents/definitions/modes/creative.rs
@@ -4,14 +4,12 @@
 //! default tool manifests of general coding, office, or assistant modes.
 
 use crate::agentic::agents::{
-    standard_harness_tool_exposure_overrides, standard_harness_tools,
-    standard_harness_user_context_policy, Agent, AgentToolPolicyOverrides, UserContextPolicy,
+    standard_harness_tools, standard_harness_user_context_policy, Agent, UserContextPolicy,
 };
 use async_trait::async_trait;
 
 pub struct CreativeHarness {
     default_tools: Vec<String>,
-    tool_exposure_overrides: AgentToolPolicyOverrides,
 }
 
 impl Default for CreativeHarness {
@@ -33,10 +31,7 @@ impl CreativeHarness {
             .into_iter()
             .map(str::to_string),
         );
-        Self {
-            default_tools,
-            tool_exposure_overrides: standard_harness_tool_exposure_overrides(),
-        }
+        Self { default_tools }
     }
 }
 
@@ -64,10 +59,6 @@ impl Agent for CreativeHarness {
 
     fn default_tools(&self) -> Vec<String> {
         self.default_tools.clone()
-    }
-
-    fn tool_exposure_overrides(&self) -> &AgentToolPolicyOverrides {
-        &self.tool_exposure_overrides
     }
 
     fn user_context_policy(&self) -> UserContextPolicy {

--- a/src/crates/assembly/core/src/agentic/agents/definitions/modes/deep_research.rs
+++ b/src/crates/assembly/core/src/agentic/agents/definitions/modes/deep_research.rs
@@ -1,10 +1,8 @@
-use crate::agentic::agents::{Agent, AgentToolPolicyOverrides, UserContextPolicy};
-use crate::agentic::tools::framework::ToolExposure;
+use crate::agentic::agents::{Agent, UserContextPolicy};
 use async_trait::async_trait;
 
 pub struct DeepResearchMode {
     default_tools: Vec<String>,
-    tool_exposure_overrides: AgentToolPolicyOverrides,
 }
 
 impl Default for DeepResearchMode {
@@ -15,9 +13,6 @@ impl Default for DeepResearchMode {
 
 impl DeepResearchMode {
     pub fn new() -> Self {
-        let mut tool_exposure_overrides = AgentToolPolicyOverrides::default();
-        tool_exposure_overrides.insert("WebSearch".to_string(), ToolExposure::Direct);
-        tool_exposure_overrides.insert("WebFetch".to_string(), ToolExposure::Direct);
         Self {
             default_tools: vec![
                 "Task".to_string(),
@@ -50,7 +45,6 @@ impl DeepResearchMode {
                 "TodoWrite".to_string(),
                 "AskUserQuestion".to_string(),
             ],
-            tool_exposure_overrides,
         }
     }
 }
@@ -79,10 +73,6 @@ impl Agent for DeepResearchMode {
 
     fn default_tools(&self) -> Vec<String> {
         self.default_tools.clone()
-    }
-
-    fn tool_exposure_overrides(&self) -> &AgentToolPolicyOverrides {
-        &self.tool_exposure_overrides
     }
 
     fn user_context_policy(&self) -> UserContextPolicy {

--- a/src/crates/assembly/core/src/agentic/agents/definitions/modes/standard.rs
+++ b/src/crates/assembly/core/src/agentic/agents/definitions/modes/standard.rs
@@ -1,17 +1,15 @@
 //! Standard Harness
 //!
-//! Uses the shared coding prompt, tools, exposure policy, and user context.
+//! Uses the shared coding prompt, tools, and user context.
 
 use crate::agentic::agents::{
-    standard_harness_tool_exposure_overrides, standard_harness_tools,
-    standard_harness_user_context_policy, Agent, AgentToolPolicyOverrides, UserContextPolicy,
+    standard_harness_tools, standard_harness_user_context_policy, Agent, UserContextPolicy,
     STANDARD_HARNESS_PROMPT_TEMPLATE,
 };
 use async_trait::async_trait;
 
 pub struct StandardHarness {
     default_tools: Vec<String>,
-    tool_exposure_overrides: AgentToolPolicyOverrides,
 }
 
 impl Default for StandardHarness {
@@ -24,7 +22,6 @@ impl StandardHarness {
     pub fn new() -> Self {
         Self {
             default_tools: standard_harness_tools(),
-            tool_exposure_overrides: standard_harness_tool_exposure_overrides(),
         }
     }
 }
@@ -53,10 +50,6 @@ impl Agent for StandardHarness {
 
     fn default_tools(&self) -> Vec<String> {
         self.default_tools.clone()
-    }
-
-    fn tool_exposure_overrides(&self) -> &AgentToolPolicyOverrides {
-        &self.tool_exposure_overrides
     }
 
     fn user_context_policy(&self) -> UserContextPolicy {

--- a/src/crates/assembly/core/src/agentic/agents/mod.rs
+++ b/src/crates/assembly/core/src/agentic/agents/mod.rs
@@ -83,16 +83,6 @@ static EMPTY_AGENT_TOOL_POLICY_OVERRIDES: std::sync::LazyLock<AgentToolPolicyOve
 static EMPTY_PERMISSION_CONSTRAINTS: std::sync::LazyLock<PermissionConstraintLayer> =
     std::sync::LazyLock::new(PermissionConstraintLayer::default);
 
-pub fn standard_harness_tool_exposure_overrides() -> AgentToolPolicyOverrides {
-    // Web research is a baseline capability of the shared coding modes; keep
-    // WebSearch/WebFetch expanded so models do not need a GetToolSpec
-    // unlock round-trip when switching between those modes.
-    let mut overrides = AgentToolPolicyOverrides::default();
-    overrides.insert("WebSearch".to_string(), ToolExposure::Direct);
-    overrides.insert("WebFetch".to_string(), ToolExposure::Direct);
-    overrides
-}
-
 pub fn standard_harness_tools() -> Vec<String> {
     vec![
         "Task".to_string(),
@@ -264,9 +254,8 @@ pub trait Agent: Send + Sync + 'static {
 #[cfg(test)]
 mod tests {
     use super::{
-        get_embedded_prompt, standard_harness_tool_exposure_overrides, standard_harness_tools,
-        standard_harness_user_context_policy, Agent, MinimalHarness, StandardHarness,
-        EMBEDDED_PROMPTS,
+        get_embedded_prompt, standard_harness_tools, standard_harness_user_context_policy, Agent,
+        MinimalHarness, StandardHarness, EMBEDDED_PROMPTS,
     };
 
     #[test]
@@ -324,13 +313,5 @@ mod tests {
         let shared_policy = standard_harness_user_context_policy();
 
         assert_eq!(StandardHarness::new().user_context_policy(), shared_policy);
-    }
-
-    #[test]
-    fn agentic_mode_uses_shared_coding_tool_exposure_overrides() {
-        let shared_overrides = standard_harness_tool_exposure_overrides();
-        let agentic = StandardHarness::new();
-
-        assert_eq!(agentic.tool_exposure_overrides(), &shared_overrides);
     }
 }

--- a/src/crates/assembly/core/src/agentic/tools/implementations/web/fetch.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/web/fetch.rs
@@ -58,10 +58,6 @@ Example usage:
         "Fetch content from a URL in raw, markdown, or JSON format.".to_string()
     }
 
-    fn default_exposure(&self) -> ToolExposure {
-        ToolExposure::Deferred
-    }
-
     fn input_schema(&self) -> Value {
         json!({
             "type": "object",

--- a/src/crates/assembly/core/src/agentic/tools/implementations/web/search.rs
+++ b/src/crates/assembly/core/src/agentic/tools/implementations/web/search.rs
@@ -98,10 +98,6 @@ impl Tool for WebSearchTool {
         "Search the web for up-to-date information and sources.".to_string()
     }
 
-    fn default_exposure(&self) -> ToolExposure {
-        ToolExposure::Deferred
-    }
-
     fn input_schema(&self) -> Value {
         json!({
             "type": "object",

--- a/src/crates/assembly/core/src/agentic/tools/manifest_resolver.rs
+++ b/src/crates/assembly/core/src/agentic/tools/manifest_resolver.rs
@@ -52,10 +52,9 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "tools-browser-web")]
     #[tokio::test]
     async fn manifest_resolver_facade_preserves_product_owner_output() {
-        let allowed_tools = vec!["Read".to_string(), "WebFetch".to_string()];
+        let allowed_tools = vec!["Read".to_string(), "SessionHistory".to_string()];
         let context = tool_context();
 
         let facade = resolve_tool_manifest(
@@ -92,7 +91,7 @@ mod tests {
 
     #[tokio::test]
     async fn visible_tools_facade_preserves_product_owner_output() {
-        let allowed_tools = vec!["Read".to_string(), "WebFetch".to_string()];
+        let allowed_tools = vec!["Read".to_string(), "SessionHistory".to_string()];
         let context = tool_context();
 
         let facade = resolve_visible_tools(

--- a/src/crates/assembly/core/src/agentic/tools/product_runtime/catalog.rs
+++ b/src/crates/assembly/core/src/agentic/tools/product_runtime/catalog.rs
@@ -691,38 +691,14 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "tools-browser-web")]
-    #[tokio::test]
-    async fn product_catalog_facade_resolves_manifest_from_same_provider_owner() {
-        let allowed_tools = vec!["Read".to_string(), "WebFetch".to_string()];
-
-        let manifest = resolve_product_tool_manifest(
-            &allowed_tools,
-            &AgentToolPolicyOverrides::default(),
-            &tool_context(Some("Standard")),
-        )
-        .await;
-
-        assert_eq!(manifest.deferred_tool_names, vec!["WebFetch".to_string()]);
-        assert_eq!(
-            manifest
-                .tool_definitions
-                .iter()
-                .map(|tool| tool.name.as_str())
-                .collect::<Vec<_>>(),
-            vec!["Read", "GetToolSpec", "CallDeferredTool"],
-            "product manifest facade must preserve prompt-visible definition order"
-        );
-    }
-
     #[tokio::test]
     async fn runtime_restrictions_hide_tools_from_manifest_and_get_tool_spec() {
-        let allowed_tools = vec!["Read".to_string(), "WebFetch".to_string()];
-        let mut context = tool_context(Some("Standard"));
+        let allowed_tools = vec!["Read".to_string(), "SessionHistory".to_string()];
+        let mut context = tool_context(Some("Claw"));
         context
             .runtime_tool_restrictions
             .denied_tool_names
-            .extend(["Read".to_string(), "WebFetch".to_string()]);
+            .extend(["Read".to_string(), "SessionHistory".to_string()]);
 
         let manifest = resolve_product_tool_manifest(
             &allowed_tools,
@@ -737,11 +713,11 @@ mod tests {
         assert!(!manifest
             .allowed_tool_names
             .iter()
-            .any(|name| name == "WebFetch"));
+            .any(|name| name == "SessionHistory"));
         assert!(!manifest
             .deferred_tool_names
             .iter()
-            .any(|name| name == "WebFetch"));
+            .any(|name| name == "SessionHistory"));
         assert!(!manifest
             .tool_definitions
             .iter()
@@ -754,13 +730,12 @@ mod tests {
             .into_iter()
             .map(|tool| tool.name().to_string())
             .collect::<Vec<_>>();
-        assert!(!deferred_names.iter().any(|name| name == "WebFetch"));
+        assert!(!deferred_names.iter().any(|name| name == "SessionHistory"));
     }
 
-    #[cfg(feature = "tools-browser-web")]
     #[tokio::test]
     async fn product_resolved_manifest_owner_matches_legacy_shape() {
-        let allowed_tools = vec!["Read".to_string(), "WebFetch".to_string()];
+        let allowed_tools = vec!["Read".to_string(), "SessionHistory".to_string()];
 
         let manifest = resolve_product_resolved_tool_manifest(
             &allowed_tools,
@@ -773,14 +748,17 @@ mod tests {
             manifest.allowed_tool_names,
             vec![
                 "Read".to_string(),
-                "WebFetch".to_string(),
+                "SessionHistory".to_string(),
                 GET_TOOL_SPEC_TOOL_NAME.to_string(),
                 "CallDeferredTool".to_string()
             ]
         );
-        assert_eq!(manifest.deferred_tool_names, vec!["WebFetch".to_string()]);
+        assert_eq!(
+            manifest.deferred_tool_names,
+            vec!["SessionHistory".to_string()]
+        );
         assert_eq!(manifest.deferred_tool_summaries.len(), 1);
-        assert_eq!(manifest.deferred_tool_summaries[0].name, "WebFetch");
+        assert_eq!(manifest.deferred_tool_summaries[0].name, "SessionHistory");
         assert!(manifest.deferred_tool_summaries[0]
             .short_description
             .as_deref()
@@ -866,7 +844,6 @@ mod tests {
         );
     }
 
-    #[cfg(all(feature = "tools-browser-web", feature = "tools-mcp"))]
     #[tokio::test]
     async fn disabled_deferred_tool_loading_exposes_builtin_and_mcp_tools_directly() {
         let registry = create_tool_registry();
@@ -878,12 +855,14 @@ mod tests {
             registry
                 .get_tool(CALL_DEFERRED_TOOL_NAME)
                 .expect("CallDeferredTool gateway"),
-            registry.get_tool("WebFetch").expect("WebFetch tool"),
+            registry
+                .get_tool("SessionHistory")
+                .expect("SessionHistory tool"),
             Arc::new(DeferredMcpCatalogTool) as Arc<dyn Tool>,
         ];
         let allowed_tools = vec![
             "Read".to_string(),
-            "WebFetch".to_string(),
+            "SessionHistory".to_string(),
             GET_TOOL_SPEC_TOOL_NAME.to_string(),
             CALL_DEFERRED_TOOL_NAME.to_string(),
             "mcp__github__search_repos".to_string(),
@@ -913,13 +892,13 @@ mod tests {
             allowed_tools,
             vec![
                 "Read".to_string(),
-                "WebFetch".to_string(),
+                "SessionHistory".to_string(),
                 "mcp__github__search_repos".to_string(),
             ]
         );
         assert!(manifest.deferred_tool_names.is_empty());
         assert!(manifest.deferred_tools.is_empty());
-        for tool_name in ["Read", "WebFetch", "mcp__github__search_repos"] {
+        for tool_name in ["Read", "SessionHistory", "mcp__github__search_repos"] {
             assert!(
                 manifest
                     .tool_definitions
@@ -943,11 +922,10 @@ mod tests {
         assert_eq!(mcp_tool.parameters["required"], json!(["query"]));
     }
 
-    #[cfg(feature = "tools-browser-web")]
     #[tokio::test]
     async fn product_resolved_visible_tools_owner_matches_registry_visibility() {
         let visible = resolve_product_resolved_visible_tools(
-            &["Read".to_string(), "WebFetch".to_string()],
+            &["Read".to_string(), "SessionHistory".to_string()],
             &AgentToolPolicyOverrides::default(),
             &tool_context(Some("Standard")),
         )
@@ -971,41 +949,39 @@ mod tests {
                 .iter()
                 .map(|tool| tool.name().to_string())
                 .collect::<Vec<_>>(),
-            vec!["WebFetch".to_string()]
+            vec!["SessionHistory".to_string()]
         );
     }
 
-    #[cfg(feature = "tools-browser-web")]
     #[tokio::test]
     async fn product_catalog_facade_resolves_get_tool_spec_results_from_same_provider_owner() {
         let results = resolve_product_get_tool_spec_results(
-            &json!({ "tool_name": "WebFetch" }),
-            &tool_context(Some("GeneralPurpose")),
+            &json!({ "tool_name": "SessionHistory" }),
+            &tool_context(Some("Claw")),
             "GetToolSpec",
         )
         .await
-        .expect("WebFetch should resolve through product GetToolSpec runtime facade");
+        .expect("SessionHistory should resolve through product GetToolSpec runtime facade");
 
         assert_eq!(results.len(), 1);
         let ToolResult::Result { data, .. } = &results[0] else {
             panic!("expected normal tool result");
         };
 
-        assert_eq!(data["tool_name"], "WebFetch");
+        assert_eq!(data["tool_name"], "SessionHistory");
         assert_eq!(data["input_schema"]["type"], "object");
         assert!(data["catalog_generation"].as_u64().is_some());
     }
 
-    #[cfg(feature = "tools-browser-web")]
     #[tokio::test]
-    async fn product_get_tool_spec_returns_assistant_hint_for_direct_webfetch_in_agentic_mode() {
+    async fn product_get_tool_spec_returns_assistant_hint_for_direct_tool() {
         let results = resolve_product_get_tool_spec_results(
-            &json!({ "tool_name": "WebFetch" }),
+            &json!({ "tool_name": "Read" }),
             &tool_context(Some("Standard")),
             "GetToolSpec",
         )
         .await
-        .expect("agentic mode expands WebFetch, so GetToolSpec should return a direct-use hint");
+        .expect("Read is direct, so GetToolSpec should return a direct-use hint");
 
         assert_eq!(results.len(), 1);
         let ToolResult::Result {
@@ -1017,7 +993,7 @@ mod tests {
             panic!("expected normal tool result");
         };
 
-        assert_eq!(data["tool_name"], "WebFetch");
+        assert_eq!(data["tool_name"], "Read");
         assert_eq!(data["already_available"], true);
         assert!(
             result_for_assistant
@@ -1149,7 +1125,16 @@ mod tests {
 
     #[cfg(feature = "tools-browser-web")]
     #[tokio::test]
-    async fn product_manifest_snapshot_preserves_deferred_tool_discovery_contract() {
+    async fn product_manifest_snapshot_exposes_web_tools_directly() {
+        use crate::agentic::tools::implementations::web::{WebFetchTool, WebSearchTool};
+
+        let registry = create_tool_registry();
+        let tool_snapshot: Vec<Arc<dyn Tool>> = vec![
+            registry.get_tool("Read").expect("Read tool"),
+            registry.get_tool("TodoWrite").expect("TodoWrite tool"),
+            Arc::new(WebSearchTool::new()),
+            Arc::new(WebFetchTool::new()),
+        ];
         let allowed_tools = vec![
             "TodoWrite".to_string(),
             "WebFetch".to_string(),
@@ -1157,10 +1142,12 @@ mod tests {
             "WebSearch".to_string(),
         ];
 
-        let manifest = resolve_product_resolved_tool_manifest(
+        let manifest = openbitfun_agent_tools::resolve_contextual_tool_manifest(
+            &tool_snapshot,
             &allowed_tools,
             &AgentToolPolicyOverrides::default(),
             &tool_context(Some("test-agent")),
+            GET_TOOL_SPEC_TOOL_NAME,
         )
         .await;
 
@@ -1171,96 +1158,27 @@ mod tests {
                 "WebFetch".to_string(),
                 "Read".to_string(),
                 "WebSearch".to_string(),
-                GET_TOOL_SPEC_TOOL_NAME.to_string(),
-                "CallDeferredTool".to_string(),
             ],
-            "GetToolSpec should be appended without reordering the allowed-list contract"
+            "direct web tools must not add deferred gateways"
         );
-        assert_eq!(
-            manifest.deferred_tool_names,
-            vec!["WebSearch".to_string(), "WebFetch".to_string()],
-            "deferred tools should follow registry snapshot order"
-        );
+        assert!(manifest.deferred_tool_names.is_empty());
         assert_eq!(
             manifest
                 .tool_definitions
                 .iter()
                 .map(|tool| tool.name.as_str())
                 .collect::<Vec<_>>(),
-            vec!["Read", "TodoWrite", "GetToolSpec", "CallDeferredTool",],
-            "prompt-visible manifest order must stay stable before owner migration"
+            vec!["Read", "WebFetch", "WebSearch", "TodoWrite"],
+            "direct web definitions must follow the model-facing tool order"
         );
     }
 
-    #[cfg(all(feature = "tools-browser-web", feature = "tools-git"))]
-    #[tokio::test]
-    async fn product_manifest_guard_preserves_deferred_gateway_surface() {
-        let allowed_tools = vec![
-            "Read".to_string(),
-            "WebFetch".to_string(),
-            "GetFileDiff".to_string(),
-            "Worktree".to_string(),
-        ];
-
-        let mut context = tool_context(Some("test-agent"));
-        context.workspace = Some(crate::agentic::WorkspaceBinding::new(
-            None,
-            std::env::current_dir().expect("absolute test workspace root"),
-        ));
-
-        let manifest = resolve_product_resolved_tool_manifest(
-            &allowed_tools,
-            &AgentToolPolicyOverrides::default(),
-            &context,
-        )
-        .await;
-
-        assert_eq!(
-            manifest.allowed_tool_names,
-            vec![
-                "Read".to_string(),
-                "WebFetch".to_string(),
-                "GetFileDiff".to_string(),
-                "Worktree".to_string(),
-                GET_TOOL_SPEC_TOOL_NAME.to_string(),
-                "CallDeferredTool".to_string(),
-            ],
-            "GetToolSpec insertion must preserve the runtime allowed-list contract"
-        );
-        assert_eq!(
-            manifest.deferred_tool_names,
-            vec![
-                "GetFileDiff".to_string(),
-                "WebFetch".to_string(),
-                "Worktree".to_string()
-            ],
-            "deferred loaded-spec list must follow product registry snapshot order"
-        );
-        assert_eq!(
-            manifest
-                .tool_definitions
-                .iter()
-                .map(|tool| tool.name.as_str())
-                .collect::<Vec<_>>(),
-            vec!["Read", "GetToolSpec", "CallDeferredTool"],
-            "prompt-visible definitions must keep the current discovery insertion and policy order stable"
-        );
-
-        for tool_name in ["GetFileDiff", "WebFetch", "Worktree"] {
-            assert!(
-                !manifest
-                    .tool_definitions
-                    .iter()
-                    .any(|tool| tool.name == tool_name),
-                "deferred target {tool_name} must not enter the provider manifest"
-            );
-        }
-    }
-
-    #[cfg(feature = "tools-browser-web")]
     #[tokio::test]
     async fn product_manifest_preserves_explicit_get_tool_spec_runtime_contract() {
-        let allowed_tools = vec![GET_TOOL_SPEC_TOOL_NAME.to_string(), "WebFetch".to_string()];
+        let allowed_tools = vec![
+            GET_TOOL_SPEC_TOOL_NAME.to_string(),
+            "SessionHistory".to_string(),
+        ];
 
         let manifest = resolve_product_resolved_tool_manifest(
             &allowed_tools,
@@ -1273,11 +1191,14 @@ mod tests {
             manifest.allowed_tool_names,
             vec![
                 GET_TOOL_SPEC_TOOL_NAME.to_string(),
-                "WebFetch".to_string(),
+                "SessionHistory".to_string(),
                 "CallDeferredTool".to_string(),
             ]
         );
-        assert_eq!(manifest.deferred_tool_names, vec!["WebFetch".to_string()]);
+        assert_eq!(
+            manifest.deferred_tool_names,
+            vec!["SessionHistory".to_string()]
+        );
         assert_eq!(
             manifest
                 .tool_definitions
@@ -1289,12 +1210,11 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "tools-browser-web")]
     #[tokio::test]
     async fn product_manifest_expands_tool_when_agent_override_requests_it() {
-        let allowed_tools = vec!["Read".to_string(), "WebFetch".to_string()];
+        let allowed_tools = vec!["Read".to_string(), "SessionHistory".to_string()];
         let mut overrides = AgentToolPolicyOverrides::default();
-        overrides.insert("WebFetch".to_string(), ToolExposure::Direct);
+        overrides.insert("SessionHistory".to_string(), ToolExposure::Direct);
 
         let manifest = resolve_product_resolved_tool_manifest(
             &allowed_tools,
@@ -1307,7 +1227,7 @@ mod tests {
         assert!(manifest
             .tool_definitions
             .iter()
-            .any(|tool| tool.name == "WebFetch"));
+            .any(|tool| tool.name == "SessionHistory"));
         assert!(!manifest
             .tool_definitions
             .iter()

--- a/src/crates/assembly/core/src/agentic/tools/registry.rs
+++ b/src/crates/assembly/core/src/agentic/tools/registry.rs
@@ -774,7 +774,6 @@ mod tests {
     fn registry_marks_deferred_tools_for_get_tool_spec() {
         let registry = create_tool_registry();
 
-        assert!(registry.is_tool_deferred("WebFetch"));
         assert!(registry.is_tool_deferred("GetFileDiff"));
         assert!(registry.is_tool_deferred("ListModels"));
         assert!(!registry.is_tool_deferred("GetToolSpec"));
@@ -801,8 +800,6 @@ mod tests {
                 "SessionHistory",
                 "Cron",
                 "PortForward",
-                "WebSearch",
-                "WebFetch",
                 "ListMCPResources",
                 "ReadMCPResource",
                 "ListMCPPrompts",


### PR DESCRIPTION
## Summary

- Expose WebSearch and WebFetch directly by default.
- Remove redundant overrides from Standard, Creative, Cowork, and DeepResearch.
- Use SessionHistory for deferred-loading tests and remove duplicate coverage.
- Fix WebSearch hover text and WebFetch link colors using theme accent tokens.

## Type and Areas

Type: Feature, bug fix, UI/UX

Areas: Rust core, Agent tool catalog, shared UI design system

## Motivation / Impact

Agents with access to WebSearch and WebFetch can call them without an initial GetToolSpec round-trip.

Expanded web tool cards previously used primary button foreground colors on transparent backgrounds, making links nearly invisible in light, black-and-white, and ink themes. Links now use theme accent colors while retaining hover and keyboard-focus underlines.

## Verification

Passed during implementation:

- `cargo test -p openbitfun-core --no-default-features --features agent-runtime,git,tools-browser-web,tools-computer-use --lib agentic::tools::implementations::web::` — 13 passed.
- `cargo test -p openbitfun-core --no-default-features --features agent-runtime,git,tools-browser-web,tools-computer-use --lib agentic::tools::product_runtime::catalog::tests` — 16 passed.
- `cargo test -p openbitfun-core --no-default-features --features agent-runtime,git,tools-browser-web,tools-computer-use --lib agentic::agents::` — 101 passed.
- `pnpm run fmt:rs`
- `pnpm run design-system:test`
- `pnpm run theme:color-audit:all`

Checked against the final two commits:

- `git diff HEAD~2 HEAD --check` — passed.

Manual theme interaction checks and remote scenario runtime validation were not performed. Full product builds and platform matrices were not run.

## Reviewer Notes

Tool arguments, execution behavior, and permission checks remain unchanged. The exposure change uses the existing default direct policy.

Deferred-loading coverage uses a tool that is deferred by default. Shared CSS fixes also apply to search-result buttons using the same component.

No persisted data migration or locale changes are required.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.