### PR TITLE
fix(ui): smooth dialog exits and expand/collapse transitions

### DIFF
--- a/design-system/packages/ui/README.md
+++ b/design-system/packages/ui/README.md
@@ -469,6 +469,8 @@ Dialog titles use 24px bold type with their own 29px line box and normal trackin
 
 Extra-large (`xl`) dialogs have an 800px maximum width and continue shrinking within the viewport gutter. Provider editing uses the floating footer; small workspace creation retains its attached footer and existing button/input sizes. The Lab workspace pattern uses local sample paths and callbacks only.
 
+Keep `Dialog` and `Sheet` mounted and set `open={false}` to close them. They retain the last committed children during the exit animation, with interaction disabled, so clearing an owner selection does not collapse the surface. Reopening uses the latest children and cancels the pending exit. Owners that conditionally mount an editor can remove it in `onExitComplete`, which runs once after the surface unmounts.
+
 PageHeader `md` uses the settings title with a primary 15px description; `display` uses the welcome heading and medium 17px introduction with a 12px gap. ActionCard uses 12px padding, section-heading typography (15px semibold), and a primary 13px single-line action description. Its inset outline does not inflate the 62px medium minimum height; longer content keeps the independent sibling actions and OverflowText behavior.
 
 KeyHint uses 10px text on a 10px line and 2px block padding. StatusPill uses a 14px line with 2px block padding; opt into `emphasis` for short mode labels such as Ask, while ordinary status descriptions retain readable content colors. LauncherButton owns a 72px minimum width, 40px height, 10px side padding, 4px gap, 12px icon and 11px monospace text. Product shells may retain a deliberate compact greeting that expands into this geometry.

