### PR TITLE
fix(web-ui): smoothly reveal newly streamed text

### DIFF
--- a/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_VERIFICATION.md
+++ b/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_VERIFICATION.md
@@ -16,6 +16,7 @@ each missing what the other had.
 
 | Test | Contract it holds |
 |---|---|
+| `../../../infrastructure/markdown/useStreamingTextReveal.test.tsx` | appended-glyph-only fading, independent batch clocks and renderers, history/remount stability, stream completion and reduced motion |
 | `modelRoundItemMemo.test.ts` | settled rows refresh continuation labels and tool grouping hints without invalidating equivalent hints |
 | `flowChatTailFollow.test.ts` | the three-quarter reservation and `hold-tail` geometry |
 | `flowChatCollapseMotion.test.ts` | collapse does not move earlier content |

--- a/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_VIRTUALIZATION.md
+++ b/src/web-ui/src/flow_chat/components/modern/FLOWCHAT_VIRTUALIZATION.md
@@ -243,3 +243,12 @@ Lab sequence own their own gaps. Thinking/Explore content has an 8px top inset;
 bounded Explore retains 8px bottom padding for its scroll fade. There is no
 negative adjacent-region margin. The resident runtime slot stays 24px high and
 continues to participate in the existing footer/reservation contract.
+
+## Streaming glyph presentation
+
+The shared Markdown renderer paints newly appended text with
+`useStreamingTextReveal`. Its CSS Highlight ranges fade on their own arrival
+clock without adding nodes or changing geometry. Mounted history and virtualized
+remounts start settled; stream completion does not restart the text. It does not
+write the viewport, change row keys, or add a mount animation inside a virtual
+item. Unsupported Highlight APIs and reduced motion display text directly.

--- a/src/web-ui/src/infrastructure/markdown/Markdown.scss
+++ b/src/web-ui/src/infrastructure/markdown/Markdown.scss
@@ -701,3 +701,11 @@
   --markdown-code-bg-elevated: color-mix(in srgb, var(--openbitfun-color-surface-canvas) 94%, var(--openbitfun-color-content-on-dark) 6%);
   --markdown-pre-border: color-mix(in srgb, var(--openbitfun-color-content-on-dark) 9%, transparent);
 }
