### PR TITLE
fix(tests): repair test-target compile errors hidden from workspace check

### DIFF
--- a/src/crates/contracts/runtime-ports/src/agent_api.rs
+++ b/src/crates/contracts/runtime-ports/src/agent_api.rs
@@ -2492,6 +2492,7 @@ mod tests {
         let request = AgentSessionCreateRequest {
             session_name: "Generated session".to_string(),
             agent_type: "Standard".to_string(),
+            agent_route_key: None,
             workspace_path: Some("/workspace/project".to_string()),
             project_workspace_path: None,
             execution_target: None,
@@ -3466,6 +3467,7 @@ mod tests {
         let mode_request = AgentSessionModeUpdateRequest {
             session_id: "session_1".to_string(),
             mode_id: "Standard".to_string(),
+            agent_route_key: None,
         };
         let workspace_request = AgentSessionWorkspaceRequest {
             session_id: "session_1".to_string(),

--- a/src/crates/interfaces/app-server/src/server/handlers/app.rs
+++ b/src/crates/interfaces/app-server/src/server/handlers/app.rs
@@ -270,7 +270,6 @@ mod tests {
             "tui.mcp",
             EXTERNAL_SOURCES_CAPABILITY,
             crate::management::ACCOUNT_CAPABILITY,
-            crate::management::SETTINGS_SYNC_CAPABILITY,
             crate::management::WORKTREES_CAPABILITY,
         ] {
             let capability = capabilities


### PR DESCRIPTION
## Summary

Repairs three compile errors that live in `#[cfg(test)]` code and are therefore invisible to the repository's `cargo check --workspace` gate (which does not pass `--all-targets`).

Fixes #— (no tracking issue; happy to open one if you prefer)

## Type and Areas

Type: bug fix

Areas: Rust core (contracts / interfaces)

## Motivation / Impact

`cargo check --workspace`, the compilation gate used in CI, does not build test
targets. As a result three errors in test code have been sitting on `main`
undetected. Any editor that analyzes test targets — rust-analyzer does so by
default — reports them immediately, and `cargo check --all-targets` reproduces
them reliably:

```
error[E0063]: missing field `agent_route_key` in initializer of `agent_api::AgentSessionCreateRequest`
  --> src/crates/contracts/runtime-ports/src/agent_api.rs:2492:23

error[E0063]: missing field `agent_route_key` in initializer of `agent_api::AgentSessionModeUpdateRequest`
  --> src/crates/contracts/runtime-ports/src/agent_api.rs:3466:28

error[E0425]: cannot find value `SETTINGS_SYNC_CAPABILITY` in module `crate::management`
  --> src/crates/interfaces/app-server/src/server/handlers/app.rs:273:32
```

The first two are missing-field errors: `agent_route_key` was added to both
request structs, but two test initializers were never updated.

The third is a stale reference. `SETTINGS_SYNC_CAPABILITY` is referenced only at
that one site and is not defined in `crate::management`, elsewhere in the crate,
or anywhere in the repository. `AppManagementCapabilities` has no `settings`
field and no matching capability id is registered, so the assertion cannot be
satisfied and the line is removed. The remaining assertions
(`ACCOUNT_CAPABILITY`, `WORKTREES_CAPABILITY`, and the rest) are unchanged.

No direct user-facing change; the fix is confined to test code and makes local
`--all-targets` builds and IDE diagnostics clean.

## Verification

```
cargo check -p openbitfun-runtime-ports --all-targets --features ts   # pass
cargo check -p openbitfun-app-server --all-targets                    # pass
cargo check --workspace --all-targets                                 # 0 errors
cargo test -p openbitfun-runtime-ports --lib                          # 78 passed; 0 failed
cargo test -p openbitfun-app-server --lib                             # 27 passed; 0 failed
cargo fmt -p openbitfun-runtime-ports -p openbitfun-app-server --check # clean
```

The `--features ts` flag is included for runtime-ports because the TS binding
export tests are feature-gated and would otherwise skip the affected code.

## Reviewer Notes

Optional follow-up worth considering: CI runs `cargo check --locked --workspace`
without `--all-targets`, which is why these errors reached `main`. Adding
`--all-targets` (or a dedicated `cargo check --workspace --all-targets` job)
would close that gap for future changes. Not included here to keep the PR
focused.

This change was AI-assisted and is fully tested at the level of the commands
listed above.
