### PR TITLE
fix(web-ui): right-align session workspace labels

### DIFF
--- a/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.scss
+++ b/src/web-ui/src/app/components/NavPanel/sections/sessions/SessionsSection.scss
@@ -236,6 +236,10 @@
     font-size: var(--openbitfun-type-meta-font-size);
     line-height: var(--openbitfun-type-body-sm-line-height);
     white-space: nowrap;
+
+    &:not([data-overflow='true']) {
+      text-align: right;
+    }
   }
 
   // Status and the menu share one trailing cell, including when status is idle.


### PR DESCRIPTION
## Summary

Right-align workspace names in the flat session list while retaining the existing overflow marquee for long names.

## Type and Areas

Type: Bug fix / UI/UX

Areas: Web UI session navigation

## Motivation / Impact

When users select “Show all sessions as one list”, workspace labels currently align to the left within their trailing column. Short and long workspace names therefore have uneven right edges. Align labels that fit to the right of that column.

## Verification

- `pnpm run check:web` — passed.
- `git diff --check` — passed.
- Remote workspace, remote control, Peer Device Mode, and Detached Dispatch were not exercised; this change only adjusts shared frontend label alignment.

## Reviewer Notes

Overflowing labels retain the shared OverflowText start alignment and marquee behavior. No persisted data, protocol, or user-facing string changes.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.
