### PR TITLE
fix(ui): improve request URL previews and prevent text clipping

### DIFF
--- a/design-system/packages/ui/src/primitives/OverflowText/OverflowText.module.css
+++ b/design-system/packages/ui/src/primitives/OverflowText/OverflowText.module.css
@@ -27,6 +27,10 @@
     min-inline-size: max-content;
     /* Keep ascent/descent inside the clipping box, including in tight controls. */
     line-height: var(--openbitfun-type-modifier-leading-intrinsic-line-height);
+    /* Font ink and fractional scaling can extend beyond the natural line box.
+       Include block-axis breathing room in the grid's intrinsic height so the
+       horizontal clipping viewport does not shave off accents or descenders. */
+    padding-block: calc(var(--openbitfun-space-1) / 2);
   }
 
   .root[data-overflow-lines] {

--- a/src/web-ui/src/infrastructure/config/components/ModelSettingsPage.scss
+++ b/src/web-ui/src/infrastructure/config/components/ModelSettingsPage.scss
@@ -1422,8 +1422,19 @@
 
   &__resolved-url {
     display: flex;
-    flex-direction: column;
-    gap: 2px;
+    align-items: baseline;
+    gap: var(--openbitfun-space-1);
+    box-sizing: border-box;
+    padding-inline: calc(var(--openbitfun-space-2) + var(--openbitfun-border-width-default));
+
+    .openbitfun-model-settings__resolved-url-label {
+      flex-shrink: 0;
+      white-space: nowrap;
+    }
+
+    .openbitfun-model-settings__resolved-url-value {
+      min-width: 0;
+    }
 
     .resolved-url__hint {
       font-size: var(--openbitfun-type-meta-font-size);

--- a/src/web-ui/src/infrastructure/config/components/ModelSettingsPage.tsx
+++ b/src/web-ui/src/infrastructure/config/components/ModelSettingsPage.tsx
@@ -348,11 +348,13 @@ function geminiBaseUrl(url: string): string {
 
 /**
  * Build a human-readable preview URL for display in the UI.
- * For gemini: always shows {base}/v1beta/models/...
+ * For Gemini, show the full streaming endpoint with a model placeholder when needed.
  */
-function previewRequestUrl(baseUrl: string, provider: string): string {
-  if (provider === 'gemini') {
-    return `${geminiBaseUrl(baseUrl.trim().replace(/\/+$/, ''))}/v1beta/models/...`;
+function previewRequestUrl(baseUrl: string, provider: string, modelName?: string): string {
+  const trimmed = baseUrl.trim().replace(/\/+$/, '');
+  if (provider === 'gemini' && !trimmed.endsWith('#')) {
+    const model = modelName?.trim();
+    return `${geminiBaseUrl(trimmed)}/v1beta/models/${model ? encodeURIComponent(model) : '{model}'}:streamGenerateContent?alt=sse`;
   }
   return resolveRequestUrl(baseUrl, provider);
 }
@@ -2869,7 +2871,9 @@ const ModelSettingsPage: React.FC = () => {
                         {editingConfig.base_url && !automaticOpenCodeRouting && (
                           <div className="openbitfun-model-settings__resolved-url">
                             <span className="openbitfun-model-settings__resolved-url-label">{t('form.resolvedUrlLabel')}</span>
-                              <span className="openbitfun-model-settings__resolved-url-value">{previewRequestUrl(editingConfig.base_url, editingConfig.provider || 'openai')}</span>
+                            <span className="openbitfun-model-settings__resolved-url-value">
+                              {previewRequestUrl(editingConfig.base_url, editingConfig.provider || 'openai', selectedModelDrafts.length === 1 ? selectedModelDrafts[0].modelName : undefined)}
+                            </span>
                           </div>
                         )}
                       </div>
@@ -2994,7 +2998,9 @@ const ModelSettingsPage: React.FC = () => {
                             {editingConfig.base_url && !automaticOpenCodeRouting && (
                               <div className="openbitfun-model-settings__resolved-url">
                                 <span className="openbitfun-model-settings__resolved-url-label">{t('form.resolvedUrlLabel')}</span>
-                              <span className="openbitfun-model-settings__resolved-url-value">{previewRequestUrl(editingConfig.base_url, editingConfig.provider || 'openai')}</span>
+                                <span className="openbitfun-model-settings__resolved-url-value">
+                                  {previewRequestUrl(editingConfig.base_url, editingConfig.provider || 'openai', selectedModelDrafts.length === 1 ? selectedModelDrafts[0].modelName : undefined)}
+                                </span>
                               </div>
                             )}
                           </div>


### PR DESCRIPTION
## Summary

- Align request URL previews with input text and keep the label and URL on one line when space permits.
- Display the full Gemini streaming endpoint, using the selected model name or a `{model}` placeholder.
- Add vertical padding to shared overflow text to prevent clipped descenders.

## Type and Areas

Type: Bug fix / UI/UX

Areas: Web UI model settings, shared design system

## Motivation / Impact

Request URL previews previously appeared on separate lines, and Gemini previews contained a hard-coded ellipsis even when space was available. Some dropdown labels also clipped the bottoms of letters such as `g` and `p`.

These changes improve alignment and readability while allowing long URLs to wrap.

## Verification

Passed:

- `pnpm run check:web`
- `pnpm run design-system:test`
- `pnpm --dir src/web-ui run test:run src/infrastructure/config/components/ModelSettingsPage.presentation.test.ts src/infrastructure/config/components/ModelSettingsDialog.presentation.test.ts`
- `git diff --check`

Manual visual verification and remote scenario testing were not performed.

## Reviewer Notes

The text padding change affects consumers of the shared `OverflowText` component. Review compact controls for spacing and clipping.

Request persistence and execution behavior are unchanged. No migration is required.

## Checklist

- [x] This PR is focused and does not include secrets, temporary prompts, generated scratch files, or unrelated artifacts.
- [x] Relevant verification is recorded above, or skipped checks are explained.
- [x] User-facing strings, docs, and locales are updated where applicable.