### PR TITLE
fix(review): show actionable errors for non-Git workspaces

### DIFF
--- a/src/web-ui/src/flow_chat/deep-review/launch/targetResolver.test.ts
+++ b/src/web-ui/src/flow_chat/deep-review/launch/targetResolver.test.ts
@@ -708,11 +708,27 @@ describe('Deep Review target resolver', () => {
   });
 
   it('still degrades an ordinary Git failure into unknown evidence', async () => {
-    mockGitGetStatus.mockRejectedValue(new Error('fatal: not a git repository'));
+    mockGitGetStatus.mockRejectedValue(new Error('Failed to get Git status: Permission denied'));
 
     const target = classifyReviewTargetFromFiles(['src/lib.rs'], 'session_files');
     const snapshot = await resolveCurrentFileReviewSnapshot('/workspace', target);
 
     expect(snapshot.targetEvidence.limitations).toContain('file_scope_target_evidence_failed');
+  });
+
+  it('preserves repository discovery failures from session files and slash commands', async () => {
+    const missingRepository = new TauriCommandError(
+      "Failed to get Git status: Repository not found: could not find repository at '/workspace'",
+      { command: 'git_get_status' },
+    );
+    mockGitGetStatus.mockRejectedValue(missingRepository);
+
+    const target = classifyReviewTargetFromFiles(['src/lib.rs'], 'session_files');
+    await expect(resolveCurrentFileReviewSnapshot('/workspace', target))
+      .rejects.toBe(missingRepository);
+    await expect(resolveSlashCommandReviewTarget('', '/workspace'))
+      .rejects.toBe(missingRepository);
+    await expect(resolveSlashCommandReviewTarget('src/lib.rs', '/workspace'))
+      .rejects.toBe(missingRepository);
   });
 });

--- a/src/web-ui/src/flow_chat/deep-review/launch/targetResolver.ts
+++ b/src/web-ui/src/flow_chat/deep-review/launch/targetResolver.ts
@@ -1,5 +1,8 @@
 import { gitAPI, systemAPI, workspaceAPI } from '@/infrastructure/api';
