### PR TITLE
fix(tray): Disable the menu on left click

### DIFF
--- a/src/apps/desktop/src/tray.rs
+++ b/src/apps/desktop/src/tray.rs
@@ -204,6 +204,7 @@ pub fn setup_tray(
     let tray = TrayIconBuilder::new()
         .icon(icon)
         .menu(&initial_menu)
+        .show_menu_on_left_click(false)
         .tooltip("OpenBitFun")
         .on_menu_event(|app, event| {
             let id = event.id.as_ref();


### PR DESCRIPTION
Keep left clicks dedicated to toggling the main window while
preserving the right-click menu. This prevents menu flicker and
the gray outline left behind when hiding the window on Windows.
