### PR TITLE
fix(peer): harden message recovery and multi-device delivery isolation

### DIFF
--- a/docs/architecture/session-projection.md
+++ b/docs/architecture/session-projection.md
@@ -25,6 +25,25 @@ remount the card or erase drafts. A mailbox-only update must survive the next
 ordinary stream update; merely asserting that the flat list contains a question
 does not prove that FlowChat can display it.
 
+## Read lifecycle and multi-session isolation
+
+`SessionStream` owns both the read fence and whether a read is in flight. A read
+ends exactly once; completion, abandonment, supersession, and attachment disposal
+must make its old handle unable to affect a subsequent read. Returning to a
+healthy projection wakes pending-message consumers even when the terminal state
+was replayed while the fence blocked submission. Those wakeups are coalesced and
+bound to the rendered surface epoch.
+
+Replayed lifecycle events establish Turn ownership before newer held events are
+released. Changing Runtime process resets old ownership; a same-process snapshot
+behind the applied position cannot clear a delivery gap. A discarded queue keeps
+the original surface stale for replay rather than delivering to another device.
+The transport also checks the captured surface epoch and surviving subscriptions
+at delayed delivery time; replacement listeners cannot receive old events.
+
+A Session restore fences only that Session. Events buffered for other Sessions
+during the read must be flushed, never cleared with the restored projection.
+
 ## The problem this replaces
 
 Seven independent writers currently produce a Session's on-screen state:

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/MessageModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/MessageModule.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   cancelSessionTask,
   drainPendingQueue,
+  installPendingQueueDrainListener,
   sendMessage,
   syncSessionModelSelection,
 } from './MessageModule';
@@ -20,6 +21,9 @@ import {
   activateSurface,
 } from '@/infrastructure/peer-device/deviceSurface';
 
+import { beginRuntimeSessionAttachment } from '@/infrastructure/peer-device/runtimeSessionEventGate';
+
+const mockSubscribeGlobal = vi.fn();
 const mockTransition = vi.fn();
 const mockGetCurrentState = vi.fn(() => 'processing');
 const mockGetStateMachine = vi.fn(() => null);
