### PR TITLE
refactor(web-ui): reuse IconButton for existing business actions

### DIFF
--- a/src/web-ui/src/app/components/panels/FilesPanel.scss
+++ b/src/web-ui/src/app/components/panels/FilesPanel.scss
@@ -274,6 +274,7 @@
   }
 
   &__search-option {
+    flex-shrink: 1;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -289,6 +290,23 @@
       background-color var(--openbitfun-motion-duration-fast) var(--openbitfun-motion-easing-standard),
       border-color var(--openbitfun-motion-duration-fast) var(--openbitfun-motion-easing-standard),
       color var(--openbitfun-motion-duration-fast) var(--openbitfun-motion-easing-standard);
+
+    // Active and responsive states remain owned by this search toolbar.
+    &::before { content: none; }
+
+    > [data-openbitfun-part='icon'] {
+      display: contents;
+    }
+
+    > :where([data-openbitfun-part='icon']) > :where(svg) {
+      inline-size: 14px;
+      block-size: 14px;
+    }
+
+    &:focus-visible {
+      outline: 2px solid color-mix(in srgb, var(--openbitfun-color-accent-default) 40%, transparent);
+      outline-offset: 2px;
+    }
 
     &:hover {
       background: var(--openbitfun-color-action-quiet-hover);

--- a/src/web-ui/src/app/components/panels/FilesPanel.tsx
+++ b/src/web-ui/src/app/components/panels/FilesPanel.tsx
@@ -1072,31 +1072,31 @@ const FilesPanel: React.FC<FilesPanelProps> = ({
               </div>
               <div className="openbitfun-files-panel__search-options">
                 <Tooltip content={t('options.caseSensitive')}>
-                  <button
+                  <IconButton
                     type="button"
                     className={`openbitfun-files-panel__search-option ${searchOptions.caseSensitive ? 'active' : ''}`}
                     onClick={() => setSearchOptions(prev => ({ ...prev, caseSensitive: !prev.caseSensitive }))}
-                  >
-                    <CaseSensitive size={14} />
-                  </button>
+                    aria-label={t('options.caseSensitive')}
+                    icon={<CaseSensitive size={14} />}
+                  />
                 </Tooltip>
                 <Tooltip content={t('options.wholeWord')}>
-                  <button
+                  <IconButton
                     type="button"
                     className={`openbitfun-files-panel__search-option ${searchOptions.wholeWord ? 'active' : ''}`}
                     onClick={() => setSearchOptions(prev => ({ ...prev, wholeWord: !prev.wholeWord }))}
-                  >
-                    <WholeWord size={14} />
-                  </button>
+                    aria-label={t('options.wholeWord')}
+                    icon={<WholeWord size={14} />}
+                  />
                 </Tooltip>
                 <Tooltip content={t('options.useRegex')}>
-                  <button
+                  <IconButton
                     type="button"
                     className={`openbitfun-files-panel__search-option ${searchOptions.useRegex ? 'active' : ''}`}
                     onClick={() => setSearchOptions(prev => ({ ...prev, useRegex: !prev.useRegex }))}
-                  >
-                    <Regex size={14} />
-                  </button>
+                    aria-label={t('options.useRegex')}
+                    icon={<Regex size={14} />}
+                  />
                 </Tooltip>
               </div>
             </div>

--- a/src/web-ui/src/flow_chat/components/btw/DeepReviewActionBar.scss
+++ b/src/web-ui/src/flow_chat/components/btw/DeepReviewActionBar.scss
@@ -103,6 +103,8 @@
   }
 
   &__controls .code-review-report-actions__button {
+    display: inline-block;
+    flex-shrink: 1;
     width: 28px;
     height: 28px;
     padding: 0;
@@ -112,6 +114,31 @@
     color: var(--openbitfun-color-content-muted);
     cursor: pointer;
     transition: background 0.2s, color 0.2s;
+
+    // The header has its own 28px actions, separate from the report card.
+    &::before { content: none; }
+
+    > [data-openbitfun-part='icon'] {
+      --openbitfun-opacity-icon-artwork: inherit;
+      display: contents;
+    }
+
+    > :where([data-openbitfun-part='icon']) > :where(svg) {
+      display: inline-block;
+      inline-size: 14px;
+      block-size: 14px;
+    }
+
+    > :where([data-openbitfun-part='icon']) > :where([data-openbitfun-component='icon']) {
+      display: inline-block;
+      inline-size: var(--openbitfun-control-icon-size-sm);
+      block-size: var(--openbitfun-control-icon-size-sm);
+    }
+
+    &:focus-visible {
+      outline: 2px solid color-mix(in srgb, var(--openbitfun-color-accent-default) 40%, transparent);
+      outline-offset: 2px;
+    }
 
     &:hover:not(:disabled) {
       background: var(--openbitfun-color-action-quiet-hover);

--- a/src/web-ui/src/flow_chat/components/btw/DeepReviewActionBar.test.tsx
+++ b/src/web-ui/src/flow_chat/components/btw/DeepReviewActionBar.test.tsx
@@ -40,7 +40,8 @@ vi.mock('react-i18next', async () => {
   };
 });
 
-vi.mock('@openbitfun/ui', () => ({
+vi.mock('@openbitfun/ui', async importOriginal => ({
+  ...await importOriginal<typeof import('@openbitfun/ui')>(),
   Icon: ({ name }: { name: string }) => <span data-openbitfun-component="icon" data-openbitfun-name={name} />,
   Button: ({
     children,

--- a/src/web-ui/src/flow_chat/components/modern/ForkSessionButton.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ForkSessionButton.test.tsx
@@ -4,6 +4,8 @@ import { createRoot, type Root } from 'react-dom/client';
 import { JSDOM } from 'jsdom';
 
 import { ForkSessionButton } from './ForkSessionButton';
+import { flowChatManager } from '../../services/FlowChatManager';
+import { notificationService } from '@/shared/notification-system';
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -22,7 +24,8 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
-vi.mock('@openbitfun/ui', () => ({
+vi.mock('@openbitfun/ui', async importOriginal => ({
+  IconButton: (await importOriginal<typeof import('@openbitfun/ui')>()).IconButton,
   Icon: ({ name, className }: { name: string; className?: string }) => (
     <span className={className} data-openbitfun-component="icon" data-openbitfun-name={name} />
   ),
@@ -53,6 +56,7 @@ describe('ForkSessionButton', () => {
   let root: Root;
 
   beforeEach(() => {
+    vi.clearAllMocks();
     dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
       pretendToBeVisual: true,
     });
@@ -96,5 +100,43 @@ describe('ForkSessionButton', () => {
     const button = container.querySelector('.model-round-item__fork-btn');
     expect(button).not.toBeNull();
     expect(button?.querySelector('[data-openbitfun-name="git"]')).not.toBeNull();
+  });
+
+  it('keeps the original pending icon and disables duplicate forks until completion', async () => {
+    let complete!: () => void;
+    vi.mocked(flowChatManager.forkChatSession).mockImplementationOnce(
+      () => new Promise<string>(resolve => { complete = () => resolve('forked-session'); }),
+    );
+    act(() => {
+      root.render(<ForkSessionButton sessionId="main-session" turnId="turn-1" />);
+    });
+
+    const button = container.querySelector<HTMLButtonElement>('.model-round-item__fork-btn')!;
+    act(() => button.click());
+
+    expect(flowChatManager.forkChatSession).toHaveBeenCalledExactlyOnceWith('main-session', 'turn-1');
+    expect(button.disabled).toBe(true);
+    expect(button.querySelector('.spinning[data-openbitfun-name="progress-25"]')).not.toBeNull();
+    expect(button.getAttribute('data-loading')).toBe('false');
+    act(() => button.click());
+    expect(flowChatManager.forkChatSession).toHaveBeenCalledTimes(1);
+
+    await act(async () => complete());
+    expect(button.disabled).toBe(false);
+    expect(button.querySelector('[data-openbitfun-name="git"]')).not.toBeNull();
+  });
+
+  it('restores the action after a failed fork without changing its error notification', async () => {
+    vi.mocked(flowChatManager.forkChatSession).mockRejectedValueOnce(new Error('Fork failed'));
+    act(() => {
+      root.render(<ForkSessionButton sessionId="main-session" turnId="turn-1" />);
+    });
+
+    const button = container.querySelector<HTMLButtonElement>('.model-round-item__fork-btn')!;
+    await act(async () => button.click());
+
+    expect(button.disabled).toBe(false);
+    expect(button.querySelector('[data-openbitfun-name="git"]')).not.toBeNull();
+    expect(notificationService.error).toHaveBeenCalledExactlyOnceWith('modelRound.forkFailed', { duration: 3500 });
   });
 });

--- a/src/web-ui/src/flow_chat/components/modern/ForkSessionButton.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ForkSessionButton.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Icon, Tooltip } from '@openbitfun/ui';
+import { Icon, IconButton, Tooltip } from '@openbitfun/ui';
 import { flowChatManager } from '../../services/FlowChatManager';
 import { flowChatStore } from '../../store/FlowChatStore';
 import { resolveSessionRelationship } from '../../utils/sessionMetadata';
@@ -53,15 +53,15 @@ export const ForkSessionButton: React.FC<ForkSessionButtonProps> = ({
       content={t('modelRound.forkDialog')}
       placement="top"
     >
-      <button
+      <IconButton
         className="model-round-item__action-btn model-round-item__fork-btn"
         onClick={handleFork}
         disabled={isForking}
-      >
-        {isForking
+        aria-label={t('modelRound.forkDialog')}
+        icon={isForking
           ? <Icon name="progress-25" size="sm" className="spinning" />
           : <Icon name="git" size="sm" />}
-      </button>
+      />
     </Tooltip>
   );
 };

--- a/src/web-ui/src/flow_chat/components/modern/ModelRoundItem.scss
+++ b/src/web-ui/src/flow_chat/components/modern/ModelRoundItem.scss
@@ -288,6 +288,21 @@
 }
 
 .model-round-item__fork-btn {
+  flex-shrink: 1;
+
+  // Do not change sibling actions or replace this action's original spinner.
+  &::before { content: none; }
+
+  > [data-openbitfun-part='icon'] {
+    --openbitfun-opacity-icon-artwork: inherit;
+    display: contents;
+  }
+
+  > :where([data-openbitfun-part='icon']) > :where([data-openbitfun-component='icon']) {
+    inline-size: var(--openbitfun-control-icon-size-sm);
+    block-size: var(--openbitfun-control-icon-size-sm);
+  }
+
   .spinning {
     animation: model-round-item-spin 1s linear infinite;
   }

--- a/src/web-ui/src/flow_chat/tool-cards/CodeReviewReportExportActions.test.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/CodeReviewReportExportActions.test.tsx
@@ -1,8 +1,15 @@
-import React from 'react';
+// @vitest-environment jsdom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CodeReviewReportExportActions } from './CodeReviewReportExportActions';
 import type { ReviewTeamRunManifest } from '@/shared/services/reviewTeamService';
+import { save } from '@tauri-apps/plugin-dialog';
+import { writeFile } from '@tauri-apps/plugin-fs';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 const formatCodeReviewReportMarkdownMock = vi.hoisted(() => vi.fn(() => '# Review'));
 
@@ -10,11 +17,13 @@ function Icon({ name }: { name: string }) {
   return <svg data-icon={name} />;
 }
 
-vi.mock('lucide-react', () => ({
+vi.mock('lucide-react', async importOriginal => ({
+  ...await importOriginal<typeof import('lucide-react')>(),
   Loader2: () => <Icon name="loader" />,
 }));
 
-vi.mock('@openbitfun/ui', () => ({
+vi.mock('@openbitfun/ui', async importOriginal => ({
+  IconButton: (await importOriginal<typeof import('@openbitfun/ui')>()).IconButton,
   Button: ({
     children,
     leadingIcon,
@@ -58,11 +67,27 @@ vi.mock('@/shared/utils/tabUtils', () => ({
   createMarkdownEditorTab: vi.fn(),
 }));
 
+vi.mock('@tauri-apps/plugin-dialog', () => ({ save: vi.fn() }));
+vi.mock('@tauri-apps/plugin-fs', () => ({ writeFile: vi.fn() }));
+
 vi.mock('../utils/codeReviewReport', () => ({
   formatCodeReviewReportMarkdown: (...args: unknown[]) => formatCodeReviewReportMarkdownMock(...args),
 }));
 
 describe('CodeReviewReportExportActions', () => {
+  let root: Root | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    if (root) act(() => root!.unmount());
+    root = undefined;
+    document.body.replaceChildren();
+    delete (window as Window & { __TAURI__?: unknown }).__TAURI__;
+  });
+
   it('uses the same copy icon as other copy buttons', () => {
     const html = renderToStaticMarkup(
       <CodeReviewReportExportActions reviewData={{ summary: { recommended_action: 'approve' } }} />,
@@ -93,6 +118,41 @@ describe('CodeReviewReportExportActions', () => {
     expect(html).toContain('aria-label="Copy Markdown"');
     expect(html).toContain('aria-label="Save Markdown"');
     expect(html).not.toContain('aria-label="Open as Markdown"');
+  });
+
+  it('keeps saving disabled while the file picker is open and does not write when cancelled', async () => {
+    Object.defineProperty(window, '__TAURI__', { value: {}, configurable: true });
+    let cancelPicker!: () => void;
+    vi.mocked(save).mockImplementationOnce(
+      () => new Promise(resolve => { cancelPicker = () => resolve(null); }),
+    );
+    const parentClick = vi.fn();
+    const container = document.createElement('div');
+    document.body.append(container);
+    root = createRoot(container);
+    act(() => {
+      root!.render(
+        <div onClick={parentClick}>
+          <CodeReviewReportExportActions reviewData={{ summary: { recommended_action: 'approve' } }} actions={['save']} />
+        </div>,
+      );
+    });
+
+    const button = container.querySelector<HTMLButtonElement>('button[aria-label="Save Markdown"]')!;
+    await act(async () => button.click());
+
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(button.disabled).toBe(true);
+    expect(button.getAttribute('data-loading')).toBe('false');
+    expect(button.querySelector('[data-icon="loader"]')).not.toBeNull();
+    act(() => button.click());
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(parentClick).not.toHaveBeenCalled();
+
+    await act(async () => cancelPicker());
+    expect(writeFile).not.toHaveBeenCalled();
+    expect(button.disabled).toBe(false);
+    expect(button.querySelector('[data-icon="arrow-down"]')).not.toBeNull();
   });
 
   it('passes the review run manifest into Markdown formatting', () => {

--- a/src/web-ui/src/flow_chat/tool-cards/CodeReviewReportExportActions.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/CodeReviewReportExportActions.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@openbitfun/ui';
+import { Button, IconButton } from '@openbitfun/ui';
 import React, { useCallback, useMemo, useState } from 'react';
 import { Loader2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -202,39 +202,36 @@ export const CodeReviewReportExportActions: React.FC<CodeReviewReportExportActio
     <div className="code-review-report-actions" onClick={(event) => event.stopPropagation()}>
       {visibleActions.has('copy') && (
         <Tooltip content={t('toolCards.codeReview.export.copyMarkdown')} placement="top">
-          <button
+          <IconButton
             type="button"
             className="code-review-report-actions__button"
             onClick={handleCopy}
             aria-label={t('toolCards.codeReview.export.copyMarkdown')}
-          >
-            {copied ? <Icon name="check-line" size="sm" /> : <Icon name="duplicate" size="sm" />}
-          </button>
+            icon={copied ? <Icon name="check-line" size="sm" /> : <Icon name="duplicate" size="sm" />}
+          />
         </Tooltip>
       )}
       {visibleActions.has('open') && (
         <Tooltip content={t('toolCards.codeReview.export.openMarkdown')} placement="top">
-          <button
+          <IconButton
             type="button"
             className="code-review-report-actions__button"
             onClick={handleOpenInEditor}
             aria-label={t('toolCards.codeReview.export.openMarkdown')}
-          >
-            <Icon name="edit" size="sm" />
-          </button>
+            icon={<Icon name="edit" size="sm" />}
+          />
         </Tooltip>
       )}
       {visibleActions.has('save') && (
         <Tooltip content={t('toolCards.codeReview.export.saveMarkdown')} placement="top">
-          <button
+          <IconButton
             type="button"
             className="code-review-report-actions__button"
             onClick={handleSave}
             disabled={saving}
             aria-label={t('toolCards.codeReview.export.saveMarkdown')}
-          >
-            {saving ? <Loader2 className="animate-spin" size={14} /> : <Icon name="arrow-down" size="sm" />}
-          </button>
+            icon={saving ? <Loader2 className="animate-spin" size={14} /> : <Icon name="arrow-down" size="sm" />}
+          />
         </Tooltip>
       )}
     </div>

--- a/src/web-ui/src/flow_chat/tool-cards/CodeReviewToolCard.scss
+++ b/src/web-ui/src/flow_chat/tool-cards/CodeReviewToolCard.scss
@@ -22,6 +22,7 @@
   }
 
   .code-review-report-actions__button {
+    flex-shrink: 1;
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -36,6 +37,29 @@
     transition:
       background 160ms ease,
       color 160ms ease;
+
+    // Preserve the report actions' feedback and the existing save spinner.
+    &::before { content: none; }
+
+    > [data-openbitfun-part='icon'] {
+      --openbitfun-opacity-icon-artwork: inherit;
+      display: contents;
+    }
+
+    > :where([data-openbitfun-part='icon']) > :where(svg) {
+      inline-size: 14px;
+      block-size: 14px;
+    }
+
+    > :where([data-openbitfun-part='icon']) > :where([data-openbitfun-component='icon']) {
+      inline-size: var(--openbitfun-control-icon-size-sm);
+      block-size: var(--openbitfun-control-icon-size-sm);
+    }
+
+    &:focus-visible {
+      outline: 2px solid color-mix(in srgb, var(--openbitfun-color-accent-default) 40%, transparent);
+      outline-offset: 2px;
+    }
 
     &:hover:not(:disabled) {
       background: var(--openbitfun-color-action-neutral-surface-hover);

--- a/src/web-ui/src/infrastructure/config/components/ModelSettingsPage.scss
+++ b/src/web-ui/src/infrastructure/config/components/ModelSettingsPage.scss
@@ -1068,6 +1068,9 @@
   }
 
   &__input-visibility-toggle {
+    inline-size: auto;
+    block-size: auto;
+    flex-shrink: 1;
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -1077,6 +1080,24 @@
     color: var(--openbitfun-color-content-muted);
     cursor: pointer;
     transition: color var(--openbitfun-motion-duration-base) var(--openbitfun-motion-easing-standard);
+
+    // Keep the input decoration's existing feedback and intrinsic icon size.
+    &::before { content: none; }
+
+    > [data-openbitfun-part='icon'] {
+      --openbitfun-opacity-icon-artwork: inherit;
+      display: contents;
+    }
+
+    > :where([data-openbitfun-part='icon']) > :where(svg) {
+      inline-size: 14px;
+      block-size: 14px;
+    }
+
+    > :where([data-openbitfun-part='icon']) > :where([data-openbitfun-component='icon']) {
+      inline-size: var(--openbitfun-control-icon-size-sm);
+      block-size: var(--openbitfun-control-icon-size-sm);
+    }
 
     &:hover {
       color: var(--openbitfun-color-content-primary);

--- a/src/web-ui/src/infrastructure/config/components/ModelSettingsPage.tsx
+++ b/src/web-ui/src/infrastructure/config/components/ModelSettingsPage.tsx
@@ -2449,15 +2449,14 @@ const ModelSettingsPage: React.FC = () => {
     const selectedModelValues = selectedModelDrafts.map(draft => draft.modelName);
     const apiKeyVisibilityLabel = showApiKey ? tComponents('hide') : tComponents('show');
     const apiKeySuffix = (
-      <button
+      <IconButton
         type="button"
         className="openbitfun-model-settings__input-visibility-toggle"
         onClick={() => setShowApiKey(prev => !prev)}
         aria-label={apiKeyVisibilityLabel}
         title={apiKeyVisibilityLabel}
-      >
-        {showApiKey ? <EyeOff size={14} /> : <Icon name="eye" size="sm" />}
-      </button>
+        icon={showApiKey ? <EyeOff size={14} /> : <Icon name="eye" size="sm" />}
+      />
     );
 
     const formatReasoningSummary = (

--- a/src/web-ui/src/infrastructure/config/components/ReasoningPresetEditor.scss
+++ b/src/web-ui/src/infrastructure/config/components/ReasoningPresetEditor.scss
@@ -288,6 +288,8 @@
   }
 
   &__row-toggle {
+    inline-size: auto;
+    block-size: auto;
     display: flex;
     flex: 0 0 auto;
     align-items: center;
@@ -298,13 +300,27 @@
     text-align: left;
     cursor: pointer;
 
+    // The disclosure retains its padding-sized target and existing focus style.
+    &::before { content: none; }
+
+    > [data-openbitfun-part='icon'] {
+      --openbitfun-opacity-icon-artwork: inherit;
+      display: contents;
+    }
+
+    > :where([data-openbitfun-part='icon']) > :where([data-openbitfun-component='icon']) {
+      inline-size: var(--openbitfun-control-icon-size-sm);
+      block-size: var(--openbitfun-control-icon-size-sm);
+    }
+
     &:focus-visible {
       outline: 2px solid var(--openbitfun-color-accent-default);
       outline-offset: 1px;
       border-radius: var(--openbitfun-radius-sm);
     }
 
-    > svg {
+    > svg,
+    > [data-openbitfun-part='icon'] > svg {
       flex-shrink: 0;
       color: var(--openbitfun-color-content-muted);
     }

--- a/src/web-ui/src/infrastructure/config/components/ReasoningPresetEditor.test.tsx
+++ b/src/web-ui/src/infrastructure/config/components/ReasoningPresetEditor.test.tsx
@@ -44,12 +44,6 @@ vi.mock('@openbitfun/ui', async importOriginal => ({
   }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
     <button type="button" {...props}>{children}</button>
   ),
-  IconButton: ({
-    children,
-    ...props
-  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
-    <button type="button" {...props}>{children}</button>
-  ),
   Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
   Switch: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input type="checkbox" {...props} />,
   Combobox: (props: SelectSpyProps) => {

--- a/src/web-ui/src/infrastructure/config/components/ReasoningPresetEditor.tsx
+++ b/src/web-ui/src/infrastructure/config/components/ReasoningPresetEditor.tsx
@@ -608,15 +608,14 @@ export const ReasoningPresetEditor: React.FC<ReasoningPresetEditorProps> = ({
                     data-openbitfun-component="reasoning-preset-editor"
                     data-openbitfun-part="presetSummary"
                   >
-                    <button
+                    <IconButton
                       type="button"
                       className="openbitfun-reasoning-preset-editor__row-toggle"
                       onClick={() => setExpandedPresetIndex(expanded ? null : presetIndex)}
                       aria-expanded={expanded}
                       aria-label={preset.label?.trim() || preset.id}
-                    >
-                      {expanded ? <Icon name="chevron-down" size="sm" /> : <Icon name="chevron-right" size="sm" />}
-                    </button>
+                      icon={expanded ? <Icon name="chevron-down" size="sm" /> : <Icon name="chevron-right" size="sm" />}
+                    />
                     <div className="openbitfun-reasoning-preset-editor__row-content">
                       {expanded ? (
                         <div className="openbitfun-reasoning-preset-editor__row-name-editor">

--- a/src/web-ui/src/shared/context-system/components/ContextCard/ContextCard.scss
+++ b/src/web-ui/src/shared/context-system/components/ContextCard/ContextCard.scss
@@ -201,6 +201,26 @@
   
   &__remove-btn {
     @extend .openbitfun-context-card__action-btn;
+
+    flex-shrink: 1;
+
+    // Keep the remove action's existing danger feedback on its root.
+    &::before { content: none; }
+
+    > [data-openbitfun-part='icon'] {
+      --openbitfun-opacity-icon-artwork: inherit;
+      display: contents;
+    }
+
+    > :where([data-openbitfun-part='icon']) > :where([data-openbitfun-component='icon']) {
+      inline-size: var(--openbitfun-control-icon-size-sm);
+      block-size: var(--openbitfun-control-icon-size-sm);
+    }
+
+    &:focus-visible {
+      outline: 2px solid color-mix(in srgb, var(--openbitfun-color-accent-default) 40%, transparent);
+      outline-offset: 2px;
+    }
     
     &:hover {
       background: var(--openbitfun-color-status-danger-surface);

--- a/src/web-ui/src/shared/context-system/components/ContextCard/ContextCard.tsx
+++ b/src/web-ui/src/shared/context-system/components/ContextCard/ContextCard.tsx
@@ -1,7 +1,7 @@
  
 
 import React, { useMemo } from 'react';
-import { OverflowText, Icon } from '@openbitfun/ui';
+import { OverflowText, Icon, IconButton } from '@openbitfun/ui';
 import { AlertCircle, Loader2 } from 'lucide-react';
 import { ContextItem } from '../../../types/context';
 import { contextRegistry } from '../../../services/ContextRegistry';
@@ -124,13 +124,13 @@ export const ContextCard: React.FC<ContextCardProps> = ({
           
           
           {onRemove && (
-            <button
+            <IconButton
               className="openbitfun-context-card__remove-btn"
               onClick={handleRemove}
               title={t('contextSystem.contextCard.removeContext')}
-            >
-              <Icon name="xmark" size="sm" />
-            </button>
+              aria-label={t('contextSystem.contextCard.removeContext')}
+              icon={<Icon name="xmark" size="sm" />}
+            />
           )}
         </div>
       )}

--- a/src/web-ui/src/tools/editor/components/DiffEditor.scss
+++ b/src/web-ui/src/tools/editor/components/DiffEditor.scss
@@ -96,6 +96,8 @@ $_diff-error-max-width: 400px;
   }
 
   &__btn {
+    inline-size: auto;
+    flex-shrink: 1;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -115,6 +117,13 @@ $_diff-error-max-width: 400px;
       border-color var(--openbitfun-motion-duration-fast) var(--openbitfun-motion-easing-standard),
       color var(--openbitfun-motion-duration-fast) var(--openbitfun-motion-easing-standard),
       box-shadow var(--openbitfun-motion-duration-fast) var(--openbitfun-motion-easing-standard);
+
+    // Keep the original text glyph metrics and root-owned hover/press effects.
+    &::before { content: none; }
+
+    > [data-openbitfun-part='icon'] {
+      display: contents;
+    }
 
     &:hover:not(:disabled) {
       background: var(--openbitfun-color-action-neutral-surface-hover);

--- a/src/web-ui/src/tools/editor/components/DiffEditor.tsx
+++ b/src/web-ui/src/tools/editor/components/DiffEditor.tsx
@@ -8,7 +8,7 @@ import { monacoAppearanceAdapter } from '@/infrastructure/appearance/adapters/Mo
 import { configManager } from '@/infrastructure/config/services/ConfigManager';
 import { EditorConfig as EditorConfigType } from '@/infrastructure/config/types';
 import { getMonacoLanguage } from '@/infrastructure/language-detection';
-import { OverflowText, LoadingState } from '@openbitfun/ui';
+import { IconButton, OverflowText, LoadingState } from '@openbitfun/ui';
 import { useNotification } from '@/shared/notification-system';
 import { createLogger } from '@/shared/utils/logger';
 import { useI18n } from '@/infrastructure/i18n';
@@ -523,33 +523,33 @@ export const DiffEditor: React.FC<DiffEditorProps> = ({
         
         <div className="diff-editor-toolbar__actions" data-openbitfun-component="diff-editor" data-openbitfun-part="toolbarActions">
           <Tooltip content={t('editor.diffEditor.prevChange')} placement="top">
-            <button
+            <IconButton
               className="diff-editor-toolbar__btn"
               onClick={navigateToPrevChange}
               disabled={changes.length === 0}
-            >
-              ↑
-            </button>
+              aria-label={t('editor.diffEditor.prevChange')}
+              icon="↑"
+            />
           </Tooltip>
           <Tooltip content={t('editor.diffEditor.nextChange')} placement="top">
-            <button
+            <IconButton
               className="diff-editor-toolbar__btn"
               onClick={navigateToNextChange}
               disabled={changes.length === 0}
-            >
-              ↓
-            </button>
+              aria-label={t('editor.diffEditor.nextChange')}
+              icon="↓"
+            />
           </Tooltip>
           <Tooltip
             content={renderSideBySide ? t('editor.diffEditor.switchToInline') : t('editor.diffEditor.switchToSideBySide')}
             placement="top"
           >
-            <button
+            <IconButton
               className="diff-editor-toolbar__btn"
               onClick={toggleViewMode}
-            >
-              {renderSideBySide ? '⊟' : '⊞'}
-            </button>
+              aria-label={renderSideBySide ? t('editor.diffEditor.switchToInline') : t('editor.diffEditor.switchToSideBySide')}
+              icon={renderSideBySide ? '⊟' : '⊞'}
+            />
           </Tooltip>
         </div>
       </div>

--- a/src/web-ui/src/tools/git/components/GitGraphView/GitGraphView.scss
+++ b/src/web-ui/src/tools/git/components/GitGraphView/GitGraphView.scss
@@ -101,6 +101,7 @@
   }
 
   &__search-nav-btn {
+    flex-shrink: 1;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -116,6 +117,24 @@
       transform 140ms cubic-bezier(0.23, 1, 0.32, 1),
       background-color 140ms ease,
       color 140ms ease;
+
+    // The existing root owns feedback; do not paint a second hover surface.
+    &::before { content: none; }
+
+    > [data-openbitfun-part='icon'] {
+      --openbitfun-opacity-icon-artwork: inherit;
+      display: contents;
+    }
+
+    > :where([data-openbitfun-part='icon']) > :where([data-openbitfun-component='icon']) {
+      inline-size: var(--openbitfun-control-icon-size-sm);
+      block-size: var(--openbitfun-control-icon-size-sm);
+    }
+
+    &:focus-visible {
+      outline: 2px solid color-mix(in srgb, var(--openbitfun-color-accent-default) 40%, transparent);
+      outline-offset: 2px;
+    }
 
     &:hover:not(:disabled) {
       background: var(--openbitfun-color-action-neutral-surface-hover);

--- a/src/web-ui/src/tools/git/components/GitGraphView/GitGraphView.tsx
+++ b/src/web-ui/src/tools/git/components/GitGraphView/GitGraphView.tsx
@@ -2,7 +2,7 @@
 /** Git commit graph view (branch graph). */
 
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
-import { Button, Icon, SearchField, ScrollArea } from '@openbitfun/ui';
+import { Button, Icon, IconButton, SearchField, ScrollArea } from '@openbitfun/ui';
 import { useTranslation } from 'react-i18next';
 import { Loader2 } from 'lucide-react';
 import { useI18n } from '@/infrastructure/i18n/hooks/useI18n';
@@ -327,22 +327,22 @@ export const GitGraphView: React.FC<GitGraphViewProps> = ({
                   <span className="git-graph-view__search-count">
                     {currentSearchIndex + 1} / {searchFilter.totalMatches}
                   </span>
-                  <button
+                  <IconButton
                     className="git-graph-view__search-nav-btn"
                     onClick={goToPreviousMatch}
                     title={t('graph.searchPrevious')}
+                    aria-label={t('graph.searchPrevious')}
                     disabled={searchFilter.totalMatches === 0}
-                  >
-                    <Icon name="chevron-up" size="sm" />
-                  </button>
-                  <button
+                    icon={<Icon name="chevron-up" size="sm" />}
+                  />
+                  <IconButton
                     className="git-graph-view__search-nav-btn"
                     onClick={goToNextMatch}
                     title={t('graph.searchNext')}
+                    aria-label={t('graph.searchNext')}
                     disabled={searchFilter.totalMatches === 0}
-                  >
-                    <Icon name="chevron-down" size="sm" />
-                  </button>
+                    icon={<Icon name="chevron-down" size="sm" />}
+                  />
                 </div>
               ) : searchFilter && debouncedSearchQuery && searchFilter.totalMatches === 0 ? (
                 <span className="git-graph-view__search-count git-graph-view__search-count--no-results">

--- a/src/web-ui/src/tools/terminal/components/ConnectedTerminal.tsx
+++ b/src/web-ui/src/tools/terminal/components/ConnectedTerminal.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useEffect, useRef, useCallback, useState, memo } from 'react';
-import { Button, Icon } from '@openbitfun/ui';
+import { Button, Icon, IconButton } from '@openbitfun/ui';
 import { useI18n } from '@/infrastructure/i18n';
 import { AlertCircle } from 'lucide-react';
 import Terminal, { TerminalRef, type TerminalOptions } from './Terminal';
@@ -506,22 +506,22 @@ const ConnectedTerminal: React.FC<ConnectedTerminalProps> = memo(({
             </span>
           </div>
           <div className="openbitfun-terminal__toolbar-right">
-            <button
+            <IconButton
               className="openbitfun-terminal__toolbar-btn"
               onClick={handleSendCtrlC}
               title="Send Ctrl+C"
+              aria-label="Send Ctrl+C"
               data-testid="shell-command-rerun"
-            >
-              <span style={{ fontSize: 'var(--openbitfun-type-micro-font-size)', fontWeight: 'var(--openbitfun-type-heading-page-font-weight)' }}>^C</span>
-            </button>
-            <button
+              icon={<span style={{ fontSize: 'var(--openbitfun-type-micro-font-size)', fontWeight: 'var(--openbitfun-type-heading-page-font-weight)' }}>^C</span>}
+            />
+            <IconButton
               className={`openbitfun-terminal__toolbar-btn${closeBehavior === 'terminate' ? ' openbitfun-terminal__toolbar-btn--danger' : ''}`}
               onClick={handleClose}
               title={closeBehavior === 'detach' ? t('actions.closeView') : t('actions.stopTerminal')}
+              aria-label={closeBehavior === 'detach' ? t('actions.closeView') : t('actions.stopTerminal')}
               data-testid="shell-panel-close"
-            >
-              {closeBehavior === 'detach' ? <Icon name="xmark" size="sm" /> : <Icon name="delete" size="sm" />}
-            </button>
+              icon={closeBehavior === 'detach' ? <Icon name="xmark" size="sm" /> : <Icon name="delete" size="sm" />}
+            />
           </div>
         </div>
       )}

--- a/src/web-ui/src/tools/terminal/components/Terminal.scss
+++ b/src/web-ui/src/tools/terminal/components/Terminal.scss
@@ -118,6 +118,7 @@
     }
 
     &-btn {
+      flex-shrink: 1;
       display: flex;
       align-items: center;
       justify-content: center;
@@ -132,6 +133,24 @@
         transform 140ms cubic-bezier(0.23, 1, 0.32, 1),
         background-color 140ms ease,
         color 140ms ease;
+
+      // Keep the terminal's quiet/pressed/danger states and text Ctrl+C glyph.
+      &::before { content: none; }
+
+      > [data-openbitfun-part='icon'] {
+        --openbitfun-opacity-icon-artwork: inherit;
+        display: contents;
+      }
+
+      > :where([data-openbitfun-part='icon']) > :where([data-openbitfun-component='icon']) {
+        inline-size: var(--openbitfun-control-icon-size-sm);
+        block-size: var(--openbitfun-control-icon-size-sm);
+      }
+
+      &:focus-visible {
+        outline: 2px solid color-mix(in srgb, var(--openbitfun-color-accent-default) 40%, transparent);
+        outline-offset: 2px;
+      }
 
       &:hover {
         background: var(--openbitfun-color-action-quiet-hover);


### PR DESCRIPTION
## Summary

Replace 17 native buttons across nine Web UI areas with the existing `@openbitfun/ui` IconButton:

- File search options
- Diff navigation and view switching
- Git search navigation
- Terminal controls
- API key visibility
- Reasoning preset expansion
- Context removal
- Session forking
- Code review report actions

Add scoped style compatibility and focused regression coverage.

## Type and Areas

Type: Refactor

Areas: Web UI

## Motivation / Impact

No intended direct user-facing change.

Reduce duplicated button implementations by reusing the existing component library. Preserve event handlers, disabled conditions, icons, custom loading indicators, tooltips, and responsive presentation.

The change does not modify component-library APIs, backend operations, persisted data, or remote routing.

## Verification

Recorded during implementation:

- `pnpm run check:web` — passed.
- `pnpm run i18n:audit` — passed.
- `pnpm --dir src/web-ui run icons:check` — passed.
- `pnpm run motion:audit` — completed; this is an intent-review inventory, not proof of visual equivalence.
- 53 focused tests — passed.
- Compilation of all 10 changed SCSS files — passed.
- AST comparison of original button attributes — completed.

Manual visual comparison and remote scenario verification remain pending.

## Reviewer Notes

Check the affected controls in light/dark themes and narrow layouts, including hover, keyboard focus, disabled, selected, and loading states.

Pay particular attention to:

- Report actions inside both tool cards and Deep Review headers.
- Session fork and report save behavior while requests are pending.
- Context removal without triggering the parent card.
- Terminal close-view versus terminate behavior.
- Correct host, session, and path targeting for remote operations.

Remote Workspace, Remote Control, Peer Device Mode, and Detached Dispatch have not been exercised for this change. Local checks do not establish remote behavior.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.