### PR TITLE
fix(mobile-web): retain login and connection identity on refresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -655,6 +655,10 @@ jobs:
         if: needs.build-impact.outputs.frontend_required != 'false'
         run: pnpm --dir src/mobile-web run type-check
 
+      - name: Test mobile web account login and reload
+        if: needs.build-impact.outputs.frontend_required != 'false'
+        run: pnpm --dir src/mobile-web run test:account-login
+
       - name: Build mobile web
         if: needs.build-impact.outputs.frontend_required != 'false'
         run: pnpm run build:mobile-web

--- a/src/mobile-web/src/App.tsx
+++ b/src/mobile-web/src/App.tsx
@@ -11,6 +11,7 @@ import {
   RemoteSessionManager,
 } from './services/RemoteSessionManager';
 import { reconcileAccountOwner } from './services/accountOwner';
+import { clearCloudAccountSession } from './services/CloudAccountSessionStore';
 import {
   clearMobileNavigation,
   saveMobileNavigation,
@@ -287,6 +288,7 @@ const AppContent: React.FC = () => {
 
   const handleDisconnect = useCallback(() => {
     navigationRef.current = null;
+    clearCloudAccountSession();
     clearMobileNavigation();
     setAccountDirectoryOpen(false);
     setPreferredDeviceId(undefined);

--- a/src/mobile-web/src/pages/PairingPage.tsx
+++ b/src/mobile-web/src/pages/PairingPage.tsx
@@ -17,12 +17,17 @@ interface PairingPageProps {
     preferredDeviceId?: string, navigation?: PairedNavigation) => void;
 }
 
+let fallbackInstallId: string | undefined;
+
 function installId(): string {
   const key = 'openbitfun.mobile.controller_id';
-  const existing = sessionStorage.getItem(key);
-  if (existing) return existing;
-  const created = generateRequestId();
-  sessionStorage.setItem(key, created);
+  try {
+    const existing = sessionStorage.getItem(key);
+    if (existing) return existing;
+  } catch { /* Unavailable storage must not break the sign-in page on mount. */ }
+  const created = fallbackInstallId ??= generateRequestId();
+  try { sessionStorage.setItem(key, created); }
+  catch { /* Retain an identity for this page when persistence is unavailable. */ }
   return created;
 }
 
@@ -38,6 +43,7 @@ const PairingPageContent: React.FC<PairingPageProps> = ({ onPaired }) => {
   const pending = useRef<AbortController | null>(null);
   const popup = useRef<Window | null>(null);
   const onPairedRef = useRef(onPaired);
+  const restoreAttempted = useRef(false);
   onPairedRef.current = onPaired;
   const targetDeviceId = accountDeviceIdFromHash(window.location.hash) || undefined;
 
@@ -56,12 +62,14 @@ const PairingPageContent: React.FC<PairingPageProps> = ({ onPaired }) => {
     const navigation = restore ? loadMobileNavigation(scope) : null;
     session.masterKey.fill(0);
     onPairedRef.current(client, new RemoteSessionManager(client),
-      targetDeviceId || navigation?.deviceId || undefined, { scope, restored: navigation });
+      navigation?.deviceId || targetDeviceId || undefined, { scope, restored: navigation });
   };
 
   useEffect(() => {
-    // Only opening a target invitation resumes the tab's authenticated controller.
-    if (targetDeviceId) {
+    // Resume both direct entry and invitations. StrictMode replays mount effects;
+    // one route must hand its restored connection to the app only once.
+    if (!restoreAttempted.current) {
+      restoreAttempted.current = true;
       const id = installId();
       const saved = loadMatchingCloudAccountSession(relayUrl, '', id);
       if (saved) connect(saved.session, id, true);

--- a/src/mobile-web/src/services/CloudAccountSessionStore.ts
+++ b/src/mobile-web/src/services/CloudAccountSessionStore.ts
@@ -29,7 +29,7 @@ export interface StoredCloudAccountSession {
   session: CloudAccountSession;
 }
 
-type StorageLike = Pick<Storage, 'getItem' | 'setItem'>;
+type StorageLike = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
 
 function stringField(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
@@ -103,6 +103,12 @@ export function saveCloudAccountSession(
   } catch {
     // Private browsing and constrained webviews may reject browser storage.
   }
+}
+
+/** Explicit disconnect/sign-out only; failed requests must retain the record. */
+export function clearCloudAccountSession(storage: StorageLike | null = storageOrNull()): void {
+  try { storage?.removeItem(ACCOUNT_SESSION_STORAGE_KEY); }
+  catch { /* Browser storage may be unavailable. */ }
 }
 
 export function loadMatchingCloudAccountSession(

--- a/src/mobile-web/src/services/controlClientIdentity.ts
+++ b/src/mobile-web/src/services/controlClientIdentity.ts
@@ -1,10 +1,24 @@
 let identity: { id: string; name: string } | undefined;
+const STORAGE_KEY = 'openbitfun.mobile.control_client_id';
 
-/** One identity per browser page, shared by managers across target/reconnect changes. */
-export function getControlClientIdentity(): { id: string; name: string } {
-  if (identity) return identity;
+function tabClientId(): string {
+  let storage: Storage | undefined;
+  try {
+    storage = window.sessionStorage;
+    const saved = storage.getItem(STORAGE_KEY);
+    if (saved && /^[a-f0-9]{32}$/.test(saved)) return saved;
+  } catch { /* Keep a page identity when browser storage is unavailable. */ }
   const bytes = crypto.getRandomValues(new Uint8Array(16));
   const id = Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('');
+  try { storage?.setItem(STORAGE_KEY, id); }
+  catch { /* Keep the in-memory identity even if persistence fails. */ }
+  return id;
+}
+
+/** One identity per browser tab, retained across reloads and target/reconnect changes. */
+export function getControlClientIdentity(): { id: string; name: string } {
+  if (identity) return identity;
+  const id = tabClientId();
   const ua = navigator.userAgent;
   const browser = /Edg\//.test(ua) ? 'Edge'
     : /Firefox\/|FxiOS\//.test(ua) ? 'Firefox'

--- a/src/mobile-web/tests/account-login.test.mjs
+++ b/src/mobile-web/tests/account-login.test.mjs
@@ -6,7 +6,7 @@ import ts from 'typescript';
 async function loadSource(relativePath, imports = {}) {
   const source = await readFile(new URL(relativePath, import.meta.url), 'utf8');
   let code = ts.transpileModule(source, {
-    compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2020 },
+    compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2020, jsx: ts.JsxEmit.React },
   }).outputText;
   code = code.replace(/from (['"])([^'"]+)\1/g, (_, quote, specifier) => (
     `from ${JSON.stringify(imports[specifier] ?? import.meta.resolve(specifier))}`
@@ -244,4 +244,167 @@ test('GitHub profile ignores corrupt/foreign cache and stale account responses',
         return { ok: true, json: async () => githubUser };
       });
   }
+});
+
+
+function memoryStorage() {
+  const entries = new Map();
+  return {
+    getItem: key => entries.get(key) ?? null,
+    setItem: (key, value) => entries.set(key, value),
+    removeItem: key => entries.delete(key),
+  };
+}
+
+const encryptionModule = await loadSource('../src/services/E2EEncryption.ts');
+const accountStoreModule = await loadSource('../src/services/CloudAccountSessionStore.ts', {
+  './E2EEncryption': encryptionModule.url, './pairingLink': links.url,
+});
+const accountStore = await import(accountStoreModule.url);
+const storedAccount = {
+  relayUrl: 'http://192.168.1.9:9700', username: '123', controllerDeviceId: 'browser-a',
+  session: { token: 'test-token', userId: '123', masterKey: new Uint8Array(32).fill(7) },
+};
+
+test('existing v2 account proof survives reload, stays scoped, and is removed only on explicit disconnect', () => {
+  const storage = memoryStorage();
+  const legacy = JSON.stringify({
+    version: 2, relay_url: storedAccount.relayUrl, username: '123', token: 'test-token',
+    user_id: '123', device_secret: Buffer.alloc(32, 7).toString('base64'), controller_device_id: 'browser-a',
+  });
+  storage.setItem('openbitfun.mobile.account_session.v2', legacy);
+  const restored = accountStore.loadMatchingCloudAccountSession(storedAccount.relayUrl, '', 'browser-a', storage);
+  assert.deepEqual(restored, storedAccount);
+  accountStore.saveCloudAccountSession(restored, storage);
+  assert.deepEqual(JSON.parse(storage.getItem('openbitfun.mobile.account_session.v2')), JSON.parse(legacy));
+  for (const [relay, username, controllerId] of [
+    ['https://remote.openbitfun.com/v/1.0.0', '', 'browser-a'],
+    [storedAccount.relayUrl, '', 'browser-b'], [storedAccount.relayUrl, '456', 'browser-a'],
+  ]) assert.equal(accountStore.loadMatchingCloudAccountSession(relay, username, controllerId, storage), null);
+  assert.equal(storage.getItem('openbitfun.mobile.account_session.v2'), legacy);
+  accountStore.clearCloudAccountSession(storage);
+  assert.equal(accountStore.loadMatchingCloudAccountSession(storedAccount.relayUrl, '', 'browser-a', storage), null);
+  for (const raw of ['{', JSON.stringify({ version: 99 })]) {
+    storage.setItem('openbitfun.mobile.account_session.v2', raw);
+    assert.equal(accountStore.loadMatchingCloudAccountSession(storedAccount.relayUrl, '', 'browser-a', storage), null);
+    assert.equal(storage.getItem('openbitfun.mobile.account_session.v2'), raw);
+  }
+});
+
+function inlineModule(code) {
+  return `data:text/javascript;base64,${Buffer.from(code).toString('base64')}`;
+}
+
+test('pairing mount resumes plain and QR routes once, retains switched target, and stays signed out after disconnect', async () => {
+  // Execute the real page's mount effects, including StrictMode effect replay.
+  // Stub presentation and network owners; restore must never start OAuth/login.
+  const hooksUrl = inlineModule(`
+    export const effects = [];
+    export const useEffect = fn => effects.push(fn);
+    export const useRef = current => ({ current });
+    export const useState = initial => [typeof initial === 'function' ? initial() : initial, () => {}];
+    export default { createElement: (type, props) => ({ type, props }) };
+  `);
+  const { effects } = await import(hooksUrl);
+  const noopUrl = inlineModule('export default () => null;');
+  const pairingModule = await loadSource('../src/pages/PairingPage.tsx', {
+    react: hooksUrl, '../components/PairingForm': noopUrl,
+    '../services/pairingLink': links.url,
+    '../i18n': inlineModule('export const useI18n = () => ({ t: key => key });'),
+    '../theme': inlineModule('export const useTheme = () => ({ isDark: false });'),
+    '../assets/openbitfun-mark-dark.png': noopUrl, '../assets/openbitfun-mark-light.png': noopUrl,
+    '../services/CloudAccountClient': inlineModule(`
+      export class CloudAccountClient { constructor() { throw new Error('Restore started OAuth'); } }
+      export const generateRequestId = () => 'new-browser';
+    `),
+    '../services/CloudAccountSessionStore': accountStoreModule.url,
+    '../services/MobileNavigationStore': navigationModule.url,
+    '../services/RelayHttpClient': inlineModule(`
+      export class RelayHttpClient { constructor(url, identity) { this.identity = structuredClone(identity); } }
+    `),
+    '../services/RemoteSessionManager': inlineModule('export class RemoteSessionManager {}'),
+    '../services/store': inlineModule(`
+      export const useMobileStore = { getState: () => ({ resetForDeviceSwitch() {},
+        setAuthenticatedUserId() {}, setAuthenticatedUserLabel() {}, setControlTarget() {}, setConnectionStatus() {} }) };
+    `),
+  });
+  const { default: PairingPage } = await import(pairingModule.url);
+  const previous = { window: globalThis.window, sessionStorage: globalThis.sessionStorage };
+  try {
+    for (const base of ['http://192.168.1.9:9700/', 'https://remote.openbitfun.com/v/1.0.0/']) {
+      for (const hash of ['', '#/pair?did=desktop-a']) {
+        const location = new URL(base + hash);
+        const relayUrl = base.replace(/\/$/, '');
+        const storage = memoryStorage();
+        globalThis.window = { location, sessionStorage: storage };
+        globalThis.sessionStorage = storage;
+        storage.setItem('openbitfun.mobile.controller_id', 'browser-a');
+        accountStore.saveCloudAccountSession({ ...storedAccount, relayUrl }, storage);
+        saveMobileNavigation({ accountId: '123', controllerDeviceId: 'browser-a', relayUrl,
+          routeKey: location.pathname + hash }, { deviceId: 'desktop-b',
+          session: { id: 'task-b', name: 'Task', agentType: 'Standard' } }, storage);
+        const paired = [];
+        const mount = () => {
+          effects.length = 0;
+          const content = PairingPage({ onPaired: (...args) => paired.push(args) });
+          effects.length = 0;
+          content.type(content.props);
+          const cleanup = effects[0]();
+          cleanup();
+          effects[0]();
+        };
+        mount();
+        assert.equal(paired.length, 1);
+        assert.equal(paired[0][0].identity.token, 'test-token');
+        assert.deepEqual(paired[0][0].identity.masterKey, storedAccount.session.masterKey);
+        assert.equal(paired[0][2], 'desktop-b');
+        assert.equal(paired[0][3].restored.session.id, 'task-b');
+        mount(); // Same storage, new component refs: a full reload.
+        assert.equal(paired.length, 2);
+        accountStore.clearCloudAccountSession();
+        mount();
+        assert.equal(paired.length, 2, 'disconnect must not restore the saved account again');
+      }
+    }
+    globalThis.window = { location: new URL('http://192.168.1.9:9700/'),
+      get sessionStorage() { throw new Error('blocked'); } };
+    globalThis.sessionStorage = { getItem() { throw new Error('blocked'); },
+      setItem() { throw new Error('blocked'); } };
+    effects.length = 0;
+    const content = PairingPage({ onPaired: () => assert.fail('unavailable storage restored an account') });
+    effects.length = 0;
+    content.type(content.props);
+    assert.doesNotThrow(() => effects[0]());
+    const app = await readFile(new URL('../src/App.tsx', import.meta.url), 'utf8');
+    assert.match(app.slice(app.indexOf('const handleDisconnect'), app.indexOf('const isAnimating')), /clearCloudAccountSession\(\)/);
+  } finally {
+    globalThis.window = previous.window;
+    globalThis.sessionStorage = previous.sessionStorage;
+  }
+});
+
+test('control ping identity survives module reloads but independent tabs keep separate connections', async () => {
+  const module = await loadSource('../src/services/controlClientIdentity.ts');
+  const previousWindow = globalThis.window;
+  let page = 0;
+  const reload = async () => (await import(`${module.url}#page-${page++}`)).getControlClientIdentity;
+  try {
+    const storage = memoryStorage();
+    globalThis.window = { sessionStorage: storage };
+    const firstPage = await reload();
+    const identity = firstPage();
+    assert.equal(firstPage(), identity);
+    for (let i = 0; i < 3; i++) assert.deepEqual((await reload())(), identity);
+    globalThis.window = { sessionStorage: memoryStorage() };
+    assert.notEqual((await reload())().id, identity.id);
+    for (const blocked of [
+      { get sessionStorage() { throw new Error('blocked'); } },
+      { sessionStorage: { getItem: () => null, setItem: () => { throw new Error('quota'); } } },
+    ]) {
+      globalThis.window = blocked;
+      const getIdentity = await reload();
+      assert.match(getIdentity().id, /^[a-f0-9]{32}$/);
+      assert.equal(getIdentity(), getIdentity());
+    }
+  } finally { globalThis.window = previousWindow; }
 });


### PR DESCRIPTION
## Summary

Fix mobile-web refreshes returning users to GitHub sign-in and adding another browser connection to the desktop's connected-client list. Same-tab reloads now restore the saved account and reuse the control client ID.

## Type and Areas

Type: Bug fix

Areas: Mobile web, Remote Connect

## Motivation / Impact

Account restoration was gated on a device invitation in the URL, so direct entry ignored the saved account after a refresh. The control ping ID was also generated per page load, causing the desktop's existing ID-based connection tracking to count each reload separately.

- Restore the tab's account on both direct and invitation routes, with one handoff during StrictMode effect replay.
- Persist the control ping ID in sessionStorage so reloads update the existing connection.
- Restore the last selected device and session within the matching navigation scope, including a device selected after opening an invitation.
- Clear saved account proof on explicit disconnect so automatic restoration does not immediately reconnect; keep the sign-in page usable when browser storage is unavailable.
- Run the mobile account/reload regression suite in frontend CI alongside type-checking and builds.

## Verification

Passed locally (36 tests total):

- `pnpm --dir src/mobile-web run test:account-login` — 14 tests, including page mount/effect replay, repeated reloads, explicit disconnect, existing v2 account records, scoped restoration, independent tab identities, and unavailable storage.
- `pnpm --dir src/mobile-web run test:ui-components` — 10 tests.
- `pnpm --dir src/mobile-web run test:images` — 4 tests.
- `pnpm --dir src/mobile-web run test:workspace-identity` — 8 tests.
- `pnpm --dir src/mobile-web run type-check`
- `pnpm run build:mobile-web`
- `git diff --check`
- `node scripts/check-git-object-sizes.mjs --base upstream/main --head HEAD`
- `pnpm run check:github-config`
- `pnpm --dir src/web-ui run test:run src/app/components/RemoteConnectDialog/RelayHttpClient.generation.test.ts src/app/components/RemoteConnectDialog/RemoteSessionManager.routing.test.ts src/app/components/RemoteConnectDialog/ConnectionHealth.generation.test.tsx src/app/components/RemoteConnectDialog/ControlTargetEpoch.subscription.test.tsx src/app/components/RemoteConnectDialog/SessionListTargetInitialization.test.tsx` — 39 additional tests passed, covering stale account/target responses, disconnect isolation, heartbeat lifecycle, and target initialization.

Remote scenario coverage: local Node tests simulate the remote-control client's LAN and official relay entry URLs, persisted credentials, and page reloads. Network/presentation owners are stubbed in the mount test. No real browser/device, live GitHub OAuth, LAN host, or official relay end-to-end session was exercised. Remote workspace, Peer Device Mode, and Detached Dispatch were not exercised.

Manual verification still to run in Chrome on Windows (the reported browser): sign in from a direct URL and a device invitation, select a desktop/session, and refresh repeatedly. Confirm that the account/session resumes and the desktop connection count stays stable. Switch devices and refresh again; then explicitly disconnect and verify the sign-in page remains after a refresh. Repeat on a mobile browser through LAN and official relay paths.

## Reviewer Notes

AI-assisted implementation; automated checks passed, manual end-to-end testing remains outstanding. Runtime changes are limited to mobile-web; frontend CI now also runs its account/reload suite. Existing account/navigation formats and the ping wire payload are preserved, with no backend protocol change or user data migration. Credentials retain their existing tab lifetime. Old connection entries created before this fix remain subject to the host's existing lease expiry.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable (no copy changes).
