### PR TITLE
refactor(flowchat): Simplify background commands

### DIFF
--- a/src/web-ui/src/flow_chat/components/modern/FlowChatHeader.scss
+++ b/src/web-ui/src/flow_chat/components/modern/FlowChatHeader.scss
@@ -396,9 +396,7 @@
 
   &__background-command-list-item-button {
     display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 2px;
+    align-items: center;
     width: 100%;
     padding: var(--openbitfun-space-2);
     border: 0;
@@ -492,18 +490,27 @@
       opacity: 0.82;
     }
 
-    span:not([data-overflow-content]) {
+    span:not([data-overflow-content]):not(.flowchat-header__background-command-icon) {
       min-width: 0;
       overflow: hidden;
     }
   }
 
-  &__background-command-list-meta {
-    width: 100%;
-    font-size: var(--openbitfun-type-flow-support-font-size);
-    color: var(--openbitfun-color-content-secondary);
-    white-space: nowrap;
-    overflow: hidden;
+  &__background-command-icon {
+    position: relative;
+    display: inline-flex;
+    flex: 0 0 auto;
+
+    &[data-running='true']::after {
+      content: '';
+      position: absolute;
+      right: -1px;
+      bottom: -1px;
+      width: 4px;
+      height: 4px;
+      border-radius: 50%;
+      background: var(--openbitfun-color-status-success-emphasis);
+    }
   }
 
   // ==================== Actions ====================

--- a/src/web-ui/src/flow_chat/components/modern/FlowChatHeader.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/FlowChatHeader.test.tsx
@@ -439,7 +439,7 @@ describe('FlowChatHeader', () => {
     expect(items[2]?.querySelector('svg')).toBeNull();
     expect(panel?.querySelector('[data-testid="flowchat-header-session-tree-content"]')).not.toBeNull();
     expect(panel?.querySelector('[data-testid="flowchat-header-background-empty"]')?.textContent)
-      .toBe('flowChatHeader.backgroundTerminalEmpty');
+      .toBe('flowChatHeader.backgroundCommandEmpty');
     expect(panel?.querySelector('[data-testid="flowchat-header-pull-requests-empty"]')?.textContent)
       .toBe('flowChatHeader.pullRequestEmpty');
     expect(panel?.querySelector('[data-testid="flowchat-header-session-overview-back"]')).toBeNull();
@@ -468,7 +468,7 @@ describe('FlowChatHeader', () => {
     );
 
     const panel = document.querySelector<HTMLElement>('.flowchat-header__session-overview-panel');
-    expect(commandSection?.textContent).toContain('flowChatHeader.backgroundTerminalEmpty');
+    expect(commandSection?.textContent).toContain('flowChatHeader.backgroundCommandEmpty');
     expect(panel?.parentElement?.getAttribute('data-openbitfun-overlay-host')).toBe('true');
     expect(panel?.style.visibility).toBe('visible');
     expect(panel?.hasAttribute('data-openbitfun-view')).toBe(false);

--- a/src/web-ui/src/flow_chat/components/modern/FlowChatHeader.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/FlowChatHeader.tsx
@@ -548,7 +548,7 @@ export const FlowChatHeader: React.FC<FlowChatHeaderProps> = ({
       ? t('flowChatHeader.sessionOverviewBackgroundFinished', {
           count: backgroundCommandCount,
         })
-      : t('flowChatHeader.backgroundTerminalEmpty');
+      : t('flowChatHeader.backgroundCommandEmpty');
   let pullRequestOverviewSummary: string;
   switch (pullRequestOverview.status) {
     case 'loading':
@@ -807,9 +807,6 @@ export const FlowChatHeader: React.FC<FlowChatHeaderProps> = ({
                   >
                     <span className="flowchat-header__session-overview-section-title">
                       <OverflowText>{t('flowChatHeader.backgroundCommandOverview')}</OverflowText>
-                      {runningBackgroundCommandCount > 0 ? (
-                        <span className="flowchat-header__session-overview-section-status" aria-hidden="true" />
-                      ) : null}
                     </span>
                     <span className="flowchat-header__session-overview-section-count" aria-hidden="true">
                       {backgroundCommandCount}
@@ -871,19 +868,20 @@ export const FlowChatHeader: React.FC<FlowChatHeaderProps> = ({
                             type="button"
                             className="flowchat-header__background-command-list-item-button flowchat-header__background-command-open-button"
                             onClick={() => handleCommandSelect(command)}
+                            aria-label={`${command.title}, ${t(command.status === 'running'
+                              ? 'flowChatHeader.backgroundCommandStatusRunning'
+                              : 'flowChatHeader.backgroundCommandStatusFinished')}`}
                           >
                             <span className="flowchat-header__background-command-list-title">
-                              <Icon name="terminal" size="xs" aria-hidden="true" />
+                              <span
+                                className="flowchat-header__background-command-icon"
+                                data-running={command.status === 'running' ? 'true' : undefined}
+                                aria-hidden="true"
+                              >
+                                <Icon name="terminal" size="xs" />
+                              </span>
                               <OverflowText>{command.title}</OverflowText>
                             </span>
-                            <OverflowText className="flowchat-header__background-command-list-meta">
-                              {[
-                                t('flowChatHeader.backgroundCommandSession', { id: command.execSessionId }),
-                                command.status === 'running'
-                                  ? t('flowChatHeader.backgroundCommandStatusRunning')
-                                  : t('flowChatHeader.backgroundCommandStatusFinished'),
-                              ].filter(Boolean).join(' · ')}
-                            </OverflowText>
                           </button>
                           {renderBackgroundCommandActions(command)}
                         </div>
@@ -897,7 +895,7 @@ export const FlowChatHeader: React.FC<FlowChatHeaderProps> = ({
                       data-openbitfun-state="empty"
                       data-testid="flowchat-header-background-empty"
                     >
-                      {t('flowChatHeader.backgroundTerminalEmpty')}
+                      {t('flowChatHeader.backgroundCommandEmpty')}
                     </div>
                   )}
                 </div>

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -1404,12 +1404,10 @@
       "error": "$t(shared:statuses.failed)",
       "idle": "Idle"
     },
-    "backgroundCommandOverview": "Background terminals",
+    "backgroundCommandOverview": "Background commands",
     "backgroundCommands": "Background commands ({{count}})",
     "backgroundCommandEmpty": "No background commands",
-    "backgroundTerminalEmpty": "No background terminals",
     "backgroundCommandUntitled": "Background command",
-    "backgroundCommandSession": "Session #{{id}}",
     "backgroundCommandStatusRunning": "Active",
     "backgroundCommandStatusFinished": "Finished",
     "backgroundCommandActions": "Command actions",

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -1404,12 +1404,10 @@
       "error": "$t(shared:statuses.failed)",
       "idle": "空闲"
     },
-    "backgroundCommandOverview": "后台终端",
+    "backgroundCommandOverview": "后台命令",
     "backgroundCommands": "后台命令（{{count}}）",
     "backgroundCommandEmpty": "暂无后台命令",
-    "backgroundTerminalEmpty": "暂无后台终端",
     "backgroundCommandUntitled": "后台命令",
-    "backgroundCommandSession": "会话 #{{id}}",
     "backgroundCommandStatusRunning": "进行中",
     "backgroundCommandStatusFinished": "已结束",
     "backgroundCommandActions": "命令操作",

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -1404,12 +1404,10 @@
       "error": "$t(shared:statuses.failed)",
       "idle": "閒置"
     },
-    "backgroundCommandOverview": "背景終端",
+    "backgroundCommandOverview": "背景命令",
     "backgroundCommands": "背景命令（{{count}}）",
     "backgroundCommandEmpty": "目前沒有背景命令",
-    "backgroundTerminalEmpty": "目前沒有背景終端",
     "backgroundCommandUntitled": "背景命令",
-    "backgroundCommandSession": "會話 #{{id}}",
     "backgroundCommandStatusRunning": "進行中",
     "backgroundCommandStatusFinished": "已結束",
     "backgroundCommandActions": "命令操作",


### PR DESCRIPTION
- Remove session IDs and status text from command rows.
- Indicate running commands with a green dot on the terminal icon,
  while preserving status in accessible labels.
- Remove the redundant activity dot from the section heading.
- Rename Background terminals to Background commands.
- Reuse the command empty-state key and remove unused translations.
