### PR TITLE
fix(permissions): default to full access and align settings dialog

### DIFF
--- a/src/crates/assembly/core/src/agentic/execution/round_executor.rs
+++ b/src/crates/assembly/core/src/agentic/execution/round_executor.rs
@@ -2133,6 +2133,8 @@ mod tests {
         use openbitfun_runtime_ports::PermissionMode;
 
         let mut global = GlobalConfig::default();
+        global.tool_permissions.policy.preset =
+            openbitfun_runtime_ports::PermissionPolicyPreset::Ask;
         global.tool_permissions.interaction.auto_approve_ask = true;
         let mut context_vars = std::collections::HashMap::new();
 

--- a/src/crates/assembly/core/src/agentic/permission_policy.rs
+++ b/src/crates/assembly/core/src/agentic/permission_policy.rs
@@ -149,6 +149,8 @@ mod tests {
     #[test]
     fn context_mode_key_outranks_the_legacy_auto_approve_flag() {
         let mut global = GlobalConfig::default();
+        global.tool_permissions.policy.preset =
+            openbitfun_runtime_ports::PermissionPolicyPreset::Ask;
         global.tool_permissions.interaction.auto_approve_ask = true;
         let mut context_vars = std::collections::HashMap::new();
 

--- a/src/crates/contracts/product-domains/src/tool_permissions.rs
+++ b/src/crates/contracts/product-domains/src/tool_permissions.rs
@@ -185,8 +185,8 @@ impl std::error::Error for PermissionRuntimeCeilingValidationError {}
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum PermissionPolicyPreset {
-    #[default]
     Ask,
+    #[default]
     FullAccess,
 }
 

--- a/src/crates/contracts/product-domains/tests/product_domain_contracts/tool_permission_contracts.rs
+++ b/src/crates/contracts/product-domains/tests/product_domain_contracts/tool_permission_contracts.rs
@@ -54,17 +54,17 @@ fn policy(preset: PermissionPolicyPreset, rules: Vec<PermissionRule>) -> Permiss
 }
 
 #[test]
-fn tool_permission_config_defaults_to_ask_with_auto_approve_disabled() {
+fn tool_permission_config_defaults_to_full_access_with_auto_approve_disabled() {
     let config = ToolPermissionConfig::default();
 
-    assert_eq!(config.policy.preset, PermissionPolicyPreset::Ask);
+    assert_eq!(config.policy.preset, PermissionPolicyPreset::FullAccess);
     assert!(config.policy.rules.is_empty());
     assert!(!config.interaction.auto_approve_ask);
     assert_eq!(
         serde_json::to_value(config).expect("serialize tool permission config"),
         json!({
             "policy": {
-                "preset": "ask",
+                "preset": "full_access",
                 "rules": [],
             },
             "interaction": {
@@ -399,7 +399,7 @@ fn task_and_skill_default_allow_do_not_authorize_child_tools() {
 }
 
 #[test]
-fn legacy_skip_confirmation_field_does_not_enable_access_or_auto_approve() {
+fn legacy_skip_confirmation_field_does_not_override_product_defaults() {
     let config: ToolPermissionConfig = serde_json::from_value(json!({
         "skip_tool_confirmation": true,
     }))
@@ -704,6 +704,12 @@ fn permission_mode_projects_onto_preset_and_auto_approval() {
 #[test]
 fn permission_mode_round_trips_through_stored_configuration() {
     let mut config = ToolPermissionConfig::default();
+    assert_eq!(
+        PermissionMode::from_config(&config),
+        PermissionMode::FullAccess
+    );
+
+    config.policy.preset = PermissionPolicyPreset::Ask;
     assert_eq!(PermissionMode::from_config(&config), PermissionMode::Ask);
 
     config.interaction.auto_approve_ask = true;
@@ -923,5 +929,24 @@ fn unset_permission_mode_is_omitted_so_old_builds_see_unchanged_files() {
     assert_eq!(
         written,
         json!({ "permission_mode": "full_access", "keep": "value" })
+    );
+}
+
+#[test]
+fn stored_permission_preferences_survive_default_change() {
+    for preset in ["ask", "full_access"] {
+        for auto_approve in [false, true] {
+            let stored = json!({
+                "policy": { "preset": preset, "rules": [] },
+                "interaction": { "auto_approve_ask": auto_approve }
+            });
+            let config: ToolPermissionConfig = serde_json::from_value(stored.clone()).unwrap();
+            assert_eq!(serde_json::to_value(config).unwrap(), stored);
+        }
+    }
+    let missing: ToolPermissionConfig = serde_json::from_value(json!({})).unwrap();
+    assert_eq!(
+        PermissionMode::from_config(&missing),
+        PermissionMode::FullAccess
     );
 }

--- a/src/web-ui/src/infrastructure/config/components/GlobalPermissionRulesDialog.scss
+++ b/src/web-ui/src/infrastructure/config/components/GlobalPermissionRulesDialog.scss
@@ -1,59 +1,8 @@
 .global-permission-rules-dialog {
   display: flex;
   flex-direction: column;
-  gap: 16px;
   min-width: 0;
-  padding-block: 4px 16px;
   color: var(--openbitfun-color-content-primary);
-
-  &__modal {
-    overflow-x: hidden;
-  }
-
-  &__intro {
-    display: flex;
-    align-items: flex-start;
-    gap: 8px;
-    padding: 8px 10px;
-    border: 1px solid var(--openbitfun-color-border-subtle);
-    border-radius: 6px;
-    background: var(--openbitfun-color-surface-subtle);
-    color: var(--openbitfun-color-content-secondary);
-    font-size: var(--openbitfun-type-label-sm-font-size);
-    line-height: var(--openbitfun-type-body-sm-line-height);
-
-    svg {
-      flex-shrink: 0;
-      margin-top: 1px;
-      color: var(--openbitfun-color-accent-default);
-    }
-
-    p {
-      margin: 0;
-    }
-  }
-
-  &__section {
-    display: flex;
-    flex-direction: column;
-    min-width: 0;
-    border: 1px solid var(--openbitfun-color-border-subtle);
-    border-radius: 8px;
-    overflow: hidden;
-  }
-
-  &__section-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 12px;
-    min-height: 44px;
-    padding: 8px 12px;
-    color: var(--openbitfun-color-content-primary);
-    font-size: var(--openbitfun-type-label-md-font-size);
-    font-weight: var(--openbitfun-type-label-selected-font-weight);
-    background: var(--openbitfun-color-surface-subtle);
-  }
 
   &__rules {
     display: flex;
@@ -64,11 +13,11 @@
   &__rule-heading,
   &__rule-row {
     display: grid;
-    grid-template-columns: minmax(120px, 0.55fr) minmax(150px, 0.65fr) minmax(220px, 1fr) auto;
+    grid-template-columns: minmax(100px, 0.55fr) minmax(120px, 0.65fr) minmax(0, 1fr) 88px;
     align-items: center;
     gap: 10px;
     min-width: 0;
-    padding-inline: 12px;
+    padding-inline: var(--openbitfun-layout-field-group-row-padding-inline);
   }
 
   &__rule-heading {
@@ -106,17 +55,8 @@
     justify-content: flex-end;
   }
 
-  &__footer {
-    display: flex;
-    justify-content: flex-end;
-    gap: 8px;
-    padding: 12px;
-    border-top: 1px solid var(--openbitfun-color-border-subtle);
-    background: var(--openbitfun-color-surface-subtle);
-  }
-
   &__empty {
-    padding: 18px 12px;
+    padding: var(--openbitfun-space-6) var(--openbitfun-layout-field-group-row-padding-inline);
     color: var(--openbitfun-color-content-muted);
     font-size: var(--openbitfun-type-label-sm-font-size);
     line-height: var(--openbitfun-type-body-sm-line-height);

--- a/src/web-ui/src/infrastructure/config/components/GlobalPermissionRulesDialog.test.tsx
+++ b/src/web-ui/src/infrastructure/config/components/GlobalPermissionRulesDialog.test.tsx
@@ -54,17 +54,20 @@ vi.mock('@openbitfun/ui', () => ({
   Dialog: ({ open, children }: { open: boolean; children: React.ReactNode }) => (
     open ? <div role="dialog">{children}</div> : null
   ),
+  DialogDescription: ({ children }: React.PropsWithChildren) => <p>{children}</p>,
+  DialogFooter: ({ children }: React.PropsWithChildren) => <footer>{children}</footer>,
   DialogBody: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
   DialogClose: (props: React.ButtonHTMLAttributes<HTMLButtonElement>) => <button type="button" {...props} />,
   DialogHeader: ({ children }: React.PropsWithChildren) => <header>{children}</header>,
   DialogHeading: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
   DialogTitle: ({ children }: React.PropsWithChildren) => <h2>{children}</h2>,
-  Button: ({ children, disabled, onClick }: {
+  Button: ({ children, disabled, onClick, 'data-permission-add-rule': addRule }: {
     children: React.ReactNode;
+    'data-permission-add-rule'?: boolean;
     disabled?: boolean;
     onClick?: () => void;
   }) => (
-    <button type="button" disabled={disabled} onClick={onClick}>{children}</button>
+    <button type="button" data-permission-add-rule={addRule} disabled={disabled} onClick={onClick}>{children}</button>
   ),
   IconButton: ({ children, disabled, onClick, 'aria-label': ariaLabel }: {
     children: React.ReactNode;
@@ -341,6 +344,17 @@ describe('GlobalPermissionRulesDialog', () => {
     });
     expect(container.querySelectorAll('.global-permission-rules-dialog__rule-row')).toHaveLength(1);
     expect(container.querySelector<HTMLSelectElement>('select[aria-label="Action"]')?.value).toBe('git');
+  });
+
+  it('returns focus to Add rule when the last rule is removed', async () => {
+    vi.useFakeTimers();
+    await renderDialog([{ action: 'read', resource: '*', effect: 'ask' }]);
+    const removeButton = container.querySelector<HTMLButtonElement>('button[aria-label="Remove rule"]');
+    await act(async () => {
+      removeButton?.focus();
+      removeButton?.click();
+    });
+    expect(document.activeElement).toBe(container.querySelector('[data-permission-add-rule]'));
   });
 
   it('cancels an old removal when the dialog closes and opens with new rules', async () => {

--- a/src/web-ui/src/infrastructure/config/components/GlobalPermissionRulesDialog.tsx
+++ b/src/web-ui/src/infrastructure/config/components/GlobalPermissionRulesDialog.tsx
@@ -11,6 +11,8 @@ import {
   Dialog,
   DialogBody,
   DialogClose,
+  DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogHeading,
   DialogTitle,
@@ -23,7 +25,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { Save, ShieldCheck } from 'lucide-react';
+import { Save } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import {
   requestSettingsDraftExit,
@@ -299,7 +301,7 @@ export const GlobalPermissionRulesDialog: React.FC<GlobalPermissionRulesDialogPr
         .get(focusTargetId)
         ?.querySelector<HTMLButtonElement>('.global-permission-rules-dialog__rule-actions button:last-of-type')
       : dialogRootRef.current?.querySelector<HTMLButtonElement>(
-        '.global-permission-rules-dialog__section-header button',
+        '[data-permission-add-rule]',
       );
     focusTarget?.focus();
   };
@@ -383,175 +385,171 @@ export const GlobalPermissionRulesDialog: React.FC<GlobalPermissionRulesDialogPr
       <DialogHeader>
         <DialogHeading>
           <DialogTitle>{t('permissionPolicy.globalRulesDialogTitle')}</DialogTitle>
+          <DialogDescription data-openbitfun-component="global-permission-rules-dialog" data-openbitfun-part="intro">
+            {t('permissionPolicy.globalRulesDialogDescription')}
+          </DialogDescription>
         </DialogHeading>
         <DialogClose disabled={isSaving} />
       </DialogHeader>
       <DialogBody>
-        <div className="global-permission-rules-dialog__modal">
-      <div ref={dialogRootRef} className="global-permission-rules-dialog" data-openbitfun-component="global-permission-rules-dialog" data-openbitfun-part="root">
-        <div data-openbitfun-component="global-permission-rules-dialog" data-openbitfun-part="intro" className="global-permission-rules-dialog__intro">
-          <ShieldCheck size={18} aria-hidden="true" />
-          <p>{t('permissionPolicy.globalRulesDialogDescription')}</p>
-        </div>
-
-        <FormSection
-          data-openbitfun-component="global-permission-rules-dialog"
-          data-openbitfun-part="section"
-          className="global-permission-rules-dialog__section"
-          title={(
-            <span data-openbitfun-component="global-permission-rules-dialog" data-openbitfun-part="sectionHeader">
-              {t('permissionPolicy.globalRulesTitle')}
-            </span>
-          )}
-          actions={(
-            <Button
-              size="sm"
-              variant="outline"
-              disabled={isSaving}
-              onClick={handleAddRule}
-              leadingIcon={<Icon name="plus" size="sm" />}
-            >
-              {t('permissionPolicy.addGlobalRule')}
-            </Button>
-          )}
-        >
-
-          {draftRules.length === 0 ? (
-            <div data-openbitfun-component="global-permission-rules-dialog" data-openbitfun-part="empty" className="global-permission-rules-dialog__empty">
-              {t('permissionPolicy.globalRulesEmpty')}
-            </div>
-          ) : (
-            <FieldGroup
-              appearance="plain"
-              dividers={false}
-              data-openbitfun-component="global-permission-rules-dialog"
-              data-openbitfun-part="rules"
-              className="global-permission-rules-dialog__rules"
-            >
-              <div className="global-permission-rules-dialog__rule-heading" aria-hidden="true">
-                <span>{t('permissionPolicy.globalRulesEffect')}</span>
-                <span>{t('permissionPolicy.globalRulesAction')}</span>
-                <span>{t('permissionPolicy.globalRulesResource')}</span>
-                <span />
-              </div>
-              {draftRules.map((rule) => {
-                const exiting = exitingRuleIds.has(rule.localId);
-                const activeIndex = activeRuleIndexes.get(rule.localId);
-                return (
-                  <div
-                    ref={(row) => {
-                      if (row) {
-                        ruleRowsRef.current.set(rule.localId, row);
-                      } else {
-                        ruleRowsRef.current.delete(rule.localId);
-                      }
-                    }}
-                    data-openbitfun-component="global-permission-rules-dialog"
-                    data-openbitfun-part="rule"
-                    data-rule-id={rule.localId}
-                    data-exiting={exiting ? 'true' : 'false'}
-                    aria-hidden={exiting || undefined}
-                    {...(exiting ? { inert: '' } : {})}
-                    key={rule.localId}
-                    className="global-permission-rules-dialog__rule-row"
-                  >
-                    <Select
-                      size="sm"
-                      value={rule.effect}
-                      options={effectOptions}
-                      aria-label={t('permissionPolicy.globalRulesEffect')}
-                      disabled={isSaving || exiting}
-                      onValueChange={(value) => updateDraftRule(rule.localId, { effect: value as PermissionEffect })}
-                    />
-                    <Select
-                      size="sm"
-                      value={rule.action}
-                      options={GLOBAL_PERMISSION_ACTION_OPTIONS}
-                      placeholder={t('permissionPolicy.globalRulesAction')}
-                      aria-label={t('permissionPolicy.globalRulesAction')}
-                      disabled={isSaving || exiting}
-                      invalid={!rule.action.trim()}
-                      onValueChange={(value) => updateDraftRule(rule.localId, { action: value as string })}
-                    />
-                    <Input
-                      value={rule.resource}
-                      placeholder={t('permissionPolicy.globalRulesResourcePlaceholder')}
-                      aria-label={t('permissionPolicy.globalRulesResource')}
-                      disabled={isSaving || exiting}
-                      invalid={!rule.resource.trim()}
-                      onChange={(event) => updateDraftRule(rule.localId, { resource: event.target.value })}
-                      size="sm"
-                    />
-                    <div data-openbitfun-component="global-permission-rules-dialog" data-openbitfun-part="ruleActions" className="global-permission-rules-dialog__rule-actions">
-                      <Tooltip content={t('permissionPolicy.moveGlobalRuleUp')}>
-                        <IconButton
-                          type="button"
-                          size="sm"
-                          aria-label={t('permissionPolicy.moveGlobalRuleUp')}
-                          disabled={isSaving || exiting || activeIndex === 0}
-                          onClick={() => moveDraftRule(rule.localId, -1)}
-                          icon={<Icon name="arrow-up" size="sm" />}
-                        />
-                      </Tooltip>
-                      <Tooltip content={t('permissionPolicy.moveGlobalRuleDown')}>
-                        <IconButton
-                          type="button"
-                          size="sm"
-                          aria-label={t('permissionPolicy.moveGlobalRuleDown')}
-                          disabled={
-                            isSaving
-                            || exiting
-                            || activeIndex === undefined
-                            || activeIndex === activeDraftRules.length - 1
-                          }
-                          onClick={() => moveDraftRule(rule.localId, 1)}
-                          icon={<Icon name="arrow-down" size="sm" />}
-                        />
-                      </Tooltip>
-                      <Tooltip content={t('permissionPolicy.removeGlobalRule')}>
-                        <IconButton
-                          type="button"
-                          size="sm"
-                          aria-label={t('permissionPolicy.removeGlobalRule')}
-                          disabled={isSaving || exiting}
-                          onClick={() => handleRemoveRule(rule.localId)}
-                          icon={<Icon name="delete" size="sm" />}
-                        />
-                      </Tooltip>
-                    </div>
-                  </div>
-                );
-              })}
-            </FieldGroup>
-          )}
-
-          {rulesDirty ? (
-            <div data-openbitfun-component="global-permission-rules-dialog" data-openbitfun-part="footer" className="global-permission-rules-dialog__footer">
+        <div ref={dialogRootRef} className="global-permission-rules-dialog" data-openbitfun-component="global-permission-rules-dialog" data-openbitfun-part="root">
+          <FormSection
+            data-openbitfun-component="global-permission-rules-dialog"
+            data-openbitfun-part="section"
+            className="global-permission-rules-dialog__section"
+            title={(
+              <span data-openbitfun-component="global-permission-rules-dialog" data-openbitfun-part="sectionHeader">
+                {t('permissionPolicy.globalRulesTitle')}
+              </span>
+            )}
+            actions={(
               <Button
-                type="button"
+                size="sm"
                 variant="fill"
-                onClick={handleDiscard}
+                data-permission-add-rule
                 disabled={isSaving}
+                onClick={handleAddRule}
+                leadingIcon={<Icon name="plus" size="sm" />}
               >
-                {t('permissionPolicy.discardGlobalRules')}
+                {t('permissionPolicy.addGlobalRule')}
               </Button>
-              <Button
-                type="button"
-                variant="primary"
-                loading={isSaving}
-                disabled={!rulesValid || isSaving}
-                onClick={() => void handleSave()}
-                leadingIcon={<Save size={14} />}
+            )}
+          >
+            {draftRules.length === 0 ? (
+              <FieldGroup>
+                <div data-openbitfun-component="global-permission-rules-dialog" data-openbitfun-part="empty" className="global-permission-rules-dialog__empty">
+                  {t('permissionPolicy.globalRulesEmpty')}
+                </div>
+              </FieldGroup>
+            ) : (
+              <FieldGroup
+                appearance="subtle"
+                dividers={false}
+                data-openbitfun-component="global-permission-rules-dialog"
+                data-openbitfun-part="rules"
+                className="global-permission-rules-dialog__rules"
               >
-
-                {t('permissionPolicy.saveGlobalRules')}
-              </Button>
-            </div>
-          ) : null}
-        </FormSection>
-      </div>
-            </div>
-            </DialogBody>
+                <div className="global-permission-rules-dialog__rule-heading" aria-hidden="true">
+                  <span>{t('permissionPolicy.globalRulesEffect')}</span>
+                  <span>{t('permissionPolicy.globalRulesAction')}</span>
+                  <span>{t('permissionPolicy.globalRulesResource')}</span>
+                  <span />
+                </div>
+                {draftRules.map((rule) => {
+                  const exiting = exitingRuleIds.has(rule.localId);
+                  const activeIndex = activeRuleIndexes.get(rule.localId);
+                  return (
+                    <div
+                      ref={(row) => {
+                        if (row) {
+                          ruleRowsRef.current.set(rule.localId, row);
+                        } else {
+                          ruleRowsRef.current.delete(rule.localId);
+                        }
+                      }}
+                      data-openbitfun-component="global-permission-rules-dialog"
+                      data-openbitfun-part="rule"
+                      data-rule-id={rule.localId}
+                      data-exiting={exiting ? 'true' : 'false'}
+                      aria-hidden={exiting || undefined}
+                      {...(exiting ? { inert: '' } : {})}
+                      key={rule.localId}
+                      className="global-permission-rules-dialog__rule-row"
+                    >
+                      <Select
+                        size="sm"
+                        value={rule.effect}
+                        options={effectOptions}
+                        aria-label={t('permissionPolicy.globalRulesEffect')}
+                        disabled={isSaving || exiting}
+                        onValueChange={(value) => updateDraftRule(rule.localId, { effect: value as PermissionEffect })}
+                      />
+                      <Select
+                        size="sm"
+                        value={rule.action}
+                        options={GLOBAL_PERMISSION_ACTION_OPTIONS}
+                        placeholder={t('permissionPolicy.globalRulesAction')}
+                        aria-label={t('permissionPolicy.globalRulesAction')}
+                        disabled={isSaving || exiting}
+                        invalid={!rule.action.trim()}
+                        onValueChange={(value) => updateDraftRule(rule.localId, { action: value as string })}
+                      />
+                      <Input
+                        value={rule.resource}
+                        placeholder={t('permissionPolicy.globalRulesResourcePlaceholder')}
+                        aria-label={t('permissionPolicy.globalRulesResource')}
+                        disabled={isSaving || exiting}
+                        invalid={!rule.resource.trim()}
+                        onChange={(event) => updateDraftRule(rule.localId, { resource: event.target.value })}
+                        size="sm"
+                      />
+                      <div data-openbitfun-component="global-permission-rules-dialog" data-openbitfun-part="ruleActions" className="global-permission-rules-dialog__rule-actions">
+                        <Tooltip content={t('permissionPolicy.moveGlobalRuleUp')}>
+                          <IconButton
+                            type="button"
+                            size="sm"
+                            aria-label={t('permissionPolicy.moveGlobalRuleUp')}
+                            disabled={isSaving || exiting || activeIndex === 0}
+                            onClick={() => moveDraftRule(rule.localId, -1)}
+                            icon={<Icon name="arrow-up" size="sm" />}
+                          />
+                        </Tooltip>
+                        <Tooltip content={t('permissionPolicy.moveGlobalRuleDown')}>
+                          <IconButton
+                            type="button"
+                            size="sm"
+                            aria-label={t('permissionPolicy.moveGlobalRuleDown')}
+                            disabled={
+                              isSaving
+                              || exiting
+                              || activeIndex === undefined
+                              || activeIndex === activeDraftRules.length - 1
+                            }
+                            onClick={() => moveDraftRule(rule.localId, 1)}
+                            icon={<Icon name="arrow-down" size="sm" />}
+                          />
+                        </Tooltip>
+                        <Tooltip content={t('permissionPolicy.removeGlobalRule')}>
+                          <IconButton
+                            type="button"
+                            size="sm"
+                            aria-label={t('permissionPolicy.removeGlobalRule')}
+                            disabled={isSaving || exiting}
+                            onClick={() => handleRemoveRule(rule.localId)}
+                            icon={<Icon name="delete" size="sm" />}
+                          />
+                        </Tooltip>
+                      </div>
+                    </div>
+                  );
+                })}
+              </FieldGroup>
+            )}
+          </FormSection>
+        </div>
+      </DialogBody>
+      {rulesDirty ? (
+        <DialogFooter data-openbitfun-component="global-permission-rules-dialog" data-openbitfun-part="footer">
+          <Button
+            type="button"
+            variant="fill"
+            onClick={handleDiscard}
+            disabled={isSaving}
+          >
+            {t('permissionPolicy.discardGlobalRules')}
+          </Button>
+          <Button
+            type="button"
+            variant="primary"
+            loading={isSaving}
+            disabled={!rulesValid || isSaving}
+            onClick={() => void handleSave()}
+            leadingIcon={<Save size={14} />}
+          >
+            {t('permissionPolicy.saveGlobalRules')}
+          </Button>
+        </DialogFooter>
+      ) : null}
     </Dialog>
   );
 };

--- a/src/web-ui/src/infrastructure/config/services/PermissionConfigService.test.ts
+++ b/src/web-ui/src/infrastructure/config/services/PermissionConfigService.test.ts
@@ -20,10 +20,29 @@ describe('PermissionConfigService', () => {
     configManagerMock.setConfig.mockResolvedValue(undefined);
   });
 
-  it('uses ask and disabled auto approval as safe defaults', async () => {
+  it('defaults missing configuration to full access with auto approval disabled', async () => {
     configManagerMock.getConfig.mockResolvedValue(undefined);
     const { permissionConfigService } = await import('./PermissionConfigService');
 
+    await expect(permissionConfigService.getConfig()).resolves.toEqual({
+      policy: { preset: 'full_access', rules: [] },
+      interaction: { auto_approve_ask: false },
+    });
+  });
+
+  it('preserves stored ask and auto approval preferences', async () => {
+    const stored = {
+      policy: { preset: 'ask', rules: [] },
+      interaction: { auto_approve_ask: true },
+    };
+    configManagerMock.getConfig.mockResolvedValue(stored);
+    const { permissionConfigService } = await import('./PermissionConfigService');
+    await expect(permissionConfigService.getConfig()).resolves.toEqual(stored);
+  });
+
+  it('keeps configuration load failures on the ask fallback', async () => {
+    configManagerMock.getConfig.mockRejectedValue(new Error('offline'));
+    const { permissionConfigService } = await import('./PermissionConfigService');
     await expect(permissionConfigService.getConfig()).resolves.toEqual({
       policy: { preset: 'ask', rules: [] },
       interaction: { auto_approve_ask: false },

--- a/src/web-ui/src/infrastructure/config/services/PermissionConfigService.ts
+++ b/src/web-ui/src/infrastructure/config/services/PermissionConfigService.ts
@@ -8,7 +8,7 @@ const CONFIG_PATH = 'tool_permissions';
 
 export const DEFAULT_TOOL_PERMISSION_CONFIG: ToolPermissionConfig = {
   policy: {
-    preset: 'ask',
+    preset: 'full_access',
     rules: [],
   },
   interaction: {
@@ -36,7 +36,9 @@ export function normalizeToolPermissionConfig(value: unknown): ToolPermissionCon
 
   return {
     policy: {
-      preset: policy.preset === 'full_access' ? 'full_access' : 'ask',
+      preset: policy.preset === undefined
+        ? DEFAULT_TOOL_PERMISSION_CONFIG.policy.preset
+        : policy.preset === 'full_access' ? 'full_access' : 'ask',
       rules,
     },
     interaction: {
@@ -52,7 +54,7 @@ export class PermissionConfigService {
     } catch (error) {
       log.warn('Failed to load tool permission config, using safe defaults', error);
       return {
-        policy: { preset: DEFAULT_TOOL_PERMISSION_CONFIG.policy.preset, rules: [] },
+        policy: { preset: 'ask', rules: [] },
         interaction: { auto_approve_ask: DEFAULT_TOOL_PERMISSION_CONFIG.interaction.auto_approve_ask },
       };
     }


### PR DESCRIPTION
## Summary

- Default new or missing tool-permission configuration to full access in Rust and the Web UI, preserving explicitly stored presets, rules, and auto-approval preferences.
- Align the global tool permission rules dialog with the shared settings design: standard title description, grouped empty/list states, and a standard footer for draft actions. Remove redundant borders and obsolete header styling, and restore focus to Add rule after deleting the last rule.
- Permission-mode selector visibility already defaults to visible; retain that behavior and its existing compatibility coverage.

## Type and Areas

Type: Bug fix / UI/UX

Areas: Rust product-domain contracts, Web UI permission settings

## Motivation / Impact

Unconfigured installations now start in full access. Existing explicit settings remain intact. Unknown frontend preset values and configuration read failures retain the ask fallback. Project and enforced permission restrictions continue to apply.

The rules editor previously combined shared form components with obsolete custom container styling, leaving the section heading and Add rule button against the outer border. It now uses the same composition as other product settings.

## Verification

Passed locally before rebasing onto the latest upstream main:

- `pnpm run fmt:rs`
- `cargo test -p openbitfun-product-domains --no-default-features --test product_domain_contracts tool_permission_contracts` — 32 passed
- `cargo test -p openbitfun-config-contracts --lib` — 87 passed, including selector visibility and persisted preference coverage
- `pnpm --dir src/web-ui run test:run src/infrastructure/config/services/PermissionConfigService.test.ts` — 6 passed
- `pnpm --dir src/web-ui exec vitest run src/infrastructure/config/components/GlobalPermissionRulesDialog.test.tsx` — 9 passed
- `pnpm run check:web` — passed, including type checking and theme/color governance; existing non-blocking appearance audit warnings remain
- `git diff --check upstream/main...HEAD` — passed after rebase

## Reviewer Notes

No schema or protocol changes. Explicit persisted ask/full-access modes and auto-approval settings have round-trip coverage. Existing explicit selector hiding is preserved.

Verification is local automated coverage only. Rendered UI was not manually verified. Remote workspace, Remote Control, Peer Device Mode, and Detached Dispatch were not exercised end to end.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable (existing localized strings are reused).
