### PR TITLE
fix(ui): suppress native button hover highlights

### DIFF
--- a/design-system/packages/ui/src/components/Button/Button.module.css
+++ b/design-system/packages/ui/src/components/Button/Button.module.css
@@ -16,6 +16,9 @@
     --_button-trailing-icon-size: 14px;
 
     position: relative;
+    /* The component owns its surface; suppress native WebKit button highlights. */
+    -webkit-appearance: none;
+    appearance: none;
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -293,6 +296,11 @@
   }
 
   @media (prefers-reduced-motion: reduce) {
+    .button,
+    .button::before {
+      transition: none;
+    }
+
     .button[data-loading="true"] .progress {
       animation: none;
       border-inline-end-color: currentColor;

--- a/design-system/packages/ui/src/components/IconButton/IconButton.module.css
+++ b/design-system/packages/ui/src/components/IconButton/IconButton.module.css
@@ -8,6 +8,9 @@
     --_icon-button-size: var(--openbitfun-control-height-sm);
 
     position: relative;
+    /* Match Button: the pseudo-element owns hover feedback, not the native control. */
+    -webkit-appearance: none;
+    appearance: none;
     box-sizing: border-box;
     display: inline-flex;
     flex: 0 0 auto;
@@ -175,6 +178,7 @@
 
   @media (prefers-reduced-motion: reduce) {
     .button,
+    .button::before,
     .progress {
       transition: none;
     }


### PR DESCRIPTION
## Summary

Disable native button appearance in shared Button and IconButton so their CSS surfaces own hover feedback. Also disable their background transitions when reduced motion is requested.

## Type and Areas

Type: Bug fix / UI/UX

Areas: Shared design system, desktop/Tauri, Web UI

## Motivation / Impact

The Connect Devices button was reported to flash unwanted white lines along its upper and lower edges on hover in macOS. Button and IconButton draw their hover backgrounds through pseudo-elements but left native button appearance enabled. Explicitly disabling native appearance addresses that potential source of additional WebKit highlights across both shared controls while preserving their existing background transitions and keyboard focus rings.

## Verification

- `pnpm run design-system:test` — passed, including component builds and Design Lab type-check. A non-fatal warning reported an occupied HMR port (24678).
- `pnpm run motion:audit` — completed; the inventory reports one existing unrelated reduced-motion item in PortForwardDialog.scss.
- `git diff --check` — passed.
- macOS WebView visual reproduction and post-change visual verification were not performed; the reported white-line symptom still needs manual confirmation.
- Remote workspace, remote control, Peer Device Mode, and Detached Dispatch were not exercised. This change only touches shared component CSS.

## Reviewer Notes

Only two component stylesheets change. No token, data, protocol, or locale changes.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.
