### PR TITLE
docs(migrator): Update migration and recovery guides

### DIFF
--- a/src/apps/data-migrator/README.md
+++ b/src/apps/data-migrator/README.md
@@ -3,17 +3,11 @@
 [中文](README.zh-CN.md)
 
 A separate, optional desktop utility for importing old **BitFun** data into
-**OpenBitFun**. It runs without installing or opening the main application, has
-its own window and settings, and never starts or restarts Desktop. OpenBitFun
-does not bundle, download, or launch it automatically.
+**OpenBitFun**.
 
 ## Download and run
 
-Look for **OpenBitFun Data Migrator** releases with a `data-migrator-v*` tag on
-the [release page](https://github.com/GCWing/OpenBitFun/releases?q=data-migrator-v&expanded=true).
-These releases have their own version and assets; the main application's
-installer does not contain the tool. If no migrator release is listed, build
-from source using the commands below.
+**Latest release: [v0.1.1 — download Data Migrator](https://github.com/GCWing/OpenBitFun/releases/tag/data-migrator-v0.1.1).**
 
 | Platform | Download | Launch |
 | --- | --- | --- |
@@ -27,55 +21,33 @@ Linux packages are built on Ubuntu 22.04. No login or network connection is
 needed for migration. ARM Windows/Linux packages are not currently produced.
 
 1. Close BitFun, OpenBitFun, their CLI instances, and background data writers.
-2. Open Data Migrator. Check the **source and destination** directories. All
-   four locations on each side can be edited; apply changes before scanning.
+2. Open Data Migrator. Check the **source and destination** directories.
 3. Select the data groups, scan, then run the preflight plan.
-4. Review the destination and conflicts, then start migration. If known writers
+4. Review the destination, scope, and conflicts, then start migration. If known writers
    remain open, the tool waits for them to stop; it does not terminate them.
 5. Read the report. Sign in again or repair paths where indicated, close the
    tool, and open OpenBitFun yourself.
 
-The report lists Sessions, workspace records, and assistant directories separately.
-Expected auxiliary exclusions (such as request traces and lock files) do not
-contribute to these displayed counts. Historical runs use their saved manifests
-for the same breakdown; missing manifests are shown as unavailable.
-
-The UI uses the shared design-system tokens bundled offline, follows the system
-light/dark/high-contrast setting, and offers English, Simplified Chinese, and
-Traditional Chinese.
-
 ## Data and compatibility
 
-The declared source range is BitFun `>=0.2.0,<1.0.0`; the archived integration
-fixture is **0.2.19**. This is format-based support, not a claim that every old
-release has been tested. The source must pass the probe and selected domain
-validators. Unsupported or corrupt data is kept and reported.
+Supported sources are **stable BitFun releases 0.2.17–0.2.19**, targeting
+**OpenBitFun 1.0**. Direct migration from 0.2.16 or earlier is not supported;
+upgrade BitFun first, launch it, and verify that your existing data is accessible.
 
-Scanning isolates invalid settings/model entries, workspace registrations, memory
-rows/files, SSH profiles, Remote Connect files/Bots, Sessions, Skills, MiniApps,
-and Agent definitions. Readable Turns within a damaged Session are recovered;
-derived Turn counts and workspace reference lists are rebuilt. Identical Turn
-copies are deduplicated; conflicting Turn identities are omitted with warnings.
-Nested user memory notes are supported. Legacy memory jobs are not read or
-imported: the runtime creates jobs on demand, and destination jobs stay intact.
-Optional Skills and MiniApps do not block importing Agent definitions.
-
-Item failures during staging are omitted from the committed manifest where the
-item has an independent storage boundary. Source data remains read-only and the
-report shows omissions and partial history recovery. Unreadable destination
-stores, unsafe paths, unsupported schemas, changed inputs, and transaction/write
-failures still protect the affected domain; independent domains can continue
-after successful rollback. A failed rollback stops execution. Review warnings
-and the report before retrying.
-
+Scanning isolates errors in individual sessions, runtime event logs, Skills,
+MiniApps, and Agent definitions. Valid items continue to migrate; skipped items
+remain in the source and are recorded in the report. Legacy session Turn counts
+are rebuilt from the actual files in the migration copy only.
+If an entire domain is unavailable, only that domain and its dependents are skipped.
+If a domain fails during execution, it is rolled back before independent domains
+continue. Execution stops if rollback cannot complete safely. Review warnings
+and the migration report before retrying.
 
 The destination is OpenBitFun: configuration schema **1**, workspace registry
 format **1**, coordination database schema **2**, and the session, memory,
 extension, and connection formats accepted by the shared storage owners in
 this source revision. Unknown product/configuration schemas and newer SQLite
-or session schemas fail validation. A future storage format requires a new
-migrator release; matching application and tool version numbers is unnecessary.
-Custom branded products are not supported by this tool.
+or session schemas fail validation.
 
 Migration covers settings and credentials; user Agents, Skills and MiniApps;
 workspaces, sessions and task records; memories; and local connection/device
@@ -90,15 +62,6 @@ staging, validation, backups, a migration lock and atomic replacement. Keep
 both applications closed until the run finishes. Cancellation and window close
 requests wait for an engine-declared safe boundary; already verified domains
 may remain imported.
-
-
-Agent coordination imports do not require historical Session/Turn references,
-parent relationships, counters, timestamps, or Swarm lineage to remain valid.
-Records that cannot be decoded or inserted under the target table constraints
-are skipped individually. Tasks without a mapped Agent are skipped instead of
-being attached to an unrelated target primary key. Existing target records still
-win conflicts; imported Agent primary keys and task references are remapped.
-Importing historical task state does not start or resume an Agent execution.
 
 ## Resume and diagnose
 
@@ -119,13 +82,52 @@ resuming them. Unreadable files are not deleted or reset.
 The tool remembers selected locations in its own `com.openbitfun.data-migrator`
 application configuration directory. It does not write main-app onboarding or
 reminder preferences. **Export failure diagnostics** writes a sanitized file
-containing result codes and journal phases; full local reports and backups
-can contain sensitive data and should stay private.
+containing result codes and journal phases. Review personal information before
+sharing full reports or optional data directories as described below.
 
 This tool only operates on files accessible on the computer where it runs.
 Remote workspace execution, remote control, Peer Device Mode and Detached
 Dispatch are not execution surfaces for it. Run it on the data-owning computer;
 importing stored connection records does not connect to or migrate a remote host.
+
+## Troubleshooting
+
+**Migration finishes, but workspaces or sessions are empty, or some data is missing**
+
+If you have already launched OpenBitFun or run a migration, existing destination data may take precedence and remain unchanged during retries.
+
+If OpenBitFun contains no new data you need to keep, you can clear its destination data and retry:
+
+1. Fully quit BitFun, OpenBitFun, and the migrator.
+2. Back up the following directories, then delete them. **This removes existing OpenBitFun settings, sessions, and other local data.**
+3. Run the migrator again, then launch OpenBitFun after migration finishes.
+
+Windows destination directories:
+
+```text
+%APPDATA%\openbitfun
+%USERPROFILE%\.openbitfun
+%LOCALAPPDATA%\OpenBitFun
+```
+
+**The issue persists after retrying**
+
+Open a report in [GitHub Issues](https://github.com/GCWing/OpenBitFun/issues) or share your feedback in the OpenBitFun user WeChat group. Include:
+
+- Your operating system and the BitFun, OpenBitFun, and migrator versions.
+- Steps to reproduce, the expected result, and the actual result.
+- The workspace and session name or ID associated with missing data.
+- Migration logs from the affected run.
+
+Windows migration log location:
+
+```text
+%APPDATA%\openbitfun\data\migrations\bitfun-to-openbitfun\runs\<run-id>\
+```
+
+Provide the log files from the affected run, such as `report.json`, `plan.json`, `journal.jsonl`, `locations.json`, and `release-observation.json` when present. The `stage` and `backup` directories contain personal data, so sharing them is optional and at your discretion; the log files listed above are usually sufficient for an initial report. Save the logs before clearing the destination directories for another attempt.
+
+Review the logs for personal information, such as usernames and paths, and redact it as needed before submitting.
 
 ## Build and release
 
@@ -153,6 +155,10 @@ and `DATA_MIGRATOR_SIGNING_PUBKEY` secrets, verify checksums/signatures, and cre
 a **draft** release for review. Manual workflow runs only upload CI artifacts.
 Publishing migrator releases does not start main-app packaging or update feeds.
 
+When publishing a new version, update the latest-release links in both README
+files on the default branch and review [RELEASE.md](RELEASE.md), the release
+description template used by the workflow. Keep guide paths stable for shared links.
+
 Each asset has a SHA-256 sidecar and a base64-encoded minisign `.sig`; the
 release also carries `SHA256SUMS` and `data-migrator.minisign.pub`. Verify the key
 against the maintainer's trusted key before checking signatures. Detached
@@ -160,3 +166,21 @@ signatures are distinct from Apple/Authenticode platform signing; the workflow
 does not currently configure those certificates or macOS notarization.
 
 Focused checks and architecture rules are in [AGENTS.md](AGENTS.md).
+
+### Handling damaged legacy data
+
+Scanning isolates invalid settings/model entries, workspace registrations, memory
+rows/files, SSH profiles, Remote Connect files/Bots, Sessions, Skills, MiniApps,
+and Agent definitions. Readable Turns within a damaged Session are recovered;
+derived Turn counts and workspace reference lists are rebuilt. Identical Turn
+copies are deduplicated; conflicting Turn identities are omitted with warnings.
+Nested user memory notes are supported. Legacy memory jobs are not read or
+imported: the runtime creates jobs on demand, and destination jobs stay intact.
+Optional Skills and MiniApps do not block importing Agent definitions.
+
+Item failures during staging are omitted from the committed manifest where the
+item has an independent storage boundary. Source data remains read-only and the
+report shows omissions and partial history recovery. Unreadable destination
+stores, unsafe paths, unsupported schemas, changed inputs, and transaction/write
+failures still protect the affected domain; independent domains can continue
+after successful rollback. A failed rollback stops execution.

--- a/src/apps/data-migrator/README.zh-CN.md
+++ b/src/apps/data-migrator/README.zh-CN.md
@@ -3,14 +3,10 @@
 [English](README.md)
 
 这是一个可选的独立桌面工具，用于将旧版 **BitFun** 数据导入 **OpenBitFun**。
-无需安装或启动主应用；工具有自己的窗口、版本和配置，完成后只关闭自身。
-主应用不会捆绑、自动下载、自动启动迁移器，也不会因为旧版数据而阻止正常启动。
 
 ## 下载和使用
 
-在 [GitHub Releases](https://github.com/GCWing/OpenBitFun/releases?q=data-migrator-v&expanded=true)
-寻找 **OpenBitFun Data Migrator**、标签以 `data-migrator-v` 开头的独立发布。
-迁移器不在主应用安装包内；如果尚未列出独立发布，请按下文从源码构建。
+**最新版本：[v0.1.1 — 下载数据迁移器](https://github.com/GCWing/OpenBitFun/releases/tag/data-migrator-v0.1.1)。**
 
 | 系统 | 下载文件 | 启动方式 |
 | --- | --- | --- |
@@ -23,30 +19,24 @@ Windows 需要 Microsoft Edge WebView2；macOS 使用系统 WebView，Linux 包�
 为构建基线。迁移不需要登录或联网，目前不产出 Windows/Linux ARM 安装包。
 
 1. 关闭 BitFun、OpenBitFun、CLI 实例及其后台数据写入进程。
-2. 启动迁移器，检查**来源和目标目录**。两侧各有设置与数据、主目录数据、Skills、SSH
-   四个位置；如需修改，先点击“使用这些目录”。
+2. 启动迁移器，检查**来源和目标目录**。
 3. 选择迁移范围，扫描数据，再运行预检。
 4. 确认目标、范围和冲突后开始迁移。发现已知写入进程时会等待其退出，不会强制终止进程。
 5. 查看结果，根据提示重新登录或修复路径，关闭迁移器，再自行打开 OpenBitFun。
 
-界面使用离线打包的共享设计系统，跟随系统深浅色和高对比度设置，并提供中英文切换。
-
 ## 支持范围与数据保护
 
-声明支持的来源是 BitFun `>=0.2.0,<1.0.0`，仓库保存的集成验证样本是 **0.2.19**。
-支持以实际数据格式和各领域校验为准，不代表已验证范围内的每个旧版本。
-未知格式、损坏数据会明确报告并保留。
+支持来源为 **BitFun 0.2.17～0.2.19 正式版**，目标为 **OpenBitFun 1.0**。
+暂不支持直接迁移 0.2.16 及更早版本；请先升级旧版 BitFun，并启动确认原有数据正常。
 
 扫描会按单个会话、运行事件日志、Skill、MiniApp 和 Agent 定义隔离异常；有效条目继续迁移，
 跳过的条目保留在来源中并记录到报告。旧会话的 Turn 计数以实际文件为准，仅在迁移副本中重建。
 整个数据域不可用时，只跳过该域及依赖它的域。执行时某域失败会先回滚，再继续无依赖的数据域；
 无法安全回滚时仍会停止。请在重试前查看警告与迁移报告。
 
-
 目标是 OpenBitFun：配置 schema **1**、工作区格式 **1**、任务协调数据库 schema **2**，
 以及此源码版本共享存储模块支持的会话、记忆、扩展和连接格式。未知产品/配置格式以及
-超出支持范围的数据库、会话版本会被拒绝。未来数据格式变更需要发布新的迁移器，
-工具版本无需与主应用版本相同；此工具不支持定制品牌产品的数据。
+超出支持范围的数据库、会话版本会被拒绝。
 
 可迁移设置与凭据、用户 Agents/Skills/MiniApps、工作区与会话及任务记录、记忆、
 本机保存的远程连接与设备记录。已有目标值优先，部分冲突会按领域规则保留双方。
@@ -54,12 +44,6 @@ Windows 需要 Microsoft Edge WebView2；macOS 使用系统 WebView，Linux 包�
 
 来源不会被自动删除。写入使用一致性快照、暂存、校验、备份、迁移锁和原子替换。
 迁移期间请保持相关应用关闭；取消或关闭窗口会等到安全边界，已验证完成的领域可能已导入。
-
-
-协调数据库不再要求历史 Session/Turn 引用、父子关系、计数、时间戳或 Swarm 层级完整有效。
-无法解析或不能写入目标表约束的记录会单独跳过；缺少 Agent 主键映射的任务也单独跳过，
-不会误挂到目标库中同号的 Agent。合并仍保持目标已有记录优先，并映射新增 Agent 主键和任务引用。
-导入历史任务状态不会启动或恢复 Agent 执行。
 
 ## 中断恢复与诊断
 
@@ -77,10 +61,49 @@ Windows 需要 Microsoft Edge WebView2；macOS 使用系统 WebView，Linux 包�
 
 迁移器只在自己的 `com.openbitfun.data-migrator` 配置目录中记住所选位置，不写主应用的
 引导或提醒状态。“导出失败诊断”生成包含结果码和执行阶段的去敏文件。
-完整本地报告与备份可能含敏感信息，请保留在本机。
+完整报告与数据目录可能含个人信息；反馈时请按下文说明检查内容，并自行选择是否提供数据目录。
 
 迁移器只操作运行电脑可访问的文件，不接入远程工作区执行、远程控制、Peer Device Mode
 或 Detached Dispatch。请在数据所在电脑上运行；迁移连接记录并不连接或迁移远端主机。
+
+## 异常排障
+
+**迁移完成，但工作区或会话为空、部分数据缺失**
+
+如果之前已经启动过 OpenBitFun 或执行过迁移，目标目录中的已有数据可能被优先保留，重试时不会覆盖。
+
+如果 OpenBitFun 中没有需要保留的新数据，可以清空目标数据后重新迁移：
+
+1. 完全退出 BitFun、OpenBitFun 和迁移器。
+2. 备份以下目录，然后删除它们。**这会清除 OpenBitFun 的现有配置、会话及其他本地数据。**
+3. 重新运行迁移器，完成后再启动 OpenBitFun。
+
+Windows 目标目录：
+
+```text
+%APPDATA%\openbitfun
+%USERPROFILE%\.openbitfun
+%LOCALAPPDATA%\OpenBitFun
+```
+
+**重试后仍然异常**
+
+请在 [GitHub Issues](https://github.com/GCWing/OpenBitFun/issues) 提交问题，或在 OpenBitFun 用户微信群中反馈，并提供：
+
+- 操作系统、BitFun 版本、OpenBitFun 版本和迁移器版本。
+- 操作步骤、预期结果及实际结果。
+- 缺失数据所属的工作区、会话名称或 ID。
+- 对应运行的迁移日志。
+
+Windows 迁移日志目录：
+
+```text
+%APPDATA%\openbitfun\data\migrations\bitfun-to-openbitfun\runs\<运行ID>\
+```
+
+请提供对应运行目录中的日志文件，例如 `report.json`、`plan.json`、`journal.jsonl`、`locations.json` 和 `release-observation.json`（如存在）。`stage` 和 `backup` 目录包含个人数据，是否一并提供可自行选择；初次反馈通常只需上述日志文件。如果准备清空目标目录重试，请先保存这份日志。
+
+提交前请检查日志中的用户名、路径等个人信息，按需脱敏。
 
 ## 开发与独立发布
 
@@ -104,6 +127,9 @@ cargo build -p openbitfun-data-migrator --bin openbitfun-data-migrator
 `DATA_MIGRATOR_SIGNING_PRIVATE_KEY_PASSWORD`、`DATA_MIGRATOR_SIGNING_PUBKEY`，
 完成签名和校验后创建草稿，审核后再发布。手动运行只生成 CI 构建产物。
 迁移器发布不会触发主应用打包或更新源。
+
+发布新版本时，同步更新默认分支上两份 README 顶部的最新版本链接，并检查工作流使用的
+[RELEASE.md](RELEASE.md) 发布描述模板。保持指南路径不变，让用户分享的链接持续有效。
 
 每个产物带 SHA-256 校验文件和 base64 编码的 minisign `.sig`，同时提供
 `SHA256SUMS` 与 `data-migrator.minisign.pub`。验证签名前应通过可信渠道确认公钥。

--- a/src/apps/data-migrator/RELEASE.md
+++ b/src/apps/data-migrator/RELEASE.md
@@ -1,16 +1,129 @@
-Optional, independently downloaded BitFun → OpenBitFun data migrator.
+# BitFun → OpenBitFun Data Migrator
 
-Extract the Windows ZIP and double-click the migrator, or open the macOS/Linux
-package. Close all BitFun/OpenBitFun data writers first. Review source,
-destination and the preflight plan before importing. Source data is retained;
-interrupted runs can be resumed from Saved migration tasks.
+将旧版 BitFun 的配置、会话、工作区及其他受支持数据迁移到 OpenBitFun。迁移器保留旧版数据，不会自动删除 BitFun 的数据目录。
 
-Declared source range: BitFun >=0.2.0,<1.0.0. Archived integration fixture: 0.2.19.
-The tool uses explicit storage-format validation and rejects unsupported data.
-No main application installation, login, network or restart handoff is required.
+Migrate settings, sessions, workspaces, and other supported data from BitFun to OpenBitFun. The migrator preserves the original BitFun data and does not automatically delete its data directories.
 
-See the README files at this release tag for compatibility, recovery, build and
-signature verification details. Every package carries a SHA-256 sidecar and a
-verified detached minisign signature. Platform code signing/notarization is not
-configured by this workflow. This draft requires maintainer review and platform
-launch checks before publication.
+最新版本与使用指南：[中文](https://github.com/GCWing/OpenBitFun/blob/main/src/apps/data-migrator/README.zh-CN.md) · Latest release and guide: [English](https://github.com/GCWing/OpenBitFun/blob/main/src/apps/data-migrator/README.md)
+
+## 中文
+
+### 支持版本
+
+- **来源：BitFun 0.2.17～0.2.19 正式版。**
+- **目标：OpenBitFun 1.0。**
+- 暂不支持直接迁移 BitFun 0.2.16 及更早版本。请先升级旧版 BitFun，并启动确认原有数据正常后再迁移。
+
+### 如何使用
+
+1. 下载本 Release 中适合你系统的迁移器，完成解压（如有）。Windows 用户解压 ZIP 后双击迁移器运行。
+2. 完全退出 BitFun 和 OpenBitFun。
+3. 使用原来运行 BitFun 的系统用户启动迁移器。
+4. 按界面提示确认来源和目标目录，选择需要迁移的数据，然后开始迁移。
+5. 迁移完成后，检查结果中的警告和跳过项，再启动 OpenBitFun 确认数据。
+
+建议迁移前备份数据，并在确认迁移结果前保留旧版 BitFun 数据。中断的迁移可以从已保存的迁移任务中恢复。
+
+### 异常排障
+
+**迁移完成，但工作区或会话为空、部分数据缺失**
+
+如果之前已经启动过 OpenBitFun 或执行过迁移，目标目录中的已有数据可能被优先保留，重试时不会覆盖。
+
+如果 OpenBitFun 中没有需要保留的新数据，可以清空目标数据后重新迁移：
+
+1. 完全退出 BitFun、OpenBitFun 和迁移器。
+2. 备份以下目录，然后删除它们。**这会清除 OpenBitFun 的现有配置、会话及其他本地数据。**
+3. 重新运行迁移器，完成后再启动 OpenBitFun。
+
+Windows 目标目录：
+
+```text
+%APPDATA%\openbitfun
+%USERPROFILE%\.openbitfun
+%LOCALAPPDATA%\OpenBitFun
+```
+
+**重试后仍然异常**
+
+请在 [GitHub Issues](https://github.com/GCWing/OpenBitFun/issues) 提交问题，或在 OpenBitFun 用户微信群中反馈，并提供：
+
+- 操作系统、BitFun 版本、OpenBitFun 版本和迁移器版本。
+- 操作步骤、预期结果及实际结果。
+- 缺失数据所属的工作区、会话名称或 ID。
+- 对应运行的迁移日志。
+
+Windows 迁移日志目录：
+
+```text
+%APPDATA%\openbitfun\data\migrations\bitfun-to-openbitfun\runs\<运行ID>\
+```
+
+请提供对应运行目录中的日志文件，例如 `report.json`、`plan.json`、`journal.jsonl`、`locations.json` 和 `release-observation.json`（如存在）。`stage` 和 `backup` 目录包含个人数据，是否一并提供可自行选择；初次反馈通常只需上述日志文件。如果准备清空目标目录重试，请先保存这份日志。
+
+提交前请检查日志中的用户名、路径等个人信息，按需脱敏。
+
+### 下载校验
+
+每个安装包均附带 SHA-256 校验文件和 minisign 分离签名。该发布流程未配置平台代码签名或 macOS 公证。兼容性、恢复及签名校验说明请参阅本 Release 标签下的迁移器 README。
+
+## English
+
+### Supported versions
+
+- **Source: stable BitFun releases 0.2.17–0.2.19.**
+- **Target: OpenBitFun 1.0.**
+- Direct migration from BitFun 0.2.16 or earlier is not supported. Upgrade BitFun first, then launch it and verify that your existing data is accessible before migrating.
+
+### How to use
+
+1. Download the migrator for your system from this release and extract it if necessary. On Windows, extract the ZIP and double-click the migrator.
+2. Fully quit BitFun and OpenBitFun.
+3. Run the migrator under the same system account you used for BitFun.
+4. Follow the prompts to confirm the source and destination directories, select the data to migrate, and start migration.
+5. Review any warnings or skipped items, then launch OpenBitFun and check your data.
+
+Back up your data before migrating. Keep the original BitFun data until you have verified the results. Interrupted runs can be resumed from saved migration tasks.
+
+### Troubleshooting
+
+**Migration finishes, but workspaces or sessions are empty, or some data is missing**
+
+If you have already launched OpenBitFun or run a migration, existing destination data may take precedence and remain unchanged during retries.
+
+If OpenBitFun contains no new data you need to keep, you can clear its destination data and retry:
+
+1. Fully quit BitFun, OpenBitFun, and the migrator.
+2. Back up the following directories, then delete them. **This removes existing OpenBitFun settings, sessions, and other local data.**
+3. Run the migrator again, then launch OpenBitFun after migration finishes.
+
+Windows destination directories:
+
+```text
+%APPDATA%\openbitfun
+%USERPROFILE%\.openbitfun
+%LOCALAPPDATA%\OpenBitFun
+```
+
+**The issue persists after retrying**
+
+Open a report in [GitHub Issues](https://github.com/GCWing/OpenBitFun/issues) or share your feedback in the OpenBitFun user WeChat group. Include:
+
+- Your operating system and the BitFun, OpenBitFun, and migrator versions.
+- Steps to reproduce, the expected result, and the actual result.
+- The workspace and session name or ID associated with missing data.
+- Migration logs from the affected run.
+
+Windows migration log location:
+
+```text
+%APPDATA%\openbitfun\data\migrations\bitfun-to-openbitfun\runs\<run-id>\
+```
+
+Provide the log files from the affected run, such as `report.json`, `plan.json`, `journal.jsonl`, `locations.json`, and `release-observation.json` when present. The `stage` and `backup` directories contain personal data, so sharing them is optional and at your discretion; the log files listed above are usually sufficient for an initial report. Save the logs before clearing the destination directories for another attempt.
+
+Review the logs for personal information, such as usernames and paths, and redact it as needed before submitting.
+
+### Download verification
+
+Each package includes a SHA-256 checksum file and a detached minisign signature. Platform code signing and macOS notarization are not configured by this release workflow. See the migrator README at this release tag for compatibility, recovery, and signature verification details.


### PR DESCRIPTION
- Align English and Chinese guides with supported versions
- Add the latest download link and release maintenance guidance
- Document backing up and clearing destination data before retrying
- Add log locations and GitHub Issues and WeChat feedback channels
- Clarify that sharing stage and backup personal data is optional
- Sync the bilingual release template with the updated instructions