+
+// Paint only the arriving glyph ranges. currentColor preserves links, syntax
+// colors and the active theme; no spans or layout-affecting row animations.
+@for $level from 0 through 31 {
+  ::highlight(openbitfun-stream-reveal-#{$level}) {
+    color: color-mix(in srgb, currentColor #{20% + $level * 2.5%}, transparent);
+  }
+}

--- a/src/web-ui/src/infrastructure/markdown/MarkdownRenderer.tsx
+++ b/src/web-ui/src/infrastructure/markdown/MarkdownRenderer.tsx
@@ -35,6 +35,7 @@ import {
 import path from 'path-browserify';
 import { getActiveSurfaceScope, onSurfaceActivated, type SurfaceScope } from '@/infrastructure/peer-device/deviceSurface';
 import './Markdown.scss';
+import { useStreamingTextReveal } from './useStreamingTextReveal';
 import { SessionMarkdownImage, type SessionImageReader } from './SessionMarkdownImage';
 import { rehypeSourceRange, type MarkdownSourceRange } from './rehypeSourceRange';
 
@@ -1677,6 +1678,9 @@ export const MarkdownRenderer = React.memo<MarkdownRendererProps>(({
     sourceRangeRef,
   ]);
   
+  const textRevealRef = useRef<HTMLDivElement>(null);
+  useStreamingTextReveal(textRevealRef, sourceRange ? contentStr.slice(sourceRange.start, sourceRange.end) : contentStr, isStreaming);
+
   const wrapperClassName = `markdown-renderer ${className}`.trim();
   const basicMarkdownRenderer = (
     <ReactMarkdown
@@ -1690,7 +1694,7 @@ export const MarkdownRenderer = React.memo<MarkdownRendererProps>(({
   );
 
   return (
-    <div className={wrapperClassName} data-openbitfun-component="markdown" data-openbitfun-part="root" data-openbitfun-state={isStreaming ? 'streaming' : undefined}>
+    <div ref={textRevealRef} className={wrapperClassName} data-openbitfun-component="markdown" data-openbitfun-part="root" data-openbitfun-state={isStreaming ? 'streaming' : undefined}>
       {renderTraceEnabled && renderTraceStartedAtMs !== null && (
         <MarkdownRenderTrace
           startedAtMs={renderTraceStartedAtMs}

--- a/src/web-ui/src/infrastructure/markdown/useStreamingTextReveal.test.tsx
+++ b/src/web-ui/src/infrastructure/markdown/useStreamingTextReveal.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import React, { act, useRef } from 'react';
+import { createRoot } from 'react-dom/client';
+const cleanups: (() => void)[] = [];
+function render(element: React.ReactNode) {
+  const container = document.createElement('div');
+  document.body.append(container);
+  const root = createRoot(container);
+  act(() => root.render(element));
+  let mounted = true;
+  const unmount = () => { if (mounted) { act(() => root.unmount()); container.remove(); mounted = false; } };
+  cleanups.push(unmount);
+  return { container, rerender: (next: React.ReactNode) => act(() => root.render(next)), unmount };
+}
+function cleanup() { cleanups.splice(0).forEach(fn => fn()); }
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { STREAMING_TEXT_REVEAL_MS, useStreamingTextReveal } from './useStreamingTextReveal';
+
+function Fixture({ text, streaming = true }: { text: string; streaming?: boolean }) {
+  const ref = useRef<HTMLDivElement>(null);
+  useStreamingTextReveal(ref, text, streaming);
+  return <div ref={ref}><p>{text}</p><button>Copy</button></div>;
+}
+let highlights: Map<string, Set<Range>>;
+const visibleRanges = () => [...highlights.values()].flatMap(value => [...value]).map(range => range.toString());
+beforeEach(() => {
+  vi.useFakeTimers();
+  highlights = new Map();
+  vi.stubGlobal('CSS', { highlights });
+  vi.stubGlobal('Highlight', Set);
+  vi.stubGlobal('matchMedia', () => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() }));
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => setTimeout(() => callback(performance.now()), 16));
+  vi.stubGlobal('cancelAnimationFrame', clearTimeout);
+});
+afterEach(() => { cleanup(); vi.useRealTimers(); vi.unstubAllGlobals(); });
+
+describe('streaming text arrival paint', () => {
+  it('fades only appended glyphs without replacing text nodes or wrapping spans', () => {
+    const view = render(<Fixture text="Already here" />);
+    const textNode = view.container.querySelector('p')!.firstChild;
+    expect(visibleRanges()).toEqual([]);
+    view.rerender(<Fixture text="Already here 新文字👨‍👩‍👧‍👦" />);
+    expect(visibleRanges()).toEqual([' 新文字👨‍👩‍👧‍👦']);
+    expect(view.container.querySelector('p')!.firstChild).toBe(textNode);
+    expect(view.container.querySelector('span')).toBeNull();
+    expect(visibleRanges().join('')).not.toContain('Copy');
+    act(() => vi.advanceTimersByTime(STREAMING_TEXT_REVEAL_MS + 20));
+    expect(visibleRanges()).toEqual([]);
+  });
+  it('does not restart earlier arrivals when another batch arrives or the stream completes', () => {
+    const view = render(<Fixture text="A" />);
+    view.rerender(<Fixture text="AB" />);
+    act(() => vi.advanceTimersByTime(96));
+    view.rerender(<Fixture text="ABC" />);
+    expect(visibleRanges().sort()).toEqual(['B', 'C']);
+    view.rerender(<Fixture text="ABC" streaming={false} />);
+    act(() => vi.advanceTimersByTime(80));
+    expect(visibleRanges()).toEqual(['C']);
+    act(() => vi.advanceTimersByTime(100));
+    expect(visibleRanges()).toEqual([]);
+  });
+  it('settles history, remounts and replacements immediately', () => {
+    const view = render(<Fixture text="History" streaming={false} />);
+    view.rerender(<Fixture text="History extended" streaming={false} />);
+    expect(visibleRanges()).toEqual([]);
+    view.rerender(<Fixture text="Different response" />);
+    expect(visibleRanges()).toEqual([]);
+    view.unmount();
+    render(<Fixture text="Already streaming on remount" />);
+    expect(visibleRanges()).toEqual([]);
+  });
+  it('keeps parallel renderer ownership independent and releases ranges on unmount', () => {
+    const first = render(<Fixture text="A" />);
+    const second = render(<Fixture text="X" />);
+    first.rerender(<Fixture text="AB" />);
+    second.rerender(<Fixture text="XY" />);
+    expect(visibleRanges()).toEqual(['B', 'Y']);
+    first.unmount();
+    expect(visibleRanges()).toEqual(['Y']);
+    second.unmount();
+    expect(visibleRanges()).toEqual([]);
+  });
+  it('honors reduced motion and works without the highlight API', () => {
+    vi.stubGlobal('matchMedia', () => ({ matches: true }));
+    const view = render(<Fixture text="A" />);
+    view.rerender(<Fixture text="AB" />);
+    expect(visibleRanges()).toEqual([]);
+    vi.stubGlobal('CSS', {});
+    view.rerender(<Fixture text="ABC" />);
+    expect(view.container.textContent).toBe('ABCCopy');
+  });
+});

--- a/src/web-ui/src/infrastructure/markdown/useStreamingTextReveal.ts
+++ b/src/web-ui/src/infrastructure/markdown/useStreamingTextReveal.ts
@@ -1,0 +1,136 @@
+import { useLayoutEffect, useRef, type RefObject } from 'react';
+
+export const STREAMING_TEXT_REVEAL_MS = 160;
+const LEVELS = 32;
+const NAME = 'openbitfun-stream-reveal-';
+type TextHighlight = Set<Range>;
+type HighlightAPI = {
+  CSS?: { highlights?: Map<string, TextHighlight> };
+  Highlight?: new (...ranges: Range[]) => TextHighlight;
+};
+interface Arrival { start: number; end: number; at: number }
+interface TextRun { node: Text; start: number; end: number }
+
+function readRuns(root: HTMLElement): { runs: TextRun[]; text: string } {
+  const walker = root.ownerDocument.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+    acceptNode: node => node.parentElement?.closest('button, [aria-hidden="true"], .katex-mathml')
+      ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT,
+  });
+  const runs: TextRun[] = [];
+  let text = '';
+  for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+    const start = text.length;
+    text += node.textContent ?? '';
+    runs.push({ node: node as Text, start, end: text.length });
+  }
+  return { runs, text };
+}
+
+/**
+ * Paint-only arrival treatment, shared by every streaming Markdown surface.
+ * Ranges leave React's text nodes, selection, wrapping and virtualizer geometry
+ * untouched. Each owner removes only its own ranges from the shared buckets.
+ * Existing text on mount (including virtualized remounts) is already settled.
+ */
+export function useStreamingTextReveal(
+  rootRef: RefObject<HTMLDivElement>, source: string, streaming: boolean,
+): void {
+  const previous = useRef<{ source: string; text: string } | null>(null);
+  const arrivals = useRef<Arrival[]>([]);
+  const owned = useRef<{ highlight: TextHighlight; range: Range }[]>([]);
+  const frame = useRef<number | null>(null);
+  const stop = () => {
+    if (frame.current !== null) cancelAnimationFrame(frame.current);
+    frame.current = null;
+    for (const { highlight, range } of owned.current) highlight.delete(range);
+    owned.current = [];
+  };
+
+  useLayoutEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+    const view = root.ownerDocument.defaultView;
+    const api = view as (Window & HighlightAPI) | null;
+    const registry = api?.CSS?.highlights;
+    const Highlight = api?.Highlight;
+    const before = previous.current;
+    // Do not traverse settled history on unrelated renderer updates.
+    if (before?.source === source && arrivals.current.length === 0) return;
+    const current = readRuns(root);
+    previous.current = { source, text: current.text };
+    const reduced = view?.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+    if (!registry || !Highlight || reduced || root.ownerDocument.hidden) {
+      stop();
+      arrivals.current = [];
+      return;
+    }
+    const appended = before && source.startsWith(before.source) && source.length > before.source.length;
+    if (before && !source.startsWith(before.source)) arrivals.current = [];
+    // Reinterpreting Markdown may replace earlier nodes. Never replay those
+    // letters; only a genuinely appended visible suffix gets a new arrival.
+    if (streaming && appended && current.text.startsWith(before.text)) {
+      arrivals.current.push({ start: before.text.length, end: current.text.length, at: performance.now() });
+    }
+    stop();
+    // Resolve ranges once per content commit. Animation frames only move those
+    // ranges between paint buckets; they do not walk a long transcript again.
+    const resolved = arrivals.current.map(arrival => {
+      const ranges: Range[] = [];
+      let low = 0;
+      let high = current.runs.length;
+      while (low < high) {
+        const middle = (low + high) >>> 1;
+        if (current.runs[middle].end <= arrival.start) low = middle + 1;
+        else high = middle;
+      }
+      for (let index = low; index < current.runs.length; index++) {
+        const run = current.runs[index];
+        if (run.start >= arrival.end) break;
+        const start = Math.max(arrival.start, run.start);
+        const end = Math.min(arrival.end, run.end);
+        if (start >= end) continue;
+        const range = root.ownerDocument.createRange();
+        range.setStart(run.node, start - run.start);
+        range.setEnd(run.node, end - run.start);
+        ranges.push(range);
+      }
+      return { arrival, ranges };
+    });
+    const paint = (now: number) => {
+      stop();
+      arrivals.current = arrivals.current.filter(arrival => now - arrival.at < STREAMING_TEXT_REVEAL_MS);
+      for (const { arrival, ranges } of resolved) {
+        if (now - arrival.at >= STREAMING_TEXT_REVEAL_MS) continue;
+        const progress = Math.max(0, (now - arrival.at) / STREAMING_TEXT_REVEAL_MS);
+        const level = Math.min(LEVELS - 1, Math.floor((1 - (1 - progress) ** 2) * LEVELS));
+        const name = `${NAME}${level}`;
+        let highlight = registry.get(name);
+        if (!highlight) {
+          highlight = new Highlight();
+          registry.set(name, highlight);
+        }
+        for (const range of ranges) {
+          highlight.add(range);
+          owned.current.push({ highlight, range });
+        }
+      }
+      if (arrivals.current.length) frame.current = requestAnimationFrame(paint);
+    };
+    // Layout timing styles newly committed glyphs before their first paint.
+    paint(performance.now());
+  }, [source, streaming, rootRef]);
+
+  useLayoutEffect(() => {
+    const media = window.matchMedia?.('(prefers-reduced-motion: reduce)');
+    const clear = () => { stop(); arrivals.current = []; };
+    const onPreference = () => { if (media?.matches) clear(); };
+    const onVisibility = () => { if (document.hidden) clear(); };
+    media?.addEventListener?.('change', onPreference);
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => {
+      clear();
+      media?.removeEventListener?.('change', onPreference);
+      document.removeEventListener('visibilitychange', onVisibility);
+    };
+  }, []);
+}


### PR DESCRIPTION
## Summary

Smooth newly streamed Markdown text with a 160 ms reveal. Previously appended batches appeared at full opacity immediately; only newly arriving glyphs now fade in, while existing text stays stable.

## Type and Areas

- Type: UI/UX bug fix
- Area: Web UI / FlowChat shared Markdown renderer

## Motivation / Impact

CSS Highlight ranges paint the arriving suffix without inserting spans, replacing text nodes, changing layout, or writing scroll positions. Each batch keeps its own arrival time, and renderers manage their ranges independently. History, remounts, reduced motion, and unsupported Highlight APIs display text immediately.

## Verification

- `NODE_OPTIONS=--no-experimental-webstorage pnpm --dir src/web-ui exec vitest run src/infrastructure/markdown/useStreamingTextReveal.test.tsx src/infrastructure/markdown/MarkdownRenderer.test.tsx` — 39 tests passed on the updated upstream base.
- `pnpm --dir src/web-ui exec eslint src/infrastructure/markdown/useStreamingTextReveal.ts src/infrastructure/markdown/MarkdownRenderer.tsx` — passed.
- `pnpm run check:web` and `pnpm run build:web` — passed for the retained streaming-only changes before updating the base.
- `git diff --check` — passed.

## Reviewer Notes

The change is limited to streaming text presentation. Native visual acceptance and live remote workspace, Remote Connect, Peer Device Mode, and Detached Dispatch scenarios were not exercised. No persistence or wire-format changes.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.
