### PR TITLE
fix(settings): keep disabled model details collapsible

### DIFF
--- a/src/web-ui/src/infrastructure/config/components/ModelSettingsPage.tsx
+++ b/src/web-ui/src/infrastructure/config/components/ModelSettingsPage.tsx
@@ -3390,6 +3390,7 @@ const ModelSettingsPage: React.FC = () => {
         onToggle={() => config.id && toggleExpanded(config.id)}
         toggleOnRowClick
         disabled={!config.enabled}
+        detailsDisabled={false}
         data-testid="settings-model-row"
         data-config-id={config.id || ''}
         data-model-id={config.model_name}

--- a/src/web-ui/src/infrastructure/config/components/common/ConfigCollectionItem.test.tsx
+++ b/src/web-ui/src/infrastructure/config/components/common/ConfigCollectionItem.test.tsx
@@ -97,6 +97,41 @@ describe('ConfigCollectionItem', () => {
     expect(container.querySelector('.openbitfun-collection-item__details-collapse')).toBeNull();
   });
 
+  it('keeps controlled details interactive after disabling the item when explicitly allowed', () => {
+    const Harness = () => {
+      const [enabled, setEnabled] = React.useState(true);
+      const [expanded, setExpanded] = React.useState(false);
+      return (
+        <ConfigCollectionItem
+          label="Model A"
+          control={<button type="button" onClick={() => setEnabled(false)}>Disable</button>}
+          details={<span>Model details</span>}
+          disabled={!enabled}
+          detailsDisabled={false}
+          expanded={expanded}
+          onToggle={() => setExpanded(value => !value)}
+          toggleOnRowClick
+        />
+      );
+    };
+    act(() => root.render(<Harness />));
+    const toggle = container.querySelector<HTMLButtonElement>('.openbitfun-collection-item__details-toggle')!;
+    const label = container.querySelector<HTMLElement>('.openbitfun-collection-item__name')!;
+    const disable = Array.from(container.querySelectorAll('button')).find(button => button.textContent === 'Disable')!;
+
+    act(() => toggle.click());
+    act(() => disable.click());
+    expect(container.querySelector('.openbitfun-collection-item')?.classList.contains('is-disabled')).toBe(true);
+    expect(toggle.disabled).toBe(false);
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    act(() => toggle.click());
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    act(() => label.click());
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    act(() => label.click());
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+  });
+
   it('optionally toggles from the row without stealing nested control clicks', () => {
     act(() => {
       root.render(

--- a/src/web-ui/src/infrastructure/config/components/common/ConfigCollectionItem.tsx
+++ b/src/web-ui/src/infrastructure/config/components/common/ConfigCollectionItem.tsx
@@ -11,6 +11,8 @@ export interface ConfigCollectionItemProps extends React.HTMLAttributes<HTMLDivE
   control: React.ReactNode;
   details?: React.ReactNode;
   disabled?: boolean;
+  /** Separates details interaction from the item's disabled appearance. */
+  detailsDisabled?: boolean;
   expanded?: boolean;
   onToggle?: () => void;
   /** Lets non-interactive row space toggle details while preserving nested controls. */
@@ -25,6 +27,7 @@ export const ConfigCollectionItem: React.FC<ConfigCollectionItemProps> = ({
   control,
   details,
   disabled = false,
+  detailsDisabled = disabled,
   expanded: expandedProp,
   onToggle,
   toggleOnRowClick = false,
@@ -39,7 +42,7 @@ export const ConfigCollectionItem: React.FC<ConfigCollectionItemProps> = ({
   const hasDetails = Boolean(details);
 
   const toggleDetails = () => {
-    if (!hasDetails || disabled) return;
+    if (!hasDetails || detailsDisabled) return;
     if (isControlled) {
       onToggle?.();
     } else {
@@ -48,7 +51,7 @@ export const ConfigCollectionItem: React.FC<ConfigCollectionItemProps> = ({
   };
 
   const handleRowClick = (event: React.MouseEvent<HTMLDivElement>) => {
-    if (!toggleOnRowClick || !hasDetails || disabled) return;
+    if (!toggleOnRowClick || !hasDetails || detailsDisabled) return;
     const target = event.target;
     if (
       target instanceof Element
@@ -68,7 +71,7 @@ export const ConfigCollectionItem: React.FC<ConfigCollectionItemProps> = ({
     >
       <div data-overflow-trigger
         className={`openbitfun-config-page-row openbitfun-config-page-row--center openbitfun-collection-item__row ${
-          toggleOnRowClick && hasDetails && !disabled ? 'openbitfun-collection-item__row--toggleable' : ''
+          toggleOnRowClick && hasDetails && !detailsDisabled ? 'openbitfun-collection-item__row--toggleable' : ''
         }`}
         data-openbitfun-component="config"
         data-openbitfun-part="collectionRow"
@@ -102,7 +105,7 @@ export const ConfigCollectionItem: React.FC<ConfigCollectionItemProps> = ({
                 type="button"
                 className="openbitfun-collection-btn openbitfun-collection-item__details-toggle"
                 onClick={toggleDetails}
-                disabled={disabled}
+                disabled={detailsDisabled}
                 aria-labelledby={labelId}
                 aria-expanded={isExpanded}
                 aria-controls={detailsId}


### PR DESCRIPTION
## Summary

Allow disabled models to expand and collapse their details using either the details button or non-interactive row space.

## Type and Areas

Type: Bug fix

Areas: Web UI, model settings

## Motivation / Impact

Previously, expanding a model and then disabling it left its details open with both collapse entry points blocked. Separate details interaction from disabled styling through an optional `detailsDisabled` prop, and explicitly keep model details interactive. Existing collection consumers retain their default disabled behavior and models retain their disabled appearance.

## Verification

- `pnpm --dir src/web-ui run test:run src/infrastructure/config/components/common/ConfigCollectionItem.test.tsx` — 4 tests passed, including controlled expand, disable, collapse, and row toggling without nested-control click interference.
- `pnpm run check:web` — passed.
- `git diff --check` — passed.
- `build-dev.bat` (`pnpm run desktop:dev`) — Windows Debug build completed; verified the executable from the changed worktree launched, its window responded, and its frontend page finished loading. The model interaction sequence was covered by component tests, not manually exercised in the native window.
- Remote workspace, remote control, Peer Device Mode, and Detached Dispatch were not exercised. This change only affects frontend details interaction; no transport or persisted configuration shapes changed.

## Reviewer Notes

`detailsDisabled` defaults to `disabled` for compatibility; only model settings opt out. No new strings or migrations are required.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.