-import { isGitRepositoryUntrustedError } from '@/infrastructure/api/errors/TauriCommandError';
+import {
+  isGitRepositoryNotFoundError,
+  isGitRepositoryUntrustedError,
+} from '@/infrastructure/api/errors/TauriCommandError';
 import type {
   GitChangedFile,
   GitDiffParams,
@@ -41,15 +44,13 @@ export interface ResolvedDeepReviewTarget {
 }
 
 /**
- * Lets an ownership rejection out of an evidence-gathering catch.
- *
- * Every other Git failure here degrades into "evidence unavailable", which is
- * the right answer for a repository we genuinely cannot read. An untrusted
- * repository is different: it is readable the moment the user says so, and
- * collapsing it into "unknown" would hide both the reason and the remedy.
+ * Preserves actionable Git failures through evidence-gathering catches.
+ * Repository discovery and ownership errors have specific launch messages;
+ * collapsing them into "unknown" would hide both the reason and the remedy.
+ * Other failures still degrade to unavailable evidence.
  */
-function rethrowIfRepositoryUntrusted(error: unknown): void {
-  if (isGitRepositoryUntrustedError(error)) {
+function rethrowActionableGitError(error: unknown): void {
+  if (isGitRepositoryUntrustedError(error) || isGitRepositoryNotFoundError(error)) {
     throw error;
   }
 }
@@ -61,7 +62,7 @@ async function resolveRevision(
   try {
     return await gitAPI.resolveRevision(workspacePath, revision);
   } catch (error) {
-    rethrowIfRepositoryUntrusted(error);
+    rethrowActionableGitError(error);
     log.warn('Failed to resolve Git revision for Review target evidence', {
       workspacePath,
       revision,
@@ -78,7 +79,7 @@ async function resolveDiff(
   try {
     return await gitAPI.getDiff(workspacePath, { ...params, reviewSafe: true });
   } catch (error) {
-    rethrowIfRepositoryUntrusted(error);
+    rethrowActionableGitError(error);
     log.warn('Failed to resolve Git diff for Review target evidence', {
       workspacePath,
       params,
@@ -554,7 +555,7 @@ export async function resolveCurrentFileReviewSnapshot(
       targetEvidence,
     };
   } catch (error) {
-    rethrowIfRepositoryUntrusted(error);
+    rethrowActionableGitError(error);
     log.warn('Failed to resolve file-scoped Review snapshot', {
       workspacePath,
       targetFiles,
@@ -750,7 +751,7 @@ export async function resolveSlashCommandReviewTarget(
         status,
       );
     } catch (error) {
-      rethrowIfRepositoryUntrusted(error);
+      rethrowActionableGitError(error);
       log.warn('Failed to resolve explicit Review file scope', {
         workspacePath,
         explicitFilePaths,
@@ -821,7 +822,7 @@ export async function resolveSlashCommandReviewTarget(
           resolveDiff(workspacePath, immutableTarget),
           resolveRevision(workspacePath, 'HEAD'),
           gitAPI.getStatus(workspacePath, 'deep_review_git_range_binding').catch((error) => {
-            rethrowIfRepositoryUntrusted(error);
+            rethrowActionableGitError(error);
             log.warn('Failed to resolve workspace binding for Git range Review', {
               workspacePath,
               error,
@@ -855,7 +856,7 @@ export async function resolveSlashCommandReviewTarget(
         }),
       };
     } catch (error) {
-      rethrowIfRepositoryUntrusted(error);
+      rethrowActionableGitError(error);
       log.warn('Failed to resolve Git target for Deep Review target', {
         workspacePath,
         gitTarget,
@@ -904,7 +905,7 @@ export async function resolveSlashCommandReviewTarget(
         targetEvidence: snapshot.targetEvidence,
       };
     } catch (error) {
-      rethrowIfRepositoryUntrusted(error);
+      rethrowActionableGitError(error);
       log.warn('Failed to resolve workspace diff for Deep Review target', {
         workspacePath,
         error,

--- a/src/web-ui/src/flow_chat/services/ReviewService.test.ts
+++ b/src/web-ui/src/flow_chat/services/ReviewService.test.ts
@@ -169,6 +169,33 @@ describe('ReviewService', () => {
     );
   });
 
+  it.each(['session files', 'slash command'])('explains a missing Git repository for %s', async (entry) => {
+    const error = new TauriCommandError('Internal error', {
+      command: 'git_get_status',
+      originalError: {
+        message: 'Internal error',
+        data: "Failed to get Git status: Repository not found: could not find repository at '/workspace'",
+      },
+    });
+    let preparation;
+    if (entry === 'session files') {
+      mocks.resolveCurrentFileReviewSnapshot.mockRejectedValueOnce(error);
+      preparation = prepareReviewLaunchFromSessionFiles(['src/file.ts'], {
+        workspacePath: '/workspace',
+      });
+    } else {
+      mocks.resolveSlashCommandReviewTarget.mockRejectedValueOnce(error);
+      preparation = prepareReviewLaunchFromSlashCommand('/review', '/workspace');
+    }
+
+    await expect(preparation).rejects.toMatchObject({
+      launchErrorMessageKey: 'deepReviewActionBar.launchError.notGitRepository',
+    });
+    expect(mocks.createBtwChildSession).not.toHaveBeenCalled();
+    expect(mocks.confirmWarning).not.toHaveBeenCalled();
+    expect(mocks.trustRepository).not.toHaveBeenCalled();
+  });
+
   it('prepares a small session review without constructing a review team', async () => {
     const prepared = await prepareReviewLaunchFromSessionFiles(
       ['src/small.ts'],
@@ -634,7 +661,7 @@ describe('ReviewService', () => {
     });
 
     await expect(prepareReviewLaunchFromSlashCommand('/review focus on auth'))
-      .rejects.toThrow('could not be prepared as bounded evidence');
+      .rejects.toThrow('files or code diff could not be read for Review');
   });
 
   it('launches standard review as a read-only CodeReview child in the shared pane', async () => {

--- a/src/web-ui/src/flow_chat/services/ReviewService.ts
+++ b/src/web-ui/src/flow_chat/services/ReviewService.ts
@@ -1,5 +1,6 @@
 import {
   gitRepositoryUntrustedPath,
+  isGitRepositoryNotFoundError,
   isGitRepositoryUntrustedError,
 } from '@/infrastructure/api/errors/TauriCommandError';
 import type {
@@ -68,6 +69,12 @@ async function prepareWithRepositoryTrust(
     // burst, so it is always worth a prompt — including right after a decline.
     return await withGitRepositoryTrustRecovery(prepare, { userInitiated: true });
   } catch (error) {
+    if (isGitRepositoryNotFoundError(error)) {
+      throw reviewTargetError(
+        'No Git repository was found in the current workspace. Review requires a Git repository with an existing commit. Open such a project and try again.',
+        'deepReviewActionBar.launchError.notGitRepository',
+      );
+    }
     if (!isGitRepositoryUntrustedError(error)) {
       throw error;
     }
@@ -283,7 +290,7 @@ async function prepareFromResolvedTarget(params: {
     ].includes(limitation))
   ) {
     throw reviewTargetError(
-      'The requested Review target could not be prepared as bounded evidence. Open its workspace or narrow the target and try again.',
+      'The files or code diff could not be read for Review. Check that the corresponding workspace is open and the target is valid, and see the logs for the specific error.',
       'deepReviewActionBar.launchError.unresolvedTarget',
     );
   }

--- a/src/web-ui/src/infrastructure/api/errors/TauriCommandError.test.ts
+++ b/src/web-ui/src/infrastructure/api/errors/TauriCommandError.test.ts
@@ -1,12 +1,41 @@
 import { describe, expect, it } from 'vitest';
 import {
   gitRepositoryUntrustedPath,
+  isGitRepositoryNotFoundError,
   isGitRepositoryUntrustedError,
   isNotAvailableError,
   isOutcomeUnknownError,
   isSessionInUseError,
   TauriCommandError,
 } from './TauriCommandError';
+
+describe('isGitRepositoryNotFoundError', () => {
+  const legacyError = "Failed to get Git status: Repository not found: could not find repository at '/workspace'; class=Repository (6); code=NotFound (-3)";
+
+  it.each([
+    legacyError,
+    new TauriCommandError(legacyError, {
+      command: 'git_get_status',
+      originalError: legacyError,
+    }),
+    { message: 'Host command failed', details: { originalError: legacyError } },
+    { message: 'Internal error', data: legacyError },
+    JSON.parse(JSON.stringify({ message: 'Internal error', data: legacyError })),
+    new Error('fatal: not a git repository (or any of the parent directories): .git'),
+  ])('recognizes existing host payloads through transport wrappers: %j', (error) => {
+    expect(isGitRepositoryNotFoundError(error)).toBe(true);
+  });
+
+  it.each([
+    'File not found: /workspace/src/file.ts',
+    'Failed to get Git status: Permission denied',
+    'git_repository_untrusted: /workspace',
+    "fatal: ambiguous argument 'HEAD': unknown revision or path not in the working tree.",
+    'Network connection timed out',
+  ])('does not misclassify another failure: %s', (message) => {
+    expect(isGitRepositoryNotFoundError(new Error(message))).toBe(false);
+  });
+});
 
 describe('isSessionInUseError', () => {
   it('recognizes local Tauri command errors without parsing human prose', () => {

--- a/src/web-ui/src/infrastructure/api/errors/TauriCommandError.ts
+++ b/src/web-ui/src/infrastructure/api/errors/TauriCommandError.ts
@@ -174,6 +174,19 @@ export function isGitRepositoryUntrustedError(error: unknown): boolean {
   return hasStableErrorPrefix(error, GIT_REPOSITORY_UNTRUSTED_PREFIX);
 }
 
+/**
+ * Existing hosts serialize Git repository discovery failures as English text.
+ * Match their specific prefixes through transport wrappers, not generic
+ * "not found" messages (which can also mean a missing file or revision).
+ */
+export function isGitRepositoryNotFoundError(error: unknown): boolean {
+  return [
+    'Failed to get Git status: Repository not found:',
+    'Repository not found:',
+    'fatal: not a git repository (or any of the parent directories):',
+  ].some((prefix) => stableErrorPayload(error, prefix) !== undefined);
+}
+
 /** Repository path Git rejected, as reported by the backend. */
 export function gitRepositoryUntrustedPath(error: unknown): string | undefined {
   const payload = stableErrorPayload(error, GIT_REPOSITORY_UNTRUSTED_PREFIX);

--- a/src/web-ui/src/locales/en-US/flow-chat.json
+++ b/src/web-ui/src/locales/en-US/flow-chat.json
@@ -1303,7 +1303,8 @@
       "emptyWorkspace": "There are no workspace changes to review.",
       "emptyExplicitScope": "The requested files or directories contain no workspace changes.",
       "missingExplicitScope": "The requested file or directory does not exist in the current workspace.",
-      "unresolvedTarget": "The Review target could not be prepared as bounded evidence. Open its workspace or narrow the target and try again.",
+      "unresolvedTarget": "The files or code diff could not be read for Review. Check that the corresponding workspace is open and the target is valid, and see the logs for the specific error.",
+      "notGitRepository": "No Git repository was found in the current workspace. Review requires a Git repository with an existing commit. Open such a project and try again.",
       "repositoryUntrusted": "Git will not read this repository because the folder is owned by another user. Trust the folder when prompted, then start Review again.",
       "uncertain": "The Review request may already be running. Its session was preserved so you can inspect or retry it safely.",
       "unknown": "Review launch failed. Please retry."

--- a/src/web-ui/src/locales/zh-CN/flow-chat.json
+++ b/src/web-ui/src/locales/zh-CN/flow-chat.json
@@ -1303,7 +1303,8 @@
       "emptyWorkspace": "当前工作区没有可审核的变更",
       "emptyExplicitScope": "请求的文件或目录没有工作区变更",
       "missingExplicitScope": "请求的文件或目录在当前工作区中不存在",
-      "unresolvedTarget": "无法将审核目标准备为有界证据，请打开对应工作区或缩小目标后重试",
+      "unresolvedTarget": "无法读取待审核的文件或代码差异，请确认已打开对应工作区、审核目标有效，并查看日志中的具体错误",
+      "notGitRepository": "当前工作区未找到 Git 仓库，暂时无法启动审核。请打开包含 Git 仓库且已有提交记录的项目后重试",
       "repositoryUntrusted": "该目录属于其他用户，Git 拒绝读取此仓库。请在提示中信任该目录后重新启动审核",
       "uncertain": "审核请求可能已经在运行。会话已保留，可安全检查或重试",
       "unknown": "审核启动失败，请重试"

--- a/src/web-ui/src/locales/zh-TW/flow-chat.json
+++ b/src/web-ui/src/locales/zh-TW/flow-chat.json
@@ -1303,7 +1303,8 @@
       "emptyWorkspace": "目前工作區沒有可審核的變更",
       "emptyExplicitScope": "要求的檔案或目錄沒有工作區變更",
       "missingExplicitScope": "要求的檔案或目錄不存在於目前工作區中",
-      "unresolvedTarget": "無法將審核目標準備為有界證據，請開啟對應工作區或縮小目標後重試",
+      "unresolvedTarget": "無法讀取待審核的檔案或程式碼差異，請確認已開啟對應工作區、審核目標有效，並查看日誌中的具體錯誤",
+      "notGitRepository": "目前工作區未找到 Git 儲存庫，暫時無法啟動審核。請開啟包含 Git 儲存庫且已有提交記錄的專案後重試",
       "repositoryUntrusted": "該目錄屬於其他使用者，Git 拒絕讀取此儲存庫。請在提示中信任該目錄後重新啟動審核",
       "uncertain": "審核要求可能已在執行。工作階段已保留，可安全檢查或重試",
       "unknown": "審核啟動失敗，請重試"


### PR DESCRIPTION
## Summary

Show a specific error when Review cannot find a Git repository in the current workspace, explaining that Review requires a repository with an existing commit.

Replace the generic “bounded evidence” message with plain-language guidance and update English, Simplified Chinese, and Traditional Chinese translations.

## Type and Areas

Type: Bug fix / UI/UX

Areas: Web UI, Review launch, API error handling, localization

## Motivation / Impact

Users could see session file changes but could not start Review in non-Git projects. Repository discovery failures were hidden behind a generic message suggesting that users reopen the workspace or narrow the target.

Both the session file Review action and `/review` now preserve the underlying failure and display an actionable message. Other errors, including repository trust failures, retain their existing handling.

## Verification

- `pnpm --dir src/web-ui exec vitest run --maxWorkers=50% src/infrastructure/api/errors/TauriCommandError.test.ts src/flow_chat/deep-review/launch/targetResolver.test.ts src/flow_chat/services/ReviewService.test.ts`
  - Passed: 3 test files, 75 tests.
- `pnpm run check:web`
  - Passed.
- `pnpm run i18n:audit`
  - Passed with zero warnings.
- `git -c core.safecrlf=false diff --check`
  - Passed.

Tests cover repository discovery failures, both Review entry points, existing host error payloads, and Peer/JSON-RPC error wrappers. No live remote workspace, remote control, Peer Device Mode, or Detached Dispatch validation was performed.

## Reviewer Notes

This change improves error reporting; it does not add Review support for non-Git projects.

Error recognition supports existing host payloads without protocol or persisted-data changes. No migration is required.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.