### PR TITLE
fix(flow-chat): omit text metadata from tool icon slots

### DIFF
--- a/design-system/packages/ui/src/flow-chat/tool-cards/ToolCardStatusSlot.tsx
+++ b/design-system/packages/ui/src/flow-chat/tool-cards/ToolCardStatusSlot.tsx
@@ -1,3 +1,4 @@
+import { isValidElement } from "react";
 import { Check, Clock, X, type LucideProps } from "lucide-react";
 import { classNames } from "../../internal/classNames";
 import type { FlowChatToolStatus } from "./FlowChatToolCard";
@@ -53,10 +54,7 @@ export function ToolCardStatusSlot({
   toolIcon,
 }: ToolCardStatusSlotProps) {
   const hasStatusGlyph = hasVisibleToolCardStatusGlyph(status);
-  const hasToolIcon = toolIcon !== undefined
-    && toolIcon !== null
-    && toolIcon !== false
-    && toolIcon !== "";
+  const hasToolIcon = isValidElement(toolIcon);
 
   if (!hasStatusGlyph && !hasToolIcon) {
     return null;

--- a/design-system/packages/ui/tests/flow-chat-tool-card.test.mjs
+++ b/design-system/packages/ui/tests/flow-chat-tool-card.test.mjs
@@ -211,6 +211,17 @@ test("cancelled and rejected tool cards rely on status copy instead of a duplica
   assert.doesNotMatch(ambientMarkup, /data-openbitfun-part="statusLayer"|lucide-x/);
 });
 
+test("default tool cards do not render a text icon", () => {
+  const markup = renderToStaticMarkup(createElement(DefaultToolCard, {
+    displayName: "Custom tool",
+    toolName: "custom_tool",
+    icon: "TOOL",
+    status: "cancelled",
+    summary: "Cancelled",
+  }));
+  assert.doesNotMatch(markup, /TOOL|data-openbitfun-part="toolIconLayer"/);
+});
+
 test("file-operation failures stay collapsed and use the warning emphasis status icon", async () => {
   const createFailedCard = (isExpanded) => renderToStaticMarkup(
     createElement(FileOperationToolCard, {

--- a/src/web-ui/src/flow_chat/tool-cards/DefaultToolCard.test.tsx
+++ b/src/web-ui/src/flow_chat/tool-cards/DefaultToolCard.test.tsx
@@ -5,6 +5,7 @@ import { createRoot, type Root } from 'react-dom/client';
 import { JSDOM } from 'jsdom';
 
 import { DefaultToolCard } from './DefaultToolCard';
+import { getToolCardConfig } from './toolCardMetadata';
 import type { FlowToolItem, ToolCardConfig } from '../types/flow-chat';
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
@@ -76,6 +77,33 @@ describe('DefaultToolCard', () => {
       root.unmount();
     });
     vi.unstubAllGlobals();
+  });
+
+  it('keeps cancelled ControlHub details toggleable without a text icon', () => {
+    const toolItem: FlowToolItem = {
+      ...completedWebFetchItem(undefined),
+      toolName: 'ControlHub',
+      status: 'cancelled',
+      toolResult: undefined,
+    };
+
+    act(() => {
+      root.render(<DefaultToolCard toolItem={toolItem} config={getToolCardConfig('ControlHub')} />);
+    });
+
+    for (const [index, expanded] of [false, true, false].entries()) {
+      expect(container.textContent).not.toContain('TOOL');
+      const button = container.querySelector<HTMLButtonElement>(
+        '[data-openbitfun-part="iconAffordanceButton"]',
+      );
+      expect(button).not.toBeNull();
+      expect(button?.getAttribute('aria-expanded')).toBe(String(expanded));
+      if (index < 2) {
+        act(() => {
+          button?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+        });
+      }
+    }
   });
 
   it('does not stringify detailed result payloads while collapsed', () => {


### PR DESCRIPTION
## Summary

Prevent plain-text tool metadata such as `TOOL` from appearing in the shared tool icon slot, while preserving React element icons and expand/collapse controls.

## Type and Areas

Type: Bug fix

Areas: Design system, Web UI tool cards

## Motivation / Impact

Legacy tool configuration stores text abbreviations in its string-valued `icon` field. The default card forwards that value to the design system, whose ReactNode icon slot previously accepted any non-empty value. When cancellation or rejection hides the status glyph, the fallback displays the string as the tool icon. Hovering or focusing the card replaces it with the disclosure arrow, making the text appear to disappear after interaction.

The shared slot now uses `isValidElement` to decide whether to render the tool icon layer. Plain strings remain valid configuration data but are not drawn as icons. Explicit React elements, including intentionally authored text elements, remain supported. This does not add cancellation-specific rendering rules or replace text with a generic icon.

## Verification

- `git diff --check`: passed.
- Added one design-system regression for omitting a text icon and one Web UI regression for expanding and collapsing a cancelled ControlHub card. Existing SVG-icon coverage is retained.
- `pnpm --dir src/web-ui run test:run src/flow_chat/tool-cards/DefaultToolCard.test.tsx`: blocked during design-system preparation because workspace dependencies are absent (`@openbitfun/token-engine`). Tests did not execute.
- `pnpm --dir design-system --filter @openbitfun/ui run build`: blocked because `vite` is unavailable without installed dependencies.
- `pnpm run check:web`: blocked by missing `typescript`.
- No manual UI or remote-scenario verification was performed.

## Reviewer Notes

Configuration values and persisted shapes are unchanged. Non-element ReactNode values no longer populate the tool icon layer; this intentionally distinguishes text metadata from element-based icons. Disclosure controls remain available for cancelled default cards.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable (not applicable).
