### PR TITLE
refactor(web-ui): adopt shared IconButton controls and fix context menu icons

### DIFF
--- a/design-system/packages/ui/src/components/Menu/MenuPopover.module.css
+++ b/design-system/packages/ui/src/components/Menu/MenuPopover.module.css
@@ -1,4 +1,21 @@
 @layer openbitfun.components {
+  /* Slot wrappers must not introduce an inline SVG baseline inside the centered row. */
+  .icon,
+  .submenuArrow {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .icon {
+    inline-size: 100%;
+    block-size: 100%;
+  }
+  .icon > :where(svg, img),
+  .icon > [data-openbitfun-component="icon"] {
+    display: block;
+    inline-size: 100%;
+    block-size: 100%;
+  }
   .submenuBoundary { display: contents; }
   .popup {
     position: fixed;

--- a/design-system/packages/ui/src/components/Menu/MenuPopover.tsx
+++ b/design-system/packages/ui/src/components/Menu/MenuPopover.tsx
@@ -203,9 +203,9 @@ function MenuLevel({ items, open, phase, treeId, onClose, onBack, anchorRef, pos
     <MenuSurface {...props} ref={node => { (menuRef as { current: HTMLDivElement | null }).current = node; }} className={classNames(styles.popup, className)} autoFocusFirstItem={open && autoFocusFirstItem && Boolean(layout)} tabIndex={-1}
       style={{ ...layout?.style, ...style, visibility: layout ? undefined : "hidden" }} data-openbitfun-native-webview-occlusion data-openbitfun-menu-tree={treeId} data-placement={layout?.placement ?? placement} data-state={phase}
       aria-hidden={!open || undefined} {...(!open ? { inert: "" } : {})} onContextMenu={event => event.preventDefault()}>
-      {items.map(item => item.separator ? <Separator key={item.id} /> : <Item key={item.id} data-menu-id={item.id} leading={item.icon ? <Leading>{item.icon}</Leading> : undefined} shortcut={item.shortcut ? <Shortcut>{item.shortcut}</Shortcut> : undefined} tone={item.tone} role={item.role} checked={item.checked}
+      {items.map(item => item.separator ? <Separator key={item.id} /> : <Item key={item.id} data-menu-id={item.id} leading={item.icon ? <Leading className={styles.icon}>{item.icon}</Leading> : undefined} shortcut={item.shortcut ? <Shortcut>{item.shortcut}</Shortcut> : undefined} tone={item.tone} role={item.role} checked={item.checked}
         disabled={item.disabled} aria-disabled={item.disabled || undefined} aria-haspopup={item.submenu?.length ? "menu" : undefined} aria-expanded={item.submenu?.length ? activeEntry?.id === item.id : undefined}
-        aria-controls={activeEntry?.id === item.id ? submenuId : undefined} metadata={item.submenu?.length ? <Arrow><Icon name="chevron-right" size="sm" /></Arrow> : undefined}
+        aria-controls={activeEntry?.id === item.id ? submenuId : undefined} metadata={item.submenu?.length ? <Arrow className={styles.submenuArrow}><Icon name="chevron-right" size="sm" /></Arrow> : undefined}
         onClick={event => { event.stopPropagation(); if (item.submenu?.length) openSubmenu(item, event.currentTarget, true); else activate(item); }}
         onPointerEnter={event => { if (activeId === null || activeId === item.id) submenuAnchor.current = event.currentTarget; keyboardOpen.current = false; intent.requestChange(!item.disabled && item.submenu?.length ? item.id : null, event); }}
         onPointerLeave={intent.requestClose}

--- a/docs/architecture/appearance-package-system.md
+++ b/docs/architecture/appearance-package-system.md
@@ -292,6 +292,12 @@ states: [
   [data-openbitfun-component="button"][data-openbitfun-part="root"][data-openbitfun-variant="primary"]:hover:not(:disabled) { ... }
 ```
 
+产品控件复用组件库时，可在 descriptor 中声明
+`componentAttribute: 'data-openbitfun-product-component'`，由编译器匹配
+`data-openbitfun-product-component` / `data-openbitfun-product-part`，避免覆盖库组件自己的标识。
+模型轮次和图片导出使用这一映射；外观包仍使用 `model-round-item`、`export-image` 及原有
+part/state 名称，无需修改已保存的包。迁移须验证旧包编译后的规则能命中实际产品节点。
+
 part 规则分四层，后者覆盖前者：
 
 1. `materials`，按数组顺序合并；

--- a/docs/architecture/appearance-package-system.md
+++ b/docs/architecture/appearance-package-system.md
@@ -295,7 +295,9 @@ states: [
 产品控件复用组件库时，可在 descriptor 中声明
 `componentAttribute: 'data-openbitfun-product-component'`，由编译器匹配
 `data-openbitfun-product-component` / `data-openbitfun-product-part`，避免覆盖库组件自己的标识。
-模型轮次和图片导出使用这一映射；外观包仍使用 `model-round-item`、`export-image` 及原有
+模型轮次、图片导出、紧凑工具栏和消息定位控件使用这一映射；外观包仍使用
+`model-round-item`、`export-image`、`toolbar-mode`、`scroll-to-latest-bar`、
+`scroll-to-turn-header-button` 及原有
 part/state 名称，无需修改已保存的包。迁移须验证旧包编译后的规则能命中实际产品节点。
 
 part 规则分四层，后者覆盖前者：

--- a/src/web-ui/src/app/layout/AppLayout.scss
+++ b/src/web-ui/src/app/layout/AppLayout.scss
@@ -117,7 +117,7 @@ html, body {
   background: var(--openbitfun-color-surface-scene);
 }
 
-.openbitfun-app-layout--toolbar-mode > [data-openbitfun-component='toolbar-mode'][data-openbitfun-part='root'] {
+.openbitfun-app-layout--toolbar-mode > [data-openbitfun-product-component='toolbar-mode'][data-openbitfun-product-part='root'] {
   position: relative;
   z-index: 1;
 }

--- a/src/web-ui/src/features/ssh-remote/RemoteFileBrowser.scss
+++ b/src/web-ui/src/features/ssh-remote/RemoteFileBrowser.scss
@@ -117,6 +117,8 @@
   }
 
   &__breadcrumb-btn {
+    inline-size: auto;
+    block-size: auto;
     display: inline-flex;
     align-items: center;
     padding: 4px 8px;
@@ -226,6 +228,10 @@
     color: var(--openbitfun-color-status-danger-content);
 
     button {
+      inline-size: auto;
+      block-size: auto;
+      display: inline-block;
+      transition: none;
       background: none;
       border: none;
       color: var(--openbitfun-color-status-danger-content);
@@ -233,6 +239,31 @@
       font-size: var(--openbitfun-type-flow-title-font-size);
       padding: 0 4px;
     }
+  }
+
+  // Preserve native action geometry and surfaces through IconButton's public slot.
+  &__breadcrumb-btn[data-openbitfun-component='icon-button'],
+  &__toolbar-btn,
+  &__error > [data-openbitfun-component='icon-button'] {
+    outline: revert;
+    outline-offset: revert;
+
+    &::before { content: none; }
+
+    > [data-openbitfun-part='icon'] {
+      --openbitfun-opacity-icon-artwork: inherit;
+      display: contents;
+    }
+
+    > :where([data-openbitfun-part='icon']) > :where(svg, [data-openbitfun-component='icon']) {
+      inline-size: 14px;
+      block-size: 14px;
+    }
+  }
+
+  &__toolbar-btn > :where([data-openbitfun-part='icon']) > :where([data-openbitfun-component='icon']) {
+    inline-size: 16px;
+    block-size: 16px;
   }
 
   &__loading {

--- a/src/web-ui/src/features/ssh-remote/RemoteFileBrowser.tsx
+++ b/src/web-ui/src/features/ssh-remote/RemoteFileBrowser.tsx
@@ -432,13 +432,13 @@ export const RemoteFileBrowser: React.FC<RemoteFileBrowserProps> = ({
               }}
               title={t('ssh.remote.clickToEditPath') || 'Click to edit path'}
             >
-              <button
+              <IconButton
                 className="remote-file-browser__breadcrumb-btn"
                 onClick={(e) => { e.stopPropagation(); navigateTo(homeAnchor); }}
                 title={t('ssh.remote.homeFolder') || 'Home folder'}
-              >
-                <Home size={14} />
-              </button>
+                aria-label={t('ssh.remote.homeFolder')}
+                icon={<Home size={14} />}
+              />
               <Icon name="chevron-right" size="xs" className="remote-file-browser__breadcrumb-sep" />
               {pathParts.length === 0 ? (
                 <span className="remote-file-browser__breadcrumb-current">/</span>
@@ -465,15 +465,15 @@ export const RemoteFileBrowser: React.FC<RemoteFileBrowserProps> = ({
 
         {/* Toolbar */}
         <div className="remote-file-browser__toolbar" data-openbitfun-component="ssh-remote" data-openbitfun-part="toolbar">
-          <button
+          <IconButton
             className="remote-file-browser__toolbar-btn"
             onClick={() => loadDirectory(currentPath)}
             title={t('actions.refresh')}
             disabled={transferBusy}
-          >
-            <Icon name="refresh" size="md" />
-          </button>
-          <button
+            aria-label={t('actions.refresh')}
+            icon={<Icon name="refresh" size="md" />}
+          />
+          <IconButton
             className="remote-file-browser__toolbar-btn"
             onClick={() => {
               const p = getRemoteParentPath(currentPath);
@@ -481,18 +481,18 @@ export const RemoteFileBrowser: React.FC<RemoteFileBrowserProps> = ({
             }}
             title="Go up"
             disabled={getRemoteParentPath(currentPath) === null || transferBusy}
-          >
-            <Icon name="arrow-left" size="md" />
-          </button>
-          <button
+            aria-label="Go up"
+            icon={<Icon name="arrow-left" size="md" />}
+          />
+          <IconButton
             type="button"
             className="remote-file-browser__toolbar-btn"
             onClick={() => void handleUploadToCurrentDir()}
             title={t('ssh.remote.upload')}
             disabled={transferBusy}
-          >
-            <Icon name="upload" size="md" />
-          </button>
+            aria-label={t('ssh.remote.upload')}
+            icon={<Icon name="upload" size="md" />}
+          />
         </div>
 
         {transferBusy && (
@@ -507,15 +507,19 @@ export const RemoteFileBrowser: React.FC<RemoteFileBrowserProps> = ({
           {error && (
             <div className="remote-file-browser__error">
               <span>{error}</span>
-              <button
+              <IconButton
                 type="button"
                 onClick={() => loadDirectory(currentPath)}
                 title={t('actions.retry') || 'Retry'}
                 style={{ marginLeft: 'auto', marginRight: 8 }}
-              >
-                <Icon name="refresh" size="sm" />
-              </button>
-              <button onClick={() => setError(null)}>×</button>
+                aria-label={t('actions.retry')}
+                icon={<Icon name="refresh" size="sm" />}
+              />
+              <IconButton
+                onClick={() => setError(null)}
+                aria-label={t('actions.close')}
+                icon={'×'}
+              />
             </div>
           )}
 

--- a/src/web-ui/src/flow_chat/components/ScrollPresenceFocus.test.tsx
+++ b/src/web-ui/src/flow_chat/components/ScrollPresenceFocus.test.tsx
@@ -5,6 +5,7 @@ import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ScrollToBottomButton } from './ScrollToBottomButton';
 import { ScrollToLatestBar } from './ScrollToLatestBar';
+import { ScrollToTurnHeaderButton } from './ScrollToTurnHeaderButton';
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -12,7 +13,8 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
-vi.mock('@openbitfun/ui', () => ({
+vi.mock('@openbitfun/ui', async importOriginal => ({
+  ...await importOriginal<typeof import('@openbitfun/ui')>(),
   Tooltip: ({ children }: { children: React.ReactNode }) => children,
 }));
 
@@ -129,5 +131,43 @@ describe('retained scroll controls', () => {
     expect(button?.getAttribute('aria-hidden')).toBe('false');
     expect(button?.hasAttribute('inert')).toBe(false);
     expect(button?.textContent).toContain('3');
+  });
+
+  it('keeps latest navigation on the whole bar and fires once per action', () => {
+    const onClick = vi.fn();
+    act(() => root.render(<ScrollToLatestBar visible onClick={onClick} inputHeight={140} />));
+    const bar = container.querySelector<HTMLElement>('[role="button"]')!;
+    const iconButton = bar.querySelector<HTMLButtonElement>('[data-openbitfun-component="icon-button"]')!;
+    expect(iconButton.tabIndex).toBe(-1);
+    expect(iconButton.getAttribute('aria-hidden')).toBe('true');
+    act(() => iconButton.click());
+    expect(onClick).toHaveBeenCalledTimes(1);
+    act(() => bar.click());
+    expect(onClick).toHaveBeenCalledTimes(2);
+    for (const key of ['Enter', ' ']) {
+      const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+      act(() => bar.dispatchEvent(event));
+      expect(event.defaultPrevented).toBe(true);
+    }
+    expect(onClick).toHaveBeenCalledTimes(4);
+    act(() => root.render(<ScrollToLatestBar visible={false} onClick={onClick} inputHeight={140} />));
+    act(() => {
+      bar.click();
+      bar.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    });
+    expect(onClick).toHaveBeenCalledTimes(4);
+  });
+
+  it('keeps current-turn navigation and its hidden tab order', () => {
+    const onClick = vi.fn();
+    act(() => root.render(<ScrollToTurnHeaderButton visible onClick={onClick} turnLabel="Current turn" />));
+    const button = container.querySelector<HTMLButtonElement>('[data-openbitfun-component="icon-button"]')!;
+    expect(button.getAttribute('aria-label')).toBe('Current turn');
+    expect(button.tabIndex).toBe(0);
+    act(() => button.click());
+    expect(onClick).toHaveBeenCalledTimes(1);
+    act(() => root.render(<ScrollToTurnHeaderButton visible={false} onClick={onClick} />));
+    expect(button.tabIndex).toBe(-1);
+    expect(button.closest('[aria-hidden="true"]')).not.toBeNull();
   });
 });

--- a/src/web-ui/src/flow_chat/components/ScrollToLatestBar.appearance.ts
+++ b/src/web-ui/src/flow_chat/components/ScrollToLatestBar.appearance.ts
@@ -2,6 +2,7 @@ import type { AppearanceSurfaceDescriptor } from '@/infrastructure/appearance';
 
 export const scrollToLatestBarAppearanceDescriptor: AppearanceSurfaceDescriptor = {
   id: 'scroll-to-latest-bar',
+  componentAttribute: 'data-openbitfun-product-component',
   parts: [{ id: 'root' }, { id: 'gradient' }, { id: 'content' }, { id: 'button' }],
   facets: [{ id: 'input', attribute: 'data-openbitfun-input', values: ['active', 'expanded', 'collapsed'] }],
 };

--- a/src/web-ui/src/flow_chat/components/ScrollToLatestBar.scss
+++ b/src/web-ui/src/flow_chat/components/ScrollToLatestBar.scss
@@ -85,6 +85,14 @@
   
   // ========== Circle arrow button ==========
   &__btn {
+    &::before { content: none; }
+
+    > [data-openbitfun-part='icon'] {
+      --openbitfun-opacity-icon-artwork: inherit;
+      inline-size: 16px;
+      block-size: 16px;
+    }
+
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/web-ui/src/flow_chat/components/ScrollToLatestBar.tsx
+++ b/src/web-ui/src/flow_chat/components/ScrollToLatestBar.tsx
@@ -1,3 +1,4 @@
+import { IconButton } from '@openbitfun/ui';
 import { ArrowDown as LucideArrowDown } from 'lucide-react';
 /**
  * Scroll-to-latest bar.
@@ -68,8 +69,8 @@ export const ScrollToLatestBar: React.FC<ScrollToLatestBarProps> = ({
     <RetainedMountBoundary present={visible}>
       <div
         ref={barRef}
-        data-openbitfun-component="scroll-to-latest-bar"
-        data-openbitfun-part="root"
+        data-openbitfun-product-component="scroll-to-latest-bar"
+        data-openbitfun-product-part="root"
         data-openbitfun-input="active"
         data-visible={visible ? 'true' : 'false'}
         className={`scroll-to-latest-bar ${className}`}
@@ -87,12 +88,13 @@ export const ScrollToLatestBar: React.FC<ScrollToLatestBarProps> = ({
         {...(!visible ? { inert: '' } : {})}
         aria-label={t('scroll.toLatest')}
       >
-        <div data-openbitfun-component="scroll-to-latest-bar" data-openbitfun-part="gradient" className="scroll-to-latest-bar__gradient" />
+        <div data-openbitfun-product-component="scroll-to-latest-bar" data-openbitfun-product-part="gradient" className="scroll-to-latest-bar__gradient" />
 
-        <div data-openbitfun-component="scroll-to-latest-bar" data-openbitfun-part="content" className="scroll-to-latest-bar__content" style={contentStyle}>
-          <button data-openbitfun-component="scroll-to-latest-bar" data-openbitfun-part="button" className="scroll-to-latest-bar__btn" aria-hidden="true" tabIndex={-1}>
-            <LucideArrowDown width="16" height="16" aria-hidden="true" />
-          </button>
+        <div data-openbitfun-product-component="scroll-to-latest-bar" data-openbitfun-product-part="content" className="scroll-to-latest-bar__content" style={contentStyle}>
+          <IconButton data-openbitfun-product-component="scroll-to-latest-bar" data-openbitfun-product-part="button" className="scroll-to-latest-bar__btn" aria-hidden="true" tabIndex={-1}
+            aria-label={t('scroll.toLatest')}
+            icon={<LucideArrowDown width="16" height="16" aria-hidden="true" />}
+          />
         </div>
       </div>
     </RetainedMountBoundary>

--- a/src/web-ui/src/flow_chat/components/ScrollToTurnHeaderButton.appearance.ts
+++ b/src/web-ui/src/flow_chat/components/ScrollToTurnHeaderButton.appearance.ts
@@ -2,6 +2,7 @@ import type { AppearanceSurfaceDescriptor } from '@/infrastructure/appearance';
 
 export const scrollToTurnHeaderButtonAppearanceDescriptor: AppearanceSurfaceDescriptor = {
   id: 'scroll-to-turn-header-button',
+  componentAttribute: 'data-openbitfun-product-component',
   parts: [{ id: 'root' }, { id: 'gradient' }, { id: 'content' }, { id: 'button' }],
   states: [{ id: 'visible', selector: { kind: 'self', suffix: '[data-openbitfun-state~="visible"]' } }],
 };

--- a/src/web-ui/src/flow_chat/components/ScrollToTurnHeaderButton.scss
+++ b/src/web-ui/src/flow_chat/components/ScrollToTurnHeaderButton.scss
@@ -53,6 +53,14 @@
 
   // ========== Circle arrow button ==========
   &__btn {
+    &::before { content: none; }
+
+    > [data-openbitfun-part='icon'] {
+      --openbitfun-opacity-icon-artwork: inherit;
+      inline-size: 16px;
+      block-size: 16px;
+    }
+
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/web-ui/src/flow_chat/components/ScrollToTurnHeaderButton.tsx
+++ b/src/web-ui/src/flow_chat/components/ScrollToTurnHeaderButton.tsx
@@ -7,7 +7,7 @@ import { ArrowUp as LucideArrowUp } from 'lucide-react';
 
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Tooltip } from '@openbitfun/ui';
+import { IconButton, Tooltip } from '@openbitfun/ui';
 import './ScrollToTurnHeaderButton.scss';
 
 interface ScrollToTurnHeaderButtonProps {
@@ -26,23 +26,22 @@ export const ScrollToTurnHeaderButton: React.FC<ScrollToTurnHeaderButtonProps> =
   const { t } = useTranslation('flow-chat');
 
   return (
-    <div data-openbitfun-component="scroll-to-turn-header-button" data-openbitfun-part="root" data-openbitfun-state={visible ? 'visible' : ''}
+    <div data-openbitfun-product-component="scroll-to-turn-header-button" data-openbitfun-product-part="root" data-openbitfun-state={visible ? 'visible' : ''}
       className={`scroll-to-turn-header-trigger ${visible ? 'scroll-to-turn-header-trigger--visible' : ''} ${className}`}
       aria-hidden={!visible}
     >
-      <div data-openbitfun-component="scroll-to-turn-header-button" data-openbitfun-part="gradient" className="scroll-to-turn-header-trigger__gradient" />
-      <div data-openbitfun-component="scroll-to-turn-header-button" data-openbitfun-part="content" className="scroll-to-turn-header-trigger__content">
+      <div data-openbitfun-product-component="scroll-to-turn-header-button" data-openbitfun-product-part="gradient" className="scroll-to-turn-header-trigger__gradient" />
+      <div data-openbitfun-product-component="scroll-to-turn-header-button" data-openbitfun-product-part="content" className="scroll-to-turn-header-trigger__content">
         <Tooltip content={turnLabel || t('scroll.toCurrentTurn')}>
-          <button
-            data-openbitfun-component="scroll-to-turn-header-button"
-            data-openbitfun-part="button"
+          <IconButton
+            data-openbitfun-product-component="scroll-to-turn-header-button"
+            data-openbitfun-product-part="button"
             className="scroll-to-turn-header-trigger__btn"
             onClick={onClick}
             aria-label={turnLabel || t('scroll.toCurrentTurn')}
             tabIndex={visible ? 0 : -1}
-          >
-            <LucideArrowUp width="16" height="16" aria-hidden="true" />
-          </button>
+            icon={<LucideArrowUp width="16" height="16" aria-hidden="true" />}
+          />
         </Tooltip>
       </div>
     </div>

--- a/src/web-ui/src/flow_chat/components/modern/ExportImageButton.appearance.ts
+++ b/src/web-ui/src/flow_chat/components/modern/ExportImageButton.appearance.ts
@@ -2,6 +2,8 @@ import type { AppearanceSurfaceDescriptor } from '@/infrastructure/appearance';
 
 export const exportImageAppearanceDescriptor: AppearanceSurfaceDescriptor = {
   id: 'export-image',
+  // Persisted package names stay stable; product hooks coexist with IconButton.
+  componentAttribute: 'data-openbitfun-product-component',
   parts: [
     { id: 'root' }, { id: 'header' }, { id: 'logo' }, { id: 'title' },
     { id: 'timestamp' }, { id: 'user' }, { id: 'assistant' }, { id: 'round' },

--- a/src/web-ui/src/flow_chat/components/modern/ExportImageButton.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ExportImageButton.tsx
@@ -11,7 +11,7 @@ import { FlowChatStore } from '../../store/FlowChatStore';
 import { notificationService } from '@/shared/notification-system';
 import { FlowTextBlock } from '../FlowTextBlock';
 import { FlowToolCard } from '../FlowToolCard';
-import { Icon, Menu, MenuItem, Tooltip } from '@openbitfun/ui';
+import { Icon, IconButton, Menu, MenuItem, Tooltip } from '@openbitfun/ui';
 import { getAppearanceOverlayHost } from '@/infrastructure/appearance/runtime/AppearanceOverlayHost';
 import { useAnchoredPopoverPosition } from '@/shared/utils/useAnchoredPopoverPosition';
 import type { DialogTurn, FlowTextItem, FlowToolItem, FlowThinkingItem } from '../../types/flow-chat';
@@ -85,38 +85,38 @@ const LOGO_PLACEHOLDER_CLASS = 'export-content__logo-placeholder';
 
 const ExportContent: React.FC<ExportContentProps> = ({ dialogTurn, expandThinking }) => {
   return (
-    <div data-openbitfun-component="export-image" data-openbitfun-part="root" className="export-content">
-      <div className="export-content__header" data-openbitfun-component="export-image" data-openbitfun-part="header">
+    <div data-openbitfun-product-component="export-image" data-openbitfun-product-part="root" className="export-content">
+      <div className="export-content__header" data-openbitfun-product-component="export-image" data-openbitfun-product-part="header">
         {/* Placeholder reserves space for the logo. The actual logo is drawn
             onto the final image via canvas compositing to avoid issues with
             embedding <img>/data URLs inside an SVG foreignObject. */}
         <div
           className={`export-content__logo ${LOGO_PLACEHOLDER_CLASS}`}
-          data-openbitfun-component="export-image"
-          data-openbitfun-part="logo"
+          data-openbitfun-product-component="export-image"
+          data-openbitfun-product-part="logo"
           aria-label="OpenBitFun"
         />
-        <div className="export-content__title-group" data-openbitfun-component="export-image" data-openbitfun-part="title">
+        <div className="export-content__title-group" data-openbitfun-product-component="export-image" data-openbitfun-product-part="title">
           <div className="export-content__title">OpenBitFun</div>
           <div className="export-content__subtitle">{i18nService.t('flow-chat:exportImage.subtitle').replace(/ /g, '\u00A0')}</div>
         </div>
-        <div className="export-content__timestamp" data-openbitfun-component="export-image" data-openbitfun-part="timestamp">
+        <div className="export-content__timestamp" data-openbitfun-product-component="export-image" data-openbitfun-product-part="timestamp">
           {i18nService.formatDate(new Date())}
         </div>
       </div>
 
       {dialogTurn.userMessage?.content && (
-        <div className="export-content__user-section" data-openbitfun-component="export-image" data-openbitfun-part="user">
+        <div className="export-content__user-section" data-openbitfun-product-component="export-image" data-openbitfun-product-part="user">
           <div className="export-content__user-bubble">
             {dialogTurn.userMessage.content}
           </div>
         </div>
       )}
 
-      <div className="export-content__ai-section" data-openbitfun-component="export-image" data-openbitfun-part="assistant">
+      <div className="export-content__ai-section" data-openbitfun-product-component="export-image" data-openbitfun-product-part="assistant">
         
         {dialogTurn.modelRounds.map((modelRound) => (
-          <div key={modelRound.id} className="export-content__model-round" data-openbitfun-component="export-image" data-openbitfun-part="round">
+          <div key={modelRound.id} className="export-content__model-round" data-openbitfun-product-component="export-image" data-openbitfun-product-part="round">
             {[...modelRound.items]
               .sort((a, b) => a.timestamp - b.timestamp)
               .map((item) => {
@@ -124,7 +124,7 @@ const ExportContent: React.FC<ExportContentProps> = ({ dialogTurn, expandThinkin
                   const textItem = item as FlowTextItem;
                   if (textItem.content && textItem.content.trim()) {
                     return (
-                      <div data-openbitfun-component="export-image" data-openbitfun-part="text" key={item.id} className="export-content__text-item">
+                      <div data-openbitfun-product-component="export-image" data-openbitfun-product-part="text" key={item.id} className="export-content__text-item">
                         <FlowTextBlock 
                           textItem={{
                             ...textItem,
@@ -137,7 +137,7 @@ const ExportContent: React.FC<ExportContentProps> = ({ dialogTurn, expandThinkin
                 } else if (item.type === 'thinking') {
                   const thinkingItem = item as FlowThinkingItem;
                   return (
-                    <div data-openbitfun-component="export-image" data-openbitfun-part="thinking" key={item.id} className={`export-content__thinking-item${expandThinking ? ' export-content__thinking-item--expanded' : ''}`}>
+                    <div data-openbitfun-product-component="export-image" data-openbitfun-product-part="thinking" key={item.id} className={`export-content__thinking-item${expandThinking ? ' export-content__thinking-item--expanded' : ''}`}>
                       <ModelThinkingDisplay 
                         thinkingItem={{
                           ...thinkingItem,
@@ -151,7 +151,7 @@ const ExportContent: React.FC<ExportContentProps> = ({ dialogTurn, expandThinkin
                 } else if (item.type === 'tool') {
                   const toolItem = item as FlowToolItem;
                   return (
-                    <div data-openbitfun-component="export-image" data-openbitfun-part="tool" key={item.id} className="export-content__tool-item">
+                    <div data-openbitfun-product-component="export-image" data-openbitfun-product-part="tool" key={item.id} className="export-content__tool-item">
                       <FlowToolCard toolItem={toolItem} />
                     </div>
                   );
@@ -162,7 +162,7 @@ const ExportContent: React.FC<ExportContentProps> = ({ dialogTurn, expandThinkin
         ))}
       </div>
 
-      <div className="export-content__footer" data-openbitfun-component="export-image" data-openbitfun-part="footer">
+      <div className="export-content__footer" data-openbitfun-product-component="export-image" data-openbitfun-product-part="footer">
         <span>{i18nService.t('flow-chat:exportImage.poweredBy').replace(/ /g, '\u00A0')}</span>
         <span className="export-content__footer-brand">OpenBitFun</span>
         <span>•</span>
@@ -584,11 +584,11 @@ export const ExportImageButton: React.FC<ExportImageButtonProps> = ({
   return (
     <>
       <Tooltip content={isExporting ? i18nService.t('flow-chat:exportImage.exporting') : i18nService.t('flow-chat:exportImage.exportToImage')} placement="top">
-        <button
+        <IconButton
           ref={buttonRef}
           className={`model-round-item__action-btn model-round-item__export-btn ${className}`}
-          data-openbitfun-component="export-image"
-          data-openbitfun-part="trigger"
+          data-openbitfun-product-component="export-image"
+          data-openbitfun-product-part="trigger"
           data-openbitfun-state={isExporting ? 'exporting' : undefined}
           onClick={() => setIsMenuOpen(current => !current)}
           disabled={isExporting}
@@ -597,11 +597,10 @@ export const ExportImageButton: React.FC<ExportImageButtonProps> = ({
           aria-label={isExporting
             ? i18nService.t('flow-chat:exportImage.exporting')
             : i18nService.t('flow-chat:exportImage.exportToImage')}
-        >
-          {isExporting
+          icon={isExporting
             ? <Icon name="progress-25" size="sm" className="spinning" />
             : <Icon name="image" size="sm" />}
-        </button>
+        />
       </Tooltip>
       {isMenuOpen && createPortal(
         <Menu

--- a/src/web-ui/src/flow_chat/components/modern/MessageExportControls.test.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/MessageExportControls.test.tsx
@@ -1,0 +1,236 @@
+// @vitest-environment jsdom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AppearanceCompiler } from '@/infrastructure/appearance/compiler/AppearanceCompiler';
+import { AppearanceRegistry } from '@/infrastructure/appearance/registry/AppearanceRegistry';
+import { APPEARANCE_SCHEMA_VERSION, type AppearancePackage } from '@/infrastructure/appearance/types';
+import type { ModelRound } from '../../types/flow-chat';
+import { ExportImageButton } from './ExportImageButton';
+import { ModelRoundItem } from './ModelRoundItem';
+import { exportImageAppearanceDescriptor } from './ExportImageButton.appearance';
+import { modelRoundItemAppearanceDescriptor } from './ModelRoundItem.appearance';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const mocks = vi.hoisted(() => ({
+  store: vi.fn(() => ({ sessions: new Map() })),
+  copyText: vi.fn(() => 'Full transcript'),
+  clipboard: vi.fn(async (_text: string) => undefined),
+  error: vi.fn(),
+  revealing: false,
+  anchor: null as HTMLButtonElement | null,
+}));
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: vi.fn() },
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock('@/infrastructure/i18n', () => ({
+  i18nService: { t: (key: string) => key },
+  useI18n: () => ({ t: (key: string) => key, formatDate: () => '12:00' }),
+}));
+vi.mock('../../store/FlowChatStore', () => ({
+  FlowChatStore: { getInstance: () => ({ getState: mocks.store }) },
+}));
+vi.mock('@/shared/notification-system', () => ({
+  notificationService: { error: mocks.error, warning: vi.fn(), success: vi.fn() },
+}));
+vi.mock('@/shared/utils/useAnchoredPopoverPosition', () => ({
+  useAnchoredPopoverPosition: ({ open, anchorRef }: {
+    open: boolean; anchorRef: React.RefObject<HTMLButtonElement | null>;
+  }) => {
+    if (!open) return null;
+    mocks.anchor = anchorRef.current;
+    return { top: 80, left: 100, placement: 'top' };
+  },
+}));
+vi.mock('@/infrastructure/appearance/runtime/AppearanceOverlayHost', () => ({
+  getAppearanceOverlayHost: () => document.body,
+}));
+vi.mock('@/infrastructure/api', () => ({ workspaceAPI: {} }));
+vi.mock('../FlowTextBlock', () => ({ FlowTextBlock: () => <span>Answer</span> }));
+vi.mock('../FlowToolCard', () => ({ FlowToolCard: () => null }));
+vi.mock('../../tool-cards/ModelThinkingDisplay', () => ({ ModelThinkingDisplay: () => null }));
+vi.mock('../subagent/SubagentProjectionView', () => ({ SubagentProjectionView: () => null }));
+vi.mock('./ForkSessionButton', () => ({ ForkSessionButton: () => null }));
+vi.mock('./FlowChatContext', () => ({
+  useFlowChatContext: () => ({ sessionId: 'session-1', allowTranscriptExport: true }),
+}));
+vi.mock('../../hooks/TypewriterRevealGate', () => ({
+  TypewriterRevealGateProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('../../hooks/typewriterRevealGateContext', () => ({
+  useCreateTypewriterRevealGate: () => ({ isAnyRevealing: mocks.revealing }),
+}));
+vi.mock('../../utils/dialogTurnCopy', () => ({ buildDialogTurnCopyText: mocks.copyText }));
+
+const round: ModelRound = {
+  id: 'round-1', index: 0, startTime: 1, status: 'completed',
+  isStreaming: false, isComplete: true,
+  items: [{ id: 'text-1', type: 'text', timestamp: 1, status: 'completed', content: 'Answer', isStreaming: false }],
+};
+
+// This package uses the pre-migration component/part/state names on disk.
+const legacyPackage: AppearancePackage = {
+  schema: 'openbitfun.appearance', schemaVersion: APPEARANCE_SCHEMA_VERSION,
+  id: 'test.message-actions', name: 'Message actions', version: '1.0.0', mode: 'dark',
+  components: {
+    'model-round-item': { parts: {
+      root: { base: { opacity: { kind: 'number', value: 0.9 } } },
+      action: { states: { copied: { opacity: { kind: 'number', value: 0.8 } } } },
+    } },
+    'export-image': { parts: {
+      trigger: { states: { exporting: { opacity: { kind: 'number', value: 0.7 } } } },
+    } },
+  },
+};
+
+function compileLegacyPackage() {
+  const serialized = JSON.stringify(legacyPackage);
+  const restored = JSON.parse(serialized) as AppearancePackage;
+  const registry = new AppearanceRegistry()
+    .registerComponent(modelRoundItemAppearanceDescriptor)
+    .registerComponent(exportImageAppearanceDescriptor);
+  const snapshot = new AppearanceCompiler(registry).compile(restored, 1);
+  expect(JSON.stringify(restored)).toBe(serialized);
+  document.documentElement.setAttribute('data-openbitfun-appearance', snapshot.id);
+  document.documentElement.setAttribute('data-openbitfun-appearance-revision', String(snapshot.revision));
+  const style = document.createElement('style');
+  style.textContent = snapshot.cssText;
+  document.head.appendChild(style);
+  return style;
+}
+
+function expectCompiledRuleMatches(style: HTMLStyleElement, element: Element, opacity: string) {
+  const rule = Array.from(style.sheet!.cssRules).find(candidate =>
+    candidate instanceof CSSStyleRule && candidate.style.opacity === opacity,
+  ) as CSSStyleRule | undefined;
+  expect(rule).toBeDefined();
+  expect(document.querySelector(rule!.selectorText)).toBe(element);
+}
+
+describe('message copy and image export controls', () => {
+  let root: Root;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mocks.revealing = false;
+    mocks.anchor = null;
+    mocks.copyText.mockReturnValue('Full transcript');
+    Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText: mocks.clipboard } });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    document.head.querySelectorAll('style').forEach(style => style.remove());
+    document.documentElement.removeAttribute('data-openbitfun-appearance');
+    document.documentElement.removeAttribute('data-openbitfun-appearance-revision');
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('anchors the export menu to the button and retains inside/outside and Escape handling', () => {
+    act(() => root.render(<ExportImageButton turnId="turn-1" />));
+    const trigger = container.querySelector<HTMLButtonElement>('.model-round-item__export-btn')!;
+    act(() => trigger.click());
+    expect(mocks.anchor).toBe(trigger);
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    expect(document.querySelector('.export-image-menu')).not.toBeNull();
+    act(() => trigger.querySelector('[data-openbitfun-part="icon"]')!
+      .dispatchEvent(new MouseEvent('mousedown', { bubbles: true })));
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    act(() => document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })));
+    expect(document.querySelector('.export-image-menu')).toBeNull();
+    act(() => trigger.click());
+    act(() => document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true })));
+    expect(document.querySelector('.export-image-menu')).toBeNull();
+  });
+
+  it.each(['exportImage.collapsedThinking', 'exportImage.expandedThinking'])(
+    'retains pending feedback and recovers after a missing Turn through %s', async label => {
+      const style = compileLegacyPackage();
+      act(() => root.render(<ExportImageButton turnId="missing-turn" />));
+      const trigger = container.querySelector<HTMLButtonElement>('.model-round-item__export-btn')!;
+      act(() => trigger.click());
+      const action = Array.from(document.querySelectorAll<HTMLButtonElement>('.export-image-menu button'))
+        .find(button => button.textContent === label)!;
+      act(() => action.click());
+      expect(trigger.disabled).toBe(true);
+      expect(trigger.querySelector('.spinning')).not.toBeNull();
+      expect(trigger.getAttribute('data-loading')).toBe('false');
+      expectCompiledRuleMatches(style, trigger, '0.7');
+      act(() => trigger.click());
+      expect(document.querySelector('.export-image-menu')).toBeNull();
+      await act(async () => vi.advanceTimersByTimeAsync(50));
+      expect(mocks.store).toHaveBeenCalledTimes(1);
+      expect(mocks.error).toHaveBeenCalledExactlyOnceWith('flow-chat:exportImage.dialogNotFound');
+      expect(trigger.disabled).toBe(false);
+      expect(trigger.querySelector('.spinning')).toBeNull();
+    },
+  );
+
+  it.each(['full', 'result'] as const)('copies %s once and keeps legacy appearance on the copied button', async scope => {
+    const style = compileLegacyPackage();
+    act(() => root.render(<ModelRoundItem round={round} turnId="turn-1" isLastRound isTurnComplete />));
+    const trigger = container.querySelector<HTMLButtonElement>('[data-testid="model-round-copy-btn"]')!;
+    expectCompiledRuleMatches(style, container.querySelector('[data-testid="chat-assistant-message"]')!, '0.9');
+    act(() => trigger.click());
+    expect(mocks.anchor).toBe(trigger);
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    await act(async () => document.querySelector<HTMLButtonElement>(`[data-testid="model-round-copy-${scope}"]`)!.click());
+    expect(mocks.copyText).toHaveBeenCalledExactlyOnceWith('turn-1', scope, expect.any(Object));
+    expect(mocks.clipboard).toHaveBeenCalledExactlyOnceWith('Full transcript');
+    expect(document.querySelector('[data-testid="model-round-copy-menu"]')).toBeNull();
+    expectCompiledRuleMatches(style, trigger, '0.8');
+    await act(async () => vi.advanceTimersByTimeAsync(2000));
+    expect(trigger.classList.contains('copied')).toBe(false);
+  });
+
+  it('keeps copy disabled and outside the tab order while typewriter output is catching up', () => {
+    mocks.revealing = true;
+    act(() => root.render(<ModelRoundItem round={round} turnId="turn-1" isLastRound isTurnComplete />));
+    const trigger = container.querySelector<HTMLButtonElement>('[data-testid="model-round-copy-btn"]')!;
+    expect(trigger.disabled).toBe(true);
+    expect(trigger.tabIndex).toBe(-1);
+    act(() => trigger.click());
+    expect(document.querySelector('[data-testid="model-round-copy-menu"]')).toBeNull();
+  });
+
+  it('expands a failed attempt and copies its diagnostic without changing the history state', async () => {
+    const withHistory: ModelRound = {
+      ...round,
+      attempts: [
+        {
+          id: 'attempt-1', index: 0, status: 'failed', items: [],
+          diagnostic: {
+            attemptId: 'attempt-1', attemptIndex: 0,
+            category: 'transient_request_error', rawError: 'Request timed out',
+          },
+        },
+        { id: 'attempt-2', index: 1, status: 'completed', items: round.items },
+      ],
+    };
+    act(() => root.render(<ModelRoundItem round={withHistory} turnId="turn-1" isLastRound isTurnComplete />));
+    act(() => container.querySelector<HTMLButtonElement>('.model-round-item__retry-toggle')!.click());
+    const toggle = container.querySelector<HTMLButtonElement>('.model-round-item__attempt-diagnostic-toggle')!;
+    act(() => toggle.querySelector('svg')!.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    expect(document.getElementById(toggle.getAttribute('aria-controls')!)?.textContent).toContain('Request timed out');
+    const copy = container.querySelector<HTMLButtonElement>('.model-round-item__attempt-diagnostic-copy')!;
+    await act(async () => copy.click());
+    expect(mocks.clipboard).toHaveBeenCalledExactlyOnceWith('Request timed out');
+    expect(copy.getAttribute('data-openbitfun-state')).toBe('copied');
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    act(() => toggle.click());
+    expect(container.querySelector('.model-round-item__attempt-diagnostic-details')).toBeNull();
+    expect(container.querySelector('.model-round-item__retry-attempt')).not.toBeNull();
+  });
+});

--- a/src/web-ui/src/flow_chat/components/modern/ModelRoundItem.appearance.ts
+++ b/src/web-ui/src/flow_chat/components/modern/ModelRoundItem.appearance.ts
@@ -2,6 +2,8 @@ import type { AppearanceSurfaceDescriptor } from '@/infrastructure/appearance';
 
 export const modelRoundItemAppearanceDescriptor: AppearanceSurfaceDescriptor = {
   id: 'model-round-item',
+  // Persisted package names stay stable; product hooks coexist with IconButton.
+  componentAttribute: 'data-openbitfun-product-component',
   parts: [
     { id: 'root' },
     { id: 'retryHistory' },

--- a/src/web-ui/src/flow_chat/components/modern/ModelRoundItem.scss
+++ b/src/web-ui/src/flow_chat/components/modern/ModelRoundItem.scss
@@ -144,6 +144,8 @@
 
 .model-round-item__attempt-diagnostic-toggle,
 .model-round-item__attempt-diagnostic-copy {
+  flex-shrink: 1;
+  transition: none;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -155,6 +157,18 @@
   background: transparent;
   color: var(--openbitfun-color-content-muted);
   cursor: pointer;
+
+  &::before { content: none; }
+
+  > [data-openbitfun-part='icon'] {
+    --openbitfun-opacity-icon-artwork: inherit;
+    display: contents;
+  }
+
+  > :where([data-openbitfun-part='icon']) > :where(svg, [data-openbitfun-component='icon']) {
+    inline-size: 13px;
+    block-size: 13px;
+  }
 
   &:hover {
     background: color-mix(in srgb, var(--openbitfun-color-content-on-dark) 8%, transparent);
@@ -287,10 +301,12 @@
   z-index: var(--openbitfun-layer-popover);
 }
 
-.model-round-item__fork-btn {
+.model-round-item__fork-btn,
+.model-round-item__copy-btn,
+.model-round-item__export-btn {
   flex-shrink: 1;
 
-  // Do not change sibling actions or replace this action's original spinner.
+  // Preserve footer action geometry, feedback, and the existing pending icons.
   &::before { content: none; }
 
   > [data-openbitfun-part='icon'] {
@@ -302,7 +318,9 @@
     inline-size: var(--openbitfun-control-icon-size-sm);
     block-size: var(--openbitfun-control-icon-size-sm);
   }
+}
 
+.model-round-item__fork-btn {
   .spinning {
     animation: model-round-item-spin 1s linear infinite;
   }

--- a/src/web-ui/src/flow_chat/components/modern/ModelRoundItem.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/ModelRoundItem.tsx
@@ -10,7 +10,7 @@
 import React, { useMemo, useState, useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
-import { Icon, Menu, MenuItem, Tooltip } from '@openbitfun/ui';
+import { Icon, IconButton, Menu, MenuItem, Tooltip } from '@openbitfun/ui';
 import { CircleAlert } from 'lucide-react';
 import type { ModelRound, ModelRoundAttempt, ModelRoundAttemptDiagnostic, FlowItem, FlowTextItem, FlowToolItem, FlowThinkingItem, ToolRejectOptions } from '../../types/flow-chat';
 import { useI18n } from '@/infrastructure/i18n';
@@ -167,17 +167,16 @@ const AttemptDiagnosticDetails: React.FC<{ diagnostic: ModelRoundAttemptDiagnost
 
   const renderCopyButton = (value: string, valueKey: string) => (
     <Tooltip content={copiedValue === valueKey ? t('modelRound.attemptDiagnostics.copied') : t('modelRound.attemptDiagnostics.copy')} placement="top">
-      <button
+      <IconButton
         type="button"
         className="model-round-item__attempt-diagnostic-copy"
-        data-openbitfun-component="model-round-item"
-        data-openbitfun-part="action"
+        data-openbitfun-product-component="model-round-item"
+        data-openbitfun-product-part="action"
         data-openbitfun-state={copiedValue === valueKey ? 'copied' : undefined}
         onClick={() => void copyValue(value, valueKey)}
         aria-label={t('modelRound.attemptDiagnostics.copy')}
-      >
-        {copiedValue === valueKey ? <Icon name="check-line" size="lg" style={{ width: 13, height: 13 }} /> : <Icon name="duplicate" size="lg" style={{ width: 13, height: 13 }} />}
-      </button>
+        icon={copiedValue === valueKey ? <Icon name="check-line" size="lg" style={{ width: 13, height: 13 }} /> : <Icon name="duplicate" size="lg" style={{ width: 13, height: 13 }} />}
+      />
     </Tooltip>
   );
 
@@ -186,38 +185,37 @@ const AttemptDiagnosticDetails: React.FC<{ diagnostic: ModelRoundAttemptDiagnost
   return (
     <>
       <Tooltip content={isOpen ? t('modelRound.attemptDiagnostics.hide') : t('modelRound.attemptDiagnostics.show')} placement="top">
-        <button
+        <IconButton
           type="button"
           className="model-round-item__attempt-diagnostic-toggle"
-          data-openbitfun-component="model-round-item"
-          data-openbitfun-part="diagnosticToggle"
+          data-openbitfun-product-component="model-round-item"
+          data-openbitfun-product-part="diagnosticToggle"
           data-openbitfun-state={isOpen ? 'expanded' : undefined}
           onClick={() => setIsOpen(current => !current)}
           aria-expanded={isOpen}
           aria-controls={detailsId}
           aria-label={isOpen ? t('modelRound.attemptDiagnostics.hide') : t('modelRound.attemptDiagnostics.show')}
-        >
-          <CircleAlert size={13} aria-hidden="true" />
-        </button>
+          icon={<CircleAlert size={13} aria-hidden="true" />}
+        />
       </Tooltip>
 
       {isOpen && (
         <div
           id={detailsId}
           className="model-round-item__attempt-diagnostic-details"
-          data-openbitfun-component="model-round-item"
-          data-openbitfun-part="diagnosticDetails"
+          data-openbitfun-product-component="model-round-item"
+          data-openbitfun-product-part="diagnosticDetails"
         >
           <div
             className="model-round-item__attempt-diagnostic-category"
-            data-openbitfun-component="model-round-item"
-            data-openbitfun-part="diagnosticSection"
+            data-openbitfun-product-component="model-round-item"
+            data-openbitfun-product-part="diagnosticSection"
           >
             {attemptDiagnosticCategoryLabel(diagnostic, t)}
           </div>
 
           {diagnostic.rawError && (
-            <div className="model-round-item__attempt-diagnostic-section" data-openbitfun-component="model-round-item" data-openbitfun-part="diagnosticSection">
+            <div className="model-round-item__attempt-diagnostic-section" data-openbitfun-product-component="model-round-item" data-openbitfun-product-part="diagnosticSection">
               <div className="model-round-item__attempt-diagnostic-section-header">
                 <span>{t('modelRound.attemptDiagnostics.providerError')}</span>
                 {renderCopyButton(diagnostic.rawError, 'raw-error')}
@@ -232,8 +230,8 @@ const AttemptDiagnosticDetails: React.FC<{ diagnostic: ModelRoundAttemptDiagnost
               <div
                 key={`${toolCall.toolId ?? toolCall.toolName ?? 'tool'}:${index}`}
                 className="model-round-item__attempt-diagnostic-section"
-                data-openbitfun-component="model-round-item"
-                data-openbitfun-part="diagnosticSection"
+                data-openbitfun-product-component="model-round-item"
+                data-openbitfun-product-part="diagnosticSection"
               >
                 <div className="model-round-item__attempt-diagnostic-tool-title">
                   {t('modelRound.attemptDiagnostics.toolArguments', { name: toolLabel })}
@@ -320,8 +318,8 @@ const TaskWithSubagentWrapper: React.FC<TaskWithSubagentWrapperProps> = React.me
   return (
     <div
       className={className}
-      data-openbitfun-component="model-round-item"
-      data-openbitfun-part="subagent"
+      data-openbitfun-product-component="model-round-item"
+      data-openbitfun-product-part="subagent"
       data-openbitfun-state={!isCollapsed ? 'expanded' : undefined}
     >
       <FlowItemRenderer
@@ -581,8 +579,8 @@ export const ModelRoundItem = React.memo<ModelRoundItemProps>(
         className={getModelRoundItemClassName({
           isVisuallyStreaming,
         })}
-        data-openbitfun-component="model-round-item"
-        data-openbitfun-part="root"
+        data-openbitfun-product-component="model-round-item"
+        data-openbitfun-product-part="root"
         data-openbitfun-status={round.status}
         data-openbitfun-state={isVisuallyStreaming ? 'streaming' : undefined}
         data-testid="chat-assistant-message"
@@ -608,12 +606,12 @@ export const ModelRoundItem = React.memo<ModelRoundItemProps>(
         )}
 
         {historyRounds.length > 0 && (
-          <div className="model-round-item__retry-history" data-openbitfun-component="model-round-item" data-openbitfun-part="retryHistory">
+          <div className="model-round-item__retry-history" data-openbitfun-product-component="model-round-item" data-openbitfun-product-part="retryHistory">
             <button
               type="button"
               className="model-round-item__retry-toggle"
-              data-openbitfun-component="model-round-item"
-              data-openbitfun-part="retryToggle"
+              data-openbitfun-product-component="model-round-item"
+              data-openbitfun-product-part="retryToggle"
               data-openbitfun-state={showRoundHistory ? 'expanded' : undefined}
               onClick={() => setShowRoundHistory(current => !current)}
             >
@@ -639,17 +637,17 @@ export const ModelRoundItem = React.memo<ModelRoundItemProps>(
               });
 
               return (
-                <div key={historyRound.id} className="model-round-item__retry-attempt" data-openbitfun-component="model-round-item" data-openbitfun-part="retryAttempt">
-                  <div className="model-round-item__retry-attempt-label" data-openbitfun-component="model-round-item" data-openbitfun-part="attemptLabel">
+                <div key={historyRound.id} className="model-round-item__retry-attempt" data-openbitfun-product-component="model-round-item" data-openbitfun-product-part="retryAttempt">
+                  <div className="model-round-item__retry-attempt-label" data-openbitfun-product-component="model-round-item" data-openbitfun-product-part="attemptLabel">
                     {t('modelRound.roundRetryLabel', { index: historyIndex + 1 })}
                   </div>
                   {historyOlderAttempts.length > 0 && (
-                    <div className="model-round-item__retry-history" data-openbitfun-component="model-round-item" data-openbitfun-part="retryHistory">
+                    <div className="model-round-item__retry-history" data-openbitfun-product-component="model-round-item" data-openbitfun-product-part="retryHistory">
                       <button
                         type="button"
                         className="model-round-item__retry-toggle"
-                        data-openbitfun-component="model-round-item"
-                        data-openbitfun-part="retryToggle"
+                        data-openbitfun-product-component="model-round-item"
+                        data-openbitfun-product-part="retryToggle"
                         data-openbitfun-state={showHistoryRoundAttempts ? 'expanded' : undefined}
                         onClick={() => toggleHistoryRoundAttempts(historyRound.id)}
                       >
@@ -667,8 +665,8 @@ export const ModelRoundItem = React.memo<ModelRoundItemProps>(
                         });
 
                         return (
-                          <div key={attempt.id} className="model-round-item__retry-attempt" data-openbitfun-component="model-round-item" data-openbitfun-part="retryAttempt">
-                            <div className="model-round-item__retry-attempt-label" data-openbitfun-component="model-round-item" data-openbitfun-part="attemptLabel">
+                          <div key={attempt.id} className="model-round-item__retry-attempt" data-openbitfun-product-component="model-round-item" data-openbitfun-product-part="retryAttempt">
+                            <div className="model-round-item__retry-attempt-label" data-openbitfun-product-component="model-round-item" data-openbitfun-product-part="attemptLabel">
                               <span>{t('modelRound.attemptLabel', { index: attempt.index })}</span>
                               {attempt.diagnostic && <AttemptDiagnosticDetails diagnostic={attempt.diagnostic} />}
                             </div>
@@ -694,12 +692,12 @@ export const ModelRoundItem = React.memo<ModelRoundItemProps>(
         )}
 
         {historicalAttempts.length > 0 && (
-          <div className="model-round-item__retry-history" data-openbitfun-component="model-round-item" data-openbitfun-part="retryHistory">
+          <div className="model-round-item__retry-history" data-openbitfun-product-component="model-round-item" data-openbitfun-product-part="retryHistory">
             <button
               type="button"
               className="model-round-item__retry-toggle"
-              data-openbitfun-component="model-round-item"
-              data-openbitfun-part="retryToggle"
+              data-openbitfun-product-component="model-round-item"
+              data-openbitfun-product-part="retryToggle"
               data-openbitfun-state={showRetryHistory ? 'expanded' : undefined}
               onClick={() => setShowRetryHistory(current => !current)}
             >
@@ -717,8 +715,8 @@ export const ModelRoundItem = React.memo<ModelRoundItemProps>(
               });
 
               return (
-                <div key={attempt.id} className="model-round-item__retry-attempt" data-openbitfun-component="model-round-item" data-openbitfun-part="retryAttempt">
-                  <div className="model-round-item__retry-attempt-label" data-openbitfun-component="model-round-item" data-openbitfun-part="attemptLabel">
+                <div key={attempt.id} className="model-round-item__retry-attempt" data-openbitfun-product-component="model-round-item" data-openbitfun-product-part="retryAttempt">
+                  <div className="model-round-item__retry-attempt-label" data-openbitfun-product-component="model-round-item" data-openbitfun-product-part="attemptLabel">
                     <span>{t('modelRound.attemptLabel', { index: attempt.index })}</span>
                     {attempt.diagnostic && <AttemptDiagnosticDetails diagnostic={attempt.diagnostic} />}
                   </div>
@@ -742,8 +740,8 @@ export const ModelRoundItem = React.memo<ModelRoundItemProps>(
         {canvasArtifactItems.length > 0 && (
           <div
             className="model-round-item__canvas-attachments"
-            data-openbitfun-component="model-round-item"
-            data-openbitfun-part="canvasAttachments"
+            data-openbitfun-product-component="model-round-item"
+            data-openbitfun-product-part="canvasAttachments"
           >
             {canvasArtifactItems.map((item, index) => (
               <FlowItemRenderer
@@ -761,24 +759,24 @@ export const ModelRoundItem = React.memo<ModelRoundItemProps>(
         {shouldReserveFooter && (
           <div
             className={`model-round-item__footer${shouldRevealFooter ? '' : ' model-round-item__footer--pending'}`}
-            data-openbitfun-component="model-round-item"
-            data-openbitfun-part="footer"
+            data-openbitfun-product-component="model-round-item"
+            data-openbitfun-product-part="footer"
             data-openbitfun-state={shouldRevealFooter ? undefined : 'pending'}
             aria-hidden={!shouldRevealFooter}
           >
             {completionMetaItems.length > 0 && (
               <div
                 className="model-round-item__meta"
-                data-openbitfun-component="model-round-item"
-                data-openbitfun-part="meta"
+                data-openbitfun-product-component="model-round-item"
+                data-openbitfun-product-part="meta"
                 aria-label={t('modelRound.meta.label')}
               >
                 {completionMetaItems.map(item => (
                   <span
                     key={item.key}
                     className="model-round-item__meta-item"
-                    data-openbitfun-component="model-round-item"
-                    data-openbitfun-part="metaItem"
+                    data-openbitfun-product-component="model-round-item"
+                    data-openbitfun-product-part="metaItem"
                     aria-label={`${item.label}: ${item.value}`}
                   >
                     {item.value}
@@ -791,7 +789,7 @@ export const ModelRoundItem = React.memo<ModelRoundItemProps>(
 
             {allowTranscriptExport && <div className="model-round-item__copy-menu-anchor">
               <Tooltip content={copied ? t('modelRound.copiedDialog') : t('modelRound.copyDialog')} placement="top">
-                <button
+                <IconButton
                   ref={copyButtonRef}
                   className={`model-round-item__action-btn model-round-item__copy-btn ${copied ? 'copied' : ''}`}
                   onClick={() => setIsCopyMenuOpen(current => !current)}
@@ -801,9 +799,9 @@ export const ModelRoundItem = React.memo<ModelRoundItemProps>(
                   aria-expanded={isCopyMenuOpen}
                   aria-label={copied ? t('modelRound.copiedDialog') : t('modelRound.copyDialog')}
                   data-testid="model-round-copy-btn"
-                 data-openbitfun-component="model-round-item" data-openbitfun-part="action" data-openbitfun-state={copied ? 'copied' : undefined}>
-                  <Icon name={copied ? 'check-line' : 'duplicate'} size="sm" />
-                </button>
+                  data-openbitfun-product-component="model-round-item" data-openbitfun-product-part="action" data-openbitfun-state={copied ? 'copied' : undefined}
+                  icon={<Icon name={copied ? 'check-line' : 'duplicate'} size="sm" />}
+                />
               </Tooltip>
 
               {isCopyMenuOpen && createPortal(
@@ -908,7 +906,7 @@ const FlowItemRenderer: React.FC<FlowItemRendererProps> = ({
       const toolItem = item as FlowToolItem;
 
       return (
-        <div className="flowchat-flow-item" data-flow-item-id={item.id} data-flow-item-type="tool" data-openbitfun-component="model-round-item" data-openbitfun-part="toolItem">
+        <div className="flowchat-flow-item" data-flow-item-id={item.id} data-flow-item-type="tool" data-openbitfun-product-component="model-round-item" data-openbitfun-product-part="toolItem">
           <FlowToolCard
             toolItem={toolItem}
             isLastItem={isLastItem}

--- a/src/web-ui/src/flow_chat/components/modern/UserMessageItem.scss
+++ b/src/web-ui/src/flow_chat/components/modern/UserMessageItem.scss
@@ -207,7 +207,7 @@
 .user-message-item__copy-btn,
 .user-message-item__edit-btn,
 .user-message-item__rollback-btn {
-  // Align with the IconButton ghost variant.
+  // Keep the message action feedback and original pending indicator.
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -226,6 +226,18 @@
   align-self: center;
   outline: none;
   user-select: none;
+
+  &::before { content: none; }
+
+  > [data-openbitfun-part='icon'] {
+    --openbitfun-opacity-icon-artwork: inherit;
+    display: contents;
+  }
+
+  > :where([data-openbitfun-part='icon']) > :where(svg, [data-openbitfun-component='icon']) {
+    inline-size: 14px;
+    block-size: 14px;
+  }
 
   &:hover:not(:disabled) {
     background: transparent;

--- a/src/web-ui/src/flow_chat/components/modern/UserMessageItem.tsx
+++ b/src/web-ui/src/flow_chat/components/modern/UserMessageItem.tsx
@@ -26,7 +26,7 @@ import { globalEventBus } from '@/infrastructure/event-bus';
 import { shouldIgnoreCardToggleClick } from '@/shared/utils/textSelection';
 import { observeElementResize } from '@/shared/utils/sharedResizeObserver';
 import { formatContextForPrompt } from '@/shared/utils/contextPrompt';
-import { Tooltip, Icon } from '@openbitfun/ui';
+import { Tooltip, Icon, IconButton } from '@openbitfun/ui';
 import { confirmDanger } from '@/infrastructure/confirm-dialog';
 import { ToolProcessingDots } from '@openbitfun/ui/flow-chat';
 import { UserMessageEditComposer } from './UserMessageEditComposer';
@@ -670,51 +670,48 @@ export const UserMessageItem = React.memo<UserMessageItemProps>(
           {!isEditing && (
             <div className="user-message-item__actions" data-openbitfun-component="user-message-item" data-openbitfun-part="actions">
               <Tooltip content={copied ? t('message.copied') : t('message.copy')}>
-                <button
+                <IconButton
                   type="button"
                   className={`user-message-item__copy-btn ${copied ? 'copied' : ''}`}
                   onClick={handleCopy}
                   aria-label={copied ? t('message.copied') : t('message.copy')}
-                >
-                  {copied ? <Icon name="check-line" size="sm" /> : <Icon name="duplicate" size="sm" />}
-                </button>
+                  icon={copied ? <Icon name="check-line" size="sm" /> : <Icon name="duplicate" size="sm" />}
+                />
               </Tooltip>
               {canShowEditAction && (
                 <Tooltip content={canEdit ? t('message.edit') : editDisabledReason}>
-                  <button
+                  <IconButton
                     type="button"
                     className="user-message-item__edit-btn"
                     onClick={handleBeginEdit}
                     disabled={!canEdit}
                     aria-label={canEdit ? t('message.edit') : editDisabledReason}
-                  >
-                    <Icon name="edit" size="sm" />
-                  </button>
+                    icon={<Icon name="edit" size="sm" />}
+                  />
                 </Tooltip>
               )}
               {isFailed ? (
                 <Tooltip content={t('message.fillToInput')}>
-                  <button
+                  <IconButton
                     className="user-message-item__copy-btn"
                     onClick={handleFillToInput}
-                  >
-                    <Icon name="arrow-down" size="sm" />
-                  </button>
+                    aria-label={t('message.fillToInput')}
+                    icon={<Icon name="arrow-down" size="sm" />}
+                  />
                 </Tooltip>
               ) : canShowRollbackAction && !steeringStatus ? (
                 <Tooltip content={rollbackTooltip}>
-                  <button
+                  <IconButton
                     className="user-message-item__rollback-btn"
                     onClick={handleRollback}
                     disabled={!canRollback}
                     aria-label={rollbackTooltip}
-                  >
-                    {sessionMutation?.kind === 'rollback' && sessionMutation.targetTurnId === turnId ? (
+                    icon={sessionMutation?.kind === 'rollback' && sessionMutation.targetTurnId === turnId ? (
                       <Loader2 size={14} className="user-message-item__rollback-spinner" />
                     ) : (
                       <RotateCcw size={14} />
                     )}
-                  </button>
+                  />
                 </Tooltip>
               ) : null}
             </div>

--- a/src/web-ui/src/flow_chat/components/toolbar-mode/ToolbarMode.appearance.ts
+++ b/src/web-ui/src/flow_chat/components/toolbar-mode/ToolbarMode.appearance.ts
@@ -2,6 +2,7 @@ import type { AppearanceSurfaceDescriptor } from '@/infrastructure/appearance';
 
 export const toolbarModeAppearanceDescriptor: AppearanceSurfaceDescriptor = {
   id: 'toolbar-mode',
+  componentAttribute: 'data-openbitfun-product-component',
   parts: [
     { id: 'root' }, { id: 'header' }, { id: 'headerLeft' }, { id: 'title' },
     { id: 'headerActions' }, { id: 'overflowTrigger' }, { id: 'overflowMenu' },

--- a/src/web-ui/src/flow_chat/components/toolbar-mode/ToolbarMode.scss
+++ b/src/web-ui/src/flow_chat/components/toolbar-mode/ToolbarMode.scss
@@ -492,6 +492,24 @@ $transition-timing: cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .toolbar-btn {
+  // The existing variants retain their surfaces; the shared component owns the button.
+  &::before { content: none; }
+
+  > [data-openbitfun-part='icon'] {
+    --openbitfun-opacity-icon-artwork: inherit;
+    display: contents;
+  }
+
+  > :where([data-openbitfun-part='icon']) > :where(svg) {
+    inline-size: 14px;
+    block-size: 14px;
+  }
+
+  > :where([data-openbitfun-part='icon']) > :where([data-openbitfun-component='icon']) {
+    inline-size: 16px;
+    block-size: 16px;
+  }
+
   flex-shrink: 0;
   align-self: center;
   width: 32px;

--- a/src/web-ui/src/flow_chat/components/toolbar-mode/ToolbarMode.tsx
+++ b/src/web-ui/src/flow_chat/components/toolbar-mode/ToolbarMode.tsx
@@ -13,7 +13,7 @@
 import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
-import { OverflowText, Menu, MenuItem } from '@openbitfun/ui';
+import { IconButton, OverflowText, Menu, MenuItem } from '@openbitfun/ui';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import { Square, Maximize2, MoreVertical, PanelTopOpen, PanelTopClose } from 'lucide-react';
 import { useToolbarModeContext } from './ToolbarModeContext';
@@ -235,49 +235,49 @@ export const ToolbarMode: React.FC = () => {
   ].filter(Boolean).join(' ');
 
   return (
-    <div data-openbitfun-component="toolbar-mode" data-openbitfun-part="root" data-openbitfun-communication-mode={isExpanded && isVoiceMode ? 'voice' : 'chat'} data-openbitfun-state={[
+    <div data-openbitfun-product-component="toolbar-mode" data-openbitfun-product-part="root" data-openbitfun-communication-mode={isExpanded && isVoiceMode ? 'voice' : 'chat'} data-openbitfun-state={[
       isExpanded && 'expanded',
       currentStreamState.isStreaming && 'processing',
       toolbarState.hasError && 'error',
       toolbarState.hasPendingConfirmation && 'confirm',
     ].filter(Boolean).join(' ') || undefined} className={containerClassName} onMouseDown={handleStartDrag}>
-      {!(isExpanded && isVoiceMode) && <div className="openbitfun-toolbar-mode__header" data-openbitfun-component="toolbar-mode" data-openbitfun-part="header">
-        <div className="openbitfun-toolbar-mode__header-left" data-openbitfun-component="toolbar-mode" data-openbitfun-part="headerLeft">
+      {!(isExpanded && isVoiceMode) && <div className="openbitfun-toolbar-mode__header" data-openbitfun-product-component="toolbar-mode" data-openbitfun-product-part="header">
+        <div className="openbitfun-toolbar-mode__header-left" data-openbitfun-product-component="toolbar-mode" data-openbitfun-product-part="headerLeft">
           {isExpanded ? <SessionMenu onOpenChange={handleSessionMenuOpenChange} /> : null}
         </div>
 
-        <div className="openbitfun-toolbar-mode__title-wrapper" data-openbitfun-component="toolbar-mode" data-openbitfun-part="title">
+        <div className="openbitfun-toolbar-mode__title-wrapper" data-openbitfun-product-component="toolbar-mode" data-openbitfun-product-part="title">
           <div className="openbitfun-toolbar-mode__title-display" title={surfaceTitle}>
             <OverflowText className="openbitfun-toolbar-mode__title-text">{surfaceTitle}</OverflowText>
           </div>
         </div>
 
-        <div className="openbitfun-toolbar-mode__header-right" data-openbitfun-component="toolbar-mode" data-openbitfun-part="headerActions">
+        <div className="openbitfun-toolbar-mode__header-right" data-openbitfun-product-component="toolbar-mode" data-openbitfun-product-part="headerActions">
           <div className="openbitfun-toolbar-mode__header-drag-area" aria-hidden="true" />
           <div className="openbitfun-toolbar-mode__header-overflow">
             {isExpanded ? (
               <>
                 <Tooltip content={t('toolCards.toolbar.moreMenu')}>
-                  <button
+                  <IconButton
                     ref={headerOverflowTriggerRef}
                     type="button"
                     className="toolbar-btn toolbar-btn--overflow openbitfun-toolbar-mode__overflow-trigger"
-                    data-openbitfun-component="toolbar-mode"
-                    data-openbitfun-part="overflowTrigger"
+                    data-openbitfun-product-component="toolbar-mode"
+                    data-openbitfun-product-part="overflowTrigger"
                     data-openbitfun-state={showHeaderOverflowMenu ? 'open' : undefined}
                     onClick={toggleHeaderOverflowMenu}
                     aria-expanded={showHeaderOverflowMenu}
                     aria-haspopup="menu"
-                  >
-                    <MoreVertical size={14} />
-                  </button>
+                    aria-label={t('toolCards.toolbar.moreMenu')}
+                    icon={<MoreVertical size={14} />}
+                  />
                 </Tooltip>
                 {showHeaderOverflowMenu && createPortal(
                   <Menu
                     ref={headerOverflowRef}
                     className="openbitfun-toolbar-mode__overflow-menu"
-                    data-openbitfun-component="toolbar-mode"
-                    data-openbitfun-part="overflowMenu"
+                    data-openbitfun-product-component="toolbar-mode"
+                    data-openbitfun-product-part="overflowMenu"
                     data-openbitfun-state="open"
                     data-openbitfun-placement={headerOverflowLayout?.placement ?? 'bottom'}
                     style={{
@@ -290,8 +290,8 @@ export const ToolbarMode: React.FC = () => {
                     <MenuItem
                       type="button"
                       leading={<PanelTopClose size={14} />}
-                      data-openbitfun-component="toolbar-mode"
-                      data-openbitfun-part="overflowItem"
+                      data-openbitfun-product-component="toolbar-mode"
+                      data-openbitfun-product-part="overflowItem"
                       onClick={() => {
                         void handleToggleExpanded();
                         setShowHeaderOverflowMenu(false);
@@ -302,8 +302,8 @@ export const ToolbarMode: React.FC = () => {
                     <MenuItem
                       type="button"
                       leading={<Maximize2 size={14} />}
-                      data-openbitfun-component="toolbar-mode"
-                      data-openbitfun-part="overflowItem"
+                      data-openbitfun-product-component="toolbar-mode"
+                      data-openbitfun-product-part="overflowItem"
                       onClick={() => {
                         void handleExpand();
                         setShowHeaderOverflowMenu(false);
@@ -316,26 +316,24 @@ export const ToolbarMode: React.FC = () => {
                 )}
               </>
             ) : (
-              <div className="openbitfun-toolbar-mode__header-collapsed-actions" data-openbitfun-component="toolbar-mode" data-openbitfun-part="collapsedActions">
+              <div className="openbitfun-toolbar-mode__header-collapsed-actions" data-openbitfun-product-component="toolbar-mode" data-openbitfun-product-part="collapsedActions">
                 <Tooltip content={t('toolCards.toolbar.expandChat')}>
-                  <button
+                  <IconButton
                     type="button"
                     className="toolbar-btn toolbar-btn--overflow"
                     onClick={() => void handleToggleExpanded()}
                     aria-label={t('toolCards.toolbar.expandChat')}
-                  >
-                    <PanelTopOpen size={14} />
-                  </button>
+                    icon={<PanelTopOpen size={14} />}
+                  />
                 </Tooltip>
                 <Tooltip content={t('session.restoreMain')}>
-                  <button
+                  <IconButton
                     type="button"
                     className="toolbar-btn toolbar-btn--expand"
                     onClick={() => void handleExpand()}
                     aria-label={t('session.restoreMain')}
-                  >
-                    <Maximize2 size={14} />
-                  </button>
+                    icon={<Maximize2 size={14} />}
+                  />
                 </Tooltip>
               </div>
             )}
@@ -348,8 +346,8 @@ export const ToolbarMode: React.FC = () => {
            text/voice mode while ChatPane remains the one shared chat surface. */
         <div
           className="openbitfun-toolbar-mode__session-surface"
-          data-openbitfun-component="toolbar-mode"
-          data-openbitfun-part="sessionSurface"
+          data-openbitfun-product-component="toolbar-mode"
+          data-openbitfun-product-part="sessionSurface"
         >
           <ConversationModeSurface onCloseVoice={handleToggleExpanded} switchTestId="toolbar-realtime-voice-mode-switch">
             <ChatPane
@@ -362,50 +360,53 @@ export const ToolbarMode: React.FC = () => {
           </ConversationModeSurface>
         </div>
       ) : (
-        <div className="openbitfun-toolbar-mode__content-row" data-openbitfun-component="toolbar-mode" data-openbitfun-part="content">
-          <div data-overflow-trigger className="openbitfun-toolbar-mode__stream-content" onClick={() => void handleToggleExpanded()} data-openbitfun-component="toolbar-mode" data-openbitfun-part="stream" data-openbitfun-content-kind={currentStreamState.toolName ? 'tool' : toolbarState.todoProgress && toolbarState.todoProgress.total > 0 ? 'todo' : 'text'} data-openbitfun-state={currentStreamState.isStreaming ? 'streaming' : undefined}>
+        <div className="openbitfun-toolbar-mode__content-row" data-openbitfun-product-component="toolbar-mode" data-openbitfun-product-part="content">
+          <div data-overflow-trigger className="openbitfun-toolbar-mode__stream-content" onClick={() => void handleToggleExpanded()} data-openbitfun-product-component="toolbar-mode" data-openbitfun-product-part="stream" data-openbitfun-content-kind={currentStreamState.toolName ? 'tool' : toolbarState.todoProgress && toolbarState.todoProgress.total > 0 ? 'todo' : 'text'} data-openbitfun-state={currentStreamState.isStreaming ? 'streaming' : undefined}>
             {currentStreamState.toolName ? (
-              <div className="openbitfun-toolbar-mode__tool" data-openbitfun-component="toolbar-mode" data-openbitfun-part="tool">
-                <span className="openbitfun-toolbar-mode__tool-name" data-openbitfun-component="toolbar-mode" data-openbitfun-part="toolName">{currentStreamState.toolName}</span>
-                <OverflowText className="openbitfun-toolbar-mode__tool-summary" data-openbitfun-component="toolbar-mode" data-openbitfun-part="toolSummary">{currentStreamState.content || t('toolCards.toolbar.executing')}</OverflowText>
+              <div className="openbitfun-toolbar-mode__tool" data-openbitfun-product-component="toolbar-mode" data-openbitfun-product-part="tool">
+                <span className="openbitfun-toolbar-mode__tool-name" data-openbitfun-product-component="toolbar-mode" data-openbitfun-product-part="toolName">{currentStreamState.toolName}</span>
+                <OverflowText className="openbitfun-toolbar-mode__tool-summary" data-openbitfun-product-component="toolbar-mode" data-openbitfun-product-part="toolSummary">{currentStreamState.content || t('toolCards.toolbar.executing')}</OverflowText>
               </div>
             ) : toolbarState.todoProgress && toolbarState.todoProgress.total > 0 ? (
-              <div className="openbitfun-toolbar-mode__todo" data-openbitfun-component="toolbar-mode" data-openbitfun-part="todo">
-                <span className="openbitfun-toolbar-mode__todo-progress" data-openbitfun-component="toolbar-mode" data-openbitfun-part="todoProgress">
+              <div className="openbitfun-toolbar-mode__todo" data-openbitfun-product-component="toolbar-mode" data-openbitfun-product-part="todo">
+                <span className="openbitfun-toolbar-mode__todo-progress" data-openbitfun-product-component="toolbar-mode" data-openbitfun-product-part="todoProgress">
                   {toolbarState.todoProgress.completed}/{toolbarState.todoProgress.total}
                 </span>
-                <OverflowText className="openbitfun-toolbar-mode__todo-current" data-openbitfun-component="toolbar-mode" data-openbitfun-part="todoCurrent">
+                <OverflowText className="openbitfun-toolbar-mode__todo-current" data-openbitfun-product-component="toolbar-mode" data-openbitfun-product-part="todoCurrent">
                   {toolbarState.todoProgress.current || currentStreamState.content}
                 </OverflowText>
               </div>
             ) : (
-              <OverflowText className={`openbitfun-toolbar-mode__text ${currentStreamState.isStreaming ? 'openbitfun-toolbar-mode__text--streaming' : ''}`} data-openbitfun-component="toolbar-mode" data-openbitfun-part="streamText">
+              <OverflowText className={`openbitfun-toolbar-mode__text ${currentStreamState.isStreaming ? 'openbitfun-toolbar-mode__text--streaming' : ''}`} data-openbitfun-product-component="toolbar-mode" data-openbitfun-product-part="streamText">
                 {currentStreamState.content || (currentStreamState.isStreaming ? t('toolCards.toolbar.processing') : (lastMessageContent || t('toolCards.toolbar.startNewChat')))}
               </OverflowText>
             )}
           </div>
 
-          <div className="openbitfun-toolbar-mode__controls" data-openbitfun-component="toolbar-mode" data-openbitfun-part="controls">
+          <div className="openbitfun-toolbar-mode__controls" data-openbitfun-product-component="toolbar-mode" data-openbitfun-product-part="controls">
             {toolbarState.hasPendingConfirmation && (
               <>
                 <Tooltip content={t('toolCards.common.confirm')}>
-                  <button className="toolbar-btn toolbar-btn--confirm" onClick={handleConfirm}>
-                    <Icon name="check-line" size="md" />
-                  </button>
+                  <IconButton className="toolbar-btn toolbar-btn--confirm" onClick={handleConfirm}
+                    aria-label={t('toolCards.common.confirm')}
+                    icon={<Icon name="check-line" size="md" />}
+                  />
                 </Tooltip>
                 <Tooltip content={t('toolCards.common.cancel')}>
-                  <button className="toolbar-btn toolbar-btn--reject" onClick={handleReject}>
-                    <Icon name="xmark" size="md" />
-                  </button>
+                  <IconButton className="toolbar-btn toolbar-btn--reject" onClick={handleReject}
+                    aria-label={t('toolCards.common.cancel')}
+                    icon={<Icon name="xmark" size="md" />}
+                  />
                 </Tooltip>
               </>
             )}
 
             {currentStreamState.isStreaming && !toolbarState.hasPendingConfirmation && (
               <Tooltip content={t('planner.cancel')}>
-                <button className="toolbar-btn toolbar-btn--cancel-compact" onClick={handleCancel}>
-                  <Square size={12} />
-                </button>
+                <IconButton className="toolbar-btn toolbar-btn--cancel-compact" onClick={handleCancel}
+                  aria-label={t('planner.cancel')}
+                  icon={<Square size={12} />}
+                />
               </Tooltip>
             )}
           </div>

--- a/src/web-ui/src/flow_chat/components/toolbar-mode/ToolbarModeActions.test.tsx
+++ b/src/web-ui/src/flow_chat/components/toolbar-mode/ToolbarModeActions.test.tsx
@@ -1,0 +1,170 @@
+// @vitest-environment jsdom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AppearanceCompiler } from '@/infrastructure/appearance/compiler/AppearanceCompiler';
+import { AppearanceRegistry } from '@/infrastructure/appearance/registry/AppearanceRegistry';
+import { APPEARANCE_SCHEMA_VERSION, type AppearancePackage } from '@/infrastructure/appearance/types';
+import { ToolbarMode } from './ToolbarMode';
+import { toolbarModeAppearanceDescriptor } from './ToolbarMode.appearance';
+import { ScrollToLatestBar } from '../ScrollToLatestBar';
+import { ScrollToTurnHeaderButton } from '../ScrollToTurnHeaderButton';
+import { scrollToLatestBarAppearanceDescriptor } from '../ScrollToLatestBar.appearance';
+import { scrollToTurnHeaderButtonAppearanceDescriptor } from '../ScrollToTurnHeaderButton.appearance';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const mocks = vi.hoisted(() => ({
+  expanded: false,
+  pending: false,
+  toggle: vi.fn(async () => {}),
+  disable: vi.fn(async () => {}),
+  drag: vi.fn(async () => {}),
+  anchor: null as HTMLButtonElement | null,
+}));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('./ToolbarModeContext', () => ({ useToolbarModeContext: () => ({
+  isToolbarMode: true, isExpanded: mocks.expanded,
+  toggleExpanded: mocks.toggle, disableToolbarMode: mocks.disable,
+  toolbarState: { hasPendingConfirmation: mocks.pending, pendingToolId: 'tool-1' },
+}) }));
+vi.mock('@tauri-apps/api/window', () => ({ getCurrentWindow: () => ({ startDragging: mocks.drag }) }));
+vi.mock('@/infrastructure/runtime', () => ({ isMacOSDesktopRuntime: () => false }));
+vi.mock('@/infrastructure/contexts/WorkspaceContext', () => ({ useCurrentWorkspace: () => ({ workspacePath: '/repo' }) }));
+vi.mock('../session-menu', () => ({
+  SessionMenu: () => null,
+  useFlowChatSessions: () => ({ sessionTitle: 'Session', activeSession: { dialogTurns: [{ status: 'processing' }] } }),
+}));
+vi.mock('../voice/RealtimeVoiceCallContext', () => ({ useRealtimeVoiceCall: () => ({ phase: 'idle', end: vi.fn() }) }));
+vi.mock('../voice/ConversationModeSurface', () => ({ ConversationModeSurface: () => null }));
+vi.mock('@/app/scenes/session/ChatPane', () => ({ default: () => null }));
+vi.mock('@/infrastructure/appearance/runtime/AppearanceOverlayHost', () => ({ getAppearanceOverlayHost: () => document.body }));
+vi.mock('@/shared/utils/useAnchoredPopoverPosition', () => ({
+  useAnchoredPopoverPosition: ({ open, anchorRef }: { open: boolean; anchorRef: React.RefObject<HTMLButtonElement | null> }) => {
+    if (!open) return null;
+    mocks.anchor = anchorRef.current;
+    return { top: 40, left: 80, placement: 'bottom' };
+  },
+}));
+
+describe('toolbar icon actions and legacy Appearance hooks', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mocks.expanded = false;
+    mocks.pending = false;
+    mocks.anchor = null;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    document.querySelectorAll('[data-test-legacy-style]').forEach(node => node.remove());
+    document.documentElement.removeAttribute('data-openbitfun-appearance');
+    document.documentElement.removeAttribute('data-openbitfun-appearance-revision');
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('dispatches confirm, reject and stop once and keeps controls out of window dragging', async () => {
+    const confirm = vi.fn();
+    const reject = vi.fn();
+    const cancel = vi.fn();
+    window.addEventListener('toolbar-tool-confirm', confirm);
+    window.addEventListener('toolbar-tool-reject', reject);
+    window.addEventListener('toolbar-cancel-task', cancel);
+    try {
+      mocks.pending = true;
+      act(() => root.render(<ToolbarMode />));
+      for (const action of ['confirm', 'reject']) {
+        const icon = container.querySelector(`.toolbar-btn--${action} svg`)!;
+        act(() => {
+          icon.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+          icon.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        });
+      }
+      expect(confirm).toHaveBeenCalledTimes(1);
+      expect(reject).toHaveBeenCalledTimes(1);
+      expect((confirm.mock.calls[0][0] as CustomEvent).detail).toEqual({ toolId: 'tool-1' });
+      expect((reject.mock.calls[0][0] as CustomEvent).detail).toEqual({ toolId: 'tool-1' });
+      expect(mocks.drag).not.toHaveBeenCalled();
+      mocks.pending = false;
+      act(() => root.render(<ToolbarMode />));
+      act(() => container.querySelector<HTMLButtonElement>('.toolbar-btn--cancel-compact')!.click());
+      expect(cancel).toHaveBeenCalledTimes(1);
+      await act(async () => container.querySelector<HTMLButtonElement>('.toolbar-btn--overflow')!.click());
+      await act(async () => container.querySelector<HTMLButtonElement>('.toolbar-btn--expand')!.click());
+      expect(mocks.toggle).toHaveBeenCalledTimes(1);
+      expect(mocks.disable).toHaveBeenCalledTimes(1);
+    } finally {
+      window.removeEventListener('toolbar-tool-confirm', confirm);
+      window.removeEventListener('toolbar-tool-reject', reject);
+      window.removeEventListener('toolbar-cancel-task', cancel);
+    }
+  });
+
+  it('anchors the overflow menu to its button and preserves outside dismissal', () => {
+    mocks.expanded = true;
+    act(() => root.render(<ToolbarMode />));
+    const trigger = container.querySelector<HTMLButtonElement>('.openbitfun-toolbar-mode__overflow-trigger')!;
+    act(() => trigger.querySelector('svg')!.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    expect(mocks.anchor).toBe(trigger);
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    const menu = document.querySelector('.openbitfun-toolbar-mode__overflow-menu')!;
+    act(() => vi.advanceTimersByTime(0));
+    act(() => menu.dispatchEvent(new MouseEvent('mousedown', { bubbles: true })));
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    act(() => document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true })));
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('matches old package part rules against the actual migrated controls', () => {
+    mocks.expanded = true;
+    act(() => root.render(<>
+      <ToolbarMode />
+      <ScrollToLatestBar visible onClick={vi.fn()} />
+      <ScrollToTurnHeaderButton visible onClick={vi.fn()} />
+    </>));
+    const pkg: AppearancePackage = {
+      schema: 'openbitfun.appearance', schemaVersion: APPEARANCE_SCHEMA_VERSION,
+      id: 'test.toolbar-scroll', name: 'Toolbar and scroll controls', version: '1.0.0', mode: 'dark',
+      components: {
+        'toolbar-mode': { parts: { overflowTrigger: { states: { expanded: { opacity: { kind: 'number', value: 0.41 } } } } } },
+        'scroll-to-latest-bar': { parts: { button: { base: { opacity: { kind: 'number', value: 0.42 } } } } },
+        'scroll-to-turn-header-button': { parts: { button: { base: { opacity: { kind: 'number', value: 0.43 } } } } },
+      },
+    };
+    const serialized = JSON.stringify(pkg);
+    const restored = JSON.parse(serialized) as AppearancePackage;
+    const registry = new AppearanceRegistry()
+      .registerComponent(toolbarModeAppearanceDescriptor)
+      .registerComponent(scrollToLatestBarAppearanceDescriptor)
+      .registerComponent(scrollToTurnHeaderButtonAppearanceDescriptor);
+    const snapshot = new AppearanceCompiler(registry).compile(restored, 1);
+    expect(JSON.stringify(restored)).toBe(serialized);
+    document.documentElement.setAttribute('data-openbitfun-appearance', snapshot.id);
+    document.documentElement.setAttribute('data-openbitfun-appearance-revision', String(snapshot.revision));
+    const style = document.createElement('style');
+    style.dataset.testLegacyStyle = '';
+    style.textContent = snapshot.cssText;
+    document.head.appendChild(style);
+    for (const [selector, opacity] of [
+      ['.openbitfun-toolbar-mode__overflow-trigger', '0.41'],
+      ['.scroll-to-latest-bar__btn', '0.42'],
+      ['.scroll-to-turn-header-trigger__btn', '0.43'],
+    ]) {
+      const button = container.querySelector(selector)!;
+      expect(button.getAttribute('data-openbitfun-component')).toBe('icon-button');
+      const rule = Array.from(style.sheet!.cssRules).find(candidate =>
+        candidate instanceof CSSStyleRule && candidate.style.opacity === opacity,
+      ) as CSSStyleRule | undefined;
+      expect(rule).toBeDefined();
+      expect(document.querySelector(rule!.selectorText)).toBe(button);
+    }
+  });
+});

--- a/src/web-ui/src/infrastructure/appearance/compiler/AppearanceCompiler.test.ts
+++ b/src/web-ui/src/infrastructure/appearance/compiler/AppearanceCompiler.test.ts
@@ -1039,7 +1039,7 @@ describe('AppearanceCompiler', () => {
     expect(snapshot.cssText).toContain('[data-openbitfun-component="assistant-config-page"][data-openbitfun-part="persona"][data-openbitfun-state~="selected"]');
     expect(snapshot.cssText).toContain('[data-openbitfun-component="assistant-defaults-page"][data-openbitfun-part="skill"][data-openbitfun-state~="covered"]');
     expect(snapshot.cssText).toContain('[data-openbitfun-component="task-detail-panel"][data-openbitfun-part="root"][data-openbitfun-state~="empty"]');
-    expect(snapshot.cssText).toContain('[data-openbitfun-component="toolbar-mode"][data-openbitfun-part="root"][data-openbitfun-state~="expanded"]');
+    expect(snapshot.cssText).toContain('[data-openbitfun-product-component="toolbar-mode"][data-openbitfun-product-part="root"][data-openbitfun-state~="expanded"]');
     expect(snapshot.cssText).toContain('[data-openbitfun-component="mcp-tool-display"][data-openbitfun-part="expanded"][data-openbitfun-state~="expanded"]');
     expect(snapshot.cssText).toContain('[data-openbitfun-component="skills-config"][data-openbitfun-part="marketItem"][data-openbitfun-state~="installed"]');
     expect(snapshot.cssText).toContain('[data-openbitfun-component="diff-editor"][data-openbitfun-part="loading"][data-openbitfun-state~="loading"]');

--- a/src/web-ui/src/infrastructure/appearance/compiler/AppearanceCompiler.test.ts
+++ b/src/web-ui/src/infrastructure/appearance/compiler/AppearanceCompiler.test.ts
@@ -1019,8 +1019,8 @@ describe('AppearanceCompiler', () => {
     expect(snapshot.cssText).toContain('[data-openbitfun-component="scheduled-jobs-view"][data-openbitfun-part="job"][data-openbitfun-state~="expanded"]');
     expect(snapshot.cssText).toContain('[data-openbitfun-component="deep-review-action-bar"][data-openbitfun-part="root"][data-openbitfun-phase="review_completed"][data-openbitfun-variant="success"]');
     expect(snapshot.cssText).toContain('[data-openbitfun-component="rich-text-input"][data-openbitfun-part="contextTag"][data-openbitfun-context-type="widget-reference"]');
-    expect(snapshot.cssText).toContain('[data-openbitfun-component="model-round-item"][data-openbitfun-part="root"][data-openbitfun-status="streaming"]');
-    expect(snapshot.cssText).toContain('[data-openbitfun-component="model-round-item"][data-openbitfun-part="action"][data-openbitfun-state~="copied"]');
+    expect(snapshot.cssText).toContain('[data-openbitfun-product-component="model-round-item"][data-openbitfun-product-part="root"][data-openbitfun-status="streaming"]');
+    expect(snapshot.cssText).toContain('[data-openbitfun-product-component="model-round-item"][data-openbitfun-product-part="action"][data-openbitfun-state~="copied"]');
     expect(snapshot.cssText).toContain('[data-openbitfun-component="flexible-panel"][data-openbitfun-part="code"][data-openbitfun-state~="needsFix"]');
     expect(snapshot.cssText).toContain('[data-openbitfun-component="btw-session-panel"][data-openbitfun-part="root"][data-openbitfun-view="session"]');
     expect(snapshot.cssText).toContain('[data-openbitfun-component="model-selector"][data-openbitfun-part="trigger"][data-openbitfun-state~="open"]');
@@ -1046,7 +1046,7 @@ describe('AppearanceCompiler', () => {
     expect(snapshot.cssText).toContain('[data-openbitfun-component="agent-companion-desktop-pet"][data-openbitfun-part="hitbox"][data-openbitfun-state~="attention"]');
     expect(snapshot.cssText).toContain('[data-openbitfun-product-component="tool-group-picker"][data-openbitfun-product-part="token"][data-openbitfun-state~="selected"]');
     expect(snapshot.cssText).toContain('[data-openbitfun-component="inline-diff-preview"][data-openbitfun-part="root"][data-openbitfun-state~="empty"]');
-    expect(snapshot.cssText).toContain('[data-openbitfun-component="export-image"][data-openbitfun-part="trigger"][data-openbitfun-state~="exporting"]');
+    expect(snapshot.cssText).toContain('[data-openbitfun-product-component="export-image"][data-openbitfun-product-part="trigger"][data-openbitfun-state~="exporting"]');
     expect(snapshot.cssText).toContain('[data-openbitfun-component="user-message-item"][data-openbitfun-part="root"][data-openbitfun-state~="failed"]');
     expect(snapshot.cssText).toContain('[data-openbitfun-component="session-usage-report-card"][data-openbitfun-part="loading"][data-openbitfun-state~="loading"]');
     expect(snapshot.cssText).toContain('[data-openbitfun-component="create-plan-display"][data-openbitfun-part="todos"][data-openbitfun-state~="expanded"]');

--- a/src/web-ui/src/infrastructure/config/components/ExternalSourcesConfig.scss
+++ b/src/web-ui/src/infrastructure/config/components/ExternalSourcesConfig.scss
@@ -319,6 +319,8 @@
   }
 
   &__icon-action {
+    flex-shrink: 1;
+    transition: none;
     display: grid;
     width: 30px;
     height: 30px;
@@ -329,6 +331,18 @@
     color: var(--openbitfun-color-content-secondary);
     background: transparent;
     cursor: pointer;
+
+    &::before { content: none; }
+
+    > [data-openbitfun-part='icon'] {
+      --openbitfun-opacity-icon-artwork: inherit;
+      display: contents;
+    }
+
+    > :where([data-openbitfun-part='icon']) > :where([data-openbitfun-component='icon']) {
+      inline-size: var(--openbitfun-control-icon-size-md);
+      block-size: var(--openbitfun-control-icon-size-md);
+    }
 
     &:hover,
     &:focus-visible,

--- a/src/web-ui/src/infrastructure/config/components/ExternalSourcesConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/ExternalSourcesConfig.tsx
@@ -1,4 +1,4 @@
-import { Button, Combobox, ConfirmDialog, Icon, Select, Switch, Tooltip } from '@openbitfun/ui';
+import { Button, Combobox, ConfirmDialog, Icon, IconButton, Select, Switch, Tooltip } from '@openbitfun/ui';
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
@@ -1875,7 +1875,7 @@ const ExternalSourcesConfig: React.FC<ExternalSourcesConfigProps> = ({
                                 })}
                               />
                               <Tooltip content={t('policy.capabilitiesHint')} placement="top">
-                                <button
+                                <IconButton
                                   type="button"
                                   className="openbitfun-external-sources-config__icon-action"
                                   aria-label={t('policy.capabilitiesFor', {
@@ -1889,9 +1889,8 @@ const ExternalSourcesConfig: React.FC<ExternalSourcesConfigProps> = ({
                                     else next.add(ecosystem.ecosystemId);
                                     return next;
                                   })}
-                                >
-                                  <Icon name="settings" size="md" aria-hidden="true" />
-                                </button>
+                                  icon={<Icon name="settings" size="md" aria-hidden="true" />}
+                                />
                               </Tooltip>
                             </div>
                           </div>
@@ -2096,7 +2095,7 @@ const ExternalSourcesConfig: React.FC<ExternalSourcesConfigProps> = ({
                       })}
                     />
                     <Tooltip content={t('policy.capabilitiesHint')} placement="top">
-                      <button
+                      <IconButton
                         type="button"
                         className="openbitfun-external-sources-config__icon-action"
                         aria-label={t('policy.capabilitiesFor', {
@@ -2110,9 +2109,8 @@ const ExternalSourcesConfig: React.FC<ExternalSourcesConfigProps> = ({
                           else next.add(ecosystem.ecosystemId);
                           return next;
                         })}
-                      >
-                        <Icon name="settings" size="md" aria-hidden="true" />
-                      </button>
+                        icon={<Icon name="settings" size="md" aria-hidden="true" />}
+                      />
                     </Tooltip>
                   </div>
                 </div>

--- a/src/web-ui/src/infrastructure/config/components/SkillsConfig.tsx
+++ b/src/web-ui/src/infrastructure/config/components/SkillsConfig.tsx
@@ -335,14 +335,14 @@ const SkillsConfig: React.FC = () => {
       </>
     );
     const control = canDeleteSkill(skill) ? (
-        <button
+        <IconButton
           type="button"
           className="openbitfun-collection-btn openbitfun-collection-btn--danger"
           onClick={() => setDeleteConfirm({ show: true, skill })}
           title={t('list.item.deleteTooltip')}
-        >
-          <Icon name="delete" size="sm" />
-        </button>
+          aria-label={t('list.item.deleteTooltip')}
+          icon={<Icon name="delete" size="sm" />}
+        />
     ) : null;
     const details = (
       <div data-openbitfun-component="skills-config" data-openbitfun-part="details">

--- a/src/web-ui/src/infrastructure/config/components/common/ConfigCollectionItem.scss
+++ b/src/web-ui/src/infrastructure/config/components/common/ConfigCollectionItem.scss
@@ -173,6 +173,28 @@
     background: color-mix(in srgb, var(--openbitfun-color-status-danger-content) 8%, transparent);
     color: var(--openbitfun-color-status-danger-content);
   }
+
+  // Preserve collection action geometry and feedback for the shared button root.
+  &[data-openbitfun-component='icon-button'] {
+    flex-shrink: 1;
+
+    &::before { content: none; }
+
+    &:focus-visible {
+      outline: 2px solid color-mix(in srgb, var(--openbitfun-color-accent-default) 40%, transparent);
+      outline-offset: 2px;
+    }
+
+    > [data-openbitfun-part='icon'] {
+      --openbitfun-opacity-icon-artwork: inherit;
+      display: contents;
+    }
+
+    > :where([data-openbitfun-part='icon']) > :where([data-openbitfun-component='icon']) {
+      inline-size: 14px;
+      block-size: 14px;
+    }
+  }
 }
 
 // ─── empty row ─────────────────────────────────────────────────────────────────

--- a/src/web-ui/src/infrastructure/config/components/common/ConfigCollectionItem.test.tsx
+++ b/src/web-ui/src/infrastructure/config/components/common/ConfigCollectionItem.test.tsx
@@ -136,7 +136,7 @@ describe('ConfigCollectionItem', () => {
     act(() => {
       root.render(
         <ConfigCollectionItem
-          label="Model A"
+          label={<span>Model A</span>}
           control={<button type="button">Edit</button>}
           details={<span>Model details</span>}
           toggleOnRowClick
@@ -151,6 +151,15 @@ describe('ConfigCollectionItem', () => {
     const toggle = container.querySelector<HTMLButtonElement>('.openbitfun-collection-item__details-toggle');
 
     expect(row?.classList.contains('openbitfun-collection-item__row--toggleable')).toBe(true);
+    expect(document.getElementById(toggle!.getAttribute('aria-labelledby')!)?.textContent).toBe('Model A');
+
+    // A click on the nested icon must toggle once, without toggling the row again.
+    act(() => {
+      toggle?.querySelector('svg')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(toggle?.getAttribute('aria-expanded')).toBe('true');
+    act(() => toggle?.click());
+    expect(toggle?.getAttribute('aria-expanded')).toBe('false');
 
     act(() => {
       control?.click();

--- a/src/web-ui/src/infrastructure/config/components/common/ConfigCollectionItem.tsx
+++ b/src/web-ui/src/infrastructure/config/components/common/ConfigCollectionItem.tsx
@@ -1,5 +1,5 @@
 import React, { useId, useState } from 'react';
-import { OverflowText, Icon } from '@openbitfun/ui';
+import { OverflowText, Icon, IconButton } from '@openbitfun/ui';
 ;
 import { RetainedMountBoundary } from '@/shared/presence';
 import './ConfigCollectionItem.scss';
@@ -101,17 +101,17 @@ export const ConfigCollectionItem: React.FC<ConfigCollectionItemProps> = ({
           <div className="openbitfun-collection-item__control">
             {control}
             {hasDetails ? (
-              <button
+              <IconButton
                 type="button"
                 className="openbitfun-collection-btn openbitfun-collection-item__details-toggle"
                 onClick={toggleDetails}
                 disabled={detailsDisabled}
+                aria-label={typeof label === 'string' ? label : ''}
                 aria-labelledby={labelId}
                 aria-expanded={isExpanded}
                 aria-controls={detailsId}
-              >
-                <Icon name="chevron-down" size="sm" aria-hidden="true" />
-              </button>
+                icon={<Icon name="chevron-down" size="sm" aria-hidden="true" />}
+              />
             ) : null}
           </div>
         </div>

--- a/src/web-ui/src/shared/context-menu-system/components/ContextMenuRenderer.tsx
+++ b/src/web-ui/src/shared/context-menu-system/components/ContextMenuRenderer.tsx
@@ -33,6 +33,7 @@ const CONTEXT_MENU_CATALOG: Record<string, IconName> = {
   Pin: 'pin',
   Plus: 'plus',
   Search: 'search',
+  Terminal: 'terminal',
   RefreshCw: 'refresh',
   X: 'xmark',
 };

--- a/src/web-ui/src/shared/context-menu-system/components/ui/ContextMenu.test.tsx
+++ b/src/web-ui/src/shared/context-menu-system/components/ui/ContextMenu.test.tsx
@@ -5,6 +5,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ContextMenu } from './ContextMenu';
 import type { ContextMenuItem } from './types';
+import { ContextMenuRenderer } from '../ContextMenuRenderer';
+import { useContextMenuStore } from '../../store/ContextMenuStore';
 
 vi.mock('@/shared/utils/logger', () => ({
   createLogger: () => ({ error: vi.fn() }),
@@ -37,6 +39,7 @@ describe('ContextMenu presence', () => {
 
   afterEach(() => {
     act(() => root.unmount());
+    useContextMenuStore.getState().reset();
     vi.useRealTimers();
     dom.window.close();
   });
@@ -262,5 +265,29 @@ describe('ContextMenu presence', () => {
     expect(document.querySelector('[data-openbitfun-component="menu"][data-openbitfun-product-part="root"]')).not.toBeNull();
     expect(document.querySelector('[data-openbitfun-product-part="item"][data-openbitfun-state="disabled"]')?.getAttribute('aria-disabled')).toBe('true');
     expect(document.querySelector('[data-openbitfun-product-part="item"][data-openbitfun-state="submenu-active"]')?.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('resolves the file explorer terminal icon and forwards layout classes through product slots', () => {
+    useContextMenuStore.setState({
+      visible: true,
+      position: { x: 20, y: 20 },
+      items: [
+        { id: 'file-new-terminal', label: 'New terminal here', icon: 'Terminal' },
+        { id: 'file-paste', label: 'Paste', icon: 'Clipboard', shortcut: 'Ctrl+V' },
+        { id: 'file-new', label: 'New', icon: 'Plus', submenu: [{ id: 'file-new-file', label: 'New file', icon: 'FilePlus' }] },
+      ],
+    });
+    act(() => root.render(<ContextMenuRenderer />));
+    const terminal = document.querySelector('[data-menu-id="file-new-terminal"]')!;
+    expect(terminal.querySelector('[data-openbitfun-name="terminal"] svg')).not.toBeNull();
+    expect(terminal.querySelector('i.Terminal')).toBeNull();
+    const iconSlots = Array.from(document.querySelectorAll<HTMLElement>('[data-openbitfun-product-part="icon"]'));
+    expect(iconSlots).toHaveLength(3);
+    for (const slot of iconSlots) {
+      expect(slot.className).not.toBe('');
+      expect(slot.parentElement?.getAttribute('data-openbitfun-part')).toBe('leading');
+      expect(slot.querySelector('svg')).not.toBeNull();
+    }
+    expect(document.querySelector<HTMLElement>('[data-openbitfun-product-part="submenuArrow"]')?.className).toBeTruthy();
   });
 });

--- a/src/web-ui/src/tools/openbitfun-canvas/OpenBitFunCanvasPanel.scss
+++ b/src/web-ui/src/tools/openbitfun-canvas/OpenBitFunCanvasPanel.scss
@@ -24,6 +24,28 @@
 }
 
 .openbitfun-canvas-panel__toolbar-button {
+  // Keep the existing canvas surface and authored icon sizes through the public slot.
+  transition: none;
+  outline: revert;
+  outline-offset: revert;
+
+  &::before { content: none; }
+
+  > [data-openbitfun-part='icon'] {
+    --openbitfun-opacity-icon-artwork: inherit;
+    display: contents;
+  }
+
+  > :where([data-openbitfun-part='icon']) > :where(svg) {
+    inline-size: 15px;
+    block-size: 15px;
+  }
+
+  > :where([data-openbitfun-part='icon']) > :where([data-openbitfun-component='icon']) {
+    inline-size: 14px;
+    block-size: 14px;
+  }
+
   display: inline-flex;
   align-items: center;
   justify-content: center;

--- a/src/web-ui/src/tools/openbitfun-canvas/OpenBitFunCanvasPanel.tsx
+++ b/src/web-ui/src/tools/openbitfun-canvas/OpenBitFunCanvasPanel.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import { Icon } from '@openbitfun/ui';
+import { Icon, IconButton } from '@openbitfun/ui';
 import { AlertTriangle, Code2, Loader2, MousePointer2 } from 'lucide-react';
 import path from 'path-browserify';
 import { flowChatStore } from '@/flow_chat/store/FlowChatStore';
@@ -1015,7 +1015,7 @@ export const OpenBitFunCanvasPanel: React.FC<OpenBitFunCanvasPanelProps> = ({
   return (
     <div className="openbitfun-canvas-panel" data-openbitfun-component="canvas-tool" data-openbitfun-part="root">
       <div className="openbitfun-canvas-panel__toolbar" data-openbitfun-component="canvas-tool" data-openbitfun-part="toolbar">
-        <button
+        <IconButton
           type="button"
           className={`openbitfun-canvas-panel__toolbar-button${sourceVisible ? ' openbitfun-canvas-panel__toolbar-button--active' : ''}`}
           aria-pressed={sourceVisible}
@@ -1023,28 +1023,26 @@ export const OpenBitFunCanvasPanel: React.FC<OpenBitFunCanvasPanelProps> = ({
           title={sourceVisible ? 'Hide Canvas source' : 'Show Canvas source'}
           disabled={!hasSourceDialogText}
           onClick={() => setSourceVisible(value => !value)}
-        >
-          <Code2 size={15} />
-        </button>
-        <button
+          icon={<Code2 size={15} />}
+        />
+        <IconButton
           type="button"
           className={`openbitfun-canvas-panel__toolbar-button${designMode ? ' openbitfun-canvas-panel__toolbar-button--active' : ''}`}
           aria-pressed={designMode}
           title="Select Canvas element"
           onClick={() => setDesignMode(value => !value)}
-        >
-          <MousePointer2 size={15} />
-        </button>
-        <button
+          aria-label="Select Canvas element"
+          icon={<MousePointer2 size={15} />}
+        />
+        <IconButton
           type="button"
           className="openbitfun-canvas-panel__toolbar-button"
           title="Export HTML"
           aria-label="Export Canvas HTML"
           disabled={exportingHtml}
           onClick={handleExportHtml}
-        >
-          {exportingHtml ? <Loader2 size={15} className="openbitfun-canvas-panel__toolbar-icon--spin" /> : <Icon name="arrow-down" size="sm" />}
-        </button>
+          icon={exportingHtml ? <Loader2 size={15} className="openbitfun-canvas-panel__toolbar-icon--spin" /> : <Icon name="arrow-down" size="sm" />}
+        />
       </div>
       {isFrameReady && (
         <iframe


### PR DESCRIPTION
## Summary

- Replace 29 native icon buttons with the shared `IconButton` across settings, message actions, image export, Canvas, remote file browsing, toolbars, and scroll controls.
- Preserve existing handlers, disabled states, icon sizing, and persisted Appearance package mappings.
- Fix context menu icon alignment and add the missing icon for “New terminal here”.
- Add regression coverage for menu behavior, action dispatch, focus restoration, and legacy Appearance selectors.

## Type and Areas

Type: Refactor, bug fix, UI/UX

Areas: Web UI, shared UI components, Appearance system

## Motivation / Impact

Existing icon actions duplicated button markup and styling. This change adopts shared controls while retaining their existing behavior and presentation.

File explorer context menus also displayed icons above the text centerline, and the terminal action had no visible icon. Centering the menu icon wrappers and registering the terminal icon fixes both issues.

## Verification

The following checks passed during implementation. They were not rerun solely for this PR description:

```bash
pnpm run check:web
pnpm run i18n:audit
pnpm --dir src/web-ui run icons:check
node --test design-system/packages/ui/tests/menu.test.mjs
```

Focused tests also passed for settings collection controls, message/export actions, toolbar actions, scroll focus restoration, Canvas, context menus, file explorer menu providers, Appearance compilation, icon integration, and startup preloading.

Targeted production-file ESLint and modified SCSS compilation passed. `motion:audit` was reviewed as an inventory.

Manual visual verification and end-to-end testing of Remote Workspace, Remote Control, Peer Device Mode, and Detached Dispatch were not performed.

## Reviewer Notes

- Existing Appearance package surface, part, and state names remain compatible. Migrated controls use product-specific DOM attributes alongside shared component identifiers.
- Menu alignment is corrected in the shared `MenuPopover`, including submenu arrows.
- Terminal creation logic and resource-scope propagation are unchanged.
- No persisted-data migration or backend protocol changes are required.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.