### PR TITLE
fix(flow-chat): keep remote question cards in the rendered attempt

### DIFF
--- a/docs/architecture/session-projection.md
+++ b/docs/architecture/session-projection.md
@@ -8,6 +8,23 @@ Read [`peer-device-mode.md`](peer-device-mode.md) for how a controller reaches
 another device. This document is about what happens to the data once it
 arrives, and applies identically on the local surface.
 
+## Interaction and attempt ownership
+
+The current mailbox reconciler updates both representations of a model round:
+`attempts[].items` owns attempt-aware rendering and subsequent streaming writes;
+`items` is its flattened projection used by attention indicators and consumers
+without attempt support. Recovered questions, including child-agent questions
+projected into the controlling parent Session, must enter the current
+non-diagnostic attempt. Diagnostic attempts remain history. Legacy rounds without
+attempts keep their flat representation.
+
+Reconciliation applies replacements and removals to both representations before
+publishing the Session. An authoritative empty mailbox removes pending synthetic
+cards but preserves completed tool results. Replaying the same revision must not
+remount the card or erase drafts. A mailbox-only update must survive the next
+ordinary stream update; merely asserting that the flat list contains a question
+does not prove that FlowChat can display it.
+
 ## The problem this replaces
 
 Seven independent writers currently produce a Session's on-screen state:

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flowChatStore, mergeModelRoundAttemptDiagnostics } from './FlowChatStore';
+import { sessionToVirtualItems } from './modernFlowChatStore';
+import { buildModelRoundItemGroups } from '../components/modern/modelRoundItemGrouping';
 import { sessionCompletionReceipt } from '../utils/sessionCompletionReceipt';
 import {
   LOCAL_SURFACE_ID,
@@ -2096,6 +2098,80 @@ describe('FlowChatStore historical session hydration state', () => {
       questions: [],
     })).toBe(true);
     expect(askUserQuestionDraftStore.getState().drafts[draftKey]).toBeUndefined();
