### PR TITLE
fix(flow-chat): stop repainting finalized streamed text

### DIFF
--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/TextChunkModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/TextChunkModule.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import type { AnyFlowItem, DialogTurn, FlowToolItem, ModelRound, Session } from '../../types/flow-chat';
-import { processNormalTextChunkInternal, processThinkingChunkInternal } from './TextChunkModule';
+import {
+  completeActiveTextItems,
+  processNormalTextChunkInternal,
+  processThinkingChunkInternal,
+} from './TextChunkModule';
 
 function makeContext(session: Session): any {
   return {
@@ -31,7 +35,20 @@ function makeContext(session: Session): any {
           }
         }
       },
-      batchUpdateModelRoundItems: () => {},
+      batchUpdateModelRoundItems: (
+        _sessionId: string,
+        _turnId: string,
+        updates: Array<{ itemId: string; changes: Partial<AnyFlowItem> }>,
+      ) => {
+        for (const round of session.dialogTurns[0].modelRounds) {
+          for (const update of updates) {
+            const item = round.items.find(candidate => candidate.id === update.itemId);
+            if (item) {
+              Object.assign(item, update.changes);
+            }
+          }
+        }
+      },
       updateDialogTurn: (
         _sessionId: string,
         _turnId: string,
@@ -308,5 +325,40 @@ describe('processNormalTextChunkInternal', () => {
       'reasoning',
       'summary',
     ]);
+  });
+
+  // Issue 2778: the same assistant sentence was painted several times in a long
+  // turn. Finalizing active text items at a round boundary drops the item
+  // registration but keeps the accumulated text buffer, so the next chunk in
+  // that round finds no reusable item and creates a second item seeded with the
+  // whole buffer. Painting must not repeat text an earlier item already shows.
+  it('does not repaint already shown text when a round continues after active text items were finalized', () => {
+    const session = makeSession();
+    const context = makeContext(session);
+
+    processNormalTextChunkInternal(
+      context,
+      'session-1',
+      'turn-1',
+      'round-1',
+      '看来只有 part3 入队成功，',
+    );
+
+    // Exactly what the model-round-start handler does before building a round.
+    completeActiveTextItems(context, 'session-1', 'turn-1');
+
+    processNormalTextChunkInternal(context, 'session-1', 'turn-1', 'round-1', '补上 part1/2。');
+
+    const painted = session.dialogTurns[0].modelRounds[0].items
+      .filter(item => item.type === 'text')
+      .map(item => (item as any).content as string);
+
+    const firstSegment = painted[0];
+    const repaintedSegments = painted
+      .slice(1)
+      .filter(text => text.includes(firstSegment));
+
+    expect(repaintedSegments).toEqual([]);
+    expect(painted.join('')).toBe('看来只有 part3 入队成功，补上 part1/2。');
   });
 });

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/TextChunkModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/TextChunkModule.ts
@@ -290,7 +290,7 @@ export function completeActiveTextItems(
   if (sessionActiveTextItems && sessionActiveTextItems.size > 0) {
     const itemsToComplete = Array.from(sessionActiveTextItems.entries());
     const batchUpdates = itemsToComplete
-      .map(([_roundId, itemId]) => ({
+      .map(([_streamKey, itemId]) => ({
         itemId,
         changes: {
           isStreaming: false,
@@ -300,6 +300,18 @@ export function completeActiveTextItems(
     
     if (batchUpdates.length > 0) {
       context.flowChatStore.batchUpdateModelRoundItems(sessionId, turnId, batchUpdates);
+    }
+
+    // A finalized segment must release its accumulated text together with its
+    // item registration. Keeping the buffer made the next chunk of the same
+    // stream key create a second item seeded with everything already painted
+    // (issue 2778). The item stays the source of truth for its own content, so
+    // a genuine late chunk still continues it through the reuse path.
+    const sessionContentBuffer = context.contentBuffers.get(sessionId);
+    if (sessionContentBuffer) {
+      for (const [streamKey] of itemsToComplete) {
+        sessionContentBuffer.delete(streamKey);
+      }
     }
     
     sessionActiveTextItems.clear();


### PR DESCRIPTION
## Problem

Fixes #2778 — in a long turn the same assistant text was painted several times even though the model emitted it once (reported on the remote-control / multi-device session path).

## Root cause

`completeActiveTextItems` in `src/web-ui/src/flow_chat/services/flow-chat-manager/TextChunkModule.ts` finalizes the active text items at a model-round boundary. It cleared the item registrations but left each stream key's accumulated entries in the session content buffer. The next chunk for the same stream key then found no reusable item and opened a **new** text item seeded with the whole accumulated buffer, so the first segment showed up again inside the second item.

## Fix

`completeActiveTextItems` now releases the accumulated buffer entries together with the item registrations it finalizes. The item itself stays the source of truth for its own content, so a genuine late chunk still continues the existing item through the existing reuse path.

Changed files:

- `src/web-ui/src/flow_chat/services/flow-chat-manager/TextChunkModule.ts` (+14/-3)
- `src/web-ui/src/flow_chat/services/flow-chat-manager/TextChunkModule.test.ts` (+56/-1)

## Validation

| Check | Result |
|---|---|
| `vitest run flow_chat/services/flow-chat-manager/TextChunkModule.test.ts flow_chat/services/flow-chat-manager/EventHandlerModule.test.ts` | 2 files / 60 tests passed, exit 0 |
| `tsc --noEmit` (web-ui) | exit 0, no output |
| New regression test on the unpatched module | `1 failed \| 7 passed` — the second text item re-contained the whole first segment |
| Same test with the fix | passes |

The regression test replays the round-boundary sequence: paint a segment, finalize active text items, then apply the next chunk of the same stream key.

## Notes / residual risk

- The reported scenario was a two-device remote-control session; that path was not exercised end to end here. What is proven is the deterministic code-level defect and that painting no longer repeats text an earlier item already shows.
- Re-delivery of already applied chunks remains a separate concern owned by the position-admitted projection contract; this change only removes the duplicated full-segment repaint.
