### PR TITLE
fix(ui): vertically center permission pill and shared overflow labels

### DIFF
--- a/design-system/packages/ui/README.md
+++ b/design-system/packages/ui/README.md
@@ -113,8 +113,10 @@ Use `OverflowText` for single-line, non-editable labels instead of local
 defaults to **fade-out truncation with an interaction marquee**: a background-independent
 gradient mask at the inline end, followed by scrolling on hover or keyboard focus.
 Both effects apply only when the text actually overflows. Short labels remain untouched.
-Single-line text uses a baseline-aligned inner box with the font's natural leading
-so tight control line heights do not clip descenders. This applies to plain-text
+Single-line text uses a vertically centered inner box with the font's natural leading
+so tight control line heights do not clip descenders. The outer box keeps at least
+the owner's line height (`1lh`), without an extra inline baseline strut shifting
+the text relative to adjacent icons. This applies to plain-text
 fade and marquee labels; multiline clamps and rich composition retain their layout.
 Let text slots size naturally in the block direction instead of forcing a text-height
 box or adding outer pixel padding to compensate for clipped glyphs.

--- a/design-system/packages/ui/src/primitives/OverflowText/OverflowText.module.css
+++ b/design-system/packages/ui/src/primitives/OverflowText/OverflowText.module.css
@@ -12,14 +12,21 @@
     white-space: nowrap;
   }
 
+  .root:has(> .content) {
+    /* Center the natural text box without an anonymous inline baseline strut.
+       Keep the owner's leading as a minimum, and let taller fonts expand it.
+       The zero-minimum track still allows long labels to overflow horizontally. */
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    align-items: center;
+    min-block-size: 1lh;
+  }
+
   .content {
-    display: inline-block;
+    display: block;
     min-inline-size: max-content;
-    /* Include the font's ascent/descent inside the clipping box, even when a
-       compact control inherits leading of 1. Baseline alignment preserves any
-       larger leading supplied by the owner without cutting off glyph ink. */
+    /* Keep ascent/descent inside the clipping box, including in tight controls. */
     line-height: var(--openbitfun-type-modifier-leading-intrinsic-line-height);
-    vertical-align: baseline;
   }
 
   .root[data-overflow-lines] {


### PR DESCRIPTION
## Summary

Fix vertically offset text in the composer permission pill through the shared `OverflowText` component.

- Center single-line content using grid layout instead of inline baseline alignment.
- Preserve the owner's line height as a minimum while allowing taller fonts to expand the text box.
- Update the component documentation.

## Type and Areas

Type: Bug fix / UI/UX

Areas: Shared design system, web UI, composer controls

## Motivation / Impact

The permission button already centered its children, but the label's inner inline box still participated in baseline alignment. Combined with natural font leading, this could position visible text above adjacent icons.

The shared fix also covers workspace and branch labels, status pills, menu items, and dropdown values using the same structure. It retains descender protection, horizontal truncation, and marquee behavior. Multiline clamps and default rich-content layouts remain unchanged.

## Verification

Passed:

- `pnpm run design-system:test`
- `pnpm --dir src/web-ui exec vitest run src/shared/ui/OverflowText.test.tsx src/flow_chat/components/ChatInputWorkspaceStrip.test.tsx src/flow_chat/components/ChatInputWorkspaceStripLayout.test.ts` — 75 tests passed.
- `pnpm run check:web:appearance`
- `git diff --check`

Actual desktop visual verification remains pending. Automated checks do not establish final visual alignment.

## Reviewer Notes

- AI-assisted implementation.
- Review icon/text alignment across fonts, scaling settings, and short or overflowing labels.
- Remote workspace, remote control, Peer Device Mode, and Detached Dispatch were not exercised.
- No persisted-data, protocol, or localization changes.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.