+  });
+
+  it.each(['single', 'retry', 'diagnostic', 'answered'] as const)('keeps recovered questions in the rendered attempt and settles them without resurrection (%s)', (scenario) => {
+    const retry = scenario === 'retry';
+    const task = { id: 'task', type: 'tool', toolName: 'Task', status: 'running',
+      timestamp: 2, toolCall: { id: 'task', input: {} }, requiresConfirmation: false } as const;
+    const attempt = { id: 'attempt-live', index: retry ? 2 : 1, status: 'streaming' as const,
+      items: [{ ...task, attemptId: 'attempt-live', attemptIndex: retry ? 2 : 1 }] };
+    const older = { id: 'attempt-old', index: 1, status: 'superseded' as const,
+      items: [{ ...task, id: 'old-task', status: 'cancelled' as const,
+        attemptId: 'attempt-old', attemptIndex: 1 }] };
+    const attempts = scenario === 'diagnostic'
+      ? [{ ...attempt, diagnostic: { category: 'invalid_tool_arguments' } }]
+      : retry ? [older, attempt] : [attempt];
+    const originalRound = { id: 'round-live', index: 0, status: 'streaming' as const,
+      isStreaming: true, isComplete: false, startTime: 1,
+      attempts, items: attempts.flatMap(entry => entry.items) };
+    flowChatStore.setState(() => ({
+      sessions: new Map([['history-1', createSession({ sessionId: 'history-1',
+        dialogTurns: [{ id: 'turn-live', sessionId: 'history-1',
+          userMessage: { id: 'user', content: 'ask me', timestamp: 1 },
+          modelRounds: [originalRound], status: 'processing', startTime: 1 }] })]]),
+      activeSessionId: 'history-1',
+    }));
+    const snapshot = { revision: 7, questions: [{ toolId: 'child-question',
+      sessionId: 'history-1', dialogTurnId: 'turn-live',
+      questions: { questions: [{ question: 'Which time zone?' }] }, registeredAtMs: 3 }] };
+    const round = () => flowChatStore.getState().sessions.get('history-1')!.dialogTurns[0].modelRounds[0];
+    flowChatStore.reconcilePendingUserQuestions('history-1', snapshot);
+    expect(round().attempts!.at(-1)!.items).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'child-question', status: 'waiting',
+        attemptId: scenario === 'diagnostic' ? 'runtime-interaction:round-live' : 'attempt-live', isParamsStreaming: false }),
+    ]));
+    expect(round().items).toEqual(round().attempts!.flatMap(entry => entry.items));
+    const visibleRound = sessionToVirtualItems(flowChatStore.getState().sessions.get('history-1')!)
+      .find(item => item.type === 'model-round');
+    expect(visibleRound?.type).toBe('model-round');
+    if (visibleRound?.type === 'model-round') {
+      const displayed = [...visibleRound.data.attempts!].reverse().find(entry => !entry.diagnostic)!;
+      expect(buildModelRoundItemGroups({ items: displayed.items, isStreaming: true,
+        disableExploreGrouping: false, isCollapsibleTool: () => false }))
+        .toContainEqual({ type: 'critical', item: expect.objectContaining({ id: 'child-question' }) });
+    }
+    // Same-revision refresh is idempotent and retains the visible question.
+    const beforeRefresh = round();
+    flowChatStore.reconcilePendingUserQuestions('history-1', snapshot);
+    expect(round()).toBe(beforeRefresh);
+    flowChatStore.updateModelRoundItem('history-1', 'turn-live', 'child-question', { isParamsStreaming: true });
+    flowChatStore.reconcilePendingUserQuestions('history-1', snapshot);
+    expect(round().attempts!.at(-1)!.items.find(item => item.id === 'child-question'))
+      .toMatchObject({ status: 'waiting', isParamsStreaming: false });
+    expect(originalRound.items).toHaveLength(retry ? 2 : 1);
+    expect(attempt.items).toHaveLength(1);
+    if (retry) expect(round().attempts![0].items).toEqual(older.items);
+
+    // The ordinary streaming update path rebuilds items from attempts.
+    flowChatStore.updateModelRound('history-1', 'turn-live', 'round-live', current => ({ ...current }));
+    expect(round().items.some(item => item.id === 'child-question')).toBe(true);
+    if (scenario === 'answered') {
+      flowChatStore.updateModelRoundItem('history-1', 'turn-live', 'child-question', {
+        status: 'completed', toolResult: { success: true, result: { answers: { '0': 'UTC' } } },
+      });
+    }
+    flowChatStore.reconcilePendingUserQuestions('history-1', { revision: 8, questions: [] });
+    if (scenario === 'answered') {
+      expect(round().items.find(item => item.id === 'child-question')).toMatchObject({ status: 'completed' });
+      expect(round().items.find(item => item.id === 'child-question')).not.toHaveProperty('_runtimeInteractionProjection');
+      expect(round().items).toEqual(round().attempts!.flatMap(entry => entry.items));
+      return;
+    }
+    expect(round().items.some(item => item.id === 'child-question')).toBe(false);
+    expect(round().attempts!.flatMap(entry => entry.items).some(item => item.id === 'child-question')).toBe(false);
+    flowChatStore.updateModelRound('history-1', 'turn-live', 'round-live', current => ({ ...current }));
+    expect(round().items.some(item => item.id === 'child-question')).toBe(false);
   });
 
   it('re-enables a same-revision mailbox card changed back to parameter streaming', () => {

--- a/src/web-ui/src/flow_chat/store/FlowChatStore.ts
+++ b/src/web-ui/src/flow_chat/store/FlowChatStore.ts
@@ -1010,11 +1010,58 @@ function reconcilePendingUserQuestionSnapshot(
     }
   }
 
+  for (const turn of nextTurns) {
+    turn.modelRounds = turn.modelRounds.map(round => {
+      const reconciled = reconcileInteractionAttemptItems(round);
+      changed ||= reconciled !== round;
+      return reconciled;
+    });
+  }
+
   return {
     turns: changed ? nextTurns : turns,
     changed,
     revisionApplied: fullyApplied,
   };
+}
+
+/** Keep mailbox edits in the attempt owner used by rendering and later stream writes. */
+function reconcileInteractionAttemptItems(round: ModelRound): ModelRound {
+  if (!round.attempts?.length) return round;
+  const attemptItems = flattenRoundAttemptItems(round);
+  const isMailboxItem = (item: AnyFlowItem) => item.type === 'tool' &&
+    item._runtimeInteractionProjection?.kind === 'user_question';
+  if (!round.items.some(isMailboxItem) && !attemptItems.some(isMailboxItem)) return round;
+  if (attemptItems.length === round.items.length &&
+      attemptItems.every((item, index) => item === round.items[index])) return round;
+
+  const itemsById = new Map(round.items.map(item => [item.id, item]));
+  const ownedIds = new Set(round.attempts.flatMap(attempt => attempt.items.map(item => item.id)));
+  const added = round.items.filter(item => !ownedIds.has(item.id));
+  const attempts = round.attempts.map(attempt => ({
+    ...attempt,
+    items: attempt.items.flatMap(item => {
+      const replacement = itemsById.get(item.id);
+      return replacement ? [replacement] : [];
+    }),
+  }));
+  if (added.length) {
+    // Diagnostic-only attempts remain history. A recovered interaction must
+    // have a visible current owner, even when the checkpoint has no live attempt.
+    let active = sortAttemptEntries(attempts).at(-1);
+    if (!active || active.diagnostic || active.status === 'superseded') {
+      active = {
+        id: `runtime-interaction:${round.id}`,
+        index: Math.max(...attempts.map(attempt => attempt.index)) + 1,
+        status: 'streaming',
+        items: [],
+      };
+      attempts.push(active);
+    }
+    const owner = active;
+    owner.items.push(...added.map(item => withAttemptMetadata(item, owner)));
+  }
+  return synchronizeRoundAttempts({ ...round, attempts });
 }
 
 function itemMatchesIdentity(item: AnyFlowItem, itemId: string): boolean {


### PR DESCRIPTION
Remote question recovery updated only `round.items`, while attempt-aware FlowChat renders `round.attempts[].items`. A delegated AskUserQuestion could therefore appear in the companion bubble but have no answerable chat card; the next stream write could also erase the recovered question.

Reconcile mailbox additions, replacements, and removals with the attempt owner before publishing the session. Preserve retry/diagnostic history and completed results, keep legacy flat rounds working, and avoid changes on repeated snapshots. The shared frontend fix applies to desktop and web controllers; no host-specific fallback or protocol change is introduced.

Validation:
- 262 focused tests passed across FlowChat state, virtual projection, presentation sync, peer refresh, ordered stream delivery, question cards, and surface-scoped drafts.
- New regression failed before the fix and passes with single attempts, retry history, diagnostic-only history, answer completion, same-revision restoration, and subsequent stream writes.
- `pnpm run check:web` and final `pnpm run type-check:web` passed.
- Peer Device behavior exercised through mocked remote snapshot/replay and surface submission contracts. No live Mac-to-Linux device test or new Remote Workspace, mobile/IM Remote Connect, or Detached Dispatch execution is claimed.
