### PR TITLE
fix(harmonyos): refresh sidebar sessions without loading flicker

### DIFF
--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/actions/AppRootPresentationActions.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/actions/AppRootPresentationActions.ets
@@ -64,8 +64,9 @@ export interface SidebarPresentationActions {
   readonly scanDesktop: () => void;
   /** Opens the QR scanner from the device-section add button. */
   readonly addDesktop: () => void;
-  /** Refreshes account device presence from the relay. */
+  /** Refreshes device presence and the disclosed workspace session lists. */
   readonly refreshDevices: () => Promise<void>;
+  readonly refreshSessions: () => Promise<void>;
   readonly settings: () => void;
   readonly openAccount: () => void;
   readonly openSession: (session: RemoteSession) => void;
@@ -123,7 +124,7 @@ export function emptyAppRootPresentationActions(): AppRootPresentationActions {
     },
     onSidebar: {
       close: () => {}, newChat: () => {}, enterCode: () => {}, scanDesktop: () => {}, addDesktop: () => {},
-      refreshDevices: async () => {}, settings: () => {}, openAccount: () => {},
+      refreshDevices: async () => {}, refreshSessions: async () => {}, settings: () => {}, openAccount: () => {},
       openSession: () => {}, deleteSession: () => {}
     },
     onSettings: {

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/AppRootPresentation.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/AppRootPresentation.ets
@@ -311,6 +311,7 @@ export struct AppRootPresentation {
   }
 
   private restoreWideMasterPane(): void {
+    void this.actions.onSidebar.refreshSessions();
     const previewLayout = this.filePreviewLayout();
     if (WideLayoutGeometry.restoreMasterClosesPreview(previewLayout)) {
       // Focus split temporarily borrows the master pane's space. Restoring the

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/SidebarDeviceGroup.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/SidebarDeviceGroup.ets
@@ -41,13 +41,12 @@ struct SidebarWorkspaceGroup {
   @Param bodyIndent: number = 10;
   @Param expanded: boolean = false;
   @Param loadStatus: WorkspaceDirectoryStatus = 'idle';
+  @Param hasLoadedSessions: boolean = false;
   @Param supportsHarnessProfiles: boolean = false;
   @Event onOpenWorkspace: (path: string) => void = (_path: string) => {};
   @Event onExpandWorkspace: (path: string) => Promise<void> = async (_path: string) => {};
   @Event onExpandedChange: (path: string, expanded: boolean) => void =
     (_path: string, _expanded: boolean) => {};
-  @Event onLoadStatusChange: (path: string, status: WorkspaceDirectoryStatus) => void =
-    (_path: string, _status: WorkspaceDirectoryStatus) => {};
   @Event onCreateInWorkspace: (path: string, agentType: string) => void =
     (_path: string, _agentType: string) => {};
   @Event onOpenSession: (session: RemoteSession) => void = (_session: RemoteSession) => {};
@@ -55,18 +54,11 @@ struct SidebarWorkspaceGroup {
   @Local visibleSessionCount: number = SidebarDirectoryPreviewPolicy.PREVIEW_COUNT;
   @Local showCreateMenu: boolean = false;
 
-  @Monitor('sessions')
-  onSessionsChanged(): void {
-    if (this.sessions.length > 0) {
-      this.onLoadStatusChange(this.path, 'ready');
-    }
-  }
-
   build() {
     Column() {
       this.WorkspaceRow()
       if (this.expanded) {
-        if (this.loadStatus === 'loading') {
+        if (this.loadStatus === 'loading' && !this.hasLoadedSessions && this.sessions.length === 0) {
           this.SessionLoadingRow()
         } else if (this.loadStatus === 'failed') {
           this.SessionRetryRow()
@@ -293,17 +285,10 @@ struct SidebarWorkspaceGroup {
   }
 
   private async loadSessions(): Promise<void> {
-    if (this.loadStatus === 'loading') {
-      return;
-    }
-    this.onLoadStatusChange(this.path, 'loading');
     try {
       await this.onExpandWorkspace(this.path);
-      this.onLoadStatusChange(this.path, 'ready');
     } catch (_err) {
-      // Keep failure local to this branch; the retry row is answerable without
-      // collapsing it and sibling disclosure state stays untouched.
-      this.onLoadStatusChange(this.path, 'failed');
+      // The request owner records failure without clearing cached rows.
     }
   }
 
@@ -361,8 +346,6 @@ export struct SidebarDeviceGroup {
   @Event onExpandWorkspace: (path: string) => Promise<void> = async (_path: string) => {};
   @Event onWorkspaceExpandedChange: (path: string, expanded: boolean) => void =
     (_path: string, _expanded: boolean) => {};
-  @Event onWorkspaceLoadStatusChange: (path: string, status: WorkspaceDirectoryStatus) => void =
-    (_path: string, _status: WorkspaceDirectoryStatus) => {};
   @Local visibleWorkspaceCount: number = SidebarDirectoryPreviewPolicy.PREVIEW_COUNT;
   private readonly projectionCache: SessionListProjectionCache = new SessionListProjectionCache();
 
@@ -396,12 +379,11 @@ export struct SidebarDeviceGroup {
               supportsHarnessProfiles: this.supportsHarnessProfiles,
               bodyIndent: this.bodyIndent(),
               expanded: this.directoryState.workspaceExpanded(this.device.deviceId, entry.path),
-              loadStatus: this.sessionsFor(entry.path).length > 0 ?
-                'ready' : this.directoryState.workspaceStatus(this.device.deviceId, entry.path),
+              loadStatus: this.directoryState.workspaceStatus(this.device.deviceId, entry.path),
+              hasLoadedSessions: this.directoryState.workspaceHasLoadedSessions(this.device.deviceId, entry.path),
               onOpenWorkspace: this.onOpenWorkspace,
               onExpandWorkspace: this.onExpandWorkspace,
               onExpandedChange: this.onWorkspaceExpandedChange,
-              onLoadStatusChange: this.onWorkspaceLoadStatusChange,
               onCreateInWorkspace: this.onCreateInWorkspace,
               onOpenSession: this.onOpenSession,
               onSessionActions: this.onSessionActions

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/SidebarWorkspaceSection.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/SidebarWorkspaceSection.ets
@@ -4,7 +4,6 @@ import { RemoteI18n } from '../../i18n/RemoteI18n';
 import {
   DeviceDirectoryEntry,
   DeviceDirectoryState,
-  WorkspaceDirectoryStatus,
   emptyDeviceDirectoryEntry
 } from '../state/DeviceDirectoryState';
 import { SidebarDirectoryPreviewPolicy } from '../policy/SidebarDirectoryPreviewPolicy';
@@ -258,9 +257,6 @@ export struct SidebarWorkspaceSection {
         },
         onWorkspaceExpandedChange: (path: string, expanded: boolean): void => {
           this.directoryState.setWorkspaceExpanded(entry.deviceId, path, expanded);
-        },
-        onWorkspaceLoadStatusChange: (path: string, status: WorkspaceDirectoryStatus): void => {
-          this.directoryState.setWorkspaceStatus(entry.deviceId, path, status);
         }
       })
     }

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/runtime/AppRootRuntime.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/runtime/AppRootRuntime.ets
@@ -1,4 +1,4 @@
-import { RemoteSession, SessionSummary } from '../../model/RemoteModels';
+import { RemoteSession, SessionSummary, SessionListResult } from '../../model/RemoteModels';
 import { RemoteI18n } from '../../i18n/RemoteI18n';
 import { ConnectionErrorPolicy } from '../../services/ConnectionErrorPolicy';
 import { CloudAccountDevice } from '../../services/CloudAccountClient';
@@ -312,14 +312,18 @@ export class AppRootRuntime extends AppRootRuntimeComposition {
     if (targetDeviceId.length === 0 || targetPath.length === 0) {
       return;
     }
-    if (this.isConnectedDirectoryTarget(targetDeviceId)) {
-      const sessions = await this.sessionManager.listSessionsForWorkspace(targetPath, 50);
-      this.deviceDirectoryViewModel.captureWorkspaceSessions(targetDeviceId, targetPath, sessions);
-      this.remoteWorkspaceSessions = this.replaceWorkspaceSessions(targetPath, sessions);
-      this.publishRemoteWorkspaceSessions();
-      return;
-    }
     await this.deviceDirectoryViewModel.loadWorkspaceSessions(targetDeviceId, targetPath);
+  }
+
+  publishWorkspaceSessionPage(path: string, result: SessionListResult): void {
+    this.remoteWorkspaceSessions = this.replaceWorkspaceSessions(path, result.sessions);
+    if (path === this.remotePageState.workspacePath) {
+      // Update the controller as well as the sidebar so a later title change
+      // cannot republish the old current-workspace list.
+      this.remoteSessionController.setSessions(result.sessions, result.hasMore);
+    } else {
+      this.publishRemoteWorkspaceSessions();
+    }
   }
 
   private isConnectedDirectoryTarget(deviceId: string): boolean {
@@ -338,7 +342,9 @@ export class AppRootRuntime extends AppRootRuntimeComposition {
     });
     // The device rows are only on screen from here, and a desktop that came
     // online since the last look would otherwise stay grey.
-    void this.settingsController.refreshAccountDevicesIfStale(DEVICE_PRESENCE_MAX_AGE_MS);
+    void this.settingsController.refreshAccountDevicesIfStale(DEVICE_PRESENCE_MAX_AGE_MS).then(() =>
+      this.deviceDirectoryViewModel.refreshExpandedWorkspaceSessions()
+    );
   }
 
   closeAppSidebar(): void {

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/runtime/AppRootRuntimeComposition.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/runtime/AppRootRuntimeComposition.ets
@@ -9,6 +9,7 @@ import {
   RecentWorkspaceEntry,
   SelectedImageAttachment,
   SessionSummary,
+  SessionListResult,
   WorkspaceInfo
 } from '../../model/RemoteModels';
 import { RemoteI18n } from '../../i18n/RemoteI18n';
@@ -125,6 +126,7 @@ export abstract class AppRootRuntimeComposition {
   abstract openWorkspacePickerOnDevice(deviceId: string): Promise<void>;
   abstract pickImages(): Promise<void>;
   abstract publishRemoteSessions(sessions: RemoteSession[], hasMore: boolean): void;
+  abstract publishWorkspaceSessionPage(path: string, result: SessionListResult): void;
   abstract reconcileCreatedRemoteSession(session: SessionSummary): Promise<void>;
   abstract reconnect(): Promise<void>;
   abstract reconnectActiveRemote(): Promise<void>;
@@ -672,7 +674,11 @@ export abstract class AppRootRuntimeComposition {
           return this.remotePageState.controlTargetDeviceId || this.remotePageState.desktopId;
         },
         activeDeviceConnected: (): boolean =>
-          (this.remotePageState.connectionState as ConnectionState) === ConnectionState.Connected
+          (this.remotePageState.connectionState as ConnectionState) === ConnectionState.Connected,
+        loadActiveWorkspaceSessions: (path: string): Promise<SessionListResult> =>
+          this.sessionManager.listSessionPageForWorkspace(path, 50),
+        onActiveWorkspaceSessions: (path: string, result: SessionListResult): void =>
+          this.publishWorkspaceSessionPage(path, result)
       },
       this.remoteSessionListStore
     );
@@ -812,7 +818,9 @@ export abstract class AppRootRuntimeComposition {
       },
       refreshDevices: async (): Promise<void> => {
         await this.settingsController.refreshAccountDevicesIfStale(0);
+        await this.deviceDirectoryViewModel.refreshExpandedWorkspaceSessions();
       },
+      refreshSessions: (): Promise<void> => this.deviceDirectoryViewModel.refreshExpandedWorkspaceSessions(),
       settings: (): void => { this.closeAppSidebar(); this.appShellState.openSettings('general'); },
       openAccount: (): void => {
         this.closeAppSidebar();

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/state/DeviceDirectoryState.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/state/DeviceDirectoryState.ets
@@ -10,6 +10,7 @@ export class WorkspaceDirectoryState {
   @Trace path: string = '';
   @Trace expanded: boolean = false;
   @Trace status: WorkspaceDirectoryStatus = 'idle';
+  @Trace hasLoadedSessions: boolean = false;
 }
 
 /**
@@ -71,6 +72,19 @@ export class DeviceDirectoryState {
 
   workspaceStatus(deviceId: string, path: string): WorkspaceDirectoryStatus {
     return this.findWorkspace(deviceId, path)?.status || 'idle';
+  }
+
+  workspaceHasLoadedSessions(deviceId: string, path: string): boolean {
+    return this.findWorkspace(deviceId, path)?.hasLoadedSessions || false;
+  }
+
+  /** A request retains this object so a reset cannot publish into its successor. */
+  workspaceLoadState(deviceId: string, path: string): WorkspaceDirectoryState {
+    return this.ensureWorkspace(deviceId, path);
+  }
+
+  isCurrentWorkspaceLoad(state: WorkspaceDirectoryState): boolean {
+    return this.findWorkspace(state.deviceId, state.path) === state;
   }
 
   setWorkspaceExpanded(deviceId: string, path: string, expanded: boolean): void {

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/viewmodel/DeviceDirectoryViewModel.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/viewmodel/DeviceDirectoryViewModel.ets
@@ -1,4 +1,4 @@
-import { RecentWorkspaceEntry, RemoteSession } from '../../model/RemoteModels';
+import { RecentWorkspaceEntry, RemoteSession, SessionListResult } from '../../model/RemoteModels';
 import {
   AccountDeviceDirectory,
   AccountDeviceDirectorySource
@@ -10,9 +10,11 @@ import { RemoteLogger } from '../../services/RemoteLogger';
 import { RemoteSessionListStore } from '../../services/RemoteSessionListCache';
 import { stampRemoteSessionsDevice } from '../../services/RemoteSessionIdentity';
 import { RemoteUiState } from '../../services/RemoteUiState';
+import { mapInConcurrentBatches, CONCURRENT_WORKSPACE_LISTINGS } from '../../services/ConcurrentWorkspaceListing';
 import {
   DeviceDirectoryEntry,
   DeviceDirectoryState,
+  WorkspaceDirectoryState,
   emptyDeviceDirectoryEntry
 } from '../state/DeviceDirectoryState';
 
@@ -21,6 +23,8 @@ export interface DeviceDirectoryViewModelHooks {
   readonly activeDeviceId: () => string;
   /** Whether the conversation link to [activeDeviceId] is currently live. */
   readonly activeDeviceConnected: () => boolean;
+  readonly loadActiveWorkspaceSessions?: (path: string) => Promise<SessionListResult>;
+  readonly onActiveWorkspaceSessions?: (path: string, result: SessionListResult) => void;
 }
 
 /** Selection, loading, and retry for the sidebar's device directory. */
@@ -30,7 +34,8 @@ export class DeviceDirectoryViewModel {
   private readonly hooks: DeviceDirectoryViewModelHooks;
   private readonly directory?: AccountDeviceDirectorySource;
   private readonly inFlight: Set<string> = new Set<string>();
-  private readonly workspaceInFlight: Set<string> = new Set<string>();
+  private readonly workspaceInFlight: Map<WorkspaceDirectoryState, Promise<void>> =
+    new Map<WorkspaceDirectoryState, Promise<void>>();
   /** Device whose control-target catalog request currently owns `loading`. */
   private liveCatalogDeviceId: string = '';
 
@@ -296,29 +301,82 @@ export class DeviceDirectoryViewModel {
   async loadWorkspaceSessions(deviceId: string, path: string): Promise<void> {
     const entry = this.state.find(deviceId);
     const normalizedPath = path.trim();
-    if (!entry || normalizedPath.length === 0 || !entry.online) {
+    const active = deviceId === this.hooks.activeDeviceId() && this.hooks.activeDeviceConnected();
+    if (normalizedPath.length === 0 || (!active && (!entry || !entry.online))) {
       return;
     }
-    const requestKey = `${deviceId}\u0001${normalizedPath}`;
-    if (this.workspaceInFlight.has(requestKey)) {
-      return;
+    const scope = this.state.workspaceLoadState(deviceId, normalizedPath);
+    const pending = this.workspaceInFlight.get(scope);
+    if (pending) {
+      return pending;
     }
-    const source = this.directorySource();
-    if (!source) {
-      throw new Error('Account device directory is unavailable.');
-    }
-    this.workspaceInFlight.add(requestKey);
+    const request = this.fetchWorkspaceSessions(scope, entry, normalizedPath, active);
+    this.workspaceInFlight.set(scope, request);
     try {
-      const sessions = await new DeviceDirectoryCoordinator(source)
-        .loadWorkspaceSessions(deviceId, normalizedPath);
-      entry.sessions = DeviceDirectoryViewModel.replaceWorkspaceSessions(
-        entry.sessions,
-        normalizedPath,
-        sessions
-      );
-      await this.persistDevice(deviceId, entry.workspaces, entry.sessions);
+      await request;
     } finally {
-      this.workspaceInFlight.delete(requestKey);
+      this.workspaceInFlight.delete(scope);
+    }
+  }
+
+  /** Refresh only the workspace branches actually disclosed in the sidebar. */
+  async refreshExpandedWorkspaceSessions(): Promise<void> {
+    const selected = this.state.selectedDeviceId;
+    const scopes = this.state.workspaceDirectory.filter((item: WorkspaceDirectoryState): boolean =>
+      item.deviceId === selected && item.expanded
+    );
+    await mapInConcurrentBatches(scopes, async (scope: WorkspaceDirectoryState): Promise<void> => {
+      if (!this.state.isCurrentWorkspaceLoad(scope) || !scope.expanded ||
+        this.state.selectedDeviceId !== selected) return;
+      try {
+        await this.loadWorkspaceSessions(scope.deviceId, scope.path);
+      } catch (_err) {
+        // Each failed branch exposes its own retry row and retains its cache.
+      }
+    }, CONCURRENT_WORKSPACE_LISTINGS);
+  }
+
+  private async fetchWorkspaceSessions(
+    scope: WorkspaceDirectoryState,
+    entry: DeviceDirectoryEntry | undefined,
+    path: string,
+    active: boolean
+  ): Promise<void> {
+    const binding = this.hooks.credentials();
+    const isCurrent = (): boolean => {
+      const currentBinding = this.hooks.credentials();
+      return this.state.isCurrentWorkspaceLoad(scope) && this.state.find(scope.deviceId) === entry &&
+        binding?.session === currentBinding?.session && binding?.relayUrl === currentBinding?.relayUrl &&
+        (!active || (scope.deviceId === this.hooks.activeDeviceId() && this.hooks.activeDeviceConnected()));
+    };
+    scope.status = 'loading';
+    try {
+      if (active && this.hooks.loadActiveWorkspaceSessions && this.hooks.onActiveWorkspaceSessions) {
+        const result = await this.hooks.loadActiveWorkspaceSessions(path);
+        if (!isCurrent()) return;
+        this.captureWorkspaceSessions(scope.deviceId, path, result.sessions);
+        this.hooks.onActiveWorkspaceSessions(path, result);
+      } else {
+        const source = this.directorySource();
+        if (!source || !entry) throw new Error('Account device directory is unavailable.');
+        const sessions = await new DeviceDirectoryCoordinator(source).loadWorkspaceSessions(scope.deviceId, path);
+        if (!isCurrent()) return;
+        entry.sessions = DeviceDirectoryViewModel.replaceWorkspaceSessions(entry.sessions, path, sessions);
+        await this.persistDevice(scope.deviceId, entry.workspaces, entry.sessions);
+      }
+      if (isCurrent()) {
+        scope.hasLoadedSessions = true;
+        scope.status = 'ready';
+      }
+    } catch (err) {
+      if (isCurrent()) {
+        scope.status = 'failed';
+        throw new Error(err instanceof Error ? err.message : String(err));
+      }
+    } finally {
+      // A target switch can abandon a live request without replacing this
+      // device's disclosure object. Do not strand it in `loading` on return.
+      if (this.state.isCurrentWorkspaceLoad(scope) && scope.status === 'loading') scope.status = 'idle';
     }
   }
 

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/services/RemoteSessionController.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/services/RemoteSessionController.ets
@@ -39,6 +39,9 @@ export class RemoteSessionController {
   private hasMore: boolean = false;
   private offset: number = 0;
   private openGeneration: number = 0;
+  private listGeneration: number = 0;
+  private listing: boolean = false;
+  private loadingMore: boolean = false;
 
   constructor(
     client: RemoteSessionClient,
@@ -58,6 +61,7 @@ export class RemoteSessionController {
   }
 
   setSessions(sessions: RemoteSession[], hasMore: boolean): void {
+    this.supersedeListRequest();
     this.sessions = sessions.slice();
     this.hasMore = hasMore;
     this.offset = this.sessions.length;
@@ -65,6 +69,7 @@ export class RemoteSessionController {
   }
 
   clearSessions(): void {
+    this.supersedeListRequest();
     this.sessions = [];
     this.hasMore = false;
     this.offset = 0;
@@ -86,6 +91,8 @@ export class RemoteSessionController {
     if (!remoteAvailable) {
       return;
     }
+    const generation = this.supersedeListRequest();
+    this.listing = true;
     try {
       if (!isConnected) {
         this.callbacks.onReconnecting();
@@ -94,6 +101,7 @@ export class RemoteSessionController {
       this.callbacks.onLoading(true);
       this.offset = 0;
       const result = await this.client.listSessions(this.pageSize, this.offset, query, filter);
+      if (generation !== this.listGeneration) return;
       this.sessions = result.sessions;
       this.hasMore = result.hasMore;
       this.offset = this.sessions.length;
@@ -102,10 +110,11 @@ export class RemoteSessionController {
       this.callbacks.onStatusText(RemoteI18n.t('connection.connected'));
       this.callbacks.onStartHeartbeat();
     } catch (err) {
+      if (generation !== this.listGeneration) return;
       this.callbacks.onSessionError(ConnectionErrorPolicy.errorText(err));
       this.callbacks.onConnectionFailed(err);
     } finally {
-      this.callbacks.onLoading(false);
+      if (generation === this.listGeneration) this.finishListRequest();
     }
   }
 
@@ -118,23 +127,41 @@ export class RemoteSessionController {
     if (isBusy || !this.hasMore || !remoteAvailable) {
       return;
     }
+    const generation = this.supersedeListRequest();
+    this.listing = true;
+    this.loadingMore = true;
     try {
       this.callbacks.onBusy(true);
       this.callbacks.onLoading(true);
       this.callbacks.onStatusText(RemoteI18n.t('status.loadMoreSessions'));
       const result = await this.client.listSessions(this.pageSize, this.offset, query, filter);
+      if (generation !== this.listGeneration) return;
       this.sessions = RemoteUiState.mergeSessions(this.sessions, result.sessions);
       this.hasMore = result.hasMore;
       this.offset = this.sessions.length;
       this.callbacks.onSessions(this.sessions, this.hasMore);
       this.callbacks.onStatusText(RemoteI18n.t('status.sessionsUpdated'));
     } catch (err) {
+      if (generation !== this.listGeneration) return;
       this.callbacks.onSessionError(ConnectionErrorPolicy.errorText(err));
       this.callbacks.onConnectionFailed(err);
     } finally {
-      this.callbacks.onBusy(false);
-      this.callbacks.onLoading(false);
+      if (generation === this.listGeneration) this.finishListRequest();
     }
+  }
+
+  /** A sidebar snapshot or target reset supersedes older list responses. */
+  private supersedeListRequest(): number {
+    this.listGeneration++;
+    this.finishListRequest();
+    return this.listGeneration;
+  }
+
+  private finishListRequest(): void {
+    if (this.loadingMore) this.callbacks.onBusy(false);
+    if (this.listing) this.callbacks.onLoading(false);
+    this.loadingMore = false;
+    this.listing = false;
   }
 
   async create(

--- a/src/apps/mobile/harmonyos/entry/src/main/ets/services/RemoteSessionManager.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/services/RemoteSessionManager.ets
@@ -135,15 +135,22 @@ export class RemoteSessionManager implements RemoteChatCommandClient, RemoteFile
   }
 
   async listSessionsForWorkspace(workspacePath: string, limit: number = 50): Promise<RemoteSession[]> {
+    return (await this.listSessionPageForWorkspace(workspacePath, limit)).sessions;
+  }
+
+  async listSessionPageForWorkspace(workspacePath: string, limit: number = 50): Promise<SessionListResult> {
     const path = workspacePath.trim();
     if (path.length === 0) {
-      return [];
+      return { sessions: [], hasMore: false };
     }
     const response = await this.send<SessionListResponse>(
       RemoteCommandFactory.listSessions(path, limit, 0, ''),
       INTERACTIVE_DIRECTORY_TIMEOUT_MS
     );
-    return stampRemoteSessionsWorkspace(RemoteResponseMapper.sessions(response.sessions || []), path);
+    return {
+      sessions: stampRemoteSessionsWorkspace(RemoteResponseMapper.sessions(response.sessions || []), path),
+      hasMore: response.has_more || false
+    };
   }
 
   async listSessions(limit: number, offset: number, query: string, agentType: string): Promise<SessionListResult> {

--- a/src/apps/mobile/harmonyos/entry/src/test/DeviceDirectoryUnit.test.ets
+++ b/src/apps/mobile/harmonyos/entry/src/test/DeviceDirectoryUnit.test.ets
@@ -1,6 +1,7 @@
 import { describe, it, expect } from '@ohos/hypium';
-import { AssistantEntry, RecentWorkspaceEntry, RemoteSession } from '../main/ets/model/RemoteModels';
+import { AssistantEntry, RecentWorkspaceEntry, RemoteSession, SessionListResult } from '../main/ets/model/RemoteModels';
 import { AccountDeviceDirectorySource } from '../main/ets/services/AccountDeviceDirectory';
+import { CloudAccountDevice } from '../main/ets/services/CloudAccountClient';
 import {
   mapInConcurrentBatches,
   mergeUniqueSessions
@@ -629,6 +630,180 @@ export default function deviceDirectoryUnitTest() {
       expect(sessions.some((item: RemoteSession): boolean => item.id === 'a-old')).assertFalse();
       expect(sessions.some((item: RemoteSession): boolean => item.id === 'a-new')).assertTrue();
       expect(sessions.some((item: RemoteSession): boolean => item.id === 'b-cached')).assertTrue();
+    });
+
+    it('refreshes ready cached branches only on the selected online device', 0, async () => {
+      const source = new FakeAccountDeviceDirectory();
+      const state = new DeviceDirectoryState();
+      const viewModel = new DeviceDirectoryViewModel(state, {
+        credentials: () => undefined,
+        activeDeviceId: () => '',
+        activeDeviceConnected: () => false
+      }, undefined, source);
+      viewModel.syncDevices([
+        { deviceId: 'desk-a', deviceName: 'A', online: true },
+        { deviceId: 'desk-b', deviceName: 'B', online: true }
+      ]);
+      state.select('desk-a');
+      state.setWorkspaceExpanded('desk-a', '/open', true);
+      state.setWorkspaceExpanded('desk-a', '/closed', false);
+      state.setWorkspaceExpanded('desk-b', '/open', true);
+      state.setWorkspaceStatus('desk-a', '/open', 'ready');
+      viewModel.captureWorkspaceSessions('desk-a', '/open', [sessionIn('desk-a', '/open', 'old', 'Old')]);
+      viewModel.captureWorkspaceSessions('desk-a', '/closed', [sessionIn('desk-a', '/closed', 'sibling', 'Sibling')]);
+      source.sessionsByDevicePath.set('desk-a:/open', [
+        sessionIn('desk-a', '/open', 'new', 'New'), sessionIn('desk-a', '/open', 'old', 'Old')
+      ]);
+      await viewModel.refreshExpandedWorkspaceSessions();
+      expect(source.listedWorkspacePaths.length).assertEqual(1);
+      expect(source.listedWorkspacePaths[0]).assertEqual('desk-a:/open');
+      expect(state.find('desk-a')?.sessions.length).assertEqual(3);
+      expect(state.find('desk-a')?.sessions[0].id).assertEqual('new');
+      expect(state.workspaceExpanded('desk-a', '/open')).assertTrue();
+      expect(state.workspaceStatus('desk-a', '/open')).assertEqual('ready');
+
+      viewModel.syncDevices([
+        { deviceId: 'desk-a', deviceName: 'A', online: false },
+        { deviceId: 'desk-b', deviceName: 'B', online: true }
+      ]);
+      await viewModel.refreshExpandedWorkspaceSessions();
+      expect(source.listedWorkspacePaths.length).assertEqual(1);
+    });
+
+    it('preserves cached rows on failure and replaces them with a successful empty list', 0, async () => {
+      const source = new FakeAccountDeviceDirectory();
+      const state = new DeviceDirectoryState();
+      const viewModel = new DeviceDirectoryViewModel(state, {
+        credentials: () => undefined, activeDeviceId: () => '', activeDeviceConnected: () => false
+      }, undefined, source);
+      viewModel.syncDevices([{ deviceId: 'desk-a', deviceName: 'A', online: true }]);
+      state.select('desk-a');
+      state.setWorkspaceExpanded('desk-a', '/a', true);
+      viewModel.captureWorkspaceSessions('desk-a', '/a', [sessionIn('desk-a', '/a', 'old', 'Old')]);
+      source.failingPaths = ['desk-a:/a'];
+      await viewModel.refreshExpandedWorkspaceSessions();
+      expect(state.workspaceStatus('desk-a', '/a')).assertEqual('failed');
+      expect(state.workspaceHasLoadedSessions('desk-a', '/a')).assertFalse();
+      expect(state.find('desk-a')?.sessions[0].id).assertEqual('old');
+      source.failingPaths = [];
+      await viewModel.loadWorkspaceSessions('desk-a', '/a');
+      expect(state.workspaceStatus('desk-a', '/a')).assertEqual('ready');
+      expect(state.find('desk-a')?.sessions.length).assertEqual(0);
+      expect(state.workspaceHasLoadedSessions('desk-a', '/a')).assertTrue();
+    });
+
+    it('joins simultaneous refreshes without clearing the visible cache', 0, async () => {
+      const source = new GatedAccountDeviceDirectory();
+      const state = new DeviceDirectoryState();
+      const viewModel = new DeviceDirectoryViewModel(state, {
+        credentials: () => undefined, activeDeviceId: () => '', activeDeviceConnected: () => false
+      }, undefined, source);
+      viewModel.syncDevices([{ deviceId: 'desk-a', deviceName: 'A', online: true }]);
+      viewModel.captureWorkspaceSessions('desk-a', '/a', [sessionIn('desk-a', '/a', 'old', 'Old')]);
+      const first = viewModel.loadWorkspaceSessions('desk-a', '/a');
+      await source.workspacesListed;
+      const second = viewModel.loadWorkspaceSessions('desk-a', '/a');
+      expect(state.workspaceStatus('desk-a', '/a')).assertEqual('loading');
+      expect(state.find('desk-a')?.sessions[0].id).assertEqual('old');
+      source.releaseSessions();
+      await Promise.all([first, second]);
+      expect(source.listedWorkspacePaths.length).assertEqual(1);
+      expect(state.workspaceStatus('desk-a', '/a')).assertEqual('ready');
+      expect(state.workspaceHasLoadedSessions('desk-a', '/a')).assertTrue();
+    });
+
+    it('discards an old directory request after account state is replaced', 0, async () => {
+      const source = new GatedAccountDeviceDirectory();
+      const state = new DeviceDirectoryState();
+      const viewModel = new DeviceDirectoryViewModel(state, {
+        credentials: () => undefined, activeDeviceId: () => '', activeDeviceConnected: () => false
+      }, undefined, source);
+      const devices: CloudAccountDevice[] = [{ deviceId: 'desk-a', deviceName: 'A', online: true }];
+      viewModel.syncDevices(devices);
+      source.sessionsByDevicePath.set('desk-a:/a', [sessionIn('desk-a', '/a', 'late', 'Late')]);
+      const pending = viewModel.loadWorkspaceSessions('desk-a', '/a');
+      await source.workspacesListed;
+      state.clear();
+      viewModel.syncDevices(devices);
+      source.releaseSessions();
+      await pending;
+      expect(state.find('desk-a')?.sessions.length).assertEqual(0);
+      expect(state.workspaceStatus('desk-a', '/a')).assertEqual('idle');
+    });
+
+    it('publishes the live workspace page with its pagination state', 0, async () => {
+      const state = new DeviceDirectoryState();
+      const published: SessionListResult[] = [];
+      const viewModel = new DeviceDirectoryViewModel(state, {
+        credentials: () => undefined,
+        activeDeviceId: () => 'desk-a',
+        activeDeviceConnected: () => true,
+        loadActiveWorkspaceSessions: async (path: string): Promise<SessionListResult> => {
+          return { sessions: [sessionIn('desk-a', path, 'new', 'New')], hasMore: true };
+        },
+        onActiveWorkspaceSessions: (_path: string, page: SessionListResult): void => { published.push(page); }
+      });
+      // A live target may be visible without an account-directory row.
+      state.select('desk-a');
+      state.setWorkspaceExpanded('desk-a', '/a', true);
+      await viewModel.refreshExpandedWorkspaceSessions();
+      expect(published.length).assertEqual(1);
+      expect(published[0].sessions[0].id).assertEqual('new');
+      expect(published[0].hasMore).assertTrue();
+      expect(state.workspaceStatus('desk-a', '/a')).assertEqual('ready');
+    });
+
+    it('does not publish live results after switching the control target', 0, async () => {
+      const state = new DeviceDirectoryState();
+      let activeId = 'desk-a';
+      let release: () => void = () => {};
+      const hold = new Promise<void>((resolve: () => void) => { release = resolve; });
+      let published = 0;
+      const viewModel = new DeviceDirectoryViewModel(state, {
+        credentials: () => undefined,
+        activeDeviceId: () => activeId,
+        activeDeviceConnected: () => true,
+        loadActiveWorkspaceSessions: async (): Promise<SessionListResult> => {
+          await hold;
+          return { sessions: [sessionIn('desk-a', '/a', 'late', 'Late')], hasMore: false };
+        },
+        onActiveWorkspaceSessions: (): void => { published++; }
+      });
+      const pending = viewModel.loadWorkspaceSessions('desk-a', '/a');
+      activeId = 'desk-b';
+      release();
+      await pending;
+      expect(published).assertEqual(0);
+      expect(state.workspaceStatus('desk-a', '/a')).assertEqual('idle');
+    });
+
+    it('keeps a late previous-connection response out of the new workspace generation', 0, async () => {
+      const state = new DeviceDirectoryState();
+      let release: () => void = () => {};
+      const hold = new Promise<void>((resolve: () => void) => { release = resolve; });
+      let requests = 0;
+      const published: string[] = [];
+      const viewModel = new DeviceDirectoryViewModel(state, {
+        credentials: () => undefined,
+        activeDeviceId: () => 'desk-a',
+        activeDeviceConnected: () => true,
+        loadActiveWorkspaceSessions: async (): Promise<SessionListResult> => {
+          const index = ++requests;
+          if (index === 1) await hold;
+          return { sessions: [sessionIn('desk-a', '/a', `${index}`, 'Page')], hasMore: false };
+        },
+        onActiveWorkspaceSessions: (_path: string, result: SessionListResult): void => {
+          published.push(result.sessions[0].id);
+        }
+      });
+      const old = viewModel.loadWorkspaceSessions('desk-a', '/a');
+      state.resetWorkspaceDirectory('desk-a');
+      await viewModel.loadWorkspaceSessions('desk-a', '/a');
+      release();
+      await old;
+      expect(published.length).assertEqual(1);
+      expect(published[0]).assertEqual('2');
+      expect(state.workspaceStatus('desk-a', '/a')).assertEqual('ready');
     });
   });
 

--- a/src/apps/mobile/harmonyos/entry/src/test/RemoteControllersUnit.test.ets
+++ b/src/apps/mobile/harmonyos/entry/src/test/RemoteControllersUnit.test.ets
@@ -254,6 +254,20 @@ class MultiBlockingFileInfoClient extends FakeRemoteFileDownloadClient {
   }
 }
 
+class HeldSessionListClient extends FakeRemoteSessionClient {
+  private releaseList: () => void = () => {};
+  private readonly hold: Promise<void> = new Promise<void>((resolve: () => void) => {
+    this.releaseList = resolve;
+  });
+
+  release(): void { this.releaseList(); }
+
+  async listSessions(limit: number, offset: number, query: string, agentType: string): Promise<SessionListResult> {
+    await this.hold;
+    return super.listSessions(limit, offset, query, agentType);
+  }
+}
+
 export default function remoteControllersUnitTest() {
   describe('ToolFileReferenceResolver', () => {
     it('extracts structured single-file paths from supported tools', 0, () => {
@@ -1246,6 +1260,64 @@ export default function remoteControllersUnitTest() {
       expect(projection.hasMore).assertFalse();
       expect(busyEvents[0]).assertTrue();
       expect(busyEvents[1]).assertFalse();
+    });
+
+    it('keeps a sidebar snapshot when an older refresh or pagination request completes', 0, async () => {
+      for (const paginate of [false, true]) {
+        const client = new HeldSessionListClient();
+        client.listResults = [{ sessions: [remoteSession('stale', 'Stale')], hasMore: true }];
+        const projection = new RemoteSessionProjectionRecord();
+        let loading = false;
+        let busy = false;
+        let errors = 0;
+        const controller = new RemoteSessionController(client, 8, {
+          onSessions: (sessions: RemoteSession[], hasMore: boolean): void => {
+            projection.sessions = sessions;
+            projection.hasMore = hasMore;
+          },
+          onActiveSession: () => {}, onStatusText: () => {},
+          onBusy: (value: boolean): void => { busy = value; },
+          onLoading: (value: boolean): void => { loading = value; },
+          onSessionError: (): void => { errors++; },
+          onReconnecting: () => {}, onConnected: () => {},
+          onConnectionFailed: (): void => { errors++; }, onStartHeartbeat: () => {}
+        });
+        controller.setSessions([remoteSession('cached', 'Cached')], true);
+        const pending = paginate ? controller.loadMore('', '', false, true) :
+          controller.refresh('', '', true, true);
+        expect(loading).assertTrue();
+        controller.setSessions([remoteSession('fresh', 'Fresh')], false);
+        expect(loading).assertFalse();
+        expect(busy).assertFalse();
+        client.release();
+        await pending;
+        controller.updateSessionTitle('fresh', 'Renamed');
+        expect(projection.sessions.length).assertEqual(1);
+        expect(projection.sessions[0].id).assertEqual('fresh');
+        expect(projection.sessions[0].title).assertEqual('Renamed');
+        expect(projection.hasMore).assertFalse();
+        expect(errors).assertEqual(0);
+      }
+    });
+
+    it('ignores a late list failure after the target list is cleared', 0, async () => {
+      const client = new HeldSessionListClient();
+      client.shouldFailList = true;
+      let errors = 0;
+      let loading = false;
+      const controller = new RemoteSessionController(client, 8, {
+        onSessions: () => {}, onActiveSession: () => {}, onStatusText: () => {}, onBusy: () => {},
+        onLoading: (value: boolean): void => { loading = value; },
+        onSessionError: (): void => { errors++; },
+        onReconnecting: () => {}, onConnected: () => {},
+        onConnectionFailed: (): void => { errors++; }, onStartHeartbeat: () => {}
+      });
+      const pending = controller.refresh('', '', true, true);
+      controller.clearSessions();
+      client.release();
+      await pending;
+      expect(loading).assertFalse();
+      expect(errors).assertEqual(0);
     });
 
     it('creates and opens sessions through active-session callbacks', 0, async () => {


### PR DESCRIPTION
## Summary

Refresh HarmonyOS sidebar session lists when the sidebar opens or is restored and when the user presses the refresh button. Cached lists, including previously loaded empty lists, refresh without a loading row. Workspace expansion retains its existing lazy-loading behavior.

## Type and Areas

Type: Bug fix

Areas: Native HarmonyOS controller, sidebar/session state, focused regression tests.

## Motivation / Impact

After the phone loaded a workspace, a session created on Desktop could remain absent from the phone's sidebar. Cached rows prevented another list request, and the refresh button only updated device presence.

The sidebar now refreshes the selected online device's disclosed workspaces, retaining cached rows, selection, and disclosure state. Current-workspace results also update the session controller. Requests are coalesced, and stale account, connection, refresh, or pagination responses cannot overwrite newer snapshots.

## Verification

- `node scripts/check-harmonyos-architecture.mjs`: passed.
- `git diff --check`: passed.
- `node scripts/check-git-object-sizes.mjs --base origin/main --head HEAD`: passed for all 12 changed blobs.
- Focused host execution of `DeviceDirectoryUnit.test.ets` and the `RemoteSessionController` suite in `RemoteControllersUnit.test.ets`: 40/40 passed using a temporary harness with platform APIs mocked. The real list implementations and checked-in test bodies were executed.
- `hvigorw --mode module -p product=default -p module=entry@default assembleHap --no-daemon`: passed in WSL with the installed HarmonyOS toolchain. Verified build inputs, HAP ZIP integrity, ArkTS bytecode, AArch64 library, and Windows handoff SHA-256.
- Debug-signed HAP installed on a connected physical HarmonyOS phone. Independently verified the signature and installed bundle information.
- `hvigorw --mode module -p module=entry@default -p ohos.test.type=LocalTest test --no-daemon`: the SDK runner stalled at its Linux execution stage; this is not counted as a passing native test run.

## Reviewer Notes

- AI-assisted; testing level: lightly tested (focused logic, native build, and installation).
- Compact and wide sidebar entry points share the refresh owner. Interactive before/after UI checks and screenshots have not been captured.
- Remote-control session listing was exercised with simulated sources. Live remote workspace, Peer Device Mode, and Detached Dispatch scenarios have not been exercised.
- The loaded-list marker is in-memory state; no persisted data or wire format migration is required.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable. No new copy is introduced.