--- a/design-system/packages/ui/src/components/Dialog/Dialog.tsx
+++ b/design-system/packages/ui/src/components/Dialog/Dialog.tsx
@@ -5,7 +5,9 @@ import {
   isValidElement,
   useCallback,
   useContext,
+  useEffect,
   useId,
+  useLayoutEffect,
   useMemo,
   useRef,
   type HTMLAttributes,
@@ -64,6 +66,8 @@ interface OverlaySurfaceProps
   initialFocusRef?: RefObject<HTMLElement | null>;
   kind: "dialog" | "sheet";
   onOpenChange: (open: false, reason: DialogCloseReason) => void;
+  /** Called after the closed surface has finished exiting and unmounted. */
+  onExitComplete?: () => void;
   open: boolean;
   placement?: SheetPlacement;
   preventScroll?: boolean;
@@ -84,6 +88,7 @@ const OverlaySurface = forwardRef<HTMLDivElement, OverlaySurfaceProps>(function 
   initialFocusRef,
   kind,
   onOpenChange,
+  onExitComplete,
   open,
   placement,
   preventScroll = true,
@@ -99,9 +104,23 @@ const OverlaySurface = forwardRef<HTMLDivElement, OverlaySurfaceProps>(function 
   const surfaceRef = useRef<HTMLDivElement | null>(null);
   const titleId = `openbitfun-dialog-title-${useId()}`;
   const descriptionId = `openbitfun-dialog-description-${useId()}`;
-  const hasTitle = containsType(children, DialogTitle);
-  const hasDescription = containsType(children, DialogDescription);
   const { present, state } = usePresence(open, EXIT_DURATION_MS);
+  const lastOpenChildren = useRef<ReactNode>(null);
+  const wasPresent = useRef(present);
+  // Owners often clear selection or form state in the same update as closing.
+  // Keep the last committed content until the exit finishes to preserve geometry.
+  useLayoutEffect(() => {
+    if (open) lastOpenChildren.current = children;
+    else if (!present) lastOpenChildren.current = null;
+  }, [children, open, present]);
+  useEffect(() => {
+    const completed = wasPresent.current && !present && !open;
+    wasPresent.current = present;
+    if (completed) onExitComplete?.();
+  }, [onExitComplete, open, present]);
+  const renderedChildren = open ? children : lastOpenChildren.current;
+  const hasTitle = containsType(renderedChildren, DialogTitle);
+  const hasDescription = containsType(renderedChildren, DialogDescription);
 
   const close = useCallback((reason: DialogCloseReason) => {
     if (open) onOpenChange(false, reason);
@@ -152,6 +171,7 @@ const OverlaySurface = forwardRef<HTMLDivElement, OverlaySurfaceProps>(function 
         <DialogContext.Provider value={context}>
           <div
             {...surfaceProps}
+            {...(!open ? { inert: "" } : {})}
             aria-describedby={ariaDescribedBy ?? (hasDescription ? descriptionId : undefined)}
             aria-hidden={exiting || undefined}
             aria-label={ariaLabel}
@@ -167,7 +187,7 @@ const OverlaySurface = forwardRef<HTMLDivElement, OverlaySurfaceProps>(function 
             role={role}
             tabIndex={-1}
           >
-            {children}
+            {renderedChildren}
           </div>
         </DialogContext.Provider>
       </div>

--- a/design-system/packages/ui/src/components/Disclosure/Disclosure.module.css
+++ b/design-system/packages/ui/src/components/Disclosure/Disclosure.module.css
@@ -112,7 +112,7 @@
     opacity: 0;
     transition:
       grid-template-rows var(--openbitfun-motion-duration-normal) var(--openbitfun-motion-easing-standard),
-      opacity var(--openbitfun-motion-duration-fast) var(--openbitfun-motion-easing-standard),
+      opacity var(--openbitfun-motion-duration-normal) var(--openbitfun-motion-easing-standard),
       visibility 0s linear var(--openbitfun-motion-duration-normal);
   }
 

--- a/design-system/packages/ui/src/flow-chat/tool-cards/FlowChatToolCard.module.css
+++ b/design-system/packages/ui/src/flow-chat/tool-cards/FlowChatToolCard.module.css
@@ -385,7 +385,7 @@
     visibility: hidden;
     transition:
       grid-template-rows var(--_tool-card-collapse-duration) var(--openbitfun-motion-easing-standard),
-      opacity var(--openbitfun-motion-duration-fast) var(--openbitfun-motion-easing-standard),
+      opacity var(--_tool-card-collapse-duration) var(--openbitfun-motion-easing-standard),
       visibility 0s linear var(--_tool-card-collapse-duration);
   }
 

--- a/src/web-ui/src/app/components/NavPanel/MainNav.tsx
+++ b/src/web-ui/src/app/components/NavPanel/MainNav.tsx
@@ -493,83 +493,87 @@ const MainNav: React.FC<MainNavProps> = ({
             <div
               className={`openbitfun-nav-panel__top-action-sublist${isExtensionsOpen ? ' is-open' : ''}`}
               data-testid="agent-skill-tabs"
+              aria-hidden={!isExtensionsOpen}
+              {...(!isExtensionsOpen ? { inert: '' } : {})}
             >
-              <Tooltip content={agentsTooltip} placement="right" followCursor>
-                <button data-overflow-trigger
-                  type="button"
-                  className={[
-                    'openbitfun-nav-panel__top-action-btn',
-                    'openbitfun-nav-panel__top-action-btn--sub',
-                    isAgentsActive ? 'is-active' : '',
-                  ].filter(Boolean).join(' ')}
-                  data-openbitfun-component="nav-panel"
-                  data-openbitfun-part="topAction"
-                  data-openbitfun-action="agents"
-                  data-openbitfun-state={isAgentsActive ? 'active' : ''}
-                  onClick={handleOpenAgents}
-                  aria-label={agentsTooltip}
-                  data-testid="agent-tab"
-                >
-                  <span className="openbitfun-nav-panel__top-action-icon-slot" aria-hidden="true">
-                    <Icon glyph={Users} size="sm" />
-                  </span>
-                  <OverflowText>{t('nav.items.agents')}</OverflowText>
-                </button>
-              </Tooltip>
+              <div className="openbitfun-nav-panel__top-action-sublist-inner">
+                <Tooltip content={agentsTooltip} placement="right" followCursor>
+                  <button data-overflow-trigger
+                    type="button"
+                    className={[
+                      'openbitfun-nav-panel__top-action-btn',
+                      'openbitfun-nav-panel__top-action-btn--sub',
+                      isAgentsActive ? 'is-active' : '',
+                    ].filter(Boolean).join(' ')}
+                    data-openbitfun-component="nav-panel"
+                    data-openbitfun-part="topAction"
+                    data-openbitfun-action="agents"
+                    data-openbitfun-state={isAgentsActive ? 'active' : ''}
+                    onClick={handleOpenAgents}
+                    aria-label={agentsTooltip}
+                    data-testid="agent-tab"
+                  >
+                    <span className="openbitfun-nav-panel__top-action-icon-slot" aria-hidden="true">
+                      <Icon glyph={Users} size="sm" />
+                    </span>
+                    <OverflowText>{t('nav.items.agents')}</OverflowText>
+                  </button>
+                </Tooltip>
 
-              <Tooltip content={skillsTooltip} placement="right" followCursor>
-                <button data-overflow-trigger
-                  type="button"
-                  className={[
-                    'openbitfun-nav-panel__top-action-btn',
-                    'openbitfun-nav-panel__top-action-btn--sub',
-                    isSkillsActive ? 'is-active' : '',
-                  ].filter(Boolean).join(' ')}
-                  data-openbitfun-component="nav-panel"
-                  data-openbitfun-part="topAction"
-                  data-openbitfun-action="skills"
-                  data-openbitfun-state={isSkillsActive ? 'active' : ''}
-                  onClick={handleOpenSkills}
-                  aria-label={skillsTooltip}
-                  data-testid="skill-tab"
-                >
-                  <span className="openbitfun-nav-panel__top-action-icon-slot" aria-hidden="true">
-                    <Icon name="extension" size="sm" />
-                  </span>
-                  <OverflowText>{t('nav.items.skills')}</OverflowText>
-                </button>
-              </Tooltip>
+                <Tooltip content={skillsTooltip} placement="right" followCursor>
+                  <button data-overflow-trigger
+                    type="button"
+                    className={[
+                      'openbitfun-nav-panel__top-action-btn',
+                      'openbitfun-nav-panel__top-action-btn--sub',
+                      isSkillsActive ? 'is-active' : '',
+                    ].filter(Boolean).join(' ')}
+                    data-openbitfun-component="nav-panel"
+                    data-openbitfun-part="topAction"
+                    data-openbitfun-action="skills"
+                    data-openbitfun-state={isSkillsActive ? 'active' : ''}
+                    onClick={handleOpenSkills}
+                    aria-label={skillsTooltip}
+                    data-testid="skill-tab"
+                  >
+                    <span className="openbitfun-nav-panel__top-action-icon-slot" aria-hidden="true">
+                      <Icon name="extension" size="sm" />
+                    </span>
+                    <OverflowText>{t('nav.items.skills')}</OverflowText>
+                  </button>
+                </Tooltip>
 
-              <Tooltip content={ecosystemCompatibilityTooltip} placement="right" followCursor>
-                <button data-overflow-trigger
-                  type="button"
-                  className={[
-                    'openbitfun-nav-panel__top-action-btn',
-                    'openbitfun-nav-panel__top-action-btn--sub',
-                    isEcosystemCompatibilityActive ? 'is-active' : '',
-                  ].filter(Boolean).join(' ')}
-                  data-openbitfun-component="nav-panel"
-                  data-openbitfun-part="topAction"
-                  data-openbitfun-action="ecosystem-compatibility"
-                  data-openbitfun-state={isEcosystemCompatibilityActive ? 'active' : ''}
-                  onClick={handleOpenEcosystemCompatibility}
-                  aria-label={ecosystemCompatibilityTooltip}
-                  data-testid="ecosystem-compatibility-tab"
-                >
-                  <span className="openbitfun-nav-panel__top-action-icon-slot" aria-hidden="true">
-                    <Icon glyph={Network} size="sm" />
-                  </span>
-                  <OverflowText>{t('nav.items.ecosystemCompatibility')}</OverflowText>
-                  {hasUnseenEcosystemCompatibility ? (
-                    <span
-                      className="openbitfun-nav-panel__top-action-unseen"
-                      data-openbitfun-component="nav-panel"
-                      data-openbitfun-part="topActionUnseen"
-                      aria-hidden="true"
-                    />
-                  ) : null}
-                </button>
-              </Tooltip>
+                <Tooltip content={ecosystemCompatibilityTooltip} placement="right" followCursor>
+                  <button data-overflow-trigger
+                    type="button"
+                    className={[
+                      'openbitfun-nav-panel__top-action-btn',
+                      'openbitfun-nav-panel__top-action-btn--sub',
+                      isEcosystemCompatibilityActive ? 'is-active' : '',
+                    ].filter(Boolean).join(' ')}
+                    data-openbitfun-component="nav-panel"
+                    data-openbitfun-part="topAction"
+                    data-openbitfun-action="ecosystem-compatibility"
+                    data-openbitfun-state={isEcosystemCompatibilityActive ? 'active' : ''}
+                    onClick={handleOpenEcosystemCompatibility}
+                    aria-label={ecosystemCompatibilityTooltip}
+                    data-testid="ecosystem-compatibility-tab"
+                  >
+                    <span className="openbitfun-nav-panel__top-action-icon-slot" aria-hidden="true">
+                      <Icon glyph={Network} size="sm" />
+                    </span>
+                    <OverflowText>{t('nav.items.ecosystemCompatibility')}</OverflowText>
+                    {hasUnseenEcosystemCompatibility ? (
+                      <span
+                        className="openbitfun-nav-panel__top-action-unseen"
+                        data-openbitfun-component="nav-panel"
+                        data-openbitfun-part="topActionUnseen"
+                        aria-hidden="true"
+                      />
+                    ) : null}
+                  </button>
+                </Tooltip>
+              </div>
             </div>
           </div>
         </div>

--- a/src/web-ui/src/app/components/NavPanel/NavPanel.scss
+++ b/src/web-ui/src/app/components/NavPanel/NavPanel.scss
@@ -2196,19 +2196,24 @@ $_section-header-height: 22px;
 }
 
 .openbitfun-nav-panel__top-action-sublist {
+  display: grid;
+  grid-template-rows: 0fr;
+  opacity: 0;
+  transition: grid-template-rows 180ms var(--openbitfun-motion-easing-standard),
+              opacity 180ms var(--openbitfun-motion-easing-standard);
+
+  &.is-open {
+    grid-template-rows: 1fr;
+    opacity: 1;
+  }
+}
+
+.openbitfun-nav-panel__top-action-sublist-inner {
   display: flex;
   flex-direction: column;
   gap: calc(var(--openbitfun-space-1) / 2);
+  min-height: 0;
   overflow: hidden;
-  max-height: 0;
-  opacity: 0;
-  transition: max-height 0.22s var(--openbitfun-motion-easing-standard),
-              opacity 0.15s var(--openbitfun-motion-easing-standard);
-
-  &.is-open {
-    max-height: 104px;
-    opacity: 1;
-  }
 }
 
 .openbitfun-nav-panel__session-view-toggle {
@@ -2447,11 +2452,6 @@ $_section-header-height: 22px;
 
   &__top-action-expand {
     gap: calc(var(--openbitfun-space-1) / 2);
-  }
-
-  &__top-action-sublist {
-    gap: calc(var(--openbitfun-space-1) / 2);
-    transition: none;
   }
 
   &__top-action-btn {
@@ -2747,6 +2747,10 @@ $_section-header-height: 22px;
 
   .openbitfun-device-overview__backup.is-syncing svg {
     animation: none;
+  }
+
+  .openbitfun-nav-panel__top-action-sublist {
+    transition: none;
   }
 }
 

--- a/src/web-ui/src/app/components/NavPanel/NavPanelLayout.test.ts
+++ b/src/web-ui/src/app/components/NavPanel/NavPanelLayout.test.ts
@@ -48,7 +48,7 @@ describe('NavPanel layout styles', () => {
     const sectionHeaderBlock = extractBlock(stylesheet, '&__section-header');
     const itemsBlock = extractBlock(stylesheet, '&__items');
     const topActionExpandBlock = extractBlock(stylesheet, '&__top-action-expand');
-    const topActionSublistBlock = extractBlock(stylesheet, '&__top-action-sublist');
+    const topActionSublistBlock = extractBlock(stylesheet, '.openbitfun-nav-panel__top-action-sublist-inner');
 
     expect(itemsBlock).toContain('padding: 2px var(--openbitfun-space-1);');
     expect(itemsBlock).toContain('gap: calc(var(--openbitfun-space-1) / 2);');

--- a/src/web-ui/src/app/scenes/skills/components/SkillGroupEditor.test.tsx
+++ b/src/web-ui/src/app/scenes/skills/components/SkillGroupEditor.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SkillGroupEditor } from './SkillGroupEditor';
+
+vi.mock('@/infrastructure/i18n/hooks/useI18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+describe('SkillGroupEditor exit', () => {
+  let root: Root;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  it.each(['close', 'save'])('finishes the exit before the parent removes the draft after %s', async (action) => {
+    const onClose = vi.fn();
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    await act(async () => root.render(
+      <SkillGroupEditor
+        draft={{ group: { id: 'example', name: 'Example', skillKeys: [] }, original: null }}
+        skills={[]} catalogReady saving={false}
+        onClose={onClose} onSave={onSave} onCopy={() => undefined}
+      />,
+    ));
+    const surface = document.querySelector<HTMLElement>('[data-testid="skill-group-editor"]')!;
+    await act(async () => {
+      if (action === 'save') surface.querySelector('form')!.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+      else surface.querySelector<HTMLButtonElement>('[data-openbitfun-part="close"]')!.click();
+    });
+    expect(onSave).toHaveBeenCalledTimes(action === 'save' ? 1 : 0);
+    expect(onClose).not.toHaveBeenCalled();
+    expect(surface.dataset.state).toBe('exiting');
+    expect(surface.querySelector('input')?.value).toBe('Example');
+    act(() => vi.advanceTimersByTime(180));
+    expect(surface.isConnected).toBe(false);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/web-ui/src/app/scenes/skills/components/SkillGroupEditor.tsx
+++ b/src/web-ui/src/app/scenes/skills/components/SkillGroupEditor.tsx
@@ -31,6 +31,7 @@ export function SkillGroupEditor({ draft, skills, catalogReady, saving, onClose,
   const { t: tComponents } = useI18n('components');
   const nameId = useId();
   const errorId = useId();
+  const [open, setOpen] = useState(true);
   const [name, setName] = useState(draft.group.name);
   const [skillKeys, setSkillKeys] = useState(draft.group.skillKeys);
   const [query, setQuery] = useState('');
@@ -69,7 +70,7 @@ export function SkillGroupEditor({ draft, skills, catalogReady, saving, onClose,
         confirmingClose.current = false;
       }
     }
-    onClose();
+    setOpen(false);
   };
 
   const save = async () => {
@@ -79,7 +80,7 @@ export function SkillGroupEditor({ draft, skills, catalogReady, saving, onClose,
     setError(null);
     try {
       await onSave({ ...draft.group, name, skillKeys });
-      onClose();
+      setOpen(false);
     } catch (saveError) {
       if (!isSurfaceChangedError(saveError)) setError(skillGroupErrorMessage(saveError, t, 'save'));
     } finally {
@@ -88,7 +89,7 @@ export function SkillGroupEditor({ draft, skills, catalogReady, saving, onClose,
   };
 
   return (
-    <Dialog open onOpenChange={open => { if (!open) void close(); }} size="lg" data-testid="skill-group-editor">
+    <Dialog open={open} onOpenChange={nextOpen => { if (!nextOpen) void close(); }} onExitComplete={onClose} size="lg" data-testid="skill-group-editor">
       <DialogHeader>
         <DialogHeading>
           <DialogTitle>{draft.readOnly ? draft.group.name : t(draft.original ? 'groups.edit' : 'groups.create')}</DialogTitle>

--- a/src/web-ui/src/features/ssh-remote/SSHAuthPromptDialog.test.tsx
+++ b/src/web-ui/src/features/ssh-remote/SSHAuthPromptDialog.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { expect, it, vi } from 'vitest';
+import { SSHAuthPromptDialog } from './SSHAuthPromptDialog';
+
+vi.mock('@/infrastructure/i18n', () => ({ useI18n: () => ({ t: (key: string) => key }) }));
+vi.mock('./pickSshPrivateKeyPath', () => ({ pickSshPrivateKeyPath: vi.fn(), pickSshCertificatePath: vi.fn() }));
+
+it('retains the SSH prompt during exit and clears credentials before reopening', () => {
+  vi.useFakeTimers();
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const render = (open: boolean) => act(() => root.render(
+    <SSHAuthPromptDialog open={open} targetDescription={open ? 'user@remote:22' : ''}
+      defaultAuthMethod="password" initialUsername={open ? 'user' : ''} lockUsername
+      onSubmit={() => undefined} onCancel={() => undefined} />,
+  ));
+  try {
+    render(true);
+    const surface = document.querySelector<HTMLElement>('[role="dialog"]')!;
+    const password = surface.querySelector<HTMLInputElement>('input[type="password"]')!;
+    act(() => {
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!.call(password, 'test-password');
+      password.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    render(false);
+    expect(surface.dataset.state).toBe('exiting');
+    expect(surface.textContent).toContain('user@remote:22');
+    expect(password.isConnected).toBe(true);
+    act(() => vi.advanceTimersByTime(180));
+    expect(surface.isConnected).toBe(false);
+    render(true);
+    expect(document.querySelector<HTMLInputElement>('input[type="password"]')?.value).toBe('');
+  } finally {
+    act(() => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+  }
+});

--- a/src/web-ui/src/features/ssh-remote/SSHAuthPromptDialog.tsx
+++ b/src/web-ui/src/features/ssh-remote/SSHAuthPromptDialog.tsx
@@ -74,7 +74,12 @@ export const SSHAuthPromptDialog: React.FC<SSHAuthPromptDialogProps> = ({
   const passwordRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    if (!open) return;
+    if (!open) {
+      setPassword('');
+      setPassphrase('');
+      setVerificationCode('');
+      return;
+    }
     setAuthMethod(defaultAuthMethod);
     setUsername(initialUsername);
     setPassword('');

--- a/src/web-ui/src/features/ssh-remote/SSHConnectionDialog.tsx
+++ b/src/web-ui/src/features/ssh-remote/SSHConnectionDialog.tsx
@@ -1494,36 +1494,34 @@ export const SSHConnectionDialog: React.FC<SSHConnectionDialogProps> = ({
               </DialogBody>
       </Dialog>
 
-      {open && credentialsPrompt && (
-        <SSHAuthPromptDialog
-          open
-          targetDescription={`${credentialsPrompt.username}@${credentialsPrompt.host}:${credentialsPrompt.port}`}
-          defaultAuthMethod={
-            credentialsPrompt.authType.type === 'PrivateKey'
-              ? 'privateKey'
-              : credentialsPrompt.authType.type === 'Agent'
-                ? 'agent'
-                : credentialsPrompt.authType.type === 'KeyboardInteractive'
-                  ? 'keyboardInteractive'
-                  : 'password'
-          }
-          defaultKeyPath={
-            credentialsPrompt.authType.type === 'PrivateKey'
-              ? credentialsPrompt.authType.keyPath
-              : '~/.ssh/id_rsa'
-          }
-          defaultCertificatePath={
-            credentialsPrompt.authType.type === 'PrivateKey'
-              ? credentialsPrompt.authType.certificatePath
-              : undefined
-          }
-          initialUsername={credentialsPrompt.username}
-          lockUsername
-          onSubmit={handleCredentialsPromptSubmit}
-          onCancel={handleCredentialsPromptCancel}
-          isConnecting={isConnecting}
-        />
-      )}
+      <SSHAuthPromptDialog
+        open={open && credentialsPrompt !== null}
+        targetDescription={credentialsPrompt ? `${credentialsPrompt.username}@${credentialsPrompt.host}:${credentialsPrompt.port}` : ''}
+        defaultAuthMethod={
+          credentialsPrompt?.authType.type === 'PrivateKey'
+            ? 'privateKey'
+            : credentialsPrompt?.authType.type === 'Agent'
+              ? 'agent'
+              : credentialsPrompt?.authType.type === 'KeyboardInteractive'
+                ? 'keyboardInteractive'
+                : 'password'
+        }
+        defaultKeyPath={
+          credentialsPrompt?.authType.type === 'PrivateKey'
+            ? credentialsPrompt.authType.keyPath
+            : '~/.ssh/id_rsa'
+        }
+        defaultCertificatePath={
+          credentialsPrompt?.authType.type === 'PrivateKey'
+            ? credentialsPrompt.authType.certificatePath
+            : undefined
+        }
+        initialUsername={credentialsPrompt?.username ?? ''}
+        lockUsername
+        onSubmit={handleCredentialsPromptSubmit}
+        onCancel={handleCredentialsPromptCancel}
+        isConnecting={isConnecting}
+      />
     </>
   );
 };

--- a/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_VIRTUALIZATION.md
+++ b/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_VIRTUALIZATION.md
@@ -145,6 +145,10 @@ Tool cards reflow naturally and dispatch only `tool-card-toggle` after an
 expanded-state change, so the virtualizer can remeasure. There is no
 pre-collapse intent event and no per-card compensation.
 
+`SmoothHeightCollapse` starts its completion timer in the animation frame that
+applies the target height. A delayed frame must not shorten the transition or
+unmount closing content early. Reversing a toggle cancels both the frame and timer.
+
 User-message text and both message-edit inputs use the same `flow-control`
 font-size role as the composer and rendered replies, following the user's font
 preference. User-message text also uses the reply's regular weight. Its

--- a/src/web-ui/src/flow_chat/components/modern/SmoothHeightCollapse.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/SmoothHeightCollapse.test.tsx
@@ -52,6 +52,7 @@ describe('SmoothHeightCollapse', () => {
     container.remove();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+    vi.useRealTimers();
   });
 
   it('does not replay an opening animation when only animation mode changes', () => {
@@ -136,5 +137,19 @@ describe('SmoothHeightCollapse', () => {
     const expected = `${FLOWCHAT_COLLAPSE_DURATION_MS}ms, ${FLOWCHAT_COLLAPSE_DURATION_MS}ms, ${FLOWCHAT_COLLAPSE_DURATION_MS}ms`;
     expect(collapse?.style.transitionDuration).toBe(expected);
     expect(collapse?.classList.contains('smooth-height-collapse--closing')).toBe(true);
+  });
+
+  it('retains closing content for the full duration after a delayed animation frame', () => {
+    vi.useFakeTimers();
+    act(() => root.render(<SmoothHeightCollapse isOpen><div>content</div></SmoothHeightCollapse>));
+    act(() => root.render(<SmoothHeightCollapse isOpen={false}><div>content</div></SmoothHeightCollapse>));
+    act(() => vi.advanceTimersByTime(FLOWCHAT_COLLAPSE_DURATION_MS));
+    expect(container.textContent).toBe('content');
+    const startFrame = requestAnimationFrameSpy.mock.calls.at(-1)?.[0] as FrameRequestCallback;
+    act(() => startFrame(performance.now()));
+    act(() => vi.advanceTimersByTime(FLOWCHAT_COLLAPSE_DURATION_MS - 1));
+    expect(container.textContent).toBe('content');
+    act(() => vi.advanceTimersByTime(1));
+    expect(container.textContent).toBe('');
   });
 });

--- a/src/web-ui/src/flow_chat/components/modern/SmoothHeightCollapse.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/SmoothHeightCollapse.tsx
@@ -66,11 +66,11 @@ export const SmoothHeightCollapse: React.FC<SmoothHeightCollapseProps> = ({
       setHeight(`${startHeight}px`);
       frameId = window.requestAnimationFrame(() => {
         setHeight(`${inner.scrollHeight}px`);
+        timeoutId = window.setTimeout(() => {
+          setPhase('open');
+          setHeight('auto');
+        }, durationMs);
       });
-      timeoutId = window.setTimeout(() => {
-        setPhase('open');
-        setHeight('auto');
-      }, durationMs);
     } else {
       const startHeight =
         outerRef.current?.getBoundingClientRect().height ??
@@ -79,10 +79,11 @@ export const SmoothHeightCollapse: React.FC<SmoothHeightCollapseProps> = ({
       setHeight(`${startHeight}px`);
       frameId = window.requestAnimationFrame(() => {
         setHeight('0px');
+        // The transition starts with this frame, not when the toggle was requested.
+        timeoutId = window.setTimeout(() => {
+          setPhase('closed');
+        }, durationMs);
       });
-      timeoutId = window.setTimeout(() => {
-        setPhase('closed');
-      }, durationMs);
     }
 
     return () => {

--- a/src/web-ui/src/flow_chat/components/usage/SessionUsageModal.test.tsx
+++ b/src/web-ui/src/flow_chat/components/usage/SessionUsageModal.test.tsx
@@ -88,6 +88,7 @@ describe('SessionUsageModal', () => {
     act(() => root.unmount());
     container.remove();
     closeSessionUsageModal();
+    vi.useRealTimers();
   });
 
   it('renders nothing until there is a report to show', () => {
@@ -114,6 +115,19 @@ describe('SessionUsageModal', () => {
     expect(isChatPopupActive()).toBe(false);
     // The afterEach unmount would otherwise run against a torn-down root.
     root = createRoot(container);
+  });
+
+  it('keeps the report visible during closing instead of unmounting immediately', () => {
+    vi.useFakeTimers();
+    showReport();
+    const surface = document.querySelector<HTMLElement>('[data-testid="session-usage-modal"]')!;
+    const contents = surface.textContent;
+    act(() => closeSessionUsageModal());
+    expect(surface.isConnected).toBe(true);
+    expect(surface.dataset.state).toBe('exiting');
+    expect(surface.textContent).toBe(contents);
+    act(() => vi.advanceTimersByTime(180));
+    expect(surface.isConnected).toBe(false);
   });
 
   it('hands over to the panel rather than competing with it', async () => {

--- a/src/web-ui/src/flow_chat/components/usage/SessionUsageModal.tsx
+++ b/src/web-ui/src/flow_chat/components/usage/SessionUsageModal.tsx
@@ -67,11 +67,9 @@ export const SessionUsageModal: React.FC = () => {
     });
   }, [markdown, sessionId, t, workspacePath]);
 
-  if (!open) return null;
-
   return (
     <Dialog
-      open
+      open={open}
       onOpenChange={(nextOpen) => { if (!nextOpen) closeSessionUsageModal(); }}
       size="xl"
       className="session-usage-dialog"

--- a/src/web-ui/src/infrastructure/config/components/ConfigForm.scss
+++ b/src/web-ui/src/infrastructure/config/components/ConfigForm.scss
@@ -631,7 +631,7 @@ $config-input-height: 32px;
   opacity: 0;
   transition:
     grid-template-rows 180ms var(--openbitfun-motion-easing-standard),
-    opacity 120ms ease;
+    opacity 180ms var(--openbitfun-motion-easing-standard);
 
   &[data-open='true'] {
     grid-template-rows: 1fr;

--- a/src/web-ui/src/infrastructure/config/components/common/ConfigCollectionItem.scss
+++ b/src/web-ui/src/infrastructure/config/components/common/ConfigCollectionItem.scss
@@ -113,6 +113,11 @@
   &[data-open='true'] {
     grid-template-rows: 1fr;
     opacity: 1;
+
+    @starting-style {
+      grid-template-rows: 0fr;
+      opacity: 0;
+    }
   }
 }
 

--- a/src/web-ui/src/shared/announcement-system/components/ReleaseLetterModal.test.tsx
+++ b/src/web-ui/src/shared/announcement-system/components/ReleaseLetterModal.test.tsx
@@ -263,7 +263,23 @@ describe('ReleaseLetterModal', () => {
     act(() => motionQuery.dispatchEvent(new Event('change')));
     act(() => document.querySelector<HTMLButtonElement>('.release-letter__version-mark')!.click());
     expect(frames.size).toBe(1);
+    const scene = document.querySelector('.release-letter-scene')!;
+    const drawing = scene.querySelector('.release-letter-drawing')!.outerHTML;
     act(() => useAnnouncementStore.getState().closeModal());
     expect(frames.size).toBe(0);
+    expect(document.querySelector('.release-letter-scene')).toBe(scene);
+    expect(document.querySelector('[role="dialog"]')?.getAttribute('data-state')).toBe('exiting');
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'));
+      window.dispatchEvent(new Event('resize'));
+      motionQuery.matches = true;
+      motionQuery.dispatchEvent(new Event('change'));
+      vi.advanceTimersByTime(179);
+    });
+    expect(frames.size).toBe(0);
+    expect(document.querySelector('.release-letter-scene')).toBe(scene);
+    expect(scene.querySelector('.release-letter-drawing')!.outerHTML).toBe(drawing);
+    act(() => vi.advanceTimersByTime(1));
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
   });
 });

--- a/src/web-ui/src/shared/announcement-system/components/ReleaseLetterModal.tsx
+++ b/src/web-ui/src/shared/announcement-system/components/ReleaseLetterModal.tsx
@@ -37,7 +37,9 @@ function ReleaseLetterScene({ title, body, titleId, descriptionId, closable }: {
   title: string; body: string; titleId: string; descriptionId: string; closable: boolean;
 }) {
   const { t, currentLanguage } = useAnnouncementI18n();
-  const { sceneRef, replay, skip, bounce } = useReleaseLetterMotion();
+  // Dialog retains this scene during exit; stop its work when visibility changes.
+  const modalVisible = useAnnouncementStore(state => state.modalVisible);
+  const { sceneRef, replay, skip, bounce } = useReleaseLetterMotion(modalVisible);
   const paragraphs = parseReleaseLetterBody(body);
   return (
     <div ref={sceneRef} className="release-letter-scene" data-motion-state="intro" data-content-ready="false" lang={currentLanguage}>

--- a/src/web-ui/src/shared/announcement-system/hooks/useReleaseLetterMotion.ts
+++ b/src/web-ui/src/shared/announcement-system/hooks/useReleaseLetterMotion.ts
@@ -7,13 +7,13 @@ import {
   type LetterBox,
 } from '../components/releaseLetterMotion';
 
-export function useReleaseLetterMotion() {
+export function useReleaseLetterMotion(active: boolean) {
   const sceneRef = useRef<HTMLDivElement>(null);
   const controls = useRef({ replay: () => {}, skip: () => {}, bounce: () => {} });
 
   useLayoutEffect(() => {
     const scene = sceneRef.current;
-    if (!scene) return;
+    if (!scene || !active) return;
     const find = <T extends Element>(selector: string) => scene.querySelector<T>(selector)!;
     const drawing = createLetterDrawing(find<SVGSVGElement>('.release-letter-drawing'));
     const background = find<HTMLElement>('.release-letter__construction');
@@ -194,7 +194,7 @@ export function useReleaseLetterMotion() {
       media?.removeEventListener('change', motionChanged);
       controls.current = { replay() {}, skip() {}, bounce() {} };
     };
-  }, []);
+  }, [active]);
 
   return {
     sceneRef,

--- a/src/web-ui/src/shared/ui/Dialog.test.tsx
+++ b/src/web-ui/src/shared/ui/Dialog.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Dialog, DialogBody, DialogDescription, DialogHeader, DialogHeading, DialogTitle, Sheet } from '@openbitfun/ui';
+
+describe('overlay exit content', () => {
+  let root: Root;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  it.each([Dialog, Sheet])('preserves committed content until exit, then accepts a fresh selection', (Surface) => {
+    const onExitComplete = vi.fn();
+    function render(open: boolean, selected: string | null) {
+      act(() => root.render(
+        <Surface open={open} onOpenChange={() => undefined} onExitComplete={onExitComplete}>
+          <DialogHeader>
+            <DialogHeading>
+              <DialogTitle>{selected ?? 'No selection'}</DialogTitle>
+              {selected && <DialogDescription>{selected} description</DialogDescription>}
+            </DialogHeading>
+          </DialogHeader>
+          <DialogBody>{selected && <input aria-label="Draft" value={selected} readOnly />}</DialogBody>
+        </Surface>,
+      ));
+    }
+    render(false, null);
+    expect(onExitComplete).not.toHaveBeenCalled();
+    render(true, 'First');
+    const surface = document.querySelector<HTMLElement>('[role="dialog"]')!;
+    const input = surface.querySelector('input');
+    const descriptionId = surface.getAttribute('aria-describedby');
+    render(true, 'Edited');
+    render(false, null);
+    expect(surface.dataset.state).toBe('exiting');
+    expect(surface.hasAttribute('inert')).toBe(true);
+    expect(surface.getAttribute('aria-describedby')).toBe(descriptionId);
+    expect(surface.textContent).toContain('Edited description');
+    expect(surface.textContent).not.toContain('No selection');
+    expect(surface.querySelector('input')).toBe(input);
+    expect(input?.value).toBe('Edited');
+    act(() => vi.advanceTimersByTime(90));
+    render(true, 'Second');
+    expect(surface.hasAttribute('inert')).toBe(false);
+    expect(input?.value).toBe('Second');
+    act(() => vi.advanceTimersByTime(180));
+    expect(surface.isConnected).toBe(true);
+    expect(onExitComplete).not.toHaveBeenCalled();
+    render(false, null);
+    act(() => vi.advanceTimersByTime(179));
+    expect(surface.isConnected).toBe(true);
+    expect(input?.value).toBe('Second');
+    act(() => vi.advanceTimersByTime(1));
+    expect(surface.isConnected).toBe(false);
+    expect(onExitComplete).toHaveBeenCalledTimes(1);
+    render(false, null);
+    expect(onExitComplete).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Preserve dialog and sheet content throughout exit animations, and provide an `onExitComplete` callback for deferred unmounting.
- Keep skill editor, session usage, and SSH authentication dialogs mounted until their exit completes.
- Synchronize height and opacity transitions across navigation, settings, disclosures, and tool cards.
- Start collapse completion timers when the animation frame begins to prevent premature content removal.

## Type and Areas

Type: Bug fix / UI/UX

Areas: Web UI, shared design system, tests, docs

## Motivation / Impact

Closing some dialogs cleared their content before the exit animation finished, briefly leaving an empty or header-only shell. Expand/collapse transitions could also fade content too early, snap on first expansion, or end before the final animation frame.

These changes preserve layout during dismissal and align transition timing for smoother interactions, including rapid close/reopen actions.

## Verification

- 57 focused tests passed, covering overlay retention, exit callbacks, rapid reopening, SSH authentication, and collapse timing.
- `pnpm run design-system:check` — passed.
- `pnpm run check:web` — passed.
- `pnpm --dir src/web-ui run lint` — passed with one existing unrelated warning.
- `pnpm run motion:audit` — passed.
- `git diff --check` — passed.

Actual desktop animation appearance and remote scenarios were not manually exercised. SSH dialog coverage uses component tests, not a live remote connection.

## Reviewer Notes

Exiting overlays are inert. Owners that conditionally remove a dialog can use `onExitComplete` to defer removal until the animation finishes.

No persisted formats, backend behavior, or remote protocols change. Documentation covers overlay ownership and collapse timing.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.