### PR TITLE
fix(input): preserve image previews after session switches

### DIFF
--- a/src/web-ui/src/flow_chat/components/ChatInput.tsx
+++ b/src/web-ui/src/flow_chat/components/ChatInput.tsx
@@ -935,7 +935,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       }
       collapseVerificationRafRef.current = requestAnimationFrame(() => {
         collapseVerificationRafRef.current = null;
-        measureIsMultiLine('collapse-confirmation');
+        measureIsMultiLineRef.current?.('collapse-confirmation');
       });
       return;
     }
@@ -962,8 +962,10 @@ export const ChatInput: React.FC<ChatInputProps> = ({
     if (!el) return;
     let rafId: number;
     const observer = new MutationObserver(() => {
+      cancelAnimationFrame(rafId);
       rafId = requestAnimationFrame(() => {
-        measureIsMultiLine('mutation-observer');
+        // Session restoration can change attachments after this observer mounts.
+        measureIsMultiLineRef.current?.('mutation-observer');
         checkDomEmpty();
       });
     });
@@ -972,9 +974,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       observer.disconnect();
       cancelAnimationFrame(rafId);
     };
-  // measureIsMultiLine / checkDomEmpty capture latest closure values
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [checkDomEmpty]);
 
   useEffect(() => {
     const containerEl = containerRef.current;


### PR DESCRIPTION
## Summary

Keep pasted image previews visible after switching away from a session and returning. Delayed DOM measurements and collapse confirmations now call the latest layout callback through its existing ref, and repeated DOM mutations coalesce into one pending animation frame.

## Type and Areas

Type: Bug fix

Areas: Web UI / chat composer

## Motivation / Impact

The DOM observer retained the callback from the composer's initial mount. Depending on its initial state and callback ordering, a later measurement could use an outdated image count, collapse the composer, and hide restored previews. Pasting another image could expand it again and reveal both attachments. Reading the current callback preserves the existing rule that image attachments keep the composer expanded.

## Verification

- `pnpm run check:web` passed, including TypeScript and appearance/theme checks.
- `pnpm --dir src/web-ui run test:run src/flow_chat/components/ChatInputImagePreview.test.tsx src/flow_chat/components/ChatInputDraftRecovery.test.ts src/flow_chat/components/ChatInputWorkspaceStripLayout.test.ts src/flow_chat/store/sessionComposerStore.test.ts src/app/services/sessionSceneLifecycle.test.ts src/flow_chat/services/sessionActivation.test.ts src/flow_chat/services/storeSync.test.ts src/app/stores/sceneStore.test.ts` passed: 8 files, 102 tests.
- An isolated simulation using the actual measurement and observer callbacks reproduced collapse with the stale callback and preserved expansion with the current callback. This does not establish the full live session-switch event ordering.
- `pnpm run desktop:dev` completed the Windows debug build and launched the application; the window responded and the local Vite endpoint returned HTTP 200.
- `git diff --check` passed.

## Reviewer Notes

This is a frontend scheduling fix. Attachment storage, session draft restoration, and the existing expansion rules are unchanged. No persisted or wire shapes change. Validation covered local Windows development and focused frontend tests; remote workspace, remote control, Peer Device Mode, and Detached Dispatch were not exercised end to end. The intermittent image-paste/session-switch sequence has not been confirmed in a live end-to-end test.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable. (Not applicable.)
