### PR TITLE
docs(deploy): document live origin 1.X release-sync cutover

### DIFF
--- a/deploy/openbitfun-host/README.md
+++ b/deploy/openbitfun-host/README.md
@@ -246,6 +246,32 @@ python3 -c "import json; print(json.load(open(\"/srv/openbitfun-release/download
 `version`。日志里若再出现 `Failed to download openbitfun-installer.exe`，说明跑到了
 旧脚本，停下来改 cron，不要手工改清单。
 
+稳定镜像跟随 GitHub `/releases/latest`，不按版本名是否包含 `beta` 分类。
+例如 `v1.0.0-beta` 是 `prerelease=false` 的 Latest，必须进入默认稳定镜像；
+`OPENBITFUN_RELEASE_CHANNEL=beta` 读取的是独立的 `channel-v1-beta`。
+
+#### 已有源站的 1.X 同步切换
+
+2026-09-11 的故障来自部署未对齐：root cron 仍执行
+`/root/repos/BitFun/scripts/openbitfun-release-sync.sh`，读取兼容旧客户端的
+`latest.json` 得到 0.2.19，随后因 Relay 仓库名称校验失败退出。只更新
+OpenBitFun checkout 不会修改已有 crontab。
+
+在仍运行的源站修复时，先备份当前 crontab、同步脚本与根清单，再核对：
+
+- cron 只执行 `/root/repos/OpenBitFun/scripts/openbitfun-release-sync.sh`，日志为
+  `/var/log/openbitfun-release-sync.log`。只替换该任务行，保留其它任务。
+- 实际执行的脚本读取 `latest-v1.json` 和 `linux-binaries-v1.json`，并校验
+  `ghcr.io/gcwing/openbitfun-relay-server`。不要放宽校验来兼容错配的新旧清单。
+- 脚本输出与 Nginx `/release/` alias 必须指向同一目录。当前 `lwb` 保留
+  `/srv/bitfun-release` 的历史文件，以 `/srv/openbitfun-release` 软链接指向它；
+  Nginx 仍使用原 alias。迁移到新机时复制真实文件到新的标准目录，不能只复制
+  指向旧路径的软链接。
+- 手动执行一次脚本，等日志出现 `sync complete`，再检查公网下载页、
+  `downloads.json`、`latest-v1.json`、`linux-binaries-v1.json` 及所有平台下载链接。
+  比较切换前后的旧清单 SHA-256，确认 `latest.json`、`linux-binaries.json`
+  保持不变，并验证旧版本下载链接仍可用。
+
 锁文件默认是 `/var/lock/openbitfun-release-sync.lock`，不要再指向
 `/root/repos/OpenBitFun-AutoUpdate/sync.lock`，也不要放进 `/srv/openbitfun-release`
 （该目录由 Nginx `/release/` 对外提供）。


### PR DESCRIPTION
## Summary
- Document that the production stable release mirror follows GitHub `/releases/latest`, so a Latest tag such as `v1.0.0-beta` must land in the default channel rather than being classified by the version name.
- Record the 2026-09-11 live-origin cutover: retarget root cron to the in-repo OpenBitFun sync script, keep other cron jobs, and do not rewrite the full crontab.
- Keep Relay image-name validation and the 0.2 legacy manifests intact while verifying public download links after a manual `sync complete`.

## Test plan
- [ ] Read `deploy/openbitfun-host/README.md` section “已有源站的 1.X 同步切换” against the live `lwb` cron, script path, and `/release/` alias.
- [ ] Confirm the documented script still reads `latest-v1.json` / `linux-binaries-v1.json` and checks `ghcr.io/gcwing/openbitfun-relay-server`.
- [ ] Confirm legacy `latest.json` and `linux-binaries.json` remain unchanged after a successful sync.