### PR TITLE
fix(ui): prevent text clipping in workspace selectors and compact labels

### DIFF
--- a/design-system/packages/design-tokens/README.md
+++ b/design-system/packages/design-tokens/README.md
@@ -77,6 +77,10 @@ metrics during migration. `type.modifier.leading.support` provides the compact
 1.45 supporting-text rhythm used when an 11px role must align to a 16px line.
 `type.modifier.leading.tight` provides 1.2 leading for compact message bubbles:
 18px at the default 15px body size, scaling with user typography preferences.
+`type.modifier.leading.intrinsic` uses `normal` for the inner single-line text
+box in `OverflowText`. The browser includes the selected font's ascent/descent;
+existing numeric leading roles cannot express those platform-dependent metrics.
+The outer line box retains any larger leading supplied by its owning control.
 
 `layout.searchDialog` owns the shared Lab/product search composition: 800 × 460
 when space permits, 20px inset and query-to-scope gap, and a 30px query row.

--- a/design-system/packages/design-tokens/src/system.tokens.json
+++ b/design-system/packages/design-tokens/src/system.tokens.json
@@ -328,6 +328,10 @@
     "modifier": {
       "$description": "Single-property semantic modifiers for intentional deviations from a complete typography role.",
       "leading": {
+        "intrinsic": {
+          "$description": "Font-metric leading for OverflowText's inner single-line box. Numeric leading cannot express platform font ascent/descent; the outer box retains the owner's larger line height.",
+          "lineHeight": { "$type": "string", "$value": "normal" }
+        },
         "none": { "lineHeight": { "$value": "{lineHeight.none}" } },
         "tight": {
           "$description": "Compact text leading for message bubbles: 18px at the default 15px body size, scaling with user typography.",

--- a/design-system/packages/ui/README.md
+++ b/design-system/packages/ui/README.md
@@ -113,6 +113,11 @@ Use `OverflowText` for single-line, non-editable labels instead of local
 defaults to **fade-out truncation with an interaction marquee**: a background-independent
 gradient mask at the inline end, followed by scrolling on hover or keyboard focus.
 Both effects apply only when the text actually overflows. Short labels remain untouched.
+Single-line text uses a baseline-aligned inner box with the font's natural leading
+so tight control line heights do not clip descenders. This applies to plain-text
+fade and marquee labels; multiline clamps and rich composition retain their layout.
+Let text slots size naturally in the block direction instead of forcing a text-height
+box or adding outer pixel padding to compensate for clipped glyphs.
 Overflowing labels also open a wrapping, selectable tooltip on hover or keyboard
 focus, including when motion is reduced. The tooltip uses the owning
 `data-overflow-trigger` control and groups its clipped text slots into one popup.

--- a/design-system/packages/ui/src/primitives/OverflowText/OverflowText.module.css
+++ b/design-system/packages/ui/src/primitives/OverflowText/OverflowText.module.css
@@ -15,7 +15,11 @@
   .content {
     display: inline-block;
     min-inline-size: max-content;
-    vertical-align: top;
+    /* Include the font's ascent/descent inside the clipping box, even when a
+       compact control inherits leading of 1. Baseline alignment preserves any
+       larger leading supplied by the owner without cutting off glyph ink. */
+    line-height: var(--openbitfun-type-modifier-leading-intrinsic-line-height);
+    vertical-align: baseline;
   }
 
   .root[data-overflow-lines] {

--- a/design-system/packages/ui/src/primitives/OverflowText/OverflowText.tsx
+++ b/design-system/packages/ui/src/primitives/OverflowText/OverflowText.tsx
@@ -86,10 +86,9 @@ export const OverflowText = forwardRef<HTMLElement, OverflowTextProps>(
       if (!element || !content) return;
 
       const distance = Math.max(0, content.scrollWidth - element.clientWidth);
-      // A compact single-line label can have glyph ink extend slightly beyond
-      // its line box without any text being clipped. Only multiline clamps use
-      // vertical overflow as a truncation signal; single-line slots are clipped
-      // exclusively on the inline axis.
+      // Single-line text has a font-metric-sized content box; only multiline
+      // clamps use vertical overflow as a truncation signal. Horizontal
+      // measurement still uses the full content width for fade and marquee.
       const hasVerticalClampOverflow = lines !== undefined
         && element.clientHeight > 0
         && element.scrollHeight > element.clientHeight;
@@ -193,7 +192,7 @@ export const OverflowText = forwardRef<HTMLElement, OverflowTextProps>(
         style={resolvedStyle}
         title={hasOverflowTooltip ? undefined : title}
       >
-        {behavior === "marquee" ? (
+        {behavior === "marquee" || (textOnly && lines === undefined) ? (
           <span className={styles.content} data-openbitfun-part="content" data-overflow-content="" ref={contentRef}>
             {children}
           </span>

--- a/src/apps/data-migrator/ui/generated/design-system.css
+++ b/src/apps/data-migrator/ui/generated/design-system.css
@@ -615,6 +615,7 @@
     --openbitfun-type-micro-line-height: var(--openbitfun-line-height-compact);
     --openbitfun-type-modifier-leading-balanced-line-height: var(--openbitfun-line-height-balanced);
     --openbitfun-type-modifier-leading-dense-line-height: var(--openbitfun-line-height-dense);
+    --openbitfun-type-modifier-leading-intrinsic-line-height: normal;
     --openbitfun-type-modifier-leading-loose-line-height: var(--openbitfun-line-height-loose);
     --openbitfun-type-modifier-leading-none-line-height: var(--openbitfun-line-height-none);
     --openbitfun-type-modifier-leading-snug-line-height: var(--openbitfun-line-height-snug);

--- a/src/web-ui/src/features/dispatch/DispatchTargetPicker.scss
+++ b/src/web-ui/src/features/dispatch/DispatchTargetPicker.scss
@@ -22,7 +22,7 @@
     color: var(--openbitfun-color-content-secondary);
     font: inherit;
     font-size: var(--openbitfun-type-flow-micro-font-size);
-    line-height: var(--openbitfun-type-modifier-leading-none-line-height);
+    line-height: var(--openbitfun-type-flow-support-line-height);
     cursor: pointer;
     transition:
       background-color 120ms ease,

--- a/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStrip.scss
+++ b/src/web-ui/src/flow_chat/components/ChatInputWorkspaceStrip.scss
@@ -50,7 +50,7 @@ $track-item-gap: 10px;
   // controls restate it here. Shape — the pill and its hover fill — is what
   // says a control is a control, so a label never needs a size of its own.
   font-size: var(--openbitfun-type-flow-meta-font-size);
-  line-height: var(--openbitfun-type-modifier-leading-none-line-height);
+  line-height: var(--openbitfun-type-flow-support-line-height);
   letter-spacing: inherit;
   white-space: nowrap;
   cursor: pointer;
@@ -130,7 +130,6 @@ $track-item-gap: 10px;
       > span:not([data-overflow-content]) {
         min-width: 0;
         overflow: hidden;
-        padding-bottom: 1px;
       }
     }
   }
@@ -180,7 +179,6 @@ $track-item-gap: 10px;
     > span:not([data-overflow-content]) {
       min-width: 0;
       overflow: hidden;
-      padding-bottom: 1px;
     }
   }
 
@@ -241,7 +239,6 @@ $track-item-gap: 10px;
     min-width: 0;
     max-width: 88px;
     overflow: hidden;
-    padding-bottom: 1px;
     white-space: nowrap;
     font-weight: var(--openbitfun-type-label-sm-font-weight);
   }
@@ -384,15 +381,6 @@ $track-item-gap: 10px;
     }
   }
 
-  /*
-   * Product sans faces have different vertical metrics across platform font
-   * profiles. Keep the shared 1px optical compensation on every text span so
-   * labels remain aligned with icons and with one another.
-   */
-  &__worktree-label {
-    padding-bottom: 1px;
-  }
-
   // The one thing on the track that is a subject rather than a qualifier, so
   // it carries full weight either way. With more than one workspace open it is
   // also the switcher; the pill metrics apply to both forms so a static
@@ -414,7 +402,7 @@ $track-item-gap: 10px;
     font-family:var(--openbitfun-type-body-sm-font-family);
     font-size: inherit;
     font-weight: var(--openbitfun-type-label-sm-font-weight);
-    line-height: var(--openbitfun-type-modifier-leading-none-line-height);
+    line-height: var(--openbitfun-type-flow-support-line-height);
     white-space: nowrap;
     cursor: default;
   }
@@ -422,7 +410,6 @@ $track-item-gap: 10px;
   &__workspace-name {
     min-width: 0;
     overflow: hidden;
-    padding-bottom: 1px;
   }
 
   // Only the interactive form answers a click — the hover fill is the whole
@@ -462,7 +449,6 @@ $track-item-gap: 10px;
     font-weight: inherit;
     flex: 1 1 auto;
     overflow: hidden;
-    padding-bottom: 1px;
   }
 
   // Shares the permission menu's floating surface so both popovers off this

--- a/src/web-ui/src/shared/ui/OverflowText.test.tsx
+++ b/src/web-ui/src/shared/ui/OverflowText.test.tsx
@@ -57,10 +57,10 @@ describe('overflow text full-content access', () => {
     vi.useRealTimers();
   });
 
-  it('shows the complete label from the entire owning control and keeps its click behavior', () => {
+  it.each(['marquee', 'fade'] as const)('shows the complete %s label from the owning control and keeps its click behavior', (behavior) => {
     const onClick = vi.fn();
     render(<button data-overflow-trigger aria-describedby="help" onClick={onClick}>
-      <OverflowText>{longLabel}</OverflowText>
+      <OverflowText behavior={behavior}>{longLabel}</OverflowText>
     </button>);
     const button = host.querySelector('button')!;
     hover(button);


### PR DESCRIPTION
## Summary

Fix clipped letter descenders in the composer workspace selector and its menu.

- Give single-line `OverflowText` content font-derived leading and baseline alignment in both fade and marquee modes.
- Unify composer context-strip and dispatch-target line heights, removing ineffective outer 1px padding adjustments.
- Document the typography contract and regenerate the Data Migrator’s bundled token CSS.

## Type and Areas

Type: Bug fix / UI/UX

Areas: Shared design system, web UI, composer workspace selector, dispatch target picker

## Motivation / Impact

Tight line heights combined with `overflow: hidden` could crop the lower strokes of letters such as `g`, `j`, and `y`. Padding outside the clipping element could not restore those strokes.

The shared fix accommodates font metrics across platform fonts and covers other controls using `OverflowText`, including menus and dropdown options. Horizontal truncation, hover tooltips, selection behavior, and multiline clamping are preserved.

## Verification

Passed:

- `pnpm run design-system:check`
- `pnpm --dir src/web-ui exec vitest run src/shared/ui/OverflowText.test.tsx src/flow_chat/components/ChatInputWorkspaceStrip.test.tsx src/flow_chat/components/ChatInputWorkspaceStripLayout.test.ts` — 75 tests passed.
- `pnpm run type-check:web`
- `pnpm run typography:audit`
- `pnpm run appearance:contract-audit`
- `pnpm run theme:color-audit:all`
- `pnpm run theme:visual-contract`
- `git diff --check`

The initial color audit detected stale Data Migrator token CSS. Regenerated it with `pnpm run data-migrator:theme:generate`; the subsequent audit passed.

## Reviewer Notes

- AI-assisted implementation; automated checks passed. Actual desktop visual verification remains pending.
- Remote workspace, remote control, Peer Device Mode, and Detached Dispatch were not exercised.
- No persisted-data or protocol changes. The typography token is additive.
- Review compact labels with different fonts and scaling settings, particularly workspace names and paths containing descenders.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.