### PR TITLE
fix(harmonyos): scroll composer text beyond visible lines

### DIFF
--- a/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/ComposerBar.ets
+++ b/src/apps/mobile/harmonyos/entry/src/main/ets/pages/components/ComposerBar.ets
@@ -363,7 +363,9 @@ export struct ComposerBar {
           top: this.isComposerExpanded() ? 10 : 0,
           bottom: this.isComposerExpanded() ? 8 : 0
         })
-        .maxLines(this.isComposerExpanded() ? 4 : 1)
+        // Limit the viewport, not the editable text; keep overflow scrollable.
+        .textOverflow(TextOverflow.Clip)
+        .maxLines(this.isComposerExpanded() ? 4 : 1, { overflowMode: MaxLinesMode.SCROLL })
         .defaultFocus(false)
         .onFocus(() => {
           this.inputFocused = true;


### PR DESCRIPTION
## Summary

Enable native TextArea scrolling when the HarmonyOS composer exceeds its visible line count.

## Type and Areas

Type: Bug fix

Areas: HarmonyOS native mobile composer

## Motivation / Impact

Previously, entering a fifth line could leave the caret and new text invisible because the ordinary TextArea maxLines overload clips overflow. Explicit scrolling mode retains the four-line expanded viewport and one-line collapsed viewport while allowing users to edit the full draft. Compact and wide layouts share this input component. Input, voice, attachment, and submission callbacks are unchanged.

## Verification

- `node scripts/check-harmonyos-architecture.mjs`: passed after rebasing onto current main.
- `git diff origin/main...HEAD --check`: passed.
- Native HarmonyOS `hvigorw --mode module -p product=default -p module=entry@default assembleHap --no-daemon`: passed before rebase; the changed source file is byte-identical after rebase.
- HAP ZIP integrity, ArkTS bytecode, AArch64 library, and build-source consistency checks passed. Debug signing and installation on a physical HarmonyOS phone succeeded.
- `hvigorw --mode module -p module=entry@default -p ohos.test.type=LocalTest test --no-daemon`: test compilation passed, but Linux test execution stalled and was stopped by a 45-second timeout; no runtime test pass is claimed.
- Actual touch scrolling, caret tracking, and compact/wide/foldable transitions have not yet been manually verified. Installation alone is not remote-session behavior validation. The full rebased tree has not been rebuilt.

## Reviewer Notes

Uses the native scrolling overflow API available since API 20, below the app's minimum API 21. No data or protocol migration is required. AI-assisted change, with runtime UI validation still pending.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.