### PR TITLE
fix(release): allow 1.0.0-beta to install marketplace packages

### DIFF
--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -134,3 +134,9 @@ For release workflow and channel-isolation changes, run
 `node --test scripts/relay/package-contract.test.mjs scripts/tauri-release-manifest.test.mjs`.
 These checks exercise release conditions, image tag selection, Beta manifest
 generation, and asset collection with fixtures; they do not build or publish packages.
+
+The inaugural public `1.0.0-beta` release supports marketplace packages declaring
+minimum OpenBitFun `1.0.0`. This is an explicit product compatibility exception;
+numbered beta and RC builds retain their normal SemVer ordering, and updater
+version comparisons are unchanged. Requirements above `1.0.0` still reject this
+release. The shared policy lives in `product-domains::product_release`.

--- a/src/apps/cli/tests/terminal_process_contracts.rs
+++ b/src/apps/cli/tests/terminal_process_contracts.rs
@@ -31,6 +31,8 @@ const EXEC_STREAM_SIZE: PtySize = PtySize {
 const STARTUP_INPUT: &[u8] = b"exercise active turn resize Q7Z9";
 const STARTUP_INPUT_SENTINEL: &str = "Q7Z9";
 const MULTILINE_INPUT_SENTINEL: &str = "M7Q4";
+// Must not match the product version in the startup header (for example beta).
+const MULTILINE_TAIL_SENTINEL: &str = "Z9R2";
 const RECOVERY_INPUT: &[u8] = b"READY_AFTER_CANCEL K4W8";
 const RECOVERY_INPUT_SENTINEL: &str = "K4W8";
 
@@ -117,12 +119,16 @@ fn interactive_startup_survives_resize_multiline_input_and_emits_cleanup() {
     // Ratatui emits only changed cells, so the sentinel must not share characters
     // with the startup placeholder at the same screen positions.
     #[cfg(unix)]
-    process.write(b"\x1b[200~M7Q4\r\nbeta\x1b[201~");
+    process.write(
+        format!("\x1b[200~{MULTILINE_INPUT_SENTINEL}\r\n{MULTILINE_TAIL_SENTINEL}\x1b[201~")
+            .as_bytes(),
+    );
     #[cfg(windows)]
     {
         let mut rapid_input = MULTILINE_INPUT_SENTINEL.as_bytes().to_vec();
         rapid_input.extend(std::iter::repeat_n(b'a', 251));
-        rapid_input.extend_from_slice(b"\rbeta");
+        rapid_input.push(b'\r');
+        rapid_input.extend_from_slice(MULTILINE_TAIL_SENTINEL.as_bytes());
         process.write(&rapid_input);
     }
 
@@ -132,7 +138,7 @@ fn interactive_startup_survives_resize_multiline_input_and_emits_cleanup() {
         "interactive startup did not render multiline input",
     );
     process.expect_output(
-        "beta",
+        MULTILINE_TAIL_SENTINEL,
         Duration::from_secs(15),
         "interactive startup did not render the multiline input tail",
     );
@@ -152,7 +158,7 @@ fn interactive_startup_survives_resize_multiline_input_and_emits_cleanup() {
         "paste text was not rendered:\n{output}"
     );
     assert!(
-        output.contains("beta"),
+        output.contains(MULTILINE_TAIL_SENTINEL),
         "paste tail was not rendered:\n{output}"
     );
     assert!(

--- a/src/apps/desktop/src/api/appearance_market_api.rs
+++ b/src/apps/desktop/src/api/appearance_market_api.rs
@@ -14,7 +14,9 @@ use openbitfun_product_domains::appearance_market::{
     AppearanceMarketSubmissionStatus, AppearanceReviewDecision, AppearanceReviewDecisionRequest,
     APPEARANCE_MARKET_MAX_PACKAGE_BYTES,
 };
-use openbitfun_product_domains::product_release::OPENBITFUN_INITIAL_RELEASE_VERSION;
+use openbitfun_product_domains::product_release::{
+    supports_market_minimum_version, OPENBITFUN_INITIAL_RELEASE_VERSION,
+};
 use openbitfun_services_integrations::appearance_market::{
     resolve_appearance_release_target, submit_appearance_package, suggest_appearance_slug,
     AppearanceMarketBrowseRequest, AppearanceMarketClient, AppearanceReleaseTarget,
@@ -358,7 +360,7 @@ fn validate_minimum_openbitfun_version(minimum: &str) -> Result<(), String> {
     }
     let current = semver::Version::parse(env!("CARGO_PKG_VERSION"))
         .map_err(|_| "The current OpenBitFun version is invalid.".to_string())?;
-    if current < minimum {
+    if !supports_market_minimum_version(&current, &minimum) {
         return Err(format!(
             "This Appearance requires OpenBitFun {minimum} or newer. Current version: {current}."
         ));

--- a/src/apps/desktop/src/api/miniapp_market_api.rs
+++ b/src/apps/desktop/src/api/miniapp_market_api.rs
@@ -15,7 +15,9 @@ use openbitfun_product_domains::miniapp::market::{
     CursorPage, InstalledMarketOrigin, MarketListingDetail, MarketListingSummary, MarketRelease,
     MarketSubmission, MarketSubmissionDraftRequest,
 };
-use openbitfun_product_domains::product_release::OPENBITFUN_INITIAL_RELEASE_VERSION;
+use openbitfun_product_domains::product_release::{
+    supports_market_minimum_version, OPENBITFUN_INITIAL_RELEASE_VERSION,
+};
 use openbitfun_services_integrations::miniapp_market::{
     submit_installed_app, validate_market_package, FavoriteAggregate, MarketBrowseRequest,
     MarketClient, RatingAggregate, ValidatedMarketPackage,
@@ -676,7 +678,7 @@ fn validate_minimum_openbitfun_version(minimum: &str) -> Result<(), String> {
     }
     let current = semver::Version::parse(env!("CARGO_PKG_VERSION"))
         .map_err(|_| "The current OpenBitFun version is invalid.".to_string())?;
-    if current < minimum {
+    if !supports_market_minimum_version(&current, &minimum) {
         return Err(format!(
             "This MiniApp requires OpenBitFun {minimum} or newer. Current version: {current}."
         ));

--- a/src/crates/contracts/product-domains/src/product_release.rs
+++ b/src/crates/contracts/product-domains/src/product_release.rs
@@ -5,9 +5,47 @@ use semver::Version;
 /// OpenBitFun begins as a new product at this release.
 pub const OPENBITFUN_INITIAL_RELEASE_VERSION: Version = Version::new(1, 0, 0);
 
+/// Market packages use stable product compatibility versions. The inaugural
+/// public release is named `1.0.0-beta`, but supports the 1.0.0 market contract.
+/// Keep this exception separate from updater SemVer ordering and from numbered
+/// beta / release-candidate builds, which retain normal prerelease semantics.
+pub fn supports_market_minimum_version(current: &Version, minimum: &Version) -> bool {
+    current >= minimum
+        || (current.major == 1
+            && current.minor == 0
+            && current.patch == 0
+            && current.pre.as_str() == "beta"
+            && minimum == &OPENBITFUN_INITIAL_RELEASE_VERSION)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::OPENBITFUN_INITIAL_RELEASE_VERSION;
+    use super::*;
+
+    #[test]
+    fn inaugural_beta_supports_stable_market_contract_only() {
+        let initial = &OPENBITFUN_INITIAL_RELEASE_VERSION;
+        let beta = Version::parse("1.0.0-beta").unwrap();
+        assert!(supports_market_minimum_version(&beta, initial));
+        assert!(!supports_market_minimum_version(
+            &beta,
+            &Version::new(1, 0, 1)
+        ));
+        for version in ["0.2.19", "1.0.0-beta.1", "1.0.0-rc.1"] {
+            assert!(!supports_market_minimum_version(
+                &Version::parse(version).unwrap(),
+                initial
+            ));
+        }
+        assert!(supports_market_minimum_version(
+            &Version::new(1, 0, 0),
+            initial
+        ));
+        assert!(supports_market_minimum_version(
+            &Version::new(1, 1, 0),
+            initial
+        ));
+    }
 
     #[test]
     fn initial_release_is_stable_one_zero_zero() {


### PR DESCRIPTION
The public `1.0.0-beta` release currently rejects every marketplace package declaring the initial `1.0.0` minimum because ordinary SemVer places beta below stable. Both Desktop marketplace CI tests reproduce this failure.

Add a shared, explicit marketplace compatibility exception for the inaugural `1.0.0-beta` release and use it in MiniApp and Appearance downloads. Higher minimum versions, numbered betas, release candidates, and updater ordering retain their existing behavior.

Validation: `cargo test --locked -p openbitfun-product-domains --no-default-features product_release` passes both tests, covering the inaugural beta, higher requirements, old versions, numbered betas, RCs and stable versions; changed Rust files formatted and `git diff --check` passes. Desktop integration tests remain covered by CI. No remote scenario was exercised locally; the policy is pure and uses the executing host's version.

The Windows startup PTY test also used `beta` as its multiline tail marker. The new version header already contains that text, so the test could send Ctrl+C before the input tail rendered. Use a distinct marker for both platforms while retaining the same input, cleanup, and exit assertions. Its Windows validation runs in CI.
