### PR TITLE
fix: rename built-in companion to Fangling

### DIFF
--- a/src/web-ui/public/agent-companion-pets/openbitfun-girl/README.md
+++ b/src/web-ui/public/agent-companion-pets/openbitfun-girl/README.md
@@ -1,17 +1,17 @@
-# Feiling (绯翎)
+# Fangling (芳翎)
 
 ![Idle, wave, and pointer-look preview](preview.gif)
 
-Feiling is an original chibi adaptation of the OpenBitFun Girl character, with a
+Fangling is an original chibi adaptation of the OpenBitFun Girl character, with a
 small, softly oval face, a compact black-and-ivory bell skirt, and tiny legs with
-rounded shoes. Her name combines crimson and feather imagery to evoke Bifang.
+rounded shoes. Her name pairs the sound "fang" from Bifang with feather imagery.
 Silver hair and OpenBitFun ornaments preserve the character's identity: both the
 outer outline and the inner opening of each logo are rounded six-sided hexagons.
 The artwork was created with AI image generation from the character illustration,
 the official brand mark, and the requested short-legged proportions.
 
 The built-in picker lists this pet immediately after the default blue-golden
-cat. Feiling keeps the `openbitfun-girl` package ID and paths so saved selections
+cat. Fangling keeps the `openbitfun-girl` package ID and paths so saved selections
 continue to work after the display-name change. The earlier OpenBitFun Bifang
 mascot remains a separate preset.
 

--- a/src/web-ui/public/agent-companion-pets/openbitfun-girl/pet.json
+++ b/src/web-ui/public/agent-companion-pets/openbitfun-girl/pet.json
@@ -1,7 +1,7 @@
 {
   "id": "openbitfun-girl",
-  "displayName": "绯翎",
-  "description": "Feiling, a silver-haired short-legged companion with a softly oval face and hollow rounded-hexagon ornaments.",
+  "displayName": "芳翎",
+  "description": "Fangling, a silver-haired short-legged companion with a softly oval face and hollow rounded-hexagon ornaments.",
   "spriteVersionNumber": 2,
   "spritesheetPath": "spritesheet.webp"
 }

--- a/src/web-ui/src/infrastructure/config/services/AgentCompanionPetService.test.ts
+++ b/src/web-ui/src/infrastructure/config/services/AgentCompanionPetService.test.ts
@@ -48,7 +48,7 @@ describe('AgentCompanionPetService built-in presets', () => {
     expect(invoke).not.toHaveBeenCalled();
   });
 
-  it('lists Feiling second and resolves its packaged v2 layout without host access', async () => {
+  it('lists Fangling second and resolves its packaged v2 layout without host access', async () => {
     const { listAgentCompanionPets, resolveAgentCompanionPet } = await import('./AgentCompanionPetService');
     const pets = await listAgentCompanionPets();
     const girl = pets[1];

--- a/src/web-ui/src/infrastructure/config/services/AgentCompanionPetService.ts
+++ b/src/web-ui/src/infrastructure/config/services/AgentCompanionPetService.ts
@@ -69,7 +69,7 @@ const BUILTIN_PETS: AgentCompanionPetSelection[] = [
   {
     id: 'openbitfun-girl',
     displayName: BUILTIN_PET_DISPLAY_NAMES.openbitfunGirl,
-    description: 'Feiling, a silver-haired short-legged companion with a softly oval face and hollow rounded-hexagon ornaments.',
+    description: 'Fangling, a silver-haired short-legged companion with a softly oval face and hollow rounded-hexagon ornaments.',
     source: 'preset',
     packagePath: `${BUILTIN_PET_BASE}/openbitfun-girl`,
     spritesheetPath: `${BUILTIN_PET_BASE}/openbitfun-girl/spritesheet.webp`,

--- a/src/web-ui/src/infrastructure/config/services/agentCompanionBuiltinPetMetadata.json
+++ b/src/web-ui/src/infrastructure/config/services/agentCompanionBuiltinPetMetadata.json
@@ -1,7 +1,7 @@
 {
   "displayNames": {
     "blueGolden": "困困",
-    "openbitfunGirl": "绯翎",
+    "openbitfunGirl": "芳翎",
     "goldWhale": "大肥鱼",
     "gugugaga": "咕咕嘎嘎",
     "jiyi": "吉伊"


### PR DESCRIPTION
## Summary

Renames the built-in companion from **绯翎 / Feiling** to **芳翎 / Fangling**, retaining the requested “fang” sound from Bifang and the feather imagery. Updates the catalog label, packaged manifest, English descriptions, README, and test name.

## Type and Areas

UI copy; Web UI companion catalog and bundled pet documentation.

## Motivation / Impact

Uses the user-selected name. The package keeps its `openbitfun-girl` ID and paths, so saved selections continue to resolve. Artwork, v2 layout, second position, and default cat are unchanged.

## Verification

- `pnpm --dir src/web-ui run test:run src/infrastructure/config/services/AgentCompanionPetService.test.ts src/infrastructure/config/services/AgentCompanionPetCompatibility.test.ts src/infrastructure/config/services/agentCompanionPetSprite.test.ts`: 3 files, 9 tests passed.
- `pnpm run check:web`: passed, with existing non-blocking Appearance warnings.
- `pnpm run i18n:audit`: passed with zero warnings.
- `git diff --check`: passed; no previous display-name references remain under `src/web-ui`.

Only local checks were exercised. No live remote-workspace, remote-control, peer-device, or detached-dispatch session was tested; this copy-only change adds no runtime or protocol behavior.

## Reviewer Notes

AI-assisted implementation; lightly tested at product level with focused automated checks. Follow-up naming refinement to #2987.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above.
- [x] User-facing strings and owning documentation are updated.