@@ -52,6 +56,7 @@ vi.mock('../../state-machine', () => ({
     FINISHING: 'finishing',
   },
   stateMachineManager: {
+    subscribeGlobal: (...args: unknown[]) => mockSubscribeGlobal(...args),
     getCurrentState: (...args: unknown[]) => mockGetCurrentState(...args),
     get: (...args: unknown[]) => mockGetStateMachine(...args),
     transition: (...args: any[]) => mockTransition(...args),
@@ -556,6 +561,58 @@ describe('MessageModule cancellation', () => {
       composerDraft: pendingQueueDraft,
     }));
     expect(mockStartDialogTurn).not.toHaveBeenCalled();
+  });
+
+  it('sends a queued message once when snapshot replay became idle behind the attachment fence', async () => {
+    mockGetCurrentState.mockReturnValue('idle');
+    mockEnsureBackendSession.mockResolvedValue(undefined);
+    mockStartDialogTurn.mockResolvedValue({ sessionId: 'resume-session', turnId: 'next-turn', status: 'started' });
+    const session: any = { sessionId: 'resume-session', sessionKind: 'normal', mode: 'Standard',
+      titleStatus: 'generated', dialogTurns: [], config: { modelName: 'primary' }, maxContextTokens: 32000 };
+    const pending = { id: 'queued', sessionId: session.sessionId, content: 'next', status: 'queued', retryCount: 0 };
+    mockPendingList.mockReturnValue([pending]);
+    mockPendingSetStatus.mockImplementation((_session, _id, status) => { pending.status = status; });
+    const context: any = {
+      flowChatStore: {
+        getSurfaceGeneration: () => 0,
+        getState: () => ({ sessions: new Map([[session.sessionId, session]]) }),
+        addDialogTurn: vi.fn((_sessionId: string, turn: any) => session.dialogTurns.push(turn)),
+        deleteDialogTurn: vi.fn((_sessionId: string, turnId: string) => {
+          session.dialogTurns = session.dialogTurns.filter((turn: any) => turn.id !== turnId);
+        }),
+        updateSessionLastSubmittedMode: vi.fn(),
+        updateSessionMode: vi.fn(),
+        updateSessionModelName: vi.fn(),
+        updateSessionMaxContextTokens: vi.fn(),
+      },
+      processingManager: {
+        registerStatus: vi.fn(),
+        clearSessionStatus: vi.fn(),
+      },
+      userCancelledSessionIds: new Set<string>(),
+      pendingHistoryLoads: new Map(),
+      contentBuffers: new Map(),
+      activeTextItems: new Map(),
+    };
+    installPendingQueueDrainListener(context);
+    const onIdle = mockSubscribeGlobal.mock.calls.at(-1)![0];
+    const attachment = beginRuntimeSessionAttachment(LOCAL_SURFACE_ID, session.sessionId);
+    onIdle(session.sessionId, { currentState: 'idle' });
+    await Promise.resolve();
+    expect(mockStartDialogTurn).not.toHaveBeenCalled();
+    attachment.finish({ streamId: 'host', cursor: 5 });
+    // A held terminal delivery may report IDLE as well; coalesce the wakeups.
+    onIdle(session.sessionId, { currentState: 'idle' });
+    await vi.waitFor(() => expect(mockStartDialogTurn).toHaveBeenCalledTimes(1));
+    expect(mockPendingRemove).toHaveBeenCalledWith(session.sessionId, pending.id);
+
+    pending.status = 'queued';
+    const nextAttachment = beginRuntimeSessionAttachment(LOCAL_SURFACE_ID, session.sessionId);
+    nextAttachment.finish({ streamId: 'host', cursor: 6 });
+    activateSurface('peer-other');
+    await Promise.resolve();
+    expect(mockStartDialogTurn).toHaveBeenCalledTimes(1);
+    activateSurface(LOCAL_SURFACE_ID);
   });
 
   it('holds pending input while an interrupt outcome is still in flight', async () => {

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/MessageModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/MessageModule.ts
@@ -20,7 +20,11 @@ import type { FlowChatContext } from './types';
 import { isProjectedSessionEmpty } from '../../utils/flowChatTurnIdentity';
 import type { ImageContextData as ImageInputContextData } from '@/infrastructure/api/service-api/ImageContextTypes';
 import { pendingQueueManager } from './PendingQueueModule';
-import { isRuntimeSessionAttachmentInFlight } from '@/infrastructure/peer-device/runtimeSessionEventGate';
+import {
+  isRuntimeSessionAttachmentInFlight,
+  isRuntimeSessionProjectionStale,
+  subscribeRuntimeSessionAttachmentFinished,
+} from '@/infrastructure/peer-device/runtimeSessionEventGate';
 import { isSessionInUseError } from '@/infrastructure/api/errors/TauriCommandError';
 import { i18nService } from '@/infrastructure/i18n';
 import { driverForSession } from '../../session-drivers/registry';
@@ -529,7 +533,8 @@ export async function drainPendingQueue(
   sessionId: string,
   options?: { allowInterruptedRecoveryAbandon?: boolean },
 ): Promise<void> {
-  if (isRuntimeSessionAttachmentInFlight(getActiveSurfaceId(), sessionId)) {
+  if (isRuntimeSessionAttachmentInFlight(getActiveSurfaceId(), sessionId) ||
+      isRuntimeSessionProjectionStale(getActiveSurfaceId(), sessionId)) {
     return;
   }
   const machineState = stateMachineManager.getCurrentState(sessionId);
@@ -620,6 +625,21 @@ export async function drainPendingQueue(
 let queueDrainListenerInstalled = false;
 let queueDrainContext: FlowChatContext | null = null;
 
+const scheduledQueueDrains = new Set<string>();
+
+function schedulePendingQueueDrain(sessionId: string): void {
+  const scope = getActiveSurfaceScope();
+  const key = JSON.stringify([scope.surfaceId, scope.epoch, sessionId]);
+  if (scheduledQueueDrains.has(key)) return;
+  scheduledQueueDrains.add(key);
+  queueMicrotask(() => {
+    scheduledQueueDrains.delete(key);
+    if (!scope.isCurrent() || !queueDrainContext) return;
+    if (pendingQueueManager.list(sessionId).length === 0) return;
+    void drainPendingQueue(queueDrainContext, sessionId);
+  });
+}
+
 /** Install (once) the state-machine listener that drains the queue when a session returns to IDLE. */
 export function installPendingQueueDrainListener(context: FlowChatContext): void {
   queueDrainContext = context;
@@ -629,8 +649,9 @@ export function installPendingQueueDrainListener(context: FlowChatContext): void
   queueDrainListenerInstalled = true;
   stateMachineManager.subscribeGlobal((sessionId, machine) => {
     if (machine.currentState !== SessionExecutionState.IDLE) return;
-    if (!queueDrainContext) return;
-    if (pendingQueueManager.list(sessionId).length === 0) return;
-    void drainPendingQueue(queueDrainContext, sessionId);
+    schedulePendingQueueDrain(sessionId);
+  });
+  subscribeRuntimeSessionAttachmentFinished((surfaceId, sessionId) => {
+    if (surfaceId === getActiveSurfaceId()) schedulePendingQueueDrain(sessionId);
   });
 }

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.test.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.test.ts
@@ -398,7 +398,7 @@ describe('PeerSessionRefreshModule re-attach after a surface switch', () => {
     cleanup();
   });
 
-  it('replays the Runtime projection before reconciling the blocking mailbox', async () => {
+  it('preserves other-session events while replaying the Runtime projection before its mailbox', async () => {
     stateMachineMock.get.mockReturnValue({
       getCurrentState: () => 'idle',
       getContext: () => ({ lastUpdateTime: 0, version: 0 }),
@@ -424,15 +424,22 @@ describe('PeerSessionRefreshModule re-attach after a surface switch', () => {
         },
       ],
     };
-    const refresh = vi.fn(async () => ({
-      applied: true,
-      backendState: 'Processing { current_turn_id: "turn-live", phase: Streaming }',
-      latestTurnId: 'turn-live',
-      latestTurnStatus: 'processing',
-      runtimeEventSnapshot,
-      pendingUserQuestions: { revision: 2, questions: [] },
-    }));
+    const pendingOtherSession: string[] = [];
+    const paintedOtherSession: string[] = [];
+    const refresh = vi.fn(async () => {
+      pendingOtherSession.push('other-session text');
+      return {
+        applied: true,
+        backendState: 'Processing { current_turn_id: "turn-live", phase: Streaming }',
+        latestTurnId: 'turn-live',
+        latestTurnStatus: 'processing',
+        runtimeEventSnapshot,
+        pendingUserQuestions: { revision: 2, questions: [] },
+      };
+    });
     const context = contextWithSnapshot(refresh);
+    context.eventBatcher.flushNow.mockImplementation(() => paintedOtherSession.push(...pendingOtherSession.splice(0)));
+    context.eventBatcher.clear.mockImplementation(() => { pendingOtherSession.length = 0; });
 
     const cleanup = installPeerSessionRefresh(context);
     await vi.advanceTimersByTimeAsync(1);
@@ -447,7 +454,8 @@ describe('PeerSessionRefreshModule re-attach after a surface switch', () => {
       'agentic://text-chunk',
       runtimeEventSnapshot.events[1].payload,
     );
-    expect(context.eventBatcher.clear).toHaveBeenCalled();
+    expect(paintedOtherSession).toEqual(['other-session text']);
+    expect(context.eventBatcher.clear).not.toHaveBeenCalled();
     expect(context.flowChatStore.prepareRuntimeTurnReplay).toHaveBeenCalledWith(
       'session-1',
       'turn-live',

--- a/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.ts
+++ b/src/web-ui/src/flow_chat/services/flow-chat-manager/PeerSessionRefreshModule.ts
@@ -336,7 +336,7 @@ async function tryIncrementalCatchUp(
 
     attachment.finish(
       { streamId: backfill.streamId, cursor: backfill.cursor },
-      { projectionCaughtUp: true },
+      { projectionCaughtUp: true, events: backfill.events },
     );
     fenceResolved = true;
     log.debug('Runtime session projection caught up incrementally', {
@@ -359,7 +359,7 @@ async function tryIncrementalCatchUp(
     if (!fenceResolved) {
       // Release the held events rather than stranding them. On a superseded
       // read this is a no-op, which is why it is safe unconditionally.
-      attachment.abort();
+      attachment.abort({ discard: !surfaceScope.isCurrent() });
     }
   }
 }
@@ -575,7 +575,7 @@ export function installPeerSessionRefresh(context: FlowChatContext): () => void 
           attachment.finish({
             streamId: snapshot.streamId,
             cursor: snapshot.cursor,
-          }, { projectionCaughtUp: true });
+          }, { projectionCaughtUp: true, events: snapshot.events });
           attachmentFinished = true;
           log.debug('Runtime session projection already current', {
             sessionId,
@@ -587,7 +587,9 @@ export function installPeerSessionRefresh(context: FlowChatContext): () => void 
         // Establish an empty current-Turn base before replay. The journal is
         // authoritative for everything after DialogTurnStarted, so no
         // UI-written partial checkpoint is allowed to overlap it.
-        context.eventBatcher.clear();
+        // Only this Session is fenced. Other Sessions may have accumulated
+        // text/tool events during the read; publish them instead of erasing them.
+        context.eventBatcher.flushNow();
         context.contentBuffers.delete(sessionId);
         context.activeTextItems.delete(sessionId);
         const replayTurnId = snapshot.activeTurnId ?? result.latestTurnId;
@@ -633,7 +635,7 @@ export function installPeerSessionRefresh(context: FlowChatContext): () => void 
         attachment.finish({
           streamId: snapshot.streamId,
           cursor: snapshot.cursor,
-        }, { projectionCaughtUp });
+        }, { projectionCaughtUp, events: snapshot.events });
         attachmentFinished = true;
         if (!projectionCaughtUp) {
           markRuntimeSessionProjectionStale(surfaceScope.surfaceId, sessionId);

--- a/src/web-ui/src/flow_chat/session-stream/SessionStream.test.ts
+++ b/src/web-ui/src/flow_chat/session-stream/SessionStream.test.ts
@@ -141,6 +141,34 @@ describe('SessionStream', () => {
     expect(stream.appliedPosition()).toEqual(at(1, 'runtime-b'));
   });
 
+  it('establishes replayed ownership before releasing newer events from a restarted host', () => {
+    const stream = sessionStream('peer-linux', 'session');
+    stream.offer(COMPLETED, textAt('turn'), at(10), () => {});
+    const read = stream.beginRead();
+    const delivered: string[] = [];
+    stream.offer(TEXT, textAt('turn'), at(3, 'runtime-b'), () => delivered.push('text'));
+    read.settle(at(2, 'runtime-b'), [{ eventName: STARTED, payload: textAt('turn') }]);
+    expect(delivered).toEqual(['text']);
+    expect(stream.persistedMayWrite('turn')).toBe(false);
+    const completed = stream.beginRead();
+    stream.offer(TEXT, textAt('turn'), at(5, 'runtime-b'), () => delivered.push('late'));
+    completed.settle(at(4, 'runtime-b'), [{ eventName: COMPLETED, payload: textAt('turn') }]);
+    expect(delivered).toEqual(['text']);
+    expect(stream.persistedMayWrite('turn')).toBe(true);
+  });
+
+  it('does not clear a delivery gap with a snapshot behind the missing range', () => {
+    const stream = sessionStream('peer-linux', 'session');
+    stream.offer(TEXT, textAt('turn'), at(1), () => {});
+    stream.offer(TEXT, textAt('turn'), at(5), () => {});
+    stream.beginRead().settle(at(3));
+    expect(stream.hasGap()).toBe(true);
+    stream.commitAppliedPosition(at(4));
+    expect(stream.hasGap()).toBe(true);
+    stream.beginRead().settle(at(5));
+    expect(stream.hasGap()).toBe(false);
+  });
+
   it('applies an unpositioned write rather than hiding it', () => {
     const stream = sessionStream('local', 'session');
     stream.offer(TEXT, textAt('turn'), at(5), () => {});

--- a/src/web-ui/src/flow_chat/session-stream/SessionStream.ts
+++ b/src/web-ui/src/flow_chat/session-stream/SessionStream.ts
@@ -56,6 +56,10 @@ export class SessionStream {
     readonly sessionId: string,
   ) {}
 
+  isReadInFlight(): boolean {
+    return this.held !== null;
+  }
+
   appliedPosition(): RuntimePosition | null {
     return this.applied;
   }
@@ -161,11 +165,13 @@ export class SessionStream {
     const generation = ++this.prefixGeneration;
     this.held = this.held ?? [];
 
-    const isCurrent = (): boolean => this.prefixGeneration === generation;
+    let closed = false;
+    const isCurrent = (): boolean => !closed && this.prefixGeneration === generation;
     const takeHeld = (): HeldWrite[] | null => {
       if (!isCurrent()) {
         return null;
       }
+      closed = true;
       const held = this.held ?? [];
       this.held = null;
       return held;
@@ -173,20 +179,29 @@ export class SessionStream {
 
     return {
       isCurrent,
-      settle: (position: RuntimePosition | null) => {
+      settle: (position, events = []) => {
         const held = takeHeld();
         if (!held) {
           return;
         }
         if (position) {
-          this.applied = advancePosition(this.applied, position);
-          this.gapAt = null;
+          const coversApplied = !this.applied || this.applied.streamId !== position.streamId ||
+            position.cursor >= this.applied.cursor;
+          this.commitAppliedPosition(position);
+          if (coversApplied) {
+            for (const event of events) this.observeApplied(event.eventName, event.payload);
+          }
         }
         this.releaseHeld(held);
       },
-      abandon: () => {
+      abandon: (options) => {
         const held = takeHeld();
-        if (held) {
+        if (!held) return;
+        if (options?.discard) {
+          // A surface we left cannot paint this queue. Keep its cursor behind
+          // and require replay when returning, including for legacy events.
+          if (held.length) this.markProjectionBehind();
+        } else {
           this.releaseHeld(held);
         }
       },
@@ -209,8 +224,11 @@ export class SessionStream {
    * a snapshot prefix or a backfill suffix the caller painted itself.
    */
   commitAppliedPosition(position: RuntimePosition): void {
+    if (this.applied?.streamId !== position.streamId) this.ownership.reset();
+    if (!this.applied || this.applied.streamId !== position.streamId || position.cursor >= this.applied.cursor) {
+      this.gapAt = null;
+    }
     this.applied = advancePosition(this.applied, position);
-    this.gapAt = null;
   }
 
   /** Observe ownership for content applied outside `offer`, in order. */
@@ -233,12 +251,12 @@ export class SessionStream {
 }
 
 export interface SessionStreamRead {
-  /** False once a newer read superseded this one. */
+  /** False once completed, abandoned, or superseded by a newer read. */
   isCurrent(): boolean;
   /** Finish at `position` and release everything ahead of it, in order. */
-  settle(position: RuntimePosition | null): void;
-  /** Give up without advancing; held writes are released unchanged. */
-  abandon(): void;
+  settle(position: RuntimePosition | null, events?: ReadonlyArray<{ eventName: string; payload: unknown }>): void;
+  /** Give up without advancing; discard only when the original surface cannot paint. */
+  abandon(options?: { discard?: boolean }): void;
 }
 
 const streams = new Map<string, SessionStream>();

--- a/src/web-ui/src/infrastructure/api/adapters/tauri-adapter.test.ts
+++ b/src/web-ui/src/infrastructure/api/adapters/tauri-adapter.test.ts
@@ -3,6 +3,7 @@ import { isExpectedTauriRequestError, TauriTransportAdapter } from './tauri-adap
 import {
   beginRuntimeSessionAttachment,
   resetRuntimeSessionEventGateForTest,
+  isRuntimeSessionProjectionStale,
   RUNTIME_EVENT_CURSOR_KEY,
   RUNTIME_EVENT_STREAM_ID_KEY,
 } from '@/infrastructure/peer-device/runtimeSessionEventGate';
@@ -168,7 +169,28 @@ describe('Tauri adapter expected errors', () => {
     expect(underlyingUnlisten).toHaveBeenCalledOnce();
   });
 
-  it('releases a held event to the subscribers that owned it on arrival', async () => {
+  it('rejects delayed source-device events after the rendered device changes', async () => {
+    let nativeEvent: (event: { payload: unknown }) => void = () => {};
+    listenMock.mockImplementation(async (_event: string, handler: typeof nativeEvent) => {
+      nativeEvent = handler;
+      return vi.fn();
+    });
+    const adapter = new TauriTransportAdapter();
+    const delivered = vi.fn();
+    const unlisten = adapter.listen('agentic://text-chunk', delivered);
+    await adapter.waitForListenerRegistrations();
+    const attachment = beginRuntimeSessionAttachment('local', 'same-session');
+    nativeEvent({ payload: { sessionId: 'same-session', text: 'local-secret',
+      [RUNTIME_EVENT_STREAM_ID_KEY]: 'local-runtime', [RUNTIME_EVENT_CURSOR_KEY]: 2 } });
+    setActiveSurfaceDeviceId('peer-b');
+    attachment.finish({ streamId: 'local-runtime', cursor: 1 });
+    expect(delivered).not.toHaveBeenCalled();
+    expect(isRuntimeSessionProjectionStale('local', 'same-session')).toBe(true);
+    unlisten();
+    await adapter.disconnect();
+  });
+
+  it('does not release a held event to unsubscribed or replacement listeners', async () => {
     const handlers = new Map<string, (event: { payload: unknown }) => void>();
     listenMock.mockImplementation(async (event: string, handler: (event: { payload: unknown }) => void) => {
       handlers.set(event, handler);
@@ -197,12 +219,9 @@ describe('Tauri adapter expected errors', () => {
     await secondAdapter.waitForListenerRegistrations();
 
     attachment.finish({ streamId: 'runtime-1', cursor: 1 });
-    expect(first).toHaveBeenCalledOnce();
-    expect(first).toHaveBeenCalledWith({
-      sessionId: 'session-1',
-      text: 'held',
-    });
+    expect(first).not.toHaveBeenCalled();
     expect(second).not.toHaveBeenCalled();
+    expect(isRuntimeSessionProjectionStale('local', 'session-1')).toBe(true);
 
     unlistenSecond();
   });

--- a/src/web-ui/src/infrastructure/api/adapters/tauri-adapter.ts
+++ b/src/web-ui/src/infrastructure/api/adapters/tauri-adapter.ts
@@ -4,9 +4,9 @@ import { listen, UnlistenFn } from '@tauri-apps/api/event';
 import { elapsedMs, nowMs } from '@/shared/utils/timing';
 import { ITransportAdapter, type TransportRequestTiming } from './base';
 import { createLogger } from '@/shared/utils/logger';
-import { routeSurfaceEvent } from '@/infrastructure/peer-device/deviceSurfaceRouting';
-import { surfaceIdForDevice } from '@/infrastructure/peer-device/deviceSurface';
-import { routeRuntimeSessionEvent } from '@/infrastructure/peer-device/runtimeSessionEventGate';
+import { getActiveSurfaceDeviceId, isSurfaceScopedEvent, routeSurfaceEvent } from '@/infrastructure/peer-device/deviceSurfaceRouting';
+import { getActiveSurfaceScope, surfaceIdForDevice } from '@/infrastructure/peer-device/deviceSurface';
+import { markRuntimeSessionProjectionStale, routeRuntimeSessionEvent } from '@/infrastructure/peer-device/runtimeSessionEventGate';
 import { sanitizeErrorForLog } from '../logSanitizer';
 
 const log = createLogger('TauriAdapter');
@@ -63,8 +63,8 @@ function registerSharedTauriEventListener(
 
     // Capture the logical listeners that owned the event when it arrived. A
     // Session read may hold delivery after accepting the write; those owners
-    // must still paint it when released, while later subscribers must not
-    // receive the native event retroactively.
+    // may paint it if still subscribed when released; later subscribers must
+    // not receive the native event retroactively.
     const subscriptions = [...shared.subscriptions];
 
     // Peer devices stay attached while the UI renders another device, so
@@ -75,12 +75,24 @@ function registerSharedTauriEventListener(
       return;
     }
 
+    const sourceSurfaceId = surfaceIdForDevice(route.sourceDeviceId);
+    const scope = getActiveSurfaceScope();
     routeRuntimeSessionEvent(
-      surfaceIdForDevice(route.sourceDeviceId),
+      sourceSurfaceId,
       event,
       route.payload,
       payload => {
-        for (const subscription of subscriptions) {
+        // Fenced delivery can outlive a device switch or an unsubscribe. Never
+        // call an obsolete listener against the newly selected store container.
+        const currentSubscriptions = subscriptions.filter(subscription => shared.subscriptions.has(subscription));
+        if (!scope.isCurrent() ||
+            (isSurfaceScopedEvent(event) && getActiveSurfaceDeviceId() !== route.sourceDeviceId) ||
+            shared.closed || currentSubscriptions.length === 0) {
+          const sessionId = (payload as { sessionId?: unknown } | null)?.sessionId;
+          if (typeof sessionId === 'string') markRuntimeSessionProjectionStale(sourceSurfaceId, sessionId);
+          return;
+        }
+        for (const subscription of currentSubscriptions) {
           try {
             subscription.callback(payload);
           } catch (error) {

--- a/src/web-ui/src/infrastructure/peer-device/runtimeSessionEventGate.test.ts
+++ b/src/web-ui/src/infrastructure/peer-device/runtimeSessionEventGate.test.ts
@@ -1,7 +1,9 @@
+import { discardSessionStreams } from '@/flow_chat/session-stream/SessionStream';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   beginRuntimeSessionAttachment,
   isRuntimeSessionProjectionStale,
+  isRuntimeSessionAttachmentInFlight,
   markRuntimeSessionProjectionStale,
   readRuntimeSessionProgress,
   resetRuntimeSessionEventGateForTest,
@@ -9,6 +11,7 @@ import {
   RUNTIME_EVENT_CURSOR_KEY,
   RUNTIME_EVENT_STREAM_ID_KEY,
   subscribeRuntimeSessionEventGaps,
+  subscribeRuntimeSessionAttachmentFinished,
 } from './runtimeSessionEventGate';
 
 function payload(sessionId: string, streamId: string, cursor: number, text: string) {
@@ -25,6 +28,55 @@ afterEach(() => {
 });
 
 describe('runtimeSessionEventGate', () => {
+  it.each(['finish', 'abort', 'discard'] as const)('ends the attachment fence after %s and ignores repeated completion', (mode) => {
+    const attachment = beginRuntimeSessionAttachment('local', 'session');
+    const delivered = vi.fn();
+    routeRuntimeSessionEvent('local', 'agentic://text-chunk', payload('session', 'a', 2, 'held'), delivered);
+    expect(isRuntimeSessionAttachmentInFlight('local', 'session')).toBe(true);
+    if (mode === 'finish') attachment.finish({ streamId: 'a', cursor: 1 });
+    else attachment.abort({ discard: mode === 'discard' });
+    expect(attachment.isCurrent()).toBe(false);
+    expect(isRuntimeSessionAttachmentInFlight('local', 'session')).toBe(false);
+    expect(delivered).toHaveBeenCalledTimes(mode === 'discard' ? 0 : 1);
+    const before = readRuntimeSessionProgress('local', 'session');
+    attachment.finish({ streamId: 'a', cursor: 99 });
+    expect(readRuntimeSessionProgress('local', 'session')).toEqual(before);
+    if (mode === 'discard') expect(isRuntimeSessionProjectionStale('local', 'session')).toBe(true);
+  });
+
+  it('isolates a disposed attachment from a new connection to the same device', () => {
+    const disposed = beginRuntimeSessionAttachment('peer-a', 'session');
+    discardSessionStreams('peer-a');
+    const reconnected = beginRuntimeSessionAttachment('peer-a', 'session');
+    disposed.abort({ discard: true });
+    expect(disposed.isCurrent()).toBe(false);
+    expect(isRuntimeSessionAttachmentInFlight('peer-a', 'session')).toBe(true);
+    reconnected.finish({ streamId: 'new-host', cursor: 1 });
+    expect(isRuntimeSessionAttachmentInFlight('peer-a', 'session')).toBe(false);
+  });
+
+  it('notifies queue consumers only after a healthy attachment is closed', () => {
+    const finished = vi.fn(() => expect(isRuntimeSessionAttachmentInFlight('local', 'session')).toBe(false));
+    const unsubscribe = subscribeRuntimeSessionAttachmentFinished(finished);
+    const obsolete = beginRuntimeSessionAttachment('local', 'session');
+    const current = beginRuntimeSessionAttachment('local', 'session');
+    obsolete.abort({ discard: true });
+    expect(current.isCurrent()).toBe(true);
+    current.finish({ streamId: 'a', cursor: 2 }, { projectionCaughtUp: false });
+    expect(finished).not.toHaveBeenCalled();
+    beginRuntimeSessionAttachment('local', 'session').finish({ streamId: 'a', cursor: 2 });
+    expect(finished).toHaveBeenCalledExactlyOnceWith('local', 'session');
+    unsubscribe();
+  });
+
+  it('does not let a superseded failed read poison a newer successful attachment', () => {
+    const old = beginRuntimeSessionAttachment('local', 'session');
+    const current = beginRuntimeSessionAttachment('local', 'session');
+    current.finish({ streamId: 'a', cursor: 5 });
+    old.finish({ streamId: 'a', cursor: 4 }, { projectionCaughtUp: false });
+    expect(isRuntimeSessionProjectionStale('local', 'session')).toBe(false);
+  });
+
   it('strips cursor metadata on the ordinary live path', () => {
     const delivered = vi.fn();
     routeRuntimeSessionEvent(

--- a/src/web-ui/src/infrastructure/peer-device/runtimeSessionEventGate.ts
+++ b/src/web-ui/src/infrastructure/peer-device/runtimeSessionEventGate.ts
@@ -15,7 +15,6 @@ import {
   peekSessionStream,
   resetSessionStreamsForTest,
   sessionStream,
-  type SessionStreamRead,
 } from '@/flow_chat/session-stream/SessionStream';
 import {
   isRuntimePosition,
@@ -25,6 +24,8 @@ import {
 /** Keep in sync with the Rust `SessionEventJournal` delivery-envelope keys. */
 export const RUNTIME_EVENT_STREAM_ID_KEY = '__openbitfunRuntimeStreamId';
 export const RUNTIME_EVENT_CURSOR_KEY = '__openbitfunRuntimeEventCursor';
+
+const attachmentFinishedListeners = new Set<(surfaceId: DeviceSurfaceId, sessionId: string) => void>();
 
 const gapListeners = new Set<(surfaceId: DeviceSurfaceId, sessionId: string) => void>();
 
@@ -70,9 +71,17 @@ export interface RuntimeSessionAttachmentHandle {
   requiresReplay(snapshot: { streamId: string; cursor: number }): boolean;
   finish(
     snapshot: { streamId: string; cursor: number },
-    options?: { projectionCaughtUp?: boolean },
+    options?: { projectionCaughtUp?: boolean; events?: ReadonlyArray<{ eventName: string; payload: unknown }> },
   ): void;
   abort(options?: { discard?: boolean }): void;
+}
+
+/** Wake consumers whose work was deferred while the projection was rebuilding. */
+export function subscribeRuntimeSessionAttachmentFinished(
+  listener: (surfaceId: DeviceSurfaceId, sessionId: string) => void,
+): () => void {
+  attachmentFinishedListeners.add(listener);
+  return () => attachmentFinishedListeners.delete(listener);
 }
 
 export function subscribeRuntimeSessionEventGaps(
@@ -121,17 +130,11 @@ export function readRuntimeSessionProgress(
   return peekSessionStream(surfaceId, sessionId)?.appliedPosition() ?? null;
 }
 
-const inFlightReads = new Map<string, SessionStreamRead>();
-
-function readKey(surfaceId: DeviceSurfaceId, sessionId: string): string {
-  return JSON.stringify([surfaceId, sessionId]);
-}
-
 export function isRuntimeSessionAttachmentInFlight(
   surfaceId: DeviceSurfaceId,
   sessionId: string,
 ): boolean {
-  return inFlightReads.get(readKey(surfaceId, sessionId))?.isCurrent() === true;
+  return peekSessionStream(surfaceId, sessionId)?.isReadInFlight() === true;
 }
 
 export function beginRuntimeSessionAttachment(
@@ -140,10 +143,11 @@ export function beginRuntimeSessionAttachment(
 ): RuntimeSessionAttachmentHandle {
   const stream = sessionStream(surfaceId, sessionId);
   const read = stream.beginRead();
-  inFlightReads.set(readKey(surfaceId, sessionId), read);
+  const isCurrent = () => read.isCurrent() &&
+    peekSessionStream(surfaceId, sessionId) === stream;
 
   return {
-    isCurrent: () => read.isCurrent(),
+    isCurrent,
     requiresReplay(snapshot) {
       // Under the contract this is ordering, not inspection: replay when the
       // snapshot reaches past what is applied, when it belongs to another
@@ -155,7 +159,8 @@ export function beginRuntimeSessionAttachment(
       return applied.streamId !== snapshot.streamId || applied.cursor < snapshot.cursor;
     },
     finish(snapshot, options) {
-      read.settle(isRuntimePosition(snapshot) ? snapshot : null);
+      if (!isCurrent()) return;
+      read.settle(isRuntimePosition(snapshot) ? snapshot : null, options?.events);
       if (options?.projectionCaughtUp === false) {
         // Mark only. Notifying here would schedule a repair for a read that
         // just ran, and the caller reports it through
@@ -163,15 +168,13 @@ export function beginRuntimeSessionAttachment(
         // same flag and correctly stays silent.
         stream.markProjectionBehind();
       }
+      if (!stream.hasGap()) {
+        for (const listener of attachmentFinishedListeners) listener(surfaceId, sessionId);
+      }
     },
     abort(options) {
-      if (options?.discard === true) {
-        // Held writes belong to whichever read supersedes this one; releasing
-        // them here would apply them against a projection it is rebuilding.
-        read.settle(null);
-        return;
-      }
-      read.abandon();
+      if (!isCurrent()) return;
+      read.abandon(options);
     },
   };
 }
@@ -219,7 +222,7 @@ export function routeRuntimeSessionEvent<T>(
 
 export function resetRuntimeSessionEventGateForTest(): void {
   gapListeners.clear();
-  inFlightReads.clear();
+  attachmentFinishedListeners.clear();
   // Positions live on the streams now, so clearing only this module's maps
   // would leak applied state between tests.
   resetSessionStreamsForTest();


### PR DESCRIPTION
Peer recovery could leave the message queue permanently fenced after a read finished, deliver buffered events through obsolete listeners after a device switch, or discard another session’s text/tool events while replaying one session. Snapshot replay also advanced its cursor without updating turn ownership, and an older snapshot could incorrectly clear a delivery gap.

- Make SessionStream the single owner of read liveness. Closed, superseded, and disposed attachment handles cannot affect subsequent reads; discarding a departed surface’s queue requires replay instead of painting it.
- Wake the pending queue after healthy recovery, coalesce terminal/recovery wakeups, and fence the deferred send by surface epoch.
- Validate the original surface and surviving subscriptions when delayed Tauri events are released. Replacement listeners do not receive old deliveries; the source projection is marked for repair.
- Flush other sessions’ buffered events before rebuilding the restored session.
- Apply replayed lifecycle ownership before releasing newer events, reset ownership across runtime processes, and retain gaps when a snapshot is behind.

Validation:
- 433 tests passed across 23 focused test files: peer connection/surface isolation, Tauri/peer/WebSocket adapters, stream ordering, recovery, pending messages, batching, store sync, FlowChat state, and question cards.
- Regression tests cover read completion/abort/discard, stale overlapping/disposed handles, queue wakeup and device switching, delayed unsubscribed listeners, concurrent-session preservation, runtime restart ownership, and lagging gap repair. Read-lifecycle and ownership tests were observed failing before their fixes.
- `pnpm run check:web`, final `pnpm run type-check:web`, and `git diff --check` passed.

Remote coverage is deterministic controller/host-contract simulation. No live Mac/Linux/Windows device matrix, mobile/IM Remote Connect, SSH/Docker workspace, or Detached Dispatch end-to-end execution is claimed. This change adds no wire-protocol or persisted-data migration and keeps legacy unpositioned events working.
